### PR TITLE
docs(readme): move existing hero banner to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+
 [![npm version](https://img.shields.io/npm/v/@fmarzochi/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@fmarzochi/egc) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
 
 <div align="center">
@@ -7,10 +9,6 @@
 **Your AI remembers your project across sessions and tools.**
 
 </div>
-
----
-
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 
 ---
 


### PR DESCRIPTION
## Summary

Move o hero banner de dentro do corpo do README para o topo absoluto, antes dos badges.

## Mudancas

- `assets/hero.png` referenciado na linha 1 do README (era linha 13, entre dois separadores `---`)
- Os dois separadores `---` que enquadravam o banner foram removidos (tornaram-se redundantes)
- Todos os badges, links, navegacao e conteudo permanecem identicos

## Arquivos alterados

- `README.md` (unico arquivo modificado)

## Validacao

- [x] Apenas `README.md` foi alterado
- [x] `assets/hero.png` nao foi tocado
- [x] Nenhum texto, link, badge ou secao foi alterado
- [x] Banner exibido continua sendo `assets/hero.png`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the README hero banner to the top, above all badges, to improve first-impression visibility. Removed the two "---" separators; the hero still uses assets/hero.png, and no other content, links, or badges were changed.

<sup>Written for commit c5633e1a23dcd3012ae4a22bdaf5bca91b647087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README layout by repositioning the hero image to the top of the document for improved visibility and flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->