### PR TITLE
docs: add Sponsors section with first backer avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ EGC is built by one developer, maintained in the open, and used by people who ar
 
 Every contribution, financial or otherwise, goes toward keeping this maintained, documented, and free.
 
+### Sponsors
+
+Support from the community keeps this project alive and independent.
+
+**Backers**
+
+<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="48" height="48" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
+
+**Monthly sponsors** · _be the first_
+
 ---
 
 <div align="center">


### PR DESCRIPTION
## Summary

- Adds a `### Sponsors` subsection inside the existing Support EGC section
- Shows @chizormaangel-commits (first one-time backer) with avatar image linked to their GitHub profile
- Keeps a Monthly sponsors placeholder for future growth
- No existing content removed or modified

## Test plan

- [ ] Avatar renders on GitHub README preview
- [ ] Hyperlink on avatar opens correct profile
- [ ] Monthly sponsors placeholder visible below backers row
- [ ] Section does not clutter existing Support EGC content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Sponsors subsection under the Support EGC section in the README. Shows the first backer `@chizormaangel-commits` with a linked avatar, includes a brief community support note, and a "Monthly sponsors · be the first" placeholder.

<sup>Written for commit 265531c14bfe47f895ff162a04efe75365610900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Sponsors section to the README with a short community support statement.
  * Introduced a Backers subsection showing a linked backer avatar.
  * Added a "Monthly sponsors" label with a "be the first" placeholder to encourage recurring support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->