### PR TITLE
docs: add TROUBLESHOOTING.md for common install errors

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,37 @@
+# Troubleshooting
+
+## `EACCES: permission denied` on macOS
+
+**Symptom:** `npm install -g @egchq/egc` fails with:
+
+```
+npm error code EACCES
+npm error syscall mkdir
+npm error path /usr/local/lib/node_modules/@egchq
+npm error errno -13
+```
+
+**Cause:** Node.js was installed system-wide (via the official installer or Homebrew) and npm cannot write to `/usr/local/lib/node_modules` without root access.
+
+**Fix:** Use a Node version manager so Node lives under your home directory and global installs work without `sudo`.
+
+With [nvm](https://github.com/nvm-sh/nvm):
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+# restart your terminal, then:
+nvm install --lts
+nvm use --lts
+npm install -g @egchq/egc
+```
+
+With [fnm](https://github.com/Schniz/fnm) (faster):
+
+```bash
+brew install fnm
+fnm install --lts
+fnm use lts-latest
+npm install -g @egchq/egc
+```
+
+If you prefer not to change your Node installation, the alternative is to [configure a custom npm global prefix](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) under your home directory.


### PR DESCRIPTION
## Summary

- Adds `TROUBLESHOOTING.md` to the repo root with the `EACCES: permission denied` fix for macOS users who have Node installed system-wide
- Reverts the inline note that was briefly added to the `README.md` installation section — troubleshooting content belongs in a dedicated file, not in the install flow

## Why

Reported by a first-time contributor testing the macOS installer (#94). The error is a common npm permissions issue on macOS when Node is installed via the official installer or Homebrew instead of nvm/fnm. It is not a bug in EGC but it is confusing enough to document.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add TROUBLESHOOTING.md with steps to fix the macOS npm `EACCES: permission denied` error when globally installing `@egchq/egc`. Covers fixes using `nvm` or `fnm`, plus an npm prefix alternative to avoid sudo.

<sup>Written for commit 10de903e3e7fa636edae1cf05642e3d67779d93d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a macOS troubleshooting guide for `EACCES: permission denied` errors during global package installation, with remediation steps using Node version managers (nvm, fnm) and an alternative npm custom global prefix approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->