### PR TITLE
fix(utils): auto-detect active harness in getEGCDir()

### DIFF
--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -8,8 +8,6 @@ const { applyMigrations, getAppliedMigrations } = require('./migrations');
 const { createQueryApi } = require('./queries');
 const { assertValidEntity, validateEntity } = require('./schema');
 
-const DEFAULT_STATE_STORE_RELATIVE_PATH = path.join('.gemini', 'egc', 'state.db');
-
 // Try to load better-sqlite3. On Windows without Build Tools the native
 // module may not compile: in that case we fall back to a null/amnesiac
 // store so the installer and CLI degrade gracefully instead of crashing.
@@ -29,8 +27,24 @@ function resolveStateStorePath(options = {}) {
     return path.resolve(options.dbPath);
   }
 
-  const homeDir = options.homeDir || process.env.HOME || os.homedir();
-  return path.join(homeDir, DEFAULT_STATE_STORE_RELATIVE_PATH);
+  const { getEGCDir } = require('../utils');
+
+  if (options.homeDir) {
+    const savedHome = process.env.HOME;
+    const savedUserProfile = process.env.USERPROFILE;
+    try {
+      process.env.HOME = options.homeDir;
+      process.env.USERPROFILE = options.homeDir;
+      return path.join(getEGCDir(), 'egc', 'state.db');
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = savedUserProfile;
+    }
+  }
+
+  return path.join(getEGCDir(), 'egc', 'state.db');
 }
 
 function sanitizeNamedParams(params) {
@@ -179,7 +193,6 @@ async function createStateStore(options = {}) {
 }
 
 module.exports = {
-  DEFAULT_STATE_STORE_RELATIVE_PATH,
   createStateStore,
   resolveStateStorePath,
 };

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
 const { applyMigrations, getAppliedMigrations } = require('./migrations');

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -31,15 +31,19 @@ function resolveStateStorePath(options = {}) {
   if (options.homeDir) {
     const savedHome = process.env.HOME;
     const savedUserProfile = process.env.USERPROFILE;
+    const savedEgcDir = process.env.EGC_DIR;
     try {
       process.env.HOME = options.homeDir;
       process.env.USERPROFILE = options.homeDir;
+      delete process.env.EGC_DIR;
       return path.join(getEGCDir(), 'egc', 'state.db');
     } finally {
       if (savedHome === undefined) delete process.env.HOME;
       else process.env.HOME = savedHome;
       if (savedUserProfile === undefined) delete process.env.USERPROFILE;
       else process.env.USERPROFILE = savedUserProfile;
+      if (savedEgcDir === undefined) delete process.env.EGC_DIR;
+      else process.env.EGC_DIR = savedEgcDir;
     }
   }
 

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -33,7 +33,7 @@ function getHomeDir() {
 }
 
 /**
- * Get the EGC config directory (~/.gemini)
+ * Get the EGC config directory
  * @deprecated Use getEGCDir() for canonical EGC runtime.
  */
 function getClaudeDir() {
@@ -41,10 +41,80 @@ function getClaudeDir() {
 }
 
 /**
- * Get the EGC config directory
+ * Get the EGC config directory for the active harness.
+ *
+ * Resolution order:
+ *   1. EGC_DIR env var (explicit override)
+ *   2. Harness-specific env vars injected at hook time (see docs/spec/harness-env-vars.md)
+ *   3. __dirname prefix match against known harness home dirs (production install)
+ *   4. ~/.egc (harness-agnostic fallback)
  */
 function getEGCDir() {
-  return path.join(getHomeDir(), '.gemini');
+  if (process.env.EGC_DIR) return process.env.EGC_DIR;
+
+  const home = getHomeDir();
+  const env = process.env;
+
+  // Gemini CLI / Antigravity AGY: GEMINI_PROJECT_DIR is injected by the CLI at hook time.
+  // Check this before CLAUDE_PROJECT_DIR because Gemini CLI sets both as a compat alias.
+  if (env.GEMINI_PROJECT_DIR || env.GEMINI_PLUGIN_ROOT) {
+    return path.join(home, '.gemini');
+  }
+
+  // Claude Code: CLAUDE_PROJECT_DIR or CLAUDE_PLUGIN_ROOT is injected by the CLI.
+  if (env.CLAUDE_PROJECT_DIR || env.CLAUDE_PLUGIN_ROOT) {
+    return path.join(home, '.claude');
+  }
+
+  // CodeBuddy: CODEBUDDY_PROJECT_DIR or CODEBUDDY_PLUGIN_ROOT is injected at hook time.
+  if (env.CODEBUDDY_PROJECT_DIR || env.CODEBUDDY_PLUGIN_ROOT) {
+    return path.join(home, '.codebuddy');
+  }
+
+  // VS Code Copilot: VSCODE_AGENT is set when running inside a Copilot agent action.
+  if (env.VSCODE_AGENT || env.GITHUB_COPILOT_API_TOKEN) {
+    return path.join(home, '.github');
+  }
+
+  // Kiro (AWS): KIRO_HOOK_FILE is set for file-triggered hooks.
+  if (env.KIRO_HOOK_FILE || env.KIRO_FILE_PATH) {
+    return path.join(home, '.kiro');
+  }
+
+  // Trae (ByteDance): TRAE_ENV distinguishes China vs global build.
+  if (env.TRAE_ENV) {
+    return path.join(home, env.TRAE_ENV === 'cn' ? '.trae-cn' : '.trae');
+  }
+
+  // Tier 2: __dirname prefix match (harnesses without unique runtime env vars at hook time).
+  // Longest-prefix-first to avoid false matches (e.g. .config/opencode before .config).
+  const sep = path.sep;
+  const harnessDirs = [
+    path.join(home, '.codeium', 'windsurf'),
+    path.join(home, '.config', 'opencode'),
+    path.join(home, '.config', 'zed'),
+    path.join(home, '.gemini'),
+    path.join(home, '.claude'),
+    path.join(home, '.agents'),
+    path.join(home, '.amp'),
+    path.join(home, '.github'),
+    path.join(home, '.kiro'),
+    path.join(home, '.trae'),
+  ];
+
+  for (const dir of harnessDirs) {
+    if (__dirname === dir || __dirname.startsWith(dir + sep)) {
+      return dir;
+    }
+  }
+
+  // Tier 3: first existing harness dir under HOME (dev/test environments where
+  // __dirname points to the source repo rather than a harness install path).
+  for (const dir of harnessDirs) {
+    if (fs.existsSync(dir)) return dir;
+  }
+
+  return path.join(home, '.egc');
 }
 
 /**

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -95,11 +95,13 @@ function getEGCDir() {
     path.join(home, '.config', 'zed'),
     path.join(home, '.gemini'),
     path.join(home, '.claude'),
+    path.join(home, '.cursor'),
     path.join(home, '.agents'),
     path.join(home, '.amp'),
     path.join(home, '.github'),
     path.join(home, '.kiro'),
     path.join(home, '.trae'),
+    path.join(home, '.trae-cn'),
   ];
 
   for (const dir of harnessDirs) {

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -32,6 +32,7 @@ function withTempHome(homeDir) {
   return {
     HOME: homeDir,
     USERPROFILE: homeDir,
+    EGC_DIR: path.join(homeDir, '.gemini'),
   };
 }
 

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -946,9 +946,19 @@ async function runTests() {
 
   if (
     await asyncTest('creates compaction log', async () => {
-      await runScript(path.join(scriptsDir, 'pre-compact.js'));
-      const logFile = path.join(getCanonicalSessionsDir(os.homedir()), 'compaction-log.txt');
-      assert.ok(fs.existsSync(logFile), 'Compaction log should exist');
+      const isoHome = path.join(os.tmpdir(), `egc-compact-create-${Date.now()}`);
+      const sessionsDir = getCanonicalSessionsDir(isoHome);
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      try {
+        await runScript(path.join(scriptsDir, 'pre-compact.js'), '', {
+          HOME: isoHome,
+          USERPROFILE: isoHome
+        });
+        const logFile = path.join(sessionsDir, 'compaction-log.txt');
+        assert.ok(fs.existsSync(logFile), 'Compaction log should exist');
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
     })
   )
     passed++;

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -83,11 +83,11 @@ function sleepMs(ms) {
 }
 
 function getCanonicalSessionsDir(homeDir) {
-  return path.join(homeDir, '.gemini', 'session-data');
+  return path.join(homeDir, '.egc', 'session-data');
 }
 
 function getLegacySessionsDir(homeDir) {
-  return path.join(homeDir, '.gemini', 'sessions');
+  return path.join(homeDir, '.egc', 'sessions');
 }
 
 function getSessionStartAdditionalContext(stdout) {
@@ -348,7 +348,7 @@ async function runTests() {
     await asyncTest('exits 0 even with isolated empty HOME', async () => {
       const isoHome = path.join(os.tmpdir(), `egc-iso-start-${Date.now()}`);
       fs.mkdirSync(getCanonicalSessionsDir(isoHome), { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
       try {
         const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
           HOME: isoHome,
@@ -377,7 +377,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-tpl-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const sessionFile = path.join(sessionsDir, '2026-02-11-abcd1234-session.tmp');
       fs.writeFileSync(sessionFile, '## Current State\n\n[Session context goes here]\n');
@@ -403,7 +403,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-real-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const sessionFile = path.join(sessionsDir, '2026-02-11-efgh5678-session.tmp');
       fs.writeFileSync(sessionFile, '# Real Session\n\nI worked on authentication refactor.\n');
@@ -445,7 +445,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-large-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const sessionFile = path.join(sessionsDir, '2026-02-11-large000-session.tmp');
       fs.writeFileSync(sessionFile, `# Large Session\n\nSTART_MARKER\n${'A'.repeat(20000)}\nEND_MARKER\n`);
@@ -474,7 +474,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-max-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const sessionFile = path.join(sessionsDir, '2026-02-11-max0000-session.tmp');
       fs.writeFileSync(sessionFile, `# Sized Session\n\n${'B'.repeat(1200)}\n`);
@@ -502,7 +502,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-disabled-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const sessionFile = path.join(sessionsDir, '2026-02-11-disabled-session.tmp');
       fs.writeFileSync(sessionFile, '# Disabled Session\n\nDO_NOT_INJECT_THIS\n');
@@ -539,7 +539,7 @@ async function runTests() {
 
       fs.mkdirSync(canonicalDir, { recursive: true });
       fs.mkdirSync(legacyDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       fs.writeFileSync(canonicalFile, '# Canonical Session\n\nUse the canonical session-data copy.\n');
       fs.writeFileSync(legacyFile, '# Legacy Session\n\nDo not prefer the legacy duplicate.\n');
@@ -568,7 +568,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-ansi-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const sessionFile = path.join(sessionsDir, '2026-02-11-winansi00-session.tmp');
       fs.writeFileSync(
@@ -600,7 +600,7 @@ async function runTests() {
   if (
     await asyncTest('reports learned skills count', async () => {
       const isoHome = path.join(os.tmpdir(), `egc-skills-start-${Date.now()}`);
-      const learnedDir = path.join(isoHome, '.gemini', 'skills', 'learned');
+      const learnedDir = path.join(isoHome, '.egc', 'skills', 'learned');
       fs.mkdirSync(learnedDir, { recursive: true });
       fs.mkdirSync(getCanonicalSessionsDir(isoHome), { recursive: true });
 
@@ -625,7 +625,7 @@ async function runTests() {
   if (
     await asyncTest('injects learned skills into session-start additional context', async () => {
       const isoHome = path.join(os.tmpdir(), `egc-skills-context-${Date.now()}`);
-      const learnedDir = path.join(isoHome, '.gemini', 'skills', 'learned');
+      const learnedDir = path.join(isoHome, '.egc', 'skills', 'learned');
       fs.mkdirSync(learnedDir, { recursive: true });
       fs.mkdirSync(getCanonicalSessionsDir(isoHome), { recursive: true });
 
@@ -1448,7 +1448,7 @@ async function runTests() {
       fs.writeFileSync(filePath, 'export const value = 1;\n');
       createCommandShim(binDir, 'npx', logFile);
       const isolatedHome = path.join(testDir, 'isolated-home');
-      fs.mkdirSync(path.join(isolatedHome, '.gemini'), { recursive: true });
+      fs.mkdirSync(path.join(isolatedHome, '.egc'), { recursive: true });
 
       const stdinJson = JSON.stringify({ tool_input: { file_path: filePath } });
       const result = await runScript(path.join(scriptsDir, 'post-edit-format.js'), stdinJson, withPrependedPath(binDir, {
@@ -3570,7 +3570,7 @@ async function runTests() {
     await asyncTest('exits 0 with empty sessions directory (no recent sessions)', async () => {
       const isoHome = path.join(os.tmpdir(), `egc-start-empty-${Date.now()}`);
       fs.mkdirSync(getCanonicalSessionsDir(isoHome), { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
       try {
         const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
           HOME: isoHome,
@@ -3593,7 +3593,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-start-blank-${Date.now()}`);
       const sessionsDir = getCanonicalSessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const today = new Date().toISOString().slice(0, 10);
       const sessionFile = path.join(sessionsDir, `${today}-blank-session.tmp`);
@@ -4275,7 +4275,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-start-empty-file-${Date.now()}`);
       const sessionsDir = getCanonicalSessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const today = new Date().toISOString().slice(0, 10);
       const sessionFile = path.join(sessionsDir, `${today}-empty0000-session.tmp`);
@@ -4372,11 +4372,11 @@ async function runTests() {
     await asyncTest('reports available session aliases on startup', async () => {
       const isoHome = path.join(os.tmpdir(), `egc-start-alias-${Date.now()}`);
       fs.mkdirSync(getCanonicalSessionsDir(isoHome), { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       // Pre-populate the aliases file
       fs.writeFileSync(
-        path.join(isoHome, '.gemini', 'session-aliases.json'),
+        path.join(isoHome, '.egc', 'session-aliases.json'),
         JSON.stringify({
           version: '1.0',
           aliases: {
@@ -4441,7 +4441,7 @@ async function runTests() {
   if (
     await asyncTest('exits 0 when sessions path is a file (not a directory)', async () => {
       const isoHome = path.join(os.tmpdir(), `egc-start-blocked-${Date.now()}`);
-      fs.mkdirSync(path.join(isoHome, '.gemini'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc'), { recursive: true });
       // Block sessions dir creation by placing a file at that path
       fs.writeFileSync(getCanonicalSessionsDir(isoHome), 'blocked');
 
@@ -4508,7 +4508,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-start-7day-${Date.now()}`);
       const sessionsDir = getCanonicalSessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const recentFile = path.join(sessionsDir, '2026-02-06-recent69-session.tmp');
       fs.writeFileSync(recentFile, '# Recent Session\n\nRECENT CONTENT HERE');
@@ -4543,7 +4543,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-start-prune-${Date.now()}`);
       const sessionsDir = getCanonicalSessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const recentFile = path.join(sessionsDir, '2026-02-10-keepme-session.tmp');
       fs.writeFileSync(recentFile, '# Recent Session\n\nKEEP ME');
@@ -4581,7 +4581,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-start-multi-${Date.now()}`);
       const sessionsDir = getCanonicalSessionsDir(isoHome);
       fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
 
       const now = Date.now();
 
@@ -5013,7 +5013,7 @@ async function runTests() {
       const isoHome = path.join(os.tmpdir(), `egc-r71-ss-default-${Date.now()}`);
       const isoProject = path.join(isoHome, 'project');
       fs.mkdirSync(getCanonicalSessionsDir(isoHome), { recursive: true });
-      fs.mkdirSync(path.join(isoHome, '.gemini', 'skills', 'learned'), { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.egc', 'skills', 'learned'), { recursive: true });
       fs.mkdirSync(isoProject, { recursive: true });
       // No package.json, no lock files, no package-manager.json: forces default source
 

--- a/tests/hooks/session-activity-tracker.test.js
+++ b/tests/hooks/session-activity-tracker.test.js
@@ -44,6 +44,7 @@ function withTempHome(homeDir) {
   return {
     HOME: homeDir,
     USERPROFILE: homeDir,
+    EGC_DIR: path.join(homeDir, '.gemini'),
   };
 }
 

--- a/tests/integration/hooks.test.js
+++ b/tests/integration/hooks.test.js
@@ -709,7 +709,7 @@ async function runTests() {
       assert.strictEqual(result.code, 0, 'Should exit 0');
       assert.ok(result.stderr.includes('[SessionEnd]'), 'Should have SessionEnd log');
 
-      const sessionsDir = path.join(testDir, '.gemini', 'sessions');
+      const sessionsDir = path.join(testDir, '.egc', 'sessions');
       if (fs.existsSync(sessionsDir)) {
         const files = fs.readdirSync(sessionsDir).filter(f => f.endsWith('.tmp'));
         assert.ok(files.length > 0, 'Should create a session file');
@@ -777,7 +777,7 @@ async function runTests() {
 
       assert.strictEqual(result.code, 0, 'Should exit 0');
 
-      const sessionsDir = path.join(testDir, '.gemini', 'sessions');
+      const sessionsDir = path.join(testDir, '.egc', 'sessions');
       if (fs.existsSync(sessionsDir)) {
         const files = fs.readdirSync(sessionsDir).filter(f => f.endsWith('.tmp'));
         assert.ok(files.length > 0, 'Should create session file');

--- a/tests/integration/hooks.test.js
+++ b/tests/integration/hooks.test.js
@@ -386,7 +386,8 @@ async function runTests() {
         {
           HOME: testDir,
           GEMINI_PROJECT_DIR: projectDir,
-          EGC_SESSION_ID: sessionId
+          EGC_SESSION_ID: sessionId,
+          EGC_DIR: path.join(testDir, '.gemini'),
         }
       );
 
@@ -447,6 +448,7 @@ async function runTests() {
         {
           HOME: testDir,
           GEMINI_PROJECT_DIR: projectDir,
+          EGC_DIR: path.join(testDir, '.gemini'),
         }
       );
 
@@ -480,7 +482,8 @@ async function runTests() {
         {
           HOME: testDir,
           GEMINI_PROJECT_DIR: projectDir,
-          EGC_SESSION_ID: sessionId
+          EGC_SESSION_ID: sessionId,
+          EGC_DIR: path.join(testDir, '.gemini'),
         }
       );
 
@@ -499,7 +502,8 @@ async function runTests() {
         {
           HOME: testDir,
           GEMINI_PROJECT_DIR: projectDir,
-          EGC_SESSION_ID: sessionId
+          EGC_SESSION_ID: sessionId,
+          EGC_DIR: path.join(testDir, '.gemini'),
         }
       );
 

--- a/tests/lib/state-store.test.js
+++ b/tests/lib/state-store.test.js
@@ -262,7 +262,7 @@ async function runTests() {
     const homeDir = createTempDir('egc-state-home-');
 
     try {
-      const expectedPath = path.join(homeDir, '.gemini', 'egc', 'state.db');
+      const expectedPath = path.join(homeDir, '.egc', 'egc', 'state.db');
       assert.strictEqual(resolveStateStorePath({ homeDir }), expectedPath);
 
       const firstStore = await createStateStore({ homeDir });

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -108,14 +108,14 @@ function runTests() {
     const egcDir = utils.getEGCDir();
     const homeDir = utils.getHomeDir();
     assert.ok(egcDir.startsWith(homeDir), 'EGC dir should be under home');
-    assert.ok(egcDir.includes('.gemini'), 'Should contain .gemini');
+    assert.ok(egcDir !== homeDir, 'EGC dir should be a subdirectory of home');
   })) passed++; else failed++;
 
   if (test('getSessionsDir returns path under EGC dir', () => {
     const sessionsDir = utils.getSessionsDir();
     const egcDir = utils.getEGCDir();
     assert.ok(sessionsDir.startsWith(egcDir), 'Sessions should be under EGC dir');
-    assert.ok(sessionsDir.endsWith(path.join('.gemini', 'session-data')) || sessionsDir.endsWith('/.gemini/session-data'), 'Should use canonical session-data directory');
+    assert.ok(sessionsDir.endsWith('session-data'), 'Should use canonical session-data directory');
   })) passed++; else failed++;
 
   if (test('getSessionSearchDirs includes canonical and legacy paths', () => {
@@ -654,9 +654,9 @@ function runTests() {
   // getLearnedSkillsDir() test
   console.log('\ngetLearnedSkillsDir():');
 
-  if (test('getLearnedSkillsDir returns path under Gemini dir', () => {
+  if (test('getLearnedSkillsDir returns path under EGC dir', () => {
     const dir = utils.getLearnedSkillsDir();
-    assert.ok(dir.includes('.gemini'));
+    assert.ok(dir.startsWith(utils.getEGCDir()), 'Should be under EGC dir');
     assert.ok(dir.includes('skills'));
     assert.ok(dir.includes('learned'));
   })) passed++; else failed++;

--- a/tests/scripts/setup-package-manager.test.js
+++ b/tests/scripts/setup-package-manager.test.js
@@ -268,7 +268,7 @@ function runTests() {
       assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}. stderr: ${result.stderr}`);
       assert.ok(result.stdout.includes('Global preference set to'), 'Should show success message');
       assert.ok(result.stdout.includes('npm'), 'Should mention npm');
-      const configPath = path.join(tmpDir, '.gemini', 'package-manager.json');
+      const configPath = path.join(tmpDir, '.egc', 'package-manager.json');
       assert.ok(fs.existsSync(configPath), 'Config file should be created');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
       assert.strictEqual(config.packageManager, 'npm', 'Config should contain npm');
@@ -286,7 +286,7 @@ function runTests() {
       const result = run(['npm'], { HOME: tmpDir, USERPROFILE: tmpDir });
       assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}. stderr: ${result.stderr}`);
       assert.ok(result.stdout.includes('Global preference set to'), 'Should show success message');
-      const configPath = path.join(tmpDir, '.gemini', 'package-manager.json');
+      const configPath = path.join(tmpDir, '.egc', 'package-manager.json');
       assert.ok(fs.existsSync(configPath), 'Config file should be created');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
       assert.strictEqual(config.packageManager, 'npm', 'Config should contain npm');


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `~/.gemini` path in `getEGCDir()` with a 4-tier harness auto-detection strategy
- Fixes `resolveStateStorePath()` in `state-store/index.js` which was also hardcoding `.gemini`, causing a side-effect that poisoned the existing-dir fallback during hook execution
- Updates all tests to reflect the new harness-agnostic behavior

## Detection order

1. `EGC_DIR` env var (explicit override)
2. Harness-specific env vars injected at hook time (`GEMINI_PROJECT_DIR`, `CLAUDE_PROJECT_DIR`, `CODEBUDDY_PROJECT_DIR`, `VSCODE_AGENT`, `KIRO_HOOK_FILE`, `TRAE_ENV`, etc.)
3. `__dirname` prefix match against known harness home dirs (production install)
4. Existing dir fallback (dev/test environments)
5. `~/.egc` (harness-agnostic fallback)

## Supported harnesses

| Harness | EGC Dir | Detection |
|---|---|---|
| Gemini CLI / AGY | `~/.gemini` | `GEMINI_PROJECT_DIR` or `GEMINI_PLUGIN_ROOT` |
| Claude Code | `~/.claude` | `CLAUDE_PROJECT_DIR` or `CLAUDE_PLUGIN_ROOT` |
| CodeBuddy | `~/.codebuddy` | `CODEBUDDY_PROJECT_DIR` or `CODEBUDDY_PLUGIN_ROOT` |
| VS Code Copilot | `~/.github` | `VSCODE_AGENT` or `GITHUB_COPILOT_API_TOKEN` |
| Kiro | `~/.kiro` | `KIRO_HOOK_FILE` or `KIRO_FILE_PATH` |
| Trae | `~/.trae` / `~/.trae-cn` | `TRAE_ENV` |
| Windsurf, OpenCode, Zed, Amp | respective dirs | `__dirname` prefix |
| Codex CLI, Cursor | `~/.agents`, `~/.cursor` | existing dir fallback |

## Test plan

- [x] `npm test` passes 2404/2404 tests (0 failures)
- [x] `state-store.test.js`: `resolveStateStorePath({ homeDir })` correctly resolves under the provided homeDir
- [x] `hooks.test.js`: session-start / session-end tests use `EGC_DIR` env var to pin the path in isolated test environments
- [x] `utils.test.js`: `getEGCDir()` assertions updated to check path structure instead of hardcoded `.gemini`

Closes #180

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detect the active harness in `getEGCDir()` and use it in `resolveStateStorePath()` to replace the hardcoded `~/.gemini`, keeping paths consistent across environments. Also improves test isolation and path checks. Closes #180.

- **Bug Fixes**
  - `getEGCDir()` resolves in order: `EGC_DIR` env → harness env vars (`GEMINI_PROJECT_DIR`, `CLAUDE_PROJECT_DIR`, `VSCODE_AGENT`, `KIRO_HOOK_FILE`, `TRAE_ENV`, etc.) → `__dirname` prefix match → first existing harness dir → fallback `~/.egc`; adds support for `.cursor` and `.trae-cn`.
  - `resolveStateStorePath()` uses `getEGCDir()` and, when `homeDir` is provided, temporarily overrides `HOME`/`USERPROFILE` and clears `EGC_DIR` (restored after) so resolution honors the override.
  - Tests are harness-agnostic: canonical paths use `.egc`, integration checks updated from `.gemini/sessions` to `.egc/sessions`, the compaction-log test runs in a temp HOME, and `EGC_DIR` is pinned where needed.
  - Removed unused `os` import from `state-store/index.js`.

<sup>Written for commit 9dc14eb16270e5cb748947f12e9a1807bf046f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal directory structure organization, transitioning configuration and state storage from `.gemini` to `.egc` directories.
  * Improved home directory resolution logic to automatically detect and adapt to different development environments based on runtime conditions.
  * Removed deprecated directory path exports and consolidated directory resolution functions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->