### PR TITLE
fix(test): guard waitForFile against empty reads on Windows

### DIFF
--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -128,7 +128,8 @@ function waitForFile(filePath, timeoutMs = 5000) {
   const started = Date.now();
   while (Date.now() - started < timeoutMs) {
     if (fs.existsSync(filePath)) {
-      return fs.readFileSync(filePath, 'utf8');
+      const content = fs.readFileSync(filePath, 'utf8');
+      if (content.trim()) return content;
     }
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
   }


### PR DESCRIPTION
## Summary

- Adds a non-empty content guard to `waitForFile()` in `tests/hooks/mcp-health-check.test.js`

## Root cause

`waitForFile` had a TOCTOU race: `fs.existsSync` returned true before the spawned server process finished writing the port file. On Windows Node 18.x, `fs.readFileSync` then returned an empty string, causing the subsequent `waitForHttpReady` call to receive a malformed URL (`http://127.0.0.1:/mcp`) and fail.

The fix loops until the file contains non-empty content, eliminating the race window.

## Scope

- One file: `tests/hooks/mcp-health-check.test.js`
- Two lines changed (lines 130-131)
- Zero production files touched
- Zero test cases removed

## Test plan

- [ ] `node tests/hooks/mcp-health-check.test.js` - 20/20 pass
- [ ] `node tests/run-all.js` - no regressions vs baseline
- [ ] CI green across all matrix combinations including windows-latest Node 18.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file-waiting utility to ensure files contain meaningful content before proceeding, rather than returning when files are empty or contain only whitespace. This increases reliability of operations dependent on complete file state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fmarzochi/everything-gemini/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->