### PR TITLE
fix: register egc-memory-load under SessionStart (#174)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -131,6 +131,17 @@
         ],
         "description": "EGC cross-runtime session lifecycle bridge (SessionStart)",
         "id": "sessionstart:egc-session-bridge"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js sessionstart:egc-memory-load scripts/hooks/egc-memory-load.js standard,strict"
+          }
+        ],
+        "description": "Load persistent EGC memory state at session start",
+        "id": "sessionstart:egc-memory-load"
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary

- `egc-memory-load.js` existed but was never wired into `hooks/hooks.json`
- Persistent EGC memory was never injected at session start as a result
- Adds `sessionstart:egc-memory-load` to the `SessionStart` array, following the same bootstrap pattern as `sessionstart:egc-session-bridge`

Closes #174

## Note

This supersedes #181. The fix is identical to Kunal's contribution (@Kunall7890) — co-authorship preserved in the commit. The original PR could not be merged due to a DCO sign-off issue that was not resolved after instructions were provided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads persistent EGC memory at session start by registering `sessionstart:egc-memory-load` in the `SessionStart` hook list. Wires the existing `scripts/hooks/egc-memory-load.js` into `hooks/hooks.json` using the same bootstrap pattern as `sessionstart:egc-session-bridge`.

<sup>Written for commit bf2885d0b10ea6ea4cf52238992ec774d07460e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session initialization with automatic memory management during startup.

* **Chores**
  * Updated session hook configuration to include memory optimization during session start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->