### PR TITLE
ci(crowdin): add daily schedule trigger

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - README.md
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

- Adds a `schedule` trigger (daily at 06:00 UTC) to the Crowdin sync workflow
- The workflow already checks translation progress via the Crowdin API and creates a PR automatically when any language reaches 100%
- Previously, this only ran on pushes to `README.md` on main; now it also runs daily so translators do not need to wait for a source change to trigger the PR creation

## How it works

1. Daily at 06:00 UTC, the workflow queries `GET /projects/{id}/languages/progress`
2. If minimum progress across all languages is 100%: downloads translations and opens a PR
3. If below 100%: uploads sources only and logs the current percentage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a daily 06:00 UTC cron trigger to the Crowdin sync workflow so it can open translation PRs as soon as any language hits 100%, without requiring a README.md change. Existing push and manual triggers remain unchanged.

<sup>Written for commit 8da0a309a98805aabd94211a0243a6dd9d4a0cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

