### PR TITLE
chore: migrate npm publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,16 +129,5 @@ jobs:
           make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
 
       - name: Publish npm package
-        if: steps.npm_publish_state.outputs.already_published != 'true' && env.NPM_TOKEN != ''
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: steps.npm_publish_state.outputs.already_published != 'true'
         run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"
-
-      - name: Skip npm publish (no NPM_TOKEN configured)
-        if: steps.npm_publish_state.outputs.already_published != 'true' && env.NPM_TOKEN == ''
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "::notice::npm publish skipped — secrets.NPM_TOKEN is not configured."
-          echo "::notice::Set NPM_TOKEN in repository secrets to enable automated publishing."

--- a/tests/scripts/release-publish.test.js
+++ b/tests/scripts/release-publish.test.js
@@ -48,7 +48,9 @@ for (const workflow of [
 
   test(`${workflow} publishes new tag versions to npm`, () => {
     assert.match(content, /npm publish --access public --provenance/);
-    assert.match(content, /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
+    if (workflow === '.github/workflows/reusable-release.yml') {
+      assert.match(content, /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
+    }
   });
 
   test(`${workflow} creates the GitHub Release before publishing to npm`, () => {


### PR DESCRIPTION
## Summary

- Removes `NPM_TOKEN` secret dependency from the release workflow
- Publishes to npm via OIDC Trusted Publishing (never expires)
- No functional change to the release process — same `npm publish --provenance` command

## What changed

`release.yml` step "Publish npm package":
- Before: gated on `secrets.NPM_TOKEN`, used `NODE_AUTH_TOKEN` for classic token auth
- After: no token needed, npm exchanges the OIDC token automatically (`id-token: write` already granted, `registry-url` already set via `setup-node`)

The fallback "Skip npm publish (no NPM_TOKEN configured)" step is removed — it no longer applies.

## Pre-requisite (done in npm UI)

Trusted Publisher configured at npmjs.com/package/@egchq/egc:
- Publisher: GitHub Actions
- Org/user: Fmarzochi
- Repo: EGC
- Workflow: release.yml

## Test plan

- [ ] CI passes on this PR
- [ ] Next release tag triggers publish without NPM_TOKEN in secrets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch npm publishing to OIDC Trusted Publishing so releases no longer need the `NPM_TOKEN` secret. Also add a preinstall guard to fail fast on unwritable global installs; the `npm publish --provenance` command is unchanged.

- **Refactors**
  - `release.yml`: remove `NPM_TOKEN`/`NODE_AUTH_TOKEN` and the skip-publish step; rely on OIDC via `setup-node`.
  - `tests/scripts/release-publish.test.js`: expect OIDC flow for `release.yml`; keep token check for `reusable-release.yml`.

- **Bug Fixes**
  - Add `scripts/preinstall.js` and `"preinstall"` to stop global installs when the target dir isn’t writable; includes `nvm`/`fnm` guidance.
  - Update TROUBLESHOOTING with `eval "$(fnm env --use-on-cd)"` for better `fnm` setup.

<sup>Written for commit f0d1d1ec5620e33fa2dddfa10cf7f9ed12c47add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the package release workflow by removing token validation checks.
  * Updated how npm package publishing is triggered during the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->