### PR TITLE
refactor: reduce cyclomatic complexity in four production scripts

### DIFF
--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -30,6 +30,42 @@ const SUMMARY_START_MARKER = '<!-- EGC:SUMMARY:START -->';
 const SUMMARY_END_MARKER = '<!-- EGC:SUMMARY:END -->';
 const SESSION_SEPARATOR = '\n---\n';
 
+function extractUserMessage(entry) {
+  if (entry.type !== 'user' && entry.role !== 'user' && entry.message?.role !== 'user') {
+    return '';
+  }
+  const rawContent = entry.message?.content ?? entry.content;
+  const text = typeof rawContent === 'string'
+    ? rawContent
+    : Array.isArray(rawContent)
+      ? rawContent.map(c => (c && c.text) || '').join(' ')
+      : '';
+  return stripAnsi(text).trim();
+}
+
+function extractDirectToolUse(entry, toolsUsed, filesModified) {
+  if (entry.type !== 'tool_use' && !entry.tool_name) return;
+  const toolName = entry.tool_name || entry.name || '';
+  if (toolName) toolsUsed.add(toolName);
+  const filePath = entry.tool_input?.file_path || entry.input?.file_path || '';
+  if (filePath && (toolName === 'Edit' || toolName === 'Write')) {
+    filesModified.add(filePath);
+  }
+}
+
+function extractAssistantBlockToolUse(entry, toolsUsed, filesModified) {
+  if (entry.type !== 'assistant' || !Array.isArray(entry.message?.content)) return;
+  for (const block of entry.message.content) {
+    if (block.type !== 'tool_use') continue;
+    const toolName = block.name || '';
+    if (toolName) toolsUsed.add(toolName);
+    const filePath = block.input?.file_path || '';
+    if (filePath && (toolName === 'Edit' || toolName === 'Write')) {
+      filesModified.add(filePath);
+    }
+  }
+}
+
 /**
  * Extract a meaningful summary from the session transcript.
  * Reads the JSONL transcript and pulls out key information:
@@ -51,46 +87,13 @@ function extractSessionSummary(transcriptPath) {
     try {
       const entry = JSON.parse(line);
 
-      // Collect user messages (first 200 chars each)
-      if (entry.type === 'user' || entry.role === 'user' || entry.message?.role === 'user') {
-        // Support both direct content and nested message.content (Gemini Code JSONL format)
-        const rawContent = entry.message?.content ?? entry.content;
-        const text = typeof rawContent === 'string'
-          ? rawContent
-          : Array.isArray(rawContent)
-            ? rawContent.map(c => (c && c.text) || '').join(' ')
-            : '';
-        const cleaned = stripAnsi(text).trim();
-        if (cleaned) {
-          userMessages.push(cleaned.slice(0, 200));
-        }
+      const userText = extractUserMessage(entry);
+      if (userText) {
+        userMessages.push(userText.slice(0, 200));
       }
 
-      // Collect tool names and modified files (direct tool_use entries)
-      if (entry.type === 'tool_use' || entry.tool_name) {
-        const toolName = entry.tool_name || entry.name || '';
-        if (toolName) toolsUsed.add(toolName);
-
-        const filePath = entry.tool_input?.file_path || entry.input?.file_path || '';
-        if (filePath && (toolName === 'Edit' || toolName === 'Write')) {
-          filesModified.add(filePath);
-        }
-      }
-
-      // Extract tool uses from assistant message content blocks (Gemini Code JSONL format)
-      if (entry.type === 'assistant' && Array.isArray(entry.message?.content)) {
-        for (const block of entry.message.content) {
-          if (block.type === 'tool_use') {
-            const toolName = block.name || '';
-            if (toolName) toolsUsed.add(toolName);
-
-            const filePath = block.input?.file_path || '';
-            if (filePath && (toolName === 'Edit' || toolName === 'Write')) {
-              filesModified.add(filePath);
-            }
-          }
-        }
-      }
+      extractDirectToolUse(entry, toolsUsed, filesModified);
+      extractAssistantBlockToolUse(entry, toolsUsed, filesModified);
     } catch {
       parseErrors++;
     }
@@ -103,7 +106,7 @@ function extractSessionSummary(transcriptPath) {
   if (userMessages.length === 0) return null;
 
   return {
-    userMessages: userMessages.slice(-10), // Last 10 user messages
+    userMessages: userMessages.slice(-10),
     toolsUsed: Array.from(toolsUsed).slice(0, 20),
     filesModified: Array.from(filesModified).slice(0, 30),
     totalMessages: userMessages.length

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -31,6 +31,147 @@ function readJson(filePath, label) {
   }
 }
 
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function validateNoAdditionalProperties(value, instancePath, allowedKeys, pushError) {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.includes(key)) {
+      pushError(`${instancePath}/${key}`, 'must NOT have additional properties');
+    }
+  }
+}
+
+function validateStringArray(value, instancePath, pushError) {
+  if (!Array.isArray(value)) {
+    pushError(instancePath, 'must be array');
+    return;
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (!isNonEmptyString(value[index])) {
+      pushError(`${instancePath}/${index}`, 'must be non-empty string');
+    }
+  }
+}
+
+function validateOptionalString(value, instancePath, pushError) {
+  if (value !== undefined && value !== null && !isNonEmptyString(value)) {
+    pushError(instancePath, 'must be string or null');
+  }
+}
+
+function validateStateTarget(target, pushError) {
+  if (!target || typeof target !== 'object' || Array.isArray(target)) {
+    pushError('/target', 'must be object');
+    return;
+  }
+
+  validateNoAdditionalProperties(target, '/target', ['id', 'target', 'kind', 'root', 'installStatePath'], pushError);
+  if (!isNonEmptyString(target.id)) {
+    pushError('/target/id', 'must be non-empty string');
+  }
+  validateOptionalString(target.target, '/target/target', pushError);
+  if (target.kind !== undefined && !['home', 'project'].includes(target.kind)) {
+    pushError('/target/kind', 'must be equal to one of the allowed values');
+  }
+  if (!isNonEmptyString(target.root)) {
+    pushError('/target/root', 'must be non-empty string');
+  }
+  if (!isNonEmptyString(target.installStatePath)) {
+    pushError('/target/installStatePath', 'must be non-empty string');
+  }
+}
+
+function validateStateRequest(request, pushError) {
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    pushError('/request', 'must be object');
+    return;
+  }
+
+  validateNoAdditionalProperties(
+    request,
+    '/request',
+    ['profile', 'modules', 'includeComponents', 'excludeComponents', 'legacyLanguages', 'legacyMode'],
+    pushError
+  );
+  if (!(Object.prototype.hasOwnProperty.call(request, 'profile') && (request.profile === null || typeof request.profile === 'string'))) {
+    pushError('/request/profile', 'must be string or null');
+  }
+  validateStringArray(request.modules, '/request/modules', pushError);
+  validateStringArray(request.includeComponents, '/request/includeComponents', pushError);
+  validateStringArray(request.excludeComponents, '/request/excludeComponents', pushError);
+  validateStringArray(request.legacyLanguages, '/request/legacyLanguages', pushError);
+  if (typeof request.legacyMode !== 'boolean') {
+    pushError('/request/legacyMode', 'must be boolean');
+  }
+}
+
+function validateStateResolution(resolution, pushError) {
+  if (!resolution || typeof resolution !== 'object' || Array.isArray(resolution)) {
+    pushError('/resolution', 'must be object');
+    return;
+  }
+
+  validateNoAdditionalProperties(resolution, '/resolution', ['selectedModules', 'skippedModules'], pushError);
+  validateStringArray(resolution.selectedModules, '/resolution/selectedModules', pushError);
+  validateStringArray(resolution.skippedModules, '/resolution/skippedModules', pushError);
+}
+
+function validateStateSource(source, pushError) {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    pushError('/source', 'must be object');
+    return;
+  }
+
+  validateNoAdditionalProperties(source, '/source', ['repoVersion', 'repoCommit', 'manifestVersion'], pushError);
+  validateOptionalString(source.repoVersion, '/source/repoVersion', pushError);
+  validateOptionalString(source.repoCommit, '/source/repoCommit', pushError);
+  if (!Number.isInteger(source.manifestVersion) || source.manifestVersion < 1) {
+    pushError('/source/manifestVersion', 'must be integer >= 1');
+  }
+}
+
+function validateStateOperations(operations, pushError) {
+  if (!Array.isArray(operations)) {
+    pushError('/operations', 'must be array');
+    return;
+  }
+
+  for (let index = 0; index < operations.length; index += 1) {
+    const operation = operations[index];
+    const instancePath = `/operations/${index}`;
+
+    if (!operation || typeof operation !== 'object' || Array.isArray(operation)) {
+      pushError(instancePath, 'must be object');
+      continue;
+    }
+
+    if (!isNonEmptyString(operation.kind)) {
+      pushError(`${instancePath}/kind`, 'must be non-empty string');
+    }
+    if (!isNonEmptyString(operation.moduleId)) {
+      pushError(`${instancePath}/moduleId`, 'must be non-empty string');
+    }
+    if (!isNonEmptyString(operation.sourceRelativePath)) {
+      pushError(`${instancePath}/sourceRelativePath`, 'must be non-empty string');
+    }
+    if (!isNonEmptyString(operation.destinationPath)) {
+      pushError(`${instancePath}/destinationPath`, 'must be non-empty string');
+    }
+    if (!isNonEmptyString(operation.strategy)) {
+      pushError(`${instancePath}/strategy`, 'must be non-empty string');
+    }
+    if (!isNonEmptyString(operation.ownership)) {
+      pushError(`${instancePath}/ownership`, 'must be non-empty string');
+    }
+    if (typeof operation.scaffoldOnly !== 'boolean') {
+      pushError(`${instancePath}/scaffoldOnly`, 'must be boolean');
+    }
+  }
+}
+
 function getValidator() {
   if (cachedValidator) {
     return cachedValidator;
@@ -53,41 +194,7 @@ function createFallbackValidator() {
     validate.errors = errors;
 
     function pushError(instancePath, message) {
-      errors.push({
-        instancePath,
-        message,
-      });
-    }
-
-    function isNonEmptyString(value) {
-      return typeof value === 'string' && value.length > 0;
-    }
-
-    function validateNoAdditionalProperties(value, instancePath, allowedKeys) {
-      for (const key of Object.keys(value)) {
-        if (!allowedKeys.includes(key)) {
-          pushError(`${instancePath}/${key}`, 'must NOT have additional properties');
-        }
-      }
-    }
-
-    function validateStringArray(value, instancePath) {
-      if (!Array.isArray(value)) {
-        pushError(instancePath, 'must be array');
-        return;
-      }
-
-      for (let index = 0; index < value.length; index += 1) {
-        if (!isNonEmptyString(value[index])) {
-          pushError(`${instancePath}/${index}`, 'must be non-empty string');
-        }
-      }
-    }
-
-    function validateOptionalString(value, instancePath) {
-      if (value !== undefined && value !== null && !isNonEmptyString(value)) {
-        pushError(instancePath, 'must be string or null');
-      }
+      errors.push({ instancePath, message });
     }
 
     if (!state || typeof state !== 'object' || Array.isArray(state)) {
@@ -98,7 +205,8 @@ function createFallbackValidator() {
     validateNoAdditionalProperties(
       state,
       '',
-      ['schemaVersion', 'installedAt', 'lastValidatedAt', 'target', 'request', 'resolution', 'source', 'operations']
+      ['schemaVersion', 'installedAt', 'lastValidatedAt', 'target', 'request', 'resolution', 'source', 'operations'],
+      pushError
     );
 
     if (state.schemaVersion !== 'egc.install.v1') {
@@ -113,103 +221,11 @@ function createFallbackValidator() {
       pushError('/lastValidatedAt', 'must be non-empty string');
     }
 
-    const target = state.target;
-    if (!target || typeof target !== 'object' || Array.isArray(target)) {
-      pushError('/target', 'must be object');
-    } else {
-      validateNoAdditionalProperties(target, '/target', ['id', 'target', 'kind', 'root', 'installStatePath']);
-      if (!isNonEmptyString(target.id)) {
-        pushError('/target/id', 'must be non-empty string');
-      }
-      validateOptionalString(target.target, '/target/target');
-      if (target.kind !== undefined && !['home', 'project'].includes(target.kind)) {
-        pushError('/target/kind', 'must be equal to one of the allowed values');
-      }
-      if (!isNonEmptyString(target.root)) {
-        pushError('/target/root', 'must be non-empty string');
-      }
-      if (!isNonEmptyString(target.installStatePath)) {
-        pushError('/target/installStatePath', 'must be non-empty string');
-      }
-    }
-
-    const request = state.request;
-    if (!request || typeof request !== 'object' || Array.isArray(request)) {
-      pushError('/request', 'must be object');
-    } else {
-      validateNoAdditionalProperties(
-        request,
-        '/request',
-        ['profile', 'modules', 'includeComponents', 'excludeComponents', 'legacyLanguages', 'legacyMode']
-      );
-      if (!(Object.prototype.hasOwnProperty.call(request, 'profile') && (request.profile === null || typeof request.profile === 'string'))) {
-        pushError('/request/profile', 'must be string or null');
-      }
-      validateStringArray(request.modules, '/request/modules');
-      validateStringArray(request.includeComponents, '/request/includeComponents');
-      validateStringArray(request.excludeComponents, '/request/excludeComponents');
-      validateStringArray(request.legacyLanguages, '/request/legacyLanguages');
-      if (typeof request.legacyMode !== 'boolean') {
-        pushError('/request/legacyMode', 'must be boolean');
-      }
-    }
-
-    const resolution = state.resolution;
-    if (!resolution || typeof resolution !== 'object' || Array.isArray(resolution)) {
-      pushError('/resolution', 'must be object');
-    } else {
-      validateNoAdditionalProperties(resolution, '/resolution', ['selectedModules', 'skippedModules']);
-      validateStringArray(resolution.selectedModules, '/resolution/selectedModules');
-      validateStringArray(resolution.skippedModules, '/resolution/skippedModules');
-    }
-
-    const source = state.source;
-    if (!source || typeof source !== 'object' || Array.isArray(source)) {
-      pushError('/source', 'must be object');
-    } else {
-      validateNoAdditionalProperties(source, '/source', ['repoVersion', 'repoCommit', 'manifestVersion']);
-      validateOptionalString(source.repoVersion, '/source/repoVersion');
-      validateOptionalString(source.repoCommit, '/source/repoCommit');
-      if (!Number.isInteger(source.manifestVersion) || source.manifestVersion < 1) {
-        pushError('/source/manifestVersion', 'must be integer >= 1');
-      }
-    }
-
-    if (!Array.isArray(state.operations)) {
-      pushError('/operations', 'must be array');
-    } else {
-      for (let index = 0; index < state.operations.length; index += 1) {
-        const operation = state.operations[index];
-        const instancePath = `/operations/${index}`;
-
-        if (!operation || typeof operation !== 'object' || Array.isArray(operation)) {
-          pushError(instancePath, 'must be object');
-          continue;
-        }
-
-        if (!isNonEmptyString(operation.kind)) {
-          pushError(`${instancePath}/kind`, 'must be non-empty string');
-        }
-        if (!isNonEmptyString(operation.moduleId)) {
-          pushError(`${instancePath}/moduleId`, 'must be non-empty string');
-        }
-        if (!isNonEmptyString(operation.sourceRelativePath)) {
-          pushError(`${instancePath}/sourceRelativePath`, 'must be non-empty string');
-        }
-        if (!isNonEmptyString(operation.destinationPath)) {
-          pushError(`${instancePath}/destinationPath`, 'must be non-empty string');
-        }
-        if (!isNonEmptyString(operation.strategy)) {
-          pushError(`${instancePath}/strategy`, 'must be non-empty string');
-        }
-        if (!isNonEmptyString(operation.ownership)) {
-          pushError(`${instancePath}/ownership`, 'must be non-empty string');
-        }
-        if (typeof operation.scaffoldOnly !== 'boolean') {
-          pushError(`${instancePath}/scaffoldOnly`, 'must be boolean');
-        }
-      }
-    }
+    validateStateTarget(state.target, pushError);
+    validateStateRequest(state.request, pushError);
+    validateStateResolution(state.resolution, pushError);
+    validateStateSource(state.source, pushError);
+    validateStateOperations(state.operations, pushError);
 
     return errors.length === 0;
   };

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -1,5 +1,9 @@
 'use strict';
 
+function pushSegment(current, segments) {
+  if (current.trim()) segments.push(current.trim());
+}
+
 /**
  * Split a shell command into segments by operators (&&, ||, ;, &)
  * while respecting quoting (single/double) and escaped characters.
@@ -44,7 +48,7 @@ function splitShellSegments(command) {
 
     // && operator
     if (ch === '&' && next === '&') {
-      if (current.trim()) segments.push(current.trim());
+      pushSegment(current, segments);
       current = '';
       i++;
       continue;
@@ -52,7 +56,7 @@ function splitShellSegments(command) {
 
     // || operator
     if (ch === '|' && next === '|') {
-      if (current.trim()) segments.push(current.trim());
+      pushSegment(current, segments);
       current = '';
       i++;
       continue;
@@ -60,7 +64,7 @@ function splitShellSegments(command) {
 
     // ; separator
     if (ch === ';') {
-      if (current.trim()) segments.push(current.trim());
+      pushSegment(current, segments);
       current = '';
       continue;
     }
@@ -71,7 +75,7 @@ function splitShellSegments(command) {
         current += ch;
         continue;
       }
-      if (current.trim()) segments.push(current.trim());
+      pushSegment(current, segments);
       current = '';
       continue;
     }
@@ -79,7 +83,7 @@ function splitShellSegments(command) {
     current += ch;
   }
 
-  if (current.trim()) segments.push(current.trim());
+  pushSegment(current, segments);
   return segments;
 }
 

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -382,6 +382,59 @@ function toIso(date) {
   return date ? date.toISOString() : null;
 }
 
+function buildSignals(latestWake, latestAssistantProgressAt, pendingToolList, parseErrors, nowMs, normalizedOptions) {
+  const signals = [];
+  if (latestWake) {
+    const scheduledAt = parseTimestamp(latestWake.scheduledAt);
+    const dueAt = parseTimestamp(latestWake.dueAt);
+    const thresholdMs = scheduledAt
+      ? scheduledAt.getTime() + latestWake.delaySeconds * normalizedOptions.wakeGraceMultiplier * 1000
+      : null;
+    const hasAssistantProgressAfterDue = Boolean(
+      dueAt
+      && latestAssistantProgressAt
+      && latestAssistantProgressAt.getTime() >= dueAt.getTime()
+    );
+
+    if (thresholdMs && nowMs >= thresholdMs && !hasAssistantProgressAfterDue) {
+      signals.push({
+        delaySeconds: latestWake.delaySeconds,
+        dueAt: latestWake.dueAt,
+        overdueSeconds: dueAt ? Math.max(0, Math.floor((nowMs - dueAt.getTime()) / 1000)) : null,
+        scheduledAt: latestWake.scheduledAt,
+        toolUseId: latestWake.toolUseId,
+        type: 'schedule_wakeup_overdue',
+      });
+    }
+  }
+
+  for (const tool of pendingToolList) {
+    if (
+      tool.name === 'Bash'
+      && tool.ageSeconds !== null
+      && tool.ageSeconds >= normalizedOptions.bashTimeoutSeconds
+    ) {
+      signals.push({
+        ageSeconds: tool.ageSeconds,
+        command: tool.command,
+        startedAt: tool.startedAt,
+        thresholdSeconds: normalizedOptions.bashTimeoutSeconds,
+        toolUseId: tool.toolUseId,
+        type: 'pending_bash_tool_result',
+      });
+    }
+  }
+
+  if (parseErrors > 0) {
+    signals.push({
+      count: parseErrors,
+      type: 'transcript_parse_errors',
+    });
+  }
+
+  return signals;
+}
+
 function buildRecommendation(signals) {
   if (signals.some(signal => signal.type === 'pending_bash_tool_result')) {
     return 'Open the transcript or interrupt the parked session; the Bash result appears stale.';
@@ -462,54 +515,7 @@ function analyzeTranscript(transcriptPath, options = {}) {
     };
   });
 
-  const signals = [];
-  if (latestWake) {
-    const scheduledAt = parseTimestamp(latestWake.scheduledAt);
-    const dueAt = parseTimestamp(latestWake.dueAt);
-    const thresholdMs = scheduledAt
-      ? scheduledAt.getTime() + latestWake.delaySeconds * normalizedOptions.wakeGraceMultiplier * 1000
-      : null;
-    const hasAssistantProgressAfterDue = Boolean(
-      dueAt
-      && latestAssistantProgressAt
-      && latestAssistantProgressAt.getTime() >= dueAt.getTime()
-    );
-
-    if (thresholdMs && nowMs >= thresholdMs && !hasAssistantProgressAfterDue) {
-      signals.push({
-        delaySeconds: latestWake.delaySeconds,
-        dueAt: latestWake.dueAt,
-        overdueSeconds: dueAt ? Math.max(0, Math.floor((nowMs - dueAt.getTime()) / 1000)) : null,
-        scheduledAt: latestWake.scheduledAt,
-        toolUseId: latestWake.toolUseId,
-        type: 'schedule_wakeup_overdue',
-      });
-    }
-  }
-
-  for (const tool of pendingToolList) {
-    if (
-      tool.name === 'Bash'
-      && tool.ageSeconds !== null
-      && tool.ageSeconds >= normalizedOptions.bashTimeoutSeconds
-    ) {
-      signals.push({
-        ageSeconds: tool.ageSeconds,
-        command: tool.command,
-        startedAt: tool.startedAt,
-        thresholdSeconds: normalizedOptions.bashTimeoutSeconds,
-        toolUseId: tool.toolUseId,
-        type: 'pending_bash_tool_result',
-      });
-    }
-  }
-
-  if (parseErrors > 0) {
-    signals.push({
-      count: parseErrors,
-      type: 'transcript_parse_errors',
-    });
-  }
+  const signals = buildSignals(latestWake, latestAssistantProgressAt, pendingToolList, parseErrors, nowMs, normalizedOptions);
 
   return {
     eventCount: entries.length,


### PR DESCRIPTION
## Summary

- **`scripts/lib/shell-split.js`**: extracted `pushSegment` helper — eliminates DRY violation repeated in 5 locations (CC: ~24 → ~20)
- **`scripts/hooks/session-end.js`**: extracted `extractUserMessage`, `extractDirectToolUse`, `extractAssistantBlockToolUse` — separates Claude and Gemini JSONL format handling (CC: 27 → ~8)
- **`scripts/loop-status.js`**: extracted `buildSignals` — isolates signal generation phase from accumulation loop (CC: ~31 → ~14)
- **`scripts/lib/install-state.js`**: extracted `validateStateTarget`, `validateStateRequest`, `validateStateResolution`, `validateStateSource`, `validateStateOperations` to module scope — section validators receive `pushError` as callback (CC: ~36 → ~10)

## Behavior preservation

No observable behavior changed. All exports are identical. No validations removed. No logic altered — only moved.

## Test plan

- [x] `shell-split.test.js` — 19/19 tests passing
- [x] `session-end` coverage via `hooks.test.js` — 226/226 tests passing
- [x] `loop-status.test.js` — 25/25 tests passing
- [x] `install-state.test.js` — 16/16 tests passing
- [x] Full `npm test` suite — exit code 0
- [x] 12 CI/CD workflows analyzed — none affected
- [x] 9-agent review pipeline: Auditor, Behavioral Analysis, Engineering, Security, Contracts, Testability, Build Validator, CI/CD Reviewer, Final Auditor — all approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored four production scripts to lower cyclomatic complexity by extracting small helper functions. No behavior changes; all exports and validations are unchanged.

- **Refactors**
  - scripts/lib/shell-split.js: added pushSegment helper to remove repeated trim/push logic.
  - scripts/hooks/session-end.js: extracted extractUserMessage, extractDirectToolUse, extractAssistantBlockToolUse to isolate format handling.
  - scripts/loop-status.js: extracted buildSignals to separate signal generation from the analysis loop.
  - scripts/lib/install-state.js: extracted validateStateTarget/Request/Resolution/Source/Operations to module scope; validators accept a pushError callback.

<sup>Written for commit 92e98be0773473133cc1b22de9c267bb8732c32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization improving transcript parsing, tool-usage and file-detection logic, validation of installation state, shell command segmenting, and loop-status signal generation.
  * Results: more consistent parsing and validation, clearer error tracking for transcripts, and more reliable detection of timeouts/stale results — all behind-the-scenes stability and correctness improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->