### PR TITLE
feat: deterministic SessionStart memory hook for Claude Code installs

### DIFF
--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+'use strict';
+
+// Claude Code SessionStart hook. Prints the EGC state file for the current
+// project so the session always starts with persistent memory loaded.
+// Read-only by design: it never executes project code and never fails the
+// session. Missing or unreadable state exits silently with code 0.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function readStdinJson() {
+  try {
+    const raw = fs.readFileSync(0, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (_error) {
+    // No stdin payload or invalid JSON: fall back to environment values.
+  }
+  return {};
+}
+
+function resolveProjectPath(input) {
+  if (typeof input.cwd === 'string' && input.cwd.length > 0) {
+    return input.cwd;
+  }
+  return process.env.CLAUDE_PROJECT_DIR || process.env.PWD || process.cwd();
+}
+
+function projectSlug(projectPath) {
+  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+function main() {
+  try {
+    const input = readStdinJson();
+    const projectPath = resolveProjectPath(input);
+    const stateFile = path.join(
+      os.homedir(),
+      '.egc',
+      'state',
+      `${projectSlug(projectPath)}.md`
+    );
+
+    if (!fs.existsSync(stateFile)) {
+      process.exit(0);
+    }
+
+    const content = fs.readFileSync(stateFile, 'utf8');
+    if (!content.trim()) {
+      process.exit(0);
+    }
+
+    process.stdout.write(
+      'EGC persistent memory for this project (restored automatically):\n\n'
+      + content
+    );
+  } catch (_error) {
+    // Never break session startup because of memory loading.
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -1,0 +1,237 @@
+'use strict';
+
+// Manages the EGC SessionStart hook entry inside Claude Code settings.json.
+// All merges are additive and idempotent: third-party hooks and unrelated
+// settings keys are always preserved, and the EGC entry is identified by the
+// installed hook script path so uninstall removes only what EGC added.
+
+const fs = require('fs');
+const path = require('path');
+
+const SESSION_START_EVENT = 'SessionStart';
+const HOOK_OPERATION_KIND = 'merge-claude-settings-hooks';
+const HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/claude-session-start.js';
+const HOOK_MODULE_ID = 'claude-session-state-hook';
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildSessionStartCommand(hookScriptPath) {
+  return `node "${hookScriptPath}"`;
+}
+
+function resolveHookScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'egc', 'hooks', 'claude-session-start.js');
+}
+
+function resolveSettingsPath(targetRoot) {
+  return path.join(targetRoot, 'settings.json');
+}
+
+function isEgcHookEntry(entry, hookScriptPath) {
+  return (
+    isPlainObject(entry)
+    && typeof entry.command === 'string'
+    && entry.command.includes(hookScriptPath)
+  );
+}
+
+function matcherGroupHasEgcEntry(group, hookScriptPath) {
+  return (
+    isPlainObject(group)
+    && Array.isArray(group.hooks)
+    && group.hooks.some(entry => isEgcHookEntry(entry, hookScriptPath))
+  );
+}
+
+function hasSessionStartHook(settings, hookScriptPath) {
+  if (!isPlainObject(settings) || !isPlainObject(settings.hooks)) {
+    return false;
+  }
+
+  const groups = settings.hooks[SESSION_START_EVENT];
+  return Array.isArray(groups)
+    && groups.some(group => matcherGroupHasEgcEntry(group, hookScriptPath));
+}
+
+function addSessionStartHook(settings, hookScriptPath) {
+  const base = isPlainObject(settings) ? settings : {};
+
+  if (hasSessionStartHook(base, hookScriptPath)) {
+    return { settings: base, changed: false };
+  }
+
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const groups = Array.isArray(hooks[SESSION_START_EVENT])
+    ? hooks[SESSION_START_EVENT].slice()
+    : [];
+
+  groups.push({
+    hooks: [
+      {
+        type: 'command',
+        command: buildSessionStartCommand(hookScriptPath),
+      },
+    ],
+  });
+  hooks[SESSION_START_EVENT] = groups;
+
+  return {
+    settings: { ...base, hooks },
+    changed: true,
+  };
+}
+
+function removeSessionStartHook(settings, hookScriptPath) {
+  if (
+    !isPlainObject(settings)
+    || !isPlainObject(settings.hooks)
+    || !Array.isArray(settings.hooks[SESSION_START_EVENT])
+  ) {
+    return { settings, changed: false };
+  }
+
+  let changed = false;
+  const groups = [];
+
+  for (const group of settings.hooks[SESSION_START_EVENT]) {
+    if (!matcherGroupHasEgcEntry(group, hookScriptPath)) {
+      groups.push(group);
+      continue;
+    }
+
+    changed = true;
+    const remainingEntries = group.hooks.filter(
+      entry => !isEgcHookEntry(entry, hookScriptPath)
+    );
+    if (remainingEntries.length > 0) {
+      groups.push({ ...group, hooks: remainingEntries });
+    }
+  }
+
+  if (!changed) {
+    return { settings, changed: false };
+  }
+
+  const hooks = { ...settings.hooks };
+  if (groups.length > 0) {
+    hooks[SESSION_START_EVENT] = groups;
+  } else {
+    delete hooks[SESSION_START_EVENT];
+  }
+
+  const next = { ...settings };
+  if (Object.keys(hooks).length > 0) {
+    next.hooks = hooks;
+  } else {
+    delete next.hooks;
+  }
+
+  return { settings: next, changed: true };
+}
+
+function readSettingsFile(settingsPath) {
+  if (!fs.existsSync(settingsPath)) {
+    return {};
+  }
+
+  const raw = fs.readFileSync(settingsPath, 'utf8');
+  if (!raw.trim()) {
+    return {};
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse Claude Code settings at ${settingsPath}: ${error.message}`,
+      { cause: error }
+    );
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `Invalid Claude Code settings at ${settingsPath}: expected a JSON object`
+    );
+  }
+
+  return parsed;
+}
+
+function writeSettingsFile(settingsPath, settings) {
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8');
+}
+
+function applySessionStartHookToFile(settingsPath, hookScriptPath) {
+  const current = readSettingsFile(settingsPath);
+  const { settings, changed } = addSessionStartHook(current, hookScriptPath);
+
+  if (changed) {
+    writeSettingsFile(settingsPath, settings);
+  }
+
+  return { changed };
+}
+
+function removeSessionStartHookFromFile(settingsPath, hookScriptPath) {
+  if (!fs.existsSync(settingsPath)) {
+    return { changed: false };
+  }
+
+  const current = readSettingsFile(settingsPath);
+  const { settings, changed } = removeSessionStartHook(current, hookScriptPath);
+
+  if (changed) {
+    writeSettingsFile(settingsPath, settings);
+  }
+
+  return { changed };
+}
+
+function inspectSessionStartHookFile(settingsPath, hookScriptPath) {
+  try {
+    return hasSessionStartHook(readSettingsFile(settingsPath), hookScriptPath)
+      ? 'ok'
+      : 'drifted';
+  } catch (_error) {
+    return 'drifted';
+  }
+}
+
+function createSessionStartHookMergeOperation(targetRoot) {
+  const hookScriptPath = resolveHookScriptDestination(targetRoot);
+
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: HOOK_MODULE_ID,
+    sourceRelativePath: HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: resolveSettingsPath(targetRoot),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: SESSION_START_EVENT,
+    hookScriptPath,
+    hookCommand: buildSessionStartCommand(hookScriptPath),
+  };
+}
+
+module.exports = {
+  HOOK_MODULE_ID,
+  HOOK_OPERATION_KIND,
+  HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  SESSION_START_EVENT,
+  addSessionStartHook,
+  applySessionStartHookToFile,
+  buildSessionStartCommand,
+  createSessionStartHookMergeOperation,
+  hasSessionStartHook,
+  inspectSessionStartHookFile,
+  readSettingsFile,
+  removeSessionStartHook,
+  removeSessionStartHookFromFile,
+  resolveHookScriptDestination,
+  resolveSettingsPath,
+};

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -12,6 +12,7 @@ const {
   resolveInstallPlan,
 } = require('./install-manifests');
 const { getInstallTargetAdapter } = require('./install-targets/registry');
+const { HOOK_OPERATION_KIND } = require('./claude-settings-hooks');
 
 const LANGUAGE_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const GEMINI_EGC_NAMESPACE = 'egc';
@@ -584,6 +585,10 @@ function createLegacyCompatInstallPlan(options = {}) {
 }
 
 function materializeScaffoldOperation(sourceRoot, operation) {
+  if (operation.kind === HOOK_OPERATION_KIND) {
+    return [{ ...operation, scaffoldOnly: false }];
+  }
+
   if (operation.kind === 'merge-json') {
     return [{
       kind: 'merge-json',

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -11,6 +11,12 @@ const {
   getInstallTargetAdapter,
   listInstallTargetAdapters,
 } = require('./install-targets/registry');
+const {
+  HOOK_OPERATION_KIND,
+  applySessionStartHookToFile,
+  inspectSessionStartHookFile,
+  removeSessionStartHookFromFile,
+} = require('./claude-settings-hooks');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
 
@@ -357,6 +363,11 @@ function executeRepairOperation(repoRoot, operation) {
     return;
   }
 
+  if (operation.kind === HOOK_OPERATION_KIND) {
+    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+    return;
+  }
+
   throw new Error(`Unsupported repair operation kind: ${operation.kind}`);
 }
 
@@ -437,11 +448,19 @@ function uninstallRemove(operation) {
   return { removedPaths: [], cleanupTargets: [] };
 }
 
+function uninstallClaudeSettingsHook(operation) {
+  // Strips only the EGC-managed SessionStart entry. The settings file itself
+  // is never deleted because Claude Code and the user own its other keys.
+  removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
+  return { removedPaths: [], cleanupTargets: [] };
+}
+
 const UNINSTALL_HANDLERS = {
   'copy-file': uninstallCopyFile,
   'render-template': uninstallRenderTemplate,
   'merge-json': uninstallMergeJson,
   'remove': uninstallRemove,
+  [HOOK_OPERATION_KIND]: uninstallClaudeSettingsHook,
 };
 
 function executeUninstallOperation(operation) {
@@ -525,6 +544,14 @@ function inspectManagedOperation(repoRoot, operation) {
 
   if (operation.kind === 'merge-json') {
     return inspectMergeJsonOperation(operation, destinationPath);
+  }
+
+  if (operation.kind === HOOK_OPERATION_KIND) {
+    return inspectResult(
+      inspectSessionStartHookFile(destinationPath, operation.hookScriptPath),
+      operation,
+      destinationPath
+    );
   }
 
   return inspectResult('unverified', operation, destinationPath);

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -6,6 +6,25 @@ const {
   isForeignPlatformPath,
   normalizeRelativePath,
 } = require('./helpers');
+const {
+  HOOK_MODULE_ID,
+  HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  createSessionStartHookMergeOperation,
+  resolveHookScriptDestination,
+} = require('../claude-settings-hooks');
+
+function createSessionStateHookOperations(adapter, targetRoot) {
+  return [
+    createRemappedOperation(
+      adapter,
+      HOOK_MODULE_ID,
+      HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ),
+    createSessionStartHookMergeOperation(targetRoot),
+  ];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'claude-home',
@@ -25,7 +44,7 @@ module.exports = createInstallTargetAdapter({
     };
     const targetRoot = adapter.resolveRoot(planningInput);
 
-    return modules.flatMap(module => {
+    const moduleOperations = modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];
       return paths
         .filter(p => !isForeignPlatformPath(p, adapter.target))
@@ -51,5 +70,12 @@ module.exports = createInstallTargetAdapter({
           return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
         });
     });
+
+    // Deterministic memory loading: every Claude Code install registers the
+    // SessionStart state hook, even when no content modules are selected.
+    return [
+      ...moduleOperations,
+      ...createSessionStateHookOperations(adapter, targetRoot),
+    ];
   },
 });

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -5,6 +5,10 @@ const path = require('path');
 
 const { writeInstallState } = require('../install-state');
 const { filterMcpConfig, parseDisabledMcpServers } = require('../mcp-config');
+const {
+  HOOK_OPERATION_KIND,
+  applySessionStartHookToFile,
+} = require('../claude-settings-hooks');
 
 function readJsonObject(filePath, label) {
   let parsed;
@@ -121,6 +125,11 @@ function applyInstallPlan(plan) {
 
   for (const operation of plan.operations) {
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
+
+    if (operation.kind === HOOK_OPERATION_KIND) {
+      applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+      continue;
+    }
 
     if (operation.kind === 'merge-json') {
       const payload = cloneJsonValue(operation.mergePayload);

--- a/tests/hooks/claude-session-start.test.js
+++ b/tests/hooks/claude-session-start.test.js
@@ -1,0 +1,148 @@
+/**
+ * Subprocess tests for scripts/hooks/claude-session-start.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'claude-session-start.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function runHook(homeDir, stdinPayload, extraEnv = {}) {
+  const result = spawnSync('node', [SCRIPT], {
+    input: stdinPayload,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      CLAUDE_PROJECT_DIR: '',
+      PWD: '',
+      ...extraEnv,
+    },
+    timeout: 10000,
+  });
+
+  return {
+    code: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function writeStateFile(homeDir, slug, content) {
+  const stateDir = path.join(homeDir, '.egc', 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, `${slug}.md`), content);
+}
+
+function runTests() {
+  console.log('\n=== Testing claude-session-start.js hook ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('prints the state file for the cwd received on stdin', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      writeStateFile(homeDir, 'workspace--demo', '# Project State\n- resume feature X\n');
+
+      const result = runHook(
+        homeDir,
+        JSON.stringify({ cwd: '/workspace/demo', hook_event_name: 'SessionStart' })
+      );
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('EGC persistent memory'));
+      assert.ok(result.stdout.includes('resume feature X'));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('uses the same slug sanitization as the egc-memory server', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      writeStateFile(homeDir, 'My_Projects--app_v2_0', 'sanitized slug state\n');
+
+      const result = runHook(
+        homeDir,
+        JSON.stringify({ cwd: '/home/user/My Projects/app v2.0' })
+      );
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('sanitized slug state'));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('exits silently with code 0 when no state file exists', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      const result = runHook(homeDir, JSON.stringify({ cwd: '/workspace/empty' }));
+
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('exits silently with code 0 when the state file is blank', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      writeStateFile(homeDir, 'workspace--blank', '   \n\n');
+
+      const result = runHook(homeDir, JSON.stringify({ cwd: '/workspace/blank' }));
+
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('tolerates invalid stdin and falls back to environment paths', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      writeStateFile(homeDir, 'env--project', 'state from env fallback\n');
+
+      const result = runHook(homeDir, 'not json at all', {
+        CLAUDE_PROJECT_DIR: '/env/project',
+      });
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('state from env fallback'));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/claude-settings-hooks.test.js
+++ b/tests/lib/claude-settings-hooks.test.js
@@ -1,0 +1,300 @@
+/**
+ * Tests for scripts/lib/claude-settings-hooks.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  HOOK_MODULE_ID,
+  HOOK_OPERATION_KIND,
+  HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  SESSION_START_EVENT,
+  addSessionStartHook,
+  applySessionStartHookToFile,
+  buildSessionStartCommand,
+  createSessionStartHookMergeOperation,
+  hasSessionStartHook,
+  inspectSessionStartHookFile,
+  removeSessionStartHook,
+  removeSessionStartHookFromFile,
+  resolveHookScriptDestination,
+  resolveSettingsPath,
+} = require('../../scripts/lib/claude-settings-hooks');
+
+const HOOK_SCRIPT_PATH = '/home/user/.claude/egc/hooks/claude-session-start.js';
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function thirdPartySettings() {
+  return {
+    model: 'opus',
+    permissions: { allow: ['Bash(npm test)'] },
+    hooks: {
+      SessionStart: [
+        {
+          matcher: 'startup',
+          hooks: [{ type: 'command', command: 'echo third-party' }],
+        },
+      ],
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [{ type: 'command', command: 'echo guard' }],
+        },
+      ],
+    },
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing claude-settings-hooks.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('adds the SessionStart hook to empty settings', () => {
+    const { settings, changed } = addSessionStartHook({}, HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings.hooks[SESSION_START_EVENT], [
+      {
+        hooks: [
+          { type: 'command', command: buildSessionStartCommand(HOOK_SCRIPT_PATH) },
+        ],
+      },
+    ]);
+    assert.ok(hasSessionStartHook(settings, HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('add is idempotent and reports no change when the hook exists', () => {
+    const first = addSessionStartHook({}, HOOK_SCRIPT_PATH);
+    const second = addSessionStartHook(first.settings, HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.settings.hooks[SESSION_START_EVENT].length, 1);
+  })) passed++; else failed++;
+
+  if (test('add preserves third-party hooks and unrelated settings keys', () => {
+    const { settings } = addSessionStartHook(thirdPartySettings(), HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(settings.model, 'opus');
+    assert.deepStrictEqual(settings.permissions, { allow: ['Bash(npm test)'] });
+    assert.strictEqual(settings.hooks.PreToolUse.length, 1);
+    assert.strictEqual(settings.hooks[SESSION_START_EVENT].length, 2);
+    assert.strictEqual(
+      settings.hooks[SESSION_START_EVENT][0].hooks[0].command,
+      'echo third-party'
+    );
+    assert.ok(hasSessionStartHook(settings, HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('remove strips only the EGC entry and keeps third-party hooks', () => {
+    const installed = addSessionStartHook(thirdPartySettings(), HOOK_SCRIPT_PATH).settings;
+    const { settings, changed } = removeSessionStartHook(installed, HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.strictEqual(settings.model, 'opus');
+    assert.strictEqual(settings.hooks[SESSION_START_EVENT].length, 1);
+    assert.strictEqual(
+      settings.hooks[SESSION_START_EVENT][0].hooks[0].command,
+      'echo third-party'
+    );
+    assert.strictEqual(settings.hooks.PreToolUse.length, 1);
+    assert.ok(!hasSessionStartHook(settings, HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('remove keeps sibling entries when the EGC entry shares a matcher group', () => {
+    const settings = {
+      hooks: {
+        [SESSION_START_EVENT]: [
+          {
+            hooks: [
+              { type: 'command', command: 'echo sibling' },
+              { type: 'command', command: buildSessionStartCommand(HOOK_SCRIPT_PATH) },
+            ],
+          },
+        ],
+      },
+    };
+    const result = removeSessionStartHook(settings, HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(result.changed, true);
+    assert.deepStrictEqual(result.settings.hooks[SESSION_START_EVENT], [
+      { hooks: [{ type: 'command', command: 'echo sibling' }] },
+    ]);
+  })) passed++; else failed++;
+
+  if (test('remove drops empty hooks containers when EGC was the only hook', () => {
+    const installed = addSessionStartHook({ model: 'opus' }, HOOK_SCRIPT_PATH).settings;
+    const { settings, changed } = removeSessionStartHook(installed, HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings, { model: 'opus' });
+  })) passed++; else failed++;
+
+  if (test('remove is a no-op when the hook is not registered', () => {
+    const settings = thirdPartySettings();
+    const result = removeSessionStartHook(settings, HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(result.changed, false);
+    assert.deepStrictEqual(result.settings, settings);
+  })) passed++; else failed++;
+
+  if (test('applySessionStartHookToFile creates settings.json when absent', () => {
+    const homeDir = createTempDir('claude-settings-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, '.claude', 'settings.json');
+      const result = applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, true);
+      assert.ok(hasSessionStartHook(readJson(settingsPath), HOOK_SCRIPT_PATH));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('applySessionStartHookToFile merges into existing settings without rewriting other keys', () => {
+    const homeDir = createTempDir('claude-settings-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify(thirdPartySettings(), null, 2));
+
+      applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH);
+      const repeat = applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH);
+      const settings = readJson(settingsPath);
+
+      assert.strictEqual(repeat.changed, false);
+      assert.strictEqual(settings.model, 'opus');
+      assert.strictEqual(settings.hooks[SESSION_START_EVENT].length, 2);
+      assert.strictEqual(settings.hooks.PreToolUse.length, 1);
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('applySessionStartHookToFile treats an empty settings file as an empty object', () => {
+    const homeDir = createTempDir('claude-settings-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, '\n');
+
+      const result = applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, true);
+      assert.ok(hasSessionStartHook(readJson(settingsPath), HOOK_SCRIPT_PATH));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('applySessionStartHookToFile rejects invalid JSON instead of overwriting it', () => {
+    const homeDir = createTempDir('claude-settings-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, '{ not json');
+
+      assert.throws(
+        () => applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH),
+        /Failed to parse Claude Code settings/
+      );
+      assert.strictEqual(fs.readFileSync(settingsPath, 'utf8'), '{ not json');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('removeSessionStartHookFromFile never deletes settings.json', () => {
+    const homeDir = createTempDir('claude-settings-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH);
+
+      const result = removeSessionStartHookFromFile(settingsPath, HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, true);
+      assert.ok(fs.existsSync(settingsPath));
+      assert.deepStrictEqual(readJson(settingsPath), {});
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('removeSessionStartHookFromFile is a no-op when settings.json is absent', () => {
+    const homeDir = createTempDir('claude-settings-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      const result = removeSessionStartHookFromFile(settingsPath, HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, false);
+      assert.ok(!fs.existsSync(settingsPath));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectSessionStartHookFile reports ok, drifted, and invalid JSON as drifted', () => {
+    const homeDir = createTempDir('claude-settings-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+
+      fs.writeFileSync(settingsPath, JSON.stringify(thirdPartySettings()));
+      assert.strictEqual(inspectSessionStartHookFile(settingsPath, HOOK_SCRIPT_PATH), 'drifted');
+
+      applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH);
+      assert.strictEqual(inspectSessionStartHookFile(settingsPath, HOOK_SCRIPT_PATH), 'ok');
+
+      fs.writeFileSync(settingsPath, '{ not json');
+      assert.strictEqual(inspectSessionStartHookFile(settingsPath, HOOK_SCRIPT_PATH), 'drifted');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('createSessionStartHookMergeOperation builds a managed operation for the target root', () => {
+    const targetRoot = path.join('/home/user', '.claude');
+    const operation = createSessionStartHookMergeOperation(targetRoot);
+
+    assert.strictEqual(operation.kind, HOOK_OPERATION_KIND);
+    assert.strictEqual(operation.moduleId, HOOK_MODULE_ID);
+    assert.strictEqual(operation.sourceRelativePath, HOOK_SCRIPT_SOURCE_RELATIVE_PATH);
+    assert.strictEqual(operation.destinationPath, resolveSettingsPath(targetRoot));
+    assert.strictEqual(operation.ownership, 'managed');
+    assert.strictEqual(operation.scaffoldOnly, false);
+    assert.strictEqual(operation.hookEvent, SESSION_START_EVENT);
+    assert.strictEqual(operation.hookScriptPath, resolveHookScriptDestination(targetRoot));
+    assert.strictEqual(
+      operation.hookCommand,
+      buildSessionStartCommand(resolveHookScriptDestination(targetRoot))
+    );
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -18,6 +18,13 @@ const {
   createInstallState,
   writeInstallState,
 } = require('../../scripts/lib/install-state');
+const {
+  HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  applySessionStartHookToFile,
+  createSessionStartHookMergeOperation,
+  resolveHookScriptDestination,
+  resolveSettingsPath,
+} = require('../../scripts/lib/claude-settings-hooks');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const CURRENT_PACKAGE_VERSION = JSON.parse(
@@ -93,6 +100,58 @@ function writeCursorState(projectRoot, overrides = {}) {
     installStatePath: options.installStatePath,
     state: options,
   };
+}
+
+function writeClaudeSessionHookState(homeDir, options = {}) {
+  const targetRoot = path.join(homeDir, '.claude');
+  const installStatePath = path.join(targetRoot, 'egc', 'install-state.json');
+  const settingsPath = resolveSettingsPath(targetRoot);
+  const hookScriptPath = resolveHookScriptDestination(targetRoot);
+  const hookScriptSourcePath = path.join(REPO_ROOT, HOOK_SCRIPT_SOURCE_RELATIVE_PATH);
+
+  fs.mkdirSync(path.dirname(hookScriptPath), { recursive: true });
+  fs.copyFileSync(hookScriptSourcePath, hookScriptPath);
+  if (options.existingSettings) {
+    fs.writeFileSync(settingsPath, JSON.stringify(options.existingSettings, null, 2));
+  }
+  applySessionStartHookToFile(settingsPath, hookScriptPath);
+
+  writeState(installStatePath, {
+    adapter: { id: 'claude-home', target: 'claude', kind: 'home' },
+    targetRoot,
+    installStatePath,
+    request: {
+      profile: null,
+      modules: [],
+      includeComponents: [],
+      excludeComponents: [],
+      legacyLanguages: [],
+      legacyMode: true,
+    },
+    resolution: {
+      selectedModules: [],
+      skippedModules: [],
+    },
+    operations: [
+      {
+        kind: 'copy-file',
+        moduleId: 'claude-session-state-hook',
+        sourceRelativePath: HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+        destinationPath: hookScriptPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      },
+      createSessionStartHookMergeOperation(targetRoot),
+    ],
+    source: {
+      repoVersion: CURRENT_PACKAGE_VERSION,
+      repoCommit: 'abc123',
+      manifestVersion: CURRENT_MANIFEST_VERSION,
+    },
+  });
+
+  return { targetRoot, installStatePath, settingsPath, hookScriptPath };
 }
 
 function managedOperation(kind, destinationPath, overrides = {}) {
@@ -1598,6 +1657,132 @@ function runTests() {
       cleanup(homeDir);
       cleanup(unsupportedProjectRoot);
       cleanup(missingPayloadProjectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('doctor reports a removed Claude SessionStart hook as drift', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeClaudeSessionHookState(homeDir);
+
+      let report = buildDoctorReport({
+        homeDir,
+        projectRoot,
+        targets: ['claude'],
+      });
+      assert.strictEqual(report.results[0].status, 'ok');
+
+      fs.writeFileSync(installed.settingsPath, JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { matcher: 'startup', hooks: [{ type: 'command', command: 'echo third-party' }] },
+          ],
+        },
+      }, null, 2));
+
+      report = buildDoctorReport({
+        homeDir,
+        projectRoot,
+        targets: ['claude'],
+      });
+      assert.strictEqual(report.results[0].status, 'warning');
+      const driftIssue = report.results[0].issues.find(
+        issue => issue.code === 'drifted-managed-files'
+      );
+      assert.ok(driftIssue, 'Should flag the missing hook entry as drift');
+      assert.ok(driftIssue.paths.includes(installed.settingsPath));
+
+      fs.rmSync(installed.settingsPath);
+      report = buildDoctorReport({
+        homeDir,
+        projectRoot,
+        targets: ['claude'],
+      });
+      assert.strictEqual(report.results[0].status, 'error');
+      assert.ok(report.results[0].issues.some(issue => issue.code === 'missing-managed-files'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair restores the Claude SessionStart hook without touching third-party hooks', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeClaudeSessionHookState(homeDir);
+      fs.writeFileSync(installed.settingsPath, JSON.stringify({
+        model: 'opus',
+        hooks: {
+          SessionStart: [
+            { matcher: 'startup', hooks: [{ type: 'command', command: 'echo third-party' }] },
+          ],
+        },
+      }, null, 2));
+
+      const result = repairInstalledStates({
+        homeDir,
+        projectRoot,
+        targets: ['claude'],
+      });
+      assert.strictEqual(result.results[0].status, 'repaired');
+      assert.ok(result.results[0].repairedPaths.includes(installed.settingsPath));
+
+      const settings = JSON.parse(fs.readFileSync(installed.settingsPath, 'utf8'));
+      assert.strictEqual(settings.model, 'opus');
+      assert.strictEqual(settings.hooks.SessionStart.length, 2);
+      assert.strictEqual(settings.hooks.SessionStart[0].hooks[0].command, 'echo third-party');
+      assert.ok(
+        settings.hooks.SessionStart[1].hooks[0].command.includes(installed.hookScriptPath)
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('uninstall removes only the EGC Claude hook and keeps settings.json', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeClaudeSessionHookState(homeDir, {
+        existingSettings: {
+          model: 'opus',
+          hooks: {
+            SessionStart: [
+              { matcher: 'startup', hooks: [{ type: 'command', command: 'echo third-party' }] },
+            ],
+            PreToolUse: [
+              { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo guard' }] },
+            ],
+          },
+        },
+      });
+
+      const result = uninstallInstalledStates({
+        homeDir,
+        projectRoot,
+        targets: ['claude'],
+      });
+      assert.strictEqual(result.results[0].status, 'uninstalled');
+      assert.ok(!fs.existsSync(installed.hookScriptPath));
+      assert.ok(!fs.existsSync(installed.installStatePath));
+
+      const settings = JSON.parse(fs.readFileSync(installed.settingsPath, 'utf8'));
+      assert.strictEqual(settings.model, 'opus');
+      assert.deepStrictEqual(settings.hooks.SessionStart, [
+        { matcher: 'startup', hooks: [{ type: 'command', command: 'echo third-party' }] },
+      ]);
+      assert.deepStrictEqual(settings.hooks.PreToolUse, [
+        { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo guard' }] },
+      ]);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
     }
   })) passed++; else failed++;
 

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -599,6 +599,42 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('claude adapter always plans the SessionStart state hook operations', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'claude',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+    const hookScriptPath = path.join(
+      homeDir, '.claude', 'egc', 'hooks', 'claude-session-start.js'
+    );
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/claude-session-start.js'
+        && operation.destinationPath === hookScriptPath
+      )),
+      'Should plan the hook script copy even with no modules selected'
+    );
+
+    const mergeOperation = plan.operations.find(
+      operation => operation.kind === 'merge-claude-settings-hooks'
+    );
+    assert.ok(mergeOperation, 'Should plan the settings.json hook merge');
+    assert.strictEqual(
+      mergeOperation.destinationPath,
+      path.join(homeDir, '.claude', 'settings.json')
+    );
+    assert.strictEqual(mergeOperation.ownership, 'managed');
+    assert.strictEqual(mergeOperation.hookEvent, 'SessionStart');
+    assert.strictEqual(mergeOperation.hookScriptPath, hookScriptPath);
+    assert.ok(mergeOperation.hookCommand.includes(hookScriptPath));
+  })) passed++; else failed++;
+
   if (test('resolves codex adapter root to ~/.agents and install-state path', () => {
     const adapter = getInstallTargetAdapter('codex');
     const homeDir = '/Users/example';

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -324,6 +324,100 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('installs the Claude Code SessionStart state hook and records install-state', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const result = run(['--target', 'claude', '--modules', 'workflow-quality'], {
+        cwd: projectDir,
+        homeDir,
+      });
+      assert.strictEqual(result.code, 0, result.stderr);
+
+      const claudeRoot = path.join(homeDir, '.claude');
+      const hookScriptPath = path.join(claudeRoot, 'egc', 'hooks', 'claude-session-start.js');
+      assert.ok(fs.existsSync(hookScriptPath), 'Should copy the session-start hook script');
+
+      const settings = readJson(path.join(claudeRoot, 'settings.json'));
+      const sessionStartGroups = settings.hooks.SessionStart;
+      assert.strictEqual(sessionStartGroups.length, 1);
+      assert.ok(
+        sessionStartGroups[0].hooks[0].command.includes(hookScriptPath),
+        'SessionStart hook should invoke the installed EGC script'
+      );
+
+      const state = readJson(path.join(claudeRoot, 'egc', 'install-state.json'));
+      assert.ok(
+        state.operations.some(operation => (
+          operation.kind === 'merge-claude-settings-hooks'
+          && operation.destinationPath === path.join(claudeRoot, 'settings.json')
+          && operation.hookScriptPath === hookScriptPath
+        )),
+        'Should record the settings.json hook merge in install-state'
+      );
+      assert.ok(
+        state.operations.some(operation => (
+          operation.kind === 'copy-file'
+          && operation.destinationPath === hookScriptPath
+        )),
+        'Should record the hook script copy in install-state'
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('claude reinstall is idempotent and preserves third-party settings.json content', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const claudeRoot = path.join(homeDir, '.claude');
+      const settingsPath = path.join(claudeRoot, 'settings.json');
+      fs.mkdirSync(claudeRoot, { recursive: true });
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        model: 'opus',
+        hooks: {
+          SessionStart: [
+            { matcher: 'startup', hooks: [{ type: 'command', command: 'echo third-party' }] },
+          ],
+          PreToolUse: [
+            { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo guard' }] },
+          ],
+        },
+      }, null, 2));
+
+      const first = run(['--target', 'claude', '--modules', 'workflow-quality'], {
+        cwd: projectDir,
+        homeDir,
+      });
+      assert.strictEqual(first.code, 0, first.stderr);
+      const second = run(['--target', 'claude', '--modules', 'workflow-quality'], {
+        cwd: projectDir,
+        homeDir,
+      });
+      assert.strictEqual(second.code, 0, second.stderr);
+
+      const settings = readJson(settingsPath);
+      assert.strictEqual(settings.model, 'opus');
+      assert.strictEqual(settings.hooks.PreToolUse.length, 1);
+
+      const sessionStartGroups = settings.hooks.SessionStart;
+      assert.strictEqual(sessionStartGroups.length, 2, 'Reinstall must not duplicate the EGC hook');
+      assert.strictEqual(sessionStartGroups[0].hooks[0].command, 'echo third-party');
+      assert.ok(
+        sessionStartGroups[1].hooks[0].command.includes(
+          path.join(claudeRoot, 'egc', 'hooks', 'claude-session-start.js')
+        )
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('preserves existing top-level Gemini rules and skills during managed install', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');


### PR DESCRIPTION
## Summary

The Claude Code target now registers a SessionStart hook in the user's `~/.claude/settings.json` that prints the EGC state file for the current project. Persistent memory is restored in every session deterministically, without depending on the model honoring CLAUDE.md instructions.

- Hook script only reads `~/.egc/state/<slug>.md` (same slug derivation as egc-memory) and always exits 0, so session startup can never break
- settings.json merge is additive and idempotent: third-party hooks preserved, no duplicates on reinstall, invalid JSON rejected instead of overwritten
- Uninstall strips only the EGC entry and never deletes settings.json; doctor reports drift; repair re-merges in place
- 52 new asserts across unit, subprocess and E2E install tests, all under fake HOME

## Known friction surfaced (not fixed here)

Skill modules targeting claude are all skipped because they depend on `platform-configs`, which does not list claude. Tracked separately.

## Test plan

- `npm test`: 2299/2299 (run before and after rebase)
- `npm run lint`: 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic SessionStart hook to Claude Code installs that restores EGC project memory from ~/.egc/state so sessions always load persistent memory without relying on CLAUDE.md. No user action needed beyond installing or reinstalling the Claude target.

- **New Features**
  - Always planned (even with no modules): copies a read‑only hook to ~/.claude/egc/hooks and merges it into ~/.claude/settings.json; merge is additive and idempotent (preserves third‑party hooks, never duplicates, rejects invalid JSON).
  - Hook behavior: reads ~/.egc/state/<slug>.md for the current project (slug matches egc-memory; cwd from stdin with env fallback), prints it, and always exits 0; never runs project code.
  - Lifecycle: uninstall removes only the EGC SessionStart entry; doctor flags drift and missing files; repair re‑merges the entry; settings.json is never deleted.

<sup>Written for commit 2d19ffa2d6d627a8950e2fa6f6c4b3d400ed6da3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic session state persistence that is managed during installation, repair, and uninstall workflows.

* **Tests**
  * Added comprehensive test coverage for session state management and installation lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->