### PR TITLE
docs(readme): npm badge e instalação via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![version](https://img.shields.io/github/package-json/v/Fmarzochi/EGC?color=cb3837&logo=npm&logoColor=white)](https://github.com/Fmarzochi/EGC) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
+[![npm version](https://img.shields.io/npm/v/@fmarzochi/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@fmarzochi/egc) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
 
 <div align="center">
 
@@ -76,6 +76,13 @@ The money saved is small. The time and interrupted flow are not.
 ---
 
 ## Installation
+
+### Via npm (recomendado)
+
+```bash
+npm install -g @fmarzochi/egc
+egc install
+```
 
 ### Linux / macOS
 


### PR DESCRIPTION
## Summary

- Badge de versão atualizado: aponta para `npmjs.com/package/@fmarzochi/egc` em vez do GitHub
- Adicionada opção de instalação via `npm install -g @fmarzochi/egc` na seção Installation

Necessário após publicação do pacote `@fmarzochi/egc@1.0.0` no npm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated README to show the npm version badge linking to the registry for `@fmarzochi/egc`, and added a recommended install via `npm install -g @fmarzochi/egc` then `egc install`.
This aligns the docs with the package now on npm and makes installation clearer.

<sup>Written for commit 49842979f74228266bf336a2ba26d0b039497216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a recommended "Via npm" installation subsection with example install and setup commands.
  * Updated the top version badge to reference the scoped npm package.
  * Clarified installation guidance for a smoother first-time setup and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->