### PR TITLE
fix(glama): add maintainers field to glama.json

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -62,5 +62,6 @@
       "name": "Felipe Marzochi",
       "url": "https://github.com/Fmarzochi"
     }
-  ]
+  ],
+  "maintainers": ["Fmarzochi"]
 }


### PR DESCRIPTION
Adds the required `maintainers` field so Glama recognizes the glama.json file and checks off the 'No glama.json' item in the quality checklist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the required `maintainers` field to `glama.json` so Glama recognizes the file and clears the "No glama.json" checklist item. Set maintainers to [`Fmarzochi`].

<sup>Written for commit 99f4ce76dbe7b605c2b7d8691bd28e2e7caeecda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to formally document project maintainers information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->