### PR TITLE
fix: parse all require blocks in go.mod dependency detection

### DIFF
--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -240,9 +240,8 @@ function getGoDeps(projectDir) {
     if (!fs.existsSync(modPath)) return [];
     const content = fs.readFileSync(modPath, 'utf8');
     const deps = [];
-    const requireBlock = content.match(/require\s*\(([\s\S]*?)\)/);
-    if (requireBlock) {
-      requireBlock[1].split('\n').forEach(line => {
+    for (const block of content.matchAll(/require\s*\(([\s\S]*?)\)/g)) {
+      block[1].split('\n').forEach(line => {
         const trimmed = line.trim();
         if (trimmed && !trimmed.startsWith('//')) {
           const parts = trimmed.split(/\s+/);

--- a/tests/lib/project-detect.test.js
+++ b/tests/lib/project-detect.test.js
@@ -348,6 +348,33 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('getGoDeps reads multiple require blocks in go.mod', () => {
+    const dir = createTempDir();
+    try {
+      const gomod = [
+        'module test',
+        '',
+        'go 1.22',
+        '',
+        'require (',
+        '\tgithub.com/gin-gonic/gin v1.9.1',
+        ')',
+        '',
+        'require (',
+        '\tgithub.com/lib/pq v1.10.9 // indirect',
+        '\tgolang.org/x/net v0.21.0 // indirect',
+        ')'
+      ].join('\n');
+      writeTestFile(dir, 'go.mod', gomod);
+      const deps = getGoDeps(dir);
+      assert.ok(deps.some(d => d.includes('gin-gonic/gin')), 'should include direct dep');
+      assert.ok(deps.some(d => d.includes('lib/pq')), 'should include indirect dep from second block');
+      assert.ok(deps.some(d => d.includes('golang.org/x/net')), 'should include all entries from second block');
+    } finally {
+      cleanupDir(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('getRustDeps reads Cargo.toml', () => {
     const dir = createTempDir();
     try {


### PR DESCRIPTION
## Summary

- `getGoDeps` used `.match()` without the `g` flag, so only the first `require (...)` block in `go.mod` was parsed
- `go mod tidy` routinely generates two separate `require` blocks (direct + indirect), so frameworks like `gin` or `echo` listed as indirect deps were silently missed
- Replaced `.match()` with `matchAll()` + `g` flag to iterate over all blocks
- Added a test covering the two-block case

## Test plan

- [ ] `node tests/lib/project-detect.test.js` passes (30/30)
- [ ] New test: `getGoDeps reads multiple require blocks in go.mod`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Go dependency detection by parsing all `require (...)` blocks in `go.mod`, ensuring indirect dependencies are included. This switches to `matchAll` with a global regex and adds a test for the two-block case.

- **Bug Fixes**
  - Replaced `.match()` with `matchAll()` + `/g` to iterate all `require` blocks.
  - Now captures dependencies from both direct and indirect blocks.
  - Added a test for the multiple-block scenario.

<sup>Written for commit a9f4e29b7dda44a5cc9ec7ad9a1038fe9a6bfcc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go module dependency extraction to properly process all require blocks in configuration files instead of only the first occurrence, ensuring comprehensive dependency detection.

* **Tests**
  * Added test coverage to validate extraction of multiple require blocks, including both direct and indirect dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->