### PR TITLE
fix(security): remove env-derived session ID from observer lease log

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -522,7 +522,7 @@ async function main() {
       hook: 'SessionStart',
       projectRoot: observerContext.projectRoot
     });
-    log(`[SessionStart] Registered observer lease for ${observerSessionId}`);
+    log('[SessionStart] Registered observer lease');
   } else {
     log('[SessionStart] No EGC_SESSION_ID available; skipping observer lease registration');
   }


### PR DESCRIPTION
## Summary

- CodeQL alert #12 (js/clear-text-logging) found a new taint path after PR #45
- `EGC_SESSION_ID`/`ECC_SESSION_ID` flow through `getActiveSessionId()` -> `resolveSessionId()` -> `observerSessionId` -> `log()` at `session-start.js:525`
- Fix: remove `${observerSessionId}` from the log message (same pattern as PR #45)

## Test plan

- [ ] CI passes
- [ ] CodeQL rescan closes alert #12 on main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove env-derived session IDs from the observer lease log to fix CodeQL alert #12 (clear-text logging). Prevents logging `EGC_SESSION_ID`/`ECC_SESSION_ID` while keeping useful context.

- **Bug Fixes**
  - Removed `${observerSessionId}` from the `[SessionStart] Registered observer lease` log in `scripts/hooks/session-start.js` to eliminate the taint path into `log()`.

<sup>Written for commit 5b6da9a4541c9dfc5a0ae6665933848bb3a8cb6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/everything-gemini/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified session start logging to use a generic message format instead of including specific session identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->