### PR TITLE
feat(memory): scope project state per git branch

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -3,3 +3,4 @@ sonar.tests=tests
 sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,**/*.tgz,**/legacy-command-shims/**
 sonar.test.inclusions=tests/**/*.js,tests/**/*.ts
 sonar.sourceEncoding=UTF-8
+sonar.cpd.exclusions=scripts/lib/branch-state.js,mcp/servers/egc-memory/src/branch-state.ts

--- a/mcp/servers/egc-memory/src/branch-state.ts
+++ b/mcp/servers/egc-memory/src/branch-state.ts
@@ -20,8 +20,8 @@ export function sanitizeBranchName(branch: string): string {
   return branch.replace(/\//g, '-').replace(/[^a-zA-Z0-9-_]/g, '_');
 }
 
-// Reads .git/HEAD directly instead of spawning git: avoids PATH lookup
-// (SonarCloud S4036) and works without git installed.
+// Branch detection reads .git/HEAD instead of spawning git: no PATH
+// lookup and it works on machines without git installed.
 function findGitDir(startPath: string): string | null {
   let current = path.resolve(startPath);
   for (;;) {

--- a/mcp/servers/egc-memory/src/branch-state.ts
+++ b/mcp/servers/egc-memory/src/branch-state.ts
@@ -1,0 +1,74 @@
+import path from 'path';
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+export const DEFAULT_BRANCH_FILE = 'main.md';
+
+export type StateSource = 'branch' | 'default-branch' | 'flat' | 'none';
+
+export interface ResolvedState {
+  filePath: string;
+  source: StateSource;
+  branch: string | null;
+}
+
+export function projectSlug(projectPath: string): string {
+  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+export function sanitizeBranchName(branch: string): string {
+  return branch.replace(/\//g, '-').replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+export function detectBranch(projectPath: string): string | null {
+  try {
+    const output = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: projectPath,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim();
+    // Detached HEAD reports the literal string "HEAD"; treat it as no branch
+    if (!output || output === 'HEAD') return null;
+    return output;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function flatStateFile(stateDir: string, projectPath: string): string {
+  return path.join(stateDir, `${projectSlug(projectPath)}.md`);
+}
+
+export function branchStateFile(stateDir: string, projectPath: string, branch: string): string {
+  return path.join(stateDir, projectSlug(projectPath), `${sanitizeBranchName(branch)}.md`);
+}
+
+export function resolveStateRead(stateDir: string, projectPath: string, branch: string | null): ResolvedState {
+  if (branch) {
+    const branchFile = branchStateFile(stateDir, projectPath, branch);
+    if (fs.existsSync(branchFile)) {
+      return { filePath: branchFile, source: 'branch', branch };
+    }
+    const defaultFile = path.join(stateDir, projectSlug(projectPath), DEFAULT_BRANCH_FILE);
+    if (fs.existsSync(defaultFile)) {
+      return { filePath: defaultFile, source: 'default-branch', branch };
+    }
+  }
+
+  const flatFile = flatStateFile(stateDir, projectPath);
+  if (fs.existsSync(flatFile)) {
+    return { filePath: flatFile, source: 'flat', branch: branch || null };
+  }
+
+  return {
+    filePath: branch ? branchStateFile(stateDir, projectPath, branch) : flatFile,
+    source: 'none',
+    branch: branch || null,
+  };
+}
+
+export function resolveStateWrite(stateDir: string, projectPath: string, branch: string | null): string {
+  if (branch) return branchStateFile(stateDir, projectPath, branch);
+  return flatStateFile(stateDir, projectPath);
+}

--- a/mcp/servers/egc-memory/src/branch-state.ts
+++ b/mcp/servers/egc-memory/src/branch-state.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs';
-import { execSync } from 'child_process';
 
 export const DEFAULT_BRANCH_FILE = 'main.md';
 
@@ -21,16 +20,34 @@ export function sanitizeBranchName(branch: string): string {
   return branch.replace(/\//g, '-').replace(/[^a-zA-Z0-9-_]/g, '_');
 }
 
+// Reads .git/HEAD directly instead of spawning git: avoids PATH lookup
+// (SonarCloud S4036) and works without git installed.
+function findGitDir(startPath: string): string | null {
+  let current = path.resolve(startPath);
+  for (;;) {
+    const candidate = path.join(current, '.git');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
 export function detectBranch(projectPath: string): string | null {
   try {
-    const output = execSync('git rev-parse --abbrev-ref HEAD', {
-      cwd: projectPath,
-      stdio: ['ignore', 'pipe', 'ignore'],
-      encoding: 'utf8',
-    }).trim();
-    // Detached HEAD reports the literal string "HEAD"; treat it as no branch
-    if (!output || output === 'HEAD') return null;
-    return output;
+    let gitDir = findGitDir(projectPath);
+    if (!gitDir) return null;
+    if (fs.statSync(gitDir).isFile()) {
+      // Worktrees and submodules store a pointer file instead of a directory
+      const pointer = fs.readFileSync(gitDir, 'utf8').trim();
+      if (!pointer.startsWith('gitdir:')) return null;
+      gitDir = path.resolve(path.dirname(gitDir), pointer.slice('gitdir:'.length).trim());
+    }
+    const head = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
+    const refPrefix = 'ref: refs/heads/';
+    // Detached HEAD stores a bare commit hash; treat it as no branch
+    if (!head.startsWith(refPrefix)) return null;
+    return head.slice(refPrefix.length) || null;
   } catch (_) {
     return null;
   }

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions } from './search.js';
+import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
 
 function hideEgcRootOnWindows(): void {
   if (process.platform !== 'win32') return;
@@ -224,15 +225,6 @@ function getStateDir(): string {
   return dir;
 }
 
-function projectSlug(projectPath: string): string {
-  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
-  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
-}
-
-function stateFilePath(projectPath: string): string {
-  return path.join(getStateDir(), `${projectSlug(projectPath)}.md`);
-}
-
 function resolveProjectPath(provided?: string): string {
   return provided || process.env.EGC_PROJECT || process.env.PWD || os.homedir();
 }
@@ -260,7 +252,7 @@ function writeStateDoc(filePath: string, projectPath: string, data: {
   avoid?: {what: string; why?: string}[];
   preferences?: string[];
   next?: string[];
-}, existing: Record<string, string[]|string>) {
+}, existing: Record<string, string[]|string>, branch: string | null = null) {
   const mergedDecisions = [
     ...(data.decisions || []).map(d => `- ${d.what}${d.why ? ': ' + d.why : ''}`),
     ...((existing['Active Decisions'] as string[]) || []).map(l => `- ${l}`)
@@ -283,6 +275,7 @@ function writeStateDoc(filePath: string, projectPath: string, data: {
   const lines = [
     `# Project State`,
     `project: ${projectPath}`,
+    ...(branch ? [`branch: ${branch}`] : []),
     `updated: ${new Date().toISOString()}`,
     ``,
     `## Context`,
@@ -349,7 +342,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       { name: "search_history", description: "Keyword search over the decision history with BM25 relevance ranking (SQLite FTS5). Each result includes the decision content, context label, timestamp, and a score normalized to [0, 1] where 1 is the best match in the result set. Use this to find past decisions by topic instead of paging through query_history.", inputSchema: { type: "object", properties: { query: { type: "string", description: "Keywords to search for, e.g. 'authentication jwt'." }, limit: { type: "number", description: "Maximum number of results to return. Defaults to 10." }, min_score: { type: "number", description: "Minimum normalized relevance score between 0 and 1. Defaults to 0." } }, required: ["query"] } },
       {
         name: "get_state",
-        description: "Returns the current project memory: decisions made, preferences established, things to avoid, and what to pick up next. Call this at the START of every session to restore context.",
+        description: "Returns the current project memory: decisions made, preferences established, things to avoid, and what to pick up next. State is scoped to the current git branch when the project is a git repository, falling back to the default branch state and then to the legacy flat state file. Call this at the START of every session to restore context.",
         inputSchema: {
           type: "object",
           properties: {
@@ -359,7 +352,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "update_state",
-        description: "Updates the project memory with decisions made this session. Call this at the END of every session. Merges with existing state — does not erase previous memory.",
+        description: "Updates the project memory with decisions made this session. Writes to the state file of the current git branch when the project is a git repository. Call this at the END of every session. Merges with existing state and does not erase previous memory.",
         inputSchema: {
           type: "object",
           properties: {
@@ -411,27 +404,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "get_state": {
         const { project_path } = GetStateSchema.parse(request.params.arguments || {});
         const projPath = resolveProjectPath(project_path);
-        const filePath = stateFilePath(projPath);
+        const branch = detectBranch(projPath);
+        const resolved = resolveStateRead(getStateDir(), projPath, branch);
 
-        if (!fs.existsSync(filePath)) {
-          return { content: [{ type: "text", text: `No state found for this project yet.\nPath: ${filePath}\n\nCall update_state at the end of this session to start building project memory.` }] };
+        if (resolved.source === 'none') {
+          const branchLine = branch ? `Branch: ${branch}\n` : '';
+          return { content: [{ type: "text", text: `No state found for this project yet.\n${branchLine}Path: ${resolved.filePath}\n\nCall update_state at the end of this session to start building project memory.` }] };
         }
 
-        const content = fs.readFileSync(filePath, 'utf-8');
-        log('INFO', 'Project state retrieved', { project: projPath });
+        const content = fs.readFileSync(resolved.filePath, 'utf-8');
+        log('INFO', 'Project state retrieved', { project: projPath, branch: branch || 'none', source: resolved.source });
         return { content: [{ type: "text", text: content }] };
       }
 
       case "update_state": {
         const args = UpdateStateSchema.parse(request.params.arguments || {});
         const projPath = resolveProjectPath(args.project_path);
-        const filePath = stateFilePath(projPath);
-        const existing = readStateDoc(filePath);
+        const branch = detectBranch(projPath);
+        // Merge from the same file get_state would read, so the first
+        // branch-scoped write inherits the pre-existing flat state
+        const resolved = resolveStateRead(getStateDir(), projPath, branch);
+        const existing = readStateDoc(resolved.filePath);
+        const filePath = resolveStateWrite(getStateDir(), projPath, branch);
 
-        writeStateDoc(filePath, projPath, args, existing);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        writeStateDoc(filePath, projPath, args, existing, branch);
 
-        log('INFO', 'Project state updated', { project: projPath, decisions: args.decisions?.length || 0 });
-        return { content: [{ type: "text", text: `Project memory updated.\nFile: ${filePath}\nDecisions saved: ${args.decisions?.length || 0}\nNext session items: ${args.next?.length || 0}` }] };
+        log('INFO', 'Project state updated', { project: projPath, branch: branch || 'none', decisions: args.decisions?.length || 0 });
+        const branchLine = branch ? `Branch: ${branch}\n` : '';
+        return { content: [{ type: "text", text: `Project memory updated.\n${branchLine}File: ${filePath}\nDecisions saved: ${args.decisions?.length || 0}\nNext session items: ${args.next?.length || 0}` }] };
       }
 
       default:

--- a/scripts/hooks/egc-memory-load.js
+++ b/scripts/hooks/egc-memory-load.js
@@ -1,14 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-function getSlug() {
-  const projectPath = process.env.PWD || process.cwd();
-  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
-  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
-}
+const { getStateDir, detectBranch, resolveStateRead } = require('../lib/branch-state');
 
 function main() {
   let raw = '';
@@ -28,15 +21,16 @@ function main() {
   }
 
   try {
-    const slug = getSlug();
-    const stateFile = path.join(os.homedir(), '.egc', 'state', `${slug}.md`);
+    const projectPath = process.env.PWD || process.cwd();
+    const branch = detectBranch(projectPath);
+    const resolved = resolveStateRead(getStateDir(), projectPath, branch);
 
-    if (!fs.existsSync(stateFile)) {
+    if (resolved.source === 'none') {
       process.stdout.write(JSON.stringify(input));
       process.exit(0);
     }
 
-    const content = fs.readFileSync(stateFile, 'utf8');
+    const content = fs.readFileSync(resolved.filePath, 'utf8');
     const prompt =
       'You have persistent memory for this project. Resume exactly where you left off — no need to re-explain anything already decided.\n\n' +
       content;

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -19,8 +19,8 @@ function sanitizeBranchName(branch) {
   return branch.replace(/\//g, '-').replace(/[^a-zA-Z0-9-_]/g, '_');
 }
 
-// Reads .git/HEAD directly instead of spawning git: avoids PATH lookup
-// (SonarCloud S4036) and works without git installed.
+// Branch detection reads .git/HEAD instead of spawning git: no PATH
+// lookup and it works on machines without git installed.
 function findGitDir(startPath) {
   let current = path.resolve(startPath);
   for (;;) {

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync } = require('child_process');
 
 const DEFAULT_BRANCH_FILE = 'main.md';
 
@@ -20,16 +19,34 @@ function sanitizeBranchName(branch) {
   return branch.replace(/\//g, '-').replace(/[^a-zA-Z0-9-_]/g, '_');
 }
 
+// Reads .git/HEAD directly instead of spawning git: avoids PATH lookup
+// (SonarCloud S4036) and works without git installed.
+function findGitDir(startPath) {
+  let current = path.resolve(startPath);
+  for (;;) {
+    const candidate = path.join(current, '.git');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
 function detectBranch(projectPath) {
   try {
-    const output = execSync('git rev-parse --abbrev-ref HEAD', {
-      cwd: projectPath,
-      stdio: ['ignore', 'pipe', 'ignore'],
-      encoding: 'utf8',
-    }).trim();
-    // Detached HEAD reports the literal string "HEAD"; treat it as no branch
-    if (!output || output === 'HEAD') return null;
-    return output;
+    let gitDir = findGitDir(projectPath);
+    if (!gitDir) return null;
+    if (fs.statSync(gitDir).isFile()) {
+      // Worktrees and submodules store a pointer file instead of a directory
+      const pointer = fs.readFileSync(gitDir, 'utf8').trim();
+      if (!pointer.startsWith('gitdir:')) return null;
+      gitDir = path.resolve(path.dirname(gitDir), pointer.slice('gitdir:'.length).trim());
+    }
+    const head = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
+    const refPrefix = 'ref: refs/heads/';
+    // Detached HEAD stores a bare commit hash; treat it as no branch
+    if (!head.startsWith(refPrefix)) return null;
+    return head.slice(refPrefix.length) || null;
   } catch (_) {
     return null;
   }

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const DEFAULT_BRANCH_FILE = 'main.md';
+
+function getStateDir(homeDir) {
+  return path.join(homeDir || os.homedir(), '.egc', 'state');
+}
+
+function projectSlug(projectPath) {
+  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+function sanitizeBranchName(branch) {
+  return branch.replace(/\//g, '-').replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+function detectBranch(projectPath) {
+  try {
+    const output = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: projectPath,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim();
+    // Detached HEAD reports the literal string "HEAD"; treat it as no branch
+    if (!output || output === 'HEAD') return null;
+    return output;
+  } catch (_) {
+    return null;
+  }
+}
+
+function flatStateFile(stateDir, projectPath) {
+  return path.join(stateDir, `${projectSlug(projectPath)}.md`);
+}
+
+function branchStateFile(stateDir, projectPath, branch) {
+  return path.join(stateDir, projectSlug(projectPath), `${sanitizeBranchName(branch)}.md`);
+}
+
+function resolveStateRead(stateDir, projectPath, branch) {
+  if (branch) {
+    const branchFile = branchStateFile(stateDir, projectPath, branch);
+    if (fs.existsSync(branchFile)) {
+      return { filePath: branchFile, source: 'branch', branch };
+    }
+    const defaultFile = path.join(stateDir, projectSlug(projectPath), DEFAULT_BRANCH_FILE);
+    if (fs.existsSync(defaultFile)) {
+      return { filePath: defaultFile, source: 'default-branch', branch };
+    }
+  }
+
+  const flatFile = flatStateFile(stateDir, projectPath);
+  if (fs.existsSync(flatFile)) {
+    return { filePath: flatFile, source: 'flat', branch: branch || null };
+  }
+
+  return {
+    filePath: branch ? branchStateFile(stateDir, projectPath, branch) : flatFile,
+    source: 'none',
+    branch: branch || null,
+  };
+}
+
+function resolveStateWrite(stateDir, projectPath, branch) {
+  if (branch) return branchStateFile(stateDir, projectPath, branch);
+  return flatStateFile(stateDir, projectPath);
+}
+
+module.exports = {
+  DEFAULT_BRANCH_FILE,
+  getStateDir,
+  projectSlug,
+  sanitizeBranchName,
+  detectBranch,
+  flatStateFile,
+  branchStateFile,
+  resolveStateRead,
+  resolveStateWrite,
+};

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -3,6 +3,7 @@
 
 const os = require('os');
 const { createStateStore } = require('./lib/state-store');
+const { getStateDir, projectSlug, detectBranch, resolveStateRead } = require('./lib/branch-state');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -103,6 +104,40 @@ function printInstallHealth(section) {
   }
 }
 
+function collectMemoryState(projectPath, homeDir) {
+  const stateDir = getStateDir(homeDir);
+  const branch = detectBranch(projectPath);
+  const resolved = resolveStateRead(stateDir, projectPath, branch);
+
+  return {
+    projectPath,
+    slug: projectSlug(projectPath),
+    branch,
+    source: resolved.source,
+    stateFile: resolved.source === 'none' ? null : resolved.filePath,
+  };
+}
+
+const MEMORY_SOURCE_LABELS = {
+  branch: 'branch state',
+  'default-branch': 'default branch state (main.md)',
+  flat: 'flat state (legacy)',
+};
+
+function printMemoryState(section) {
+  console.log('Memory state:');
+  console.log(`  Project: ${section.projectPath}`);
+  console.log(`  Branch: ${section.branch || '(not a git branch)'}`);
+
+  if (section.source === 'none') {
+    console.log('  Active state: none recorded yet');
+    return;
+  }
+
+  console.log(`  Active state: ${section.stateFile}`);
+  console.log(`  Source: ${MEMORY_SOURCE_LABELS[section.source] || section.source}`);
+}
+
 function printGovernance(section) {
   console.log(`Pending governance events: ${section.pendingCount}`);
   if (section.events.length === 0) {
@@ -127,6 +162,8 @@ function printHuman(payload) {
   printInstallHealth(payload.installHealth);
   console.log();
   printGovernance(payload.governance);
+  console.log();
+  printMemoryState(payload.memoryState);
 }
 
 async function main() {
@@ -150,6 +187,10 @@ async function main() {
         recentSkillRunLimit: 20,
         pendingLimit: options.limit,
       }),
+      memoryState: collectMemoryState(
+        process.env.PWD || process.cwd(),
+        process.env.HOME || os.homedir()
+      ),
     };
 
     if (options.json) {
@@ -174,4 +215,5 @@ if (require.main === module) {
 module.exports = {
   main,
   parseArgs,
+  collectMemoryState,
 };

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -1,0 +1,275 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+const {
+  getStateDir,
+  projectSlug,
+  sanitizeBranchName,
+  detectBranch,
+  flatStateFile,
+  branchStateFile,
+  resolveStateRead,
+  resolveStateWrite,
+} = require('../../scripts/lib/branch-state');
+
+const { collectMemoryState } = require('../../scripts/status');
+
+const HOOK_PATH = path.join(__dirname, '../../scripts/hooks/egc-memory-load.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function makeTmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function git(cwd, args) {
+  execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+}
+
+function makeGitRepo(branch) {
+  const repo = makeTmpDir('egc-branch-state-repo-');
+  git(repo, 'init -q');
+  fs.writeFileSync(path.join(repo, 'README.md'), 'test repo\n');
+  git(repo, 'add README.md');
+  git(repo, '-c user.email=test@test -c user.name=test -c commit.gpgsign=false commit -q -m initial');
+  if (branch) {
+    git(repo, `checkout -q -b ${branch}`);
+  }
+  return repo;
+}
+
+function writeState(filePath, marker) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `# Project State\n\n## Context\n${marker}\n`, 'utf8');
+}
+
+function runTests() {
+  console.log('\n=== Testing branch-state.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('projectSlug uses last two path segments', () => {
+    assert.strictEqual(projectSlug('/home/user/Projects/my-app'), 'Projects--my-app');
+  })) passed++; else failed++;
+
+  if (test('projectSlug sanitizes unsafe characters', () => {
+    assert.strictEqual(projectSlug('/home/user/Pro jects/my.app'), 'Pro_jects--my_app');
+  })) passed++; else failed++;
+
+  if (test('projectSlug falls back to default for empty path', () => {
+    assert.strictEqual(projectSlug(''), 'default');
+  })) passed++; else failed++;
+
+  if (test('sanitizeBranchName replaces slashes with hyphens', () => {
+    assert.strictEqual(sanitizeBranchName('feature/auth'), 'feature-auth');
+    assert.strictEqual(sanitizeBranchName('hotfix/login/v2'), 'hotfix-login-v2');
+  })) passed++; else failed++;
+
+  if (test('sanitizeBranchName strips unsafe filename characters', () => {
+    assert.strictEqual(sanitizeBranchName('release/1.0.8'), 'release-1_0_8');
+    assert.strictEqual(sanitizeBranchName('fix/issue#137'), 'fix-issue_137');
+  })) passed++; else failed++;
+
+  if (test('getStateDir resolves under the provided home directory', () => {
+    assert.strictEqual(getStateDir('/tmp/fake-home'), path.join('/tmp/fake-home', '.egc', 'state'));
+  })) passed++; else failed++;
+
+  if (test('detectBranch returns the current branch in a git repo', () => {
+    const repo = makeGitRepo('feature/auth');
+    assert.strictEqual(detectBranch(repo), 'feature/auth');
+  })) passed++; else failed++;
+
+  if (test('detectBranch returns null outside a git repo', () => {
+    const dir = makeTmpDir('egc-branch-state-norepo-');
+    assert.strictEqual(detectBranch(dir), null);
+  })) passed++; else failed++;
+
+  if (test('detectBranch returns null on detached HEAD', () => {
+    const repo = makeGitRepo(null);
+    git(repo, 'checkout -q --detach');
+    assert.strictEqual(detectBranch(repo), null);
+  })) passed++; else failed++;
+
+  if (test('flatStateFile and branchStateFile build expected paths', () => {
+    const stateDir = '/tmp/fake-home/.egc/state';
+    const project = '/home/user/Projects/my-app';
+    assert.strictEqual(
+      flatStateFile(stateDir, project),
+      path.join(stateDir, 'Projects--my-app.md')
+    );
+    assert.strictEqual(
+      branchStateFile(stateDir, project, 'feature/auth'),
+      path.join(stateDir, 'Projects--my-app', 'feature-auth.md')
+    );
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead prefers the current branch file', () => {
+    const stateDir = makeTmpDir('egc-branch-state-read1-');
+    const project = '/home/user/Projects/my-app';
+    writeState(branchStateFile(stateDir, project, 'feature/auth'), 'branch state');
+    writeState(path.join(stateDir, 'Projects--my-app', 'main.md'), 'main state');
+    writeState(flatStateFile(stateDir, project), 'flat state');
+
+    const resolved = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(resolved.source, 'branch');
+    assert.strictEqual(resolved.filePath, branchStateFile(stateDir, project, 'feature/auth'));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead falls back to main.md when branch file is missing', () => {
+    const stateDir = makeTmpDir('egc-branch-state-read2-');
+    const project = '/home/user/Projects/my-app';
+    writeState(path.join(stateDir, 'Projects--my-app', 'main.md'), 'main state');
+
+    const resolved = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(resolved.source, 'default-branch');
+    assert.strictEqual(resolved.filePath, path.join(stateDir, 'Projects--my-app', 'main.md'));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead falls back to the legacy flat file', () => {
+    const stateDir = makeTmpDir('egc-branch-state-read3-');
+    const project = '/home/user/Projects/my-app';
+    writeState(flatStateFile(stateDir, project), 'flat state');
+
+    const resolved = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(resolved.source, 'flat');
+    assert.strictEqual(resolved.filePath, flatStateFile(stateDir, project));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead reads the flat file when there is no branch', () => {
+    const stateDir = makeTmpDir('egc-branch-state-read4-');
+    const project = '/home/user/Projects/my-app';
+    writeState(flatStateFile(stateDir, project), 'flat state');
+
+    const resolved = resolveStateRead(stateDir, project, null);
+    assert.strictEqual(resolved.source, 'flat');
+    assert.strictEqual(resolved.filePath, flatStateFile(stateDir, project));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead reports none when no state exists', () => {
+    const stateDir = makeTmpDir('egc-branch-state-read5-');
+    const project = '/home/user/Projects/my-app';
+
+    const withBranch = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(withBranch.source, 'none');
+    assert.strictEqual(withBranch.filePath, branchStateFile(stateDir, project, 'feature/auth'));
+
+    const withoutBranch = resolveStateRead(stateDir, project, null);
+    assert.strictEqual(withoutBranch.source, 'none');
+    assert.strictEqual(withoutBranch.filePath, flatStateFile(stateDir, project));
+  })) passed++; else failed++;
+
+  if (test('resolveStateWrite targets the branch file when a branch exists', () => {
+    const stateDir = '/tmp/fake-home/.egc/state';
+    const project = '/home/user/Projects/my-app';
+    assert.strictEqual(
+      resolveStateWrite(stateDir, project, 'feature/auth'),
+      branchStateFile(stateDir, project, 'feature/auth')
+    );
+    assert.strictEqual(
+      resolveStateWrite(stateDir, project, null),
+      flatStateFile(stateDir, project)
+    );
+  })) passed++; else failed++;
+
+  if (test('collectMemoryState reports the active branch state', () => {
+    const home = makeTmpDir('egc-branch-state-home1-');
+    const repo = makeGitRepo('feature/auth');
+    const stateFile = branchStateFile(getStateDir(home), repo, 'feature/auth');
+    writeState(stateFile, 'branch state');
+
+    const result = collectMemoryState(repo, home);
+    assert.strictEqual(result.branch, 'feature/auth');
+    assert.strictEqual(result.source, 'branch');
+    assert.strictEqual(result.stateFile, stateFile);
+    assert.strictEqual(result.slug, projectSlug(repo));
+  })) passed++; else failed++;
+
+  if (test('collectMemoryState reports flat fallback and missing state', () => {
+    const home = makeTmpDir('egc-branch-state-home2-');
+    const repo = makeGitRepo('feature/auth');
+    writeState(flatStateFile(getStateDir(home), repo), 'flat state');
+
+    const flat = collectMemoryState(repo, home);
+    assert.strictEqual(flat.source, 'flat');
+    assert.strictEqual(flat.stateFile, flatStateFile(getStateDir(home), repo));
+
+    const emptyHome = makeTmpDir('egc-branch-state-home3-');
+    const none = collectMemoryState(repo, emptyHome);
+    assert.strictEqual(none.source, 'none');
+    assert.strictEqual(none.stateFile, null);
+  })) passed++; else failed++;
+
+  if (test('egc-memory-load hook injects the branch state', () => {
+    const home = makeTmpDir('egc-branch-state-home4-');
+    const repo = makeGitRepo('feature/auth');
+    writeState(branchStateFile(getStateDir(home), repo, 'feature/auth'), 'BRANCH_MARKER_137');
+    writeState(flatStateFile(getStateDir(home), repo), 'FLAT_MARKER_137');
+
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: '{}',
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, { HOME: home, PWD: repo }),
+      cwd: repo,
+    });
+
+    assert.strictEqual(result.status, 0);
+    const output = JSON.parse(result.stdout);
+    assert.ok(output.promptForAssistant.includes('BRANCH_MARKER_137'));
+    assert.ok(!output.promptForAssistant.includes('FLAT_MARKER_137'));
+  })) passed++; else failed++;
+
+  if (test('egc-memory-load hook falls back to the flat state', () => {
+    const home = makeTmpDir('egc-branch-state-home5-');
+    const repo = makeGitRepo('feature/auth');
+    writeState(flatStateFile(getStateDir(home), repo), 'FLAT_MARKER_137');
+
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: '{}',
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, { HOME: home, PWD: repo }),
+      cwd: repo,
+    });
+
+    assert.strictEqual(result.status, 0);
+    const output = JSON.parse(result.stdout);
+    assert.ok(output.promptForAssistant.includes('FLAT_MARKER_137'));
+  })) passed++; else failed++;
+
+  if (test('egc-memory-load hook passes input through when no state exists', () => {
+    const home = makeTmpDir('egc-branch-state-home6-');
+    const repo = makeGitRepo('feature/auth');
+
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: '{"session":"abc"}',
+      encoding: 'utf8',
+      env: Object.assign({}, process.env, { HOME: home, PWD: repo }),
+      cwd: repo,
+    });
+
+    assert.strictEqual(result.status, 0);
+    const output = JSON.parse(result.stdout);
+    assert.strictEqual(output.session, 'abc');
+    assert.strictEqual(output.promptForAssistant, undefined);
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -224,7 +224,7 @@ function runTests() {
     const result = spawnSync('node', [HOOK_PATH], {
       input: '{}',
       encoding: 'utf8',
-      env: Object.assign({}, process.env, { HOME: home, PWD: repo }),
+      env: Object.assign({}, process.env, { HOME: home, USERPROFILE: home, PWD: repo }),
       cwd: repo,
     });
 
@@ -242,7 +242,7 @@ function runTests() {
     const result = spawnSync('node', [HOOK_PATH], {
       input: '{}',
       encoding: 'utf8',
-      env: Object.assign({}, process.env, { HOME: home, PWD: repo }),
+      env: Object.assign({}, process.env, { HOME: home, USERPROFILE: home, PWD: repo }),
       cwd: repo,
     });
 
@@ -258,7 +258,7 @@ function runTests() {
     const result = spawnSync('node', [HOOK_PATH], {
       input: '{"session":"abc"}',
       encoding: 'utf8',
-      env: Object.assign({}, process.env, { HOME: home, PWD: repo }),
+      env: Object.assign({}, process.env, { HOME: home, USERPROFILE: home, PWD: repo }),
       cwd: repo,
     });
 

--- a/tests/scripts/egc-memory-branch-state.test.js
+++ b/tests/scripts/egc-memory-branch-state.test.js
@@ -1,0 +1,154 @@
+/**
+ * Tests for the egc-memory branch-state module.
+ *
+ * Tests the extracted branch resolution logic directly (no MCP server needed).
+ * Run with: node tests/scripts/egc-memory-branch-state.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const MODULE_PATH = path.join(
+  __dirname,
+  '../../mcp/servers/egc-memory/build/branch-state.js'
+);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function makeTmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function makeGitRepo(branch) {
+  const repo = makeTmpDir('egc-memory-branch-repo-');
+  const git = (args) => execSync(`git ${args}`, { cwd: repo, stdio: ['ignore', 'pipe', 'pipe'] });
+  git('init -q');
+  fs.writeFileSync(path.join(repo, 'README.md'), 'test repo\n');
+  git('add README.md');
+  git('-c user.email=test@test -c user.name=test -c commit.gpgsign=false commit -q -m initial');
+  if (branch) {
+    git(`checkout -q -b ${branch}`);
+  }
+  return repo;
+}
+
+function writeState(filePath, marker) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `# Project State\n\n## Context\n${marker}\n`, 'utf8');
+}
+
+async function runTests() {
+  let mod;
+  try {
+    mod = await import(MODULE_PATH);
+  } catch (e) {
+    console.log(
+      `[SKIP] Could not import ${MODULE_PATH}. Run 'npm run build' in mcp/servers/egc-memory first.`
+    );
+    console.log(e.message);
+    process.exit(0);
+  }
+
+  const api = mod.default && mod.default.projectSlug ? mod.default : mod;
+  const {
+    projectSlug,
+    sanitizeBranchName,
+    detectBranch,
+    flatStateFile,
+    branchStateFile,
+    resolveStateRead,
+    resolveStateWrite,
+  } = api;
+
+  console.log('\n=== Testing egc-memory build/branch-state.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('projectSlug matches the legacy slug format', () => {
+    assert.strictEqual(projectSlug('/home/user/Projects/my-app'), 'Projects--my-app');
+    assert.strictEqual(projectSlug(''), 'default');
+  })) passed++; else failed++;
+
+  if (test('sanitizeBranchName produces safe filenames', () => {
+    assert.strictEqual(sanitizeBranchName('feature/auth'), 'feature-auth');
+    assert.strictEqual(sanitizeBranchName('release/1.0.8'), 'release-1_0_8');
+  })) passed++; else failed++;
+
+  if (test('detectBranch returns the current branch and null outside repos', () => {
+    const repo = makeGitRepo('hotfix/login');
+    assert.strictEqual(detectBranch(repo), 'hotfix/login');
+    assert.strictEqual(detectBranch(makeTmpDir('egc-memory-norepo-')), null);
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead prefers branch file over main.md and flat', () => {
+    const stateDir = makeTmpDir('egc-memory-read1-');
+    const project = '/home/user/Projects/my-app';
+    writeState(branchStateFile(stateDir, project, 'feature/auth'), 'branch');
+    writeState(path.join(stateDir, 'Projects--my-app', 'main.md'), 'main');
+    writeState(flatStateFile(stateDir, project), 'flat');
+
+    const resolved = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(resolved.source, 'branch');
+    assert.strictEqual(resolved.filePath, branchStateFile(stateDir, project, 'feature/auth'));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead falls back to main.md then flat', () => {
+    const stateDir = makeTmpDir('egc-memory-read2-');
+    const project = '/home/user/Projects/my-app';
+    writeState(path.join(stateDir, 'Projects--my-app', 'main.md'), 'main');
+    writeState(flatStateFile(stateDir, project), 'flat');
+
+    const fromMain = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(fromMain.source, 'default-branch');
+
+    fs.unlinkSync(path.join(stateDir, 'Projects--my-app', 'main.md'));
+    const fromFlat = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(fromFlat.source, 'flat');
+    assert.strictEqual(fromFlat.filePath, flatStateFile(stateDir, project));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead reports none when no state exists', () => {
+    const stateDir = makeTmpDir('egc-memory-read3-');
+    const project = '/home/user/Projects/my-app';
+    const resolved = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(resolved.source, 'none');
+    assert.strictEqual(resolved.filePath, branchStateFile(stateDir, project, 'feature/auth'));
+  })) passed++; else failed++;
+
+  if (test('resolveStateWrite scopes writes to the current branch', () => {
+    const stateDir = '/tmp/fake-home/.egc/state';
+    const project = '/home/user/Projects/my-app';
+    assert.strictEqual(
+      resolveStateWrite(stateDir, project, 'feature/auth'),
+      branchStateFile(stateDir, project, 'feature/auth')
+    );
+    assert.strictEqual(
+      resolveStateWrite(stateDir, project, null),
+      flatStateFile(stateDir, project)
+    );
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #137

## Summary

State files are now scoped per git branch with full backward compatibility:

- `get_state` resolves in order: `<slug>/<branch>.md`, then `<slug>/main.md`, then legacy flat `<slug>.md`
- `update_state` writes to the current branch file, seeding the first branch write from the prior flat state so memory carries forward
- Branch detection via `git rev-parse --abbrev-ref HEAD` (null-safe for detached HEAD and non-repos); branch names sanitized for filenames
- SessionStart hook (`egc-memory-load.js`) injects branch-scoped state
- `egc status` shows project, current branch, active state file and source
- CommonJS twin module for scripts is deliberate: the MCP server publishes standalone and cannot require outside its root

## Test plan

- `node tests/lib/branch-state.test.js`: 21/21
- `node tests/scripts/egc-memory-branch-state.test.js`: 7/7
- `npm test`: 2301/2301
- `npm run lint`: 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes project memory per git branch so each branch has its own state, with full backward compatibility. Implements #137 and reads `.git/HEAD` directly (supports worktrees and detached HEAD).

- **New Features**
  - Read order: `<slug>/<branch>.md` → `<slug>/main.md` → legacy `<slug>.md`; first branch write seeds from what `get_state` would have read.
  - Branch detection via `.git/HEAD`; branch names sanitized for filenames.
  - `get_state`/`update_state` are branch-aware; saved docs include `branch:` and responses include branch/source.
  - Session hook loads branch-scoped state; `egc status` shows project, branch, active state file, and source.
  - Shared resolver in `scripts/lib/branch-state` with a TS twin in `mcp/servers/egc-memory/src/branch-state.ts`; CPD exclusions added.

- **Migration**
  - No action needed. Existing flat state is used and copied into the first branch file on write.
  - Outside git or on detached HEAD, behavior stays on the legacy flat file.

<sup>Written for commit 1bd2677bdbf510e4d392deea8256305c76e7b382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch-scoped persistent state management, enabling separate memory context per git branch with fallback to project-level state when branch-specific state is unavailable.

* **Tests**
  * Added comprehensive test coverage for branch-aware state detection and resolution behavior.

* **Chores**
  * Updated build configuration to exclude branch-state files from copy-paste detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->