### PR TITLE
fix(ux): show actionable error when target IDE is not installed

### DIFF
--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -703,7 +703,14 @@ function createManifestInstallPlan(options = {}) {
     targetRoot: plan.targetRoot,
     installRoot: plan.targetRoot,
     installStatePath: plan.installStatePath,
-    warnings: Array.isArray(options.warnings) ? [...options.warnings] : [],
+    warnings: [
+      ...(Array.isArray(options.warnings) ? options.warnings : []),
+      ...(Array.isArray(plan.validationIssues)
+        ? plan.validationIssues
+            .filter(issue => issue.severity === 'warning')
+            .map(issue => issue.message)
+        : []),
+    ],
     languages: legacyLanguages,
     legacyLanguages,
     profileId: plan.profileId,

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -533,6 +533,7 @@ function resolveInstallPlan(options = {}) {
     targetAdapterId: scaffoldPlan ? scaffoldPlan.adapter.id : null,
     targetRoot: scaffoldPlan ? scaffoldPlan.targetRoot : null,
     installStatePath: scaffoldPlan ? scaffoldPlan.installStatePath : null,
+    validationIssues: scaffoldPlan ? scaffoldPlan.validationIssues : [],
     operations: scaffoldPlan ? scaffoldPlan.operations : [],
   };
 }

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -101,6 +101,19 @@ function createManagedOperation({
   };
 }
 
+const IDE_INSTALL_URLS = Object.freeze({
+  claude:       { name: 'Claude Code',        url: 'https://claude.ai/download' },
+  cursor:       { name: 'Cursor',             url: 'https://cursor.sh' },
+  gemini:       { name: 'Gemini CLI',         url: 'https://github.com/google-gemini/gemini-cli' },
+  antigravity:  { name: 'Antigravity CLI',    url: 'https://github.com/google-gemini/gemini-cli' },
+  codex:        { name: 'Codex CLI',          url: 'https://github.com/openai/codex' },
+  opencode:     { name: 'OpenCode',           url: 'https://opencode.ai' },
+  codebuddy:    { name: 'CodeBuddy',          url: 'https://copilot.tencent.com' },
+  windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
+  amp:          { name: 'Amp',                url: 'https://ampcode.com' },
+  copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },
+});
+
 function defaultValidateAdapterInput(config, input = {}) {
   if (config.kind === 'project' && !input.projectRoot && !input.repoRoot) {
     return [
@@ -122,7 +135,28 @@ function defaultValidateAdapterInput(config, input = {}) {
     ];
   }
 
-  return [];
+  const issues = [];
+  const baseRoot = config.kind === 'home'
+    ? (input.homeDir || os.homedir())
+    : (input.projectRoot || input.repoRoot);
+
+  if (baseRoot && config.rootSegments && config.rootSegments.length > 0) {
+    const rootDir = path.join(baseRoot, config.rootSegments[0]);
+    if (!fs.existsSync(rootDir)) {
+      const ide = IDE_INSTALL_URLS[config.target];
+      if (ide) {
+        issues.push(buildValidationIssue(
+          'warning',
+          'ide-not-detected',
+          `${ide.name} does not appear to be installed on this machine.\n` +
+          `  Expected config directory not found: ${rootDir}\n` +
+          `  To install ${ide.name}, visit: ${ide.url}`
+        ));
+      }
+    }
+  }
+
+  return issues;
 }
 
 function createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options = {}) {

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -453,16 +453,18 @@ function runTests() {
 
     assert.strictEqual(typeof claudeAdapter.planOperations, 'function');
     assert.strictEqual(typeof claudeAdapter.validate, 'function');
-    assert.deepStrictEqual(
-      claudeAdapter.validate({ homeDir: '/Users/example', repoRoot: '/repo/egc' }),
-      []
+    assert.ok(
+      !claudeAdapter.validate({ homeDir: '/Users/example', repoRoot: '/repo/egc' })
+        .some(i => i.severity === 'error'),
+      'claude adapter should have no blocking validation errors'
     );
 
     assert.strictEqual(typeof cursorAdapter.planOperations, 'function');
     assert.strictEqual(typeof cursorAdapter.validate, 'function');
-    assert.deepStrictEqual(
-      cursorAdapter.validate({ projectRoot: '/workspace/app', repoRoot: '/repo/egc' }),
-      []
+    assert.ok(
+      !cursorAdapter.validate({ projectRoot: '/workspace/app', repoRoot: '/repo/egc' })
+        .some(i => i.severity === 'error'),
+      'cursor adapter should have no blocking validation errors'
     );
   })) passed++; else failed++;
 
@@ -549,9 +551,10 @@ function runTests() {
 
     assert.strictEqual(typeof codebuddyAdapter.planOperations, 'function');
     assert.strictEqual(typeof codebuddyAdapter.validate, 'function');
-    assert.deepStrictEqual(
-      codebuddyAdapter.validate({ projectRoot: '/workspace/app', repoRoot: '/repo/egc' }),
-      []
+    assert.ok(
+      !codebuddyAdapter.validate({ projectRoot: '/workspace/app', repoRoot: '/repo/egc' })
+        .some(i => i.severity === 'error'),
+      'codebuddy adapter should have no blocking validation errors'
     );
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary

- Adds pre-flight IDE detection to all install-target adapters
- When the IDE config directory does not exist, surfaces a structured warning with the IDE name, expected path, and install URL — instead of silently writing files to an orphaned directory
- Warning is non-blocking: install proceeds, but the user sees clear guidance

## Example output

```
Warning:
- Cursor does not appear to be installed on this machine.
  Expected config directory not found: /home/user/.cursor
  To install Cursor, visit: https://cursor.sh
```

## What changed

- `scripts/lib/install-targets/helpers.js`: added `IDE_INSTALL_URLS` lookup table and pre-flight check in `defaultValidateAdapterInput`
- `scripts/lib/install-manifests.js`: propagates `validationIssues` from scaffold plan
- `scripts/lib/install-executor.js`: maps `warning` severity validation issues to the plan's `warnings` array

Closes #92

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a clear, actionable warning when the target IDE isn’t installed by checking for its config directory before install. Install continues, but users see the IDE name, expected path, and a download link.

- **Bug Fixes**
  - Added pre-flight IDE detection and a non-blocking warning with IDE name, expected path, and install URL (`IDE_INSTALL_URLS`).
  - Propagates `validationIssues` into the plan and CLI warnings (via `resolveInstallPlan` and executor) so messages are shown to users.
  - Updated tests to allow warning-only validation results (assert no error-severity issues).

<sup>Written for commit 8c55f7735ae562ea31140b2e78bbc4093a78e843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now detects missing IDE directories and shows helpful download/install links.
  * Validation warnings from plans are now aggregated with user-provided warnings so install plans display comprehensive warnings.

* **Tests**
  * Validation-related tests relaxed to allow non-blocking warnings rather than requiring strictly empty validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->