### PR TITLE
fix(release): add --ignore-scripts to npm install for supply chain safety

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -64,7 +64,7 @@ sed -i "s/Extended Global Context v${CURRENT}/Extended Global Context v${VERSION
 
 update_latest_release_heading "$ROOT_ZH_CN_README_FILE"
 
-npm install --package-lock-only --silent
+npm install --package-lock-only --ignore-scripts --silent
 sed -i "s/\"version\": \"${CURRENT}\"/\"version\": \"${VERSION}\"/g" .opencode/package-lock.json
 
 echo "Verifying npm pack payload..."


### PR DESCRIPTION
## Summary

- Adds `--ignore-scripts` flag to `npm install --package-lock-only` in `scripts/release.sh`
- Prevents execution of arbitrary lifecycle scripts during lockfile updates
- Resolves Scorecard supply-chain alert #44 (PinnedDependencies / npmCommand not pinned by hash)

## What changed

`scripts/release.sh:67`

```diff
-npm install --package-lock-only --silent
+npm install --package-lock-only --ignore-scripts --silent
```

The `--ignore-scripts` flag ensures that no package lifecycle scripts (`preinstall`, `postinstall`, etc.) run when updating the lockfile, reducing supply chain risk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--ignore-scripts` to `npm install --package-lock-only` in `scripts/release.sh` to prevent lifecycle scripts from running during lockfile updates, reducing supply-chain risk in the release pipeline.

<sup>Written for commit bce15f46f1438d50802e1fa516d849dee3a04ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release script updated to avoid running package lifecycle scripts when updating the lockfile, improving safety and consistency of release/version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->