### PR TITLE
refactor(package): rename npm package to @egc/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 
-[![npm version](https://img.shields.io/npm/v/@fmarzochi/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@fmarzochi/egc) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
+[![npm version](https://img.shields.io/npm/v/@egc/cli?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egc/cli) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
 
 <div align="center">
 
@@ -78,7 +78,7 @@ The money saved is small. The time and interrupted flow are not.
 ### Via npm (recommended)
 
 ```bash
-npm install -g @fmarzochi/egc
+npm install -g @egc/cli
 egc install
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fmarzochi/egc",
+  "name": "@egc/cli",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fmarzochi/egc",
+      "name": "@egc/cli",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fmarzochi/egc",
+  "name": "@egc/cli",
   "version": "1.0.0",
   "description": "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools.",
   "author": "Felipe Marzochi <fmarzochi@gmail.com> (https://github.com/Fmarzochi)",

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -4,7 +4,7 @@
  *
  * Runs the same steps as install.sh but in Node so the flow works
  * identically on Windows, macOS, and Linux. Designed to be the entry
- * point invoked by `npx @fmarzochi/egc init`.
+ * point invoked by `npx @egc/cli init`.
  *
  * Steps:
  *   1. Verify Node >= 18
@@ -45,7 +45,7 @@ egc init — first-run bootstrap
 
 Usage:
   egc init [options]
-  npx @fmarzochi/egc init [options]
+  npx @egc/cli init [options]
 
 Options:
   --dry-run     Print the install plan without writing files
@@ -54,9 +54,9 @@ Options:
   --help, -h    Show this help
 
 Examples:
-  npx @fmarzochi/egc init                  # interactive install
-  npx @fmarzochi/egc init --dry-run        # preview only
-  npx @fmarzochi/egc init --mcp-only --yes # CI-friendly MCP-only setup
+  npx @egc/cli init                  # interactive install
+  npx @egc/cli init --dry-run        # preview only
+  npx @egc/cli init --mcp-only --yes # CI-friendly MCP-only setup
 `);
   process.exit(0);
 }


### PR DESCRIPTION
## Summary

- Rename npm package from `@fmarzochi/egc` to `@egc/cli`
- Install command: `npm install -g @egc/cli`
- npx command: `npx @egc/cli init`

## Motivation

`@fmarzochi/egc` tied the package to a personal GitHub username, which is not appropriate for a product intended for broad team adoption. The new name uses a brand-scoped identifier independent of any individual contributor.

**Note:** The `egc` npm org must be created at npmjs.com before publishing. The binary name (`egc`) remains unchanged.

## Test plan

- [x] `npm test` — 2244/2244 passing
- [x] Binary name unchanged: `egc install`, `egc doctor`, etc.
- [x] No remaining `@fmarzochi/egc` references in codebase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the npm package from `@fmarzochi/egc` to `@egc/cli` for a brand-scoped distribution and updated docs and script references. The `egc` binary name stays the same.

- **Migration**
  - Install: `npm install -g @egc/cli`; npx: `npx @egc/cli init`
  - Commands unchanged: use `egc install`, `egc doctor`, etc.
  - Maintainers: create the `egc` org on npm before publishing

<sup>Written for commit e21253ca1a149db6c2a9a9fe673ab239ae900b40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package name to `@egc/cli`. Installation instructions and help text have been updated to reflect the new package identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->