### PR TITLE
feat: state consolidation pipeline with rule-based layering

### DIFF
--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  DEFAULT_THRESHOLD,
+  WORKING_WINDOW_DAYS,
+  EPISODIC_WINDOW_DAYS,
+  stateFilePath,
+  consolidateState,
+  backupStateFile,
+} = require('./lib/state-consolidate');
+
+function showHelp(exitCode = 0) {
+  console.log(`
+Usage: node scripts/consolidate.js [--dry-run] [--force] [--json] [--project <path>] [--threshold <lines>]
+
+Compact the project state file (~/.egc/state/<slug>.md) when it grows past a
+line threshold (default: ${DEFAULT_THRESHOLD}, override with --threshold or the
+EGC_CONSOLIDATE_THRESHOLD environment variable).
+
+Rule-based layering by entry age:
+  Working layer   last ${WORKING_WINDOW_DAYS} days, kept verbatim
+  Episodic layer  last ${EPISODIC_WINDOW_DAYS} days, summarized per week
+  Semantic layer  older entries, condensed to core facts
+
+Entry dates are extracted from the entry text (YYYY-MM-DD or DD/MM/YYYY).
+Entries without a recognizable date are treated as semantic layer. The
+Context and Next Session sections are never layered, only deduplicated.
+
+The original file is always copied to ~/.egc/state/archive/ before rewrite.
+
+Options:
+  --dry-run            Preview the consolidated output without writing
+  --force              Consolidate even when below the threshold
+  --json               Emit a machine-readable report
+  --project <path>     Project root (defaults to the current directory)
+  --threshold <lines>  Line count that triggers consolidation
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const parsed = {
+    dryRun: false,
+    force: false,
+    json: false,
+    project: null,
+    threshold: null,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--force') {
+      parsed.force = true;
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--project') {
+      parsed.project = args[index + 1] || null;
+      index += 1;
+    } else if (arg === '--threshold') {
+      parsed.threshold = Number.parseInt(args[index + 1], 10);
+      if (!Number.isInteger(parsed.threshold) || parsed.threshold < 1) {
+        throw new Error(`Invalid threshold: ${args[index + 1]}`);
+      }
+      index += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function resolveThreshold(options) {
+  if (options.threshold) return options.threshold;
+
+  const fromEnv = Number.parseInt(process.env.EGC_CONSOLIDATE_THRESHOLD || '', 10);
+  if (Number.isInteger(fromEnv) && fromEnv >= 1) return fromEnv;
+
+  return DEFAULT_THRESHOLD;
+}
+
+function printHuman(report) {
+  console.log('State consolidation report:\n');
+  console.log(`- Project: ${report.project}`);
+  console.log(`- State file: ${report.stateFile}`);
+
+  if (report.status === 'missing') {
+    console.log('- Status: MISSING (no state file for this project yet)');
+    return;
+  }
+
+  if (report.status === 'skipped') {
+    console.log(`- Status: SKIPPED (${report.linesBefore} lines, threshold ${report.threshold})`);
+    console.log('- Nothing to consolidate. Use --force to run anyway.');
+    return;
+  }
+
+  console.log(`- Status: ${report.dryRun ? 'DRY-RUN' : 'CONSOLIDATED'}`);
+  console.log(`- Lines: ${report.linesBefore} before, ${report.linesAfter} after (threshold ${report.threshold})`);
+  console.log(`- Working entries kept verbatim: ${report.stats.workingKept}`);
+  console.log(`- Episodic weeks summarized: ${report.stats.episodicWeeks}`);
+  console.log(`- Semantic facts condensed: ${report.stats.semanticFacts}`);
+  console.log(`- Duplicates removed: ${report.stats.duplicatesRemoved}`);
+
+  if (report.backup) {
+    console.log(`- Backup: ${report.backup}`);
+  }
+
+  if (report.dryRun) {
+    console.log('\nPreview of consolidated state:\n');
+    console.log(report.output);
+  }
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv);
+    if (options.help) {
+      showHelp(0);
+    }
+
+    const homeDir = process.env.HOME || os.homedir();
+    const project = path.resolve(options.project || process.cwd());
+    const stateFile = stateFilePath(homeDir, project);
+    const threshold = resolveThreshold(options);
+
+    const report = {
+      project,
+      stateFile,
+      threshold,
+      dryRun: options.dryRun,
+      status: 'skipped',
+      backup: null,
+    };
+
+    if (!fs.existsSync(stateFile)) {
+      report.status = 'missing';
+      if (options.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printHuman(report);
+      }
+      return;
+    }
+
+    const content = fs.readFileSync(stateFile, 'utf8');
+    const result = consolidateState(content, { threshold });
+
+    report.linesBefore = result.linesBefore;
+    report.linesAfter = result.linesAfter;
+    report.stats = result.stats;
+
+    if (!result.needed && !options.force) {
+      if (options.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printHuman(report);
+      }
+      return;
+    }
+
+    report.status = options.dryRun ? 'dry-run' : 'consolidated';
+
+    if (options.dryRun) {
+      report.output = result.output;
+    } else {
+      report.backup = backupStateFile(homeDir, stateFile);
+      fs.writeFileSync(stateFile, result.output, 'utf8');
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      printHuman({ ...report, output: result.output });
+    }
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -62,7 +62,11 @@ function parseArgs(argv) {
     } else if (arg === '--json') {
       parsed.json = true;
     } else if (arg === '--project') {
-      parsed.project = args[index + 1] || null;
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('Missing value for --project');
+      }
+      parsed.project = value;
       index += 1;
     } else if (arg === '--threshold') {
       parsed.threshold = Number.parseInt(args[index + 1], 10);

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -27,6 +27,10 @@ const COMMANDS = {
     script: 'consult.js',
     description: 'Recommend EGC components and profiles from a natural language query',
   },
+  consolidate: {
+    script: 'consolidate.js',
+    description: 'Compact oversized project state files into layered summaries',
+  },
   'install-plan': {
     script: 'install-plan.js',
     description: 'Alias for plan',
@@ -79,6 +83,7 @@ const PRIMARY_COMMANDS = [
   'plan',
   'catalog',
   'consult',
+  'consolidate',
   'list-installed',
   'doctor',
   'repair',
@@ -120,6 +125,7 @@ Examples:
   egc catalog components --family language
   egc catalog show framework:nextjs
   egc consult "security reviews"
+  egc consolidate --dry-run
   egc list-installed --json
   egc doctor --target cursor
   egc repair --dry-run

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -1,0 +1,290 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_THRESHOLD = 40;
+const WORKING_WINDOW_DAYS = 7;
+const EPISODIC_WINDOW_DAYS = 30;
+const SEMANTIC_FACTS_PER_LINE = 3;
+
+// Sections that hold the active queue or freeform context. They are never
+// layered by age: rewriting them would erase actionable short-term memory.
+const VERBATIM_SECTIONS = new Set(['Context', 'Next Session']);
+
+const ISO_DATE_RE = /\b(\d{4})-(\d{2})-(\d{2})\b/;
+const BR_DATE_RE = /\b(\d{2})\/(\d{2})\/(\d{4})\b/;
+
+function projectSlug(projectPath) {
+  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+function stateDir(homeDir) {
+  return path.join(homeDir, '.egc', 'state');
+}
+
+function stateFilePath(homeDir, projectPath) {
+  return path.join(stateDir(homeDir), `${projectSlug(projectPath)}.md`);
+}
+
+function archiveDir(homeDir) {
+  return path.join(stateDir(homeDir), 'archive');
+}
+
+function buildDate(year, month, day) {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) return null;
+  return date;
+}
+
+function extractEntryDate(text) {
+  const iso = text.match(ISO_DATE_RE);
+  if (iso) {
+    const date = buildDate(Number(iso[1]), Number(iso[2]), Number(iso[3]));
+    if (date) return date;
+  }
+
+  const br = text.match(BR_DATE_RE);
+  if (br) {
+    const date = buildDate(Number(br[3]), Number(br[2]), Number(br[1]));
+    if (date) return date;
+  }
+
+  return null;
+}
+
+function ageInDays(date, now) {
+  const diff = now.getTime() - date.getTime();
+  if (diff < 0) return 0;
+  return diff / (24 * 60 * 60 * 1000);
+}
+
+function classifyEntry(text, now) {
+  const date = extractEntryDate(text);
+  if (!date) return { layer: 'semantic', date: null };
+
+  const age = ageInDays(date, now);
+  if (age <= WORKING_WINDOW_DAYS) return { layer: 'working', date };
+  if (age <= EPISODIC_WINDOW_DAYS) return { layer: 'episodic', date };
+  return { layer: 'semantic', date };
+}
+
+function weekStart(date) {
+  const result = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const mondayOffset = (result.getUTCDay() + 6) % 7;
+  result.setUTCDate(result.getUTCDate() - mondayOffset);
+  return result;
+}
+
+function formatDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function normalizeKey(text) {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/[.,;:!?]+$/g, '')
+    .trim();
+}
+
+function stripDateTokens(text) {
+  return text
+    .replace(/[([]?\s*\d{4}-\d{2}-\d{2}\s*[)\]]?/g, ' ')
+    .replace(/[([]?\s*\d{2}\/\d{2}\/\d{4}\s*[)\]]?/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/^[\s:,-]+|[\s:,-]+$/g, '')
+    .trim();
+}
+
+// Entries follow the "what: why" shape produced by update_state. The rationale
+// is dropped only when the "what" part is long enough to stand alone, so short
+// prefixes like "fix: lint" are kept whole.
+function coreFact(text) {
+  const cleaned = stripDateTokens(text);
+  const separator = cleaned.indexOf(': ');
+  if (separator >= 12) return cleaned.slice(0, separator).trim();
+  return cleaned;
+}
+
+function chunk(items, size) {
+  const groups = [];
+  for (let index = 0; index < items.length; index += size) {
+    groups.push(items.slice(index, index + size));
+  }
+  return groups;
+}
+
+function parseStateDocument(content) {
+  const lines = content.split('\n');
+  const header = [];
+  const sections = [];
+  let current = null;
+
+  for (const line of lines) {
+    const heading = line.match(/^## (.+)$/);
+    if (heading) {
+      current = { title: heading[1].trim(), lines: [] };
+      sections.push(current);
+      continue;
+    }
+    if (!current) {
+      header.push(line);
+      continue;
+    }
+    current.lines.push(line);
+  }
+
+  while (header.length > 0 && header[header.length - 1].trim() === '') {
+    header.pop();
+  }
+
+  return { header, sections };
+}
+
+function consolidateSection(section, now, stats) {
+  const bodyLines = section.lines.filter(line => line.trim() !== '');
+
+  if (VERBATIM_SECTIONS.has(section.title) || bodyLines.some(line => !line.startsWith('- '))) {
+    const seen = new Set();
+    const kept = [];
+    for (const line of bodyLines) {
+      const key = normalizeKey(line.replace(/^- /, ''));
+      if (seen.has(key)) {
+        stats.duplicatesRemoved += 1;
+        continue;
+      }
+      seen.add(key);
+      kept.push(line);
+    }
+    return kept;
+  }
+
+  const seen = new Set();
+  const working = [];
+  const episodicByWeek = new Map();
+  const semantic = [];
+
+  for (const line of bodyLines) {
+    const text = line.replace(/^- /, '').trim();
+    const key = normalizeKey(text);
+    if (seen.has(key)) {
+      stats.duplicatesRemoved += 1;
+      continue;
+    }
+    seen.add(key);
+
+    const { layer, date } = classifyEntry(text, now);
+    if (layer === 'working') {
+      working.push(line);
+      stats.workingKept += 1;
+    } else if (layer === 'episodic') {
+      const week = formatDate(weekStart(date));
+      if (!episodicByWeek.has(week)) episodicByWeek.set(week, []);
+      episodicByWeek.get(week).push(coreFact(text));
+    } else {
+      semantic.push(coreFact(text));
+    }
+  }
+
+  const output = [...working];
+
+  const weeks = [...episodicByWeek.keys()].sort().reverse();
+  for (const week of weeks) {
+    output.push(`- Week of ${week}: ${episodicByWeek.get(week).join('; ')}`);
+    stats.episodicWeeks += 1;
+  }
+
+  const semanticDeduped = [];
+  const semanticSeen = new Set();
+  for (const fact of semantic) {
+    const key = normalizeKey(fact);
+    if (!fact || semanticSeen.has(key)) {
+      if (fact) stats.duplicatesRemoved += 1;
+      continue;
+    }
+    semanticSeen.add(key);
+    semanticDeduped.push(fact);
+  }
+
+  for (const group of chunk(semanticDeduped, SEMANTIC_FACTS_PER_LINE)) {
+    output.push(`- ${group.join('; ')}`);
+  }
+  stats.semanticFacts += semanticDeduped.length;
+
+  return output;
+}
+
+function renderDocument(header, sectionOutputs) {
+  const lines = [...header, ''];
+  for (const section of sectionOutputs) {
+    lines.push(`## ${section.title}`);
+    lines.push(...section.lines);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function countLines(content) {
+  return content.split('\n').length;
+}
+
+function consolidateState(content, options = {}) {
+  const now = options.now || new Date();
+  const threshold = options.threshold || DEFAULT_THRESHOLD;
+
+  const stats = {
+    workingKept: 0,
+    episodicWeeks: 0,
+    semanticFacts: 0,
+    duplicatesRemoved: 0,
+  };
+
+  const linesBefore = countLines(content);
+  const needed = linesBefore > threshold;
+
+  const { header, sections } = parseStateDocument(content);
+  const sectionOutputs = sections.map(section => ({
+    title: section.title,
+    lines: consolidateSection(section, now, stats),
+  }));
+
+  const output = renderDocument(header, sectionOutputs);
+
+  return {
+    needed,
+    threshold,
+    linesBefore,
+    linesAfter: countLines(output),
+    output,
+    stats,
+  };
+}
+
+function backupStateFile(homeDir, filePath, now = new Date()) {
+  const dir = archiveDir(homeDir);
+  fs.mkdirSync(dir, { recursive: true });
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  const base = path.basename(filePath, '.md');
+  const backupPath = path.join(dir, `${base}.${stamp}.md`);
+  fs.copyFileSync(filePath, backupPath);
+  return backupPath;
+}
+
+module.exports = {
+  DEFAULT_THRESHOLD,
+  WORKING_WINDOW_DAYS,
+  EPISODIC_WINDOW_DAYS,
+  projectSlug,
+  stateFilePath,
+  archiveDir,
+  extractEntryDate,
+  classifyEntry,
+  weekStart,
+  coreFact,
+  parseStateDocument,
+  consolidateState,
+  backupStateFile,
+};

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -85,8 +85,8 @@ function formatDate(date) {
 const TRAILING_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?']);
 const EDGE_FILLER = new Set([' ', '\t', ':', ',', '-']);
 
-// Character-by-character trimming avoids the anchored +$ regexes that
-// SonarCloud flags as vulnerable to super-linear backtracking.
+// Trimming scans characters instead of using anchored +$ regexes,
+// which backtrack super-linearly on crafted input.
 function trimTrailingChars(text, chars) {
   let end = text.length;
   while (end > 0 && chars.has(text[end - 1])) end -= 1;
@@ -108,8 +108,9 @@ function normalizeKey(text) {
 
 function stripDateTokens(text) {
   const withoutDates = text
-    .replace(/[([]?\d{4}-\d{2}-\d{2}[)\]]?/g, ' ')
-    .replace(/[([]?\d{2}\/\d{2}\/\d{4}[)\]]?/g, ' ')
+    .replace(/\d{4}-\d{2}-\d{2}/g, ' ')
+    .replace(/\d{2}\/\d{2}\/\d{4}/g, ' ')
+    .replace(/[([] *[)\]]/g, ' ')
     .replace(/\s+/g, ' ');
   return trimEdgeChars(withoutDates, EDGE_FILLER).trim();
 }

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -82,21 +82,36 @@ function formatDate(date) {
   return date.toISOString().slice(0, 10);
 }
 
+const TRAILING_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?']);
+const EDGE_FILLER = new Set([' ', '\t', ':', ',', '-']);
+
+// Character-by-character trimming avoids the anchored +$ regexes that
+// SonarCloud flags as vulnerable to super-linear backtracking.
+function trimTrailingChars(text, chars) {
+  let end = text.length;
+  while (end > 0 && chars.has(text[end - 1])) end -= 1;
+  return text.slice(0, end);
+}
+
+function trimEdgeChars(text, chars) {
+  let start = 0;
+  let end = text.length;
+  while (start < end && chars.has(text[start])) start += 1;
+  while (end > start && chars.has(text[end - 1])) end -= 1;
+  return text.slice(start, end);
+}
+
 function normalizeKey(text) {
-  return text
-    .toLowerCase()
-    .replace(/\s+/g, ' ')
-    .replace(/[.,;:!?]+$/g, '')
-    .trim();
+  const collapsed = text.toLowerCase().replace(/\s+/g, ' ');
+  return trimTrailingChars(collapsed, TRAILING_PUNCTUATION).trim();
 }
 
 function stripDateTokens(text) {
-  return text
-    .replace(/[([]?\s*\d{4}-\d{2}-\d{2}\s*[)\]]?/g, ' ')
-    .replace(/[([]?\s*\d{2}\/\d{2}\/\d{4}\s*[)\]]?/g, ' ')
-    .replace(/\s+/g, ' ')
-    .replace(/^[\s:,-]+|[\s:,-]+$/g, '')
-    .trim();
+  const withoutDates = text
+    .replace(/[([]?\d{4}-\d{2}-\d{2}[)\]]?/g, ' ')
+    .replace(/[([]?\d{2}\/\d{2}\/\d{4}[)\]]?/g, ' ')
+    .replace(/\s+/g, ' ');
+  return trimEdgeChars(withoutDates, EDGE_FILLER).trim();
 }
 
 // Entries follow the "what: why" shape produced by update_state. The rationale
@@ -191,7 +206,7 @@ function consolidateSection(section, now, stats) {
 
   const output = [...working];
 
-  const weeks = [...episodicByWeek.keys()].sort().reverse();
+  const weeks = [...episodicByWeek.keys()].sort((a, b) => a.localeCompare(b)).reverse();
   for (const week of weeks) {
     output.push(`- Week of ${week}: ${episodicByWeek.get(week).join('; ')}`);
     stats.episodicWeeks += 1;

--- a/tests/scripts/consolidate.test.js
+++ b/tests/scripts/consolidate.test.js
@@ -1,0 +1,318 @@
+/**
+ * Tests for scripts/consolidate.js and scripts/lib/state-consolidate.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'consolidate.js');
+const {
+  stateFilePath,
+  archiveDir,
+  weekStart,
+  extractEntryDate,
+  classifyEntry,
+  coreFact,
+} = require('../../scripts/lib/state-consolidate');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function daysAgo(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function weekLabel(isoDate) {
+  return weekStart(new Date(`${isoDate}T00:00:00Z`)).toISOString().slice(0, 10);
+}
+
+function writeState(homeDir, projectDir, content) {
+  const filePath = stateFilePath(homeDir, projectDir);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
+
+function sampleState(projectDir) {
+  const recent = daysAgo(2);
+  const episodic = daysAgo(15);
+  const old = daysAgo(60);
+
+  return [
+    '# Project State',
+    `project: ${projectDir}`,
+    'updated: 2026-06-12T10:00:00.000Z',
+    '',
+    '## Context',
+    'EGC memory pipeline, stabilization phase.',
+    '',
+    '## Active Decisions',
+    `- Adopted layered consolidation (${recent}): keeps state under control`,
+    `- Adopted SQLite WAL journaling mode (${episodic}): avoids lock errors`,
+    `- Standardized error logging format (${episodic}): JSON lines on stderr`,
+    `- Chose Node 20 as minimum runtime baseline (${old}): matches LTS schedule`,
+    '- Project uses CommonJS modules everywhere',
+    '- Project uses CommonJS modules everywhere',
+    '',
+    '## Do Not Repeat',
+    `- Editing install-state by hand corrupted doctor output (${old})`,
+    '- Running npm install without ci flag drifted the lockfile',
+    '',
+    '## Preferences',
+    '- Conventional commit messages',
+    '',
+    '## Next Session',
+    '- Review consolidation output with real state files',
+    '',
+  ].join('\n');
+}
+
+function run(args = [], options = {}) {
+  const env = {
+    ...process.env,
+    HOME: options.homeDir || process.env.HOME,
+    USERPROFILE: options.homeDir || process.env.USERPROFILE || process.env.HOME,
+  };
+  delete env.EGC_CONSOLIDATE_THRESHOLD;
+  Object.assign(env, options.env || {});
+
+  try {
+    const stdout = execFileSync('node', [SCRIPT, ...args], {
+      cwd: options.cwd,
+      env,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: process.platform === 'win32' ? 30000 : 10000,
+    });
+
+    return { code: 0, stdout, stderr: '' };
+  } catch (error) {
+    return {
+      code: error.status || 1,
+      stdout: error.stdout || '',
+      stderr: error.stderr || '',
+    };
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing consolidate.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('extracts ISO and BR dates, ignores invalid ones', () => {
+    assert.strictEqual(extractEntryDate('done (2026-06-01)').toISOString().slice(0, 10), '2026-06-01');
+    assert.strictEqual(extractEntryDate('done em 01/06/2026').toISOString().slice(0, 10), '2026-06-01');
+    assert.strictEqual(extractEntryDate('checked 2026-13-40 invalid'), null);
+    assert.strictEqual(extractEntryDate('no date here'), null);
+  })) passed++; else failed++;
+
+  if (test('classifies entries into working, episodic, and semantic layers', () => {
+    const now = new Date();
+    assert.strictEqual(classifyEntry(`x (${daysAgo(2)})`, now).layer, 'working');
+    assert.strictEqual(classifyEntry(`x (${daysAgo(15)})`, now).layer, 'episodic');
+    assert.strictEqual(classifyEntry(`x (${daysAgo(60)})`, now).layer, 'semantic');
+    assert.strictEqual(classifyEntry('x without date', now).layer, 'semantic');
+  })) passed++; else failed++;
+
+  if (test('coreFact drops the rationale but keeps short prefixes whole', () => {
+    assert.strictEqual(coreFact('Adopted SQLite WAL journaling (2026-05-01): avoids lock errors'), 'Adopted SQLite WAL journaling');
+    assert.strictEqual(coreFact('fix: lint errors'), 'fix: lint errors');
+  })) passed++; else failed++;
+
+  if (test('skips files below the threshold', () => {
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      const filePath = writeState(homeDir, projectDir, sampleState(projectDir));
+      const before = fs.readFileSync(filePath, 'utf8');
+
+      const result = run(['--project', projectDir], { homeDir, cwd: projectDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('SKIPPED'));
+      assert.strictEqual(fs.readFileSync(filePath, 'utf8'), before);
+      assert.ok(!fs.existsSync(archiveDir(homeDir)));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('dry-run previews without touching the state file', () => {
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      const filePath = writeState(homeDir, projectDir, sampleState(projectDir));
+      const before = fs.readFileSync(filePath, 'utf8');
+
+      const result = run(['--project', projectDir, '--threshold', '10', '--dry-run'], { homeDir, cwd: projectDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('DRY-RUN'));
+      assert.ok(result.stdout.includes('Preview of consolidated state'));
+      assert.ok(result.stdout.includes('## Active Decisions'));
+      assert.strictEqual(fs.readFileSync(filePath, 'utf8'), before);
+      assert.ok(!fs.existsSync(archiveDir(homeDir)));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('consolidates oversized state with backup and layered output', () => {
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      const filePath = writeState(homeDir, projectDir, sampleState(projectDir));
+      const before = fs.readFileSync(filePath, 'utf8');
+
+      const result = run(['--project', projectDir, '--threshold', '10'], { homeDir, cwd: projectDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('CONSOLIDATED'));
+
+      const backups = fs.readdirSync(archiveDir(homeDir));
+      assert.strictEqual(backups.length, 1);
+      const backupContent = fs.readFileSync(path.join(archiveDir(homeDir), backups[0]), 'utf8');
+      assert.strictEqual(backupContent, before);
+
+      const after = fs.readFileSync(filePath, 'utf8');
+
+      for (const heading of ['## Context', '## Active Decisions', '## Do Not Repeat', '## Preferences', '## Next Session']) {
+        assert.ok(after.includes(heading), `missing heading ${heading}`);
+      }
+
+      assert.ok(after.includes(`- Adopted layered consolidation (${daysAgo(2)}): keeps state under control`));
+
+      const expectedWeek = weekLabel(daysAgo(15));
+      assert.ok(after.includes(`- Week of ${expectedWeek}: Adopted SQLite WAL journaling mode; Standardized error logging format`));
+      assert.ok(!after.includes('avoids lock errors'));
+
+      assert.ok(after.includes('Chose Node 20 as minimum runtime baseline'));
+      assert.ok(!after.includes('matches LTS schedule'));
+      assert.ok(after.includes('Project uses CommonJS modules everywhere'));
+
+      assert.ok(after.includes('- Review consolidation output with real state files'));
+
+      assert.ok(after.split('\n').length < before.split('\n').length);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('emits a JSON report with stats and backup path', () => {
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      writeState(homeDir, projectDir, sampleState(projectDir));
+
+      const result = run(['--project', projectDir, '--threshold', '10', '--json'], { homeDir, cwd: projectDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+
+      const report = JSON.parse(result.stdout);
+      assert.strictEqual(report.status, 'consolidated');
+      assert.ok(report.linesBefore > report.linesAfter);
+      assert.strictEqual(report.stats.workingKept, 1);
+      assert.strictEqual(report.stats.episodicWeeks, 1);
+      assert.ok(report.stats.semanticFacts >= 3);
+      assert.ok(report.stats.duplicatesRemoved >= 1);
+      assert.ok(fs.existsSync(report.backup));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('force consolidates a file below the threshold', () => {
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      const filePath = writeState(homeDir, projectDir, sampleState(projectDir));
+
+      const result = run(['--project', projectDir, '--force'], { homeDir, cwd: projectDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('CONSOLIDATED'));
+      assert.strictEqual(fs.readdirSync(archiveDir(homeDir)).length, 1);
+      assert.ok(fs.readFileSync(filePath, 'utf8').includes('## Active Decisions'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('reports missing state file without failing', () => {
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      const result = run(['--project', projectDir], { homeDir, cwd: projectDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('MISSING'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('honors the EGC_CONSOLIDATE_THRESHOLD environment variable', () => {
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      writeState(homeDir, projectDir, sampleState(projectDir));
+
+      const result = run(['--project', projectDir], {
+        homeDir,
+        cwd: projectDir,
+        env: { EGC_CONSOLIDATE_THRESHOLD: '10' },
+      });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('CONSOLIDATED'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('rejects unknown arguments', () => {
+    const result = run(['--bogus']);
+    assert.strictEqual(result.code, 1);
+    assert.ok(result.stderr.includes('Unknown argument'));
+  })) passed++; else failed++;
+
+  if (test('rejects an invalid threshold', () => {
+    const result = run(['--threshold', 'abc']);
+    assert.strictEqual(result.code, 1);
+    assert.ok(result.stderr.includes('Invalid threshold'));
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/consolidate.test.js
+++ b/tests/scripts/consolidate.test.js
@@ -311,6 +311,22 @@ function runTests() {
     assert.ok(result.stderr.includes('Invalid threshold'));
   })) passed++; else failed++;
 
+  if (test('rejects --project without a value', () => {
+    const result = run(['--project']);
+    assert.strictEqual(result.code, 1);
+    assert.ok(result.stderr.includes('Missing value for --project'));
+
+    const followedByFlag = run(['--project', '--dry-run']);
+    assert.strictEqual(followedByFlag.code, 1);
+    assert.ok(followedByFlag.stderr.includes('Missing value for --project'));
+  })) passed++; else failed++;
+
+  if (test('strips bracketed dates with surrounding spaces', () => {
+    assert.strictEqual(coreFact('Chose SQLite ( 2026-01-15 ) for storage'), 'Chose SQLite for storage');
+    assert.strictEqual(coreFact('Chose SQLite [ 12/01/2026 ] for storage'), 'Chose SQLite for storage');
+    assert.strictEqual(coreFact('Chose SQLite (2026-01-15) for storage'), 'Chose SQLite for storage');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/egc.test.js
+++ b/tests/scripts/egc.test.js
@@ -74,6 +74,7 @@ function main() {
       assert.match(result.stdout, /doctor/);
       assert.match(result.stdout, /auto-update/);
       assert.match(result.stdout, /consult/);
+      assert.match(result.stdout, /consolidate/);
       assert.match(result.stdout, /loop-status/);
     }],
     ['prints package version with --version', () => {


### PR DESCRIPTION
Closes #143

## Summary

`egc consolidate` compacts oversized state.md files in three layers, rule-based and local-first (no LLM dependency in this delivery):

| Layer | Window | Treatment |
|---|---|---|
| Working | up to 7 days | kept verbatim |
| Episodic | 8 to 30 days | one bullet per week |
| Semantic | older or undated | core facts, grouped |

- `--dry-run`, `--force`, `--json`, `--threshold` (default 40 lines, env `EGC_CONSOLIDATE_THRESHOLD`)
- Backup written before any rewrite; Context and Next Session sections never layered, only deduplicated
- 12 new tests; full suite 2285/2285 green, lint 0 errors

## Test plan

- `node tests/scripts/consolidate.test.js`: 12/12
- `npm test`: 2285/2285
- `npm run lint`: 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `egc consolidate` to compact oversized project state files with a rule-based, local-first pipeline. Addresses #143 by keeping recent work intact and summarizing older notes to reduce noise.

- **New Features**
  - Three layers by age: Working (≤7 days) kept verbatim; Episodic (≤30 days) summarized per week; Semantic (older/undated) condensed to core facts (3 per line).
  - Dates parsed from entry text (`YYYY-MM-DD`, `DD/MM/YYYY`); undated entries go to the semantic layer.
  - `Context` and `Next Session` are preserved; duplicates across sections are removed.
  - Flags `--dry-run`, `--force`, `--json`, `--project`, `--threshold` (default 40 or env `EGC_CONSOLIDATE_THRESHOLD`); automatic backup to `~/.egc/state/archive/`; command registered in `scripts/egc.js`; 12 tests added.

- **Bug Fixes**
  - Replaced backtracking-prone regex trims with character-level helpers and added an explicit week sort comparator for stable, safe layering.
  - Validates `--project` requires a value (fails fast) and restores stripping of spaced bracketed dates (e.g., `( 2026-01-15 )`).

<sup>Written for commit ea159a39306e5adc829feab1c25082392208a4c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

