### PR TITLE
chore: add CodeRabbit config and PR size guard

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,49 @@
+language: "en-US"
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+
+  path_filters:
+    # Exclude pure prompt/content markdown files from the 150-file review limit.
+    # These files contain no executable code and only need prose quality checks,
+    # which are handled separately. Keeping them in scope would exhaust the
+    # per-PR file budget on style-only PRs.
+    - "!skills/**"
+    - "!.agents/skills/**"
+    - "!agents/**"
+    - "!commands/**"
+    - "!examples/**"
+    - "!rules/**"
+    - "!memory/**"
+    - "!.cursor/skills/**"
+    - "!.kiro/skills/**"
+    - "!.opencode/prompts/**"
+
+    # Always review code, configuration, and infrastructure.
+    - "scripts/**"
+    - "mcp/**"
+    - "src/**"
+    - "tests/**"
+    - "hooks/**"
+    - "schemas/**"
+    - "docs/**"
+    - "manifests/**"
+    - ".github/**"
+    - "*.json"
+    - "*.yaml"
+    - "*.yml"
+    - "*.ts"
+    - "*.js"
+    - "*.sh"
+    - "*.ps1"
+    - "README.md"
+    - "CHANGELOG.md"
+    - "AGENTS.md"
+    - "CLAUDE.md"
+    - "GEMINI.md"

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -1,0 +1,45 @@
+name: PR Size Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-pr-size:
+    name: Check PR file count
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check changed code files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FILES=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json files --jq '
+              [.files[].path | select(
+                test("^scripts/") or
+                test("^mcp/") or
+                test("^src/") or
+                test("^tests/") or
+                test("^hooks/") or
+                test("^schemas/") or
+                test("^docs/") or
+                test("^manifests/") or
+                test("^\\.github/") or
+                test("\\.(ts|js|sh|ps1|json|yaml|yml)$") or
+                test("^(README|CHANGELOG|AGENTS|CLAUDE|GEMINI)\\.md$")
+              )] | length
+            ')
+
+          echo "Code files in PR: $FILES"
+
+          if [ "$FILES" -gt 150 ]; then
+            echo "::error::This PR changes $FILES code files, exceeding the CodeRabbit 150-file review limit. Split the PR into smaller batches so all files get reviewed."
+            exit 1
+          fi
+
+          if [ "$FILES" -gt 100 ]; then
+            echo "::warning::This PR changes $FILES code files. Approaching the 150-file CodeRabbit review limit."
+          fi
+
+          echo "PR size OK: $FILES code files (limit: 150)"

--- a/.kiro/docs/longform-guide.md
+++ b/.kiro/docs/longform-guide.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This guide explores the philosophy and practice of agentic workflows,a development methodology where AI agents become active collaborators in the software development process. Rather than treating AI as a code completion tool, agentic workflows position AI as a thinking partner that can plan, execute, review, and iterate on complex tasks.
+This guide explores the philosophy and practice of agentic workflows, a development methodology where AI agents become active collaborators in the software development process. Rather than treating AI as a code completion tool, agentic workflows position AI as a thinking partner that can plan, execute, review, and iterate on complex tasks.
 
 ## What Are Agentic Workflows?
 

--- a/.kiro/docs/security-guide.md
+++ b/.kiro/docs/security-guide.md
@@ -491,6 +491,6 @@ For production:
 
 ## Conclusion
 
-Security in agentic workflows requires vigilance and layered defenses. By following these best practices,reviewing agent output, using security-focused agents and hooks, maintaining security steering files, and securing MCP servers,you can leverage the power of AI agents while maintaining strong security posture.
+Security in agentic workflows requires vigilance and layered defenses. By following these best practices, reviewing agent output, using security-focused agents and hooks, maintaining security steering files, and securing MCP servers, you can leverage the power of AI agents while maintaining strong security posture.
 
 Remember: agents are tools that amplify your capabilities, but security remains your responsibility. Trust but verify, use defense in depth, and always prioritize security in your development workflow.

--- a/skills/ai/continuous-learning/SKILL.md
+++ b/skills/ai/continuous-learning/SKILL.md
@@ -110,7 +110,7 @@ Homunculus v2 takes a more sophisticated approach:
 | Sharing | None | Export/import instincts |
 
 **Key insight from homunculus:**
-> "v1 relied on skills to observe. Skills are probabilistic,they fire ~50-80% of the time. v2 uses hooks for observation (100% reliable) and instincts as the atomic unit of learned behavior."
+> "v1 relied on skills to observe. Skills are probabilistic, they fire ~50-80% of the time. v2 uses hooks for observation (100% reliable) and instincts as the atomic unit of learned behavior."
 
 ### Potential v2 Enhancements
 

--- a/skills/backend/springboot-patterns/SKILL.md
+++ b/skills/backend/springboot-patterns/SKILL.md
@@ -269,7 +269,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
    * 4. Configure server.tomcat.remoteip.trusted-proxies or equivalent for your container
    *
    * Without this configuration, request.getRemoteAddr() returns the proxy IP, not the client IP.
-   * Do NOT read X-Forwarded-For directly,it is trivially spoofable without trusted proxy handling.
+   * Do NOT read X-Forwarded-For directly, it is trivially spoofable without trusted proxy handling.
    */
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,

--- a/skills/testing/springboot-verification/SKILL.md
+++ b/skills/testing/springboot-verification/SKILL.md
@@ -228,4 +228,4 @@ Issues to Fix:
 - Re-run phases on significant changes or every 30–60 minutes in long sessions
 - Keep a short loop: `mvn -T 4 test` + spotbugs for quick feedback
 
-**Remember**: Fast feedback beats late surprises. Keep the gate strict,treat warnings as defects in production systems.
+**Remember**: Fast feedback beats late surprises. Keep the gate strict, treat warnings as defects in production systems.


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` with `path_filters` that excludes pure prompt/content markdown files (skills, agents, commands, examples, rules, memory) from CodeRabbit's 150-file review budget. Code files are always reviewed.
- Add `pr-size-check.yml` CI workflow that fails if a PR changes more than 150 code files, and warns above 100. Prevents future PRs from silently exceeding the CodeRabbit review limit.

## Why

A PR with 394 files triggered CodeRabbit's auto-skip (limit is 150 files). Most of those files were skill/agent markdown content with no executable code. This config separates content files from code files so the review budget is spent on what matters.

## Test plan

- [ ] CI passes
- [ ] CodeRabbit reviews this PR without skipping
- [ ] Future PRs with large skill changes do not consume the file budget
- [ ] Future PRs with large code changes fail the size check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CodeRabbit config to focus reviews on code and a CI guard to enforce the 150 code-file limit. This prevents review skips and keeps large content-only PRs from burning the review budget.

- **New Features**
  - Added `.coderabbit.yaml` with `path_filters` to exclude content-only markdown (e.g., `skills/**`, `agents/**`) and always include code paths and common extensions for review.
  - Added `.github/workflows/pr-size-check.yml` to count changed code files; warns above 100 and fails above 150, using patterns aligned with the CodeRabbit config.

<sup>Written for commit 58cdc2b669037d121940afd0592d02208f083e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

