### PR TITLE
docs: normalize dash style in token savings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Rebuilding context from scratch costs ~1,500 tokens per session. EGC's state fil
 | | Without EGC | With EGC |
 |---|---|---|
 | Context overhead per session | ~1,500 tokens | ~200 tokens |
-| 20 sessions/month | ~$0.08–$0.09 | ~$0.011–$0.012 |
+| 20 sessions/month | ~$0.08-$0.09 | ~$0.011-$0.012 |
 | Time re-explaining context | 10 min/session | 0 |
 
 The money saved is small. The time and interrupted flow are not.


### PR DESCRIPTION
Minor style fix to test CodeRabbit Assertive mode review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized dash style in the README token-savings table to ensure consistent rendering across Markdown viewers. Replaced en dashes in price ranges with standard hyphens.

<sup>Written for commit dfbcabf64e4c7e3427b8fef39c4921d25697d2cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

