### PR TITLE
docs: add Zed to supported tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ready to pick up the next items:
 
 The AI already knows what you were building, what decisions you made, what failed, and exactly where you stopped. You didn't type anything. You just started working.
 
-After `sh install.sh`, the memory protocol is injected into the global instruction files for Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Windsurf, Amp, VS Code Copilot, Kiro, Trae, and CodeBuddy, so the AI reads state at the start of each session and saves it at the end. For tools where the AI instruction file isn't read automatically (varies by tool version), you may need to add the project's `CLAUDE.md` or equivalent to the session context manually.
+After `sh install.sh`, the memory protocol is injected into the global instruction files for Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Windsurf, Amp, VS Code Copilot, Zed, Kiro, Trae, and CodeBuddy, so the AI reads state at the start of each session and saves it at the end. For tools where the AI instruction file isn't read automatically (varies by tool version), you may need to add the project's `CLAUDE.md` or equivalent to the session context manually.
 
 ---
 
@@ -46,7 +46,7 @@ It gets worse when you switch tools. Move from Cursor to Claude Code and you sta
 
 One install. Every tool. Permanent memory.
 
-`sh install.sh` detects which AI tools you have installed (Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Windsurf, Amp, VS Code Copilot, Kiro, Trae, CodeBuddy) and registers the MCP servers in all of them. It also runs a cognitive bootstrap that writes the memory protocol into the global instruction files for each tool, so the AI is instructed to call `get_state({})` at the start of every session and `update_state({...})` at the end.
+`sh install.sh` detects which AI tools you have installed (Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Windsurf, Amp, VS Code Copilot, Zed, Kiro, Trae, CodeBuddy) and registers the MCP servers in all of them. It also runs a cognitive bootstrap that writes the memory protocol into the global instruction files for each tool, so the AI is instructed to call `get_state({})` at the start of every session and `update_state({...})` at the end.
 
 For every supported tool:
 - **Open any session** → AI reads your project state → picks up where you left off


### PR DESCRIPTION
Add Zed to the two inline tool lists in README.md that were not updated when PR #116 landed:

- Line 33: tools listed after "sh install.sh injects the memory protocol"
- Line 49: tools listed in "sh install.sh detects which AI tools you have installed"

The supported tools table already includes Zed (added in PR #116). This is a text-only fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Zed to the two inline tool lists in README. Keeps the lists consistent with the supported tools table and documents that `sh install.sh` detects Zed and injects the memory protocol.

<sup>Written for commit 083694d97120a2b9714961ab468345c542ab1901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor updates to README.md formatting and clarity in sections describing EGC functionality and implementation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->