### PR TITLE
feat: add CycloneDX SBOM and Codecov coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,39 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npx c8 --reporter=lcov --reporter=text-summary node tests/run-all.js
+        env:
+          GEMINI_CODE_PACKAGE_MANAGER: npm
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,5 +35,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       id-token: write
       attestations: write
@@ -105,15 +106,15 @@ jobs:
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.17.0
         with:
           path: .
-          artifact-name: sbom.spdx.json
-          output-file: sbom.spdx.json
-          format: spdx-json
+          artifact-name: sbom.cyclonedx.json
+          output-file: sbom.cyclonedx.json
+          format: cyclonedx-json
 
       - name: Attest SBOM
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: ${{ steps.pack.outputs.tarball }}
-          sbom-path: sbom.spdx.json
+          sbom-path: sbom.cyclonedx.json
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0


### PR DESCRIPTION
## Summary

- **SBOM CycloneDX**: Changes release workflow from SPDX to CycloneDX format (`cyclonedx-json`). The `anchore/sbom-action` auto-attaches the SBOM to GitHub Releases. Added `actions: read` permission required by the action to find workflow artifacts when attaching to releases.
- **Codecov**: New `coverage.yml` workflow using `c8` (V8 native coverage, no transpilation needed) + `codecov/codecov-action@v5`. Runs on push to main and PRs. Coverage file: `coverage/lcov.info`.

## Notes

- c8 works with the custom `tests/run-all.js` runner because it sets `NODE_V8_COVERAGE` so child processes spawned via `spawnSync` also write coverage data.
- Codecov uses tokenless upload for public repos (v5 feature). No secret needed.
- `fail_ci_if_error: false` ensures the coverage step never blocks the build.

## Test plan

- [ ] Merge and trigger a release tag to verify SBOM is attached as `sbom.cyclonedx.json`
- [ ] Verify coverage job runs and uploads to codecov.io after account setup at codecov.io/gh/Fmarzochi/EGC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release SBOM generation to CycloneDX and add a Codecov coverage workflow using `c8`. SBOMs are auto-attached to Releases; coverage runs on PRs and `main` without blocking builds.

- **New Features**
  - Release SBOM: generate `cyclonedx-json` as `sbom.cyclonedx.json`, auto-attach via `anchore/sbom-action`, added `actions: read` permission, updated SBOM attestation path.
  - Coverage: new `.github/workflows/coverage.yml` runs tests with `c8` and uploads `coverage/lcov.info` via `codecov/codecov-action@v5` on PRs and `main`, using `CODECOV_TOKEN`; `fail_ci_if_error: false`.

<sup>Written for commit 71e35372d6790ae61f778f41c122266b983b0e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

