### PR TITLE
fix: upgrade to Node 24 for OIDC Trusted Publishing (npm >= 11.5.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -131,5 +131,3 @@ jobs:
       - name: Publish npm package
         if: steps.npm_publish_state.outputs.already_published != 'true'
         run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
## Root cause

`node-version: '20.x'` ships with npm 10.x. OIDC Trusted Publishing requires **npm >= 11.5.1** (Node.js 24+). With npm 10, there is no OIDC exchange — it falls through to `ENEEDAUTH`.

The explicit `NODE_AUTH_TOKEN: ''` added in #122 also masked the real issue without fixing it.

## Changes

- `node-version: '20.x'` → `'24'` (npm 11.x included, supports OIDC natively)
- Remove `NODE_AUTH_TOKEN: ''` (no longer needed; npm 11.5.1+ picks up the OIDC token automatically with `id-token: write`)

## Prerequisite (manual step on npmjs.com)

Before this workflow can publish, you must configure a **Trusted Publisher** on the `@egchq/egc` package settings at npmjs.com:

- GitHub owner: `Fmarzochi`
- Repository: `EGC`
- Workflow filename: `release.yml`

Reference: https://docs.npmjs.com/trusted-publishers

## Test plan

- [ ] CI passes
- [ ] Trusted Publisher configured on npmjs.com
- [ ] Recreate tag v1.0.8 to trigger Release workflow
- [ ] `npm publish` succeeds via OIDC (no NPM_TOKEN needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade release workflow to Node.js 24 to enable `npm` OIDC Trusted Publishing and remove `NODE_AUTH_TOKEN`. This fixes ENEEDAUTH by using `npm` 11.5.1+ for token exchange.

- **Bug Fixes**
  - Use Node 24 (bundles `npm` 11.x) so OIDC exchange works; Node 20’s `npm` 10.x caused ENEEDAUTH.
  - Remove `NODE_AUTH_TOKEN` override; `npm` 11.5.1+ picks up the OIDC token automatically.

- **Migration**
  - Configure a Trusted Publisher on npmjs.com for `@egchq/egc` (owner: Fmarzochi, repo: EGC, workflow: release.yml).
  - Recreate the release tag to trigger publish after setup.

<sup>Written for commit 4800a37b424c7e36c03f7dc73c9ee4c5beb63808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal release pipeline infrastructure to improve publishing reliability and process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->