### PR TITLE
README: move installation to docs/installation.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,62 +73,15 @@ The money saved is small. The time and interrupted flow are not.
 
 ---
 
-## Installation
-
-### Via npm (recommended)
+## Install with one command
 
 ```bash
-npm install -g @egchq/egc
-egc install
+npm install -g @egchq/egc && egc install
 ```
 
-### Linux / macOS
+Works on Linux, macOS, and Windows. Requires [Node.js 20+](https://nodejs.org/en/download).
 
-You need [Node.js 20 or later](https://nodejs.org/en/download). Not sure if you have it? Open a terminal and run `node --version`. If it shows 20 or higher, you're ready.
-
-```bash
-git clone https://github.com/Fmarzochi/EGC.git
-cd EGC
-sh install.sh
-```
-
-The installer runs these steps:
-
-1. Compiles the MCP servers (`egc-guardian`, `egc-memory`)
-2. Initializes the local SQLite database
-3. Runs the cognitive bootstrap: writes the memory protocol into `~/.claude/CLAUDE.md` (Claude Code) and `~/.gemini/GEMINI.md` (AGY), creating the files if they don't exist, idempotent
-4. Registers both MCP servers in every detected tool's config file
-5. Asks interactively whether to install the prompt library (63 agents, 229 skills, 76 commands), skipped automatically in CI
-
-The installer will print which tools it found and registered:
-
-```
-EGC install
-  node v22.0.0
-  building egc-guardian...
-  building egc-memory...
-  initializing database...
-  bootstrapping cognitive protocol...
-  ✓ ~/.claude/CLAUDE.md updated
-  ✓ ~/.gemini/GEMINI.md updated
-  registering MCP servers...
-  ✓ registered in Antigravity CLI
-  ✓ registered in Claude Code (global)
-  ✓ registered in Cursor
-
-Install prompt library? (63 agents, 229 skills, 76 commands) [y/N]:
-
-Installation complete.
-Run 'egc doctor' to verify.
-```
-
-### Windows
-
-```powershell
-git clone https://github.com/Fmarzochi/EGC.git
-cd EGC
-.\install.ps1
-```
+[Full installation guide](docs/installation.md) — git clone, manual steps, Windows PowerShell, troubleshooting.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,80 @@
+# Installation Guide
+
+## Via npm (recommended)
+
+Requires [Node.js 20 or later](https://nodejs.org/en/download).
+
+```bash
+npm install -g @egchq/egc
+egc install
+```
+
+That's it. The installer detects which AI tools you have installed and configures all of them automatically.
+
+---
+
+## Linux / macOS (from source)
+
+Not sure if you have Node.js 20? Run `node --version`. If it shows 20 or higher, you're ready.
+
+```bash
+git clone https://github.com/Fmarzochi/EGC.git
+cd EGC
+sh install.sh
+```
+
+### What the installer does
+
+1. Compiles the MCP servers (`egc-guardian`, `egc-memory`)
+2. Initializes the local SQLite database
+3. Runs the cognitive bootstrap: writes the memory protocol into `~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, and equivalent files for each detected tool
+4. Registers both MCP servers in every detected tool's config file
+5. Asks interactively whether to install the prompt library (63 agents, 229 skills, 76 commands) — skipped automatically in CI
+
+### Example output
+
+```
+EGC install
+  node v22.0.0
+  building egc-guardian...
+  building egc-memory...
+  initializing database...
+  bootstrapping cognitive protocol...
+  ✓ ~/.claude/CLAUDE.md updated
+  ✓ ~/.gemini/GEMINI.md updated
+  registering MCP servers...
+  ✓ registered in Antigravity CLI
+  ✓ registered in Claude Code (global)
+  ✓ registered in Cursor
+
+Install prompt library? (63 agents, 229 skills, 76 commands) [y/N]:
+
+Installation complete.
+Run 'egc doctor' to verify.
+```
+
+---
+
+## Windows
+
+```powershell
+git clone https://github.com/Fmarzochi/EGC.git
+cd EGC
+.\install.ps1
+```
+
+---
+
+## Verify the install
+
+```bash
+egc doctor
+```
+
+This checks that both MCP servers are built, registered, and reachable in every detected tool.
+
+---
+
+## Troubleshooting
+
+See [TROUBLESHOOTING.md](guides/TROUBLESHOOTING.md) for common issues including permission errors, Node.js version mismatches, and manual MCP registration steps.


### PR DESCRIPTION
README was acting as a manual, not a storefront. This turns it into a marketing page.

## Changes

- Installation section replaced with a single one-liner + link to docs
- Full installation guide moved to `docs/installation.md`
- Hero, badges, token table, problem/solution sections untouched

The README now converts: person lands, reads the problem, copies one command, done.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the README to a focused landing page by replacing the long install section with a one‑liner and a link to the full guide. All detailed steps moved to `docs/installation.md`; quick install: `npm install -g @egchq/egc && egc install`.

<sup>Written for commit 6f01ca8770874c237e9068ce097330f94cd4a39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with simplified installation instructions using a single quick-start command, directing users to comprehensive documentation for detailed setup steps.
  * Created comprehensive installation guide with detailed step-by-step instructions for multiple operating systems, system health verification procedures, and dedicated troubleshooting resources to resolve common issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->