### PR TITLE
feat: add --version flag to egc CLI

### DIFF
--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -2,6 +2,7 @@
 
 const { spawnSync } = require('child_process');
 const path = require('path');
+const { version: PACKAGE_VERSION } = require('../package.json');
 const { listAvailableLanguages } = require('./lib/install-executor');
 const { formatOSC8 } = require('./lib/utils');
 
@@ -147,6 +148,10 @@ function resolveCommand(argv) {
     return { mode: 'help' };
   }
 
+  if (firstArg === '--version' || firstArg === '-v') {
+    return { mode: 'version' };
+  }
+
   if (firstArg === 'help') {
     return {
       mode: 'help-command',
@@ -233,6 +238,11 @@ function main() {
 
     if (resolution.mode === 'help') {
       showHelp(0);
+    }
+
+    if (resolution.mode === 'version') {
+      console.log(PACKAGE_VERSION);
+      process.exit(0);
     }
 
     if (resolution.mode === 'help-command') {

--- a/tests/scripts/egc.test.js
+++ b/tests/scripts/egc.test.js
@@ -11,6 +11,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'egc.js');
+const PACKAGE_VERSION = require('../../package.json').version;
 
 function runCli(args, options = {}) {
   const envOverrides = {
@@ -74,6 +75,18 @@ function main() {
       assert.match(result.stdout, /auto-update/);
       assert.match(result.stdout, /consult/);
       assert.match(result.stdout, /loop-status/);
+    }],
+    ['prints package version with --version', () => {
+      const result = runCli(['--version']);
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout.trim(), PACKAGE_VERSION);
+      assert.strictEqual(result.stderr, '');
+    }],
+    ['prints package version with -v alias', () => {
+      const result = runCli(['-v']);
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout.trim(), PACKAGE_VERSION);
+      assert.strictEqual(result.stderr, '');
     }],
     ['delegates explicit install command', () => {
       const result = runCli(['install', '--dry-run', '--json', 'typescript']);


### PR DESCRIPTION
Adds standard \--version\ / \-v\ support to the top-level \egc\ entrypoint.

**Behavior:**
- \egc --version\ prints the semver from \package.json\ and exits 0
- \egc -v\ works as an alias
- Handled before subcommand routing so it does not get passed to install

**Tests:** Two new cases in \	ests/scripts/egc.test.js\; all 18 CLI tests pass locally.

closes #91

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add --version and -v flags to the `egc` CLI to print the version from `package.json` and exit 0. Handled before subcommand routing so it never reaches install; tests cover both flags.

<sup>Written for commit b36694ab11178fdbc6f25d4578fee8b7e9c960f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI now supports `--version` and `-v` flags to display the current application version.

* **Tests**
  * Added automated tests verifying both `--version` and `-v` return the exact application version on stdout and exit successfully with no stderr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->