### PR TITLE
docs(readme): prioritize familiar AI tools in onboarding examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## This is what EGC looks like in practice
 
-You open AGY on a project you haven't touched in two weeks. Without typing anything:
+You open Claude Code on a project you haven't touched in two weeks. Without typing anything:
 
 ```
 State loaded from egc-memory via ~/.egc/state/Projetos--everything-gemini.md
@@ -32,7 +32,7 @@ Ready to pick up the next items:
 
 The AI already knows what you were building, what decisions you made, what failed, and exactly where you stopped. You didn't type anything. You just started working.
 
-After `sh install.sh`, the memory protocol is injected into the global instruction files for Claude Code, AGY/Gemini CLI, Cursor, Codex, OpenCode, Kiro, Trae, and CodeBuddy — so the AI reads state at the start of each session and saves it at the end. For tools where the AI instruction file isn't read automatically (varies by tool version), you may need to add the project's `CLAUDE.md` or equivalent to the session context manually.
+After `sh install.sh`, the memory protocol is injected into the global instruction files for Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Kiro, Trae, and CodeBuddy — so the AI reads state at the start of each session and saves it at the end. For tools where the AI instruction file isn't read automatically (varies by tool version), you may need to add the project's `CLAUDE.md` or equivalent to the session context manually.
 
 ---
 
@@ -48,7 +48,7 @@ It gets worse when you switch tools. Move from Cursor to Claude Code and you sta
 
 One install. Every tool. Permanent memory.
 
-`sh install.sh` detects which AI tools you have installed — Claude Code, AGY, Cursor, Kiro, Codex, OpenCode, Trae, CodeBuddy — and registers the MCP servers in all of them. It also runs a cognitive bootstrap that writes the memory protocol into the global instruction files for each tool, so the AI is instructed to call `get_state({})` at the start of every session and `update_state({...})` at the end.
+`sh install.sh` detects which AI tools you have installed — Claude Code, Cursor, Codex, Gemini CLI, Kiro, OpenCode, Trae, CodeBuddy — and registers the MCP servers in all of them. It also runs a cognitive bootstrap that writes the memory protocol into the global instruction files for each tool, so the AI is instructed to call `get_state({})` at the start of every session and `update_state({...})` at the end.
 
 For every supported tool:
 - **Open any session** → AI reads your project state → picks up where you left off


### PR DESCRIPTION
Reorders the tool lists in the onboarding section to lead with the most familiar tools (Claude Code, Cursor, Codex) before Gemini CLI, improving first-read flow for developers coming from popular editors.

Three lines changed:
- Line 19: replace AGY with Claude Code in the opening scenario
- Line 35: reorder tool list to Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Kiro, Trae, CodeBuddy
- Line 51: same reorder in the install.sh description

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the onboarding tool lists to lead with the most familiar editors (Claude Code, Cursor, Codex) and updated the opening example to use Claude Code instead of AGY. This improves first-read clarity and aligns the `install.sh` descriptions across sections.

<sup>Written for commit 0abbd8bca2d1cc891df511a8b5e97b4ec6690bf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/everything-gemini/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to document expanded code editor and IDE platform support
  * Revised implementation examples and practical guides for improved clarity
  * Enhanced documentation for tool-specific instruction file integration workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fmarzochi/everything-gemini/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->