### PR TITLE
docs: add Support/Sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![version](https://img.shields.io/github/package-json/v/Fmarzochi/EGC?color=cb3837&logo=npm&logoColor=white)](https://github.com/Fmarzochi/EGC) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
+[![npm version](https://img.shields.io/npm/v/@fmarzochi/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@fmarzochi/egc) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
 
 <div align="center">
 
@@ -76,6 +76,13 @@ The money saved is small. The time and interrupted flow are not.
 ---
 
 ## Installation
+
+### Via npm (recomendado)
+
+```bash
+npm install -g @fmarzochi/egc
+egc install
+```
 
 ### Linux / macOS
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,25 @@ The branch `legacy-runtime` preserves the full historical architecture for anyon
 
 ---
 
+## Support EGC
+
+EGC solves a problem that no company has solved: **AI memory that persists across sessions, across tools, and across CLIs.**
+
+Close Claude Code and open Cursor. The AI already knows your project. Switch to Codex. Same context. No re-explaining. No lost decisions. No starting from zero.
+
+That's not a feature. It's a shift in how AI-assisted engineering works.
+
+EGC is built by one developer, maintained in the open, and used by people who are done re-explaining context every session. If it saves you time — consider giving back:
+
+- **[Sponsor on GitHub](https://github.com/sponsors/Fmarzochi)** — direct support, any amount
+- **Star the repository** — helps other developers find it
+- **Contribute** — agents, skills, commands, bug fixes, docs ([CONTRIBUTING.md](CONTRIBUTING.md))
+- **Share** — if EGC changed how you work, tell someone
+
+Every contribution — financial or otherwise — goes toward keeping this maintained, documented, and free.
+
+---
+
 <div align="center">
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)


### PR DESCRIPTION
## Summary

- Adds a **Support EGC** section to the README before the footer
- Highlights the unique differentiator: persistent AI memory across sessions and across CLIs (a problem no company has solved)
- Includes GitHub Sponsors link, star CTA, contribution CTA, and sharing CTA

## Why

The repository branding was updated but the sponsors/support section was missing entirely. Contributors and users landing on the page had no clear way to support the project or understand why it deserves support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Support EGC section to the README with sponsor, star, contribute, and share CTAs, and explains the differentiator: persistent AI memory across sessions and CLIs. Also updates the npm badge to the published `@fmarzochi/egc` package and adds a simple npm install snippet.

<sup>Written for commit 4b675727ebbbb847004b68d6b67f4ed815ad0281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package references and installation instructions to reflect scoped npm package name
  * Added npm installation subsection with setup commands
  * Added support section highlighting AI memory capabilities with links for sponsorship and community engagement options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->