### PR TITLE
refactor(branding): replace remaining Everything Gemini display names with EGC

### DIFF
--- a/.codebuddy/install.js
+++ b/.codebuddy/install.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * EGC CodeBuddy Installer (Cross-platform Node.js version)
- * Installs Everything Gemini Code workflows into a CodeBuddy project.
+ * Installs EGC workflows into a CodeBuddy project.
  *
  * Usage:
  *   node install.js              # Install to current directory

--- a/.codebuddy/install.sh
+++ b/.codebuddy/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # EGC CodeBuddy Installer
-# Installs Everything Gemini Code workflows into a CodeBuddy project.
+# Installs EGC workflows into a CodeBuddy project.
 #
 # Usage:
 #   ./install.sh              # Install to current directory

--- a/.codebuddy/uninstall.js
+++ b/.codebuddy/uninstall.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * EGC CodeBuddy Uninstaller (Cross-platform Node.js version)
- * Uninstalls Everything Gemini Code workflows from a CodeBuddy project.
+ * Uninstalls EGC workflows from a CodeBuddy project.
  *
  * Usage:
  *   node uninstall.js              # Uninstall from current directory

--- a/.codebuddy/uninstall.sh
+++ b/.codebuddy/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # EGC CodeBuddy Uninstaller
-# Uninstalls Everything Gemini Code workflows from a CodeBuddy project.
+# Uninstalls EGC workflows from a CodeBuddy project.
 #
 # Usage:
 #   ./uninstall.sh              # Uninstall from current directory

--- a/.opencode/index.ts
+++ b/.opencode/index.ts
@@ -1,5 +1,5 @@
 /**
- * Everything Gemini Code (EGC) Plugin for OpenCode
+ * EGC - Extended Global Context plugin for OpenCode
  *
  * This package provides the published EGC OpenCode plugin module:
  * - Plugin hooks (auto-format, TypeScript check, console.log warning, env injection, etc.)
@@ -47,7 +47,7 @@ export const VERSION = "1.0.0"
 export const metadata = {
   name: "egc-universal",
   version: VERSION,
-  description: "Everything Gemini Code plugin for OpenCode",
+  description: "EGC plugin for OpenCode",
   author: "Fmarzochi",
   features: {
     agents: 13,

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -1,5 +1,5 @@
 /**
- * Everything Gemini Code (EGC) Plugin Hooks for OpenCode
+ * EGC - Extended Global Context plugin hooks for OpenCode
  *
  * This plugin translates Gemini Code hooks to OpenCode's plugin system.
  * OpenCode's plugin system is MORE sophisticated than Gemini Code with 20+ events

--- a/.opencode/plugins/index.ts
+++ b/.opencode/plugins/index.ts
@@ -1,5 +1,5 @@
 /**
- * Everything Gemini Code (EGC) Plugins for OpenCode
+ * EGC - Extended Global Context plugins for OpenCode
  *
  * This module exports all EGC plugins for OpenCode integration.
  * Plugins provide hook-based automation that mirrors Gemini Code's hook system

--- a/.trae/uninstall.sh
+++ b/.trae/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # EGC Trae Uninstaller
-# Uninstalls Everything Gemini Code workflows from a Trae project.
+# Uninstalls EGC workflows from a Trae project.
 #
 # Usage:
 #   ./uninstall.sh              # Uninstall from current directory

--- a/docs/architecture/ARCHITECTURE-IMPROVEMENTS.md
+++ b/docs/architecture/ARCHITECTURE-IMPROVEMENTS.md
@@ -1,6 +1,6 @@
 # Architecture Improvement Recommendations
 
-This document captures architect-level improvements for the Everything gemini Code (egc) project. It is written from the perspective of a gemini Code coding architect aiming to improve maintainability, consistency, and long-term quality.
+This document captures architect-level improvements for the EGC - Extended Global Context project. It is written from the perspective of a EGC coding architect aiming to improve maintainability, consistency, and long-term quality.
 
 ---
 

--- a/docs/architecture/SINGLE-AGENT-OPERATIONAL-MODEL.md
+++ b/docs/architecture/SINGLE-AGENT-OPERATIONAL-MODEL.md
@@ -1,6 +1,6 @@
 # Single-Agent Operational Model
 
-This document establishes the official and permanent operational governance for the Everything Gemini (EGC) project. It strictly enforces a single-agent execution paradigm, explicitly prohibiting automatic orchestration, recursive delegation, and any modification of the host system's global state.
+This document establishes the official and permanent operational governance for the EGC - Extended Global Context project. It strictly enforces a single-agent execution paradigm, explicitly prohibiting automatic orchestration, recursive delegation, and any modification of the host system's global state.
 
 ## Core Directives
 

--- a/docs/governance/SUBSYSTEM-MAP.md
+++ b/docs/governance/SUBSYSTEM-MAP.md
@@ -1,7 +1,7 @@
 # EGC Subsystem Map
 
 This page classifies the top-level subsystems and notable subtrees of the
-Everything Gemini repository so contributors can tell at a glance what is
+EGC repository so contributors can tell at a glance what is
 alive, what is generated, what is preserved for history, and what is
 dormant.
 

--- a/docs/guides/SKILL-DEVELOPMENT-GUIDE.md
+++ b/docs/guides/SKILL-DEVELOPMENT-GUIDE.md
@@ -1,6 +1,6 @@
 # Skill Development Guide
 
-A comprehensive guide to creating effective skills for Everything gemini Code (egc).
+A comprehensive guide to creating effective skills for EGC - Extended Global Context.
 
 ## Table of Contents
 

--- a/scripts/claw.js
+++ b/scripts/claw.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * NanoClaw v2 — Barebones Agent REPL for Everything Gemini Code
+ * NanoClaw v2 — Barebones Agent REPL for EGC
  *
  * Zero external dependencies. Session-aware REPL around `egc -p`.
  */

--- a/scripts/codemaps/generate.ts
+++ b/scripts/codemaps/generate.ts
@@ -2,7 +2,7 @@
 /**
  * scripts/codemaps/generate.ts
  *
- * Codemap Generator for everything-gemini (EGC)
+ * Codemap Generator for EGC
  *
  * Scans the current working directory and generates architectural
  * codemap documentation under docs/CODEMAPS/ as specified by the

--- a/scripts/codex/check-codex-global-state.sh
+++ b/scripts/codex/check-codex-global-state.sh
@@ -81,7 +81,7 @@ require_file "$CONFIG_FILE" "Global config.toml"
 require_file "$AGENTS_FILE" "Global AGENTS.md"
 
 if [[ -f "$AGENTS_FILE" ]]; then
-  if search_file '^# Everything Gemini Code \(EGC\)' "$AGENTS_FILE"; then
+  if search_file '^# EGC' "$AGENTS_FILE"; then
     ok "AGENTS contains EGC root instructions"
   else
     fail "AGENTS missing EGC root instructions"

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -494,7 +494,7 @@ function getConsumerChecks(rootDir) {
       points: 4,
       scopes: ['repo'],
       path: '~/.gemini/plugins/egc/ (legacy everything-gemini paths also supported)',
-      description: 'Everything Gemini Code is installed for the active user or project',
+      description: 'EGC is installed for the active user or project',
       pass: Boolean(pluginInstall),
       fix: 'Install the EGC plugin for this user or project before auditing project-specific harness quality.',
     },

--- a/scripts/sync-egc-to-codex.sh
+++ b/scripts/sync-egc-to-codex.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync Everything Gemini Code (EGC) assets into a local Codex CLI setup.
+# Sync EGC assets into a local Codex CLI setup.
 # - Backs up ~/.codex config and AGENTS.md
 # - Merges EGC AGENTS.md into existing AGENTS.md (marker-based, preserves user content)
 # - Generates prompt files from commands/*.md

--- a/tests/scripts/codex-hooks.test.js
+++ b/tests/scripts/codex-hooks.test.js
@@ -437,7 +437,7 @@ if (
       assert.strictEqual(syncResult.status, 0, `${syncResult.stdout}\n${syncResult.stderr}`);
 
       const syncedAgents = fs.readFileSync(agentsPath, 'utf8');
-      assert.match(syncedAgents, /^# Everything Gemini Code \(EGC\) — Agent Instructions/m);
+      assert.match(syncedAgents, /^# EGC/m);
       assert.match(syncedAgents, /^# Codex Supplement \(From EGC \.codex\/AGENTS\.md\)/m);
 
       const syncedConfig = fs.readFileSync(configPath, 'utf8');


### PR DESCRIPTION
## Summary

- Replaces all remaining "Everything Gemini Code" and "Everything Gemini" display names with "EGC" or "EGC - Extended Global Context" across 18 files
- Technical backward-compat identifiers (legacy plugin slugs like `'everything-gemini'` in path arrays, test fixtures for old paths) are intentionally preserved
- Updates Discussion #17 body via GraphQL
- Fixes codex-hooks test assertion and check-codex-global-state pattern to match the current AGENTS.md header (`# EGC` instead of `# Everything Gemini Code (EGC) - Agent Instructions`)

## Files changed

- `.codebuddy/` and `.trae/` shell helpers: comment headers
- `.opencode/` plugins: comment headers and description string
- `docs/`: architecture, governance, and guides display names
- `scripts/`: claw.js, generate.ts, harness-audit.js, sync script, codex check script
- `tests/`: codex-hooks assertion updated to match current AGENTS.md

## Test plan

- [ ] CI passes (codex-hooks test now matches current AGENTS.md header)
- [ ] No functional code changed, only comments and display strings
- [ ] Legacy path identifiers remain intact for backward compatibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced remaining “Everything Gemini Code/Everything Gemini” display names with “EGC” or “EGC - Extended Global Context” across installers, plugins, scripts, and docs. Updated Codex checks and tests to expect “# EGC” in AGENTS.md; no functional changes.

- **Refactors**
  - Standardized display names to EGC in comments, headers, and descriptions across 18 files, including `.opencode` plugin metadata/hooks, CodeBuddy/Trae installers, docs, and helper scripts.
  - Preserved legacy identifiers for compatibility (e.g., `everything-gemini` slugs and paths).

- **Bug Fixes**
  - Updated `tests/scripts/codex-hooks.test.js` and `scripts/codex/check-codex-global-state.sh` to match the `AGENTS.md` root header (`# EGC`).

<sup>Written for commit 4664d864e4826d05ec7081706659381b76c85e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project name and descriptions to "EGC - Extended Global Context" across docs and guides.

* **Chores**
  * Standardized branding and naming in installer/uninstaller scripts, plugins, and utility headers.

* **Tests**
  * Adjusted test assertions and validation messages to match the new EGC naming and header patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->