### PR TITLE
feat: add engineering-auditor agent, commands, and skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # EGC — Agent Catalog
 
-Extended Global Context (EGC) is a production-grade, multi-agent system providing 62 specialized agents, 228+ skills, 74 commands to any compatible AI coding environment.
+Extended Global Context (EGC) is a production-grade, multi-agent system providing 63 specialized agents, 229+ skills, 76 commands to any compatible AI coding environment.
 
 ## Quick Start
 
@@ -13,9 +13,9 @@ node scripts/install-apply.js --target egc
 ## Project Structure
 
 ```
-agents/     — 62 specialized subagents
-skills/     — 228+ workflow skills and domain knowledge
-commands/   — 74 slash commands
+agents/     — 63 specialized subagents
+skills/     — 229+ workflow skills and domain knowledge
+commands/   — 76 slash commands
 ```
 
 ## Agents

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Everything Gemini Code (EGC)
+Extended Global Context (EGC)
 Production Runtime Framework
 
 Copyright (c) 2026 Felipe Marzochi

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The installer runs these steps:
 2. Initializes the local SQLite database
 3. Runs the cognitive bootstrap: writes the memory protocol into `~/.claude/CLAUDE.md` (Claude Code) and `~/.gemini/GEMINI.md` (AGY), creating the files if they don't exist, idempotent
 4. Registers both MCP servers in every detected tool's config file
-5. Asks interactively whether to install the prompt library (62 agents, 228 skills, 74 commands), skipped automatically in CI
+5. Asks interactively whether to install the prompt library (63 agents, 229 skills, 76 commands), skipped automatically in CI
 
 The installer will print which tools it found and registered:
 
@@ -116,7 +116,7 @@ EGC install
   ✓ registered in Claude Code (global)
   ✓ registered in Cursor
 
-Install prompt library? (62 agents, 228 skills, 74 commands) [y/N]:
+Install prompt library? (63 agents, 229 skills, 76 commands) [y/N]:
 
 Installation complete.
 Run 'egc doctor' to verify.
@@ -134,13 +134,13 @@ cd EGC
 
 ## Prompt library
 
-The prompt library is optional. During `sh install.sh`, you'll be asked whether to install it. In CI or non-interactive shells, this step is skipped. Install once to get access to 62 agents, 228 skills, and 74 commands written from real experience, not generated.
+The prompt library is optional. During `sh install.sh`, you'll be asked whether to install it. In CI or non-interactive shells, this step is skipped. Install once to get access to 63 agents, 229 skills, and 76 commands written from real experience, not generated.
 
 | Type | Count | What it is |
 |---|---|---|
-| Agents | 62 agents | Persona and behavior definitions |
-| Skills | 228 skills | Domain-specific workflow runbooks |
-| Commands | 74 commands | Command definitions and lifecycle hooks |
+| Agents | 63 agents | Persona and behavior definitions |
+| Skills | 229 skills | Domain-specific workflow runbooks |
+| Commands | 76 commands | Command definitions and lifecycle hooks |
 | Rules | 111 | Constraints and governance directives |
 
 Organized per harness under `.cursor/`, `.claude/`, `.gemini/`, `.kiro/`, and four others. Switch tools and the same workflows follow you.
@@ -149,9 +149,9 @@ Organized per harness under `.cursor/`, `.claude/`, `.gemini/`, `.kiro/`, and fo
 
 | Component | Total | Claude Code | Gemini CLI | Claude Code native |
 |---|---|---|---|---|
-| Agents | 62 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |
-| Commands | 74 | Shared | Instruction-based | 31 |
-| Skills | 228 | Shared | 10 (native format) | 37 |
+| Agents | 63 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |
+| Commands | 76 | Shared | Instruction-based | 31 |
+| Skills | 229 | Shared | 10 (native format) | 37 |
 
 ---
 

--- a/agent.yaml
+++ b/agent.yaml
@@ -152,6 +152,8 @@ commands:
   - cpp-build
   - cpp-review
   - cpp-test
+  - engineering-audit
+  - engineering-fix
   - evolve
   - fastapi-review
   - feature-dev

--- a/agents/engineering-auditor.md
+++ b/agents/engineering-auditor.md
@@ -2,7 +2,7 @@
 name: engineering-auditor
 description: Full-spectrum engineering health auditor. Evaluates Cyclomatic Complexity, Cognitive Complexity, Nesting Depth, Function Length, File Length, Maintainability, Code Smells, Duplicate Code, Technical Debt, Type Safety, Test Coverage, Test Quality, Security Findings, Dependency Risk, Build Health, Lint Health, Documentation Coverage, and Architectural Smells. Produces a ranked issue list, an Engineering Score, and a concrete remediation plan. NEVER modifies files — audit and plan only.
 tools: ["Read", "Bash", "Grep", "Glob"]
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 You are the engineering health authority for this project. Your job is to measure, score, and plan — never to modify files.

--- a/agents/engineering-auditor.md
+++ b/agents/engineering-auditor.md
@@ -1,0 +1,308 @@
+---
+name: engineering-auditor
+description: Full-spectrum engineering health auditor. Evaluates Cyclomatic Complexity, Cognitive Complexity, Nesting Depth, Function Length, File Length, Maintainability, Code Smells, Duplicate Code, Technical Debt, Type Safety, Test Coverage, Test Quality, Security Findings, Dependency Risk, Build Health, Lint Health, Documentation Coverage, and Architectural Smells. Produces a ranked issue list, an Engineering Score, and a concrete remediation plan. NEVER modifies files — audit and plan only.
+tools: ["Read", "Bash", "Grep", "Glob"]
+model: claude-sonnet-4-6
+---
+
+You are the engineering health authority for this project. Your job is to measure, score, and plan — never to modify files.
+
+When invoked, execute the four phases below in order. Stop after Phase 3 unless the user has explicitly confirmed they want Phase 4 (execution plan delivery).
+
+---
+
+## Phase 1 — AUDIT
+
+Collect raw metrics using available tooling. Run each command, capture output, and record findings. Do not filter or summarize yet.
+
+### 1.1 Lint Health
+
+```bash
+npx eslint . --ext .ts,.tsx,.js,.jsx --format json 2>/dev/null | head -5000
+```
+
+If ESLint is not configured, run:
+```bash
+npx eslint . --ext .js,.ts --rule '{"complexity": ["warn", 10], "max-depth": ["warn", 4], "max-lines": ["warn", 300], "max-lines-per-function": ["warn", 50]}' --format json 2>/dev/null | head -5000
+```
+
+Extract: error count, warning count, files with violations, rule breakdown.
+
+### 1.2 Type Safety
+
+```bash
+npx tsc --noEmit 2>&1 | head -200
+```
+
+Count: type errors, `any` usages:
+```bash
+grep -rn "\bany\b" --include="*.ts" --include="*.tsx" . | grep -v "node_modules\|\.d\.ts\|//.*any" | wc -l
+```
+
+### 1.3 Cyclomatic Complexity
+
+```bash
+npx eslint . --ext .ts,.tsx,.js,.jsx --rule '{"complexity": ["error", 1]}' --format json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    items = []
+    for f in data:
+        for m in f.get('messages', []):
+            if m.get('ruleId') == 'complexity':
+                cc = int(''.join(filter(str.isdigit, m['message'].split('complexity of')[1].split('.')[0]))) if 'complexity of' in m['message'] else 0
+                items.append((cc, f['filePath'], m['line'], m['message']))
+    for cc, fp, line, msg in sorted(items, reverse=True)[:30]:
+        print(f'CC={cc} {fp}:{line}')
+except: pass
+" 2>/dev/null
+```
+
+### 1.4 Function and File Length
+
+```bash
+npx eslint . --ext .ts,.tsx,.js,.jsx --rule '{"max-lines-per-function": ["error", 1], "max-lines": ["error", 1]}' --format json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    fn_violations = []
+    file_violations = []
+    for f in data:
+        for m in f.get('messages', []):
+            if m.get('ruleId') == 'max-lines-per-function':
+                fn_violations.append((f['filePath'], m['line'], m['message']))
+            elif m.get('ruleId') == 'max-lines':
+                file_violations.append((f['filePath'], m['message']))
+    print('=== LONG FUNCTIONS ===')
+    for fp, line, msg in fn_violations[:20]: print(f'  {fp}:{line} {msg}')
+    print('=== LONG FILES ===')
+    for fp, msg in file_violations[:20]: print(f'  {fp} {msg}')
+except: pass
+" 2>/dev/null
+```
+
+### 1.5 Nesting Depth
+
+```bash
+npx eslint . --ext .ts,.tsx,.js,.jsx --rule '{"max-depth": ["error", 1]}' --format json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    for f in data:
+        for m in f.get('messages', []):
+            if m.get('ruleId') == 'max-depth':
+                print(f'  {f[\"filePath\"]}:{m[\"line\"]} {m[\"message\"]}')
+except: pass
+" 2>/dev/null | head -30
+```
+
+### 1.6 Test Coverage
+
+```bash
+npx c8 --reporter=text npm test 2>/dev/null | tail -30
+```
+
+If c8 unavailable:
+```bash
+npx jest --coverage --coverageReporters=text 2>/dev/null | tail -30
+```
+
+If neither works, count test files vs source files:
+```bash
+echo "Test files: $(find . -name '*.test.*' -o -name '*.spec.*' | grep -v node_modules | wc -l)"
+echo "Source files: $(find . -name '*.ts' -o -name '*.js' | grep -v 'node_modules\|\.test\.\|\.spec\.' | wc -l)"
+```
+
+### 1.7 Security
+
+```bash
+npm audit --json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    meta = d.get('metadata', {})
+    vulns = meta.get('vulnerabilities', {})
+    print(f'critical={vulns.get(\"critical\",0)} high={vulns.get(\"high\",0)} moderate={vulns.get(\"moderate\",0)} low={vulns.get(\"low\",0)}')
+except: pass
+"
+```
+
+Check for hardcoded secrets:
+```bash
+grep -rn "password\s*=\s*['\"][^'\"]\|api_key\s*=\s*['\"][^'\"]\|secret\s*=\s*['\"][^'\"]" --include="*.ts" --include="*.js" . | grep -v "node_modules\|test\|spec\|\.env" | head -20
+```
+
+### 1.8 Dependency Risk
+
+```bash
+cat package.json | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+deps = {**d.get('dependencies',{}), **d.get('devDependencies',{})}
+print(f'Total deps: {len(deps)}')
+wildcards = [k for k,v in deps.items() if v.startswith('*') or v == 'latest']
+if wildcards: print(f'Unpinned: {wildcards}')
+" 2>/dev/null
+```
+
+### 1.9 Build Health
+
+```bash
+npm run build 2>&1 | tail -20
+```
+
+### 1.10 Documentation Coverage
+
+Count files with and without JSDoc:
+```bash
+echo "Files with JSDoc: $(grep -rl '/\*\*' --include='*.ts' --include='*.js' . | grep -v node_modules | wc -l)"
+echo "Source files total: $(find . -name '*.ts' -o -name '*.js' | grep -v 'node_modules\|\.d\.ts' | wc -l)"
+```
+
+### 1.11 Duplicate Code Detection
+
+```bash
+npx jscpd . --min-lines 10 --min-tokens 50 --ignore "node_modules,build,dist" --reporters console 2>/dev/null | tail -20
+```
+
+If jscpd unavailable, skip and note it.
+
+### 1.12 Architectural Smells
+
+Look for:
+- Circular dependencies: `npx madge --circular . 2>/dev/null | head -20`
+- God files (files > 500 lines): `find . -name '*.ts' -o -name '*.js' | grep -v node_modules | xargs wc -l 2>/dev/null | sort -rn | head -10`
+- Missing barrel exports, deep relative imports (`../../..`): `grep -rn "\.\./\.\./\.\." --include="*.ts" --include="*.js" . | grep -v node_modules | wc -l`
+
+---
+
+## Phase 2 — SCORE AND RANK
+
+### Engineering Score Calculation
+
+Score each dimension 0–10 based on collected data. Use these thresholds:
+
+| Dimension | 10 (excellent) | 7 (acceptable) | 4 (warning) | 0–3 (critical) |
+|---|---|---|---|---|
+| Maintainability | CC avg < 5 | CC avg < 10 | CC avg < 20 | CC avg ≥ 20 |
+| Security | 0 vulns | low only | moderate | critical/high |
+| Testing | coverage > 80% | coverage > 60% | coverage > 30% | < 30% |
+| Architecture | 0 circular deps | < 3 | < 10 | ≥ 10 |
+| Documentation | > 70% JSDoc | > 40% | > 20% | < 20% |
+| Lint Health | 0 errors | < 10 errors | < 50 | ≥ 50 |
+| Type Safety | 0 errors, < 5 `any` | < 5 errors | < 20 | ≥ 20 |
+| Build Health | build passes | passes w/ warnings | fails on some targets | fails |
+
+Weighted average (weights):
+- Maintainability: 20%
+- Security: 20%
+- Testing: 15%
+- Architecture: 15%
+- Documentation: 10%
+- Lint Health: 10%
+- Type Safety: 5%
+- Build Health: 5%
+
+### Issue Ranking
+
+Classify every finding into:
+
+**CRITICAL** (score 0–3, fix before next release):
+- Security vulnerabilities (critical/high npm audit)
+- Build failures
+- Type errors blocking compilation
+- Cyclomatic complexity > 25
+
+**HIGH** (score 4–5, fix this sprint):
+- CC 15–25
+- Test coverage < 30%
+- Any `npm audit` moderate vulnerabilities
+- Files > 500 lines
+
+**MEDIUM** (score 6–7, fix next sprint):
+- CC 10–15
+- Functions > 80 lines
+- Nesting > 4
+- Documentation coverage < 40%
+- Duplicate code blocks
+
+**LOW** (score 8–9, backlog):
+- Minor lint warnings
+- Missing JSDoc on internal helpers
+- Unpinned wildcard deps
+
+Output format:
+
+```
+Engineering Score: X.X/10
+
+Maintainability:    X.X
+Security:           X.X
+Testing:            X.X
+Architecture:       X.X
+Documentation:      X.X
+Lint Health:        X.X
+Type Safety:        X.X
+Build Health:       X.X
+
+CRITICAL (N issues)
+  [file:line] description
+
+HIGH (N issues)
+  [file:line] description
+
+MEDIUM (N issues)
+  [file:line] description
+
+LOW (N issues)
+  [file:line] description
+```
+
+---
+
+## Phase 3 — REMEDIATION PLAN
+
+For each CRITICAL and HIGH issue, provide:
+
+1. **Root Cause** — why this happened (not just what it is)
+2. **Impact** — what breaks or degrades without a fix
+3. **Risk** — what happens if left unfixed (security exposure, maintenance burden, etc.)
+4. **Recommended Refactoring** — specific technique with example:
+   - Extract Method
+   - Early Return (guard clauses)
+   - Strategy Pattern
+   - Split Module
+   - Composition over inheritance
+   - Dependency Inversion
+   - Type Narrowing
+   - Extract Constant
+
+For MEDIUM issues, provide a brief note and the technique.
+For LOW issues, list the rule/tool to enforce.
+
+Do NOT produce code changes. Produce a plan that a developer can execute.
+
+---
+
+## Phase 4 — EXECUTION PLAN DELIVERY
+
+Only reach this phase if the user has explicitly confirmed with "yes, fix it" or "/engineering-fix".
+
+Produce a sequenced execution plan:
+
+1. List files to change, in priority order (CRITICAL first)
+2. For each file: exact refactoring to apply, expected outcome
+3. Confirm: after each file, the plan is to run lint + typecheck + tests before proceeding
+4. Note: if any check fails after a change, the change must be reverted
+
+This phase delivers the plan — execution happens via the `/engineering-fix` command.
+
+---
+
+## Constraints
+
+- NEVER modify files directly
+- NEVER run destructive commands
+- NEVER skip the confirmation step before Phase 4
+- Always report the Engineering Score even if some metrics could not be collected (mark them as N/A)
+- If a tool is not available (c8, jscpd, madge), note it as "tool unavailable" and estimate based on available data

--- a/commands/engineering-audit.md
+++ b/commands/engineering-audit.md
@@ -1,0 +1,125 @@
+---
+description: Full-spectrum engineering health audit — scores Maintainability, Security, Testing, Architecture, Documentation, Lint, Type Safety, and Build Health. Produces a ranked issue list and remediation plan. Never modifies files.
+argument-hint: [--threshold <score> | --focus <dimension> | blank for full audit]
+---
+
+# Engineering Audit
+
+**Input**: $ARGUMENTS
+
+Runs a full engineering health assessment of the current project. Produces an Engineering Score (0–10), a ranked issue list (CRITICAL / HIGH / MEDIUM / LOW), and a concrete remediation plan.
+
+This command NEVER modifies files. Use `/engineering-fix` to apply corrections after reviewing the plan.
+
+---
+
+## Argument Handling
+
+Parse `$ARGUMENTS`:
+
+| Argument | Behavior |
+|---|---|
+| `--threshold <N>` | Only report issues where score < N (e.g. `--threshold 7` shows scores below 7) |
+| `--focus <dimension>` | Run only one dimension (e.g. `--focus security`, `--focus complexity`) |
+| `--quick` | Skip slow checks (coverage, duplicate detection) — fast scan only |
+| blank | Full audit, all dimensions |
+
+---
+
+## Execution
+
+### Step 1 — Detect Project
+
+```bash
+ls package.json tsconfig.json pyproject.toml go.mod Cargo.toml 2>/dev/null
+```
+
+Identify: Node/TypeScript, Python, Go, Rust, or mixed. Adjust tool selection accordingly.
+
+### Step 2 — Run Audit
+
+Invoke the `engineering-auditor` agent with the project context and parsed arguments.
+
+The agent will:
+1. Collect metrics across all 12 dimensions (or the focused dimension if `--focus` was passed)
+2. Score each dimension 0–10
+3. Compute the weighted Engineering Score
+4. Rank all findings: CRITICAL → HIGH → MEDIUM → LOW
+
+### Step 3 — Display Report
+
+Print the full report:
+
+```
+═══════════════════════════════════════════════
+  ENGINEERING AUDIT — <project name>
+  <timestamp>
+═══════════════════════════════════════════════
+
+Engineering Score: X.X / 10
+
+  Maintainability  X.X  [████████░░]
+  Security         X.X  [█████████░]
+  Testing          X.X  [██████░░░░]
+  Architecture     X.X  [████████░░]
+  Documentation    X.X  [█████░░░░░]
+  Lint Health      X.X  [█████████░]
+  Type Safety      X.X  [████████░░]
+  Build Health     X.X  [██████████]
+
+───────────────────────────────────────────────
+CRITICAL  (N)
+───────────────────────────────────────────────
+  ▸ [file:line] description
+    Root cause: ...
+    Fix: Extract Method — split into X and Y
+
+HIGH  (N)
+───────────────────────────────────────────────
+  ▸ [file:line] description
+
+MEDIUM  (N)
+───────────────────────────────────────────────
+  ▸ [file:line] description
+
+LOW  (N)
+───────────────────────────────────────────────
+  ▸ [file:line] description
+
+───────────────────────────────────────────────
+To apply fixes: /engineering-fix
+───────────────────────────────────────────────
+```
+
+### Step 4 — Write Audit Report
+
+Save report to `.egc/audits/engineering-audit-<YYYY-MM-DD>.md`:
+
+```bash
+mkdir -p .egc/audits
+```
+
+The report includes:
+- Full score breakdown
+- All findings with file paths and line numbers
+- Remediation plan
+- Timestamp and tool versions used
+
+### Step 5 — Summarize
+
+Print a one-line summary:
+
+```
+Engineering Score: X.X/10 — N critical, N high, N medium, N low issues. Report: .egc/audits/engineering-audit-<date>.md
+```
+
+Then ask: "Run `/engineering-fix` to apply corrections, starting with CRITICAL issues?"
+
+---
+
+## Edge Cases
+
+- **No package.json**: Adjust tooling to detected language. If no language detected, scan for common source files.
+- **ESLint not installed**: Fall back to manual AST analysis for CC metrics.
+- **No tests found**: Score Testing as 0, note that no test suite was detected.
+- **CI environment**: If `$CI=true`, suppress the interactive prompt at Step 5.

--- a/commands/engineering-fix.md
+++ b/commands/engineering-fix.md
@@ -1,0 +1,178 @@
+---
+description: Applies engineering corrections from the last /engineering-audit run. Creates an isolated branch, applies changes incrementally, runs lint + typecheck + tests after each file, and reverts on failure. Requires explicit user confirmation before any modification.
+argument-hint: [--severity <critical|high|medium|low> | --file <path> | blank for CRITICAL only]
+---
+
+# Engineering Fix
+
+**Input**: $ARGUMENTS
+
+Applies the remediation plan produced by `/engineering-audit`. Operates exclusively on an isolated branch. Never modifies files directly on the current branch. Always requires explicit user confirmation before starting.
+
+---
+
+## Pre-conditions
+
+Before running any fix:
+
+1. **Confirm audit exists**:
+```bash
+ls .egc/audits/engineering-audit-*.md 2>/dev/null | sort | tail -1
+```
+If no audit report exists, stop: "Run `/engineering-audit` first."
+
+2. **Confirm working tree is clean**:
+```bash
+git status --porcelain
+```
+If uncommitted changes exist, stop: "Stash or commit your changes before running engineering-fix."
+
+3. **Confirm user intent** — print the scope and ask explicitly:
+
+```
+Ready to apply engineering fixes.
+
+Scope: <CRITICAL only | CRITICAL + HIGH | etc. based on $ARGUMENTS>
+Branch: engineering-fix/<date>
+Files to modify: N
+
+This will:
+  1. Create branch engineering-fix/<date>
+  2. Apply each fix incrementally
+  3. Run lint + typecheck + tests after each file
+  4. Revert and stop if any check fails
+
+Confirm? (yes / no)
+```
+
+Do NOT proceed without a "yes" response.
+
+---
+
+## Argument Handling
+
+| Argument | Behavior |
+|---|---|
+| `--severity critical` | Apply CRITICAL fixes only (default) |
+| `--severity high` | Apply CRITICAL + HIGH fixes |
+| `--severity medium` | Apply CRITICAL + HIGH + MEDIUM fixes |
+| `--severity all` | Apply all findings |
+| `--file <path>` | Apply fixes to one specific file only |
+| blank | CRITICAL fixes only |
+
+---
+
+## Execution
+
+### Step 1 — Create Isolated Branch
+
+```bash
+git checkout -b engineering-fix/$(date +%Y-%m-%d)
+```
+
+### Step 2 — Load Remediation Plan
+
+Read the most recent audit report:
+```bash
+cat .egc/audits/engineering-audit-$(ls .egc/audits/ | grep engineering-audit | sort | tail -1 | sed 's/engineering-audit-//' | sed 's/\.md//')
+```
+
+Extract the list of files and fixes matching the requested severity.
+
+### Step 3 — Apply Fixes Incrementally
+
+For each file in the plan (CRITICAL first, then HIGH, etc.):
+
+**3a. Show the planned change:**
+```
+Fixing: <file>:<line>
+Technique: <Extract Method | Early Return | etc.>
+Before: <brief description of current code>
+After: <brief description of target state>
+```
+
+**3b. Apply the fix** — modify the file using the specific refactoring technique from the plan.
+
+**3c. Validate immediately:**
+```bash
+npm run lint -- --quiet 2>&1 | tail -5
+npx tsc --noEmit 2>&1 | tail -10
+npm test 2>&1 | tail -20
+```
+
+**3d. On failure — revert and stop:**
+```bash
+git checkout -- <file>
+```
+Report:
+```
+Fix FAILED on <file>
+Check: <lint|typecheck|test>
+Error: <error output>
+Reverted. Stopping.
+
+Remaining fixes not applied: N files
+Run /engineering-audit to re-assess.
+```
+
+**3e. On success — commit the file:**
+```bash
+git add <file>
+git commit -s -m "refactor(<file>): <technique> to reduce <metric>"
+```
+
+### Step 4 — Final Validation
+
+After all fixes applied:
+```bash
+npm run lint
+npx tsc --noEmit
+npm test
+```
+
+If all pass:
+```
+Engineering fix complete.
+
+Applied: N fixes across M files
+Branch: engineering-fix/<date>
+All checks: lint ✓ typecheck ✓ tests ✓
+
+Next: Review the branch and open a PR when ready.
+gh pr create --title "refactor: engineering fixes <date>" --body "Automated engineering health improvements from /engineering-audit"
+```
+
+### Step 5 — Report
+
+Append a fix summary to the audit report:
+
+```markdown
+## Fix Session — <timestamp>
+
+Applied N fixes. Branch: engineering-fix/<date>.
+
+| File | Technique | Result |
+|---|---|---|
+| src/foo.ts | Extract Method | success |
+| src/bar.ts | Early Return | success |
+```
+
+---
+
+## Safety Guarantees
+
+- Isolated branch: current branch is never touched
+- Incremental commits: each file is its own commit — easy to revert individually
+- Signed commits (`-s`): DCO compliance
+- Automatic revert on any check failure
+- No force-push, no destructive operations
+- Full audit trail in `.egc/audits/`
+
+---
+
+## Edge Cases
+
+- **No audit report**: Redirect to `/engineering-audit`
+- **Fix fails lint but not tests**: Still revert — all checks must pass
+- **Large file (> 500 lines)**: Warn that manual review is recommended before applying automated fixes
+- **Merge conflict on branch creation**: Stop and report — do not attempt to resolve automatically

--- a/manifests/install-components.json
+++ b/manifests/install-components.json
@@ -434,6 +434,14 @@
       "modules": [
         "skills-extended"
       ]
+    },
+    {
+      "id": "capability:engineering-auditor",
+      "family": "capability",
+      "description": "Engineering health auditor: scores, ranks issues, and produces remediation plans across 8 quality dimensions.",
+      "modules": [
+        "engineering-auditor"
+      ]
     }
   ]
 }

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -677,6 +677,31 @@
       "defaultInstall": false,
       "cost": "heavy",
       "stability": "beta"
+    },
+    {
+      "id": "engineering-auditor",
+      "kind": "agents",
+      "description": "Full-spectrum engineering health auditor: CC, security, coverage, architecture, docs, lint, type safety, and build health.",
+      "paths": [
+        "agents/engineering-auditor.md",
+        "commands/engineering-audit.md",
+        "commands/engineering-fix.md",
+        "skills/general/engineering-audit"
+      ],
+      "targets": [
+        "egc",
+        "cursor",
+        "antigravity",
+        "codebuddy",
+        "opencode"
+      ],
+      "dependencies": [
+        "agents-core",
+        "commands-core"
+      ],
+      "defaultInstall": false,
+      "cost": "light",
+      "stability": "stable"
     }
   ]
 }

--- a/manifests/install-profiles.json
+++ b/manifests/install-profiles.json
@@ -85,7 +85,8 @@
         "devops-infra",
         "supply-chain-domain",
         "document-processing",
-        "skills-extended"
+        "skills-extended",
+        "engineering-auditor"
       ]
     }
   }

--- a/skills/general/engineering-audit/SKILL.md
+++ b/skills/general/engineering-audit/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: engineering-audit
+description: Engineering health assessment patterns, scoring thresholds, refactoring techniques, and observability guidelines for the engineering-auditor agent and commands.
+origin: EGC
+---
+
+# Engineering Audit
+
+Reference knowledge for the `engineering-auditor` agent and the `/engineering-audit` and `/engineering-fix` commands.
+
+## When to Activate
+
+- Before a release or major refactor
+- When onboarding a new project and assessing technical debt
+- When CI quality gates start failing repeatedly
+- When a team member asks "how healthy is this codebase?"
+- Periodically as part of engineering excellence initiatives
+
+---
+
+## Metric Definitions
+
+### Cyclomatic Complexity (CC)
+
+Number of linearly independent paths through a function. Measured by ESLint `complexity` rule.
+
+| CC | Meaning |
+|---|---|
+| 1–5 | Simple, testable |
+| 6–10 | Moderate — acceptable |
+| 11–20 | Complex — refactor soon |
+| 21–50 | Very complex — high risk |
+| > 50 | Unmaintainable |
+
+### Cognitive Complexity
+
+How difficult a function is to understand, accounting for nesting and control flow breaks. Different from CC: a function with three nested `if`s scores higher than three separate `if`s at the same level.
+
+### Nesting Depth
+
+Maximum levels of nested blocks (if/for/try). Measured by ESLint `max-depth` rule. Threshold: 4.
+
+### Function Length
+
+Lines of code per function. Measured by ESLint `max-lines-per-function`. Threshold: 50 lines.
+
+### File Length
+
+Total lines per file. Measured by ESLint `max-lines`. Threshold: 300 lines.
+
+### Maintainability Index
+
+Composite score derived from CC, function length, and Halstead volume. Higher is better (0–100).
+
+### Technical Debt Ratio
+
+Estimated remediation time relative to development time. SonarQube-style metric: < 5% = A, 6–10% = B, 11–20% = C, 21–50% = D, > 50% = E.
+
+---
+
+## Scoring Thresholds
+
+### Per-Dimension Score (0–10)
+
+**Maintainability**
+- 10: All functions CC ≤ 5, no function > 30 lines
+- 7: Avg CC < 10, no function > 50 lines
+- 4: Avg CC < 20, some functions 50–100 lines
+- 0–3: Any CC > 25, or functions > 200 lines
+
+**Security**
+- 10: 0 npm audit vulnerabilities
+- 7: Low severity only
+- 4: Moderate vulnerabilities
+- 0–3: Any critical or high vulnerability
+
+**Testing**
+- 10: > 90% line coverage, test:source ratio > 1.0
+- 7: > 60% coverage
+- 4: > 30% coverage
+- 0–3: < 30% coverage or no test suite
+
+**Architecture**
+- 10: 0 circular dependencies, no god files
+- 7: < 3 circular deps
+- 4: < 10 circular deps
+- 0–3: ≥ 10 circular deps or multiple god files
+
+**Documentation**
+- 10: > 80% public APIs documented (JSDoc)
+- 7: > 50%
+- 4: > 20%
+- 0–3: < 20%
+
+**Lint Health**
+- 10: 0 errors, 0 warnings
+- 7: 0 errors, < 10 warnings
+- 4: < 10 errors
+- 0–3: ≥ 10 errors
+
+**Type Safety** (TypeScript only)
+- 10: 0 type errors, 0 `any` usages
+- 7: 0 errors, < 5 `any`
+- 4: < 10 errors
+- 0–3: ≥ 10 errors or widespread `any`
+
+**Build Health**
+- 10: Build passes, no warnings
+- 7: Build passes with warnings
+- 4: Build passes on some targets
+- 0–3: Build fails
+
+### Weighted Engineering Score
+
+| Dimension | Weight |
+|---|---|
+| Maintainability | 20% |
+| Security | 20% |
+| Testing | 15% |
+| Architecture | 15% |
+| Documentation | 10% |
+| Lint Health | 10% |
+| Type Safety | 5% |
+| Build Health | 5% |
+
+---
+
+## Refactoring Techniques
+
+### Extract Method
+
+Split a long or complex function into smaller, named functions.
+
+**Before:**
+```typescript
+function processOrder(order: Order) {
+  if (!order.items || order.items.length === 0) return;
+  let total = 0;
+  for (const item of order.items) {
+    total += item.price * item.quantity;
+    if (item.discount) total -= item.discount;
+  }
+  const tax = total * 0.1;
+  total += tax;
+  if (order.coupon === 'SAVE10') total -= total * 0.1;
+  order.total = total;
+  sendConfirmationEmail(order);
+}
+```
+
+**After:**
+```typescript
+function calculateSubtotal(items: OrderItem[]): number {
+  return items.reduce((sum, item) => {
+    const lineTotal = item.price * item.quantity;
+    return sum + lineTotal - (item.discount ?? 0);
+  }, 0);
+}
+
+function applyTaxAndCoupons(subtotal: number, coupon?: string): number {
+  const withTax = subtotal * 1.1;
+  return coupon === 'SAVE10' ? withTax * 0.9 : withTax;
+}
+
+function processOrder(order: Order) {
+  if (!order.items?.length) return;
+  order.total = applyTaxAndCoupons(calculateSubtotal(order.items), order.coupon);
+  sendConfirmationEmail(order);
+}
+```
+
+### Early Return (Guard Clauses)
+
+Replace nested conditions with early returns to reduce nesting depth.
+
+**Before:**
+```typescript
+function getDiscount(user: User) {
+  if (user) {
+    if (user.isPremium) {
+      if (user.yearsActive > 5) {
+        return 0.3;
+      } else {
+        return 0.15;
+      }
+    } else {
+      return 0.05;
+    }
+  }
+  return 0;
+}
+```
+
+**After:**
+```typescript
+function getDiscount(user: User | null): number {
+  if (!user) return 0;
+  if (!user.isPremium) return 0.05;
+  return user.yearsActive > 5 ? 0.3 : 0.15;
+}
+```
+
+### Strategy Pattern
+
+Replace long `switch` or `if/else` chains with a strategy object.
+
+**Before:**
+```typescript
+function format(value: string, type: string) {
+  if (type === 'date') return new Date(value).toLocaleDateString();
+  if (type === 'currency') return `$${parseFloat(value).toFixed(2)}`;
+  if (type === 'percent') return `${parseFloat(value) * 100}%`;
+  return value;
+}
+```
+
+**After:**
+```typescript
+const formatters: Record<string, (v: string) => string> = {
+  date: (v) => new Date(v).toLocaleDateString(),
+  currency: (v) => `$${parseFloat(v).toFixed(2)}`,
+  percent: (v) => `${parseFloat(v) * 100}%`,
+};
+
+function format(value: string, type: string): string {
+  return (formatters[type] ?? ((v) => v))(value);
+}
+```
+
+### Split Module
+
+Break a god file into cohesive modules.
+
+- Group by responsibility: separate data access, business logic, and presentation
+- Each new file should be < 300 lines and have a single, clear purpose
+- Export a barrel (`index.ts`) if consumers need to import from multiple sub-modules
+
+### Type Narrowing
+
+Replace `any` with precise types using guards.
+
+**Before:**
+```typescript
+function process(data: any) {
+  return data.value.toString();
+}
+```
+
+**After:**
+```typescript
+interface Processable {
+  value: string | number;
+}
+
+function isProcessable(data: unknown): data is Processable {
+  return typeof data === 'object' && data !== null && 'value' in data;
+}
+
+function process(data: unknown): string {
+  if (!isProcessable(data)) throw new TypeError('Invalid data shape');
+  return data.value.toString();
+}
+```
+
+### Dependency Inversion
+
+Make high-level modules depend on abstractions, not concretions.
+
+**Before:**
+```typescript
+class OrderService {
+  private db = new PostgresDatabase();
+  save(order: Order) { this.db.insert(order); }
+}
+```
+
+**After:**
+```typescript
+interface Database {
+  insert(record: unknown): void;
+}
+
+class OrderService {
+  constructor(private db: Database) {}
+  save(order: Order) { this.db.insert(order); }
+}
+```
+
+---
+
+## Audit Report Format
+
+Reports are saved at `.egc/audits/engineering-audit-<YYYY-MM-DD>.md`.
+
+```markdown
+# Engineering Audit — <project> — <date>
+
+## Engineering Score: X.X / 10
+
+| Dimension | Score | Status |
+|---|---|---|
+| Maintainability | X.X | ok / warn / critical |
+| Security | X.X | ok / warn / critical |
+| ... | ... | ... |
+
+## Findings
+
+### CRITICAL (N)
+- [file:line] description — technique
+
+### HIGH (N)
+...
+
+## Remediation Plan
+
+### 1. [file] — Extract Method
+Root cause: ...
+Impact: ...
+Steps: ...
+
+## Observability Log
+
+| Timestamp | Tool | Files Analyzed | Issues Found |
+|---|---|---|---|
+| ... | ESLint | N | N |
+```
+
+---
+
+## Observability
+
+Every audit run appends to `.egc/audits/audit-log.jsonl`:
+
+```jsonl
+{"ts":"2026-06-07T22:00:00Z","tool":"eslint","files":42,"errors":3,"warnings":17}
+{"ts":"2026-06-07T22:00:01Z","tool":"tsc","errors":0,"any_count":2}
+{"ts":"2026-06-07T22:00:02Z","tool":"npm-audit","critical":0,"high":0,"moderate":1}
+{"ts":"2026-06-07T22:00:03Z","score":8.6,"dimensions":{"maintainability":8.9,"security":9.7}}
+```
+
+---
+
+## Related Skills
+
+- `security-review` — deep security analysis
+- `coding-standards` — language-specific quality standards
+- `tdd-workflow` — test coverage improvement
+- `plankton-code-quality` — additional quality patterns

--- a/tests/engineering-auditor.test.js
+++ b/tests/engineering-auditor.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const ROOT = path.join(__dirname, '..');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    failed++;
+  }
+}
+
+console.log('\n=== Testing engineering-auditor ===\n');
+
+// Agent file
+test('agent file exists', () => {
+  const p = path.join(ROOT, 'agents', 'engineering-auditor.md');
+  assert.ok(fs.existsSync(p), `Missing: ${p}`);
+});
+
+test('agent has required frontmatter fields', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'agents', 'engineering-auditor.md'), 'utf8');
+  assert.ok(content.includes('name: engineering-auditor'), 'Missing name field');
+  assert.ok(content.includes('description:'), 'Missing description field');
+  assert.ok(content.includes('tools:'), 'Missing tools field');
+  assert.ok(content.includes('model:'), 'Missing model field');
+});
+
+test('agent documents all 8 scored dimensions', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'agents', 'engineering-auditor.md'), 'utf8');
+  const dimensions = ['Maintainability', 'Security', 'Testing', 'Architecture', 'Documentation', 'Lint', 'Type Safety', 'Build'];
+  for (const d of dimensions) {
+    assert.ok(content.includes(d), `Missing dimension: ${d}`);
+  }
+});
+
+test('agent enforces NEVER modify constraint', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'agents', 'engineering-auditor.md'), 'utf8');
+  assert.ok(content.includes('NEVER modif'), 'Agent must state it never modifies files');
+});
+
+test('agent requires user confirmation before Phase 4', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'agents', 'engineering-auditor.md'), 'utf8');
+  assert.ok(content.includes('explicit') && content.includes('confirm'), 'Agent must require explicit confirmation');
+});
+
+// Command files
+test('/engineering-audit command file exists', () => {
+  const p = path.join(ROOT, 'commands', 'engineering-audit.md');
+  assert.ok(fs.existsSync(p), `Missing: ${p}`);
+});
+
+test('/engineering-fix command file exists', () => {
+  const p = path.join(ROOT, 'commands', 'engineering-fix.md');
+  assert.ok(fs.existsSync(p), `Missing: ${p}`);
+});
+
+test('engineering-audit command has description frontmatter', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'commands', 'engineering-audit.md'), 'utf8');
+  assert.ok(content.startsWith('---'), 'Must start with frontmatter');
+  assert.ok(content.includes('description:'), 'Missing description');
+});
+
+test('engineering-audit command saves report to .egc/audits/', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'commands', 'engineering-audit.md'), 'utf8');
+  assert.ok(content.includes('.egc/audits'), 'Must document report output path');
+});
+
+test('engineering-fix command requires pre-conditions check', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'commands', 'engineering-fix.md'), 'utf8');
+  assert.ok(content.includes('Pre-condition') || content.includes('pre-condition'), 'Must document pre-conditions');
+});
+
+test('engineering-fix command creates isolated branch', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'commands', 'engineering-fix.md'), 'utf8');
+  assert.ok(content.includes('engineering-fix/'), 'Must create isolated branch');
+});
+
+test('engineering-fix command reverts on failure', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'commands', 'engineering-fix.md'), 'utf8');
+  assert.ok(content.includes('revert') || content.includes('Revert'), 'Must document revert behavior');
+});
+
+test('engineering-fix command requires signed commits', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'commands', 'engineering-fix.md'), 'utf8');
+  assert.ok(content.includes('-s'), 'Must use signed commits (DCO)');
+});
+
+// Skill file
+test('skill directory exists', () => {
+  const p = path.join(ROOT, 'skills', 'general', 'engineering-audit');
+  assert.ok(fs.existsSync(p), `Missing skill directory: ${p}`);
+});
+
+test('skill SKILL.md exists', () => {
+  const p = path.join(ROOT, 'skills', 'general', 'engineering-audit', 'SKILL.md');
+  assert.ok(fs.existsSync(p), `Missing: ${p}`);
+});
+
+test('skill has required frontmatter', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'skills', 'general', 'engineering-audit', 'SKILL.md'), 'utf8');
+  assert.ok(content.includes('name: engineering-audit'), 'Missing name');
+  assert.ok(content.includes('description:'), 'Missing description');
+  assert.ok(content.includes('origin: EGC'), 'Missing origin');
+});
+
+test('skill documents refactoring techniques', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'skills', 'general', 'engineering-audit', 'SKILL.md'), 'utf8');
+  const techniques = ['Extract Method', 'Early Return', 'Strategy Pattern', 'Type Narrowing'];
+  for (const t of techniques) {
+    assert.ok(content.includes(t), `Missing technique: ${t}`);
+  }
+});
+
+test('skill documents scoring thresholds', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'skills', 'general', 'engineering-audit', 'SKILL.md'), 'utf8');
+  assert.ok(content.includes('Scoring Threshold') || content.includes('scoring threshold'), 'Missing scoring thresholds');
+});
+
+// Manifest registration
+test('engineering-auditor registered in install-modules.json', () => {
+  const modules = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifests', 'install-modules.json'), 'utf8'));
+  const found = modules.modules.find(m => m.id === 'engineering-auditor');
+  assert.ok(found, 'Module not found in install-modules.json');
+});
+
+test('engineering-auditor module has required fields', () => {
+  const modules = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifests', 'install-modules.json'), 'utf8'));
+  const m = modules.modules.find(m => m.id === 'engineering-auditor');
+  assert.ok(m.kind, 'Missing kind');
+  assert.ok(Array.isArray(m.paths) && m.paths.length > 0, 'Missing paths');
+  assert.ok(Array.isArray(m.targets) && m.targets.length > 0, 'Missing targets');
+  assert.ok(typeof m.defaultInstall === 'boolean', 'Missing defaultInstall');
+  assert.ok(m.stability, 'Missing stability');
+});
+
+test('engineering-auditor registered in install-components.json', () => {
+  const components = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifests', 'install-components.json'), 'utf8'));
+  const found = components.components.find(c => c.id === 'capability:engineering-auditor');
+  assert.ok(found, 'Component not found in install-components.json');
+});
+
+test('engineering-auditor module paths all exist', () => {
+  const modules = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifests', 'install-modules.json'), 'utf8'));
+  const m = modules.modules.find(m => m.id === 'engineering-auditor');
+  for (const p of m.paths) {
+    const full = path.join(ROOT, p);
+    assert.ok(fs.existsSync(full), `Path does not exist: ${p}`);
+  }
+});
+
+// No AI signatures or co-authorship
+test('no AI signatures in agent file', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'agents', 'engineering-auditor.md'), 'utf8');
+  assert.ok(!content.includes('Co-Authored-By'), 'No AI co-authorship allowed');
+  assert.ok(!content.includes('Generated by'), 'No AI generation markers allowed');
+});
+
+test('no AI signatures in command files', () => {
+  for (const cmd of ['engineering-audit.md', 'engineering-fix.md']) {
+    const content = fs.readFileSync(path.join(ROOT, 'commands', cmd), 'utf8');
+    assert.ok(!content.includes('Co-Authored-By'), `No AI co-authorship in ${cmd}`);
+  }
+});
+
+// Summary
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Adds a full-spectrum engineering health auditor to EGC.

- **Agent** (`engineering-auditor`): 4-phase audit covering 12 dimensions — CC, cognitive complexity, nesting, function/file length, test coverage, security, type safety, lint, duplicate code, dependency risk, build health, docs. Produces an Engineering Score (0–10) and ranked issue list. Never modifies files. Requires explicit confirmation before the execution plan phase.
- **Command** (`/engineering-audit`): slash command with `--threshold`, `--focus`, and `--quick` flags. Saves reports to `.egc/audits/`.
- **Command** (`/engineering-fix`): applies the remediation plan on an isolated branch, validates after each file, reverts automatically on failure.
- **Skill** (`engineering-audit`): reference knowledge for thresholds, scoring weights, refactoring techniques, report format, and observability schema.
- **Tests**: 24 unit tests — all passing.
- **Manifests**: registered as `capability:engineering-auditor`, opt-in (`defaultInstall: false`).

## Test plan

- [x] 24/24 unit tests passing
- [ ] CI green (CodeQL + lint + tests)
- [ ] Manual: run `/engineering-audit` on a sample project and verify report output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an engineering health auditor to EGC with an agent, two slash commands, and a skill that score code quality and guide safe fixes. Also updates counts, uses `model: sonnet`, registers commands in `agent.yaml`, adds the module to the full install profile, and fixes the LICENSE project name.

- **New Features**
  - Agent `engineering-auditor`: four-phase audit, scores 8 dimensions, ranks issues, and proposes a remediation plan; never modifies files; requires explicit confirmation before the execution plan.
  - Command `/engineering-audit`: supports `--threshold`, `--focus`, `--quick`; writes reports to `.egc/audits/`; appends `.egc/audits/audit-log.jsonl`; prints a concise summary.
  - Command `/engineering-fix`: applies the plan on an isolated branch, validates (lint + typecheck + tests) after each file, auto-reverts on failure; supports `--severity` and `--file`; uses signed commits.
  - Skill `engineering-audit`: thresholds, weights, refactoring techniques, report format, and observability schema.
  - Registration/docs: added capability `capability:engineering-auditor` and module `engineering-auditor` (`defaultInstall: false`); added to the full install profile; added `engineering-audit` and `engineering-fix` to `agent.yaml`; corrected model alias to `sonnet`; updated catalog counts (63 agents, 229+ skills, 76 commands); fixed LICENSE project name.
  - Tests: 24 unit tests covering registration and safety constraints.

- **Migration**
  - Opt in by enabling `capability:engineering-auditor` (module `engineering-auditor` is `defaultInstall: false`; included in the full install profile).
  - Run `/engineering-audit` to generate a report in `.egc/audits/`.
  - Ensure a clean working tree, then run `/engineering-fix` to apply CRITICAL (or chosen severity) fixes with confirmation.

<sup>Written for commit b7124632173441fd8ee0f9001fd356adf8143310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /engineering-audit command to run a full engineering health assessment
  * Added /engineering-fix command to apply validated remediations on an isolated branch

* **Documentation**
  * Added a comprehensive engineering-audit skill guide and updated README/AGENTS counts and project catalog

* **Install**
  * Registered an optional engineering-auditor capability/module and added it to the full install profile

* **Tests**
  * Added tests validating the engineering-auditor artifacts and required metadata

* **Chores**
  * Minor configuration and license text updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->