### PR TITLE
feat: add codecov.yml with coverage thresholds and PR comment config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,51 @@
+codecov:
+  # Do not block merges if Codecov is unavailable
+  require_ci_to_pass: false
+  # Wait for all CI jobs to finish before processing coverage
+  notify:
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        # Auto-target: use the previous commit's coverage as the baseline
+        target: auto
+        # Allow up to 1% drop before failing the status check
+        threshold: 1%
+        if_no_uploads: success
+        if_not_found: success
+    patch:
+      default:
+        # New/changed lines should be at least 80% covered
+        target: 80%
+        # Allow up to 5% miss on patch before failing
+        threshold: 5%
+        if_no_uploads: success
+        if_not_found: success
+
+comment:
+  # Update the existing comment instead of creating a new one on each push
+  behavior: default
+  # Show: coverage reach, diff summary, per-file breakdown
+  layout: "reach,diff,files"
+  # Only post if coverage actually changed in this PR
+  require_changes: true
+  # Only post if base branch coverage is available (avoids noise on first PRs)
+  require_base: true
+
+# Files that should not count toward coverage metrics
+ignore:
+  - "tests/**"
+  - "fuzz/**"
+  - "scripts/tests/**"
+  - "**/*.test.js"
+  - "**/*.spec.js"
+  - "**/*.config.js"
+  - ".github/**"
+  - ".clusterfuzzlite/**"
+  - "mcp/servers/*/build/**"


### PR DESCRIPTION
## Summary

- Adds `codecov.yml` to configure Codecov behavior for the EGC open source project.
- Suppresses noisy comments on YAML/JSON-only PRs (like the recent security fixes #197 and #198) via `require_changes: true`.
- Updates existing PR comment in-place instead of posting new ones on each push (`behavior: default`).
- Sets project coverage threshold at 1% tolerance and patch coverage at 80% minimum.
- Ignores test files, fuzzing harness, and build artifacts from metrics.

## Why

Without `codecov.yml`, Codecov posts a new comment on every push to a PR even when coverage doesn't change. The last few security-fix PRs all got "All modified and coverable lines are covered" comments because YAML/hooks.json changes have no coverable lines — noise with no signal.

## Current coverage baseline

88.64% (measured 15/06/2026)

## Test plan

- [ ] CI passes
- [ ] Codecov processes the new config (check https://app.codecov.io/gh/Fmarzochi/EGC/config)
- [ ] Next PR with no coverable changes gets no Codecov comment
- [ ] Next PR with JS changes gets a comment with diff coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `codecov.yml` to control Codecov comments and coverage checks. Reduces noise on non-code PRs and sets clear coverage gates.

- **New Features**
  - Comments: update in place; only post when coverage changes and a base exists.
  - CI: wait for all jobs; do not block merges if Codecov is down.
  - Coverage: project auto-target with 1% drop tolerance; patch coverage minimum 80% with 5% tolerance.
  - Ignore from metrics: tests, fuzz harness, configs, build artifacts, and GitHub/workflow files.

<sup>Written for commit 1cae18aaadd1db79ef7aecb86da6e3334755de16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

