### PR TITLE
fix(build): redirect build-opencode skip message to stderr

### DIFF
--- a/scripts/build-opencode.js
+++ b/scripts/build-opencode.js
@@ -25,7 +25,7 @@ function hasOpencodePeer() {
 const requireBuild = process.env.EGC_OPENCODE_BUILD === "required"
 
 if (!hasOpencodePeer() && !requireBuild) {
-  console.log("SKIP: build-opencode (@opencode-ai/plugin not installed; set EGC_OPENCODE_BUILD=required to force)")
+  process.stderr.write("SKIP: build-opencode (@opencode-ai/plugin not installed; set EGC_OPENCODE_BUILD=required to force)\n")
   process.exit(0)
 }
 

--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -27,14 +27,14 @@ function showHelp(exitCode = 0) {
 Discover EGC install components and profiles
 
 Usage:
-  node scripts/catalog.js profiles [--json]
-  node scripts/catalog.js components [--family <family>] [--target <target>] [--json]
-  node scripts/catalog.js show <component-id> [--json]
+  egc catalog profiles [--json]
+  egc catalog components [--family <family>] [--target <target>] [--json]
+  egc catalog show <component-id> [--json]
 
 Examples:
-  node scripts/catalog.js profiles
-  node scripts/catalog.js components --family language
-  node scripts/catalog.js show framework:nextjs
+  egc catalog profiles
+  egc catalog components --family language
+  egc catalog show framework:nextjs
 `);
 
   process.exit(exitCode);

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -27,7 +27,7 @@ Usage: install.sh [--target <${LEGACY_INSTALL_TARGETS.join('|')}>] [--dry-run] [
        install.sh [--dry-run] [--json] --config <path>
 
 Targets (legacy language install):
-  egc         (default) - Install EGC into ~/.gemini/
+  egc       (default) - Install EGC into ~/.gemini/
   cursor      - Install into ./.cursor/
   antigravity - Install into ./.agents/
 

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -26,10 +26,13 @@ Usage: install.sh [--target <${LEGACY_INSTALL_TARGETS.join('|')}>] [--dry-run] [
        install.sh [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--dry-run] [--json] --modules <id,id,...> [--with <component>]... [--without <component>]...
        install.sh [--dry-run] [--json] --config <path>
 
-Targets:
-  egc       (default) - Install EGC into ~/.gemini/ with managed rules/skills under rules/egc and skills/egc
-  cursor       - Install rules, hooks, and bundled Cursor configs to ./.cursor/
-  antigravity  - Install rules, workflows, skills, and agents to ./.agent/
+Targets (legacy language install):
+  egc         (default) - Install EGC into ~/.gemini/
+  cursor      - Install into ./.cursor/
+  antigravity - Install into ./.agents/
+
+Targets (profile / modules install — all supported targets):
+  ${SUPPORTED_INSTALL_TARGETS.join(', ')}
 
 Options:
   --profile <name>    Resolve and install a manifest profile

--- a/tests/opencode-plugin-hooks.test.js
+++ b/tests/opencode-plugin-hooks.test.js
@@ -34,7 +34,8 @@ async function loadPlugin() {
     cwd: repoRoot,
     encoding: "utf8",
   })
-  if (buildResult.status !== 0 || /SKIP: build-opencode/.test(buildResult.stdout || "")) {
+  const buildOutput = (buildResult.stdout || "") + (buildResult.stderr || "")
+  if (buildResult.status !== 0 || /SKIP: build-opencode/.test(buildOutput)) {
     const error = new Error(`OpenCode build unavailable: .opencode/dist (${buildResult.stderr || buildResult.stdout || "no output"})`)
     throw error
   }

--- a/tests/scripts/catalog.test.js
+++ b/tests/scripts/catalog.test.js
@@ -53,7 +53,7 @@ function runTests() {
     const result = run(['--help']);
     assert.strictEqual(result.code, 0);
     assert.ok(result.stdout.includes('Usage:'));
-    assert.ok(result.stdout.includes('node scripts/catalog.js show <component-id>'));
+    assert.ok(result.stdout.includes('egc catalog show <component-id>'));
   })) passed++; else failed++;
 
   if (test('lists install profiles', () => {

--- a/tests/scripts/egc.test.js
+++ b/tests/scripts/egc.test.js
@@ -197,7 +197,7 @@ function main() {
     ['supports help for the catalog subcommand', () => {
       const result = runCli(['help', 'catalog']);
       assert.strictEqual(result.status, 0, result.stderr);
-      assert.match(result.stdout, /node scripts\/catalog\.js show <component-id>/);
+      assert.match(result.stdout, /egc catalog show <component-id>/);
     }],
     ['supports help for the consult subcommand', () => {
       const result = runCli(['help', 'consult']);


### PR DESCRIPTION
## Summary

- `build:opencode` was printing its SKIP message to stdout via `console.log`
- When `npm pack --json` runs `prepack`, this text gets intermixed with the JSON output
- The Release workflow's "Pack npm tarball" step does `npm pack --json | node -p "JSON.parse(...)"` which then fails with `SyntaxError: Unexpected token 'S'`

## Fix

Changed `console.log(...)` to `process.stderr.write(...)` so the message goes to stderr and never touches the JSON stream.

## Test

Run `npm pack --json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'))[0].filename"` locally to confirm no parse errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect the SKIP message in `build-opencode` to stderr to avoid corrupting `npm pack --json` output when `prepack` runs without `@opencode-ai/plugin`.
Update CLI help to use `egc catalog`; split legacy language targets from profile/modules targets and list all supported targets; update tests to match the help text, restore `egc` target spacing, and detect the SKIP marker on stderr.

<sup>Written for commit a67a86b1ab38ebdd1cfa7a561760ce5bfee0d3d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted build output so skip notifications are written to stderr (exit behavior unchanged).

* **Documentation**
  * Updated CLI help text to show modern command syntax and subcommands.
  * Clarified install help with separate sections for legacy targets and supported/profile-based targets.

* **Tests**
  * Updated tests to match revised CLI help wording.
  * Updated plugin-related test to detect skip markers emitted on stdout or stderr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->