### PR TITLE
feat(egc-memory): search_history tool with FTS5 BM25 ranking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,6 @@ The EGC runtime routes tasks to the appropriate agent using the execution orches
 ## MCP Servers
 
 - `egc-guardian` — `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task`
-- `egc-memory` — `get_state`, `update_state`, `store_decision`, `query_history`
+- `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`
 
 Run `sh install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,6 @@ update_state({
 Both servers must be registered in your MCP config (`.mcp.json`):
 
 - `egc-guardian` — `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task`
-- `egc-memory` — `get_state`, `update_state`, `store_decision`, `query_history`
+- `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`
 
 Run `sh install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -52,6 +52,6 @@ update_state({
 Both servers must be registered in your MCP config (`.mcp.json`):
 
 - `egc-guardian` — `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task`
-- `egc-memory` — `get_state`, `update_state`, `store_decision`, `query_history`
+- `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`
 
 Run `sh install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.

--- a/glama.json
+++ b/glama.json
@@ -26,6 +26,10 @@
       "description": "Query past decisions. Returns a paginated list of decisions stored in the session memory."
     },
     {
+      "name": "search_history",
+      "description": "Keyword search over the decision history with BM25 relevance ranking (SQLite FTS5). Returns decisions ordered by relevance with normalized scores."
+    },
+    {
       "name": "get_project_state",
       "description": "Get current state for the active project. Returns server status metadata including storage engine and arbitration mode."
     },

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -9,6 +9,7 @@ import os from 'os';
 import fs from 'fs';
 import { execSync } from 'child_process';
 import { z } from 'zod';
+import { createSearchIndex, rebuildSearchIndex, searchDecisions } from './search.js';
 
 function hideEgcRootOnWindows(): void {
   if (process.platform !== 'win32') return;
@@ -57,6 +58,7 @@ function log(level: 'INFO'|'WARN'|'ERROR'|'AUDIT'|'DEBUG', msg: string, meta: Re
 }
 
 let dbInstance: Database | null = null;
+let searchIndexReady = false;
 
 // ============================================================================
 // SQLite Arbitration & Message Queue (Cross-Runtime Synchronization)
@@ -173,6 +175,23 @@ async function runMigrations(db: Database, dbDir: string) {
       CREATE TABLE IF NOT EXISTS operational_state (id TEXT PRIMARY KEY, value TEXT);
       CREATE TABLE IF NOT EXISTS decisions (id INTEGER PRIMARY KEY AUTOINCREMENT, context TEXT, decision TEXT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP);
     `);
+
+    // Migration 2: FTS5 index over decisions for BM25 keyword search.
+    // Triggers keep the index in sync incrementally on every write; the
+    // one-time rebuild backfills rows stored before this migration existed.
+    const hasV2 = await db.get('SELECT version FROM schema_migrations WHERE version = 2');
+    try {
+      if (!hasV2) {
+        await createSearchIndex(db);
+        await rebuildSearchIndex(db);
+        await db.run('INSERT INTO schema_migrations (version) VALUES (2)');
+      }
+      searchIndexReady = true;
+    } catch (e) {
+      // SQLite builds without FTS5 keep working; only search_history is disabled.
+      searchIndexReady = false;
+      log('WARN', 'FTS5 unavailable, search_history disabled', { error: String(e) });
+    }
   } finally {
     try { fs.unlinkSync(lockFile); } catch(e) {}
   }
@@ -291,6 +310,12 @@ const StoreDecisionSchema = z.object({
   decision: z.string().min(1).max(10000)
 });
 
+const SearchHistorySchema = z.object({
+  query: z.string().min(1).max(1000),
+  limit: z.number().min(1).max(100).optional().default(10),
+  min_score: z.number().min(0).max(1).optional().default(0)
+});
+
 const QueryHistorySchema = z.object({
   limit: z.number().min(1).max(100).optional().default(10),
   offset: z.number().min(0).optional().default(0)
@@ -321,6 +346,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       { name: "get_project_state", description: "Returns server health metadata for the active project: storage engine (sqlite-wal) and write arbitration mode (MessageQueue). Use this to verify the egc-memory server is running and responsive before calling get_state or update_state.", inputSchema: { type: "object", properties: {} } },
       { name: "store_decision", description: "Persist a single decision to the SQLite store with write-lock arbitration to prevent concurrent conflicts. Provide a short context label and the decision text. Decisions stored here are queryable via query_history and surfaced in get_state.", inputSchema: { type: "object", properties: { context: { type: "string", description: "Short label for the decision context, e.g. 'architecture' or 'dependencies'." }, decision: { type: "string", description: "The decision text to persist." } }, required: ["context", "decision"] } },
       { name: "query_history", description: "Return a paginated list of past decisions stored in the SQLite state. Each entry includes the decision text, context label, and timestamp. Use limit and offset for pagination. Useful for auditing what was decided without loading the full project state.", inputSchema: { type: "object", properties: { limit: { type: "number", description: "Maximum number of decisions to return. Defaults to 20." }, offset: { type: "number", description: "Number of decisions to skip for pagination. Defaults to 0." } } } },
+      { name: "search_history", description: "Keyword search over the decision history with BM25 relevance ranking (SQLite FTS5). Each result includes the decision content, context label, timestamp, and a score normalized to [0, 1] where 1 is the best match in the result set. Use this to find past decisions by topic instead of paging through query_history.", inputSchema: { type: "object", properties: { query: { type: "string", description: "Keywords to search for, e.g. 'authentication jwt'." }, limit: { type: "number", description: "Maximum number of results to return. Defaults to 10." }, min_score: { type: "number", description: "Minimum normalized relevance score between 0 and 1. Defaults to 0." } }, required: ["query"] } },
       {
         name: "get_state",
         description: "Returns the current project memory: decisions made, preferences established, things to avoid, and what to pick up next. Call this at the START of every session to restore context.",
@@ -369,6 +395,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { limit, offset } = QueryHistorySchema.parse(request.params.arguments || {});
         const rows = await db.all('SELECT * FROM decisions ORDER BY timestamp DESC LIMIT ? OFFSET ?', [limit, offset]);
         return { content: [{ type: "text", text: JSON.stringify({ data: rows, meta: { limit, offset } }, null, 2) }] };
+      }
+      case "search_history": {
+        const { query, limit, min_score } = SearchHistorySchema.parse(request.params.arguments);
+        if (!searchIndexReady) {
+          throw new McpError(ErrorCode.InvalidRequest, 'search_history is unavailable: this SQLite build has no FTS5 support.');
+        }
+        const results = await searchDecisions(db, query, { limit, minScore: min_score });
+        log('INFO', 'Decision history searched', { results: results.length });
+        return { content: [{ type: "text", text: JSON.stringify({ results, meta: { query, limit, min_score, count: results.length } }, null, 2) }] };
       }
       case "get_project_state": {
         return { content: [{ type: "text", text: JSON.stringify({ status: "active", engine: "sqlite-wal", arbitration: "MessageQueue" }) }] };

--- a/mcp/servers/egc-memory/src/search.ts
+++ b/mcp/servers/egc-memory/src/search.ts
@@ -1,0 +1,100 @@
+import type { Database } from 'sqlite';
+
+export interface RankedDecision {
+  id: number;
+  content: string;
+  context: string;
+  date: string;
+  score: number;
+}
+
+interface RawSearchRow {
+  id: number;
+  content: string;
+  context: string;
+  date: string;
+  rawScore: number;
+}
+
+export interface SearchOptions {
+  limit?: number;
+  minScore?: number;
+}
+
+export const DEFAULT_SEARCH_LIMIT = 10;
+
+// FTS5 MATCH has its own query grammar (AND, OR, NEAR, *, quotes). Raw user
+// input would be parsed as that grammar and could fail or change semantics,
+// so every token is double-quoted to force literal term matching.
+export function sanitizeFtsQuery(query: string): string {
+  const tokens = query.match(/[\p{L}\p{N}_]+/gu) || [];
+  return tokens.map(token => `"${token}"`).join(' OR ');
+}
+
+export async function createSearchIndex(db: Database): Promise<void> {
+  await db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS decisions_fts USING fts5(
+      context,
+      decision,
+      content='decisions',
+      content_rowid='id'
+    );
+    CREATE TRIGGER IF NOT EXISTS decisions_fts_after_insert AFTER INSERT ON decisions BEGIN
+      INSERT INTO decisions_fts(rowid, context, decision) VALUES (new.id, new.context, new.decision);
+    END;
+    CREATE TRIGGER IF NOT EXISTS decisions_fts_after_delete AFTER DELETE ON decisions BEGIN
+      INSERT INTO decisions_fts(decisions_fts, rowid, context, decision) VALUES ('delete', old.id, old.context, old.decision);
+    END;
+    CREATE TRIGGER IF NOT EXISTS decisions_fts_after_update AFTER UPDATE ON decisions BEGIN
+      INSERT INTO decisions_fts(decisions_fts, rowid, context, decision) VALUES ('delete', old.id, old.context, old.decision);
+      INSERT INTO decisions_fts(rowid, context, decision) VALUES (new.id, new.context, new.decision);
+    END;
+  `);
+}
+
+export async function rebuildSearchIndex(db: Database): Promise<void> {
+  await db.exec(`INSERT INTO decisions_fts(decisions_fts) VALUES ('rebuild')`);
+}
+
+// bm25() returns negative numbers where lower means more relevant. Scores are
+// normalized against the best match so callers get values in [0, 1], where a
+// near-zero score means the matched terms carry almost no IDF weight.
+export function rankResults(rows: RawSearchRow[]): RankedDecision[] {
+  if (rows.length === 0) return [];
+  const best = Math.max(...rows.map(row => -row.rawScore));
+  return rows.map(row => ({
+    id: row.id,
+    content: row.content,
+    context: row.context,
+    date: row.date,
+    score: best > 0 ? Math.round((-row.rawScore / best) * 100) / 100 : 0
+  }));
+}
+
+export async function searchDecisions(
+  db: Database,
+  query: string,
+  options: SearchOptions = {}
+): Promise<RankedDecision[]> {
+  const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
+  const minScore = options.minScore ?? 0;
+
+  const match = sanitizeFtsQuery(query);
+  if (!match) return [];
+
+  const rows: RawSearchRow[] = await db.all(
+    `SELECT d.id AS id,
+            d.decision AS content,
+            d.context AS context,
+            d.timestamp AS date,
+            bm25(decisions_fts) AS rawScore
+     FROM decisions_fts
+     JOIN decisions d ON d.id = decisions_fts.rowid
+     WHERE decisions_fts MATCH ?
+     ORDER BY rawScore
+     LIMIT ?`,
+    [match, limit]
+  );
+
+  return rankResults(rows).filter(result => result.score >= minScore);
+}

--- a/tests/scripts/egc-memory-search.test.js
+++ b/tests/scripts/egc-memory-search.test.js
@@ -1,0 +1,233 @@
+/**
+ * Tests for the egc-memory BM25 search module (SQLite FTS5).
+ *
+ * Imports the compiled CommonJS build and the sqlite driver bundled with the
+ * server. Skips with a clear message when the server has not been built yet.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const SERVER_ROOT = path.join(__dirname, '../../mcp/servers/egc-memory');
+const SEARCH_PATH = path.join(SERVER_ROOT, 'build', 'search.js');
+const SQLITE3_PATH = path.join(SERVER_ROOT, 'node_modules', 'sqlite3');
+const SQLITE_PATH = path.join(SERVER_ROOT, 'node_modules', 'sqlite');
+
+if (!fs.existsSync(SEARCH_PATH) || !fs.existsSync(SQLITE3_PATH) || !fs.existsSync(SQLITE_PATH)) {
+  console.error(
+    `[SKIP] Missing ${SEARCH_PATH} or server dependencies. Run 'npm ci && npm run build' in mcp/servers/egc-memory first.`
+  );
+  process.exit(0);
+}
+
+const {
+  sanitizeFtsQuery,
+  rankResults,
+  createSearchIndex,
+  rebuildSearchIndex,
+  searchDecisions,
+} = require(SEARCH_PATH);
+
+const sqlite3 = require(SQLITE3_PATH);
+const { open } = require(SQLITE_PATH);
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+async function openMemoryDb() {
+  const db = await open({ filename: ':memory:', driver: sqlite3.Database });
+  await db.exec(
+    'CREATE TABLE IF NOT EXISTS decisions (id INTEGER PRIMARY KEY AUTOINCREMENT, context TEXT, decision TEXT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP)'
+  );
+  return db;
+}
+
+async function insertDecision(db, context, decision) {
+  await db.run('INSERT INTO decisions (context, decision) VALUES (?, ?)', [context, decision]);
+}
+
+async function seedDecisions(db) {
+  await insertDecision(db, 'architecture', 'Chose JWT over server sessions for authentication because the API is stateless');
+  await insertDecision(db, 'architecture', 'Auth middleware handles refresh tokens via a rotating JWT secret');
+  await insertDecision(db, 'database', 'Use SQLite WAL mode to allow concurrent readers during writes');
+  await insertDecision(db, 'tooling', 'Adopt eslint flat config and drop the legacy rc format');
+}
+
+async function runTests() {
+  console.log('\n=== Testing egc-memory search (FTS5 BM25) ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('sanitizeFtsQuery quotes tokens and joins them with OR', async () => {
+    assert.strictEqual(sanitizeFtsQuery('authentication jwt'), '"authentication" OR "jwt"');
+    assert.strictEqual(sanitizeFtsQuery('sqlite'), '"sqlite"');
+  })) passed += 1; else failed += 1;
+
+  if (await test('sanitizeFtsQuery neutralizes FTS5 operators and punctuation', async () => {
+    assert.strictEqual(sanitizeFtsQuery('auth* AND (jwt NEAR token)'), '"auth" OR "AND" OR "jwt" OR "NEAR" OR "token"');
+    assert.strictEqual(sanitizeFtsQuery('"quoted" -minus ^caret'), '"quoted" OR "minus" OR "caret"');
+    assert.strictEqual(sanitizeFtsQuery('auth-token'), '"auth" OR "token"');
+  })) passed += 1; else failed += 1;
+
+  if (await test('sanitizeFtsQuery returns empty string when no tokens remain', async () => {
+    assert.strictEqual(sanitizeFtsQuery('   '), '');
+    assert.strictEqual(sanitizeFtsQuery('*** ()) --'), '');
+  })) passed += 1; else failed += 1;
+
+  if (await test('rankResults normalizes the best match to 1 and preserves order', async () => {
+    const ranked = rankResults([
+      { id: 1, content: 'a', context: 'x', date: 'd1', rawScore: -2.0 },
+      { id: 2, content: 'b', context: 'y', date: 'd2', rawScore: -1.0 },
+    ]);
+    assert.strictEqual(ranked.length, 2);
+    assert.strictEqual(ranked[0].id, 1);
+    assert.strictEqual(ranked[0].score, 1);
+    assert.strictEqual(ranked[1].score, 0.5);
+    assert.deepStrictEqual(rankResults([]), []);
+  })) passed += 1; else failed += 1;
+
+  if (await test('rebuild backfills decisions stored before the index existed', async () => {
+    const db = await openMemoryDb();
+    try {
+      await seedDecisions(db);
+      await createSearchIndex(db);
+      await rebuildSearchIndex(db);
+
+      const results = await searchDecisions(db, 'jwt authentication');
+      assert.ok(results.length >= 2);
+      assert.ok(results[0].content.includes('JWT'));
+      assert.strictEqual(results[0].score, 1);
+      for (const result of results) {
+        assert.strictEqual(typeof result.id, 'number');
+        assert.strictEqual(typeof result.content, 'string');
+        assert.strictEqual(typeof result.context, 'string');
+        assert.ok(result.date);
+        assert.ok(result.score >= 0 && result.score <= 1);
+      }
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  if (await test('results are ordered by descending relevance', async () => {
+    const db = await openMemoryDb();
+    try {
+      await createSearchIndex(db);
+      await seedDecisions(db);
+
+      const results = await searchDecisions(db, 'jwt refresh tokens');
+      assert.ok(results.length >= 2);
+      for (let i = 1; i < results.length; i += 1) {
+        assert.ok(results[i - 1].score >= results[i].score);
+      }
+      assert.ok(results[0].content.includes('refresh tokens'));
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  if (await test('triggers index new decisions incrementally without a rebuild', async () => {
+    const db = await openMemoryDb();
+    try {
+      await createSearchIndex(db);
+      await insertDecision(db, 'deployment', 'Ship the worker as a systemd unit instead of a cron job');
+
+      const results = await searchDecisions(db, 'systemd');
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0].context, 'deployment');
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  if (await test('triggers keep the index in sync on update and delete', async () => {
+    const db = await openMemoryDb();
+    try {
+      await createSearchIndex(db);
+      await insertDecision(db, 'cache', 'Use redis for the hot path cache');
+
+      await db.run('UPDATE decisions SET decision = ? WHERE context = ?', ['Use memcached for the hot path cache', 'cache']);
+      assert.strictEqual((await searchDecisions(db, 'redis')).length, 0);
+      assert.strictEqual((await searchDecisions(db, 'memcached')).length, 1);
+
+      await db.run('DELETE FROM decisions WHERE context = ?', ['cache']);
+      assert.strictEqual((await searchDecisions(db, 'memcached')).length, 0);
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  if (await test('respects the limit option', async () => {
+    const db = await openMemoryDb();
+    try {
+      await createSearchIndex(db);
+      await seedDecisions(db);
+
+      const results = await searchDecisions(db, 'jwt authentication tokens', { limit: 1 });
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0].score, 1);
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  if (await test('filters weak matches below min_score', async () => {
+    const db = await openMemoryDb();
+    try {
+      await createSearchIndex(db);
+      await seedDecisions(db);
+
+      const all = await searchDecisions(db, 'jwt refresh tokens');
+      const strong = await searchDecisions(db, 'jwt refresh tokens', { minScore: 0.99 });
+      assert.ok(strong.length < all.length);
+      assert.ok(strong.every(result => result.score >= 0.99));
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  if (await test('returns an empty list for no matches or token-free queries', async () => {
+    const db = await openMemoryDb();
+    try {
+      await createSearchIndex(db);
+      await seedDecisions(db);
+
+      assert.deepStrictEqual(await searchDecisions(db, 'kubernetes'), []);
+      assert.deepStrictEqual(await searchDecisions(db, '*** ()'), []);
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  if (await test('createSearchIndex is idempotent across reopens', async () => {
+    const db = await openMemoryDb();
+    try {
+      await createSearchIndex(db);
+      await createSearchIndex(db);
+      await insertDecision(db, 'idempotency', 'Index creation must be safe to run on every boot');
+
+      const results = await searchDecisions(db, 'idempotency boot');
+      assert.strictEqual(results.length, 1);
+    } finally {
+      await db.close();
+    }
+  })) passed += 1; else failed += 1;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
Closes #139

## Summary

New MCP tool `search_history(query, limit?, min_score?)` ranks decision history with SQLite FTS5 native bm25(), normalized to [0, 1].

- FTS5 virtual table with incremental sync triggers on insert/update/delete plus one-time backfill migration
- `sanitizeFtsQuery` prevents FTS5 grammar injection by quoting tokens
- Graceful fallback: server stays usable on SQLite builds without FTS5, the tool returns an explicit error instead of crashing
- 12 new tests; full suite 2285/2285 green, lint 0 errors

## Test plan

- `node tests/scripts/egc-memory-search.test.js`: 12/12
- `npm test`: 2285/2285
- `npm run lint`: 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `search_history(query, limit?, min_score?)` to `egc-memory`, using SQLite FTS5 BM25 to rank decision history and return normalized scores in [0, 1]. Helps quickly find past decisions by keyword; falls back cleanly if FTS5 isn’t available. Closes #139.

- **New Features**
  - FTS5 virtual table over `decisions` with triggers for insert/update/delete.
  - BM25 ranking with scores normalized to [0, 1].
  - `sanitizeFtsQuery` quotes tokens to avoid FTS5 grammar injection.
  - Tool registered in manifests and docs: `search_history` now listed.

- **Migration**
  - Migration v2 creates the FTS5 index and backfills existing rows.
  - Idempotent on boot; if FTS5 is missing, only `search_history` returns a clear error while the server stays usable.

<sup>Written for commit 0a1a7f54dc57803a613ca24bc5d8df9c9ea235e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

