### PR TITLE
chore: add glama.json metadata for Glama.ai listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -3,7 +3,7 @@
   "name": "EGC",
   "description": "Local MCP runtime that gives persistent cross-session memory to 12 AI coding agents (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Amp, and more). SQLite-backed state survives context resets. Install: npm install -g @egchq/egc",
   "license": "MIT",
-  "homepage": "https://egcsite.vercel.app",
+  "homepage": "https://github.com/Fmarzochi/EGC",
   "repository": "https://github.com/Fmarzochi/EGC",
   "install": {
     "npm": "@egchq/egc"

--- a/glama.json
+++ b/glama.json
@@ -8,6 +8,44 @@
   "install": {
     "npm": "@egchq/egc"
   },
+  "tools": [
+    {
+      "name": "get_state",
+      "description": "Returns the current project memory: decisions made, preferences established, things to avoid, and what to pick up next. Call this at the START of every session to restore context."
+    },
+    {
+      "name": "update_state",
+      "description": "Updates the project memory with decisions made this session. Call this at the END of every session. Merges with existing state — does not erase previous memory."
+    },
+    {
+      "name": "store_decision",
+      "description": "Store a decision with lock arbitration. Records a significant decision with its context for future reference."
+    },
+    {
+      "name": "query_history",
+      "description": "Query past decisions. Returns a paginated list of decisions stored in the session memory."
+    },
+    {
+      "name": "get_project_state",
+      "description": "Get current state for the active project. Returns the full state document for the project in the current working directory."
+    },
+    {
+      "name": "validate_command",
+      "description": "Validate command execution safety. Checks whether a shell command is safe to run before execution."
+    },
+    {
+      "name": "validate_write",
+      "description": "Validate write path safety. Checks whether a file path is safe to write before creating or modifying files."
+    },
+    {
+      "name": "reduce_context",
+      "description": "Adaptive Context Routing: Loads files and mutates payloads to save IDE token budget. Reduces context window usage by intelligently compressing file payloads."
+    },
+    {
+      "name": "orchestrate_task",
+      "description": "Routes a prompt with optional agent/skill lists and file payloads. Returns routing context and context-reduction metrics. Agent/skill selection is pass-through; provide explicit lists for deterministic routing."
+    }
+  ],
   "tags": [
     "memory",
     "persistent-context",

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://glama.ai/mcp/servers/schema.json",
+  "name": "EGC",
+  "description": "Local MCP runtime that gives persistent cross-session memory to 12 AI coding agents (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Amp, and more). SQLite-backed state survives context resets. Install: npm install -g @egchq/egc",
+  "license": "MIT",
+  "homepage": "https://egcsite.vercel.app",
+  "repository": "https://github.com/Fmarzochi/EGC",
+  "install": {
+    "npm": "@egchq/egc"
+  },
+  "tags": [
+    "memory",
+    "persistent-context",
+    "mcp",
+    "claude-code",
+    "cursor",
+    "gemini-cli",
+    "codex",
+    "windsurf",
+    "coding-assistant"
+  ],
+  "authors": [
+    {
+      "name": "Felipe Marzochi",
+      "url": "https://github.com/Fmarzochi"
+    }
+  ]
+}

--- a/glama.json
+++ b/glama.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "get_project_state",
-      "description": "Get current state for the active project. Returns the full state document for the project in the current working directory."
+      "description": "Get current state for the active project. Returns server status metadata including storage engine and arbitration mode."
     },
     {
       "name": "validate_command",


### PR DESCRIPTION
Adds `glama.json` to provide structured metadata for the Glama.ai MCP server directory.

This file enables Glama to correctly index EGC's name, description, install method, tags, and author info, which improves the quality score on the listing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `glama.json` MCP manifest for Glama.ai so EGC is indexed correctly and the listing score improves. Includes `$schema`, name/description/license, GitHub homepage and repository, `@egchq/egc` install, tags, authors, full tool catalog, and a corrected `get_project_state` description.

<sup>Written for commit a67beda8fadd22b936fae51bec3598a69b0cb14f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an MCP server metadata manifest for the EGC server to enable standardized discovery and registration. The manifest includes schema reference, server name and description, distribution details (license, homepage, repository, install instructions), a catalog of available tools with short descriptions, categorization tags, and author attribution for maintainability and tooling integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->