### PR TITLE
fix(readme): remove table borders from footer logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,18 +232,14 @@ The branch `legacy-runtime` preserves the full historical architecture for anyon
 
 <br/>
 
-<table border="0" cellspacing="0" cellpadding="0">
-  <tr>
-    <td align="center" valign="middle" style="padding-right:40px">
-      <a href="https://www.bestpractices.dev/projects/13099">
-        <img src="assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices Badge" width="110" />
-      </a>
-    </td>
-    <td align="center" valign="middle">
-      <img src="assets/images/egc-logo.png" alt="EGC Logo" width="80" /><br/>
-      Desenvolvido por <a href="https://linkedin.com/in/felipemarzochi">Felipe Marzochi</a>
-    </td>
-  </tr>
-</table>
+<a href="https://www.bestpractices.dev/projects/13099">
+  <img src="assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices Badge" width="110" />
+</a>
+&emsp;&emsp;&emsp;
+<img src="assets/images/egc-logo.png" alt="EGC Logo" width="80" />
+
+<br/>
+
+Desenvolvido por <a href="https://linkedin.com/in/felipemarzochi">Felipe Marzochi</a>
 
 </div>


### PR DESCRIPTION
Replace HTML table with inline images. Removes the visible cell borders (quadrados) that GitHub renders around the shield and EGC logo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the table wrapper in the README footer so GitHub no longer shows borders around the badge and EGC logo. Use inline images with spacing to keep them side by side.

<sup>Written for commit c5705e726ee79ba2a0039a7027f53f02681d09a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/everything-gemini/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured the footer section containing project badges and attribution for improved visual alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->