### PR TITLE
fix: translate CLI banner to English

### DIFF
--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -93,10 +93,10 @@ const PRIMARY_COMMANDS = [
 function showHelp(exitCode = 0) {
   console.log(`
 EGC — Extended Global Context
-Desenvolvido por Felipe Marzochi
+Developed by Felipe Marzochi
 @FEMARZOCHI
 ${formatOSC8('https://github.com/Fmarzochi/EGC', 'https://github.com/Fmarzochi/EGC')}
-© Todos os direitos reservados
+© All rights reserved
 
 EGC selective-install CLI
 


### PR DESCRIPTION
Translate the CLI banner from Portuguese to English for international users.

- "Desenvolvido por" -> "Developed by"
- "Todos os direitos reservados" -> "All rights reserved"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated the CLI banner to English to make the help output clear for all users. Updated "Desenvolvido por" to "Developed by" and "Todos os direitos reservados" to "All rights reserved" in scripts/egc.js.

<sup>Written for commit 46cdd05711d83531dd8bfcff64e798c8c5d6489c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI help footer text, translating language from Portuguese to English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->