### PR TITLE
fix: translate Portuguese strings to English and hide .egc on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 You open Claude Code on a project you haven't touched in two weeks. Without typing anything:
 
 ```
-State loaded from egc-memory via ~/.egc/state/Projetos--EGC.md
+State loaded from egc-memory via ~/.egc/state/Projects--MyApp.md
 
 Context and preferences acknowledged (terse responses).
 
@@ -75,7 +75,7 @@ The money saved is small. The time and interrupted flow are not.
 
 ## Installation
 
-### Via npm (recomendado)
+### Via npm (recommended)
 
 ```bash
 npm install -g @fmarzochi/egc

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -4,6 +4,17 @@ import { CallToolRequestSchema, ListToolsRequestSchema, McpError, ErrorCode } fr
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
+import { execSync } from 'child_process';
+
+function hideEgcRootOnWindows(): void {
+  if (process.platform !== 'win32') return;
+  const egcRoot = path.join(os.homedir(), '.egc');
+  try {
+    execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
+  } catch (_) {
+    // non-critical: folder works even if attribute fails
+  }
+}
 import { z } from 'zod';
 import { validateCommand, validateWrite, isProtectedPath } from './validator.js';
 
@@ -34,6 +45,7 @@ class PersistentLogger {
   constructor(serviceName: string) {
     const logDir = path.join(os.homedir(), '.egc', 'logs');
     if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+    hideEgcRootOnWindows();
     this.logPath = path.join(logDir, `${serviceName}.log`);
   }
 

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -6,7 +6,18 @@ import { open, Database } from 'sqlite';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
+import { execSync } from 'child_process';
 import { z } from 'zod';
+
+function hideEgcRootOnWindows(): void {
+  if (process.platform !== 'win32') return;
+  const egcRoot = path.join(os.homedir(), '.egc');
+  try {
+    execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
+  } catch (_) {
+    // non-critical: folder works even if attribute fails
+  }
+}
 
 class PersistentLogger {
   private logPath: string;
@@ -15,6 +26,7 @@ class PersistentLogger {
   constructor(serviceName: string) {
     const logDir = path.join(os.homedir(), '.egc', 'logs');
     if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+    hideEgcRootOnWindows();
     this.logPath = path.join(logDir, `${serviceName}.log`);
   }
 
@@ -168,6 +180,7 @@ async function getDb(): Promise<Database> {
   if (dbInstance) return dbInstance;
   const dbDir = path.join(os.homedir(), '.egc', 'memory');
   if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
+  hideEgcRootOnWindows();
   
   const dbPath = path.join(dbDir, 'state.db');
   dbInstance = await open({ filename: dbPath, driver: sqlite3.Database });
@@ -186,6 +199,7 @@ const server = new Server({ name: "egc-memory-orchestrator", version: "3.0.0" },
 function getStateDir(): string {
   const dir = path.join(os.homedir(), '.egc', 'state');
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  hideEgcRootOnWindows();
   return dir;
 }
 

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -49,7 +49,7 @@ try {
     injectProtocol(path.join(HOME, '.claude', 'CLAUDE.md'), 'Claude Code');
   }
 } catch (e) {
-  console.log(`  [cognitive] Claude Code: erro inesperado — ${e.message}`);
+  console.log(`  [cognitive] Claude Code: unexpected error — ${e.message}`);
 }
 
 // ── Gemini CLI / AGY ──────────────────────────────────────────────────────────
@@ -58,7 +58,7 @@ try {
     injectProtocol(path.join(HOME, '.gemini', 'GEMINI.md'), 'Gemini CLI');
   }
 } catch (e) {
-  console.log(`  [cognitive] Gemini CLI: erro inesperado — ${e.message}`);
+  console.log(`  [cognitive] Gemini CLI: unexpected error — ${e.message}`);
 }
 
 // ── Cursor (global User Rules via settings.json) ──────────────────────────────
@@ -79,7 +79,7 @@ try {
       try {
         obj = JSON.parse(rawContent);
       } catch (_) {
-        console.log('  [cognitive] Cursor: settings.json não é JSON válido (JSONC?) — pulando');
+        console.log('  [cognitive] Cursor: settings.json is not valid JSON (JSONC?) — skipping');
         return;
       }
       const existing = obj['cursor.rules'] || '';
@@ -96,7 +96,7 @@ try {
       injectProtocol(path.join(HOME, '.cursor', 'rules'), 'Cursor');
     }
   } catch (e) {
-    console.log(`  [cognitive] Cursor: erro inesperado — ${e.message}`);
+    console.log(`  [cognitive] Cursor: unexpected error — ${e.message}`);
   }
 })();
 
@@ -121,7 +121,7 @@ try {
       const hasKey      = /^persistent_instructions\s*=/m.test(originalContent);
 
       if (RE_TRIPLE_D.test(originalContent) || RE_TRIPLE_S.test(originalContent)) {
-        console.log('  [cognitive] Codex: persistent_instructions multiline — pulando');
+        console.log('  [cognitive] Codex: persistent_instructions multiline — skipping');
         return;
       }
 
@@ -137,7 +137,7 @@ try {
           (_, _pre, val, _post) => `persistent_instructions = "${val}${CODEX_PROTOCOL_SUFFIX}"`
         );
       } else if (hasKey) {
-        console.log('  [cognitive] Codex: persistent_instructions em formato não reconhecido — pulando');
+        console.log('  [cognitive] Codex: persistent_instructions in unrecognized format — skipping');
         return;
       } else {
         newContent = originalContent + '\n' + CODEX_PROTOCOL_FULL;
@@ -152,7 +152,7 @@ try {
     }
     console.log(`  [cognitive] Codex: memory protocol installed (${tomlPath.replace(HOME, '~')})`);
   } catch (e) {
-    console.log(`  [cognitive] Codex: erro inesperado — ${e.message}`);
+    console.log(`  [cognitive] Codex: unexpected error — ${e.message}`);
   }
 })();
 
@@ -176,7 +176,7 @@ try {
     }
     console.log(`  [cognitive] OpenCode: memory protocol installed (${target.replace(HOME, '~')})`);
   } catch (e) {
-    console.log(`  [cognitive] OpenCode: erro inesperado — ${e.message}`);
+    console.log(`  [cognitive] OpenCode: unexpected error — ${e.message}`);
   }
 })();
 
@@ -197,7 +197,7 @@ try {
       console.log(`  [cognitive] Trae (${dir}): memory protocol installed (~/${dir}/MEMORY.md)`);
     }
   } catch (e) {
-    console.log(`  [cognitive] Trae: erro inesperado — ${e.message}`);
+    console.log(`  [cognitive] Trae: unexpected error — ${e.message}`);
   }
 })();
 
@@ -219,7 +219,7 @@ try {
     }
     console.log('  [cognitive] CodeBuddy: memory protocol installed (~/.codebuddy/MEMORY.md)');
   } catch (e) {
-    console.log(`  [cognitive] CodeBuddy: erro inesperado — ${e.message}`);
+    console.log(`  [cognitive] CodeBuddy: unexpected error — ${e.message}`);
   }
 })();
 
@@ -247,6 +247,6 @@ try {
       console.log('  [cognitive] Kiro: already configured');
     }
   } catch (e) {
-    console.log(`  [cognitive] Kiro: erro inesperado — ${e.message}`);
+    console.log(`  [cognitive] Kiro: unexpected error — ${e.message}`);
   }
 })();


### PR DESCRIPTION
## Summary

- **bootstrap-cognitive.js**: 9 user-facing messages were in Portuguese (`erro inesperado`, `pulando`, `não é JSON válido`, `formato não reconhecido`) — all translated to English so non-Portuguese users see correct output during installation
- **README.md**: example state path used `Projetos--EGC.md` (a Portuguese folder name from the developer's machine) and the installation heading said `recomendado` — both corrected to language-neutral English
- **egc-memory / egc-guardian**: apply `ATTRIB +H` to `~/.egc` on Windows after directory creation so the folder is hidden by default, matching Linux/macOS behavior where dot-prefixed directories are automatically hidden

## Why this matters

EGC is a global product. When non-Portuguese users ran `sh install.sh`, they saw Portuguese error messages in the terminal output. The README also showed a Portuguese path as a documentation example, which was confusing.

## Test plan

- [ ] Run `sh install.sh` and verify all `[cognitive]` messages are in English
- [ ] Verify README example path shows `Projects--MyApp.md`
- [ ] On Windows: verify `~/.egc` gets the hidden attribute after first use
- [ ] CI green (CodeQL + tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate all Portuguese user-facing messages to English and hide the `~/.egc` folder on Windows. This fixes confusing install output and aligns Windows behavior with Linux/macOS.

- **Bug Fixes**
  - `scripts/bootstrap-cognitive.js`: translated messages (unexpected error, skipping, not valid JSON, unrecognized format) to English for consistent `[cognitive]` output.
  - `README.md`: replaced Portuguese example path and heading with English (“Projects--MyApp.md”, “recommended”).
  - `egc-memory` and `egc-guardian`: run `attrib +h` on `~/.egc` after creating logs, memory DB, or state directories on Windows; ignore failures since it’s non-critical.

<sup>Written for commit 2474481875323c859e14c299cd061dc8cc349f20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated: corrected example path and fixed an npm heading language typo.

* **New Features**
  * Windows-only behavior added to hide the application's root data directory.

* **Chores**
  * Bootstrapper messages converted from Portuguese to English for clearer error/log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->