### PR TITLE
fix(ci): remove conflicting skip_untranslated_strings from Crowdin sync

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -33,7 +33,6 @@ jobs:
           pull_request_body: "New translations synced from [Crowdin](https://crowdin.com/project/egc)."
           pull_request_base_branch_name: main
           localization_branch_name: chore/crowdin-translations
-          skip_untranslated_strings: true
           skip_untranslated_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Crowdin Sync workflow has been failing since PR #201 with:

```
❌ Some command options are invalid. Check the following parameters:
- You cannot skip strings and files at the same time. Please use one of these parameters instead.
```

Both `skip_untranslated_strings: true` and `skip_untranslated_files: true` were set. The Crowdin action does not allow these options simultaneously.

## Fix

Remove `skip_untranslated_strings`. Keep `skip_untranslated_files: true` which is the correct guard against empty translation PRs when no human translations exist yet.

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Crowdin sync workflow by removing the conflicting `skip_untranslated_strings` option. The action now runs successfully and still avoids empty translation PRs via `skip_untranslated_files: true`.

<sup>Written for commit 7f5c92b5852c65ebd881ecc84687e6c39f434efc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

