### PR TITLE
ci: remove NPM_TOKEN from reusable-release.yml, fix package name

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -12,9 +12,6 @@ on:
         required: false
         type: boolean
         default: true
-    secrets:
-      NPM_TOKEN:
-        required: false
   workflow_dispatch:
     inputs:
       tag:
@@ -107,7 +104,7 @@ jobs:
           - Better workflow and operator ergonomics
 
           ### Package Notes
-          - npm package: \`egc-universal\`
+          - npm package: \`@egchq/egc\`
           - Gemini marketplace/plugin identifier: \`egc@egc\`
           EOF
 
@@ -122,6 +119,4 @@ jobs:
 
       - name: Publish npm package
         if: steps.npm_publish_state.outputs.already_published != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"

--- a/tests/scripts/release-publish.test.js
+++ b/tests/scripts/release-publish.test.js
@@ -48,9 +48,7 @@ for (const workflow of [
 
   test(`${workflow} publishes new tag versions to npm`, () => {
     assert.match(content, /npm publish --access public --provenance/);
-    if (workflow === '.github/workflows/reusable-release.yml') {
-      assert.match(content, /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
-    }
+    assert.match(content, /id-token:\s*write/);
   });
 
   test(`${workflow} creates the GitHub Release before publishing to npm`, () => {


### PR DESCRIPTION
## Summary

- Remove `NPM_TOKEN` secret from `reusable-release.yml` — publishing uses OIDC Trusted Publishing (`id-token: write` already present), not a static token
- Fix package name: `egc-universal` -> `@egchq/egc` (same fix applied to `release.yml` in #165)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the reusable release workflow to OIDC Trusted Publishing by removing the `NPM_TOKEN` secret and `NODE_AUTH_TOKEN` usage, and fix the package name in release notes to `@egchq/egc`. Update tests to assert `id-token: write` and remove the `NPM_TOKEN` check, preventing misconfigured publishes and aligning naming with `release.yml`.

<sup>Written for commit fc31a5d7b7d42ebd6a83130a2aac791fcba795d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

