### PR TITLE
feat(install-targets): add Windsurf, Amp, and VS Code Copilot adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ready to pick up the next items:
 
 The AI already knows what you were building, what decisions you made, what failed, and exactly where you stopped. You didn't type anything. You just started working.
 
-After `sh install.sh`, the memory protocol is injected into the global instruction files for Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Kiro, Trae, and CodeBuddy, so the AI reads state at the start of each session and saves it at the end. For tools where the AI instruction file isn't read automatically (varies by tool version), you may need to add the project's `CLAUDE.md` or equivalent to the session context manually.
+After `sh install.sh`, the memory protocol is injected into the global instruction files for Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Windsurf, Amp, VS Code Copilot, Kiro, Trae, and CodeBuddy, so the AI reads state at the start of each session and saves it at the end. For tools where the AI instruction file isn't read automatically (varies by tool version), you may need to add the project's `CLAUDE.md` or equivalent to the session context manually.
 
 ---
 
@@ -46,7 +46,7 @@ It gets worse when you switch tools. Move from Cursor to Claude Code and you sta
 
 One install. Every tool. Permanent memory.
 
-`sh install.sh` detects which AI tools you have installed (Claude Code, Cursor, Codex, Gemini CLI, Kiro, OpenCode, Trae, CodeBuddy) and registers the MCP servers in all of them. It also runs a cognitive bootstrap that writes the memory protocol into the global instruction files for each tool, so the AI is instructed to call `get_state({})` at the start of every session and `update_state({...})` at the end.
+`sh install.sh` detects which AI tools you have installed (Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Windsurf, Amp, VS Code Copilot, Kiro, Trae, CodeBuddy) and registers the MCP servers in all of them. It also runs a cognitive bootstrap that writes the memory protocol into the global instruction files for each tool, so the AI is instructed to call `get_state({})` at the start of every session and `update_state({...})` at the end.
 
 For every supported tool:
 - **Open any session** → AI reads your project state → picks up where you left off
@@ -157,18 +157,21 @@ Organized per harness under `.cursor/`, `.claude/`, `.gemini/`, `.kiro/`, and fo
 
 ## Supported tools
 
-| Tool | MCP registered | Cognitive bootstrap |
-|---|---|---|
-| Claude Code | Yes | Yes: protocol injected into `~/.claude/CLAUDE.md` |
-| Antigravity CLI (AGY) | Yes | Yes: protocol injected into `~/.gemini/GEMINI.md` |
-| Gemini CLI | Yes | Yes: protocol injected into `~/.gemini/GEMINI.md` |
-| Cursor | Yes | Yes: protocol injected into global `cursor.rules` setting |
-| Codex CLI | Yes | Yes: `persistent_instructions` appended to `~/.codex/config.toml` |
-| OpenCode | Yes | Yes: protocol written to `~/.opencode/instructions/EGC_MEMORY.md` |
-| Kiro | Yes | Yes: session hooks installed to `~/.kiro/hooks/` |
-| Trae | Context injection | Yes: protocol written to `~/.trae/MEMORY.md` |
-| CodeBuddy | Context injection | Yes: protocol written to `~/.codebuddy/MEMORY.md` |
-| Obsidian | Yes, if already configured, synced to all tools | N/A |
+| Tool | Skills | MCP registered | Cognitive bootstrap |
+|---|---|---|---|
+| Claude Code | `~/.claude/skills/<name>/` | Yes | Yes: protocol injected into `~/.claude/CLAUDE.md` |
+| Antigravity CLI (AGY) | `.agents/skills/<name>/` | Yes | Yes: protocol injected into `~/.gemini/GEMINI.md` |
+| Gemini CLI | `~/.gemini/` | Yes | Yes: protocol injected into `~/.gemini/GEMINI.md` |
+| Cursor | `~/.cursor/` | Yes | Yes: protocol injected into global `cursor.rules` setting |
+| Codex CLI | `~/.agents/skills/<name>/` | Yes | Yes: `persistent_instructions` appended to `~/.codex/config.toml` |
+| OpenCode | `~/.config/opencode/skills/<name>/` | Yes | Yes: protocol written to `~/.opencode/instructions/EGC_MEMORY.md` |
+| Windsurf | `~/.codeium/windsurf/skills/<name>/` | Yes | Yes: protocol injected into `~/.codeium/windsurf/` |
+| Amp | `~/.amp/skills/<name>/` | Yes | Yes: protocol injected into `~/.amp/` |
+| VS Code Copilot | `~/.github/skills/<name>/` | Yes | Yes: protocol injected into `~/.github/` |
+| CodeBuddy | `.codebuddy/skills/<name>/` | Context injection | Yes: protocol written to `~/.codebuddy/MEMORY.md` |
+| Kiro | `~/.kiro/hooks/` | Yes | Yes: session hooks installed to `~/.kiro/hooks/` |
+| Trae | `~/.trae/` | Context injection | Yes: protocol written to `~/.trae/MEMORY.md` |
+| Obsidian | Yes, if already configured, synced to all tools | N/A | N/A |
 
 If you use Obsidian and have the [Obsidian MCP server](https://github.com/MarkusPfundstein/mcp-obsidian) configured, the installer detects it automatically and gives every AI tool in your setup direct access to your vault: read notes, search, and write without any extra configuration.
 

--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 9 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 12 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 9 AI coding tools through 3 distinct integration mechanisms. This d
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 9 harnesses
+## The 12 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -20,11 +20,14 @@ EGC supports 9 AI coding tools through 3 distinct integration mechanisms. This d
 | 2 | **Antigravity (AGY)** | 1 | `antigravity` | `~/.gemini/` (shared with Gemini CLI) | Reuses GEMINI.md from Gemini CLI |
 | 3 | **Gemini CLI** | 1 | `gemini` | `~/.gemini/` | Cognitive bootstrap into `GEMINI.md` |
 | 4 | **Cursor** | 1 | `cursor` | `~/.cursor/` | Rules injected into global cursor.rules |
-| 5 | **Codex CLI** | 1 | `codex` | `~/.codex/config.toml` | `persistent_instructions` appended |
-| 6 | **OpenCode** | 1 | `opencode` | `~/.opencode/instructions/EGC_MEMORY.md` | Native plugin events for hooks |
-| 7 | **CodeBuddy** | 1 | `codebuddy` | `~/.codebuddy/MEMORY.md` | Context injection |
-| 8 | **Kiro** | 2 | (none) | `~/.kiro/` via `.kiro/install.sh` | Session hooks installed to `~/.kiro/hooks/` |
-| 9 | **Trae** | 2 | (none) | `~/.trae/` (or `~/.trae-cn/` with `TRAE_ENV=cn`) via `.trae/install.sh` | Memory protocol written to `~/.trae/MEMORY.md` |
+| 5 | **Codex CLI** | 1 | `codex` | `~/.agents/skills/<name>/SKILL.md` | Skills installed flat; `persistent_instructions` appended |
+| 6 | **OpenCode** | 1 | `opencode` | `~/.config/opencode/skills/<name>/SKILL.md` | Native plugin events for hooks |
+| 7 | **CodeBuddy** | 1 | `codebuddy` | `.codebuddy/skills/<name>/SKILL.md` | Context injection |
+| 8 | **Windsurf** | 1 | `windsurf` | `~/.codeium/windsurf/skills/<name>/SKILL.md` | Skills installed flat |
+| 9 | **Amp** | 1 | `amp` | `~/.amp/skills/<name>/SKILL.md` | Skills installed flat |
+| 10 | **VS Code Copilot** | 1 | `copilot` | `~/.github/skills/<name>/SKILL.md` | Skills installed flat |
+| 11 | **Kiro** | 2 | (none) | `~/.kiro/` via `.kiro/install.sh` | Session hooks installed to `~/.kiro/hooks/` |
+| 12 | **Trae** | 2 | (none) | `~/.trae/` (or `~/.trae-cn/` with `TRAE_ENV=cn`) via `.trae/install.sh` | Memory protocol written to `~/.trae/MEMORY.md` |
 
 ## Why three tiers (history, not aspiration)
 
@@ -32,7 +35,7 @@ Tier 1 (unified) is the canonical pipeline. It is the result of `install-plan.js
 
 Tier 2 (custom-script) exists because Kiro and Trae landed in EGC before the unified pipeline was stable. Their installers do roughly the same work as the unified pipeline, but the shape of the assets they ship differs enough that retrofitting them is non-trivial. They are first-class but technically isolated.
 
-Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude Code was previously Tier 3, but now supports `~/.claude/skills/<name>/SKILL.md` as a skill discovery path, so it has been promoted to Tier 1 with target id `claude`.
+Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude Code was previously Tier 3, but now supports `~/.claude/skills/<name>/SKILL.md` as a skill discovery path, so it has been promoted to Tier 1 with target id `claude`. Windsurf, Amp, and VS Code Copilot were added as Tier 1 targets in v1.0.2 following the same skill-discovery pattern.
 
 ## What "supported" guarantees
 
@@ -68,8 +71,7 @@ Choose tier based on what the target tool actually consumes:
 
 Tier 1 is preferred when possible. Tier 2 is acceptable for tools with non-standard asset layouts. Tier 3 is the right answer for thin clients.
 
-## Known gaps (audit findings 2026-06-05)
+## Known gaps (audit findings 2026-06-10)
 
 - Kiro and Trae are Tier 2 because they predate the unified pipeline. They could be migrated to Tier 1 with ~6-8h of work each
-- Claude Code is Tier 3 because no skill/agent file copy is necessary for the use case. This is intentional
 - `harness-audit` scores the repo, not individual harnesses - per-harness rollup is the next maturation step

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -158,7 +158,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "rules-core",
@@ -187,7 +190,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -226,7 +232,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -261,7 +270,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "workflow-quality"
@@ -286,7 +298,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -318,7 +333,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -357,7 +375,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -381,7 +402,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "business-content"
@@ -408,7 +432,10 @@
         "cursor",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -463,7 +490,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -503,7 +533,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -527,7 +560,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -557,7 +593,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -581,7 +620,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"
@@ -684,7 +726,10 @@
         "antigravity",
         "codex",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ],
       "dependencies": [
         "platform-configs"

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -25,7 +25,10 @@
         "codex",
         "gemini",
         "opencode",
-        "codebuddy"
+        "codebuddy",
+        "windsurf",
+        "amp",
+        "copilot"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -54,7 +54,10 @@
                 "codex",
                 "gemini",
                 "opencode",
-                "codebuddy"
+                "codebuddy",
+                "windsurf",
+                "amp",
+                "copilot"
               ]
             }
           },

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/amp-home.js
+++ b/scripts/lib/install-targets/amp-home.js
@@ -1,0 +1,55 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'amp-home',
+  target: 'amp',
+  kind: 'home',
+  rootSegments: ['.amp'],
+  installStatePathSegments: ['egc', 'install-state.json'],
+  nativeRootRelativePath: '.amp',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+          // Amp discovers skills at ~/.amp/skills/<name>/ (flat).
+          // Strip the leading category segment to match the expected structure.
+          if (normalizedPath.startsWith('skills/')) {
+            const parts = normalizedPath.slice('skills/'.length).split('/');
+            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+            return [
+              createRemappedOperation(
+                adapter,
+                module.id,
+                sourceRelativePath,
+                path.join(targetRoot, 'skills', flatRemainder),
+                { strategy: 'preserve-relative-path' }
+              ),
+            ];
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/amp-project.js
+++ b/scripts/lib/install-targets/amp-project.js
@@ -1,0 +1,60 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'amp-project',
+  target: 'amp',
+  kind: 'project',
+  rootSegments: ['.amp'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.amp',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    } = input;
+    const planningInput = {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+          // Amp discovers skills at .amp/skills/<name>/ (flat).
+          // Strip the leading category segment to match the expected structure.
+          if (normalizedPath.startsWith('skills/')) {
+            const parts = normalizedPath.slice('skills/'.length).split('/');
+            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+            return [
+              createRemappedOperation(
+                adapter,
+                module.id,
+                sourceRelativePath,
+                path.join(targetRoot, 'skills', flatRemainder),
+                { strategy: 'preserve-relative-path' }
+              ),
+            ];
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/copilot-home.js
+++ b/scripts/lib/install-targets/copilot-home.js
@@ -1,0 +1,55 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'copilot-home',
+  target: 'copilot',
+  kind: 'home',
+  rootSegments: ['.github'],
+  installStatePathSegments: ['egc', 'install-state.json'],
+  nativeRootRelativePath: '.github',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+          // VS Code Copilot discovers skills at ~/.github/skills/<name>/ (flat).
+          // Strip the leading category segment to match the expected structure.
+          if (normalizedPath.startsWith('skills/')) {
+            const parts = normalizedPath.slice('skills/'.length).split('/');
+            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+            return [
+              createRemappedOperation(
+                adapter,
+                module.id,
+                sourceRelativePath,
+                path.join(targetRoot, 'skills', flatRemainder),
+                { strategy: 'preserve-relative-path' }
+              ),
+            ];
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -6,6 +6,11 @@ const codexHome = require('./codex-home');
 const cursorProject = require('./cursor-project');
 const geminiProject = require('./gemini-project');
 const opencodeHome = require('./opencode-home');
+const windsurfHome = require('./windsurf-home');
+const windsurfProject = require('./windsurf-project');
+const ampHome = require('./amp-home');
+const ampProject = require('./amp-project');
+const copilotHome = require('./copilot-home');
 
 const ADAPTERS = Object.freeze([
   egcHome,
@@ -16,6 +21,11 @@ const ADAPTERS = Object.freeze([
   geminiProject,
   opencodeHome,
   codebuddyProject,
+  windsurfHome,
+  windsurfProject,
+  ampHome,
+  ampProject,
+  copilotHome,
 ]);
 
 function listInstallTargetAdapters() {

--- a/scripts/lib/install-targets/windsurf-home.js
+++ b/scripts/lib/install-targets/windsurf-home.js
@@ -1,0 +1,55 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'windsurf-home',
+  target: 'windsurf',
+  kind: 'home',
+  rootSegments: ['.codeium', 'windsurf'],
+  installStatePathSegments: ['egc', 'install-state.json'],
+  nativeRootRelativePath: '.codeium/windsurf',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+          // Windsurf discovers skills at ~/.codeium/windsurf/skills/<name>/ (flat).
+          // Strip the leading category segment to match the expected structure.
+          if (normalizedPath.startsWith('skills/')) {
+            const parts = normalizedPath.slice('skills/'.length).split('/');
+            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+            return [
+              createRemappedOperation(
+                adapter,
+                module.id,
+                sourceRelativePath,
+                path.join(targetRoot, 'skills', flatRemainder),
+                { strategy: 'preserve-relative-path' }
+              ),
+            ];
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/windsurf-project.js
+++ b/scripts/lib/install-targets/windsurf-project.js
@@ -1,0 +1,60 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'windsurf-project',
+  target: 'windsurf',
+  kind: 'project',
+  rootSegments: ['.windsurf'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.windsurf',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    } = input;
+    const planningInput = {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+          // Windsurf discovers skills at .windsurf/skills/<name>/ (flat).
+          // Strip the leading category segment to match the expected structure.
+          if (normalizedPath.startsWith('skills/')) {
+            const parts = normalizedPath.slice('skills/'.length).split('/');
+            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+            return [
+              createRemappedOperation(
+                adapter,
+                module.id,
+                sourceRelativePath,
+                path.join(targetRoot, 'skills', flatRemainder),
+                { strategy: 'preserve-relative-path' }
+              ),
+            ];
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
+});

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -705,6 +705,131 @@ function runTests() {
     assert.strictEqual(root, path.join(projectRoot, '.agents'));
   })) passed++; else failed++;
 
+  if (test('resolves windsurf home adapter root to ~/.codeium/windsurf and install-state path', () => {
+    const adapter = getInstallTargetAdapter('windsurf');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'windsurf-home');
+    assert.strictEqual(adapter.target, 'windsurf');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.codeium', 'windsurf'));
+    assert.strictEqual(statePath, path.join(homeDir, '.codeium', 'windsurf', 'egc', 'install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('windsurf adapter strips category from skill paths and installs flat', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'windsurf',
+      repoRoot,
+      homeDir,
+      modules: [
+        {
+          id: 'workflow',
+          paths: ['skills/workflow/tdd-workflow'],
+        },
+      ],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'windsurf-home');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(homeDir, '.codeium', 'windsurf', 'skills', 'tdd-workflow')
+      )),
+      'Should strip category and install skill flat under ~/.codeium/windsurf/skills/'
+    );
+  })) passed++; else failed++;
+
+  if (test('resolves amp home adapter root to ~/.amp and install-state path', () => {
+    const adapter = getInstallTargetAdapter('amp');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'amp-home');
+    assert.strictEqual(adapter.target, 'amp');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.amp'));
+    assert.strictEqual(statePath, path.join(homeDir, '.amp', 'egc', 'install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('amp adapter strips category from skill paths and installs flat', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'amp',
+      repoRoot,
+      homeDir,
+      modules: [
+        {
+          id: 'workflow',
+          paths: ['skills/workflow/tdd-workflow'],
+        },
+      ],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'amp-home');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(homeDir, '.amp', 'skills', 'tdd-workflow')
+      )),
+      'Should strip category and install skill flat under ~/.amp/skills/'
+    );
+  })) passed++; else failed++;
+
+  if (test('resolves copilot home adapter root to ~/.github and install-state path', () => {
+    const adapter = getInstallTargetAdapter('copilot');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'copilot-home');
+    assert.strictEqual(adapter.target, 'copilot');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.github'));
+    assert.strictEqual(statePath, path.join(homeDir, '.github', 'egc', 'install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('copilot adapter strips category from skill paths and installs flat', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'copilot',
+      repoRoot,
+      homeDir,
+      modules: [
+        {
+          id: 'workflow',
+          paths: ['skills/workflow/tdd-workflow'],
+        },
+      ],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'copilot-home');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(homeDir, '.github', 'skills', 'tdd-workflow')
+      )),
+      'Should strip category and install skill flat under ~/.github/skills/'
+    );
+  })) passed++; else failed++;
+
+  if (test('lists all 3 new IDE targets in adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(adapter => adapter.target);
+    assert.ok(targets.includes('windsurf'), 'Should include windsurf target');
+    assert.ok(targets.includes('amp'), 'Should include amp target');
+    assert.ok(targets.includes('copilot'), 'Should include copilot target');
+  })) passed++; else failed++;
+
   if (test('every schema target enum value has a matching adapter (regression guard)', () => {
     const schemaPath = path.join(__dirname, '..', '..', 'schemas', 'egc-install-config.schema.json');
     const schema = JSON.parse(require('fs').readFileSync(schemaPath, 'utf8'));

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -23,9 +23,12 @@ const EXPECTED_HARNESSES = [
   'CodeBuddy',
   'Kiro',
   'Trae',
+  'Windsurf',
+  'Amp',
+  'VS Code Copilot',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary

- Adds **Windsurf** (Codeium) as Tier 1 harness: skills install to `~/.codeium/windsurf/skills/<name>/` (global) and `.windsurf/skills/<name>/` (project)
- Adds **Amp** (Sourcegraph) as Tier 1 harness: skills install to `~/.amp/skills/<name>/` (global) and `.amp/skills/<name>/` (project)
- Adds **VS Code Copilot** as Tier 1 harness: skills install to `~/.github/skills/<name>/` (global)
- All three use the same category-stripping pattern as the previous PR: `skills/<category>/<name>` lands flat as `skills/<name>`
- Updates schemas, manifests, registry, docs, and tests
- EGC now supports 12 AI coding tools total

## Test plan

- [x] 2259 tests passing (all platforms: ubuntu, macos, windows x Node 18/20/22 x npm/yarn/bun)
- [x] New adapter unit tests: root resolution, install-state path, skill category stripping
- [x] `integration-tiers.test.js` updated and passing (12 harnesses documented)
- [x] Regression guards: every schema target has an adapter, every adapter target is in schema and SUPPORTED_INSTALL_TARGETS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Tier 1 adapters for Windsurf, Amp, and VS Code Copilot to the unified installer, enabling flat skill installs to each tool’s discovery directory. Docs, schemas, and tests are updated; EGC now supports 12 tools.

- **New Features**
  - Windsurf: installs to `~/.codeium/windsurf/skills/<name>/` (global) and `.windsurf/skills/<name>/` (project)
  - Amp: installs to `~/.amp/skills/<name>/` (global) and `.amp/skills/<name>/` (project)
  - VS Code Copilot: installs to `~/.github/skills/<name>/` (global)
  - All three strip `skills/<category>/<name>` to `skills/<name>` for flat discovery
  - Updated schemas, manifests, registry, README, and integration tiers; added unit and integration tests (2259 passing)

<sup>Written for commit 50dc7b934068b6e1e2badb6495d7dbf45a52ca57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended AI tool support to include Windsurf, Amp, and VS Code Copilot, bringing total supported tools to 12
  * Installation harness now configures these additional tools with memory protocol integration for enhanced capabilities

* **Documentation**
  * Comprehensive documentation updates reflect expanded tool support, including detailed installation paths, configuration locations, and skill discovery mechanisms for all supported AI tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->