### PR TITLE
fix: clear NODE_AUTH_TOKEN so npm OIDC publish works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,3 +131,5 @@ jobs:
       - name: Publish npm package
         if: steps.npm_publish_state.outputs.already_published != 'true'
         run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
## Problem

`setup-node` with `registry-url` sets `NODE_AUTH_TOKEN` to `GITHUB_TOKEN` by default. When `npm publish --provenance` runs, it tries the OIDC exchange but falls back to `NODE_AUTH_TOKEN` (a GitHub JWT, not an npm token) when the exchange fails silently. npm returns 404 because `GITHUB_TOKEN` is not valid for npm auth.

## Fix

Clear `NODE_AUTH_TOKEN` in the publish step so npm is forced to use the OIDC token exchange (Trusted Publishing), which was already configured in npm.js in PR #119.

## Why one line

The Trusted Publishing config on npm.js is correct. The only issue was `GITHUB_TOKEN` overriding the OIDC path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force npm Trusted Publishing by clearing NODE_AUTH_TOKEN in the publish step so npm uses the OIDC exchange instead of the GITHUB_TOKEN from setup-node. Prevents 404s when running npm publish --provenance.

<sup>Written for commit d8ab9462b856030e24b6fc78cfcf36861cf14ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the npm package release workflow configuration to refine authentication handling during package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->