### PR TITLE
fix: resolve Scorecard code scanning alerts in ClusterFuzzLite files

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-javascript
+FROM gcr.io/oss-fuzz-base/base-builder-javascript@sha256:7051327a33e495e34e563383c82dd944c77773ecebf20bd9cc94311574c0af2d
 
 COPY . $SRC/egc
 WORKDIR $SRC/egc

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -8,7 +8,7 @@ cd $SRC/egc/fuzz
 npm ci
 
 cd $SRC/egc
-npm install --save-dev @jazzer.js/core
+npm install --save-dev @jazzer.js/core@4.0.0
 
 cd $SRC
 compile_javascript_fuzzer egc fuzz/fuzz-validator.js

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -3,13 +3,14 @@ name: ClusterFuzzLite batch fuzzing
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   BatchFuzzing:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -3,13 +3,14 @@ name: ClusterFuzzLite cron tasks
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   Pruning:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -3,13 +3,14 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   PR:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary

Resolves all 5 open Scorecard code scanning alerts:

- **#201, #202, #203** (Token-Permissions): moved permissions from workflow level to job level; added `permissions: {}` at workflow level to disable defaults
- **#204** (Pinned-Dependencies): pinned Dockerfile base image to digest `sha256:7051327a33e495e34e563383c82dd944c77773ecebf20bd9cc94311574c0af2d`
- **#205** (Pinned-Dependencies): pinned `@jazzer.js/core` to `4.0.0` in `build.sh`

All three cflite workflows remain `workflow_dispatch` only.

Closes #201, #202, #203, #204, #205

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened ClusterFuzzLite by fixing all Scorecard code scanning alerts: enforced least-privilege GitHub token permissions and pinned critical dependencies to exact versions.

- **Bug Fixes**
  - Moved permissions to job level in `cflite_batch.yml`, `cflite_cron.yml`, `cflite_pr.yml`; added `permissions: {}` at workflow level to disable defaults.
  - Workflows remain `workflow_dispatch` only.

- **Dependencies**
  - Pinned Docker base image `gcr.io/oss-fuzz-base/base-builder-javascript@sha256:7051327a33e495e34e563383c82dd944c77773ecebf20bd9cc94311574c0af2d`.
  - Pinned `@jazzer.js/core` to `4.0.0` in `.clusterfuzzlite/build.sh`.

<sup>Written for commit 0d669e8272d10a56d5f94bd0241a9486d0ae46e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

