### PR TITLE
fix: remove _authToken from npmrc so npm uses OIDC on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,6 @@ jobs:
 
       - name: Publish npm package
         if: steps.npm_publish_state.outputs.already_published != 'true'
-        run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ''
+        run: |
+          sed -i "/_authToken/d" "$NPM_CONFIG_USERCONFIG"
+          npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"


### PR DESCRIPTION
## Summary

- `setup-node` with `registry-url` creates a `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`
- When `NODE_AUTH_TOKEN` is empty (or explicitly set to `''`), npm sees an empty token and fails with `ENEEDAUTH` before attempting OIDC exchange
- Fix: `sed -i "/_authToken/d"` strips that line from the temp npmrc before publishing, allowing npm to use OIDC natively with `id-token: write`

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes to npm via OIDC (no `NODE_AUTH_TOKEN` needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix npm publish in CI by removing the `_authToken` line from the temp `.npmrc` before publishing. This lets `npm` use OIDC and avoids `ENEEDAUTH` when `NODE_AUTH_TOKEN` is empty.

- **Bug Fixes**
  - Strip `_authToken` from `$NPM_CONFIG_USERCONFIG` in the release job, then run `npm publish --provenance`.
  - Works with `actions/setup-node` and `id-token: write`; no `NODE_AUTH_TOKEN` needed.

<sup>Written for commit aadf68c248d6383e18a2eb128d4a2c0d1318eeae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved npm publishing workflow configuration to enhance the reliability and security of automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->