### PR TITLE
fix(ci): pin Python 3.12 on Windows to unblock node-gyp build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Setup Python 3.12 (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
       # Install dependencies
       # COREPACK_ENABLE_STRICT=0 allows pnpm to install even though
       # package.json declares "packageManager": "yarn@..."


### PR DESCRIPTION
## Problema

O runner Windows do GitHub Actions agora usa Python 3.14.5 por padrao.
O `node-gyp` nao suporta Python 3.14, causando falha na compilacao de
`better-sqlite3` com o erro `Completion callback never invoked` em todos
os jobs Windows da matrix CI.

## Causa raiz

```
gyp ERR! Completion callback never invoked!
gyp ERR! System Windows_NT 10.0.26100
better-sqlite3@npm:12.10.0 couldn't be built (exit code 6)
```

Python 3.14 quebrou a API interna que o `node-gyp` usa para invocar o
callback de finalizacao do build.

## Correcao

Adiciona um step `actions/setup-python@v5` com `python-version: '3.12'`
condicionado a `runner.os == 'Windows'`, antes do step de install. Isso
garante que o `node-gyp` use Python 3.12 (suportado) em vez de 3.14.

O step e um no-op em Linux e macOS, que ja usam Python compativel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Python 3.12 on Windows runners so `node-gyp` uses a supported version and `better-sqlite3` builds again. No changes for Linux or macOS.

- **Bug Fixes**
  - Added `actions/setup-python@v5` with `python-version: '3.12'` gated by `if: runner.os == 'Windows'` before the install step.
  - Avoids the Python 3.14 issue that caused the `node-gyp` "Completion callback never invoked" error on Windows CI.

<sup>Written for commit e09271e8436c121811b3df8d5e7315d22bb05d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to add Windows-specific Python 3.12 setup, improving test coverage on Windows runners.

---

Note: This release contains internal infrastructure improvements with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->