### PR TITLE
fix: skip untranslated files in Crowdin sync

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -32,6 +32,7 @@ jobs:
           pull_request_base_branch_name: main
           localization_branch_name: chore/crowdin-translations
           skip_untranslated_strings: true
+          skip_untranslated_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}


### PR DESCRIPTION
## Problem

The Crowdin Sync workflow (PR #201) ran on merge and downloaded translations for hundreds of languages — all empty since the project was created today and no human has translated anything yet. It also failed to create the PR because `can_approve_pull_request_reviews` was `false` at the repo level (the explicit `permissions: pull-requests: write` in the workflow was not enough; the repo-level toggle must also be enabled).

## Fix

- Add `skip_untranslated_files: true` to `crowdin-sync.yml` so the action only creates translation files when a language actually has content.
- Repo-level setting updated separately via API: `can_approve_pull_request_reviews: true` and `default_workflow_permissions: write`.

## Side effects

None. The `chore/crowdin-translations` branch created by the failed run will be deleted after this merges and the workflow is re-run with no translations to commit.

Closes: N/A (workflow improvement)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents empty translation PRs from the Crowdin sync by skipping untranslated files. The workflow now only adds files for languages with actual content.

- **Bug Fixes**
  - Added `skip_untranslated_files: true` to `.github/workflows/crowdin-sync.yml` to avoid creating empty locale files and noisy PRs.

<sup>Written for commit f3f5b38ae6e4c15788ee6adf2e66a9275c93d80e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

