### PR TITLE
docs: add PayPal donation link for non-GitHub users

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
 github: [Fmarzochi]
+custom:
+  - https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD

--- a/README.md
+++ b/README.md
@@ -233,14 +233,15 @@ Close Claude Code and open Cursor. The AI already knows your project. Switch to 
 
 That's not a feature. It's a shift in how AI-assisted engineering works.
 
-EGC is built by one developer, maintained in the open, and used by people who are done re-explaining context every session. If it saves you time — consider giving back:
+EGC is built by one developer, maintained in the open, and used by people who are done re-explaining context every session. If it saves you time, consider giving back:
 
-- **[Sponsor on GitHub](https://github.com/sponsors/Fmarzochi)** — direct support, any amount
+- **[Sponsor on GitHub](https://github.com/sponsors/Fmarzochi)** — for GitHub users, any amount
+- **[Donate via PayPal](https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD)** — no GitHub account needed
 - **Star the repository** — helps other developers find it
 - **Contribute** — agents, skills, commands, bug fixes, docs ([CONTRIBUTING.md](CONTRIBUTING.md))
 - **Share** — if EGC changed how you work, tell someone
 
-Every contribution — financial or otherwise — goes toward keeping this maintained, documented, and free.
+Every contribution, financial or otherwise, goes toward keeping this maintained, documented, and free.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds PayPal donate link (fmarzochi@gmail.com) to FUNDING.yml custom field
- Updates README Support section with PayPal as alternative to GitHub Sponsors
- Covers users who don't have a GitHub account

## Changes

- `.github/FUNDING.yml`: added `custom` field with PayPal donate URL
- `README.md`: added PayPal link alongside GitHub Sponsors link

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a PayPal donation option as an alternative to GitHub Sponsors, so people without GitHub accounts can contribute. Updates `.github/FUNDING.yml` with a `custom` PayPal link and adds the same link to the README Support section.

<sup>Written for commit f4a32ffe9466a7892f7aa5d547cae269d404258d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support section with improved messaging and enhanced presentation of contribution options.

* **Chores**
  * Added PayPal donation option to project funding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->