### PR TITLE
fix(ci): increase test job timeout to 20m for Windows native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.pm }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Root cause

`timeout-minutes: 10` on the test job. On Windows + Node 18 + yarn, `better-sqlite3` has no prebuilt binary and compiles natively via MSBuild. Setup steps (Python 3.12, MSVS, node-gyp@12) + yarn install consistently consume ~10 minutes, hitting the limit exactly and cancelling the job.

## Fix

`timeout-minutes: 10` → `20`. One line, no logic change, no new behavior.

20 minutes is enough headroom for the worst-case native build while still catching real hangs.

## Affected jobs

- `Test (windows-latest, Node 18.x, yarn)` — was consistently cancelled at ~10m28s
- `Test (windows-latest, Node 22.x, yarn)` — occasionally hit the limit too

All other jobs finish well under 10m and are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase CI test job timeout from 10 to 20 minutes to stop Windows yarn runs from timing out when `better-sqlite3` compiles natively. Adds headroom for Node 18/22 on `windows-latest` without changing any logic.

<sup>Written for commit 814ad853661a2069c06c9144e1cb1692c388b482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased test job timeout duration in CI pipeline to allow tests more time to complete before termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->