### PR TITLE
fix(egc-memory): improve tool descriptions for Glama quality score

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -317,9 +317,9 @@ const UpdateStateSchema = z.object({
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
-      { name: "get_project_state", description: "Get current state.", inputSchema: { type: "object", properties: {} } },
-      { name: "store_decision", description: "Store a decision with lock arbitration.", inputSchema: { type: "object", properties: { context: { type: "string" }, decision: { type: "string" } }, required: ["context", "decision"] } },
-      { name: "query_history", description: "Query past decisions.", inputSchema: { type: "object", properties: { limit: { type: "number" }, offset: { type: "number" } } } },
+      { name: "get_project_state", description: "Returns server health metadata for the active project: storage engine (sqlite-wal) and write arbitration mode (MessageQueue). Use this to verify the egc-memory server is running and responsive before calling get_state or update_state.", inputSchema: { type: "object", properties: {} } },
+      { name: "store_decision", description: "Persist a single decision to the SQLite store with write-lock arbitration to prevent concurrent conflicts. Provide a short context label and the decision text. Decisions stored here are queryable via query_history and surfaced in get_state.", inputSchema: { type: "object", properties: { context: { type: "string", description: "Short label for the decision context, e.g. 'architecture' or 'dependencies'." }, decision: { type: "string", description: "The decision text to persist." } }, required: ["context", "decision"] } },
+      { name: "query_history", description: "Return a paginated list of past decisions stored in the SQLite state. Each entry includes the decision text, context label, and timestamp. Use limit and offset for pagination. Useful for auditing what was decided without loading the full project state.", inputSchema: { type: "object", properties: { limit: { type: "number", description: "Maximum number of decisions to return. Defaults to 20." }, offset: { type: "number", description: "Number of decisions to skip for pagination. Defaults to 0." } } } },
       {
         name: "get_state",
         description: "Returns the current project memory: decisions made, preferences established, things to avoid, and what to pick up next. Call this at the START of every session to restore context.",


### PR DESCRIPTION
Improves descriptions for the three tools scoring below C on Glama TDQS:

- `get_project_state` (was D 1.9/5): clarifies it returns server health metadata (engine + arbitration mode), not the project state document
- `store_decision` (was C 2.3/5): explains the write-lock arbitration, required parameters, and how stored decisions surface in `get_state`
- `query_history` (was C 2.0/5): documents pagination parameters (limit/offset), return shape, and intended use case

`get_state` and `update_state` already score A (4/5) and are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies tool descriptions in the EGC memory server to improve Glama TDQS and reduce misuse. Updates `get_project_state`, `store_decision`, and `query_history` with precise behavior, inputs, and pagination defaults.

- **Refactors**
  - `get_project_state`: Returns server health metadata for the active project: storage engine `sqlite-wal` and write arbitration `MessageQueue`. Use to verify the server before `get_state`/`update_state`.
  - `store_decision`: Persists a single decision to SQLite with write-lock arbitration to avoid conflicts. Requires `context` and `decision`; input fields now include short descriptions. Results surface in `query_history` and `get_state`.
  - `query_history`: Documents pagination and return shape (text, context, timestamp). Supports `limit` (default 20) and `offset` (default 0); useful for auditing without loading full state.

<sup>Written for commit 3bbf3399f859902dcc8571cce9eb21dbcdd5a17c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded tool descriptions to more clearly document returned status metadata and expected outputs.
  * Clarified input parameter documentation with per-field descriptions, explicit required fields, and clear pagination parameter defaults and meanings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->