### PR TITLE
fix: register MCP servers in Gemini CLI config regardless of Antigravity

### DIFF
--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -93,10 +93,10 @@ const PRIMARY_COMMANDS = [
 function showHelp(exitCode = 0) {
   console.log(`
 EGC — Extended Global Context
-Desenvolvido por Felipe Marzochi
+Developed by Felipe Marzochi
 @FEMARZOCHI
 ${formatOSC8('https://github.com/Fmarzochi/EGC', 'https://github.com/Fmarzochi/EGC')}
-© Todos os direitos reservados
+© All rights reserved
 
 EGC selective-install CLI
 

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -115,7 +115,7 @@ function registerMcpServers() {
 
   const targets = [
     { name: 'Antigravity CLI', path: path.join(HOME, '.gemini', 'antigravity-cli', 'mcp_config.json'), gate: () => fs.existsSync(path.join(HOME, '.gemini', 'antigravity-cli')), format: 'json' },
-    { name: 'Gemini CLI', path: path.join(HOME, '.gemini', 'config', 'mcp_config.json'), gate: () => fs.existsSync(path.join(HOME, '.gemini', 'config')) && !fs.existsSync(path.join(HOME, '.gemini', 'antigravity-cli')), format: 'json' },
+    { name: 'Gemini CLI', path: path.join(HOME, '.gemini', 'config', 'mcp_config.json'), gate: () => fs.existsSync(path.join(HOME, '.gemini', 'config')), format: 'json' },
     { name: 'Claude Code (global)', path: path.join(HOME, '.claude', 'claude_desktop_config.json'), gate: () => fs.existsSync(path.join(HOME, '.claude')), format: 'json' },
     { name: 'Cursor', path: path.join(HOME, '.cursor', 'mcp.json'), gate: () => fs.existsSync(path.join(HOME, '.cursor')), format: 'json' },
     { name: 'Kiro', path: path.join(HOME, '.kiro', 'settings', 'mcp.json'), gate: () => fs.existsSync(path.join(HOME, '.kiro')), format: 'json' },


### PR DESCRIPTION
When both Antigravity CLI and Gemini CLI are installed, egc init was only writing the MCP server entries to the antigravity-specific config (~/.gemini/antigravity-cli/mcp_config.json) and skipping the global Gemini config (~/.gemini/config/mcp_config.json).

However, agy reads MCPs from the global config, so egc-memory and egc-guardian were never available in agy sessions after a fresh install.

Fix: remove the mutual exclusion so both configs are written when both tools are detected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP server registration in `egc init` so the global Gemini config is updated even when Antigravity is installed. This makes `egc-memory` and `egc-guardian` available in `agy` after a fresh install.

- **Bug Fixes**
  - Always write MCP entries to the global Gemini config (`~/.gemini/config/mcp_config.json`) alongside Antigravity’s config when both are present.

- **Refactors**
  - Translated the CLI banner text to English.

<sup>Written for commit a63f38461b52d6dc987a5a31f3a662788fc40e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated help documentation text
  * Improved CLI tool registration compatibility during setup to work with multiple configuration types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->