### PR TITLE
fix: remove em-dashes from Support section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,11 @@ That's not a feature. It's a shift in how AI-assisted engineering works.
 
 EGC is built by one developer, maintained in the open, and used by people who are done re-explaining context every session. If it saves you time, consider giving back:
 
-- **[Sponsor on GitHub](https://github.com/sponsors/Fmarzochi)** — for GitHub users, any amount
-- **[Donate via PayPal](https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD)** — no GitHub account needed
-- **Star the repository** — helps other developers find it
-- **Contribute** — agents, skills, commands, bug fixes, docs ([CONTRIBUTING.md](CONTRIBUTING.md))
-- **Share** — if EGC changed how you work, tell someone
+- **[Sponsor on GitHub](https://github.com/sponsors/Fmarzochi)** (for GitHub users, any amount)
+- **[Donate via PayPal](https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD)** (no GitHub account needed)
+- **Star the repository** (helps other developers find it)
+- **Contribute** (agents, skills, commands, bug fixes, docs via [CONTRIBUTING.md](CONTRIBUTING.md))
+- **Share** (if EGC changed how you work, tell someone)
 
 Every contribution, financial or otherwise, goes toward keeping this maintained, documented, and free.
 


### PR DESCRIPTION
Removes em-dashes (rule violation) from the Support section bullet points. Replaced with parentheses for cleaner formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed em dashes from the Support section bullets in `README.md`, replacing them with parentheses to align with the style guide and keep formatting consistent.

<sup>Written for commit 3958cd64eac15759388ba442e9fc06f4ee284ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Support EGC" call-to-action section with clearer, more concise descriptions and improved formatting, making support options (sponsorship, contributions, sharing) more accessible and easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->