### PR TITLE
fix(readme): restore catalog validator markers in prompt library section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ Works on Linux, macOS, and Windows. Requires [Node.js 20+](https://nodejs.org/en
 
 ## Prompt library
 
-**479 components. Ready to use. Written from real experience, not generated.**
+**479 components included.** Install once to get access to 63 agents, 229 skills, and 76 commands written from real experience, not generated.
 
 | Type | Count | What it is |
 |---|---|---|
-| Agents | 63 | Persona and behavior definitions |
-| Skills | 229 | Domain-specific workflow runbooks |
-| Commands | 76 | Command definitions and lifecycle hooks |
+| Agents | 63 agents | Persona and behavior definitions |
+| Skills | 229 skills | Domain-specific workflow runbooks |
+| Commands | 76 commands | Command definitions and lifecycle hooks |
 | Rules | 111 | Constraints and governance directives |
 
 Organized per harness under `.cursor/`, `.claude/`, `.gemini/`, `.kiro/`, and four others. Switch tools and the same workflows follow you.


### PR DESCRIPTION
PR #134 broke the catalog validator by removing two required markers from README.md:

1. The phrase `access to 63 agents, 229 skills, and 76 commands` (regex match in `catalog.js`)
2. The count suffixes in the table: `63 agents`, `229 skills`, `76 commands`

This restores both while keeping the `**479 components included.**` marketing headline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the README markers required by the catalog validator so regex checks pass again. Keeps the “479 components included” headline.

- **Bug Fixes**
  - Re-added the phrase: access to 63 agents, 229 skills, and 76 commands.
  - Restored count suffixes in the table: 63 agents, 229 skills, 76 commands.

<sup>Written for commit a373481287ab2451953dc705f1e0af7d3fdf6939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the README to emphasize the availability of 479 components in the prompt library with improved presentation of the component breakdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->