### PR TITLE
fix(readme): add captions under footer logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,12 @@ The branch `legacy-runtime` preserves the full historical architecture for anyon
   <img src="assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices Badge" width="110" />
 </a>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-<img src="assets/images/egc-logo.png" alt="EGC Logo" width="80" /><br/>
-&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-Desenvolvido por <a href="https://linkedin.com/in/felipemarzochi">Felipe Marzochi</a>
+<img src="assets/images/egc-logo.png" alt="EGC Logo" width="80" />
+
+<br/>
+
+<sub><a href="https://www.bestpractices.dev/projects/13099">OpenSSF Best Practices</a></sub>
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
+<sub>Desenvolvido por <a href="https://linkedin.com/in/felipemarzochi">Felipe Marzochi</a></sub>
 
 </div>


### PR DESCRIPTION
Adds 'OpenSSF Best Practices' link under the shield and 'Desenvolvido por Felipe Marzochi' under the EGC logo. Both as small text aligned approximately under their respective images.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add small captions under footer logos in README to improve clarity and attribution. Includes an OpenSSF Best Practices link under the badge and “Desenvolvido por Felipe Marzochi” under the EGC logo, aligned beneath each image.

<sup>Written for commit 77d758baba29c619bdfc64c3612581d5b5f367b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/everything-gemini/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README footer formatting for improved structure and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->