### PR TITLE
ci: drop Node 18 EOL and enable Windows bun/yarn coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,20 +41,6 @@ jobs:
           node-version: ${{ matrix.node }}
 
       # Package manager setup
-      - name: Setup pnpm
-        if: matrix.pm == 'pnpm' && matrix.node != '18.x'
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          # Keep an explicit pnpm major because this repo's packageManager is Yarn.
-          version: 10
-
-      - name: Setup pnpm (via Corepack)
-        if: matrix.pm == 'pnpm' && matrix.node == '18.x'
-        shell: bash
-        run: |
-          corepack enable
-          corepack prepare pnpm@9 --activate
-
       - name: Setup Yarn (via Corepack)
         if: matrix.pm == 'yarn'
         shell: bash
@@ -81,23 +67,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ matrix.node }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node }}-npm-
-
-      - name: Get pnpm store directory
-        if: matrix.pm == 'pnpm'
-        id: pnpm-cache-dir
-        shell: bash
-        env:
-          COREPACK_ENABLE_STRICT: '0'
-        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache pnpm
-        if: matrix.pm == 'pnpm'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ${{ steps.pnpm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ matrix.node }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node }}-pnpm-
 
       - name: Get yarn cache directory
         if: matrix.pm == 'yarn'
@@ -156,8 +125,6 @@ jobs:
           }
 
       # Install dependencies
-      # COREPACK_ENABLE_STRICT=0 allows pnpm to install even though
-      # package.json declares "packageManager": "yarn@..."
       - name: Install dependencies
         shell: bash
         env:
@@ -165,19 +132,6 @@ jobs:
         run: |
           case "${{ matrix.pm }}" in
             npm) npm ci ;;
-            # pnpm v10 can fail CI on ignored native build scripts
-            # (for example msgpackr-extract) even though this repo is Yarn-native
-            # and pnpm is only exercised here as a compatibility lane.
-            pnpm)
-              # better-sqlite3 has no prebuilt binary for every Node ABI
-              # (notably Node 20.x), so its install script falls back to
-              # `node-gyp rebuild`. The GitHub Actions runner ships node-gyp
-              # globally via npm, so no explicit install is needed.
-              pnpm install --config.strict-dep-builds=false --no-frozen-lockfile
-              ;;
-            # Yarn Berry (v4+) removed --ignore-engines; engine checking is no longer a core feature.
-            # --no-immutable: this is a compat lane (repo is npm-native, yarn.lock is legacy v1
-            # auto-migrated by Berry); CI must not assert lockfile-format equality across PM lanes.
             yarn) yarn install --no-immutable ;;
             bun) bun install ;;
             *) echo "Unsupported package manager: ${{ matrix.pm }}" && exit 1 ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: ['18.x', '20.x', '22.x']
+        node: ['20.x', '22.x']
         pm: [npm, yarn, bun]
-        exclude:
-          # Bun has limited Windows support
-          - os: windows-latest
-            pm: bun
-          # better-sqlite3 v12.10.0 has no prebuilt binary for Node 18 (ABI 108) on Windows.
-          # Node 18 is EOL (Apr 2025). Yarn Berry adds migration overhead that pushes install
-          # past the job limit. Windows+Node 18 coverage is maintained via the npm lane.
-          - os: windows-latest
-            pm: yarn
-            node: '18.x'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Remove Node 18 from the matrix: it reached EOL in March 2025 and `better-sqlite3` v12.x dropped it from `engines.node` with no prebuilt binary for ABI 108 on any platform
- Remove `windows + bun` exclusion: Bun v1.1+ officially supports Windows x64 per `oven-sh/setup-bun` source and bun.sh/docs
- Remove `windows + yarn + Node18` exclusion: becomes moot since Node 18 is gone

New matrix: **3 OS x 2 nodes (20, 22) x 3 PM = 18 jobs, all expected green**

## References

- Node 18 EOL: https://nodejs.org/en/about/previous-releases
- better-sqlite3 engines.node: `"20.x || 22.x || ..."` (no ABI 108)
- Bun Windows support: https://bun.sh/docs/installation#windows
- oven-sh/setup-bun explicitly handles `win32` platform

## No version bump

CI configuration only. No code, no package.json changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop Node 18 from CI (EOL; unsupported by `better-sqlite3` v12), enable Windows `bun` and `yarn` coverage, and remove dead `pnpm` setup/cache/install steps. Matrix is now 3 OS x Node 20/22 x `npm`/`yarn`/`bun` = 18 jobs, all expected green.

<sup>Written for commit 30b4fa40bb187feed12625ae12ebac0d0f425c7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI testing to target Node.js 20.x and 22.x; Node.js 18.x removed. The test matrix now runs across npm, yarn, and bun only, and pnpm-specific steps and caching have been removed, streamlining the pipeline and dependency-install paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->