### PR TITLE
refactor(package): rename to @egchq/egc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 
-[![npm version](https://img.shields.io/npm/v/@egc/cli?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egc/cli) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
+[![npm version](https://img.shields.io/npm/v/@egchq/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egchq/egc) [![Node.js >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Fmarzochi/EGC/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC)
 
 <div align="center">
 
@@ -78,7 +78,7 @@ The money saved is small. The time and interrupted flow are not.
 ### Via npm (recommended)
 
 ```bash
-npm install -g @egc/cli
+npm install -g @egchq/egc
 egc install
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@egc/cli",
+  "name": "@egchq/egc",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@egc/cli",
+      "name": "@egchq/egc",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@egc/cli",
+  "name": "@egchq/egc",
   "version": "1.0.0",
   "description": "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools.",
   "author": "Felipe Marzochi <fmarzochi@gmail.com> (https://github.com/Fmarzochi)",

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -4,7 +4,7 @@
  *
  * Runs the same steps as install.sh but in Node so the flow works
  * identically on Windows, macOS, and Linux. Designed to be the entry
- * point invoked by `npx @egc/cli init`.
+ * point invoked by `npx @egchq/egc init`.
  *
  * Steps:
  *   1. Verify Node >= 18
@@ -45,7 +45,7 @@ egc init — first-run bootstrap
 
 Usage:
   egc init [options]
-  npx @egc/cli init [options]
+  npx @egchq/egc init [options]
 
 Options:
   --dry-run     Print the install plan without writing files
@@ -54,9 +54,9 @@ Options:
   --help, -h    Show this help
 
 Examples:
-  npx @egc/cli init                  # interactive install
-  npx @egc/cli init --dry-run        # preview only
-  npx @egc/cli init --mcp-only --yes # CI-friendly MCP-only setup
+  npx @egchq/egc init                  # interactive install
+  npx @egchq/egc init --dry-run        # preview only
+  npx @egchq/egc init --mcp-only --yes # CI-friendly MCP-only setup
 `);
   process.exit(0);
 }


### PR DESCRIPTION
## Summary

- Rename npm package from `@egc/cli` to `@egchq/egc`
- Org `egchq` created on npmjs.com
- Install command: `npm install -g @egchq/egc`
- Binary name unchanged: `egc`

## Test plan
- [x] `npm test` — 2244/2244 passing
- [x] No remaining `@egc/cli` references

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the npm package from `@egc/cli` to `@egchq/egc` under the new org and updated all references. The CLI binary remains `egc`; no functional changes.

- **Migration**
  - Install with `npm install -g @egchq/egc`.
  - Use `npx @egchq/egc init` instead of `npx @egc/cli init`.

<sup>Written for commit 2c2888b85b52f4e51b84fba70c40d3709e6d2e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rebranded package name from `@egc/cli` to `@egchq/egc`.
  * Updated installation and usage instructions to reference the new package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->