### PR TITLE
fix(security): remove env-derived content from session-end log messages

### DIFF
--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -230,7 +230,7 @@ async function main() {
     if (fs.existsSync(transcriptPath)) {
       summary = extractSessionSummary(transcriptPath);
     } else {
-      log(`[SessionEnd] Transcript not found: ${transcriptPath}`);
+      log('[SessionEnd] Transcript not found');
     }
   }
 
@@ -243,7 +243,7 @@ async function main() {
       if (merged) {
         updatedContent = merged;
       } else {
-        log(`[SessionEnd] Failed to normalize header in ${sessionFile}`);
+        log('[SessionEnd] Failed to normalize session file header');
       }
     }
 
@@ -268,7 +268,7 @@ async function main() {
       writeFile(sessionFile, updatedContent);
     }
 
-    log(`[SessionEnd] Updated session file: ${sessionFile}`);
+    log('[SessionEnd] Updated session file');
   } else {
     const summarySection = summary
       ? `${buildSummaryBlock(summary)}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\``
@@ -278,7 +278,7 @@ async function main() {
 `;
 
     writeFile(sessionFile, template);
-    log(`[SessionEnd] Created session file: ${sessionFile}`);
+    log('[SessionEnd] Created session file');
   }
 
   process.exit(0);


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #12 (clear-text logging of sensitive information).

After PR #43 and #44, the alert re-appeared because CodeQL found additional taint paths in `session-end.js`:

- `process.env.GEMINI_TRANSCRIPT_PATH` -> `transcriptPath` -> `log('Transcript not found: ${transcriptPath}')`
- `process.env.EGC_SESSION_ID` -> `getSessionIdShort()` -> `shortId` -> `sessionFile` -> `log('... ${sessionFile}')`

**Fix:** Remove the dynamic env-derived content from four log messages. The static labels retain enough context for debugging.

## Changes

- `log('[SessionEnd] Transcript not found')` (was: `... ${transcriptPath}`)
- `log('[SessionEnd] Failed to normalize session file header')` (was: `... ${sessionFile}`)
- `log('[SessionEnd] Updated session file')` (was: `... ${sessionFile}`)
- `log('[SessionEnd] Created session file')` (was: `... ${sessionFile}`)

Existing tests use `includes('Transcript not found')` / `includes('Updated session file')` without the path -- no test changes needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove env-derived values from `scripts/hooks/session-end.js` log messages to prevent clear-text exposure of sensitive paths and session IDs. Replace `${transcriptPath}` and `${sessionFile}` interpolation with static labels for "Transcript not found", "Failed to normalize session file header", "Updated session file", and "Created session file".

<sup>Written for commit e5957d6c44e258d02a739bebdda04e11d2afa775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/everything-gemini/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified session-end hook logging messages to be more generic when reporting session lifecycle events, reducing diagnostic output verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->