### PR TITLE
fix(security): force js-yaml to 4.2.0 to fix CVE-2026-53550

### DIFF
--- a/fuzz/package-lock.json
+++ b/fuzz/package-lock.json
@@ -233,13 +233,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1083,13 +1080,22 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -1852,12 +1858,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/string-width": {
       "version": "3.1.0",

--- a/fuzz/package.json
+++ b/fuzz/package.json
@@ -8,6 +8,7 @@
   },
   "overrides": {
     "cross-spawn": "^7.0.6",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "js-yaml": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
   "overrides": {
     "js-yaml": "^4.2.0"
   },
+  "resolutions": {
+    "markdownlint-cli/js-yaml": "^4.2.0"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,17 +1020,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.2.0:
+js-yaml@^4.2.0, js-yaml@~4.1.1:
   version "4.2.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz"
   integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
-  dependencies:
-    argparse "^2.0.1"
-
-js-yaml@~4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

Fixes Dependabot alerts #1 and #3: `js-yaml <= 4.1.1` vulnerable to quadratic-complexity DoS in merge key handling (CVE-2026-53550, GHSA-h67p-54hq-rp68).

## Changes

### `yarn.lock`
`markdownlint-cli@0.48.0` pins `js-yaml@~4.1.1` which resolves to `4.1.1`. Yarn v1 `resolutions` does not override incompatible ranges at runtime, so the two lockfile entries are merged into a single one that resolves both `~4.1.1` and `^4.2.0` to `4.2.0`. A `resolutions` guard is also added to `package.json` for future installs.

### `fuzz/package.json` + `fuzz/package-lock.json`
Added `overrides.js-yaml: ^4.2.0` to the fuzz harness package and regenerated the lockfile. Verified: `node_modules/js-yaml` resolves to `4.2.0`, `npm audit` reports 0 vulnerabilities.

## Verification

```
grep "^js-yaml@" yarn.lock
# js-yaml@^4.2.0, js-yaml@~4.1.1: version "4.2.0"

node -e "console.log(require('./fuzz/node_modules/js-yaml/package.json').version)"
# 4.2.0
```

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force all `js-yaml` installs to 4.2.0 to remediate CVE-2026-53550 (DoS via merge keys). Removes vulnerable `<=4.1.1` paths across the repo and fuzz harness.

- **Dependencies**
  - Added root `overrides` and Yarn `resolutions` (`markdownlint-cli/js-yaml`) to pin `js-yaml@4.2.0`.
  - Updated `yarn.lock` so `~4.1.1` and `^4.2.0` both resolve to `4.2.0`.
  - Added `overrides.js-yaml: ^4.2.0` to `fuzz/package.json` and regenerated `fuzz/package-lock.json` (transitive `argparse@2.0.1`; audit clean).

<sup>Written for commit 24943b35f01aec25d11cd0997963d68b950a45af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency pinning configuration to ensure consistent build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->