### PR TITLE
fix: add explicit permissions to pr-size-check workflow

### DIFF
--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -4,10 +4,15 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   check-pr-size:
     name: Check PR file count
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
     steps:
       - name: Check changed code files
         env:

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-pr-size:


### PR DESCRIPTION
## Summary

- Replaces `permissions: {}` with explicit `contents: read` and `pull-requests: read` at the workflow level
- Resolves Scorecard alert #200 (Token-Permissions, High) and CodeQL alert #196 (Workflow does not contain permissions, Medium)

## Test plan
- [ ] CI passes
- [ ] Code scanning alerts #200 and #196 are dismissed after merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit least-privilege permissions to the PR size check workflow so it can read PR data safely. Sets `permissions` at the workflow and job levels to `contents: read` and `pull-requests: read`, resolving Scorecard alert #200 and CodeQL alert #196.

<sup>Written for commit 19acc7984060cb3227872910c366f0a5f0620dee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

