### PR TITLE
docs: simplify prompt library section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,20 +84,14 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 
 ## Prompt library
 
-**479 components included** and optional. Install once to get access to 63 agents, 229 skills, and 76 commands written from real experience. Skip them and EGC still gives you persistent memory.
-
-| Type | Count |
-|---|---|
-| Agents | 63 agents |
-| Skills | 229 skills |
-| Commands | 76 commands |
-| Rules | 111 |
+**479 components** — optional. Skip them and EGC still gives you persistent memory.
 
 | Component | Total | Claude Code | Gemini CLI | Claude Code native |
 |---|---|---|---|---|
 | Agents | 63 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |
 | Commands | 76 | Shared | Instruction-based | 31 |
 | Skills | 229 | Shared | 10 (native format) | 37 |
+| Rules | 111 | — | — | — |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,18 +86,12 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 
 **479 components** — optional. Install to get access to 63 agents, 229 skills, and 76 commands written from real experience. Skip them and EGC still gives you persistent memory.
 
-| Type | Count |
-|---|---|
-| Agents | 63 agents |
-| Skills | 229 skills |
-| Commands | 76 commands |
-| Rules | 111 |
-
 | Component | Total | Claude Code | Gemini CLI | Claude Code native |
 |---|---|---|---|---|
 | Agents | 63 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |
 | Commands | 76 | Shared | Instruction-based | 31 |
 | Skills | 229 | Shared | 10 (native format) | 37 |
+| Rules | 111 | — | — | — |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,20 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 
 ## Prompt library
 
-**479 components** — optional. Skip them and EGC still gives you persistent memory.
+**479 components** — optional. Install to get access to 63 agents, 229 skills, and 76 commands written from real experience. Skip them and EGC still gives you persistent memory.
+
+| Type | Count |
+|---|---|
+| Agents | 63 agents |
+| Skills | 229 skills |
+| Commands | 76 commands |
+| Rules | 111 |
 
 | Component | Total | Claude Code | Gemini CLI | Claude Code native |
 |---|---|---|---|---|
 | Agents | 63 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |
 | Commands | 76 | Shared | Instruction-based | 31 |
 | Skills | 229 | Shared | 10 (native format) | 37 |
-| Rules | 111 | — | — | — |
 
 ---
 

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -132,26 +132,6 @@ function parseReadmeExpectations(readmeContent) {
     { category: 'commands', mode: 'exact', expected: Number(quickStartMatch[3]), source: 'README.md quick-start summary' }
   );
 
-  const tablePatterns = [
-    { category: 'agents', regex: /\|\s*(?:\*\*)?Agents(?:\*\*)?\s*\|\s*(?:(?:PASS:|\u2705)\s*)?(\d+)\s+agents\s*\|/i, source: 'README.md comparison table' },
-    { category: 'commands', regex: /\|\s*(?:\*\*)?Commands(?:\*\*)?\s*\|\s*(?:(?:PASS:|\u2705)\s*)?(\d+)\s+commands\s*\|/i, source: 'README.md comparison table' },
-    { category: 'skills', regex: /\|\s*(?:\*\*)?Skills(?:\*\*)?\s*\|\s*(?:(?:PASS:|\u2705)\s*)?(\d+)\s+skills\s*\|/i, source: 'README.md comparison table' }
-  ];
-
-  for (const pattern of tablePatterns) {
-    const match = readmeContent.match(pattern.regex);
-    if (!match) {
-      throw new Error(`${pattern.source} is missing the ${pattern.category} row`);
-    }
-
-    expectations.push({
-      category: pattern.category,
-      mode: 'exact',
-      expected: Number(match[1]),
-      source: `${pattern.source} (${pattern.category})`
-    });
-  }
-
   const parityPatterns = [
     {
       category: 'agents',


### PR DESCRIPTION
Remove redundant first table (Agents/Skills/Commands/Rules counts) since
the second table already shows those totals in the Total column. Also
removes the verbose intro sentence and consolidates into a single line.
Rules added as a row in the main table.

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the Prompt library section in `README.md` by tightening the intro and removing the redundant Type/Count table; the main Component table now stands alone with a "Rules" row. Dropped the comparison-table CI check in `scripts/ci/catalog.js` so validation relies on the Component table’s Total column.

<sup>Written for commit 7d6656d961e96b852c3de02480b08d516ada26dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

