### PR TITLE
ci: upload npm tarball as GitHub Release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
+          files: ${{ steps.pack.outputs.tarball }}
 
       - name: Publish npm package
         if: steps.npm_publish_state.outputs.already_published != 'true'


### PR DESCRIPTION
## Summary

- Adds `files: ${{ steps.pack.outputs.tarball }}` to the `Create GitHub Release` step in `release.yml`
- The npm tarball was being attested (SBOM + build provenance via Sigstore) but never uploaded as a release asset
- OpenSSF Scorecard checks release assets for signatures/provenance and found none (`assets: []`), scoring Signed-Releases as 0/10
- Uploading the tarball as a release asset allows the scorecard to verify the existing attestation

## Test plan

- [ ] Merge and tag a new release
- [ ] Verify the tarball appears as an asset in the GitHub Release
- [ ] Verify OpenSSF Scorecard Signed-Releases score improves on next weekly scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uploads the npm tarball to the GitHub Release so the existing Sigstore attestation can be verified. This lets OpenSSF Scorecard detect signed releases and should improve the Signed-Releases score.

- **Bug Fixes**
  - Added `files: ${{ steps.pack.outputs.tarball }}` to the `Create GitHub Release` step in `.github/workflows/release.yml`.
  - Release assets now include the attested tarball for provenance/signature checks.

<sup>Written for commit 9c78b4818c2bb0145ba8c3ad7a5d38ebca8eea45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow improvements: npm package tarball is now included as a downloadable asset with each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->