### PR TITLE
fix(readme): increase spacing between footer logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,9 @@ The branch `legacy-runtime` preserves the full historical architecture for anyon
 <a href="https://www.bestpractices.dev/projects/13099">
   <img src="assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices Badge" width="110" />
 </a>
-&emsp;&emsp;&emsp;
-<img src="assets/images/egc-logo.png" alt="EGC Logo" width="80" />
-
-<br/>
-
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
+<img src="assets/images/egc-logo.png" alt="EGC Logo" width="80" /><br/>
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
 Desenvolvido por <a href="https://linkedin.com/in/felipemarzochi">Felipe Marzochi</a>
 
 </div>


### PR DESCRIPTION
More horizontal space between shield and EGC logo. Attribution indented to align visually under the logo. No table, no borders.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased horizontal spacing between the OpenSSF badge and the EGC logo in the README footer and aligned the attribution under the logo for better visual balance. Moved the line break inline with the logo to simplify the markup.

<sup>Written for commit 3957e1bc6917fbc59b87b439d7c5556c2e4455b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/everything-gemini/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated footer layout and spacing in the README to improve visual presentation and alignment of footer elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->