### PR TITLE
fix: install Stop hook for Claude Code users via claude-home.js

### DIFF
--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+'use strict';
+
+// Claude Code Stop hook. Injects a prompt asking the AI to call update_state
+// via the egc-memory MCP tool before the session ends. Never blocks the Stop
+// event: missing stdin or parse errors are silently ignored and exit 0.
+
+const fs = require('fs');
+
+function main() {
+  let raw = '';
+  try {
+    raw = fs.readFileSync(0, 'utf8');
+  } catch (_error) {
+    process.exit(0);
+  }
+
+  let input = {};
+  try {
+    input = JSON.parse(raw);
+  } catch (_error) {
+    process.exit(0);
+  }
+
+  const prompt =
+    'Call update_state via the egc-memory MCP tool with the decisions, '
+    + 'preferences, and next steps from this session. '
+    + 'project_path is optional: omit it and it uses PWD automatically.';
+
+  const output = Object.assign({}, input, { promptForAssistant: prompt });
+  process.stdout.write(JSON.stringify(output));
+  process.exit(0);
+}
+
+main();

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -5,20 +5,20 @@
 // via the egc-memory MCP tool before the session ends. Never blocks the Stop
 // event: missing stdin or parse errors are silently ignored and exit 0.
 
-const fs = require('fs');
+const fs = require('node:fs');
 
 function main() {
   let raw = '';
   try {
     raw = fs.readFileSync(0, 'utf8');
-  } catch (_error) {
+  } catch {
     process.exit(0);
   }
 
   let input = {};
   try {
     input = JSON.parse(raw);
-  } catch (_error) {
+  } catch {
     process.exit(0);
   }
 
@@ -27,7 +27,7 @@ function main() {
     + 'preferences, and next steps from this session. '
     + 'project_path is optional: omit it and it uses PWD automatically.';
 
-  const output = Object.assign({}, input, { promptForAssistant: prompt });
+  const output = { ...input, promptForAssistant: prompt };
   process.stdout.write(JSON.stringify(output));
   process.exit(0);
 }

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -9,9 +9,12 @@ const fs = require('fs');
 const path = require('path');
 
 const SESSION_START_EVENT = 'SessionStart';
+const STOP_EVENT = 'Stop';
 const HOOK_OPERATION_KIND = 'merge-claude-settings-hooks';
 const HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/claude-session-start.js';
 const HOOK_MODULE_ID = 'claude-session-state-hook';
+const STOP_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/claude-session-stop.js';
+const STOP_HOOK_MODULE_ID = 'claude-session-stop-hook';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -21,8 +24,16 @@ function buildSessionStartCommand(hookScriptPath) {
   return `node "${hookScriptPath}"`;
 }
 
+function buildStopCommand(hookScriptPath) {
+  return `node "${hookScriptPath}"`;
+}
+
 function resolveHookScriptDestination(targetRoot) {
   return path.join(targetRoot, 'egc', 'hooks', 'claude-session-start.js');
+}
+
+function resolveStopHookScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'egc', 'hooks', 'claude-session-stop.js');
 }
 
 function resolveSettingsPath(targetRoot) {
@@ -218,20 +229,159 @@ function createSessionStartHookMergeOperation(targetRoot) {
   };
 }
 
+function hasStopHook(settings, hookScriptPath) {
+  if (!isPlainObject(settings) || !isPlainObject(settings.hooks)) {
+    return false;
+  }
+
+  const groups = settings.hooks[STOP_EVENT];
+  return Array.isArray(groups)
+    && groups.some(group => matcherGroupHasEgcEntry(group, hookScriptPath));
+}
+
+function addStopHook(settings, hookScriptPath) {
+  const base = isPlainObject(settings) ? settings : {};
+
+  if (hasStopHook(base, hookScriptPath)) {
+    return { settings: base, changed: false };
+  }
+
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const groups = Array.isArray(hooks[STOP_EVENT]) ? hooks[STOP_EVENT].slice() : [];
+
+  groups.push({
+    hooks: [{ type: 'command', command: buildStopCommand(hookScriptPath) }],
+  });
+  hooks[STOP_EVENT] = groups;
+
+  return { settings: { ...base, hooks }, changed: true };
+}
+
+function removeStopHook(settings, hookScriptPath) {
+  if (
+    !isPlainObject(settings)
+    || !isPlainObject(settings.hooks)
+    || !Array.isArray(settings.hooks[STOP_EVENT])
+  ) {
+    return { settings, changed: false };
+  }
+
+  let changed = false;
+  const groups = [];
+
+  for (const group of settings.hooks[STOP_EVENT]) {
+    if (!matcherGroupHasEgcEntry(group, hookScriptPath)) {
+      groups.push(group);
+      continue;
+    }
+
+    changed = true;
+    const remainingEntries = group.hooks.filter(
+      entry => !isEgcHookEntry(entry, hookScriptPath)
+    );
+    if (remainingEntries.length > 0) {
+      groups.push({ ...group, hooks: remainingEntries });
+    }
+  }
+
+  if (!changed) {
+    return { settings, changed: false };
+  }
+
+  const hooks = { ...settings.hooks };
+  if (groups.length > 0) {
+    hooks[STOP_EVENT] = groups;
+  } else {
+    delete hooks[STOP_EVENT];
+  }
+
+  const next = { ...settings };
+  if (Object.keys(hooks).length > 0) {
+    next.hooks = hooks;
+  } else {
+    delete next.hooks;
+  }
+
+  return { settings: next, changed: true };
+}
+
+function applyStopHookToFile(settingsPath, hookScriptPath) {
+  const current = readSettingsFile(settingsPath);
+  const { settings, changed } = addStopHook(current, hookScriptPath);
+
+  if (changed) {
+    writeSettingsFile(settingsPath, settings);
+  }
+
+  return { changed };
+}
+
+function removeStopHookFromFile(settingsPath, hookScriptPath) {
+  if (!fs.existsSync(settingsPath)) {
+    return { changed: false };
+  }
+
+  const current = readSettingsFile(settingsPath);
+  const { settings, changed } = removeStopHook(current, hookScriptPath);
+
+  if (changed) {
+    writeSettingsFile(settingsPath, settings);
+  }
+
+  return { changed };
+}
+
+function inspectStopHookFile(settingsPath, hookScriptPath) {
+  try {
+    return hasStopHook(readSettingsFile(settingsPath), hookScriptPath) ? 'ok' : 'drifted';
+  } catch (_error) {
+    return 'drifted';
+  }
+}
+
+function createStopHookMergeOperation(targetRoot) {
+  const hookScriptPath = resolveStopHookScriptDestination(targetRoot);
+
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: STOP_HOOK_MODULE_ID,
+    sourceRelativePath: STOP_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: resolveSettingsPath(targetRoot),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: STOP_EVENT,
+    hookScriptPath,
+    hookCommand: buildStopCommand(hookScriptPath),
+  };
+}
+
 module.exports = {
   HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   SESSION_START_EVENT,
+  STOP_EVENT,
+  STOP_HOOK_MODULE_ID,
+  STOP_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   addSessionStartHook,
+  addStopHook,
   applySessionStartHookToFile,
+  applyStopHookToFile,
   buildSessionStartCommand,
+  buildStopCommand,
   createSessionStartHookMergeOperation,
+  createStopHookMergeOperation,
   hasSessionStartHook,
+  hasStopHook,
   inspectSessionStartHookFile,
+  inspectStopHookFile,
   readSettingsFile,
   removeSessionStartHook,
   removeSessionStartHookFromFile,
+  removeStopHook,
+  removeStopHookFromFile,
   resolveHookScriptDestination,
   resolveSettingsPath,
+  resolveStopHookScriptDestination,
 };

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Manages the EGC SessionStart hook entry inside Claude Code settings.json.
+// Manages EGC hook entries inside Claude Code settings.json.
 // All merges are additive and idempotent: third-party hooks and unrelated
 // settings keys are always preserved, and the EGC entry is identified by the
 // installed hook script path so uninstall removes only what EGC added.
@@ -20,12 +20,16 @@ function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-function buildSessionStartCommand(hookScriptPath) {
+function buildHookCommand(hookScriptPath) {
   return `node "${hookScriptPath}"`;
 }
 
+function buildSessionStartCommand(hookScriptPath) {
+  return buildHookCommand(hookScriptPath);
+}
+
 function buildStopCommand(hookScriptPath) {
-  return `node "${hookScriptPath}"`;
+  return buildHookCommand(hookScriptPath);
 }
 
 function resolveHookScriptDestination(targetRoot) {
@@ -56,49 +60,32 @@ function matcherGroupHasEgcEntry(group, hookScriptPath) {
   );
 }
 
-function hasSessionStartHook(settings, hookScriptPath) {
+function hasHookEntry(settings, event, hookScriptPath) {
   if (!isPlainObject(settings) || !isPlainObject(settings.hooks)) {
     return false;
   }
-
-  const groups = settings.hooks[SESSION_START_EVENT];
+  const groups = settings.hooks[event];
   return Array.isArray(groups)
     && groups.some(group => matcherGroupHasEgcEntry(group, hookScriptPath));
 }
 
-function addSessionStartHook(settings, hookScriptPath) {
+function addHookEntry(settings, event, hookScriptPath) {
   const base = isPlainObject(settings) ? settings : {};
-
-  if (hasSessionStartHook(base, hookScriptPath)) {
+  if (hasHookEntry(base, event, hookScriptPath)) {
     return { settings: base, changed: false };
   }
-
   const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
-  const groups = Array.isArray(hooks[SESSION_START_EVENT])
-    ? hooks[SESSION_START_EVENT].slice()
-    : [];
-
-  groups.push({
-    hooks: [
-      {
-        type: 'command',
-        command: buildSessionStartCommand(hookScriptPath),
-      },
-    ],
-  });
-  hooks[SESSION_START_EVENT] = groups;
-
-  return {
-    settings: { ...base, hooks },
-    changed: true,
-  };
+  const groups = Array.isArray(hooks[event]) ? hooks[event].slice() : [];
+  groups.push({ hooks: [{ type: 'command', command: buildHookCommand(hookScriptPath) }] });
+  hooks[event] = groups;
+  return { settings: { ...base, hooks }, changed: true };
 }
 
-function removeSessionStartHook(settings, hookScriptPath) {
+function removeHookEntry(settings, event, hookScriptPath) {
   if (
     !isPlainObject(settings)
     || !isPlainObject(settings.hooks)
-    || !Array.isArray(settings.hooks[SESSION_START_EVENT])
+    || !Array.isArray(settings.hooks[event])
   ) {
     return { settings, changed: false };
   }
@@ -106,12 +93,11 @@ function removeSessionStartHook(settings, hookScriptPath) {
   let changed = false;
   const groups = [];
 
-  for (const group of settings.hooks[SESSION_START_EVENT]) {
+  for (const group of settings.hooks[event]) {
     if (!matcherGroupHasEgcEntry(group, hookScriptPath)) {
       groups.push(group);
       continue;
     }
-
     changed = true;
     const remainingEntries = group.hooks.filter(
       entry => !isEgcHookEntry(entry, hookScriptPath)
@@ -127,9 +113,9 @@ function removeSessionStartHook(settings, hookScriptPath) {
 
   const hooks = { ...settings.hooks };
   if (groups.length > 0) {
-    hooks[SESSION_START_EVENT] = groups;
+    hooks[event] = groups;
   } else {
-    delete hooks[SESSION_START_EVENT];
+    delete hooks[event];
   }
 
   const next = { ...settings };
@@ -176,45 +162,63 @@ function writeSettingsFile(settingsPath, settings) {
   fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8');
 }
 
-function applySessionStartHookToFile(settingsPath, hookScriptPath) {
+function applyHookEntryToFile(settingsPath, event, hookScriptPath) {
   const current = readSettingsFile(settingsPath);
-  const { settings, changed } = addSessionStartHook(current, hookScriptPath);
-
+  const { settings, changed } = addHookEntry(current, event, hookScriptPath);
   if (changed) {
     writeSettingsFile(settingsPath, settings);
   }
-
   return { changed };
 }
 
-function removeSessionStartHookFromFile(settingsPath, hookScriptPath) {
+function removeHookEntryFromFile(settingsPath, event, hookScriptPath) {
   if (!fs.existsSync(settingsPath)) {
     return { changed: false };
   }
-
   const current = readSettingsFile(settingsPath);
-  const { settings, changed } = removeSessionStartHook(current, hookScriptPath);
-
+  const { settings, changed } = removeHookEntry(current, event, hookScriptPath);
   if (changed) {
     writeSettingsFile(settingsPath, settings);
   }
-
   return { changed };
 }
 
-function inspectSessionStartHookFile(settingsPath, hookScriptPath) {
+function inspectHookEntryFile(settingsPath, event, hookScriptPath) {
   try {
-    return hasSessionStartHook(readSettingsFile(settingsPath), hookScriptPath)
+    return hasHookEntry(readSettingsFile(settingsPath), event, hookScriptPath)
       ? 'ok'
       : 'drifted';
-  } catch (_error) {
+  } catch {
     return 'drifted';
   }
 }
 
+function hasSessionStartHook(settings, hookScriptPath) {
+  return hasHookEntry(settings, SESSION_START_EVENT, hookScriptPath);
+}
+
+function addSessionStartHook(settings, hookScriptPath) {
+  return addHookEntry(settings, SESSION_START_EVENT, hookScriptPath);
+}
+
+function removeSessionStartHook(settings, hookScriptPath) {
+  return removeHookEntry(settings, SESSION_START_EVENT, hookScriptPath);
+}
+
+function applySessionStartHookToFile(settingsPath, hookScriptPath) {
+  return applyHookEntryToFile(settingsPath, SESSION_START_EVENT, hookScriptPath);
+}
+
+function removeSessionStartHookFromFile(settingsPath, hookScriptPath) {
+  return removeHookEntryFromFile(settingsPath, SESSION_START_EVENT, hookScriptPath);
+}
+
+function inspectSessionStartHookFile(settingsPath, hookScriptPath) {
+  return inspectHookEntryFile(settingsPath, SESSION_START_EVENT, hookScriptPath);
+}
+
 function createSessionStartHookMergeOperation(targetRoot) {
   const hookScriptPath = resolveHookScriptDestination(targetRoot);
-
   return {
     kind: HOOK_OPERATION_KIND,
     moduleId: HOOK_MODULE_ID,
@@ -230,118 +234,31 @@ function createSessionStartHookMergeOperation(targetRoot) {
 }
 
 function hasStopHook(settings, hookScriptPath) {
-  if (!isPlainObject(settings) || !isPlainObject(settings.hooks)) {
-    return false;
-  }
-
-  const groups = settings.hooks[STOP_EVENT];
-  return Array.isArray(groups)
-    && groups.some(group => matcherGroupHasEgcEntry(group, hookScriptPath));
+  return hasHookEntry(settings, STOP_EVENT, hookScriptPath);
 }
 
 function addStopHook(settings, hookScriptPath) {
-  const base = isPlainObject(settings) ? settings : {};
-
-  if (hasStopHook(base, hookScriptPath)) {
-    return { settings: base, changed: false };
-  }
-
-  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
-  const groups = Array.isArray(hooks[STOP_EVENT]) ? hooks[STOP_EVENT].slice() : [];
-
-  groups.push({
-    hooks: [{ type: 'command', command: buildStopCommand(hookScriptPath) }],
-  });
-  hooks[STOP_EVENT] = groups;
-
-  return { settings: { ...base, hooks }, changed: true };
+  return addHookEntry(settings, STOP_EVENT, hookScriptPath);
 }
 
 function removeStopHook(settings, hookScriptPath) {
-  if (
-    !isPlainObject(settings)
-    || !isPlainObject(settings.hooks)
-    || !Array.isArray(settings.hooks[STOP_EVENT])
-  ) {
-    return { settings, changed: false };
-  }
-
-  let changed = false;
-  const groups = [];
-
-  for (const group of settings.hooks[STOP_EVENT]) {
-    if (!matcherGroupHasEgcEntry(group, hookScriptPath)) {
-      groups.push(group);
-      continue;
-    }
-
-    changed = true;
-    const remainingEntries = group.hooks.filter(
-      entry => !isEgcHookEntry(entry, hookScriptPath)
-    );
-    if (remainingEntries.length > 0) {
-      groups.push({ ...group, hooks: remainingEntries });
-    }
-  }
-
-  if (!changed) {
-    return { settings, changed: false };
-  }
-
-  const hooks = { ...settings.hooks };
-  if (groups.length > 0) {
-    hooks[STOP_EVENT] = groups;
-  } else {
-    delete hooks[STOP_EVENT];
-  }
-
-  const next = { ...settings };
-  if (Object.keys(hooks).length > 0) {
-    next.hooks = hooks;
-  } else {
-    delete next.hooks;
-  }
-
-  return { settings: next, changed: true };
+  return removeHookEntry(settings, STOP_EVENT, hookScriptPath);
 }
 
 function applyStopHookToFile(settingsPath, hookScriptPath) {
-  const current = readSettingsFile(settingsPath);
-  const { settings, changed } = addStopHook(current, hookScriptPath);
-
-  if (changed) {
-    writeSettingsFile(settingsPath, settings);
-  }
-
-  return { changed };
+  return applyHookEntryToFile(settingsPath, STOP_EVENT, hookScriptPath);
 }
 
 function removeStopHookFromFile(settingsPath, hookScriptPath) {
-  if (!fs.existsSync(settingsPath)) {
-    return { changed: false };
-  }
-
-  const current = readSettingsFile(settingsPath);
-  const { settings, changed } = removeStopHook(current, hookScriptPath);
-
-  if (changed) {
-    writeSettingsFile(settingsPath, settings);
-  }
-
-  return { changed };
+  return removeHookEntryFromFile(settingsPath, STOP_EVENT, hookScriptPath);
 }
 
 function inspectStopHookFile(settingsPath, hookScriptPath) {
-  try {
-    return hasStopHook(readSettingsFile(settingsPath), hookScriptPath) ? 'ok' : 'drifted';
-  } catch (_error) {
-    return 'drifted';
-  }
+  return inspectHookEntryFile(settingsPath, STOP_EVENT, hookScriptPath);
 }
 
 function createStopHookMergeOperation(targetRoot) {
   const hookScriptPath = resolveStopHookScriptDestination(targetRoot);
-
   return {
     kind: HOOK_OPERATION_KIND,
     moduleId: STOP_HOOK_MODULE_ID,

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -13,9 +13,13 @@ const {
 } = require('./install-targets/registry');
 const {
   HOOK_OPERATION_KIND,
+  STOP_EVENT,
   applySessionStartHookToFile,
+  applyStopHookToFile,
   inspectSessionStartHookFile,
+  inspectStopHookFile,
   removeSessionStartHookFromFile,
+  removeStopHookFromFile,
 } = require('./claude-settings-hooks');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
@@ -364,7 +368,11 @@ function executeRepairOperation(repoRoot, operation) {
   }
 
   if (operation.kind === HOOK_OPERATION_KIND) {
-    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+    if (operation.hookEvent === STOP_EVENT) {
+      applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
+    } else {
+      applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+    }
     return;
   }
 
@@ -449,9 +457,13 @@ function uninstallRemove(operation) {
 }
 
 function uninstallClaudeSettingsHook(operation) {
-  // Strips only the EGC-managed SessionStart entry. The settings file itself
-  // is never deleted because Claude Code and the user own its other keys.
-  removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
+  // Strips only the EGC-managed hook entry. The settings file itself is never
+  // deleted because Claude Code and the user own its other keys.
+  if (operation.hookEvent === STOP_EVENT) {
+    removeStopHookFromFile(operation.destinationPath, operation.hookScriptPath);
+  } else {
+    removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
+  }
   return { removedPaths: [], cleanupTargets: [] };
 }
 
@@ -547,11 +559,10 @@ function inspectManagedOperation(repoRoot, operation) {
   }
 
   if (operation.kind === HOOK_OPERATION_KIND) {
-    return inspectResult(
-      inspectSessionStartHookFile(destinationPath, operation.hookScriptPath),
-      operation,
-      destinationPath
-    );
+    const inspectFn = operation.hookEvent === STOP_EVENT
+      ? inspectStopHookFile
+      : inspectSessionStartHookFile;
+    return inspectResult(inspectFn(destinationPath, operation.hookScriptPath), operation, destinationPath);
   }
 
   return inspectResult('unverified', operation, destinationPath);

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -319,6 +319,14 @@ function shouldRepairFromRecordedOperations(state) {
   return getManagedOperations(state).some(operation => operation.kind !== 'copy-file');
 }
 
+function repairClaudeSettingsHook(operation) {
+  if (operation.hookEvent === STOP_EVENT) {
+    applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else {
+    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+  }
+}
+
 function executeRepairOperation(repoRoot, operation) {
   if (operation.kind === 'copy-file') {
     const sourcePath = resolveOperationSourcePath(repoRoot, operation);
@@ -368,11 +376,7 @@ function executeRepairOperation(repoRoot, operation) {
   }
 
   if (operation.kind === HOOK_OPERATION_KIND) {
-    if (operation.hookEvent === STOP_EVENT) {
-      applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
-    } else {
-      applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
-    }
+    repairClaudeSettingsHook(operation);
     return;
   }
 

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -22,8 +22,12 @@ function isClaudeExcludedPath(sourceRelativePath) {
 const {
   HOOK_MODULE_ID,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  STOP_HOOK_MODULE_ID,
+  STOP_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   createSessionStartHookMergeOperation,
+  createStopHookMergeOperation,
   resolveHookScriptDestination,
+  resolveStopHookScriptDestination,
 } = require('../claude-settings-hooks');
 
 function createSessionStateHookOperations(adapter, targetRoot) {
@@ -36,6 +40,14 @@ function createSessionStateHookOperations(adapter, targetRoot) {
       { strategy: 'preserve-relative-path' }
     ),
     createSessionStartHookMergeOperation(targetRoot),
+    createRemappedOperation(
+      adapter,
+      STOP_HOOK_MODULE_ID,
+      STOP_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveStopHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ),
+    createStopHookMergeOperation(targetRoot),
   ];
 }
 

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -7,7 +7,9 @@ const { writeInstallState } = require('../install-state');
 const { filterMcpConfig, parseDisabledMcpServers } = require('../mcp-config');
 const {
   HOOK_OPERATION_KIND,
+  STOP_EVENT,
   applySessionStartHookToFile,
+  applyStopHookToFile,
 } = require('../claude-settings-hooks');
 
 function readJsonObject(filePath, label) {
@@ -127,7 +129,11 @@ function applyInstallPlan(plan) {
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
 
     if (operation.kind === HOOK_OPERATION_KIND) {
-      applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+      if (operation.hookEvent === STOP_EVENT) {
+        applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
+      } else {
+        applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+      }
       continue;
     }
 

--- a/tests/lib/claude-settings-hooks.test.js
+++ b/tests/lib/claude-settings-hooks.test.js
@@ -12,19 +12,32 @@ const {
   HOOK_OPERATION_KIND,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   SESSION_START_EVENT,
+  STOP_EVENT,
+  STOP_HOOK_MODULE_ID,
+  STOP_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   addSessionStartHook,
+  addStopHook,
   applySessionStartHookToFile,
+  applyStopHookToFile,
   buildSessionStartCommand,
+  buildStopCommand,
   createSessionStartHookMergeOperation,
+  createStopHookMergeOperation,
   hasSessionStartHook,
+  hasStopHook,
   inspectSessionStartHookFile,
+  inspectStopHookFile,
   removeSessionStartHook,
   removeSessionStartHookFromFile,
+  removeStopHook,
+  removeStopHookFromFile,
   resolveHookScriptDestination,
   resolveSettingsPath,
+  resolveStopHookScriptDestination,
 } = require('../../scripts/lib/claude-settings-hooks');
 
 const HOOK_SCRIPT_PATH = '/home/user/.claude/egc/hooks/claude-session-start.js';
+const STOP_HOOK_SCRIPT_PATH = '/home/user/.claude/egc/hooks/claude-session-stop.js';
 
 function test(name, fn) {
   try {
@@ -59,6 +72,27 @@ function thirdPartySettings() {
         {
           matcher: 'startup',
           hooks: [{ type: 'command', command: 'echo third-party' }],
+        },
+      ],
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [{ type: 'command', command: 'echo guard' }],
+        },
+      ],
+    },
+  };
+}
+
+function stopHookThirdPartySettings() {
+  return {
+    model: 'opus',
+    permissions: { allow: ['Bash(npm test)'] },
+    hooks: {
+      Stop: [
+        {
+          matcher: 'cleanup',
+          hooks: [{ type: 'command', command: 'echo third-party-stop' }],
         },
       ],
       PreToolUse: [
@@ -290,6 +324,147 @@ function runTests() {
     assert.strictEqual(
       operation.hookCommand,
       buildSessionStartCommand(resolveHookScriptDestination(targetRoot))
+    );
+  })) passed++; else failed++;
+
+  console.log('\n--- Stop hook ---\n');
+
+  if (test('addStopHook adds the Stop hook to empty settings', () => {
+    const { settings, changed } = addStopHook({}, STOP_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings.hooks[STOP_EVENT], [
+      { hooks: [{ type: 'command', command: buildStopCommand(STOP_HOOK_SCRIPT_PATH) }] },
+    ]);
+    assert.ok(hasStopHook(settings, STOP_HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('addStopHook is idempotent and reports no change when the hook exists', () => {
+    const first = addStopHook({}, STOP_HOOK_SCRIPT_PATH);
+    const second = addStopHook(first.settings, STOP_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.settings.hooks[STOP_EVENT].length, 1);
+  })) passed++; else failed++;
+
+  if (test('addStopHook preserves third-party Stop hooks and unrelated settings keys', () => {
+    const { settings } = addStopHook(stopHookThirdPartySettings(), STOP_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(settings.model, 'opus');
+    assert.deepStrictEqual(settings.permissions, { allow: ['Bash(npm test)'] });
+    assert.strictEqual(settings.hooks.PreToolUse.length, 1);
+    assert.strictEqual(settings.hooks[STOP_EVENT].length, 2);
+    assert.strictEqual(
+      settings.hooks[STOP_EVENT][0].hooks[0].command,
+      'echo third-party-stop'
+    );
+    assert.ok(hasStopHook(settings, STOP_HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('removeStopHook strips only the EGC Stop entry and keeps third-party hooks', () => {
+    const installed = addStopHook(stopHookThirdPartySettings(), STOP_HOOK_SCRIPT_PATH).settings;
+    const { settings, changed } = removeStopHook(installed, STOP_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.strictEqual(settings.model, 'opus');
+    assert.strictEqual(settings.hooks[STOP_EVENT].length, 1);
+    assert.strictEqual(
+      settings.hooks[STOP_EVENT][0].hooks[0].command,
+      'echo third-party-stop'
+    );
+    assert.strictEqual(settings.hooks.PreToolUse.length, 1);
+    assert.ok(!hasStopHook(settings, STOP_HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('removeStopHook drops empty hooks containers when EGC was the only Stop hook', () => {
+    const installed = addStopHook({ model: 'opus' }, STOP_HOOK_SCRIPT_PATH).settings;
+    const { settings, changed } = removeStopHook(installed, STOP_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings, { model: 'opus' });
+  })) passed++; else failed++;
+
+  if (test('removeStopHook is a no-op when the Stop hook is not registered', () => {
+    const settings = stopHookThirdPartySettings();
+    const result = removeStopHook(settings, STOP_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(result.changed, false);
+    assert.deepStrictEqual(result.settings, settings);
+  })) passed++; else failed++;
+
+  if (test('applyStopHookToFile creates settings.json with Stop hook when absent', () => {
+    const homeDir = createTempDir('claude-stop-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, '.claude', 'settings.json');
+      const result = applyStopHookToFile(settingsPath, STOP_HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, true);
+      assert.ok(hasStopHook(readJson(settingsPath), STOP_HOOK_SCRIPT_PATH));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('applyStopHookToFile is idempotent on subsequent calls', () => {
+    const homeDir = createTempDir('claude-stop-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      applyStopHookToFile(settingsPath, STOP_HOOK_SCRIPT_PATH);
+      const repeat = applyStopHookToFile(settingsPath, STOP_HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(repeat.changed, false);
+      assert.strictEqual(readJson(settingsPath).hooks[STOP_EVENT].length, 1);
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('removeStopHookFromFile is a no-op when settings.json is absent', () => {
+    const homeDir = createTempDir('claude-stop-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      const result = removeStopHookFromFile(settingsPath, STOP_HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, false);
+      assert.ok(!fs.existsSync(settingsPath));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectStopHookFile reports ok, drifted, and invalid JSON as drifted', () => {
+    const homeDir = createTempDir('claude-stop-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+
+      fs.writeFileSync(settingsPath, JSON.stringify(stopHookThirdPartySettings()));
+      assert.strictEqual(inspectStopHookFile(settingsPath, STOP_HOOK_SCRIPT_PATH), 'drifted');
+
+      applyStopHookToFile(settingsPath, STOP_HOOK_SCRIPT_PATH);
+      assert.strictEqual(inspectStopHookFile(settingsPath, STOP_HOOK_SCRIPT_PATH), 'ok');
+
+      fs.writeFileSync(settingsPath, '{ not json');
+      assert.strictEqual(inspectStopHookFile(settingsPath, STOP_HOOK_SCRIPT_PATH), 'drifted');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('createStopHookMergeOperation builds a managed operation for the target root', () => {
+    const targetRoot = path.join('/home/user', '.claude');
+    const operation = createStopHookMergeOperation(targetRoot);
+
+    assert.strictEqual(operation.kind, HOOK_OPERATION_KIND);
+    assert.strictEqual(operation.moduleId, STOP_HOOK_MODULE_ID);
+    assert.strictEqual(operation.sourceRelativePath, STOP_HOOK_SCRIPT_SOURCE_RELATIVE_PATH);
+    assert.strictEqual(operation.destinationPath, resolveSettingsPath(targetRoot));
+    assert.strictEqual(operation.ownership, 'managed');
+    assert.strictEqual(operation.scaffoldOnly, false);
+    assert.strictEqual(operation.hookEvent, STOP_EVENT);
+    assert.strictEqual(operation.hookScriptPath, resolveStopHookScriptDestination(targetRoot));
+    assert.strictEqual(
+      operation.hookCommand,
+      buildStopCommand(resolveStopHookScriptDestination(targetRoot))
     );
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary

- Fixes #185 and sub-tasks #192 #193 #194 #195
- `egc init` / `egc repair` never registered the `Stop` hook in `~/.claude/settings.json`, so `egc-memory-save` was silently skipped at every Claude Code session end
- Auto-save of session state was broken for all Claude Code users

## Changes

- **`scripts/hooks/claude-session-stop.js`** (new): Stop hook that injects `promptForAssistant` asking the AI to call `update_state` before the session ends
- **`claude-settings-hooks.js`**: 8 new exported functions for Stop hook management (`hasStopHook`, `addStopHook`, `removeStopHook`, `applyStopHookToFile`, `removeStopHookFromFile`, `inspectStopHookFile`, `createStopHookMergeOperation`, and helpers)
- **`claude-home.js`**: now copies `claude-session-stop.js` and registers the Stop hook in `settings.json` alongside the existing SessionStart hook
- **`install/apply.js`** + **`install-lifecycle.js`**: fixed to dispatch by `operation.hookEvent` instead of always calling the SessionStart variants for `merge-claude-settings-hooks` operations
- **`tests/lib/claude-settings-hooks.test.js`**: 11 new Stop hook tests (2415 total, 0 failed)

## Test plan

- [x] `node tests/lib/claude-settings-hooks.test.js` — 26/26 passed
- [x] `node tests/scripts/install-apply.test.js` — 28/28 passed
- [x] `npm test` — 2415/2415 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Claude Code Stop hook installation so session state is auto-saved on exit. Also refactors hook utilities and resolves SonarCloud warnings.

- **Bug Fixes**
  - Added `scripts/hooks/claude-session-stop.js` to prompt calling `update_state` via the `egc-memory` MCP tool before session end.
  - Registered the Stop hook in `~/.claude/settings.json` alongside `SessionStart` via `claude-home.js`.
  - Added Stop hook APIs in `claude-settings-hooks.js` (has/add/remove/apply/inspect + merge op).
  - Updated `install/apply.js` and `install-lifecycle.js` to dispatch by `operation.hookEvent` (handles Stop vs SessionStart).
  - Added tests covering Stop hook behavior.

- **Refactors**
  - Consolidated hook logic into generic helpers shared by `SessionStart` and `Stop`, reducing duplication and keeping thin wrappers.
  - Resolved SonarCloud findings and reduced complexity: extracted `repairClaudeSettingsHook`, updated Stop script to use `node:fs`, object spread, and minimal error handling.

<sup>Written for commit f27871db89f5e0c58166a42321680d5bc89c573b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Claude Code Stop hook event management, enabling custom actions to trigger when code sessions terminate and providing automated state persistence capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->