### PR TITLE
feat(memory): lessons with confidence decay for cross-session knowledge

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -207,6 +207,29 @@ async function runMigrations(db: Database, dbDir: string) {
       await createWorkingMemoryTable(db);
       await db.run('INSERT INTO schema_migrations (version) VALUES (3)');
     }
+
+    // Migration 4: lessons table with confidence decay support.
+    const hasV4 = await db.get('SELECT version FROM schema_migrations WHERE version = 4');
+    if (!hasV4) {
+      await db.exec(`
+        CREATE TABLE IF NOT EXISTS lessons (
+          id TEXT PRIMARY KEY,
+          content TEXT NOT NULL,
+          context TEXT NOT NULL,
+          confidence REAL NOT NULL DEFAULT 0.7,
+          last_reinforced TEXT,
+          last_recalled TEXT,
+          created_at TEXT NOT NULL,
+          tags TEXT,
+          archived INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_lessons_confidence_created_at
+          ON lessons (confidence DESC, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_lessons_archived_confidence
+          ON lessons (archived, confidence DESC);
+      `);
+      await db.run('INSERT INTO schema_migrations (version) VALUES (4)');
+    }
   } finally {
     try { fs.unlinkSync(lockFile); } catch(e) {}
   }
@@ -312,6 +335,72 @@ function writeStateDoc(filePath: string, projectPath: string, data: {
   fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
 }
 
+const LESSON_REINFORCE_DELTA = 0.15;
+const LESSON_DECAY_DELTA_PER_WEEK = 0.05;
+const LESSON_DECAY_GRACE_DAYS = 30;
+const LESSON_ARCHIVE_THRESHOLD = 0.2;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+interface LessonRow {
+  id: string;
+  content: string;
+  context: string;
+  confidence: number;
+  last_reinforced: string | null;
+  last_recalled: string | null;
+  created_at: string;
+  tags: string | null;
+  archived: number;
+}
+
+function mapLessonRow(row: LessonRow) {
+  return {
+    id: row.id,
+    content: row.content,
+    context: row.context,
+    confidence: row.confidence,
+    lastReinforced: row.last_reinforced ?? null,
+    lastRecalled: row.last_recalled ?? null,
+    createdAt: row.created_at,
+    tags: row.tags ?? null,
+    archived: row.archived === 1,
+  };
+}
+
+function computeLessonDecay(confidence: number, lastRecalledIso: string | null, createdAtIso: string, nowMs: number): number {
+  const referenceMs = lastRecalledIso
+    ? new Date(lastRecalledIso).getTime()
+    : new Date(createdAtIso).getTime();
+  const elapsedMs = nowMs - referenceMs;
+  const gracePeriodMs = LESSON_DECAY_GRACE_DAYS * MS_PER_DAY;
+  if (elapsedMs <= gracePeriodMs) {
+    return confidence;
+  }
+  const weeksOverGrace = Math.floor((elapsedMs - gracePeriodMs) / MS_PER_WEEK);
+  return Math.max(0, confidence - weeksOverGrace * LESSON_DECAY_DELTA_PER_WEEK);
+}
+
+function generateLessonId(): string {
+  return `lesson-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function runLessonDecaySweep(db: Database): Promise<number> {
+  const now = Date.now();
+  const rows = await db.all<LessonRow[]>('SELECT * FROM lessons WHERE archived = 0');
+  let affected = 0;
+  for (const row of rows) {
+    const decayed = computeLessonDecay(row.confidence, row.last_reinforced, row.created_at, now);
+    if (decayed === row.confidence) {
+      continue;
+    }
+    const archived = decayed < LESSON_ARCHIVE_THRESHOLD ? 1 : 0;
+    await db.run('UPDATE lessons SET confidence = ?, archived = ? WHERE id = ?', [decayed, archived, row.id]);
+    affected++;
+  }
+  return affected;
+}
+
 const StoreDecisionSchema = z.object({
   context: z.string().min(1).max(5000),
   decision: z.string().min(1).max(10000)
@@ -326,6 +415,23 @@ const SearchHistorySchema = z.object({
 const QueryHistorySchema = z.object({
   limit: z.number().min(1).max(100).optional().default(10),
   offset: z.number().min(0).optional().default(0)
+});
+
+const LessonSaveSchema = z.object({
+  content: z.string().min(1).max(5000),
+  context: z.string().min(1).max(2000),
+  tags: z.string().max(500).optional(),
+  initial_confidence: z.number().min(0).max(1).optional().default(0.7)
+});
+
+const LessonRecallSchema = z.object({
+  query: z.string().min(1).max(1000),
+  min_confidence: z.number().min(0).max(1).optional().default(0.2),
+  limit: z.number().min(1).max(100).optional().default(10)
+});
+
+const LessonReinforceSchema = z.object({
+  id: z.string().min(1)
 });
 
 const GetStateSchema = z.object({
@@ -430,6 +536,44 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             project_path: { type: "string", description: "Absolute path to the project root. Defaults to current working directory." }
           }
         }
+      },
+      {
+        name: "lesson_save",
+        description: "Persist a new lesson learned during this session. Lessons are stored with a confidence score and decay over time when not reinforced. Use this to record patterns, rules, or observations the AI should remember across sessions.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            content: { type: "string", description: "The lesson text to store." },
+            context: { type: "string", description: "Where this lesson applies, e.g. 'code review' or 'git workflow'." },
+            tags: { type: "string", description: "Optional comma-separated tags for categorization." },
+            initial_confidence: { type: "number", description: "Starting confidence score between 0 and 1. Defaults to 0.7." }
+          },
+          required: ["content", "context"]
+        }
+      },
+      {
+        name: "lesson_recall",
+        description: "Search active lessons above a confidence threshold. Lessons below 0.2 confidence are archived and not returned by default. Returns lessons ranked by confidence score.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Keyword or topic to filter lessons by content or context." },
+            min_confidence: { type: "number", description: "Minimum confidence threshold, 0 to 1. Defaults to 0.2." },
+            limit: { type: "number", description: "Maximum number of lessons to return. Defaults to 10." }
+          },
+          required: ["query"]
+        }
+      },
+      {
+        name: "lesson_reinforce",
+        description: "Reinforce an existing lesson when the same pattern is observed again. Increases confidence by 0.15, capped at 1.0. Call this when a previously stored lesson proves relevant or a mistake is repeated.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "The lesson ID returned by lesson_save or lesson_recall." }
+          },
+          required: ["id"]
+        }
       }
     ]
   };
@@ -477,6 +621,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const swept = await sweepExpired(db);
         if (swept > 0) {
           log('INFO', 'Swept expired working memory entries', { count: swept });
+        }
+
+        // Run confidence decay sweep on every get_state call.
+        try {
+          const affected = await runLessonDecaySweep(db);
+          if (affected > 0) {
+            log('INFO', 'Lesson decay sweep ran', { affected });
+          }
+        } catch (e) {
+          log('WARN', 'Lesson decay sweep failed, continuing', { error: String(e) });
         }
 
         if (resolved.source === 'none') {
@@ -533,6 +687,68 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const projPath = resolveProjectPath(args.project_path);
         const entries = await listWorkingMemory(db, projPath);
         return { content: [{ type: "text", text: JSON.stringify(entries.map(e => ({ key: e.key, value: e.value, expires_at: e.expires_at })), null, 2) }] };
+      }
+
+      case "lesson_save": {
+        const { content, context, tags, initial_confidence } = LessonSaveSchema.parse(request.params.arguments);
+        const id = generateLessonId();
+        const now = new Date().toISOString();
+        await writeArbitrator.enqueue(async () => {
+          await db.run(
+            `INSERT INTO lessons (id, content, context, confidence, last_reinforced, last_recalled, created_at, tags, archived)
+             VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, 0)`,
+            [id, content, context, initial_confidence, now, tags ?? null]
+          );
+        });
+        log('INFO', 'Lesson saved', { id, context });
+        return { content: [{ type: "text", text: JSON.stringify({ id, content, context, confidence: initial_confidence, tags: tags ?? null, createdAt: now }, null, 2) }] };
+      }
+
+      case "lesson_recall": {
+        const { query, min_confidence, limit } = LessonRecallSchema.parse(request.params.arguments);
+        const lowerQuery = query.toLowerCase();
+        const rows = await db.all<LessonRow[]>(
+          `SELECT * FROM lessons
+           WHERE archived = 0 AND confidence >= ?
+           ORDER BY confidence DESC, created_at DESC
+           LIMIT ?`,
+          [min_confidence, limit * 3]
+        );
+        const matched = rows
+          .filter(r => r.content.toLowerCase().includes(lowerQuery) || r.context.toLowerCase().includes(lowerQuery) || (r.tags?.toLowerCase().includes(lowerQuery) ?? false))
+          .slice(0, limit)
+          .map(mapLessonRow);
+
+        const now = new Date().toISOString();
+        if (matched.length > 0) {
+          await writeArbitrator.enqueue(async () => {
+            for (const lesson of matched) {
+              await db.run('UPDATE lessons SET last_recalled = ? WHERE id = ?', [now, lesson.id]);
+            }
+          });
+        }
+
+        log('INFO', 'Lessons recalled', { query, count: matched.length });
+        return { content: [{ type: "text", text: JSON.stringify({ lessons: matched, meta: { query, min_confidence, limit, count: matched.length } }, null, 2) }] };
+      }
+
+      case "lesson_reinforce": {
+        const { id } = LessonReinforceSchema.parse(request.params.arguments);
+        const row = await db.get<LessonRow>('SELECT * FROM lessons WHERE id = ?', [id]);
+        if (!row) {
+          throw new McpError(ErrorCode.InvalidRequest, `Lesson not found: ${id}`);
+        }
+        const newConfidence = Math.min(1, row.confidence + LESSON_REINFORCE_DELTA);
+        const now = new Date().toISOString();
+        await writeArbitrator.enqueue(async () => {
+          await db.run(
+            'UPDATE lessons SET confidence = ?, last_reinforced = ?, archived = 0 WHERE id = ?',
+            [newConfidence, now, id]
+          );
+        });
+        const updated = await db.get<LessonRow>('SELECT * FROM lessons WHERE id = ?', [id]);
+        log('INFO', 'Lesson reinforced', { id, confidence: newConfidence });
+        return { content: [{ type: "text", text: JSON.stringify(updated ? mapLessonRow(updated) : { id, confidence: newConfidence }, null, 2) }] };
       }
 
       default:

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs';
 import { execSync } from 'child_process';
+import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
@@ -382,7 +383,7 @@ function computeLessonDecay(confidence: number, lastRecalledIso: string | null, 
 }
 
 function generateLessonId(): string {
-  return `lesson-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `lesson-${Date.now()}-${randomUUID().slice(0, 8)}`;
 }
 
 async function runLessonDecaySweep(db: Database): Promise<number> {
@@ -579,6 +580,68 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
+async function handleLessonSave(db: Database, args: unknown) {
+  const { content, context, tags, initial_confidence } = LessonSaveSchema.parse(args);
+  const id = generateLessonId();
+  const now = new Date().toISOString();
+  await writeArbitrator.enqueue(async () => {
+    await db.run(
+      `INSERT INTO lessons (id, content, context, confidence, last_reinforced, last_recalled, created_at, tags, archived)
+       VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, 0)`,
+      [id, content, context, initial_confidence, now, tags ?? null]
+    );
+  });
+  log('INFO', 'Lesson saved', { id, context });
+  return { content: [{ type: "text", text: JSON.stringify({ id, content, context, confidence: initial_confidence, tags: tags ?? null, createdAt: now }, null, 2) }] };
+}
+
+async function handleLessonRecall(db: Database, args: unknown) {
+  const { query, min_confidence, limit } = LessonRecallSchema.parse(args);
+  const lowerQuery = query.toLowerCase();
+  const rows = await db.all<LessonRow[]>(
+    `SELECT * FROM lessons
+     WHERE archived = 0 AND confidence >= ?
+     ORDER BY confidence DESC, created_at DESC
+     LIMIT ?`,
+    [min_confidence, limit * 3]
+  );
+  const matched = rows
+    .filter(r => r.content.toLowerCase().includes(lowerQuery) || r.context.toLowerCase().includes(lowerQuery) || (r.tags?.toLowerCase().includes(lowerQuery) ?? false))
+    .slice(0, limit)
+    .map(mapLessonRow);
+
+  const now = new Date().toISOString();
+  if (matched.length > 0) {
+    await writeArbitrator.enqueue(async () => {
+      for (const lesson of matched) {
+        await db.run('UPDATE lessons SET last_recalled = ? WHERE id = ?', [now, lesson.id]);
+      }
+    });
+  }
+
+  log('INFO', 'Lessons recalled', { query, count: matched.length });
+  return { content: [{ type: "text", text: JSON.stringify({ lessons: matched, meta: { query, min_confidence, limit, count: matched.length } }, null, 2) }] };
+}
+
+async function handleLessonReinforce(db: Database, args: unknown) {
+  const { id } = LessonReinforceSchema.parse(args);
+  const row = await db.get<LessonRow>('SELECT * FROM lessons WHERE id = ?', [id]);
+  if (!row) {
+    throw new McpError(ErrorCode.InvalidRequest, `Lesson not found: ${id}`);
+  }
+  const newConfidence = Math.min(1, row.confidence + LESSON_REINFORCE_DELTA);
+  const now = new Date().toISOString();
+  await writeArbitrator.enqueue(async () => {
+    await db.run(
+      'UPDATE lessons SET confidence = ?, last_reinforced = ?, archived = 0 WHERE id = ?',
+      [newConfidence, now, id]
+    );
+  });
+  const updated = await db.get<LessonRow>('SELECT * FROM lessons WHERE id = ?', [id]);
+  log('INFO', 'Lesson reinforced', { id, confidence: newConfidence });
+  return { content: [{ type: "text", text: JSON.stringify(updated ? mapLessonRow(updated) : { id, confidence: newConfidence }, null, 2) }] };
+}
+
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const db = await getDb();
   try {
@@ -689,67 +752,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return { content: [{ type: "text", text: JSON.stringify(entries.map(e => ({ key: e.key, value: e.value, expires_at: e.expires_at })), null, 2) }] };
       }
 
-      case "lesson_save": {
-        const { content, context, tags, initial_confidence } = LessonSaveSchema.parse(request.params.arguments);
-        const id = generateLessonId();
-        const now = new Date().toISOString();
-        await writeArbitrator.enqueue(async () => {
-          await db.run(
-            `INSERT INTO lessons (id, content, context, confidence, last_reinforced, last_recalled, created_at, tags, archived)
-             VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, 0)`,
-            [id, content, context, initial_confidence, now, tags ?? null]
-          );
-        });
-        log('INFO', 'Lesson saved', { id, context });
-        return { content: [{ type: "text", text: JSON.stringify({ id, content, context, confidence: initial_confidence, tags: tags ?? null, createdAt: now }, null, 2) }] };
-      }
+      case "lesson_save":
+        return await handleLessonSave(db, request.params.arguments);
 
-      case "lesson_recall": {
-        const { query, min_confidence, limit } = LessonRecallSchema.parse(request.params.arguments);
-        const lowerQuery = query.toLowerCase();
-        const rows = await db.all<LessonRow[]>(
-          `SELECT * FROM lessons
-           WHERE archived = 0 AND confidence >= ?
-           ORDER BY confidence DESC, created_at DESC
-           LIMIT ?`,
-          [min_confidence, limit * 3]
-        );
-        const matched = rows
-          .filter(r => r.content.toLowerCase().includes(lowerQuery) || r.context.toLowerCase().includes(lowerQuery) || (r.tags?.toLowerCase().includes(lowerQuery) ?? false))
-          .slice(0, limit)
-          .map(mapLessonRow);
+      case "lesson_recall":
+        return await handleLessonRecall(db, request.params.arguments);
 
-        const now = new Date().toISOString();
-        if (matched.length > 0) {
-          await writeArbitrator.enqueue(async () => {
-            for (const lesson of matched) {
-              await db.run('UPDATE lessons SET last_recalled = ? WHERE id = ?', [now, lesson.id]);
-            }
-          });
-        }
-
-        log('INFO', 'Lessons recalled', { query, count: matched.length });
-        return { content: [{ type: "text", text: JSON.stringify({ lessons: matched, meta: { query, min_confidence, limit, count: matched.length } }, null, 2) }] };
-      }
-
-      case "lesson_reinforce": {
-        const { id } = LessonReinforceSchema.parse(request.params.arguments);
-        const row = await db.get<LessonRow>('SELECT * FROM lessons WHERE id = ?', [id]);
-        if (!row) {
-          throw new McpError(ErrorCode.InvalidRequest, `Lesson not found: ${id}`);
-        }
-        const newConfidence = Math.min(1, row.confidence + LESSON_REINFORCE_DELTA);
-        const now = new Date().toISOString();
-        await writeArbitrator.enqueue(async () => {
-          await db.run(
-            'UPDATE lessons SET confidence = ?, last_reinforced = ?, archived = 0 WHERE id = ?',
-            [newConfidence, now, id]
-          );
-        });
-        const updated = await db.get<LessonRow>('SELECT * FROM lessons WHERE id = ?', [id]);
-        log('INFO', 'Lesson reinforced', { id, confidence: newConfidence });
-        return { content: [{ type: "text", text: JSON.stringify(updated ? mapLessonRow(updated) : { id, confidence: newConfidence }, null, 2) }] };
-      }
+      case "lesson_reinforce":
+        return await handleLessonReinforce(db, request.params.arguments);
 
       default:
         throw new McpError(ErrorCode.MethodNotFound, `Tool not found: ${request.params.name}`);

--- a/schemas/state-store.schema.json
+++ b/schemas/state-store.schema.json
@@ -52,6 +52,12 @@
       "items": {
         "$ref": "#/$defs/runtimeEvent"
       }
+    },
+    "lessons": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/lesson"
+      }
     }
   },
   "$defs": {
@@ -387,6 +393,54 @@
         },
         "timestamp": {
           "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "lesson": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "content",
+        "context",
+        "confidence",
+        "lastReinforced",
+        "lastRecalled",
+        "createdAt",
+        "tags",
+        "archived"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "content": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "context": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "lastReinforced": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "lastRecalled": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "createdAt": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "tags": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "archived": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
         }
       }
     }

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -125,6 +125,11 @@ function createNullQueryApi() {
     listInstincts: () => ({ totalCount: 0, instincts: [] }),
     insertRuntimeEvent: () => {},
     listRecentEvents: () => [],
+    upsertLesson: () => null,
+    getLessonById: () => null,
+    listLessons: () => [],
+    reinforceLesson: () => null,
+    applyDecaySweep: () => 0,
   };
 }
 

--- a/scripts/lib/state-store/migrations.js
+++ b/scripts/lib/state-store/migrations.js
@@ -138,6 +138,25 @@ CREATE INDEX IF NOT EXISTS idx_events_event_type_timestamp
   ON events (event_type, timestamp DESC);
 `;
 
+const LESSONS_SQL = `
+CREATE TABLE IF NOT EXISTS lessons (
+  id TEXT PRIMARY KEY,
+  content TEXT NOT NULL,
+  context TEXT NOT NULL,
+  confidence REAL NOT NULL DEFAULT 0.7,
+  last_reinforced TEXT,
+  last_recalled TEXT,
+  created_at TEXT NOT NULL,
+  tags TEXT,
+  archived INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_lessons_confidence_created_at
+  ON lessons (confidence DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lessons_archived_confidence
+  ON lessons (archived, confidence DESC);
+`;
+
 const MIGRATIONS = [
   {
     version: 1,
@@ -148,6 +167,11 @@ const MIGRATIONS = [
     version: 2,
     name: '002_instincts_and_events',
     sql: INSTINCTS_AND_EVENTS_SQL,
+  },
+  {
+    version: 3,
+    name: '003_lessons_confidence_decay',
+    sql: LESSONS_SQL,
   },
 ];
 

--- a/scripts/lib/state-store/queries.js
+++ b/scripts/lib/state-store/queries.js
@@ -143,6 +143,20 @@ function mapRuntimeEventRow(row) {
   };
 }
 
+function mapLessonRow(row) {
+  return {
+    id: row.id,
+    content: row.content,
+    context: row.context,
+    confidence: typeof row.confidence === 'number' ? row.confidence : 0.7,
+    lastReinforced: row.last_reinforced ?? null,
+    lastRecalled: row.last_recalled ?? null,
+    createdAt: row.created_at,
+    tags: row.tags ?? null,
+    archived: row.archived === 1 ? 1 : 0,
+  };
+}
+
 function classifyOutcome(outcome) {
   const normalized = String(outcome || '').toLowerCase();
   if (SUCCESS_OUTCOMES.has(normalized)) {
@@ -335,6 +349,47 @@ function normalizeRuntimeEventInput(event) {
     payload: event.payload ?? null,
     timestamp: event.timestamp || new Date().toISOString(),
   };
+}
+
+const REINFORCE_DELTA = 0.15;
+const DECAY_DELTA_PER_WEEK = 0.05;
+const DECAY_GRACE_DAYS = 30;
+const ARCHIVE_THRESHOLD = 0.2;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function normalizeLessonInput(lesson) {
+  let confidence = 0.7;
+  if (typeof lesson.confidence === 'number') {
+    if (!Number.isFinite(lesson.confidence)) {
+      throw new Error(`Invalid lesson.confidence: must be a finite number (got ${lesson.confidence})`);
+    }
+    confidence = Math.min(1, Math.max(0, lesson.confidence));
+  }
+
+  return {
+    id: lesson.id,
+    content: lesson.content,
+    context: lesson.context,
+    confidence,
+    lastReinforced: lesson.lastReinforced ?? null,
+    lastRecalled: lesson.lastRecalled ?? null,
+    createdAt: lesson.createdAt || new Date().toISOString(),
+    tags: lesson.tags ?? null,
+    archived: lesson.archived === 1 ? 1 : 0,
+  };
+}
+
+function computeDecayedConfidence(lesson, nowMs) {
+  const recalledMs = lesson.lastRecalled ? new Date(lesson.lastRecalled).getTime() : new Date(lesson.createdAt).getTime();
+  const elapsedMs = nowMs - recalledMs;
+  const gracePeriodMs = DECAY_GRACE_DAYS * MS_PER_DAY;
+  if (elapsedMs <= gracePeriodMs) {
+    return lesson.confidence;
+  }
+  const weeksOverGrace = Math.floor((elapsedMs - gracePeriodMs) / MS_PER_WEEK);
+  const decayed = lesson.confidence - weeksOverGrace * DECAY_DELTA_PER_WEEK;
+  return Math.max(0, decayed);
 }
 
 function createQueryApi(db) {
@@ -667,6 +722,57 @@ function createQueryApi(db) {
       timestamp = excluded.timestamp
   `);
 
+  const upsertLessonStatement = db.prepare(`
+    INSERT INTO lessons (
+      id,
+      content,
+      context,
+      confidence,
+      last_reinforced,
+      last_recalled,
+      created_at,
+      tags,
+      archived
+    ) VALUES (
+      @id,
+      @content,
+      @context,
+      @confidence,
+      @last_reinforced,
+      @last_recalled,
+      @created_at,
+      @tags,
+      @archived
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      content = excluded.content,
+      context = excluded.context,
+      confidence = excluded.confidence,
+      last_reinforced = excluded.last_reinforced,
+      last_recalled = excluded.last_recalled,
+      tags = excluded.tags,
+      archived = excluded.archived
+  `);
+
+  const getLessonStatement = db.prepare(`
+    SELECT * FROM lessons WHERE id = ?
+  `);
+
+  const listActiveLessonsStatement = db.prepare(`
+    SELECT * FROM lessons
+    WHERE archived = 0 AND confidence >= ?
+    ORDER BY confidence DESC, created_at DESC
+    LIMIT ?
+  `);
+
+  const listAllLessonsForDecayStatement = db.prepare(`
+    SELECT * FROM lessons WHERE archived = 0
+  `);
+
+  const updateLessonDecayStatement = db.prepare(`
+    UPDATE lessons SET confidence = @confidence, archived = @archived WHERE id = @id
+  `);
+
   function getSessionById(id) {
     const row = getSessionStatement.get(id);
     return row ? mapSessionRow(row) : null;
@@ -870,6 +976,76 @@ function createQueryApi(db) {
       }
       return listRecentEventsStatement.all(limit).map(mapRuntimeEventRow);
     },
+    upsertLesson(lesson) {
+      const normalized = normalizeLessonInput(lesson);
+      assertValidEntity('lesson', normalized);
+      upsertLessonStatement.run({
+        id: normalized.id,
+        content: normalized.content,
+        context: normalized.context,
+        confidence: normalized.confidence,
+        last_reinforced: normalized.lastReinforced,
+        last_recalled: normalized.lastRecalled,
+        created_at: normalized.createdAt,
+        tags: normalized.tags,
+        archived: normalized.archived,
+      });
+      const row = getLessonStatement.get(normalized.id);
+      return row ? mapLessonRow(row) : null;
+    },
+    getLessonById(id) {
+      const row = getLessonStatement.get(id);
+      return row ? mapLessonRow(row) : null;
+    },
+    listLessons(options = {}) {
+      const minConfidence = typeof options.minConfidence === 'number' ? options.minConfidence : 0.2;
+      const limit = normalizeLimit(options.limit, 20);
+      return listActiveLessonsStatement.all(minConfidence, limit).map(mapLessonRow);
+    },
+    reinforceLesson(id, nowIso) {
+      const row = getLessonStatement.get(id);
+      if (!row) {
+        return null;
+      }
+      const lesson = mapLessonRow(row);
+      const newConfidence = Math.min(1, lesson.confidence + REINFORCE_DELTA);
+      const reinforcedAt = nowIso || new Date().toISOString();
+      upsertLessonStatement.run({
+        id: lesson.id,
+        content: lesson.content,
+        context: lesson.context,
+        confidence: newConfidence,
+        last_reinforced: reinforcedAt,
+        last_recalled: lesson.lastRecalled,
+        created_at: lesson.createdAt,
+        tags: lesson.tags,
+        archived: 0,
+      });
+      const updated = getLessonStatement.get(id);
+      return updated ? mapLessonRow(updated) : null;
+    },
+    applyDecaySweep(nowIso) {
+      const now = nowIso ? new Date(nowIso).getTime() : Date.now();
+      const rows = listAllLessonsForDecayStatement.all().map(mapLessonRow);
+      let affected = 0;
+      const applyAll = db.transaction(() => {
+        for (const lesson of rows) {
+          const decayed = computeDecayedConfidence(lesson, now);
+          if (decayed === lesson.confidence) {
+            continue;
+          }
+          const archived = decayed < ARCHIVE_THRESHOLD ? 1 : 0;
+          updateLessonDecayStatement.run({
+            id: lesson.id,
+            confidence: decayed,
+            archived,
+          });
+          affected++;
+        }
+      });
+      applyAll();
+      return affected;
+    },
   };
 }
 
@@ -877,5 +1053,9 @@ module.exports = {
   ACTIVE_SESSION_STATES,
   FAILURE_OUTCOMES,
   SUCCESS_OUTCOMES,
+  REINFORCE_DELTA,
+  DECAY_DELTA_PER_WEEK,
+  DECAY_GRACE_DAYS,
+  ARCHIVE_THRESHOLD,
   createQueryApi,
 };

--- a/scripts/lib/state-store/queries.js
+++ b/scripts/lib/state-store/queries.js
@@ -362,7 +362,7 @@ function normalizeLessonInput(lesson) {
   let confidence = 0.7;
   if (typeof lesson.confidence === 'number') {
     if (!Number.isFinite(lesson.confidence)) {
-      throw new Error(`Invalid lesson.confidence: must be a finite number (got ${lesson.confidence})`);
+      throw new TypeError(`Invalid lesson.confidence: must be a finite number (got ${lesson.confidence})`);
     }
     confidence = Math.min(1, Math.max(0, lesson.confidence));
   }

--- a/scripts/lib/state-store/schema.js
+++ b/scripts/lib/state-store/schema.js
@@ -15,6 +15,7 @@ const ENTITY_DEFINITIONS = {
   governanceEvent: 'governanceEvent',
   instinct: 'instinct',
   runtimeEvent: 'runtimeEvent',
+  lesson: 'lesson',
 };
 
 let cachedSchema = null;

--- a/tests/lib/lessons-decay.test.js
+++ b/tests/lib/lessons-decay.test.js
@@ -1,0 +1,477 @@
+'use strict';
+
+/**
+ * Tests for the lessons confidence decay feature.
+ * Covers: lesson_save, lesson_recall, lesson_reinforce, decay sweep, archival.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createStateStore,
+} = require('../../scripts/lib/state-store');
+
+const {
+  REINFORCE_DELTA,
+  DECAY_DELTA_PER_WEEK,
+  DECAY_GRACE_DAYS,
+  ARCHIVE_THRESHOLD,
+} = require('../../scripts/lib/state-store/queries');
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    if (error.stack) {
+      console.log(`    ${error.stack.split('\n').slice(1, 3).join('\n    ')}`);
+    }
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupTempDir(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function daysAgo(n) {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+async function runUpsertTests(counter) {
+  if (await test('upsertLesson stores and returns a lesson with defaults', async () => {
+    const testDir = createTempDir('egc-lessons-basic-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const lesson = store.upsertLesson({
+        id: 'lesson-1',
+        content: 'Always run lint before commit',
+        context: 'git workflow',
+        confidence: 0.8,
+      });
+      store.close();
+
+      assert.strictEqual(lesson.id, 'lesson-1');
+      assert.strictEqual(lesson.content, 'Always run lint before commit');
+      assert.strictEqual(lesson.context, 'git workflow');
+      assert.strictEqual(lesson.confidence, 0.8);
+      assert.strictEqual(lesson.lastReinforced, null);
+      assert.strictEqual(lesson.lastRecalled, null);
+      assert.strictEqual(lesson.tags, null);
+      assert.strictEqual(lesson.archived, 0);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('upsertLesson clamps confidence to [0, 1]', async () => {
+    const testDir = createTempDir('egc-lessons-clamp-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const high = store.upsertLesson({ id: 'l-high', content: 'x', context: 'c', confidence: 1.5 });
+      const low = store.upsertLesson({ id: 'l-low', content: 'x', context: 'c', confidence: -0.3 });
+      store.close();
+
+      assert.strictEqual(high.confidence, 1);
+      assert.strictEqual(low.confidence, 0);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('upsertLesson defaults confidence to 0.7', async () => {
+    const testDir = createTempDir('egc-lessons-default-conf-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const lesson = store.upsertLesson({ id: 'l-def', content: 'x', context: 'c' });
+      store.close();
+
+      assert.strictEqual(lesson.confidence, 0.7);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('upsertLesson supports tags', async () => {
+    const testDir = createTempDir('egc-lessons-tags-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const lesson = store.upsertLesson({
+        id: 'l-tags',
+        content: 'Use signed commits',
+        context: 'git',
+        tags: 'security,git,dco',
+      });
+      store.close();
+
+      assert.strictEqual(lesson.tags, 'security,git,dco');
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('getLessonById returns null for unknown id', async () => {
+    const testDir = createTempDir('egc-lessons-getbyid-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const result = store.getLessonById('no-such-lesson');
+      store.close();
+
+      assert.strictEqual(result, null);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('listLessons returns lessons above min_confidence, sorted by score', async () => {
+    const testDir = createTempDir('egc-lessons-list-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      store.upsertLesson({ id: 'l-a', content: 'A', context: 'c', confidence: 0.9 });
+      store.upsertLesson({ id: 'l-b', content: 'B', context: 'c', confidence: 0.5 });
+      store.upsertLesson({ id: 'l-c', content: 'C', context: 'c', confidence: 0.1 });
+      const results = store.listLessons({ minConfidence: 0.2, limit: 10 });
+      store.close();
+
+      assert.strictEqual(results.length, 2);
+      assert.strictEqual(results[0].id, 'l-a');
+      assert.strictEqual(results[1].id, 'l-b');
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('listLessons excludes archived lessons', async () => {
+    const testDir = createTempDir('egc-lessons-archived-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      store.upsertLesson({ id: 'l-active', content: 'active', context: 'c', confidence: 0.8 });
+      store.upsertLesson({ id: 'l-arch', content: 'archived', context: 'c', confidence: 0.8, archived: 1 });
+      const results = store.listLessons({ minConfidence: 0.0, limit: 10 });
+      store.close();
+
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0].id, 'l-active');
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('upsertLesson update preserves createdAt', async () => {
+    const testDir = createTempDir('egc-lessons-update-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const originalDate = '2026-01-15T10:00:00.000Z';
+      store.upsertLesson({ id: 'l-upd', content: 'v1', context: 'c', createdAt: originalDate });
+      const updated = store.upsertLesson({ id: 'l-upd', content: 'v2', context: 'c', confidence: 0.9, createdAt: originalDate });
+      store.close();
+
+      assert.strictEqual(updated.content, 'v2');
+      assert.strictEqual(updated.confidence, 0.9);
+      assert.strictEqual(updated.createdAt, originalDate);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+}
+
+async function runReinforceTests(counter) {
+  if (await test('reinforceLesson increases confidence by REINFORCE_DELTA, capped at 1', async () => {
+    const testDir = createTempDir('egc-lessons-reinforce-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      store.upsertLesson({ id: 'l-r', content: 'x', context: 'c', confidence: 0.7 });
+      const reinforced = store.reinforceLesson('l-r');
+      store.close();
+
+      assert.ok(reinforced !== null);
+      assert.ok(Math.abs(reinforced.confidence - (0.7 + REINFORCE_DELTA)) < 0.0001);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('reinforceLesson caps confidence at 1.0', async () => {
+    const testDir = createTempDir('egc-lessons-reinforce-cap-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      store.upsertLesson({ id: 'l-cap', content: 'x', context: 'c', confidence: 0.95 });
+      const reinforced = store.reinforceLesson('l-cap');
+      store.close();
+
+      assert.strictEqual(reinforced.confidence, 1.0);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('reinforceLesson sets last_reinforced timestamp', async () => {
+    const testDir = createTempDir('egc-lessons-reinforce-ts-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      store.upsertLesson({ id: 'l-ts', content: 'x', context: 'c', confidence: 0.5 });
+      const reinforced = store.reinforceLesson('l-ts', '2026-06-13T12:00:00.000Z');
+      store.close();
+
+      assert.strictEqual(reinforced.lastReinforced, '2026-06-13T12:00:00.000Z');
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('reinforceLesson unarchives a previously archived lesson', async () => {
+    const testDir = createTempDir('egc-lessons-reinforce-unarch-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      store.upsertLesson({ id: 'l-arch2', content: 'x', context: 'c', confidence: 0.1, archived: 1 });
+      const reinforced = store.reinforceLesson('l-arch2');
+      store.close();
+
+      assert.strictEqual(reinforced.archived, 0);
+      assert.ok(reinforced.confidence > 0.1);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('reinforceLesson returns null for unknown id', async () => {
+    const testDir = createTempDir('egc-lessons-reinforce-null-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const result = store.reinforceLesson('no-such-id');
+      store.close();
+
+      assert.strictEqual(result, null);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+}
+
+async function runDecayTests(counter) {
+  if (await test('applyDecaySweep does not decay lessons within the grace period', async () => {
+    const testDir = createTempDir('egc-lessons-decay-grace-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const recentDate = daysAgo(10);
+      store.upsertLesson({
+        id: 'l-grace',
+        content: 'x',
+        context: 'c',
+        confidence: 0.8,
+        lastRecalled: recentDate,
+        createdAt: recentDate,
+      });
+      const affected = store.applyDecaySweep(new Date().toISOString());
+      const after = store.getLessonById('l-grace');
+      store.close();
+
+      assert.strictEqual(affected, 0);
+      assert.strictEqual(after.confidence, 0.8);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('applyDecaySweep decays lessons past the grace period by DECAY_DELTA_PER_WEEK per week', async () => {
+    const testDir = createTempDir('egc-lessons-decay-weeks-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const oldDate = daysAgo(DECAY_GRACE_DAYS + 14);
+      store.upsertLesson({
+        id: 'l-stale',
+        content: 'x',
+        context: 'c',
+        confidence: 0.8,
+        lastRecalled: oldDate,
+        createdAt: oldDate,
+      });
+      store.applyDecaySweep(new Date().toISOString());
+      const after = store.getLessonById('l-stale');
+      store.close();
+
+      const expectedDecay = 2 * DECAY_DELTA_PER_WEEK;
+      assert.ok(Math.abs(after.confidence - (0.8 - expectedDecay)) < 0.001, `expected ${0.8 - expectedDecay} got ${after.confidence}`);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('applyDecaySweep archives lessons that drop below ARCHIVE_THRESHOLD', async () => {
+    const testDir = createTempDir('egc-lessons-decay-archive-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const weeksNeeded = Math.ceil((0.25 - ARCHIVE_THRESHOLD) / DECAY_DELTA_PER_WEEK) + 1;
+      const daysNeeded = DECAY_GRACE_DAYS + weeksNeeded * 7;
+      const oldDate = daysAgo(daysNeeded);
+      store.upsertLesson({
+        id: 'l-fade',
+        content: 'x',
+        context: 'c',
+        confidence: 0.25,
+        createdAt: oldDate,
+        lastRecalled: oldDate,
+      });
+      store.applyDecaySweep(new Date().toISOString());
+      const after = store.getLessonById('l-fade');
+      store.close();
+
+      assert.strictEqual(after.archived, 1, `expected archived=1 but got archived=${after.archived}, confidence=${after.confidence}`);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('applyDecaySweep uses createdAt when lastRecalled is null', async () => {
+    const testDir = createTempDir('egc-lessons-decay-created-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const oldDate = daysAgo(DECAY_GRACE_DAYS + 7);
+      store.upsertLesson({
+        id: 'l-norecall',
+        content: 'x',
+        context: 'c',
+        confidence: 0.8,
+        createdAt: oldDate,
+      });
+      const affected = store.applyDecaySweep(new Date().toISOString());
+      const after = store.getLessonById('l-norecall');
+      store.close();
+
+      assert.strictEqual(affected, 1);
+      assert.ok(after.confidence < 0.8, `confidence should have decayed, got ${after.confidence}`);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('applyDecaySweep skips already archived lessons', async () => {
+    const testDir = createTempDir('egc-lessons-decay-skip-archived-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const oldDate = daysAgo(DECAY_GRACE_DAYS + 21);
+      store.upsertLesson({
+        id: 'l-already-arch',
+        content: 'x',
+        context: 'c',
+        confidence: 0.1,
+        createdAt: oldDate,
+        archived: 1,
+      });
+      const affected = store.applyDecaySweep(new Date().toISOString());
+      store.close();
+
+      assert.strictEqual(affected, 0);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('applyDecaySweep returns count of affected lessons', async () => {
+    const testDir = createTempDir('egc-lessons-decay-count-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const oldDate = daysAgo(DECAY_GRACE_DAYS + 8);
+      const recentDate = daysAgo(5);
+      store.upsertLesson({ id: 'l-old1', content: 'x', context: 'c', confidence: 0.9, createdAt: oldDate, lastRecalled: oldDate });
+      store.upsertLesson({ id: 'l-old2', content: 'x', context: 'c', confidence: 0.7, createdAt: oldDate, lastRecalled: oldDate });
+      store.upsertLesson({ id: 'l-new', content: 'x', context: 'c', confidence: 0.8, createdAt: recentDate, lastRecalled: recentDate });
+      const affected = store.applyDecaySweep(new Date().toISOString());
+      store.close();
+
+      assert.strictEqual(affected, 2);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('applyDecaySweep with controlled now timestamp decays correctly', async () => {
+    const testDir = createTempDir('egc-lessons-decay-controlled-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const baseDate = '2026-01-01T00:00:00.000Z';
+      store.upsertLesson({
+        id: 'l-ctrl',
+        content: 'x',
+        context: 'c',
+        confidence: 0.7,
+        createdAt: baseDate,
+        lastRecalled: baseDate,
+      });
+
+      const gracePlusThreeWeeks = new Date(new Date(baseDate).getTime() + (DECAY_GRACE_DAYS + 21) * 24 * 60 * 60 * 1000).toISOString();
+      store.applyDecaySweep(gracePlusThreeWeeks);
+      const after = store.getLessonById('l-ctrl');
+      store.close();
+
+      const expectedConfidence = 0.7 - 3 * DECAY_DELTA_PER_WEEK;
+      assert.ok(Math.abs(after.confidence - expectedConfidence) < 0.001, `expected ${expectedConfidence} got ${after.confidence}`);
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+
+  if (await test('listLessons does not return lessons archived by decay', async () => {
+    const testDir = createTempDir('egc-lessons-list-after-decay-');
+    const dbPath = path.join(testDir, 'state.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      const weeksNeeded = Math.ceil((0.22 - ARCHIVE_THRESHOLD) / DECAY_DELTA_PER_WEEK) + 1;
+      const oldDate = daysAgo(DECAY_GRACE_DAYS + weeksNeeded * 7);
+      store.upsertLesson({ id: 'l-will-fade', content: 'forgotten pattern', context: 'c', confidence: 0.22, createdAt: oldDate, lastRecalled: oldDate });
+      store.upsertLesson({ id: 'l-stays', content: 'active pattern', context: 'c', confidence: 0.9 });
+      store.applyDecaySweep(new Date().toISOString());
+      const results = store.listLessons({ minConfidence: 0.0, limit: 10 });
+      store.close();
+
+      const ids = results.map(r => r.id);
+      assert.ok(!ids.includes('l-will-fade'), `l-will-fade should be archived and excluded`);
+      assert.ok(ids.includes('l-stays'));
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) counter.passed += 1; else counter.failed += 1;
+}
+
+async function runTests() {
+  const counter = { passed: 0, failed: 0 };
+
+  await runUpsertTests(counter);
+  await runReinforceTests(counter);
+  await runDecayTests(counter);
+
+  console.log(`\nResults: Passed: ${counter.passed}, Failed: ${counter.failed}`);
+  process.exit(counter.failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/state-store.test.js
+++ b/tests/lib/state-store.test.js
@@ -269,18 +269,20 @@ async function runTests() {
       const firstMigrations = firstStore.getAppliedMigrations();
       firstStore.close();
 
-      assert.strictEqual(firstMigrations.length, 2);
+      assert.strictEqual(firstMigrations.length, 3);
       assert.strictEqual(firstMigrations[0].version, 1);
       assert.strictEqual(firstMigrations[1].version, 2);
+      assert.strictEqual(firstMigrations[2].version, 3);
       assert.ok(fs.existsSync(expectedPath));
 
       const secondStore = await createStateStore({ homeDir });
       const secondMigrations = secondStore.getAppliedMigrations();
       secondStore.close();
 
-      assert.strictEqual(secondMigrations.length, 2);
+      assert.strictEqual(secondMigrations.length, 3);
       assert.strictEqual(secondMigrations[0].version, 1);
       assert.strictEqual(secondMigrations[1].version, 2);
+      assert.strictEqual(secondMigrations[2].version, 3);
     } finally {
       cleanupTempDir(homeDir);
     }
@@ -296,7 +298,7 @@ async function runTests() {
 
       const store = await createStateStore({ dbPath: ':memory:' });
       assert.strictEqual(store.dbPath, ':memory:');
-      assert.strictEqual(store.getAppliedMigrations().length, 2);
+      assert.strictEqual(store.getAppliedMigrations().length, 3);
       store.close();
 
       assert.ok(!fs.existsSync(path.join(tempDir, ':memory:')));


### PR DESCRIPTION
Closes #140

## Summary

Adds a lessons layer with temporal confidence scoring, so the AI prioritizes recent and reinforced lessons and lets stale ones fade:

- New MCP tools: `lesson_save`, `lesson_recall`, `lesson_reinforce`
- Confidence rules: reinforce +0.15 capped at 1.0; 30-day grace then -0.05 per week; archived below 0.2
- `lesson_recall` filters by keyword over content/context/tags above `min_confidence` and resets the decay clock on a match
- Decay sweep runs inside `get_state`, no background process

## Design note

Lessons are a separate table, not built on `instincts`: instincts are machine-facing hook triggers, lessons are user-facing textual knowledge with temporal decay. The infrastructure pattern (migration, queries, null-store) was reused.

## Test plan

- `node tests/lib/lessons-decay.test.js`: 21/21
- `npm test`: 2374/2374
- `npm run lint`: 0 errors

Note: this branch shares a migration number with other in-flight memory PRs; the migration will be renumbered during the sequential rebase before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-session lessons with time-based confidence decay so recent and reinforced knowledge are prioritized while stale lessons fade. Implements `lesson_save`, `lesson_recall`, and `lesson_reinforce` to meet #140.

- **New Features**
  - Lessons store with decay: 30-day grace, then −0.05/week; reinforce +0.15 (max 1.0); auto-archive below 0.2.
  - Tools: `lesson_save` (persist with optional tags/initial confidence), `lesson_recall` (keyword search over content/context/tags above `min_confidence`, updates `last_recalled`), `lesson_reinforce` (boosts confidence, unarchives).
  - Decay sweep runs on every `get_state` call; no background job needed.
  - Storage/schema: new migration adds `lessons` table and indexes; query API exposes upsert/get/list/reinforce/decay; `state-store.schema.json` adds `lesson`; null-store stubs included.
  - Tests: 21 new tests; migration count assertions updated.

- **Refactors**
  - Extracted `lesson_save`, `lesson_recall`, `lesson_reinforce` handlers; switched lesson IDs to `crypto.randomUUID()`; tightened confidence/tag validation.

<sup>Written for commit a6c75c390cf4f47f65a67f278d391254e5f7a58e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added persistent lesson storage with confidence-based scoring system
* Introduced three new lesson management tools: save lessons, recall lessons by query with minimum confidence threshold, and reinforce existing lessons to boost confidence
* Integrated automatic time-based confidence decay that archives lessons below a defined threshold

<!-- end of auto-generated comment: release notes by coderabbit.ai -->