### PR TITLE
fix(security): pin Crowdin workflow actions to SHA and override js-yaml to 4.2.0

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -8,6 +8,8 @@ on:
       - README.md
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   synchronize-with-crowdin:
     name: Sync translations
@@ -18,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Crowdin sync
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2
         with:
           upload_sources: true
           upload_translations: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -2253,19 +2253,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/markdownlint-cli/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
     "markdownlint-cli": "^0.48.0",
     "typescript": "^5.3.0"
   },
+  "overrides": {
+    "js-yaml": "^4.2.0"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3"


### PR DESCRIPTION
## Security fixes

### OpenSSF Scorecard alerts (crowdin-sync.yml)

**Pinned-Dependencies** -- 2 alerts:
- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
- `crowdin/github-action@v2` -> `crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2`

**Token-Permissions** -- 2 alerts:
- Added top-level `permissions: {}` to restrict default token permissions to read-only; job-level block already had `contents: write` and `pull-requests: write`

### Dependabot alerts -- 3x js-yaml moderate CVE

`markdownlint-cli@0.48.0` declares `~4.1.1` for `js-yaml`, which is affected by a quadratic-complexity DoS vulnerability via repeated YAML merge key aliases. Added `overrides.js-yaml: ^4.2.0` to `package.json` to force all transitive consumers to use the patched version. Verified via `package-lock.json`: 0 occurrences of `4.1.1`, 1 of `4.2.0`.

Closes: security alerts in https://github.com/Fmarzochi/EGC/security

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Crowdin sync workflow to meet OpenSSF Scorecard checks and patches `js-yaml` to 4.2.0. This reduces supply-chain risk and clears Dependabot alerts.

- **Bug Fixes**
  - Added top-level `permissions: {}` in `.github/workflows/crowdin-sync.yml`; job keeps required writes. Satisfies Scorecard Token-Permissions.

- **Dependencies**
  - Pinned `actions/checkout@v4` and `crowdin/github-action@v2` to commit SHAs in `crowdin-sync.yml` to satisfy Scorecard Pinned-Dependencies.
  - Added `"overrides": { "js-yaml": "^4.2.0" }` in `package.json` to force the patched version across transitive deps from `markdownlint-cli`.

<sup>Written for commit 45624524161ceebc1ce632168d6dff4ad7ecf95b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration with enhanced security measures.
  * Adjusted dependency management to ensure consistent package versions across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->