### PR TITLE
fix(readme): footer com apenas logos clicaveis, sem texto

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,6 @@ The branch `legacy-runtime` preserves the full historical architecture for anyon
 
 <a href="https://bestpractices.dev/projects/13099"><img src="assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices" width="110" /></a>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-<a href="https://github.com/Fmarzochi"><img src="assets/images/egc-logo.png" alt="EGC" width="80" /></a>
-
-<br/>
-
-<a href="https://bestpractices.dev/projects/13099">OpenSSF Best Practices</a>
-&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-<a href="https://github.com/Fmarzochi">Desenvolvido por Felipe Marzochi</a>
+<a href="https://linkedin.com/in/felipemarzochi"><img src="assets/images/egc-logo.png" alt="EGC" width="110" /></a>
 
 </div>


### PR DESCRIPTION
## Summary

- Remove text labels from footer ("OpenSSF Best Practices" and "Desenvolvido por Felipe Marzochi")
- Equalize both logo sizes to 110px (EGC logo was 80px, now matches shield width)
- EGC logo now links to LinkedIn profile (linkedin.com/in/felipemarzochi)
- Footer is clean: only two side-by-side clickable images, no alignment issues

## Test plan

- [ ] Confirm no text labels appear under the logos
- [ ] Confirm shield (110px) links to bestpractices.dev
- [ ] Confirm EGC logo (110px) links to LinkedIn
- [ ] Confirm no visible borders

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the README footer to show only two side-by-side clickable logos at 110px, removing all text labels. The OpenSSF badge still links to bestpractices.dev, and the EGC logo now links to linkedin.com/in/felipemarzochi.

<sup>Written for commit 25dda08d26766e8dc4e233a756108069b896c788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/everything-gemini/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README footer contact links to LinkedIn profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->