### PR TITLE
feat(i18n): translate all docs to pt-BR

### DIFF
--- a/translations/pt/docs/MAINTAINERS.md
+++ b/translations/pt/docs/MAINTAINERS.md
@@ -1,0 +1,38 @@
+# Mantenedores
+
+## Proprietario do Projeto
+
+| Nome | GitHub | Funcao |
+|------|--------|------|
+| Felipe Marzochi | [@Fmarzochi](https://github.com/Fmarzochi) | Proprietario / Mantenedor Principal |
+
+## Funcoes e Responsabilidades
+
+### Proprietario / Mantenedor Principal
+
+- Autoridade final sobre direcao tecnica e decisoes de arquitetura
+- Revisa e faz merge de pull requests para o branch `main`
+- Gerencia configuracoes do repositorio GitHub, protecao de branch e controles de acesso
+- Lida com relatorios de vulnerabilidades de seguranca e coordena a divulgacao
+- Gerencia publicacao do pacote npm e releases do GitHub
+- Responde a issues e consultas da comunidade
+
+## Acesso a Recursos Sensiveis
+
+O acesso aos seguintes recursos e restrito ao proprietario do projeto:
+
+- Configuracoes de administracao do repositorio (protecao de branch, webhooks, segredos)
+- Segredos do GitHub Actions (`NPM_TOKEN`, `GITHUB_TOKEN`)
+- Direitos de publicacao no npm para o pacote `egc-universal`
+- Gerenciamento de Avisos de Seguranca do GitHub
+
+## Politica de Revisao de Contribuidores
+
+Antes de qualquer colaborador receber acesso de escrita ou administracao a recursos sensiveis:
+
+1. O contribuidor deve ter feito contribuicoes significativas ao projeto via pull requests
+2. O proprietario do projeto deve revisar o historico e a intencao do contribuidor
+3. As permissoes sao concedidas no nivel minimo necessario para a tarefa
+4. O acesso e revisado periodicamente e revogado quando nao for mais necessario
+
+Esta politica garante que acesso elevado nunca seja concedido automaticamente ou sem aprovacao explicita.

--- a/translations/pt/docs/README.md
+++ b/translations/pt/docs/README.md
@@ -1,0 +1,30 @@
+# Documentacao do EGC
+
+Este diretorio e o ponto de entrada canonico para tudo que nao e o `README.md` voltado ao usuario na raiz do repositorio.
+
+Se voce nao sabe por onde comecar, leia `governance/SUBSYSTEM-MAP.md` para a classificacao formal de cada subsistema.
+
+## Estrutura
+
+| Pasta | Finalidade | Comece aqui |
+|---|---|---|
+| `architecture/` | Arquitetura completa, atual e futura | `architecture/README.md` |
+| `governance/` | Classificacao de subsistemas, politicas de skills e agentes | `governance/README.md` |
+| `guides/` | Guias operacionais e tutoriais para contribuidores | `guides/README.md` |
+| `installation/` | Playbooks de configuracao para stacks especificas | `installation/HERMES-SETUP.md` |
+| `runtime/` | Contratos de runtime (mapa de comandos/agentes, adaptador de sessao) | arquivos diretos |
+
+## Referencias cruzadas
+
+- `README.md` raiz: visao geral do projeto voltada ao usuario e inicio rapido.
+- `.github/CONTRIBUTING.md`: governanca de engenharia e fluxo de contribuicao.
+- `docs/RULES.md`: regras de governanca do engine.
+- `.github/SECURITY.md`: divulgacao de vulnerabilidades.
+
+## Ordem de leitura para um novo contribuidor
+
+1. `README.md` raiz: o que e o EGC e como instalar.
+2. `governance/SUBSYSTEM-MAP.md`: para que serve cada diretorio.
+3. `architecture/README.md`: o modelo de runtime em camadas.
+4. `.github/CONTRIBUTING.md`: como propor mudancas.
+5. `guides/SKILL-DEVELOPMENT-GUIDE.md` se for criar uma skill, ou `guides/ANTIGRAVITY-GUIDE.md` para um exemplo completo de instalador.

--- a/translations/pt/docs/ROADMAP.md
+++ b/translations/pt/docs/ROADMAP.md
@@ -1,0 +1,40 @@
+# Roadmap do EGC
+
+Este documento descreve a direcao de desenvolvimento planejada para o EGC (Extended Global Context).
+
+## v1.1.0: Expansao de Memoria (Lancada em 13/06/2026)
+
+- `working_memory`: armazenamento transitorio chave-valor com TTL (issue #138)
+- `lessons`: conhecimento entre sessoes com decaimento de confianca (issue #140)
+- `detect_patterns`: analise comportamental a partir de eventos de hook (issue #141)
+- `compress_observations`: compressao de observacoes baseada em regras (issue #142)
+- `search_history`: busca de texto completo com ranking BM25 sobre decisoes (issue #139)
+- Estado do projeto ciente de branch: escopo de `get_state`/`update_state` por branch do git (issue #137)
+- Pipeline de consolidacao de estado a cada chamada de `update_state` (issue #143)
+- Hook SessionStart executa de forma idempotente apos reinstalacoes do harness
+
+## v1.2.0: Expansao do Ecossistema
+
+- Suporte a harnesses de IA adicionais (Zed, Windsurf, Continue)
+- Sistema de plugins para agentes e skills da comunidade
+- Perfis e substituicoes de skills por projeto
+
+## v1.3.0: Governanca e Seguranca
+
+- Revisao formal de seguranca por parte independente
+- Caso de asseguranca documentando propriedades de seguranca
+- Contribuicao de pelo menos dois mantenedores ativos (fator de onibus >= 2)
+- Geracao de SBOM (Software Bill of Materials)
+
+## v2.0.0: Runtime de Producao
+
+- API estavel do servidor MCP com interfaces versionadas
+- egc-guardian e egc-memory promovidos para GA
+- Federacao de memoria entre projetos
+- Instalacoes para times e organizacoes
+
+## Nao-Objetivos
+
+- O EGC nao visa substituir provedores de IA: ele os aumenta
+- O EGC nao armazena nem transmite codigo do usuario para terceiros
+- O EGC nao exige conectividade com a nuvem em instalacoes locais

--- a/translations/pt/docs/RULES.md
+++ b/translations/pt/docs/RULES.md
@@ -1,0 +1,57 @@
+# Regras de Governanca do EGC
+
+Estas regras governam as contribuicoes ao **Extended Global Context (EGC)**: um runtime MCP local com memoria persistente, contexto compartilhado e integracao plug-and-play para ferramentas de IA para codificacao.
+
+> **EGC - Extended Global Context**
+> **Desenvolvido por Felipe Marzochi**
+> **@MarzochiFelipe**
+> **https://github.com/Fmarzochi/EGC**
+> **© Todos os direitos reservados**
+
+---
+
+## 1. Estabilidade em Primeiro Lugar
+
+- **Estabilidade acima de Expansao:** Fortalecer o que existe antes de adicionar novas areas.
+- **Previsibilidade:** Evitar desvios arquiteturais e adicoes de frameworks sem validacao.
+- **Superficie Minima:** Nao introduzir dependencias frageis ou complexidade desnecessaria. Manter o ecossistema enxuto.
+
+## 2. Integridade do Runtime
+
+- **Servidores MCP sao o nucleo:** Mudancas em `mcp/servers/egc-guardian/` ou `mcp/servers/egc-memory/` exigem padroes de validacao mais rigorosos: ambos os servidores devem compilar e passar nos testes antes do merge.
+- **Schema de estado:** Nao quebrar o formato do arquivo de estado do egc-memory (`~/.egc/state/<slug>.md`). Arquivos de estado existentes devem permanecer lesiveis apos qualquer mudanca.
+- **Sem Falhas Silenciosas:** Nunca engolir excecoes silenciosamente. Sempre preservar a observabilidade de erros para que falhas sejam rastreaveis.
+
+## 3. Aplicacao Multiplataforma
+
+- O EGC deve funcionar em **Linux**, **Windows** e **macOS**.
+- **Sem Suposicoes de SO:** Nunca codificar caminhos absolutos do sistema. Usar resolucao dinamica de caminhos.
+- **Compatibilidade de Shell:** Scripts e hooks nao devem depender de recursos de shell exclusivos de um SO. A matriz de CI cobre todas as tres plataformas: todos os jobs devem passar.
+
+## 4. Formato do Ecossistema Cognitivo
+
+### Agentes
+
+- Agentes ficam em `agents/*.md` e definem a persona e o comportamento da IA.
+- O frontmatter deve incluir `name`, `description`, `tools` e `model`.
+- As descricoes devem ser especificas o suficiente para informar o roteamento de ferramentas.
+
+### Skills
+
+- Skills ficam em `skills/<name>/SKILL.md` e funcionam como runbooks de fluxo de trabalho.
+- O frontmatter deve incluir `name`, `description` e `origin` (`EGC` ou `community`).
+- Os corpos das skills devem incluir uma secao clara "Quando Ativar".
+
+### Hooks
+
+- Hooks interceptam eventos de ciclo de vida (ex.: `PreToolUse`, `SessionStart`) e ficam em `hooks/hooks.json`.
+- Os matchers devem ser especificos. Catch-alls amplos sao proibidos.
+- Use `exit 1` estritamente para bloquear comportamentos destrutivos; use `exit 0` caso contrario.
+- Todos os logs de hook devem se identificar (ex.: `[EGC Hook]`).
+
+## 5. Qualidade de Codigo e Padroes de Commit
+
+- **Atualizacoes Imutaveis:** Prefira atualizacoes imutaveis a mutacoes de estado compartilhado.
+- **Testar Antes de Mergear:** Execute `npm test` e verifique se todos os 2156 testes passam antes de enviar mudancas.
+- **Seguranca:** Nunca incluir chaves de API, tokens ou segredos no historico de saida ou commit.
+- **Commits:** Use commits convencionais (`feat(mcp):`, `fix(hooks):`, `docs(rules):`). Mantenha as mudancas modulares.

--- a/translations/pt/docs/TROUBLESHOOTING.md
+++ b/translations/pt/docs/TROUBLESHOOTING.md
@@ -1,0 +1,39 @@
+# Solucao de Problemas
+
+## `EACCES: permission denied` no macOS
+
+**Sintoma:** `npm install -g @egchq/egc` falha com:
+
+```
+npm error code EACCES
+npm error syscall mkdir
+npm error path /usr/local/lib/node_modules/@egchq
+npm error errno -13
+```
+
+**Causa:** O Node.js foi instalado em todo o sistema (via instalador oficial ou Homebrew) e o npm nao consegue escrever em `/usr/local/lib/node_modules` sem acesso root.
+
+**Solucao:** Use um gerenciador de versoes do Node para que o Node fique no seu diretorio home e instalacoes globais funcionem sem `sudo`.
+
+Com [nvm](https://github.com/nvm-sh/nvm):
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+# reinicie o terminal e entao:
+nvm install --lts
+nvm use --lts
+npm install -g @egchq/egc
+```
+
+Com [fnm](https://github.com/Schniz/fnm) (mais rapido):
+
+```bash
+brew install fnm
+# Adicione ao ~/.zshrc ou ~/.bash_profile e reinicie o terminal:
+eval "$(fnm env --use-on-cd)"
+fnm install --lts
+fnm use lts-latest
+npm install -g @egchq/egc
+```
+
+Se preferir nao alterar sua instalacao do Node, a alternativa e [configurar um prefixo global personalizado do npm](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) no seu diretorio home.

--- a/translations/pt/docs/architecture/ARCHITECTURE-IMPROVEMENTS.md
+++ b/translations/pt/docs/architecture/ARCHITECTURE-IMPROVEMENTS.md
@@ -1,0 +1,146 @@
+# Recomendacoes de Melhorias Arquiteturais
+
+Este documento captura melhorias em nivel de arquiteto para o projeto EGC - Extended Global Context. E escrito da perspectiva de um arquiteto de codificacao do EGC visando melhorar a manutenibilidade, consistencia e qualidade de longo prazo.
+
+---
+
+## 1. Documentacao e Fonte Unica de Verdade
+
+### 1.1 Sincronizacao de Contagem de Agentes / Comandos / Skills
+
+**Problema:** AGENTS.md declara "13 agentes especializados, 50+ skills, 33 comandos" enquanto o repositorio tem **16 agentes**, **65+ skills** e **40 comandos**. README e outros docs tambem variam. Isso causa confusao para colaboradores e usuarios.
+
+**Recomendacao:**
+
+- **Fonte unica de verdade:** Derivar contagens (e opcionalmente tabelas) do sistema de arquivos ou de um manifesto pequeno. Opcoes:
+  - **Opcao A:** Adicionar um script (ex.: `scripts/ci/catalog.js`) que escaneia `agents/*.md`, `commands/*.md` e `skills/*/SKILL.md` e gera saida JSON/Markdown. CI e docs podem consumir isso.
+  - **Opcao B:** Manter um `docs/catalog.json` (ou YAML) que lista agentes, comandos e skills com metadados; scripts e docs lem dele. Requer disciplina para atualizar em adicoes/remocoes.
+- **Curto prazo:** Sincronizar manualmente AGENTS.md, README.md e gemini.md com as contagens reais e listar quaisquer novos agentes (ex.: chief-of-staff, loop-operator, harness-optimizer) na tabela de agentes.
+
+**Impacto:** Alto: afeta a primeira impressao e a confianca dos colaboradores.
+
+---
+
+### 1.2 Mapa Comando -> Agente / Skill
+
+**Problema:** Nao existe um mapa unico legivel por maquina ou humano de "qual comando usa qual(is) agente(s) ou skill(s)." Isso vive em tabelas do README e em arquivos `.md` de comandos individuais, que podem divergir.
+
+**Recomendacao:**
+
+- Adicionar um **registro de comandos** (ex.: em `docs/` ou como frontmatter em arquivos de comando) que liste para cada comando: nome, descricao, agente(s) principal(is), skills referenciadas. Pode ser gerado do conteudo de arquivos de comando ou mantido manualmente.
+- Expor um "mapa" em docs (ex.: `docs/COMMAND-AGENT-MAP.md`) ou no catalogo gerado para descobribilidade e para ferramentas (ex.: "quais comandos usam tdd-guide?").
+
+**Impacto:** Medio: melhora a descobribilidade e a seguranca de refatoracao.
+
+---
+
+## 2. Testes e Qualidade
+
+### 2.1 Descoberta de Testes vs Lista Hardcoded
+
+**Problema:** `tests/run-all.js` usa uma **lista hardcoded** de arquivos de teste. Novos arquivos de teste nao sao executados a menos que alguem atualize `run-all.js`, entao a cobertura pode estar incompleta por omissao.
+
+**Recomendacao:**
+
+- **Descoberta baseada em glob:** Descobrir arquivos de teste por padrao (ex.: `**/*.test.js` em `tests/`) e executa-los, com uma allowlist/denylist opcional para casos especiais. Isso faz com que novos testes sejam automaticamente parte do suite.
+- Manter um unico ponto de entrada (`tests/run-all.js`) que executa testes descobertos e agrega resultados.
+
+**Impacto:** Alto: evita regressoes onde novos testes existem mas nunca sao executados.
+
+---
+
+### 2.2 Metricas de Cobertura de Testes
+
+**Problema:** Nao ha ferramenta de cobertura (ex.: nyc/c8/istanbul). O projeto nao pode afirmar "80%+ de cobertura" para seus proprios scripts; a cobertura e implicita.
+
+**Recomendacao:**
+
+- Introduzir uma ferramenta de cobertura para scripts Node (ex.: `c8` ou `nyc`) e executa-la no CI. Comece com uma baseline (ex.: 60%) e aumente com o tempo; ou pelo menos relate a cobertura no CI sem falhar para que a equipe possa ver tendencias.
+- Focar em `scripts/` (lib + hooks + ci) como o alvo principal; excluir scripts avulsos se necessario.
+
+**Impacto:** Medio: alinha o projeto com sua propria orientacao do AGENTS.md (80%+ de cobertura) e expoe caminhos nao testados.
+
+---
+
+## 3. Schema e Validacao
+
+### 3.1 Usar Schema JSON de Hooks no CI
+
+**Problema:** `schemas/hooks.schema.json` existe e define a forma da configuracao de hooks, mas `scripts/ci/validate-hooks.js` **nao o usa**. A validacao e duplicada (VALID_EVENTS, estrutura) e pode divergir do schema.
+
+**Recomendacao:**
+
+- Usar um validador de JSON Schema (ex.: `ajv`) em `validate-hooks.js` para validar `hooks/hooks.json` contra `schemas/hooks.schema.json`. Manter o validador como a fonte unica de verdade para estrutura; reter apenas verificacoes especificas de hook (ex.: sintaxe JS inline) no script.
+- Garante que schema e validador permanecam sincronizados e permite validacao em IDE/editor via `$schema` em hooks.json.
+
+**Impacto:** Medio: reduz divergencias e melhora a experiencia do colaborador ao editar hooks.
+
+---
+
+## 4. Entre Harnesses e i18n
+
+### 4.1 Sincronizacao de Subconjunto de Skills/Agentes (.agents/skills, .cursor/skills)
+
+**Problema:** `.agents/skills/` (Codex) e `.cursor/skills/` sao subconjuntos de `skills/`. Adicionar ou remover uma skill no repositorio principal requer atualizar manualmente esses subconjuntos, o que pode ser esquecido.
+
+**Recomendacao:**
+
+- Documentar no CONTRIBUTING.md que adicionar uma skill pode requerer atualizar `.agents/skills` e `.cursor/skills` (e como fazer isso).
+- Opcionalmente: uma verificacao no CI ou script que compara `skills/` com os subconjuntos e falha ou avisa se uma skill esta em um conjunto mas nao no outro quando deveria estar (ex.: por convencao ou por um pequeno manifesto).
+
+**Impacto:** Baixo a Medio: reduz divergencias entre harnesses.
+
+---
+
+### 4.2 Deriva de Traducao (docs/ zh-CN, zh-TW, ja-JP)
+
+**Problema:** Traducoes em `docs/` duplicam agentes, comandos e skills. Conforme o source em ingles evolui, as traducoes podem ficar desatualizadas sem um processo ou ferramentas claras.
+
+**Recomendacao:**
+
+- Documentar um **processo de traducao:** quando atualizar (ex.: em cada release), quem possui cada locale, e como detectar conteudo obsoleto (ex.: diff de listas de arquivos ou secoes-chave).
+- Considerar: arquivo de status de traducao (ex.: `docs/i18n-status.md`) ou CI que verifica existencia/timestamps de arquivos de traducao e avisa se o ingles foi atualizado mais recentemente do que uma traducao.
+- A longo prazo: considerar formato de extracao/placeholder (ex.: chaves i18n) para que as traducoes referenciem a mesma estrutura que o source em ingles.
+
+**Impacto:** Medio: melhora a experiencia para usuarios nao falantes de ingles e reduz confusao com traducoes desatualizadas.
+
+---
+
+## 5. Hooks e Scripts
+
+### 5.1 Consistencia de Runtime de Hook
+
+**Problema:** Hooks devem manter uma superficie de despacho Node consistente. A observacao de aprendizado continuo agora despacha por meio de `run-with-flags.js` e `observe-runner.js`, que delega a implementacao existente de `observe.sh` sem expor uma entrada de hook em modo shell.
+
+**Recomendacao:**
+
+- Preferir Node para novos hooks quando possivel (multiplataforma, runtime unico). Se shell for necessario, documente o motivo e mantenha a superficie pequena.
+- Garantir que `egc_HOOK_PROFILE` e `egc_DISABLED_HOOKS` sejam respeitados em todos os caminhos de codigo (incluindo shell) para que o comportamento seja consistente.
+
+**Impacto:** Baixo: mantem o design atual; melhora se mais hooks migrarem para Node.
+
+---
+
+## 6. Tabela Resumo
+
+| Area | Melhoria | Prioridade | Esforco |
+|------|----------|------------|---------|
+| Sync de docs | Sincronizar contagens/tabela do AGENTS.md/README | Alto | Baixo |
+| Fonte unica | Script de catalogo ou manifesto | Alto | Medio |
+| Descoberta de testes | Runner de testes baseado em glob | Alto | Baixo |
+| Cobertura | Adicionar c8/nyc e cobertura no CI | Medio | Medio |
+| Schema de hook no CI | Validar hooks.json via schema | Medio | Baixo |
+| Mapa de comandos | Registro de comando -> agente/skill | Medio | Medio |
+| Sync de subconjunto | Documentar/CI para .agents/.cursor | Baixo a Med | Baixo a Med |
+| Traducoes | Processo + deteccao de obsolescencia | Medio | Medio |
+| Runtime de hook | Preferir Node; documentar uso de shell | Baixo | Baixo |
+
+---
+
+## 7. Ganhos Rapidos (Imediatos)
+
+1. **Atualizar AGENTS.md:** Definir contagem de agentes para 16; adicionar chief-of-staff, loop-operator, harness-optimizer a tabela de agentes; alinhar contagens de skills/comandos com o repositorio.
+2. **Descoberta de testes:** Alterar `run-all.js` para descobrir `**/*.test.js` em `tests/` (com allowlist opcional) para que novos testes sejam sempre executados.
+3. **Conectar schema de hooks:** Em `validate-hooks.js`, validar `hooks/hooks.json` contra `schemas/hooks.schema.json` usando ajv (ou similar) e manter apenas verificacoes especificas de hook no script.
+
+Esses tres podem ser feitos em uma ou duas sessoes e melhoram materialmente a consistencia e a confiabilidade.

--- a/translations/pt/docs/architecture/EGC_2.0_BLUEPRINT.md
+++ b/translations/pt/docs/architecture/EGC_2.0_BLUEPRINT.md
@@ -1,0 +1,84 @@
+# BLUEPRINT ARQUITETURAL EGC 2.0: O AGENTE OS
+
+**Arquiteto:** Unidade Arquitetural EGC
+**Status:** Proposta de Design
+**Alvo:** Runtime Soberano Unificado
+**Versao:** 1.0.0 (Proposta de Design)
+
+---
+
+## 1. VISAO: DE WRAPPER A OS
+
+O EGC v1 provou a viabilidade de uma cadeia cognitiva hibrida Node/Python. No entanto, seu **Modelo de Criacao de Processos** cria sobrecarga significativa, riscos de amnesia e contornos de governanca.
+
+**EGC 2.0** faz a transicao para um **Modelo de Daemon Persistente (Agente OS)** onde o runtime vive como um unico processo de longa duracao que orquestra modelos, ferramentas e hooks por meio de IPC de alta fidelidade.
+
+---
+
+## 2. O PLANO DE CONTROLE UNIFICADO (PCU)
+
+### 2.1 Host: O Kernel Rust
+O scaffold Rust existente `egc/` sera promovido ao **Kernel do Sistema** primario.
+- **Papel:** Supervisor de processos, host TUI e broker IPC seguro.
+- **Linguagem:** Rust (por desempenho e seguranca).
+
+### 2.2 Co-Processadores: Python e Node.js
+- **Motor Python:** Hospedado como um sub-servico gerenciado para interacao com LLM e logica ReAct.
+- **Motor Node.js:** Hospedado para compatibilidade de hooks legados e roteamento CLI.
+- **Mecanismo IPC:** Unix Domain Sockets (POSIX) ou Named Pipes (Windows) usando um **protocolo baseado em Protobuf** (removendo a sobrecarga de JSON sobre STDIN).
+
+---
+
+## 3. FABRIC DE MEMORIA DETERMINISTICA
+
+### 3.1 Unificacao de Namespace
+Migracao completa de `~/.gemini/homunculus` para `~/.gemini/egc`.
+
+### 3.2 Divisao de Armazenamento
+- **Memoria Quente (RAM/SQLite):** Contexto de sessao ao vivo, instintos ativos e resultados recentes de ferramentas.
+- **Memoria Fria (JSONL/Vetor):** Arquivos de sessao de longo prazo e padroes com escopo de projeto.
+- **Schema Unificado:** Um banco de dados SQLite compartilhado gerenciado pelo Kernel Rust, acessivel via IPC por motores Python e Node.js.
+
+---
+
+## 4. GOVERNANCA DE ALTA FIDELIDADE (Bloqueio de Estado)
+
+### 4.1 O Modelo "Interceptor"
+No EGC 2.0, o `Dispatcher` e movido para o **Kernel**.
+1. **Pre-voo:** Kernel intercepta a Intencao do Modelo -> Despacha hooks de bloqueio.
+2. **Execucao:** Kernel executa a ferramenta (ou delega para sub-servico).
+3. **Pos-voo (CIENTE DO RESULTADO):** Kernel recebe o resultado -> Despacha hooks de bloqueio -> Retorna ao Modelo.
+
+### 4.2 Governanca de Erros
+Introducao dos gatilhos `PostToolUseFailure` e `SystemPanic` para permitir recuperacao agentiva antes do termino do processo CLI.
+
+---
+
+## 5. ESPECIFICACOES DE INTERFACE (RASCUNHO)
+
+### 5.1 IPC do Kernel (Pseudo-Protobuf)
+```protobuf
+message AgentRequest {
+  string session_id = 1;
+  string project_id = 2;
+  ModelHint model = 3;
+  string prompt = 4;
+}
+
+message ToolInterception {
+  string tool_name = 1;
+  map<string, string> arguments = 2;
+  EventPhase phase = 3; // PreToolUse, PostToolUse
+}
+```
+
+---
+
+## 6. ESTRATEGIA DE MIGRACAO
+
+1. **Fase Alpha:** Implementar a ponte IPC entre o TUI Rust e o Core Python.
+2. **Fase Beta:** Migrar `SessionRecorder` para o armazenamento SQLite do Kernel.
+3. **Fase Gamma:** Redirecionar a CLI `egc` para se comunicar com o Daemon em vez de criar `gemini.js`.
+
+---
+**Veredicto:** O EGC 2.0 elimina o problema do "Cerebro Isolado" criando um sistema circulatorio compartilhado para contexto e governanca.

--- a/translations/pt/docs/architecture/EGC_2.0_TECHNICAL_DESIGN.md
+++ b/translations/pt/docs/architecture/EGC_2.0_TECHNICAL_DESIGN.md
@@ -1,0 +1,90 @@
+# DESIGN TECNICO EGC 2.0: A FUNDACAO DO AGENTE OS
+
+**Arquiteto:** Unidade Arquitetural EGC
+**Status:** Especificacao Tecnica
+**Versao:** 1.0.0 (Proposta de Design)
+
+---
+
+## 1. MAPA DE INTEGRACAO DE COMPONENTES
+
+A arquitetura EGC 2.0 centraliza a orquestracao em um **Kernel Persistente Baseado em Rust**.
+
+```mermaid
+graph TD
+    CLI[egc CLI] -->|IPC| Kernel[Kernel Rust]
+    Kernel -->|Sub-processo Gerenciado| Python[Motor LLM Python]
+    Kernel -->|Sub-processo Gerenciado| Node[Worker de Hook Node.js]
+    Kernel -->|Acesso Compartilhado| DB[(SQLite State Store)]
+    Python -->|LLM API| Gemini[Google Gemini / Vertex AI]
+    Node -->|Hooks Legados| Filesystem
+```
+
+---
+
+## 2. PLANO DE CONTROLE UNIFICADO (O KERNEL)
+
+### 2.1 Orquestracao Persistente
+- O Kernel inicia como um daemon em background (`egcd`).
+- Ele mantem um pool de workers:
+    - **Pool LLM:** Processos Python para inferencia e logica.
+    - **Pool de Hooks:** Processos Node.js para execucao de governanca.
+
+### 2.2 Protocolo IPC (gRPC/Protobuf)
+Substitui o frágil piping JSON via STDIN/STDOUT.
+
+**Definicao de Servico:**
+```protobuf
+service AgentOS {
+  rpc ExecutePrompt(PromptRequest) returns (PromptResponse);
+  rpc InterceptTool(ToolCall) returns (InterceptionResult);
+  rpc LogEvent(Event) returns (Ack);
+}
+```
+
+---
+
+## 3. FABRIC DE MEMORIA DETERMINISTICA
+
+### 3.1 Schema de Armazenamento Unificado (SQLite)
+O Kernel gerencia um unico banco de dados SQLite em `~/.gemini/egc/egc.db`.
+
+**Tabelas Principais:**
+- `sessions`: `id (PK), project_id, metadata, start_time, end_time`
+- `events`: `id, session_id, event_type, payload (JSON), timestamp`
+- `instincts`: `id, project_id, trigger, content (Markdown), confidence`
+
+### 3.2 Migracao de Namespace
+- **Alvo:** `~/.gemini/egc/`
+- **Ponte:** Durante a transicao, se `~/.gemini/egc/` estiver ausente, o Kernel tentara criar symlink ou migrar dados de `~/.gemini/homunculus/`.
+
+---
+
+## 4. GOVERNANCA DE ALTA FIDELIDADE (BLOQUEIO DE ESTADO)
+
+### 4.1 O Loop Interceptor
+O Kernel implementa um gate de governanca sincrono e bloqueante para cada chamada de ferramenta.
+
+1. **`TOOL_REQUEST`**: Motor Python solicita execucao de ferramenta.
+2. **`PRE_FLIGHT_CHECK`**: Kernel despacha hooks de bloqueio para workers Node.js.
+3. **`VETO_OR_MUTATE`**: Se um hook falhar ou mutar, o Kernel responde ao Python imediatamente (bloqueando a execucao).
+4. **`EXECUTION`**: Se as verificacoes passarem, o Kernel executa a ferramenta.
+5. **`POST_FLIGHT_AUDIT`**: Kernel captura o resultado, despacha hooks cientes do resultado, depois retorna o resultado final ao Python.
+
+### 4.2 Integridade Causal
+Ao mover o loop para o Kernel, garantimos que `PostToolUse` sempre tem acesso ao valor de retorno da ferramenta *antes* que o modelo continue seu raciocinio.
+
+---
+
+## 5. SOBERANIA E COMPATIBILIDADE
+
+### 5.1 Compatibilidade de Artefatos
+- **Agentes:** O EGC 2.0 le os mesmos arquivos `agents/*.md`.
+- **Skills:** A documentacao de skills permanece autoritativa. O Kernel os injeta no contexto do motor Python.
+
+### 5.2 Soberania Ambiental
+- Elimina referencias hardcoded a `ECC_*` na logica principal.
+- Padroniza em `EGC_PROJECT_ROOT` e `EGC_SESSION_ID`.
+
+---
+**Veredicto do Arquiteto:** Este design resolve a "Fragmentacao de Processos" do v1 introduzindo um sistema circulatorio compartilhado para estado e controle, estabelecendo o EGC como um verdadeiro Agente OS soberano.

--- a/translations/pt/docs/architecture/README.md
+++ b/translations/pt/docs/architecture/README.md
@@ -1,0 +1,46 @@
+# Arquitetura do EGC
+
+O EGC possui um runtime de producao alem de uma direcao exploratoria de kernel mantida em `architecture/` para pesquisa e evolucao do ecossistema. Esta pagina e o indice: leia primeiro, depois aprofunde-se nos documentos especificos abaixo.
+
+## Runtime
+
+### Runtime Node.js + MCP (coberto pelo CI)
+
+A superficie de producao que alimenta os harnesses Gemini Code, Codex, Cursor, Antigravity, OpenCode, Kiro, Trae e Codebuddy.
+
+| Camada | Caminho | Funcao |
+|---|---|---|
+| Manifestos | `.gemini-plugin/`, `.codex-plugin/`, `.gemini-plugin/marketplace.json` | Descoberta estatica de plugins |
+| Adaptadores de instalacao | `scripts/lib/install-targets/` | Materializacao por alvo |
+| Ponto de entrada de instalacao | `scripts/install-apply.js`, `install.sh`, `install.ps1` | Instaladores voltados ao usuario |
+| Pipeline de hooks | `hooks/hooks.json` + `scripts/hooks/*` | Hooks de Pre/Post-ferramenta, sessao e governanca |
+| Gates de CI | `scripts/ci/validate-*.js`, `scripts/ci/catalog.js` | Validacao de workflow |
+
+O runtime Node/MCP e totalmente exercido pela matriz de CI (`.github/workflows/ci.yml`, `reusable-test.yml`, `reusable-validate.yml`) em Linux/macOS/Windows x Node 20/22 x npm/yarn/bun.
+
+### Scaffolding dormante (preservado)
+
+- `scripts/runtime/{router,discovery,mount-all,unmount-all,activator}.js`
+- `scripts/orchestration/router.py`
+- `scripts/health-check.js`, `scripts/generate-plugin-manifest.js`
+
+Esses resolvem um caminho `registry/` inexistente e nao tem chamadores. Consulte `scripts/runtime/README.md` e `governance/SUBSYSTEM-MAP.md` para o status DORMANT.
+
+## Exploracao arquitetural do EGC 2.0
+
+`EGC_2.0_BLUEPRINT.md` e `EGC_2.0_TECHNICAL_DESIGN.md` recolhem pesquisas de evolucao do ecossistema em torno de uma variante de plano de controle unificado (kernel Rust + engine LLM Python + worker de hook Node + armazenamento de estado SQLite). Sao estudos avancados de runtime, nao um cronograma de substituicao para os runtimes de producao documentados acima.
+
+O scaffold Rust em `egc/` esta reservado para essa exploracao. Ele nao substitui os runtimes de producao atuais.
+
+## Documentos nesta pasta
+
+| Arquivo | Escopo |
+|---|---|
+| `ARCHITECTURE-IMPROVEMENTS.md` | Melhorias e refatoracoes transversais realizadas durante a estabilizacao da v1 |
+| `EGC_2.0_BLUEPRINT.md` | Visao para o Agent OS v2.0 |
+| `EGC_2.0_TECHNICAL_DESIGN.md` | Integracao de componentes e contratos IPC da v2.0 |
+| `SELECTIVE-INSTALL-ARCHITECTURE.md` | Sistema de modulos/perfis em `manifests/install-*.json` |
+| `SELECTIVE-INSTALL-DESIGN.md` | Justificativa de design de instalacao seletiva e regras por alvo |
+| `SINGLE-AGENT-OPERATIONAL-MODEL.md` | Modelo de execucao autoritativo de agente unico |
+| `continuous-learning-v2-spec.md` | Especificacao de skill de aprendizado continuo v2 |
+| `cross-harness.md` | Como uma unica fonte de skill e exposta em Gemini Code, Codex, Cursor, OpenCode |

--- a/translations/pt/docs/architecture/SELECTIVE-INSTALL-ARCHITECTURE.md
+++ b/translations/pt/docs/architecture/SELECTIVE-INSTALL-ARCHITECTURE.md
@@ -1,0 +1,806 @@
+# Descoberta de Instalacao Seletiva do egc 2.0
+
+## Proposito
+
+Este documento transforma o requisito de instalacao seletiva do mega-plano de 11 de marco em um design concreto de descoberta do egc 2.0.
+
+O objetivo nao e apenas "menos arquivos copiados durante a instalacao." O alvo real e um sistema de instalacao que pode responder, deterministicamente:
+
+- o que foi solicitado
+- o que foi resolvido
+- o que foi copiado ou gerado
+- quais transforms especificas de target foram aplicadas
+- o que o egc possui e pode remover ou reparar com seguranca depois
+
+Esse e o contrato ausente entre a instalacao do egc 1.x e um plano de controle do egc 2.0.
+
+## Fundacao Implementada Atual
+
+O primeiro substrato de instalacao seletiva ja existe no repositorio:
+
+- `manifests/install-modules.json`
+- `manifests/install-profiles.json`
+- `schemas/install-modules.schema.json`
+- `schemas/install-profiles.schema.json`
+- `schemas/install-state.schema.json`
+- `scripts/ci/validate-install-manifests.js`
+- `scripts/lib/install-manifests.js`
+- `scripts/lib/install/request.js`
+- `scripts/lib/install/runtime.js`
+- `scripts/lib/install/apply.js`
+- `scripts/lib/install-targets/`
+- `scripts/lib/install-state.js`
+- `scripts/lib/install-executor.js`
+- `scripts/lib/install-lifecycle.js`
+- `scripts/egc.js`
+- `scripts/install-apply.js`
+- `scripts/install-plan.js`
+- `scripts/list-installed.js`
+- `scripts/doctor.js`
+
+Capacidades atuais:
+
+- catalogos de modulo e perfil legivel por maquina
+- validacao CI que entradas de manifesto apontam para caminhos reais do repositorio
+- expansao de dependencia e filtragem de target
+- planejamento de operacao com reconhecimento de adaptador
+- normalizacao canonical de requisicao para modos de instalacao legados e de manifesto
+- despacho de runtime explicito de requisicoes normalizadas em criacao de plano
+- instalacoes legadas e de manifesto escrevem install-state duravel
+- inspecao somente leitura de planos de instalacao antes de qualquer mutacao
+- roteamento CLI unificado `egc` para instalacao, planejamento e comandos de ciclo de vida
+- inspecao e mutacao de ciclo de vida via `list-installed`, `doctor`, `repair` e `uninstall`
+
+Limitacao atual:
+
+- semantica de mesclagem/remocao especifica de target ainda esta em nivel de scaffold para alguns modulos
+- compatibilidade legada com `egc-install` ainda aponta para `install.sh`
+- superficie de publicacao ainda e ampla em `package.json`
+
+## Revisao do Codigo Atual
+
+O stack de instalador atual ja e muito mais saudavel do que o instalador shell legado orientado a linguagem original, mas ainda concentra muita responsabilidade em poucos arquivos.
+
+### Caminho de Runtime Atual
+
+O fluxo de runtime hoje e:
+
+1. `install.sh`
+   thin shell wrapper que resolve a raiz real do pacote
+2. `scripts/install-apply.js`
+   CLI de instalador voltado ao usuario para modos legado e de manifesto
+3. `scripts/lib/install/request.js`
+   analise de CLI mais normalizacao canonical de requisicao
+4. `scripts/lib/install/runtime.js`
+   despacho de runtime de requisicoes normalizadas em planos de instalacao
+5. `scripts/lib/install-executor.js`
+   traducao de argumentos, compatibilidade legada, materializacao de operacao, mutacao de sistema de arquivos e escrita de install-state
+6. `scripts/lib/install-manifests.js`
+   carregamento de catalogo de modulo/perfil mais expansao de dependencia
+7. `scripts/lib/install-targets/`
+   scaffold de raiz de target e caminho de destino
+8. `scripts/lib/install-state.js`
+   leitura/escrita de install-state com schema
+9. `scripts/lib/install-lifecycle.js`
+   comportamento de doctor/repair/uninstall derivado de operacoes armazenadas
+
+Isso e suficiente para provar o substrato de instalacao seletiva, mas nao suficiente para fazer a arquitetura do instalador parecer estabelecida.
+
+### Pontos Fortes Atuais
+
+- intencao de instalacao agora e explicita por meio de `--profile` e `--modules`
+- analise de requisicao e normalizacao de requisicao agora estao separadas do shell CLI
+- resolucao de raiz de target ja esta adaptadorizada
+- comandos de ciclo de vida agora usam install-state duravel em vez de adivinhar
+- o repositorio ja tem um entrypoint Node unificado por meio de `egc` e `install-apply.js`
+
+### Acoplamento Atual Ainda Presente
+
+1. `install-executor.js` e menor do que antes, mas ainda carrega muitas camadas de planejamento e materializacao ao mesmo tempo.
+   O limite de requisicao agora esta extraido, mas traducao de requisicao legada, expansao de plano de manifesto e materializacao de operacao ainda coexistem.
+2. Adaptadores de target ainda sao muito finos.
+   Hoje eles principalmente resolvem raizes e constroem caminhos de destino. A semantica real de instalacao ainda vive em branches de executor e heuristicas de caminho.
+3. O limite planner/executor ainda nao esta suficientemente limpo.
+   `install-manifests.js` resolve modulos, mas o conjunto final de operacoes de instalacao ainda esta parcialmente construido em logica especifica do executor.
+4. Comportamento de ciclo de vida depende de operacoes registradas de baixo nivel mais do que de semanticas de modulo estaveis.
+   Isso funciona para copia de arquivo simples, mas torna-se fragil para comportamentos de mesclagem/geracao/remocao.
+5. O modo de compatibilidade esta misturado diretamente no runtime principal do instalador.
+   Instalacoes de linguagem legadas devem se comportar como um adaptador de requisicao, nao como uma arquitetura de instalador paralela.
+
+## Mudancas Arquiteturais Modulares Propostas
+
+O proximo passo arquitetural e separar o instalador em camadas explicitas, com cada camada retornando dados estaveis em vez de imediatamente mutando arquivos.
+
+### Estado Alvo
+
+O pipeline de instalacao desejado e:
+
+1. Superficie CLI
+2. normalizacao de requisicao
+3. resolucao de modulo
+4. planejamento de target
+5. planejamento de operacao
+6. execucao
+7. persistencia de install-state
+8. servicos de ciclo de vida construidos no mesmo contrato de operacao
+
+A ideia principal e simples:
+
+- manifestos descrevem conteudo
+- adaptadores descrevem semantica de aterrissagem especifica de target
+- planners descrevem o que deve acontecer
+- executores aplicam esses planos
+- comandos de ciclo de vida reutilizam o mesmo modelo de plano/estado em vez de reinventa-lo
+
+### Camadas de Runtime Propostas
+
+#### 1. Superficie CLI
+
+Responsabilidade:
+
+- analisar somente intencao do usuario
+- rotear para install, plan, doctor, repair, uninstall
+- renderizar saida humana ou JSON
+
+Nao deve possuir:
+
+- traducao de linguagem legada
+- regras de instalacao especificas de target
+- construcao de operacao
+
+Arquivos sugeridos:
+
+```text
+scripts/egc.js
+scripts/install-apply.js
+scripts/install-plan.js
+scripts/doctor.js
+scripts/repair.js
+scripts/uninstall.js
+```
+
+Esses permanecem como entrypoints, mas tornam-se thin wrappers em torno de modulos de biblioteca.
+
+#### 2. Normalizador de Requisicao
+
+Responsabilidade:
+
+- traduzir flags CLI brutas em uma requisicao de instalacao canonical
+- converter instalacoes de linguagem legadas em uma forma de requisicao de compatibilidade
+- rejeitar entradas mistas ou ambiguas cedo
+
+Requisicao canonical sugerida:
+
+```json
+{
+  "mode": "manifest",
+  "target": "cursor",
+  "profile": "developer",
+  "modules": [],
+  "legacyLanguages": [],
+  "dryRun": false
+}
+```
+
+ou, em modo de compatibilidade:
+
+```json
+{
+  "mode": "legacy-compat",
+  "target": "gemini",
+  "profile": null,
+  "modules": [],
+  "legacyLanguages": ["typescript", "python"],
+  "dryRun": false
+}
+```
+
+Isso deixa o resto do pipeline ignorar se a requisicao veio de sintaxe CLI antiga ou nova.
+
+#### 3. Resolvedor de Modulos
+
+Responsabilidade:
+
+- carregar catalogos de manifesto
+- expandir dependencias
+- rejeitar conflitos
+- filtrar modulos nao suportados por target
+- retornar um objeto de resolucao canonical
+
+Esta camada deve permanecer pura e somente leitura.
+
+Nao deve saber:
+
+- caminhos de destino no sistema de arquivos
+- semantica de mesclagem
+- estrategias de copia
+
+Arquivo mais proximo atual:
+
+- `scripts/lib/install-manifests.js`
+
+Divisao sugerida:
+
+```text
+scripts/lib/install/catalog.js
+scripts/lib/install/resolve-request.js
+scripts/lib/install/resolve-modules.js
+```
+
+#### 4. Planner de Target
+
+Responsabilidade:
+
+- selecionar o adaptador de target de instalacao
+- resolver a raiz do target
+- resolver o caminho do install-state
+- expandir regras de mapeamento de modulo para target
+- emitir intencoes de operacao com reconhecimento de target
+
+E aqui que o significado especifico de target deve viver.
+
+Exemplos:
+
+- gemini pode preservar a hierarquia nativa em `~/.gemini`
+- Cursor pode sincronizar filhos da raiz `.cursor` empacotados de forma diferente das regras
+- configuracoes geradas podem exigir semantica de mesclagem ou substituicao dependendo do target
+
+Arquivos mais proximos atuais:
+
+- `scripts/lib/install-targets/helpers.js`
+- `scripts/lib/install-targets/registry.js`
+
+Evolucao sugerida:
+
+```text
+scripts/lib/install/targets/registry.js
+scripts/lib/install/targets/gemini-home.js
+scripts/lib/install/targets/cursor-project.js
+scripts/lib/install/targets/antigravity-project.js
+```
+
+Cada adaptador deve eventualmente expor mais do que `resolveRoot`. Deve possuir mapeamento de caminho e estrategia para sua familia de target.
+
+#### 5. Planner de Operacao
+
+Responsabilidade:
+
+- transformar resolucao de modulo mais regras de adaptador em um grafo de operacao tipado
+- emitir operacoes de primeira classe como:
+  - `copy-file`
+  - `copy-tree`
+  - `merge-json`
+  - `render-template`
+  - `remove`
+- anexar metadados de propriedade e validacao
+
+Esta e a costura arquitetural ausente no instalador atual.
+
+Hoje, operacoes sao parcialmente em nivel de scaffold e parcialmente especificas do executor. O egc 2.0 deve tornar o planejamento de operacao uma fase independente para que:
+
+- `plan` se torne uma visualizacao verdadeira da execucao
+- `doctor` possa validar comportamento pretendido, nao apenas arquivos atuais
+- `repair` possa reconstruir o trabalho ausente exato com seguranca
+- `uninstall` possa reverter apenas operacoes gerenciadas
+
+#### 6. Motor de Execucao
+
+Responsabilidade:
+
+- aplicar um grafo de operacao tipado
+- aplicar regras de sobrescrita e propriedade
+- preparar escritas com seguranca
+- coletar resultados finais de operacoes aplicadas
+
+Esta camada nao deve decidir *o que* fazer. Deve decidir apenas *como* aplicar um tipo de operacao fornecido com seguranca.
+
+Arquivo mais proximo atual:
+
+- `scripts/lib/install-executor.js`
+
+Refatoracao recomendada:
+
+```text
+scripts/lib/install/executor/apply-plan.js
+scripts/lib/install/executor/apply-copy.js
+scripts/lib/install/executor/apply-merge-json.js
+scripts/lib/install/executor/apply-remove.js
+```
+
+Isso transforma a logica do executor de um grande runtime ramificado em um conjunto de pequenos handlers de operacao.
+
+#### 7. Armazenamento de Install-State
+
+Responsabilidade:
+
+- validar e persistir install-state
+- registrar requisicao canonical, resolucao e operacoes aplicadas
+- suportar comandos de ciclo de vida sem forca-los a fazer engenharia reversa das instalacoes
+
+Arquivo mais proximo atual:
+
+- `scripts/lib/install-state.js`
+
+Esta camada ja esta perto da forma certa. A principal mudanca restante e armazenar metadados de operacao mais ricos assim que semantica de mesclagem/geracao for real.
+
+#### 8. Servicos de Ciclo de Vida
+
+Responsabilidade:
+
+- `list-installed`: inspecionar somente estado
+- `doctor`: comparar visao desejada/install-state com o sistema de arquivos atual
+- `repair`: regenerar um plano a partir do estado e reaplicar operacoes seguras
+- `uninstall`: remover apenas saidas de propriedade do egc
+
+Arquivo mais proximo atual:
+
+- `scripts/lib/install-lifecycle.js`
+
+Esta camada deve eventualmente operar em tipos de operacao e politicas de propriedade, nao apenas em registros brutos `copy-file`.
+
+## Layout de Arquivo Proposto
+
+O estado final modular limpo deve parecer aproximadamente com isso:
+
+```text
+scripts/lib/install/
+  catalog.js
+  request.js
+  resolve-modules.js
+  plan-operations.js
+  state-store.js
+  targets/
+    registry.js
+    gemini-home.js
+    cursor-project.js
+    antigravity-project.js
+    codex-home.js
+    opencode-home.js
+  executor/
+    apply-plan.js
+    apply-copy.js
+    apply-merge-json.js
+    apply-render-template.js
+    apply-remove.js
+  lifecycle/
+    discover.js
+    doctor.js
+    repair.js
+    uninstall.js
+```
+
+Isso nao e uma divisao de empacotamento. E uma divisao de propriedade de codigo dentro do repositorio atual para que cada camada tenha um trabalho.
+
+## Mapa de Migracao dos Arquivos Atuais
+
+O caminho de migracao de menor risco e evolutivo, nao uma reescrita.
+
+### Manter
+
+- `install.sh` como o shim de compatibilidade publico
+- `scripts/egc.js` como a CLI unificada
+- `scripts/lib/install-state.js` como ponto de partida para o store de estado
+- IDs de adaptadores de target atuais e localizacoes de estado
+
+### Extrair
+
+- analise de requisicao e traducao de compatibilidade fora de `scripts/lib/install-executor.js`
+- planejamento de operacao com reconhecimento de target fora de branches de executor e para adaptadores de target mais modulos de planner
+- analise especifica de ciclo de vida fora do monolito de ciclo de vida compartilhado em servicos menores
+
+### Substituir Gradualmente
+
+- heuristicas amplas de copia de caminho com operacoes tipadas
+- planejamento de adaptador somente scaffold com semanticas de propriedade do adaptador
+- branches de instalacao de linguagem legada com traducao de requisicao legada no mesmo pipeline de planner/executor
+
+## Mudancas Arquiteturais Imediatas a Fazer
+
+Se o objetivo e egc 2.0 e nao apenas "funcionando suficientemente," os proximos passos de modularizacao devem ser:
+
+1. dividir `install-executor.js` em modulos de normalizacao de requisicao, planejamento de operacao e execucao
+2. mover decisoes de estrategia especificas de target para metodos de planejamento de propriedade do adaptador
+3. fazer `repair` e `uninstall` operarem em handlers de operacao tipados em vez de apenas registros `copy-file` simples
+4. ensinar os manifestos sobre estrategia de instalacao e propriedade para que o planner nao dependa mais de heuristicas de caminho
+5. reduzir a superficie de publicacao npm somente apos os limites do modulo interno estarem estaveis
+
+## Por que o Modelo Atual Nao e Suficiente
+
+Hoje o egc ainda se comporta como um copiador amplo de payload:
+
+- `install.sh` e orientado a linguagem e com branches de target pesados
+- targets sao parcialmente implicitos no layout de diretorio
+- desinstalacao, reparo e doctor agora existem mas ainda sao comandos de ciclo de vida iniciais
+- o repositorio nao pode provar o que uma instalacao anterior realmente escreveu
+- a superficie de publicacao ainda e ampla em `package.json`
+
+Isso cria os problemas ja mencionados no mega plano:
+
+- usuarios puxam mais conteudo do que seu harness ou workflow precisa
+- suporte e atualizacoes sao mais dificeis porque instalacoes nao sao registradas
+- comportamento de target diverge porque logica de instalacao e duplicada em branches shell
+- targets futuros como Codex ou OpenCode exigem mais logica de caso especial em vez de reutilizar um contrato de instalacao estavel
+
+## Tese de Design do egc 2.0
+
+A instalacao seletiva deve ser modelada como:
+
+1. resolver a intencao solicitada em um grafo de modulo canonical
+2. traduzir esse grafo por meio de um adaptador de target
+3. executar um conjunto de operacoes de instalacao determinista
+4. escrever install-state como a fonte de verdade duravel
+
+Isso significa que o egc 2.0 precisa de dois contratos, nao um:
+
+- um contrato de conteudo: quais modulos existem e como dependem uns dos outros
+- um contrato de target: como esses modulos ficam dentro de gemini, Cursor, Antigravity, Codex ou OpenCode
+
+O repositorio atual tinha apenas a primeira metade em forma inicial. O repositorio atual agora tem o primeiro slice vertical completo, mas nao a semantica especifica de target completa.
+
+## Restricoes de Design
+
+1. Manter `EGC` como o repositorio de fonte canonical.
+2. Preservar fluxos de `install.sh` existentes durante a migracao.
+3. Suportar targets com escopo de home e de projeto do mesmo planner.
+4. Tornar desinstalacao/reparo/doctor possiveis sem adivinhar.
+5. Evitar que logica de copia especifica de target volte para definicoes de modulo.
+6. Manter suporte futuro a Codex e OpenCode aditivo, nao uma reescrita.
+
+## Artefatos Canonicos
+
+### 1. Catalogo de Modulos
+
+O catalogo de modulos e o grafo de conteudo canonical.
+
+Campos atuais ja implementados:
+
+- `id`
+- `kind`
+- `description`
+- `paths`
+- `targets`
+- `dependencies`
+- `defaultInstall`
+- `cost`
+- `stability`
+
+Campos ainda necessarios para o egc 2.0:
+
+- `installStrategy`: por exemplo `copy`, `flatten-rules`, `generate`, `merge-config`
+- `ownership`: se o egc possui totalmente o caminho de destino ou apenas arquivos gerados abaixo dele
+- `pathMode`: por exemplo `preserve`, `flatten`, `target-template`
+- `conflicts`: modulos ou familias de caminho que nao podem coexistir em um target
+- `publish`: se o modulo e empacotado por padrao, opcional ou gerado pos-instalacao
+
+Forma futura sugerida:
+
+```json
+{
+  "id": "hooks-runtime",
+  "kind": "hooks",
+  "paths": ["hooks", "scripts/hooks"],
+  "targets": ["gemini", "cursor", "opencode"],
+  "dependencies": [],
+  "installStrategy": "copy",
+  "pathMode": "preserve",
+  "ownership": "managed",
+  "defaultInstall": true,
+  "cost": "medium",
+  "stability": "stable"
+}
+```
+
+### 2. Catalogo de Perfis
+
+Perfis permanecem finos.
+
+Devem expressar intencao do usuario, nao duplicar logica de target.
+
+Exemplos atuais ja implementados:
+
+- `core`
+- `developer`
+- `security`
+- `research`
+- `full`
+
+Campos ainda necessarios:
+
+- `defaultTargets`
+- `recommendedFor`
+- `excludes`
+- `requiresConfirmation`
+
+Isso deixa o egc 2.0 dizer coisas como:
+
+- `developer` e o padrao recomendado para gemini e Cursor
+- `research` pode ser pesado para instalacoes locais estreitas
+- `full` e permitido mas nao padrao
+
+### 3. Adaptadores de Target
+
+Esta e a camada ausente principal.
+
+O grafo de modulo nao deve saber:
+
+- onde fica o home do gemini
+- como o Cursor nivela ou remapeia conteudo
+- quais arquivos de configuracao precisam de semantica de mesclagem em vez de copia cega
+
+Isso pertence a um adaptador de target.
+
+Interface sugerida:
+
+```ts
+type InstallTargetAdapter = {
+  id: string;
+  kind: "home" | "project";
+  supports(target: string): boolean;
+  resolveRoot(input?: string): Promise<string>;
+  planOperations(input: InstallOperationInput): Promise<InstallOperation[]>;
+  validate?(input: InstallOperationInput): Promise<ValidationIssue[]>;
+};
+```
+
+Primeiros adaptadores sugeridos:
+
+1. `gemini-home`: escreve em `~/.gemini/...`
+2. `cursor-project`: escreve em `./.cursor/...`
+3. `antigravity-project`: escreve em `./.agent/...`
+4. `codex-home`: depois
+5. `opencode-home`: depois
+
+Isso corresponde ao mesmo padrao ja proposto no documento de descoberta de adaptador de sessao: contrato canonical primeiro, adaptador especifico de harness segundo.
+
+## Modelo de Planejamento de Instalacao
+
+A CLI atual `scripts/install-plan.js` prova que o repositorio pode resolver modulos solicitados em um conjunto de modulos filtrado.
+
+O egc 2.0 precisa da proxima camada: planejamento de operacao.
+
+Fases sugeridas:
+
+1. normalizacao de entrada: analisar `--target`, `--profile`, `--modules`, traduzir args de linguagem legados opcionalmente
+2. resolucao de modulo: expandir dependencias, rejeitar conflitos, filtrar por targets suportados
+3. planejamento de adaptador: resolver raiz do target, derivar operacoes exatas de copia ou geracao, identificar mesclagens de configuracao e remapeamentos de target
+4. saida dry-run: mostrar modulos selecionados, modulos ignorados, operacoes exatas de arquivo
+5. mutacao: executar o plano de operacao
+6. escrita de estado: persistir install-state somente apos conclusao bem-sucedida
+
+Forma de operacao sugerida:
+
+```json
+{
+  "kind": "copy",
+  "moduleId": "rules-core",
+  "source": "rules/common/coding-style.md",
+  "destination": "/Users/example/.gemini/rules/egc/common/coding-style.md",
+  "ownership": "managed",
+  "overwritePolicy": "replace"
+}
+```
+
+Outros tipos de operacao:
+
+- `copy`
+- `copy-tree`
+- `flatten-copy`
+- `render-template`
+- `merge-json`
+- `merge-jsonc`
+- `mkdir`
+- `remove`
+
+## Contrato de Install-State
+
+O install-state e o contrato duravel que o egc 1.x esta perdendo.
+
+Convencoes de caminho sugeridas:
+
+- target gemini: `~/.gemini/egc/install-state.json`
+- target Cursor: `./.cursor/egc-install-state.json`
+- target Antigravity: `./.agent/egc-install-state.json`
+- target futuro Codex: `~/.codex/egc-install-state.json`
+
+Payload sugerido:
+
+```json
+{
+  "schemaVersion": "egc.install.v1",
+  "installedAt": "2026-03-13T00:00:00Z",
+  "lastValidatedAt": "2026-03-13T00:00:00Z",
+  "target": {
+    "id": "gemini-home",
+    "root": "/Users/example/.gemini"
+  },
+  "request": {
+    "profile": "developer",
+    "modules": ["orchestration"],
+    "legacyLanguages": ["typescript", "python"]
+  },
+  "resolution": {
+    "selectedModules": [
+      "rules-core",
+      "agents-core",
+      "commands-core",
+      "hooks-runtime",
+      "platform-configs",
+      "workflow-quality",
+      "framework-language",
+      "database",
+      "orchestration"
+    ],
+    "skippedModules": []
+  },
+  "source": {
+    "repoVersion": "1.0.0",
+    "repoCommit": "git-sha",
+    "manifestVersion": 1
+  },
+  "operations": [
+    {
+      "kind": "copy",
+      "moduleId": "rules-core",
+      "destination": "/Users/example/.gemini/rules/egc/common/coding-style.md",
+      "digest": "sha256:..."
+    }
+  ]
+}
+```
+
+Requisitos de estado:
+
+- detalhes suficientes para a desinstalacao remover apenas saidas gerenciadas pelo egc
+- detalhes suficientes para o reparo comparar arquivos instalados desejados versus reais
+- detalhes suficientes para o doctor explicar a deriva em vez de adivinhar
+
+## Comandos de Ciclo de Vida
+
+Os seguintes comandos sao a superficie de ciclo de vida para install-state:
+
+1. `egc list-installed`
+2. `egc uninstall`
+3. `egc doctor`
+4. `egc repair`
+
+Status de implementacao atual:
+
+- `egc list-installed` roteia para `node scripts/list-installed.js`
+- `egc uninstall` roteia para `node scripts/uninstall.js`
+- `egc doctor` roteia para `node scripts/doctor.js`
+- `egc repair` roteia para `node scripts/repair.js`
+- entrypoints de script legados permanecem disponiveis durante a migracao
+
+### `list-installed`
+
+Responsabilidades:
+
+- mostrar id e raiz do target
+- mostrar perfil/modulos solicitados
+- mostrar modulos resolvidos
+- mostrar versao de fonte e hora de instalacao
+
+### `uninstall`
+
+Responsabilidades:
+
+- carregar install-state
+- remover apenas destinos gerenciados pelo egc registrados no estado
+- deixar arquivos nao relacionados escritos pelo usuario intocados
+- excluir install-state somente apos limpeza bem-sucedida
+
+### `doctor`
+
+Responsabilidades:
+
+- detectar arquivos gerenciados ausentes
+- detectar deriva de configuracao inesperada
+- detectar raizes de target que nao existem mais
+- detectar incompatibilidade de manifesto/versao
+
+### `repair`
+
+Responsabilidades:
+
+- reconstruir o plano de operacao desejado a partir do install-state
+- recopiar arquivos gerenciados ausentes ou derivados
+- recusar reparo se os modulos solicitados nao existirem mais no manifesto atual, a menos que exista um mapa de compatibilidade
+
+## Camada de Compatibilidade Legada
+
+O `install.sh` atual aceita:
+
+- `--target <gemini|cursor|antigravity>`
+- uma lista de nomes de linguagens
+
+Esse comportamento nao pode desaparecer em um corte porque os usuarios ja dependem dele.
+
+O egc 2.0 deve traduzir argumentos de linguagem legados em uma requisicao de compatibilidade.
+
+Abordagem sugerida:
+
+1. manter a forma CLI existente para modo legado
+2. mapear nomes de linguagens para requisicoes de modulo como `rules-core`, subconjuntos de regras compativeis com target
+3. escrever install-state mesmo para instalacoes legadas
+4. rotular a requisicao como `legacyMode: true`
+
+Exemplo:
+
+```json
+{
+  "request": {
+    "legacyMode": true,
+    "legacyLanguages": ["typescript", "python"]
+  }
+}
+```
+
+Isso mantem o comportamento antigo disponivel enquanto move todas as instalacoes para o mesmo contrato de estado.
+
+## Limite de Publicacao
+
+O pacote npm atual ainda publica um payload amplo por meio de `package.json`.
+
+O egc 2.0 deve melhorar isso cuidadosamente.
+
+Sequencia recomendada:
+
+1. manter um unico pacote npm canonical primeiro
+2. usar manifestos para direcionar a selecao em tempo de instalacao antes de alterar a forma de publicacao
+3. apenas depois considerar reduzir a superficie empacotada onde seguro
+
+Por que:
+
+- instalacao seletiva pode ser lancada antes de cirurgia agressiva de pacote
+- desinstalacao e reparo dependem de install-state mais do que de mudancas de publicacao
+- suporte a Codex/OpenCode e mais facil se a fonte do pacote permanecer unificada
+
+Direcoes possiveis mais tarde:
+
+- bundles slim gerados por perfil
+- tarballs especificos de target gerados
+- busca remota opcional de modulos pesados
+
+Essas sao Fase 3 ou posterior, nao pre-requisitos para instalacoes com reconhecimento de perfil.
+
+## Sequencia de Implementacao
+
+### Fase 1: Planner para Contrato
+
+1. manter schema e resolvedor de manifesto atuais
+2. adicionar planejamento de operacao em cima de modulos resolvidos
+3. definir schema de estado `egc.install.v1`
+4. escrever install-state em instalacao bem-sucedida
+
+### Fase 2: Adaptadores de Target
+
+1. extrair comportamento de instalacao gemini em adaptador `gemini-home`
+2. extrair comportamento de instalacao Cursor em adaptador `cursor-project`
+3. extrair comportamento de instalacao Antigravity em adaptador `antigravity-project`
+4. reduzir `install.sh` para analise de argumentos mais invocacao de adaptador
+
+### Fase 3: Ciclo de Vida
+
+1. adicionar semantica mais forte de mesclagem/remocao especifica de target
+2. estender cobertura de reparo/desinstalacao para operacoes nao de copia
+3. reduzir superficie de publicacao de pacote para o grafo de modulos em vez de pastas amplas
+4. decidir quando `egc-install` deve se tornar um alias fino para `egc install`
+
+### Fase 4: Publicacao e Targets Futuros
+
+1. avaliar reducao segura da superficie de publicacao de `package.json`
+2. adicionar `codex-home`
+3. adicionar `opencode-home`
+4. considerar bundles de perfil gerados se a pressao de empacotamento permanecer alta
+
+## Recomendacao
+
+Trate o resolvedor de manifesto atual como adaptador `0` para instalacoes:
+
+1. preservar a superficie de instalacao atual
+2. mover comportamento de copia real para tras de adaptadores de target
+3. escrever install-state para toda instalacao bem-sucedida
+4. fazer desinstalacao, doctor e repair dependerem apenas de install-state
+5. somente entao reduzir empacotamento ou adicionar mais targets
+
+Esse e o caminho mais curto do sprawl do instalador do egc 1.x para um contrato de instalacao/controle do egc 2.0 que e determinista, sustentavel e extensivel.

--- a/translations/pt/docs/architecture/SELECTIVE-INSTALL-DESIGN.md
+++ b/translations/pt/docs/architecture/SELECTIVE-INSTALL-DESIGN.md
@@ -1,0 +1,460 @@
+# Design de Instalacao Seletiva do egc
+
+## Proposito
+
+Este documento define o design de instalacao seletiva voltado ao usuario para o egc.
+
+Ele complementa `docs/SELECTIVE-INSTALL-ARCHITECTURE.md`, que foca na arquitetura interna de runtime e limites de codigo.
+
+Este documento responde primeiro as perguntas de produto e operador:
+
+- como os usuarios escolhem componentes do egc
+- como a CLI deve se sentir
+- qual arquivo de configuracao deve existir
+- como a instalacao deve se comportar entre targets de harness
+- como o design mapeia no codebase atual do egc sem exigir uma reescrita
+
+## Problema
+
+Hoje o egc ainda parece um instalador de payload grande, mesmo que o repositorio agora tenha suporte de manifesto e ciclo de vida de primeira passagem.
+
+Os usuarios precisam de um modelo mental mais simples:
+
+- instalar a baseline
+- adicionar os pacotes de linguagem que realmente usam
+- adicionar as configuracoes de framework que realmente querem
+- adicionar pacotes de capacidade opcionais como seguranca, pesquisa ou orquestracao
+
+O sistema de instalacao seletiva deve fazer o egc parecer composavel em vez de tudo ou nada.
+
+No substrato atual, os componentes voltados ao usuario ainda sao uma camada de alias sobre modulos de instalacao internos mais grosseiros. Isso significa que incluir/excluir ja e util no nivel de selecao de modulo, mas alguns limites em nivel de arquivo permanecem imperfeitos ate que o grafo de modulos subjacente seja dividido de forma mais refinada.
+
+## Objetivos
+
+1. Deixar usuarios instalar um footprint pequeno e padrao do egc rapidamente.
+2. Deixar usuarios compor instalacoes de familias de componentes reutilizaveis:
+   - regras core
+   - pacotes de linguagem
+   - pacotes de framework
+   - pacotes de capacidade
+   - configuracoes de target/plataforma
+3. Manter um UX consistente entre gemini, Cursor, Antigravity, Codex e OpenCode.
+4. Manter instalacoes inspetaveis, repara­veis e desinstalaveis.
+5. Preservar compatibilidade retroativa com o estilo atual `egc-install typescript` durante o rollout.
+
+## Nao-Objetivos
+
+- empacotar o egc em multiplos pacotes npm na primeira fase
+- construir um marketplace remoto
+- construir uma UI de plano de controle completo na mesma fase
+- resolver todos os problemas de classificacao de skills antes de lancar a instalacao seletiva
+
+## Principios de Experiencia do Usuario
+
+### 1. Comece Pequeno
+
+Um usuario deve poder obter uma instalacao util do egc com um comando:
+
+```bash
+egc install --target gemini --profile core
+```
+
+A experiencia padrao nao deve assumir que o usuario quer todas as familias de skills e todos os frameworks.
+
+### 2. Construa por Intencao
+
+O usuario deve pensar em termos de:
+
+- "Quero a baseline de desenvolvedor"
+- "Preciso de TypeScript e Python"
+- "Quero Next.js e Django"
+- "Quero o pacote de seguranca"
+
+O usuario nao deve precisar conhecer os caminhos internos brutos do repositorio.
+
+### 3. Visualize Antes de Mutar
+
+Todo caminho de instalacao deve suportar planejamento em dry-run:
+
+```bash
+egc install --target cursor --profile developer --with lang:typescript --with framework:nextjs --dry-run
+```
+
+O plano deve mostrar claramente:
+
+- componentes selecionados
+- componentes ignorados
+- raiz do target
+- caminhos gerenciados
+- localizacao esperada do install-state
+
+### 4. Configuracao Local Deve Ser de Primeira Classe
+
+Equipes devem poder commitar uma configuracao de instalacao em nivel de projeto e usar:
+
+```bash
+egc install --config egc-install.json
+```
+
+Isso permite instalacoes deterministas entre colaboradores e CI.
+
+## Modelo de Componentes
+
+O manifesto atual ja usa modulos e perfis de instalacao. O design voltado ao usuario deve manter essa estrutura interna, mas apresenta-la como quatro familias principais de componentes.
+
+Nota de implementacao de curto prazo: alguns IDs de componentes voltados ao usuario ainda resolvem para modulos internos compartilhados, especialmente na camada de linguagem/framework. O catalogo melhora o UX imediatamente enquanto preserva um caminho limpo em direcao a granularidade de modulo mais refinada em fases posteriores.
+
+### 1. Baseline
+
+Estes sao os blocos de construcao padrao do egc:
+
+- regras core
+- agentes baseline
+- comandos core
+- hooks de runtime
+- configuracoes de plataforma
+- primitivos de qualidade de workflow
+
+Exemplos de modulos internos atuais:
+
+- `rules-core`
+- `agents-core`
+- `commands-core`
+- `hooks-runtime`
+- `platform-configs`
+- `workflow-quality`
+
+### 2. Pacotes de Linguagem
+
+Pacotes de linguagem agrupam regras, orientacao e workflows para um ecossistema de linguagem.
+
+Exemplos:
+
+- `lang:typescript`
+- `lang:python`
+- `lang:go`
+- `lang:java`
+- `lang:rust`
+
+Cada pacote de linguagem deve resolver para um ou mais modulos internos mais ativos especificos do target.
+
+### 3. Pacotes de Framework
+
+Pacotes de framework ficam acima dos pacotes de linguagem e puxam regras, skills e configuracao opcional especificos do framework.
+
+Exemplos:
+
+- `framework:react`
+- `framework:nextjs`
+- `framework:django`
+- `framework:springboot`
+- `framework:laravel`
+
+Pacotes de framework devem depender do pacote de linguagem correto ou de primitivos baseline onde apropriado.
+
+### 4. Pacotes de Capacidade
+
+Pacotes de capacidade sao bundles de features do egc que cortam transversalmente.
+
+Exemplos:
+
+- `capability:security`
+- `capability:research`
+- `capability:orchestration`
+- `capability:media`
+- `capability:content`
+
+Estes devem mapear para as familias de modulo atuais ja sendo introduzidas nos manifestos.
+
+## Perfis
+
+Perfis permanecem a entrada mais rapida.
+
+Perfis voltados ao usuario recomendados:
+
+- `core`
+  baseline minima, padrao seguro para a maioria dos usuarios experimentando o egc
+- `developer`
+  melhor padrao para trabalho ativo de engenharia de software
+- `security`
+  baseline mais orientacao pesada de seguranca
+- `research`
+  baseline mais ferramentas de pesquisa/conteudo/investigacao
+- `full`
+  tudo classificado e atualmente suportado
+
+Perfis devem ser composaveis com flags adicionais `--with` e `--without`.
+
+Exemplo:
+
+```bash
+egc install --target gemini --profile developer --with lang:typescript --with framework:nextjs --without capability:orchestration
+```
+
+## Design CLI Proposto
+
+### Comandos Primarios
+
+```bash
+egc install
+egc plan
+egc list-installed
+egc doctor
+egc repair
+egc uninstall
+egc catalog
+```
+
+### CLI de Instalacao
+
+Forma recomendada:
+
+```bash
+egc install [--target <target>] [--profile <nome>] [--with <componente>]... [--without <componente>]... [--config <caminho>] [--dry-run] [--json]
+```
+
+Exemplos:
+
+```bash
+egc install --target gemini --profile core
+egc install --target cursor --profile developer --with lang:typescript --with framework:nextjs
+egc install --target antigravity --with capability:security --with lang:python
+egc install --config egc-install.json
+```
+
+### CLI de Plano
+
+Forma recomendada:
+
+```bash
+egc plan [mesmas flags de selecao que install]
+```
+
+Proposito:
+
+- produzir uma visualizacao sem mutacao
+- atuar como a superficie canonical de depuracao para instalacao seletiva
+
+### CLI de Catalogo
+
+Forma recomendada:
+
+```bash
+egc catalog profiles
+egc catalog components
+egc catalog components --family language
+egc catalog show framework:nextjs
+```
+
+Proposito:
+
+- deixar usuarios descobrir nomes de componentes validos sem ler docs
+- tornar a criacao de configuracao acessivel
+
+### CLI de Compatibilidade
+
+Esses fluxos legados ainda devem funcionar durante a migracao:
+
+```bash
+egc-install typescript
+egc-install --target cursor typescript
+egc typescript
+```
+
+Internamente, esses devem normalizar para o novo modelo de requisicao e escrever o install-state da mesma forma que instalacoes modernas.
+
+## Arquivo de Configuracao Proposto
+
+### Nome do Arquivo
+
+Padrao recomendado:
+
+- `egc-install.json`
+
+Suporte futuro opcional:
+
+- `.egc/install.json`
+
+### Forma da Configuracao
+
+```json
+{
+  "$schema": "./schemas/egc-install-config.schema.json",
+  "version": 1,
+  "target": "cursor",
+  "profile": "developer",
+  "include": [
+    "lang:typescript",
+    "lang:python",
+    "framework:nextjs",
+    "capability:security"
+  ],
+  "exclude": [
+    "capability:media"
+  ],
+  "options": {
+    "hooksProfile": "standard",
+    "mcpCatalog": "baseline",
+    "includeExamples": false
+  }
+}
+```
+
+### Semantica dos Campos
+
+- `target`
+  target de harness selecionado como `gemini`, `cursor` ou `antigravity`
+- `profile`
+  perfil baseline para comecar
+- `include`
+  componentes adicionais para adicionar
+- `exclude`
+  componentes para subtrair do resultado do perfil
+- `options`
+  flags de ajuste de target/runtime que nao alteram a identidade do componente
+
+### Regras de Precedencia
+
+1. Argumentos CLI substituem valores do arquivo de configuracao.
+2. Arquivo de configuracao substitui padroes do perfil.
+3. Padroes do perfil substituem padroes de modulo interno.
+
+Isso manteve o comportamento previsivel e facil de explicar.
+
+## Fluxo de Instalacao Modular
+
+O fluxo voltado ao usuario deve ser:
+
+1. carregar arquivo de configuracao se fornecido ou auto-detectado
+2. mesclar intencao CLI sobre intencao de configuracao
+3. normalizar a requisicao em uma selecao canonical
+4. expandir perfil em componentes baseline
+5. adicionar componentes `include`
+6. subtrair componentes `exclude`
+7. resolver dependencias e compatibilidade de target
+8. renderizar um plano
+9. aplicar operacoes se nao estiver em modo dry-run
+10. escrever install-state
+
+A propriedade de UX importante e que o mesmo fluxo alimenta:
+
+- `install`
+- `plan`
+- `repair`
+- `uninstall`
+
+Os comandos diferem em acao, nao em como o egc entende a instalacao selecionada.
+
+## Comportamento de Target
+
+A instalacao seletiva deve preservar o mesmo grafo conceitual de componentes entre todos os targets, enquanto deixa adaptadores de target decidir como o conteudo fica.
+
+### gemini
+
+Mais adequado para:
+
+- baseline egc com escopo de home
+- comandos, agentes, regras, hooks, config de plataforma, orquestracao
+
+### Cursor
+
+Mais adequado para:
+
+- instalacoes com escopo de projeto
+- regras mais automacao e configuracao local ao projeto
+
+### Antigravity
+
+Mais adequado para:
+
+- instalacoes de agente/regra/workflow com escopo de projeto
+
+### Codex / OpenCode
+
+Devem permanecer como targets aditivos em vez de forks especiais do instalador.
+
+O design de instalacao seletiva deve tornar esses apenas novos adaptadores mais novas regras de mapeamento especificas de target, nao novas arquiteturas de instalador.
+
+## Viabilidade Tecnica
+
+Este design e viavel porque o repositorio ja tem:
+
+- manifestos de modulo e perfil de instalacao
+- adaptadores de target com caminhos de install-state
+- inspecao de plano
+- registro de install-state
+- comandos de ciclo de vida
+- uma superficie CLI `egc` unificada
+
+O trabalho ausente nao e invencao conceitual. O trabalho ausente e produtizar o substrato atual em um modelo de componente voltado ao usuario mais limpo.
+
+### Viavel na Fase 1
+
+- selecao de perfil + include/exclude
+- analise de arquivo de configuracao `egc-install.json`
+- comando de catalogo/descoberta
+- mapeamento de alias de IDs de componentes voltados ao usuario para conjuntos de modulos internos
+- planejamento dry-run e JSON
+
+### Viavel na Fase 2
+
+- semantica de adaptador de target mais rica
+- operacoes com reconhecimento de mesclagem para ativos semelhantes a configuracao
+- comportamento mais forte de reparo/desinstalacao para operacoes nao de copia
+
+### Depois
+
+- superficie de publicacao reduzida
+- bundles slim gerados
+- busca remota de componentes
+
+## Mapeamento para Manifestos Atuais do egc
+
+Os manifestos atuais ainda nao expem uma taxonomia verdadeira voltada ao usuario `lang:*` / `framework:*` / `capability:*`. Isso deve ser introduzido como uma camada de apresentacao sobre os modulos existentes, nao como um segundo motor de instalador.
+
+Abordagem recomendada:
+
+- manter `install-modules.json` como o catalogo de resolucao interno
+- adicionar um catalogo de componentes voltado ao usuario que mapeia IDs de componentes amigaveis para um ou mais modulos internos
+- deixar perfis referenciar IDs de modulos internos ou IDs de componentes voltados ao usuario durante a janela de migracao
+
+Isso evita quebrar o substrato atual de instalacao seletiva enquanto melhora o UX.
+
+## Rollout Sugerido
+
+### Fase 1: Design e Descoberta
+
+- finalizar a taxonomia de componentes voltada ao usuario
+- adicionar o schema de configuracao
+- adicionar design de CLI e regras de precedencia
+
+### Fase 2: Camada de Resolucao Voltada ao Usuario
+
+- implementar aliases de componentes
+- implementar analise de arquivo de configuracao
+- implementar `include` / `exclude`
+- implementar `catalog`
+
+### Fase 3: Semantica de Target Mais Forte
+
+- mover mais logica para planejamento de propriedade do adaptador de target
+- suportar operacoes de mesclagem/geracao de forma limpa
+- melhorar fidelidade de reparo/desinstalacao
+
+### Fase 4: Otimizacao de Empacotamento
+
+- reduzir superficie publicada
+- avaliar bundles gerados
+
+## Recomendacao
+
+O proximo movimento de implementacao nao deve ser "reescrever o instalador."
+
+Deve ser:
+
+1. manter o substrato atual de manifesto/runtime
+2. adicionar um catalogo de componentes voltado ao usuario e arquivo de configuracao
+3. adicionar selecao `include` / `exclude` e descoberta de catalogo
+4. deixar o stack existente de planner e ciclo de vida consumir esse modelo
+
+Esse e o caminho mais curto do codebase atual do egc para uma experiencia real de instalacao seletiva que parece egc 2.0 em vez de um instalador legado grande.

--- a/translations/pt/docs/architecture/SINGLE-AGENT-OPERATIONAL-MODEL.md
+++ b/translations/pt/docs/architecture/SINGLE-AGENT-OPERATIONAL-MODEL.md
@@ -1,0 +1,52 @@
+# Modelo Operacional de Agente Unico
+
+Este documento estabelece a governanca operacional oficial e permanente para o projeto EGC - Extended Global Context. Ele aplica estritamente um paradigma de execucao de agente unico, proibindo explicitamente orquestracao automatica, delegacao recursiva e qualquer modificacao do estado global do sistema host.
+
+## Diretivas Principais
+
+### 1. Imutabilidade Absoluta do Estado Global
+Agentes e processos operando dentro deste repositorio **JAMAIS DEVEM** modificar:
+- `~/.gemini` (Configuracoes globais do Gemini)
+- `~/.npm-global` (Modulos NPM globais)
+- Configuracoes globais do sistema ou variaveis de ambiente.
+- O bundle interno do Google ou politicas internas da CLI.
+- Runtimes globais ou plugins globais.
+
+### 2. Localidade Estrita de Projeto
+Todos os comportamentos, scripts e execucoes devem ser:
+- **Escopo de repositorio:** Confinados inteiramente dentro dos limites do repositorio `EGC`.
+- **Local ao projeto:** Todos os caminhos de leitura, escrita e execucao de arquivos devem ser relativos a raiz do projeto.
+- **Autocontidos:** O projeto nao deve depender de dependencias externas nao padronizadas que nao estejam explicitamente declaradas no gerenciador de pacotes.
+
+### 3. Localizacao de Recursos
+Todos os recursos operacionais devem residir exclusivamente dentro da estrutura de diretorios do projeto:
+- `./agents`
+- `./skills`
+- `./scripts`
+- `./docs`
+- `./research`
+
+### 4. Comportamentos Proibidos
+Os seguintes comportamentos em tempo de execucao sao estritamente proibidos para evitar consumo composto de cota, loops infinitos e imprevisibilidade operacional:
+- `invoke_agent` (Delegacao para sub-agentes via loop principal).
+- Loops de orquestracao automatica.
+- Planejadores recursivos.
+- Investigacao automatica ou arqueologia de runtime.
+- Forensica de bundle.
+- Governanca auto-modificadora (agentes alterando estas regras principais).
+
+### 5. Modo Operacional Oficial
+O modo operacional padrao e o **Modo de Execucao de Agente Unico**. As tarefas devem ser executadas diretamente pelo agente ativo dentro de uma unica linha linear de execucao.
+
+### 6. Capacidades Multi-Agente Futuras
+Qualquer implementacao futura de fluxos de trabalho multi-agente deve seguir as seguintes restricoes:
+- Exigir autorizacao explicita (opt-in pelo usuario).
+- Ser implementada inteiramente de forma local ao projeto (por exemplo, via scripts locais orquestrando processos CLI separados, nao recursao interna de runtime).
+- Nunca alterar o ambiente global.
+- Nunca criar dependencias no layout especifico ou diretorio HOME da maquina host.
+
+### 7. Portabilidade Universal
+O repositorio foi projetado para ser totalmente portavel. Deve funcionar corretamente:
+- Em qualquer sistema operacional (Linux, macOS, Windows).
+- Em qualquer caminho de diretorio.
+- Sem nenhuma dependencia no caminho do diretorio `HOME` do usuario.

--- a/translations/pt/docs/architecture/continuous-learning-v2-spec.md
+++ b/translations/pt/docs/architecture/continuous-learning-v2-spec.md
@@ -1,0 +1,14 @@
+# Especificacao do Aprendizado Continuo v2
+
+Este documento captura a arquitetura de aprendizado continuo v2:
+
+1. Captura de observacoes baseada em hooks
+2. Loop de analise do observador em background
+3. Pontuacao e persistencia de instintos
+4. Evolucao de instintos em skills/comandos reutilizaveis
+
+A implementacao primaria vive em:
+- `skills/continuous-learning-v2/`
+- `scripts/hooks/`
+
+Use este arquivo como o caminho de referencia estavel para docs e traducoes.

--- a/translations/pt/docs/architecture/cross-harness.md
+++ b/translations/pt/docs/architecture/cross-harness.md
@@ -1,0 +1,130 @@
+# Arquitetura Entre Harnesses
+
+egc e a camada de fluxo de trabalho reutilizavel. Harnesses sao superficies de execucao.
+
+O objetivo e manter as partes duraveis do trabalho agentivo em um unico repositorio:
+
+- skills
+- regras e instrucoes
+- hooks onde o harness os suporta
+- configuracao MCP
+- manifestos de instalacao
+- padroes de sessao e orquestracao
+
+Gemini Code, Codex, OpenCode, Cursor, Gemini e futuros harnesses devem adaptar esses ativos na borda em vez de exigir um novo modelo de fluxo de trabalho para cada ferramenta.
+
+## Modelo de Portabilidade
+
+| Superficie | Fonte Compartilhada | Adaptador de Harness | Status Atual |
+|------------|--------------------|-----------------------|--------------|
+| Skills | `skills/*/SKILL.md` | plugin gemini, plugin Codex, `.agents/skills`, copias de skills do Cursor, plugin/config OpenCode | Suportado com empacotamento especifico por harness |
+| Regras e instrucoes | `rules/`, `AGENTS.md`, docs traduzidos | instalacao de regras gemini, `AGENTS.md` do Codex, regras do Cursor, instrucoes OpenCode | Suportado, mas nao identico entre harnesses |
+| Hooks | `hooks/hooks.json`, `scripts/hooks/` | hooks nativos gemini, eventos de plugin OpenCode, adaptador de hook do Cursor | Respaldado por hook em gemini/OpenCode/Cursor; respaldado por instrucao no Codex |
+| MCPs | `.mcp.json`, `mcp-configs/` | Importacao de configuracao MCP nativa por harness | Suportado onde o harness expoe MCP |
+| Comandos | `commands/`, scripts CLI | comandos slash gemini, shims de compatibilidade, entrypoints CLI | Suportado, mas semantica de comandos varia |
+| Sessoes | `egc2/`, adaptadores de sessao, scripts de orquestracao | TUI/daemon, orquestracao tmux/worktree, runners especificos por harness | Alpha |
+
+## O que Viaja Sem Alteracao
+
+`SKILL.md` e a unidade mais portavel.
+
+Uma boa skill egc deve:
+
+- usar frontmatter YAML com `name`, `description` e `origin`
+- descrever quando usar a skill
+- declarar ferramentas ou conectores necessarios sem embutir segredos
+- manter exemplos relativos ao repositorio ou genericos
+- evitar suposicoes de comandos exclusivos do harness, a menos que a secao esteja claramente rotulada
+
+A mesma skill de origem pode ser instalada em multiplos harnesses porque e principalmente instrucoes, restricoes e forma de fluxo de trabalho.
+
+## O que e Adaptado
+
+Cada harness tem comportamento diferente de carregamento e aplicacao:
+
+- Gemini Code carrega ativos de plugin e tem execucao nativa de hooks.
+- Codex le `AGENTS.md`, metadados de plugin, skills e configuracao MCP de referencia, mas a paridade de hooks e respaldada por instrucoes.
+- OpenCode tem um sistema de plugin/evento que pode reutilizar logica de hook do egc por meio de uma camada de adaptador.
+- Cursor usa seu proprio layout de regras e hooks, entao o egc mantem superficies traduzidas em `.cursor/`.
+- O suporte ao Gemini e orientado a instalacao/instrucao e deve ser tratado como uma superficie de compatibilidade, nao como paridade completa de hooks.
+
+Adaptadores devem ser finos. O comportamento compartilhado pertence a `skills/`, `rules/`, `hooks/`, `scripts/` e `mcp-configs/`.
+
+## Fronteira do Hermes
+
+Hermes nao e o runtime publico do egc.
+
+Hermes e um shell operacional que pode consumir ativos do egc:
+
+- importar skills selecionadas do egc em um diretorio de skills do Hermes
+- usar convencoes MCP do egc para acesso a ferramentas
+- rotear fluxos de trabalho de chat, CLI, cron e handoff por padroes reutilizaveis do egc
+- destilar trabalho operacional local repetido de volta em skills sanitizadas do egc
+
+O repositorio publico deve publicar padroes reutilizaveis, nao estado local do Hermes.
+
+Publique:
+
+- documentos de configuracao sanitizados
+- prompts de demonstracao relativos ao repositorio
+- skills gerais de operador
+- exemplos que nao dependem de credenciais privadas
+
+Nao publique:
+
+- tokens OAuth ou chaves de API
+- exportacoes brutas de `~/.hermes`
+- memoria pessoal de workspace
+- datasets privados
+- pacotes de automacao so-locais que nao foram revisados
+
+## Exemplo Pratico
+
+Use `skills/hermes-imports/SKILL.md` como a mesma fonte de skill entre harnesses.
+
+O fluxo de trabalho e:
+
+1. Escreva o comportamento duravel uma vez em `skills/hermes-imports/SKILL.md`.
+2. Mantenha segredos, caminhos locais e memoria bruta de operador fora da skill.
+3. Deixe cada harness adaptar como a skill e carregada.
+4. Teste a skill de origem e os metadados voltados para o harness separadamente.
+
+Gemini Code recebe a skill pela superficie de plugin gemini e pode aplicar hooks relacionados nativamente.
+
+Codex le as instrucoes do repositorio, `.codex-plugin/plugin.json` e a configuracao MCP de referencia. A mesma skill de origem ainda descreve o fluxo de trabalho, mas a paridade de hooks e respaldada por instrucoes, a menos que Codex adicione uma superficie nativa de hooks.
+
+OpenCode recebe a skill pela superficie de pacote/plugin OpenCode. O tratamento de eventos pode reutilizar logica de hook do egc pela camada de adaptador, enquanto o texto da skill permanece inalterado.
+
+Se uma mudanca requer editar tres copias do mesmo fluxo de trabalho em diferentes harnesses, a fonte compartilhada esta no lugar errado. Coloque o fluxo de trabalho de volta em `skills/`, depois adapte apenas o carregamento, a forma do evento ou o roteamento de comandos na borda do harness.
+
+## Hoje vs Depois
+
+Suportado hoje:
+
+- fonte de skill compartilhada em `skills/`
+- empacotamento de plugin Gemini Code
+- metadados de plugin Codex e configuracao MCP de referencia
+- superficie de pacote/plugin OpenCode
+- regras, hooks e skills adaptados para Cursor
+- `egc2/` como plano de controle Rust em alpha
+
+Ainda amadurecendo:
+
+- paridade exata de hooks entre todos os harnesses
+- sincronizacao automatica de skills no Hermes
+- empacotamento de release para `egc2/`
+- semantica de retomada de sessao entre harnesses
+- camadas mais profundas de memoria e planejamento de operador
+
+## Regra para Novo Trabalho
+
+Ao adicionar um fluxo de trabalho, coloque o comportamento duravel no egc primeiro.
+
+Use arquivos especificos de harness apenas para:
+
+- carregar o ativo compartilhado
+- adaptar formas de eventos
+- mapear nomes de comandos
+- lidar com limites de plataforma
+
+Se um fluxo de trabalho so funciona em um harness, documente essa fronteira diretamente.

--- a/translations/pt/docs/governance/README.md
+++ b/translations/pt/docs/governance/README.md
@@ -1,0 +1,12 @@
+# Governanca do EGC
+
+Documentos que definem como os subsistemas sao classificados, como skills e agentes sao posicionados e adaptados, e como as superficies de capacidade sao selecionadas. Leia `SUBSYSTEM-MAP.md` primeiro.
+
+| Arquivo | Escopo |
+|---|---|
+| `SUBSYSTEM-MAP.md` | Classificacao formal de cada subsistema de nivel superior (ACTIVE / GENERATED / ARCHIVAL / DORMANT / LEGACY / DEPRECATED) e a politica de governanca por classe. |
+| `SKILL-PLACEMENT-POLICY.md` | Regras para posicionar uma nova skill no namespace correto em `skills/` |
+| `skill-adaptation-policy.md` | Quando e como adaptar ou bifurcar uma skill existente |
+| `capability-surface-selection.md` | Criterios para expor uma skill em um perfil de instalacao de harness |
+
+Para contratos de runtime (mapa de comandos/agentes, adaptador de sessao), consulte `../runtime/`. Para o processo de onboarding de contribuidores, consulte o `CONTRIBUTING.md` raiz e `../README.md`.

--- a/translations/pt/docs/governance/SKILL-PLACEMENT-POLICY.md
+++ b/translations/pt/docs/governance/SKILL-PLACEMENT-POLICY.md
@@ -1,0 +1,102 @@
+# Politica de Posicionamento e Procedencia de Skills
+
+Este documento define onde ficam as skills geradas, importadas e curadas, como sao identificadas e o que e publicado.
+
+## Tipos de Skill e Posicionamento
+
+| Tipo | Caminho Raiz | Publicado | Procedencia |
+|------|--------------|-----------|-------------|
+| Curada | `skills/` (repositorio) | Sim | Nao obrigatoria |
+| Aprendida | `~/.gemini/skills/learned/` | Nao | Obrigatoria |
+| Importada | `~/.gemini/skills/imported/` | Nao | Obrigatoria |
+| Evoluida | `~/.gemini/homunculus/evolved/skills/` (global) ou `projects/<hash>/evolved/skills/` (por projeto) | Nao | Herdada do instinto de origem |
+
+Skills curadas ficam no repositorio em `skills/`. Manifestos de instalacao referenciam apenas caminhos curados. Skills geradas e importadas ficam no diretorio home do usuario e nunca sao publicadas.
+
+## Skills Curadas
+
+Localizacao: `skills/<nome-da-skill>/` com `SKILL.md` na raiz.
+
+- Incluidas nos caminhos de `manifests/install-modules.json`.
+- Validadas por `scripts/ci/validate-skills.js`.
+- Sem arquivo de procedencia. Use `origin` no frontmatter do SKILL.md (egc, community) para atribuicao.
+
+## Skills Aprendidas
+
+Localizacao: `~/.gemini/skills/learned/<nome-da-skill>/`.
+
+Criadas pelo aprendizado continuo (hook evaluate-session, comando /learn). O caminho padrao e configuravel via `skills/continuous-learning/config.json` → `learned_skills_path`.
+
+- Nao estao no repositorio. Nao sao publicadas.
+- Devem ter `.provenance.json` ao lado do `SKILL.md`.
+- Carregadas em tempo de execucao quando o diretorio existe.
+
+## Skills Importadas
+
+Localizacao: `~/.gemini/skills/imported/<nome-da-skill>/`.
+
+Skills instaladas pelo usuario de fontes externas (URL, copia de arquivo, etc.). Nao existe importador automatico ainda; o posicionamento e por convencao.
+
+- Nao estao no repositorio. Nao sao publicadas.
+- Devem ter `.provenance.json` ao lado do `SKILL.md`.
+
+## Skills Evoluidas (Aprendizado Continuo v2)
+
+Localizacao: `~/.gemini/homunculus/evolved/skills/` (global) ou `~/.gemini/homunculus/projects/<hash>/evolved/skills/` (por projeto).
+
+- Nao estao no repositorio. Nao sao publicadas.
+- Procedencia herdada dos instintos de origem; nenhum `.provenance.json` separado e necessario.
+
+## Metadados de Procedencia
+
+Obrigatorio para skills aprendidas e importadas. Arquivo: `.provenance.json` no diretorio da skill.
+
+Campos obrigatorios:
+
+| Campo | Tipo | Descricao |
+|-------|------|-----------|
+| source | string | Origem (URL, caminho ou identificador) |
+| created_at | string | Timestamp ISO 8601 |
+| confidence | number | 0 a 1 |
+| author | string | Quem ou o que produziu a skill |
+
+Schema: `schemas/provenance.schema.json`. Validacao: `scripts/lib/skill-evolution/provenance.js` → `validateProvenance`.
+
+## Comportamento do Validador
+
+### validate-skills.js
+
+Escopo: Skills curadas apenas (`skills/` no repositorio).
+
+- Se `skills/` nao existir: sair com 0 (nada para validar).
+- Para cada subdiretorio: deve conter `SKILL.md`, nao vazio.
+- Nao toca nas raizes de aprendidas/importadas/evoluidas.
+
+### validate-install-manifests.js
+
+Escopo: Somente caminhos curados. Todos os `paths` nos modulos devem existir no repositorio.
+
+- Raizes geradas/importadas estao fora do escopo. Nenhum manifesto as referencia.
+- Caminho ausente gera erro. Sem tratamento de caminho opcional.
+
+### Scripts que Usam Raizes Geradas
+
+`scripts/skills-health.js`, `scripts/lib/skill-evolution/health.js`, hooks de sessao: eles verificam `~/.gemini/skills/learned` e `~/.gemini/skills/imported`. Diretorios ausentes sao tratados como vazios; sem erros.
+
+## Publicavel vs Somente Local
+
+| Publicavel | Somente Local |
+|------------|---------------|
+| `skills/*` (curadas) | `~/.gemini/skills/learned/*` |
+| | `~/.gemini/skills/imported/*` |
+| | `~/.gemini/homunculus/**/evolved/**` |
+
+Somente skills curadas aparecem nos manifestos de instalacao e sao copiadas durante a instalacao.
+
+## Roteiro de Implementacao
+
+1. Documento de politica e schema de procedencia (esta mudanca).
+2. Adicionar validacao de procedencia aos caminhos de escrita de skills aprendidas (evaluate-session, saida /learn) para que novas skills aprendidas sempre gerem `.provenance.json`.
+3. Atualizar o instinct-cli evolve para gravar procedencia opcional ao gerar skills evoluidas.
+4. Adicionar `scripts/validate-provenance.js` ao CI para quaisquer caminhos do repositorio que nao devam conter conteudo aprendido/importado (se necessario).
+5. Documentar raizes aprendidas/importadas no CONTRIBUTING.md ou em documentacao do usuario para que colaboradores saibam que nao devem commita-las.

--- a/translations/pt/docs/governance/SUBSYSTEM-MAP.md
+++ b/translations/pt/docs/governance/SUBSYSTEM-MAP.md
@@ -1,0 +1,75 @@
+# Mapa de Subsistemas do EGC
+
+Esta pagina classifica os subsistemas de nivel superior e subarvores notaveis do repositorio EGC para que os contribuidores possam ver rapidamente o que esta ativo, o que e gerado, o que e preservado por razoes historicas e o que esta dormente.
+
+## Taxonomia
+
+- **ACTIVE**: invocado pelo CI, runtime ou fluxos de usuario suportados.
+- **GENERATED**: produzido por ferramentas; seguro para regenerar.
+- **ARCHIVAL**: instantaneo historico, preservado intencionalmente.
+- **DORMANT**: codigo presente mas nao conectado a nenhum caminho de execucao.
+- **LEGACY**: substituido; mantido para compatibilidade de migracao.
+- **DEPRECATED**: programado para remocao quando os consumidores migrarem.
+
+## Mapa
+
+### Superficies ativas
+
+| Caminho | Classe | Notas |
+|---|---|---|
+| `agents/` | ACTIVE | 62 definicoes de agentes, fonte da verdade |
+| `commands/` | ACTIVE | 74 comandos de barra |
+| `skills/` | ACTIVE | 228 skills em 14 namespaces |
+| `rules/` | ACTIVE | Regras de codificacao para varias linguagens |
+| `hooks/` | ACTIVE | Manifesto (`hooks.json`); implementacoes em `scripts/hooks/` |
+| `scripts/hooks/` | ACTIVE | 25 hooks carregados diretamente pelo `hooks/hooks.json`; restante transitivo |
+| `scripts/lib/` | ACTIVE | Bibliotecas de carregamento usadas pelos adaptadores de instalacao |
+| `scripts/lib/install-targets/` | ACTIVE | Adaptadores por alvo (cursor, codex, antigravity, gemini, codebuddy, opencode) |
+| `scripts/ci/` | ACTIVE | Validadores invocados pelo `.github/workflows/reusable-validate.yml` |
+| `scripts/install-apply.js` | ACTIVE | `bin: egc-install` |
+| `scripts/egc.js` | ACTIVE | `bin: egc` |
+| `scripts/doctor.js`, `scripts/bootstrap-state-db.js`, `scripts/build-opencode.js` | ACTIVE | scripts npm |
+| `manifests/install-{modules,profiles,components}.json` | ACTIVE | Driver do adaptador de instalacao |
+| `schemas/*.json` | ACTIVE | Validados no CI |
+| `.gemini-plugin/`, `.codex-plugin/` | ACTIVE | Manifestos de plugin |
+| `.cursor/`, `.codex/`, `.kiro/`, `.trae/`, `.codebuddy/`, `.opencode/` | ACTIVE | Pacotes de codigo-fonte especificos do harness |
+| `.agents/` | ACTIVE | Camada de materializacao; taxonomia hot/cold/shadowed |
+| `tests/` (`*.test.js`) | ACTIVE | Executado por `tests/run-all.js` (glob: `**/*.test.js`) |
+| `install.sh`, `install.ps1` | ACTIVE | Pontos de entrada multiplataforma (linha Windows coberta pelo CI) |
+
+### Gerado / regeneravel
+
+| Caminho | Classe | Notas |
+|---|---|---|
+| `src/everything_gemini.egg-info/` | GENERATED | Produzido por `pip install -e .` / setuptools; seguro para regenerar |
+| `.opencode/dist/` | GENERATED | Construido por `npm run build:opencode`; gitignored |
+| `node_modules/` | GENERATED | npm padrao |
+| `internal/registry/runtime-map.json` | ACTIVE | Cache quente gerado da topologia operacional; atualizado por `scripts/runtime/discovery.js` |
+
+### Archival
+
+| Caminho | Classe | Notas |
+|---|---|---|
+| `.agents/.agents/` | ARCHIVAL | Artefato de montagem recursiva preservado desde o baseline; links simbolicos agora relativos |
+| `internal/registry/{agents,skills}-registry.json` | ARCHIVAL | Instantaneos historicos de inventario de versao anterior |
+| `legacy-command-shims/` | ARCHIVAL | Shims de compatibilidade para muscle memory de `/tdd`, `/eval`, `/verify` |
+| `agent.yaml` | ARCHIVAL | Manifesto Spec 0.1.0; sem consumidor ativo; util como contrato historico |
+
+### Dormant
+
+| Caminho | Classe | Notas |
+|---|---|---|
+| `scripts/runtime/` (router, mount-all, unmount-all, activator) | DORMANT | `discovery.js` e ACTIVE, mas scripts de roteamento/montagem sao dormentes |
+| `scripts/orchestration/router.py` | DORMANT | Mesmo desvio de caminho de registro |
+| `scripts/health-check.js` | DORMANT | Mesmo desvio de caminho de registro |
+| `scripts/generate-plugin-manifest.js` | DORMANT | Mesmo desvio de caminho de registro |
+
+## Politica de Governanca
+
+- Itens **ACTIVE**: mudancas passam pela revisao normal.
+- Itens **GENERATED**: nao editar manualmente; regenerar a partir do codigo-fonte.
+- Itens **ARCHIVAL**: manter a menos que seja explicitamente autorizado para remocao.
+- Itens **DORMANT**: nao reativar oportunisticamente.
+- Itens **LEGACY** / **DEPRECATED**: incluir um alvo de migracao.
+
+Em caso de duvida: preservar e classificar; nao deletar.

--- a/translations/pt/docs/governance/capability-surface-selection.md
+++ b/translations/pt/docs/governance/capability-surface-selection.md
@@ -1,0 +1,70 @@
+# Selecao de Superficie de Capacidade
+
+Use isto como guia de roteamento ao decidir se uma capacidade pertence a uma rule, uma skill, um servidor MCP ou um fluxo de trabalho CLI/API simples.
+
+O EGC nao trata essas superficies como intercambiaveis. O objetivo e colocar cada capacidade na superficie mais estreita que preserva a corretude, mantem o custo de tokens sob controle e nao cria arrasto de runtime ou cadeia de suprimentos desnecessario.
+
+## O Resumo
+
+- `rules/` sao para restricoes deterministicas e sempre ativas que devem ser injetadas quando um caminho ou evento corresponder.
+- `skills/` sao para fluxos de trabalho sob demanda, playbooks mais ricos e orientacao com alto custo de tokens que deve carregar apenas quando relevante.
+- `MCP` e para capacidades estruturadas interativas que se beneficiam de uma superficie de ferramenta/recurso de longa duracao entre sessoes ou clientes.
+- `CLI` local ou scripts de repositorio sao para acoes deterministicas simples que nao precisam de um servidor persistente.
+- chamadas de `API` diretas dentro de uma skill sao para acoes remotas estreitas onde um servidor MCP completo seria mais pesado que o problema.
+
+## Ordem de Decisao
+
+Faca estas perguntas em ordem:
+
+1. Isso deve acontecer toda vez que um caminho ou evento corresponder, sem julgamento do modelo?
+   - Use uma `rule`.
+2. Isso e principalmente um playbook, fluxo de trabalho ou camada de orientacao que deve carregar apenas quando a tarefa realmente precisar?
+   - Use uma `skill`.
+3. A capacidade precisa de uma interface de ferramenta/recurso interativa estruturada que varios harnesses ou clientes devem chamar repetidamente?
+   - Use `MCP`.
+4. E uma acao local simples que pode executar como um script sem manter um servidor vivo?
+   - Use um ponto de entrada `CLI` local ou script de repositorio, depois embrulhe com uma skill se necessario.
+5. E apenas uma etapa de integracao remota estreita dentro de um fluxo de trabalho maior?
+   - Chame a `API` externa diretamente da skill ou script.
+
+## Orientacao por Superficie
+
+### Rules
+
+Use rules para:
+- invariantes de codificacao com escopo de caminho
+- andares de seguranca e restricoes de permissao
+- restricoes de harness/runtime que devem sempre se aplicar
+- lembretes deterministicos que nao devem depender do criterio do modelo
+
+### Skills
+
+Use skills para:
+- fluxos de trabalho de multiplas etapas
+- orientacao com muito julgamento
+- playbooks de dominio caros o suficiente para carregar apenas sob demanda
+- orquestracao entre scripts, APIs, ferramentas MCP e skills adjacentes
+
+### MCP
+
+Use MCP quando a capacidade se beneficia de:
+- entradas/saidas estruturadas de ferramentas
+- recursos ou prompts reutilizaveis
+- uso repetido entre clientes
+- uma interface estavel que deve funcionar em Gemini Code, Codex, Cursor, OpenCode e harnesses relacionados
+
+### CLI / Scripts de Repositorio
+
+Prefira um script local ou CLI quando:
+- a acao e deterministica
+- a inicializacao e barata
+- o fluxo de trabalho e principalmente local
+- nao ha beneficio em expor uma superficie de ferramenta/recurso persistente
+
+## Heuristica Pratica
+
+Em caso de duvida, comece menor:
+- comece com uma `rule` para invariantes deterministicas
+- comece com uma `skill` para orientacao/fluxo de trabalho
+- comece com um script para execucao de uso unico
+- promova para `MCP` apenas quando o limite estruturado do servidor estiver claramente valendo a pena

--- a/translations/pt/docs/governance/skill-adaptation-policy.md
+++ b/translations/pt/docs/governance/skill-adaptation-policy.md
@@ -1,0 +1,57 @@
+# Politica de Adaptacao de Skills
+
+O EGC aceita ideias de repositorios externos, mas as skills publicadas precisam se tornar superficies nativas do EGC.
+
+## Regra Padrao
+
+Quando uma contribuicao parte de outro repositorio open-source, pacote de prompts, plugin, harness ou configuracao pessoal:
+
+- copie a ideia, o fluxo de trabalho ou a estrutura subjacente
+- adapte-a as superficies de instalacao atuais do EGC, ao fluxo de validacao e as convencoes do repositorio
+- remova branding externo desnecessario, suposicoes de dependencias e enquadramentos especificos de upstream
+
+O objetivo e reutilizacao sem transformar o EGC em um wrapper fino em torno do runtime de outra pessoa.
+
+## Quando Manter o Nome Original
+
+Mantenha o nome original da skill apenas quando todas as seguintes condicoes forem verdadeiras:
+
+- a contribuicao e proxima de uma portagem direta
+- o nome ja e descritivo e neutro
+- a superficie ainda se comporta como o conceito upstream
+- nao ha um nome nativo do EGC melhor ja no repositorio
+
+## Quando Renomear
+
+Renomeie a skill quando o EGC expandir, restringir ou reempacotar significativamente o trabalho original.
+
+Gatilhos tipicos:
+
+- o EGC adiciona comportamento, estrutura ou orientacao substancialmente novos
+- o nome original e voltado ao fornecedor ou a marca da comunidade em vez de ser voltado ao fluxo de trabalho
+- a contribuicao se sobrpoe a uma superficie existente do EGC e precisa de um limite mais claro
+- a contribuicao agora se encaixa melhor como uma capacidade, fluxo de trabalho do operador ou camada de politica em vez de uma portagem literal
+
+## Politica de Dependencias
+
+O EGC prefere a superficie nativa mais estreita que resolve o problema:
+
+- `rules/` para restricoes deterministicas
+- `skills/` para fluxos de trabalho sob demanda
+- MCP quando um limite de ferramenta interativa de longa duracao e justificado
+- scripts locais/CLI para execucao deterministica de uso unico
+- chamadas de API diretas quando a chamada remota e estreita e nao justifica um MCP
+
+Evite publicar uma skill que existe principalmente para dizer aos usuarios que instalem ou confiem em um pacote de terceiros nao verificado.
+
+## Perguntas de Revisao
+
+Antes de fazer merge de uma skill contribuida, responda:
+
+1. Esta e uma superficie reutilizavel real no EGC, ou apenas documentacao para outra ferramenta?
+2. O nome atual ainda corresponde a superficie no formato EGC?
+3. Ja existe uma skill do EGC que possui a maior parte desse comportamento?
+4. Estamos importando um conceito ou a identidade do produto de outra pessoa?
+5. Um usuario do EGC entenderia o proposito desta skill sem conhecer o repositorio upstream?
+
+Se as respostas forem fracas, adapte mais, reduza o escopo ou nao publique.

--- a/translations/pt/docs/guides/ANTIGRAVITY-GUIDE.md
+++ b/translations/pt/docs/guides/ANTIGRAVITY-GUIDE.md
@@ -1,0 +1,156 @@
+# Guia de Configuracao e Uso do Antigravity
+
+O [Antigravity](https://antigravity.dev) do Google e uma IDE de codificacao com IA que usa a convencao de diretorio `.agent/` para configuracao. O egc oferece suporte de primeira classe ao Antigravity por meio de seu sistema de instalacao seletiva.
+
+## Inicio Rapido
+
+```bash
+# Instalar o egc com target Antigravity
+./install.sh --target antigravity typescript
+
+# Ou com multiplos modulos de linguagem
+./install.sh --target antigravity typescript python go
+```
+
+Isso instala componentes do egc no diretorio `.agent/` do seu projeto, pronto para o Antigravity usar.
+
+## Como Funciona o Mapeamento de Instalacao
+
+O egc remapeia sua estrutura de componentes para corresponder ao layout esperado pelo Antigravity:
+
+| Fonte egc | Destino Antigravity | O que contem |
+|-----------|---------------------|--------------|
+| `rules/` | `.agent/rules/` | Regras de linguagem e padroes de codificacao (niveladas) |
+| `commands/` | `.agent/workflows/` | Slash commands tornam-se workflows do Antigravity |
+| `agents/` | `.agent/skills/` | Definicoes de agentes tornam-se skills do Antigravity |
+
+> **Nota sobre `.agents/` vs `.agent/` vs `agents/`**: O instalador lida com apenas tres caminhos de origem explicitamente: `rules` -> `.agent/rules/`, `commands` -> `.agent/workflows/`, e `agents` (sem prefixo ponto) -> `.agent/skills/`. O diretorio `.agents/` (com prefixo ponto) no repositorio egc e um **layout estatico** para definicoes de skills Codex/Antigravity e configuracoes `openai.yaml`: ele nao e mapeado diretamente pelo instalador. Qualquer caminho `.agents/` passa para a operacao de scaffold padrao. Se voce quer conteudo de `.agents/skills/` disponivel no runtime do Antigravity, deve copiar manualmente para `.agent/skills/`.
+
+### Principais Diferencas do Gemini Code
+
+- **Regras sao niveladas**: O Gemini Code aninha regras em subdiretorios (`rules/common/`, `rules/typescript/`). O Antigravity espera um diretorio `rules/` plano: o instalador cuida disso automaticamente.
+- **Comandos tornam-se workflows**: Os arquivos `/command` do egc ficam em `.agent/workflows/`, que e o equivalente do Antigravity para slash commands.
+- **Agentes tornam-se skills**: Definicoes de agentes egc mapeiam para `.agent/skills/`, onde o Antigravity procura configuracoes de skills.
+
+## Estrutura de Diretorios Apos a Instalacao
+
+```
+seu-projeto/
++-- .agent/
+|   +-- rules/
+|   |   +-- coding-standards.md
+|   |   +-- testing.md
+|   |   +-- security.md
+|   |   +-- typescript.md          # regras especificas de linguagem
+|   +-- workflows/
+|   |   +-- plan.md
+|   |   +-- code-review.md
+|   |   +-- tdd.md
+|   |   +-- ...
+|   +-- skills/
+|   |   +-- planner.md
+|   |   +-- code-reviewer.md
+|   |   +-- tdd-guide.md
+|   |   +-- ...
+|   +-- egc-install-state.json     # rastreia o que o egc instalou
+```
+
+## A Configuracao de Agente `openai.yaml`
+
+Cada diretorio de skill em `.agents/skills/` contem um arquivo `agents/openai.yaml` no caminho `.agents/skills/<nome-da-skill>/agents/openai.yaml` que configura a skill para o Antigravity:
+
+```yaml
+interface:
+  display_name: "API Design"
+  short_description: "Padroes de design de API REST e boas praticas"
+  brand_color: "#F97316"
+  default_prompt: "Design REST API: recursos, status codes, paginacao"
+policy:
+  allow_implicit_invocation: true
+```
+
+| Campo | Proposito |
+|-------|-----------|
+| `display_name` | Nome legivel por humanos exibido na UI do Antigravity |
+| `short_description` | Descricao breve do que a skill faz |
+| `brand_color` | Cor hex para o badge visual da skill |
+| `default_prompt` | Prompt sugerido quando a skill e invocada manualmente |
+| `allow_implicit_invocation` | Quando `true`, o Antigravity pode ativar a skill automaticamente com base no contexto |
+
+## Gerenciando Sua Instalacao
+
+### Verificar o que Esta Instalado
+
+```bash
+node scripts/list-installed.js --target antigravity
+```
+
+### Reparar uma Instalacao Quebrada
+
+```bash
+# Primeiro, diagnostique o que esta errado
+node scripts/doctor.js --target antigravity
+
+# Depois, restaure arquivos ausentes ou derivados
+node scripts/repair.js --target antigravity
+```
+
+### Desinstalar
+
+```bash
+node scripts/uninstall.js --target antigravity
+```
+
+### Estado de Instalacao
+
+O instalador escreve `.agent/egc-install-state.json` para rastrear quais arquivos o egc possui. Isso permite desinstalacao e reparo seguros: o egc nunca tocara em arquivos que nao criou.
+
+## Adicionando Skills Customizadas para o Antigravity
+
+Se voce esta contribuindo com uma nova skill e quer que ela esteja disponivel no Antigravity:
+
+1. Crie a skill em `skills/nome-da-sua-skill/SKILL.md` normalmente
+2. Adicione uma definicao de agente em `agents/nome-da-sua-skill.md`: este e o caminho que o instalador mapeia para `.agent/skills/` em tempo de execucao, tornando sua skill disponivel no harness Antigravity
+3. Adicione a configuracao de agente Antigravity em `.agents/skills/nome-da-sua-skill/agents/openai.yaml`: este e um layout estatico do repositorio consumido pelo Codex para metadados de invocacao implicita
+4. Espelhe o conteudo do `SKILL.md` em `.agents/skills/nome-da-sua-skill/SKILL.md`: esta copia estatica e usada pelo Codex e serve como referencia para o Antigravity
+5. Mencione no seu PR que voce adicionou suporte ao Antigravity
+
+> **Distincao chave**: O instalador implanta `agents/` (sem ponto) -> `.agent/skills/`: isso e o que torna as skills disponiveis em tempo de execucao. O diretorio `.agents/` (com prefixo ponto) e um layout estatico separado para configuracoes `openai.yaml` do Codex e nao e auto-implantado pelo instalador.
+
+Veja [CONTRIBUTING.md](../../.github/CONTRIBUTING.md) para o guia completo de contribuicao.
+
+## Comparacao com Outros Targets
+
+| Feature | Gemini Code | Cursor | Codex | Antigravity |
+|---------|-------------|--------|-------|-------------|
+| Target de instalacao | `gemini-home` | `cursor-project` | `codex-home` | `antigravity` |
+| Raiz de configuracao | `~/.gemini/` | `.cursor/` | `~/.codex/` | `.agent/` |
+| Escopo | Nivel de usuario | Nivel de projeto | Nivel de usuario | Nivel de projeto |
+| Formato de regras | Diretorios aninhados | Plano | Plano | Plano |
+| Comandos | `commands/` | N/A | N/A | `workflows/` |
+| Agentes/Skills | `agents/` | N/A | N/A | `skills/` |
+| Estado de instalacao | `egc-install-state.json` | `egc-install-state.json` | `egc-install-state.json` | `egc-install-state.json` |
+
+## Solucao de Problemas
+
+### Skills nao carregando no Antigravity
+
+- Verifique se o diretorio `.agent/` existe na raiz do seu projeto (nao no diretorio home)
+- Verifique se `egc-install-state.json` foi criado: se ausente, re-execute o instalador
+- Garanta que os arquivos tenham extensao `.md` e frontmatter valido
+
+### Regras nao se aplicando
+
+- Regras devem estar em `.agent/rules/`, nao em subdiretorios
+- Execute `node scripts/doctor.js --target antigravity` para verificar a instalacao
+
+### Workflows nao disponiveis
+
+- O Antigravity procura workflows em `.agent/workflows/`, nao em `commands/`
+- Se voce copiou comandos egc manualmente, renomeie o diretorio
+
+## Recursos Relacionados
+
+- [Arquitetura de Instalacao Seletiva](./SELECTIVE-INSTALL-ARCHITECTURE.md): como o sistema de instalacao funciona internamente
+- [Design de Instalacao Seletiva](./SELECTIVE-INSTALL-DESIGN.md): decisoes de design e contratos de adaptador de target
+- [CONTRIBUTING.md](../../.github/CONTRIBUTING.md): como contribuir com skills, agentes e comandos

--- a/translations/pt/docs/guides/MANUAL-ADAPTATION-GUIDE.md
+++ b/translations/pt/docs/guides/MANUAL-ADAPTATION-GUIDE.md
@@ -1,0 +1,214 @@
+# Guia de Adaptacao Manual para Harnesses Nao Nativos
+
+Use este guia quando quiser comportamento egc dentro de um harness que nao carrega nativamente layouts `.gemini/`, `.codex/`, `.opencode/`, `.cursor/` ou `.agent/`.
+
+Este e o caminho alternativo para ferramentas como Grok e outras interfaces estilo chat que podem aceitar prompts de sistema, arquivos enviados ou instrucoes coladas, mas nao podem executar as superficies de instalacao nativas do repositorio diretamente.
+
+## Quando Usar
+
+Use adaptacao manual quando o harness alvo:
+
+- nao carrega pastas do repositorio automaticamente
+- nao suporta comandos slash customizados
+- nao suporta hooks
+- nao suporta ativacao de skill local do repositorio
+- tem acesso parcial ou nenhum acesso ao sistema de arquivos/ferramentas
+
+Prefira um target egc de primeira classe sempre que um existir:
+
+- Gemini Code
+- Codex
+- Cursor
+- OpenCode
+- CodeBuddy
+- Antigravity
+
+Use este guia somente quando precisar de comportamento egc em um harness nao nativo.
+
+## O que Voce Esta Reproduzindo
+
+Quando voce adapta o egc manualmente, esta tentando preservar quatro coisas:
+
+1. Contexto focado em vez de despejar o repositorio inteiro.
+2. Sinalizadores de ativacao de skill em vez de esperar que o modelo adivinhe o fluxo de trabalho.
+3. Intencao de comando mesmo quando o harness nao tem sistema de slash-command.
+4. Disciplina de hook mesmo quando o harness nao tem automacao nativa.
+
+Voce nao esta tentando espelhar todos os arquivos no repositorio. Voce esta tentando recriar o comportamento util com o menor bundle de contexto possivel.
+
+## O Fallback Nativo do egc
+
+Padronize para selecao manual do proprio repositorio.
+
+Comece com apenas os arquivos que realmente precisa:
+
+- uma skill de linguagem ou framework
+- uma skill de fluxo de trabalho
+- uma skill de dominio se a tarefa for especializada
+- um agente ou comando somente se o harness se beneficia de orquestracao explicita
+
+Bons exemplos minimos:
+
+- Trabalho com feature Python:
+  - `skills/python-patterns/SKILL.md`
+  - `skills/tdd-workflow/SKILL.md`
+  - `skills/verification-loop/SKILL.md`
+- Trabalho com API TypeScript:
+  - `skills/backend-patterns/SKILL.md`
+  - `skills/security-review/SKILL.md`
+  - `skills/tdd-workflow/SKILL.md`
+- Trabalho com conteudo/outbound:
+  - `skills/brand-voice/SKILL.md`
+  - `skills/content-engine/SKILL.md`
+  - `skills/crosspost/SKILL.md`
+
+Se o harness suportar upload de arquivo, envie apenas esses arquivos.
+
+Se o harness suportar apenas contexto colado, extraia as secoes relevantes e cole um bundle comprimido em vez dos arquivos completos brutos.
+
+## Empacotamento Manual de Contexto
+
+Voce nao precisa de ferramentas extras para fazer isso.
+
+Use o repositorio diretamente:
+
+```bash
+cd /path/to/EGC
+
+sed -n '1,220p' skills/tdd-workflow/SKILL.md > /tmp/egc-context.md
+printf '\n\n---\n\n' >> /tmp/egc-context.md
+sed -n '1,220p' skills/backend-patterns/SKILL.md >> /tmp/egc-context.md
+printf '\n\n---\n\n' >> /tmp/egc-context.md
+sed -n '1,220p' skills/security-review/SKILL.md >> /tmp/egc-context.md
+```
+
+Voce tambem pode usar `rg` para identificar as skills certas antes de empacotar:
+
+```bash
+rg -n "When to use|Use when|Trigger" skills -g 'SKILL.md'
+```
+
+Opcional: se voce ja usa um empacotador de repositorio como `repomix`, ele pode ajudar a comprimir arquivos selecionados em um unico documento de entrega. E uma ferramenta de conveniencia, nao o caminho canonico do egc.
+
+## Regras de Compressao
+
+Ao empacotar manualmente o egc para outro harness:
+
+- mantenha o enquadramento da tarefa
+- mantenha as condicoes de ativacao
+- mantenha as etapas do fluxo de trabalho
+- mantenha os exemplos criticos
+- remova prosa repetitiva primeiro
+- remova variantes nao relacionadas em segundo lugar
+- evite colar diretorios inteiros quando uma ou duas skills forem suficientes
+
+Se precisar de um formato de prompt mais compacto, converta as partes essenciais em um bloco estruturado compacto:
+
+```xml
+<skill name="tdd-workflow">
+  <when>Nova feature, correcao de bug ou refatoracao que deve ser test-first.</when>
+  <steps>
+    <step>Escreva um teste que falha.</step>
+    <step>Faca ele passar com a menor mudanca possivel.</step>
+    <step>Refatore e re-execute a validacao.</step>
+  </steps>
+</skill>
+```
+
+## Reproduzindo Comandos
+
+Se o harness nao tem sistema de slash-command, defina um pequeno registro de comandos no prompt de sistema ou preambulo de sessao.
+
+Exemplo:
+
+```text
+Registro de comandos:
+- /plan -> use raciocinio estilo planner, produza um plano de execucao curto, depois aja
+- /tdd -> siga a skill tdd-workflow
+- /review -> mude para modo de revisao de codigo e enumere os achados primeiro
+- /verify -> execute um loop de verificacao antes de declarar conclusao
+```
+
+Voce nao esta implementando comandos reais. Voce esta dando ao harness handles de invocacao explicitos que mapeiam para comportamentos do egc.
+
+## Reproduzindo Hooks
+
+Se o harness nao tem hooks nativos, mova a intencao do hook para as instrucoes permanentes.
+
+Exemplo:
+
+```text
+Antes de escrever codigo:
+1. Verifique se uma skill relevante deve ser ativada.
+2. Verifique se ha mudancas sensiveis de seguranca.
+3. Prefira testes antes da implementacao quando viavel.
+
+Antes de finalizar:
+1. Releia a requisicao do usuario.
+2. Verifique os principais caminhos alterados.
+3. Declare o que foi realmente validado e o que nao foi.
+```
+
+Isso nao recria automacao real, mas captura a disciplina operacional do egc.
+
+## Matriz de Capacidades do Harness
+
+| Capacidade | Targets Nativos egc | Targets de Adaptacao Manual |
+| --- | --- | --- |
+| Instalacao baseada em pasta | Nativa | Nao |
+| Slash commands | Nativa | Simulada no prompt |
+| Hooks | Nativa | Simulada no prompt |
+| Ativacao de skill | Nativa | Manual |
+| Ferramentas locais do repositorio | Nativa | Depende do harness |
+| Empacotamento de contexto | Opcional | Obrigatorio |
+
+## Configuracao Pratica Estilo Grok
+
+1. Escolha o menor bundle util.
+2. Empacote os arquivos de skill egc selecionados em um upload ou bloco colado.
+3. Adicione um registro de comando curto.
+4. Adicione instrucoes de "intencao de hook" permanentes.
+5. Comece com uma tarefa e verifique se o harness segue o fluxo de trabalho antes de escalar.
+
+Preambulo de exemplo:
+
+```text
+Voce esta operando com um bundle egc adaptado manualmente.
+
+Skills ativas:
+- backend-patterns
+- tdd-workflow
+- security-review
+
+Registro de comandos:
+- /plan
+- /tdd
+- /verify
+
+Antes de escrever codigo, siga as instrucoes da skill ativa.
+Antes de finalizar, verifique o que mudou e relate as lacunas restantes.
+```
+
+## Limitacoes
+
+A adaptacao manual e util, mas ainda e de segunda classe em comparacao com os targets nativos.
+
+Voce perde:
+
+- instalacao e sincronizacao automaticas
+- execucao nativa de hook
+- plumbing real de comandos
+- descoberta confiavel de skills em tempo de execucao
+- orquestracao integrada de multi-agente/worktree
+
+Portanto, a regra e simples:
+
+- use adaptacao manual para levar comportamento egc para harnesses nao nativos
+- use targets nativos egc sempre que quiser o sistema completo
+
+## Trabalho Relacionado
+
+- [Issue #1186](https://github.com/Fmarzochi/EGC-code/issues/1186)
+- [Discussao #1077](https://github.com/Fmarzochi/EGC-code/discussions/1077)
+- [Guia Antigravity](./ANTIGRAVITY-GUIDE.md)
+- [Solucao de Problemas](./TROUBLESHOOTING.md)

--- a/translations/pt/docs/guides/README.md
+++ b/translations/pt/docs/guides/README.md
@@ -1,0 +1,14 @@
+# Guias do EGC
+
+Guias operacionais e tutoriais para contribuidores. Estes sao documentos em formato tutorial; para arquitetura ou governanca, consulte `../architecture/` e `../governance/`.
+
+| Arquivo | Escopo |
+|---|---|
+| `SKILL-DEVELOPMENT-GUIDE.md` | Tutorial completo para criar uma nova skill (frontmatter, estrutura, posicionamento de namespace) |
+| `MANUAL-ADAPTATION-GUIDE.md` | Como portar manualmente uma skill ou hook para outro layout de harness |
+| `ANTIGRAVITY-GUIDE.md` | Exemplo completo: instalacao seletiva no harness Antigravity via `install.sh --target antigravity` |
+| `TROUBLESHOOTING.md` | Procedimentos de recuperacao para problemas comuns de runtime/instalacao |
+| `hook-bug-workarounds.md` | Solucoes documentadas para comportamentos peculiares de hooks upstream |
+| `token-optimization.md` | Orientacoes de orcamento de tokens e mecanica de desativacao do MCP no lado EGC |
+
+A subpasta `examples/` contem templates referenciados pelos guias (atualmente `product-capability-template.md` e `project-guidelines-template.md`).

--- a/translations/pt/docs/guides/SKILL-DEVELOPMENT-GUIDE.md
+++ b/translations/pt/docs/guides/SKILL-DEVELOPMENT-GUIDE.md
@@ -1,0 +1,867 @@
+# Guia de Desenvolvimento de Skills
+
+Um guia abrangente para criar skills eficazes para o EGC - Extended Global Context.
+
+## Sumario
+
+- [O que Sao Skills?](#o-que-sao-skills)
+- [Arquitetura de Skills](#arquitetura-de-skills)
+- [Criando Sua Primeira Skill](#criando-sua-primeira-skill)
+- [Categorias de Skills](#categorias-de-skills)
+- [Escrevendo Conteudo Eficaz de Skill](#escrevendo-conteudo-eficaz-de-skill)
+- [Boas Praticas](#boas-praticas)
+- [Padroes Comuns](#padroes-comuns)
+- [Testando Sua Skill](#testando-sua-skill)
+- [Submetendo Sua Skill](#submetendo-sua-skill)
+- [Galeria de Exemplos](#galeria-de-exemplos)
+
+---
+
+## O que Sao Skills?
+
+Skills sao **modulos de conhecimento** que o Gemini Code carrega com base no contexto. Elas fornecem:
+
+- **Expertise de dominio**: Padroes de framework, idiomas de linguagem, boas praticas
+- **Definicoes de fluxo de trabalho**: Processos passo a passo para tarefas comuns
+- **Material de referencia**: Trechos de codigo, checklists, arvores de decisao
+- **Injecao de contexto**: Ativam quando condicoes especificas sao atendidas
+
+Ao contrario de **agentes** (subassistentes especializados) ou **comandos** (acoes disparadas pelo usuario), skills sao conhecimento passivo que o Gemini Code referencia quando relevante.
+
+### Quando as Skills Ativam
+
+Skills ativam quando:
+- A tarefa do usuario corresponde ao dominio da skill
+- O Gemini Code detecta contexto relevante
+- Um comando referencia uma skill
+- Um agente precisa de conhecimento de dominio
+
+### Skill vs Agente vs Comando
+
+| Componente | Proposito | Ativacao |
+|------------|-----------|----------|
+| **Skill** | Repositorio de conhecimento | Baseada em contexto (automatica) |
+| **Agente** | Executor de tarefas | Delegacao explicita |
+| **Comando** | Acao do usuario | Invocado pelo usuario (`/comando`) |
+| **Hook** | Automacao | Disparado por evento |
+| **Regra** | Diretrizes sempre ativas | Sempre ativo |
+
+---
+
+## Arquitetura de Skills
+
+### Estrutura de Arquivos
+
+```
+skills/
++-- nome-da-sua-skill/
+    +-- SKILL.md           # Obrigatorio: Definicao principal da skill
+    +-- examples/          # Opcional: Exemplos de codigo
+    |   +-- basic.ts
+    |   +-- advanced.ts
+    +-- references/        # Opcional: Referencias externas
+        +-- links.md
+```
+
+### Formato do SKILL.md
+
+```markdown
+---
+name: nome-da-skill
+description: Descricao breve mostrada na lista de skills e usada para auto-ativacao
+origin: egc
+---
+
+# Titulo da Skill
+
+Visao geral breve do que esta skill cobre.
+
+## Quando Ativar
+
+Descreva cenarios onde o gemini deve usar esta skill.
+
+## Conceitos Principais
+
+Padroes e diretrizes principais.
+
+## Exemplos de Codigo
+
+\`\`\`typescript
+// Exemplos praticos e testados
+\`\`\`
+
+## Anti-Padroes
+
+Mostre o que NAO fazer com exemplos concretos.
+
+## Boas Praticas
+
+- Diretrizes acionaveis
+- O que fazer e o que evitar
+
+## Skills Relacionadas
+
+Links para skills complementares.
+```
+
+### Campos do Frontmatter YAML
+
+| Campo | Obrigatorio | Descricao |
+|-------|-------------|-----------|
+| `name` | Sim | Identificador em minusculo com hifens (ex.: `react-patterns`) |
+| `description` | Sim | Descricao de uma linha para lista de skills e auto-ativacao |
+| `origin` | Nao | Identificador de fonte (ex.: `egc`, `community`, nome do projeto) |
+| `tags` | Nao | Array de tags para categorizacao |
+| `version` | Nao | Versao da skill para rastrear atualizacoes |
+
+---
+
+## Criando Sua Primeira Skill
+
+### Etapa 1: Escolha um Foco
+
+Boas skills sao **focadas e acionaveis**:
+
+| BOAS: Bom Foco | RUINS: Muito Amplo |
+|----------------|-------------------|
+| `react-hook-patterns` | `react` |
+| `postgresql-indexing` | `databases` |
+| `pytest-fixtures` | `python-testing` |
+| `nextjs-app-router` | `nextjs` |
+
+### Etapa 2: Crie o Diretorio
+
+```bash
+mkdir -p skills/nome-da-sua-skill
+```
+
+### Etapa 3: Escreva o SKILL.md
+
+Template minimo:
+
+```markdown
+---
+name: nome-da-sua-skill
+description: Descricao breve de quando usar esta skill
+---
+
+# Titulo da Sua Skill
+
+Visao geral breve (1 a 2 sentencas).
+
+## Quando Ativar
+
+- Cenario 1
+- Cenario 2
+- Cenario 3
+
+## Conceitos Principais
+
+### Conceito 1
+
+Explicacao com exemplos.
+
+### Conceito 2
+
+Outro padrao com codigo.
+
+## Exemplos de Codigo
+
+\`\`\`typescript
+// Exemplo pratico
+\`\`\`
+
+## Boas Praticas
+
+- Faca isso
+- Evite aquilo
+
+## Skills Relacionadas
+
+- `skill-relacionada-1`
+- `skill-relacionada-2`
+```
+
+### Etapa 4: Adicione Conteudo
+
+Escreva conteudo que o Gemini possa **usar imediatamente**:
+
+- BOM: Exemplos de codigo prontos para copiar
+- BOM: Arvores de decisao claras
+- BOM: Checklists de verificacao
+- RUIM: Explicacoes vagas sem exemplos
+- RUIM: Prosa longa sem orientacao acionavel
+
+---
+
+## Categorias de Skills
+
+### Padroes de Linguagem
+
+Foco em codigo idiomatico, convencoes de nomenclatura e padroes especificos da linguagem.
+
+**Exemplos:** `python-patterns`, `golang-patterns`, `typescript-standards`
+
+```markdown
+---
+name: python-patterns
+description: Idiomas Python, boas praticas e padroes para codigo limpo e idiomatico.
+---
+
+# Padroes Python
+
+## Quando Ativar
+
+- Escrevendo codigo Python
+- Refatorando modulos Python
+- Revisao de codigo Python
+
+## Conceitos Principais
+
+### Gerenciadores de Contexto
+
+\`\`\`python
+# Sempre use gerenciadores de contexto para recursos
+with open('arquivo.txt') as f:
+    conteudo = f.read()
+\`\`\`
+```
+
+### Padroes de Framework
+
+Foco em convencoes especificas do framework, padroes comuns e anti-padroes.
+
+**Exemplos:** `django-patterns`, `nextjs-patterns`, `springboot-patterns`
+
+### Skills de Fluxo de Trabalho
+
+Definem processos passo a passo para tarefas comuns de desenvolvimento.
+
+**Exemplos:** `tdd-workflow`, `code-review-workflow`, `deployment-checklist`
+
+### Conhecimento de Dominio
+
+Conhecimento especializado para dominios especificos (seguranca, performance, etc.).
+
+**Exemplos:** `security-review`, `performance-optimization`, `api-design`
+
+### Integracao de Ferramentas
+
+Orientacao para usar ferramentas, bibliotecas ou servicos especificos.
+
+**Exemplos:** `supabase-patterns`, `docker-patterns`, `mcp-server-patterns`
+
+---
+
+## Escrevendo Conteudo Eficaz de Skill
+
+### 1. Comece com "Quando Ativar"
+
+Esta secao e **critica** para auto-ativacao. Seja especifico:
+
+```markdown
+## Quando Ativar
+
+- Criando novos componentes React
+- Refatorando componentes existentes
+- Depurando problemas de estado React
+- Revisando codigo React para boas praticas
+```
+
+### 2. Use "Mostrar, Nao Contar"
+
+Ruim:
+```markdown
+## Tratamento de Erros
+
+Sempre trate erros adequadamente em funcoes async.
+```
+
+Bom:
+```markdown
+## Tratamento de Erros
+
+\`\`\`typescript
+async function fetchData(url: string) {
+  try {
+    const response = await fetch(url)
+
+    if (!response.ok) {
+      throw new Error(\`HTTP \${response.status}: \${response.statusText}\`)
+    }
+
+    return await response.json()
+  } catch (error) {
+    console.error('Fetch falhou:', error)
+    throw new Error('Falha ao buscar dados')
+  }
+}
+\`\`\`
+
+### Pontos Chave
+
+- Verifique \`response.ok\` antes de analisar
+- Logue erros para depuracao
+- Re-lance com mensagem amigavel ao usuario
+```
+
+### 3. Inclua Anti-Padroes
+
+Mostre o que NAO fazer:
+
+```markdown
+## Anti-Padroes
+
+### RUIM: Mutacao Direta de Estado
+
+\`\`\`typescript
+// NUNCA faca isso
+user.name = 'Novo Nome'
+items.push(novoItem)
+\`\`\`
+
+### BOM: Atualizacoes Imutaveis
+
+\`\`\`typescript
+// SEMPRE faca isso
+const userAtualizado = { ...user, name: 'Novo Nome' }
+const itensAtualizados = [...items, novoItem]
+\`\`\`
+```
+
+### 4. Forneca Checklists
+
+Checklists sao acionaveis e faceis de seguir:
+
+```markdown
+## Checklist Pre-Deploy
+
+- [ ] Todos os testes passando
+- [ ] Sem console.log em codigo de producao
+- [ ] Variaveis de ambiente documentadas
+- [ ] Segredos nao hardcoded
+- [ ] Tratamento de erros completo
+- [ ] Validacao de entrada implementada
+```
+
+### 5. Use Arvores de Decisao
+
+Para decisoes complexas:
+
+```markdown
+## Escolhendo a Abordagem Certa
+
+\`\`\`
+Precisa buscar dados?
++-- Requisicao unica -> use fetch diretamente
++-- Multiplas independentes -> Promise.all()
++-- Multiplas dependentes -> await sequencialmente
++-- Com cache -> use SWR ou React Query
+\`\`\`
+```
+
+---
+
+## Boas Praticas
+
+### FACA
+
+| Pratica | Exemplo |
+|---------|---------|
+| **Seja especifico** | "Use `useCallback` para handlers de eventos passados para componentes filhos" |
+| **Mostre exemplos** | Inclua codigo pronto para copiar |
+| **Explique O POR QUE** | "Imutabilidade evita efeitos colaterais inesperados no estado React" |
+| **Vincule skills relacionadas** | "Veja tambem: `react-performance`" |
+| **Mantenha o foco** | Uma skill = um dominio/conceito |
+| **Use secoes** | Headers claros para facil leitura |
+
+### NAO FACA
+
+| Pratica | Por que e Ruim |
+|---------|----------------|
+| **Seja vago** | "Escreva bom codigo" - nao e acionavel |
+| **Prosa longa** | Dificil de analisar, melhor como codigo |
+| **Cubra muito** | "Padroes Python, Django e Flask" - muito amplo |
+| **Pule exemplos** | Teoria sem pratica e menos util |
+| **Ignore anti-padroes** | Aprender o que NAO fazer e valioso |
+
+### Diretrizes de Conteudo
+
+1. **Tamanho**: 200 a 500 linhas tipico, 800 linhas maximo
+2. **Blocos de codigo**: Inclua identificador de linguagem
+3. **Headers**: Use hierarquia `##` e `###`
+4. **Listas**: Use `-` para nao ordenadas, `1.` para ordenadas
+5. **Tabelas**: Para comparacoes e referencias
+
+---
+
+## Padroes Comuns
+
+### Padrao 1: Skill de Padroes
+
+```markdown
+---
+name: padroes-de-linguagem
+description: Padroes de codificacao e boas praticas para [linguagem].
+---
+
+# Padroes de [Linguagem]
+
+## Quando Ativar
+
+- Escrevendo codigo [linguagem]
+- Revisao de codigo
+- Configurando lint
+
+## Convencoes de Nomenclatura
+
+| Elemento | Convencao | Exemplo |
+|----------|-----------|---------|
+| Variaveis | camelCase | nomeUsuario |
+| Constantes | SCREAMING_SNAKE | MAX_TENTATIVAS |
+| Funcoes | camelCase | buscarUsuario |
+| Classes | PascalCase | ServicoUsuario |
+
+## Exemplos de Codigo
+
+[Inclua exemplos praticos]
+
+## Configuracao de Lint
+
+[Inclua configuracao]
+
+## Skills Relacionadas
+
+- `testes-de-linguagem`
+- `seguranca-de-linguagem`
+```
+
+### Padrao 2: Skill de Fluxo de Trabalho
+
+```markdown
+---
+name: fluxo-de-tarefa
+description: Fluxo de trabalho passo a passo para [tarefa].
+---
+
+# Fluxo de Trabalho de [Tarefa]
+
+## Quando Ativar
+
+- [Gatilho 1]
+- [Gatilho 2]
+
+## Pre-requisitos
+
+- [Requisito 1]
+- [Requisito 2]
+
+## Etapas
+
+### Etapa 1: [Nome]
+
+[Descricao]
+
+\`\`\`bash
+[Comandos]
+\`\`\`
+
+### Etapa 2: [Nome]
+
+[Descricao]
+
+## Verificacao
+
+- [ ] [Verificacao 1]
+- [ ] [Verificacao 2]
+
+## Solucao de Problemas
+
+| Problema | Solucao |
+|----------|---------|
+| [Problema] | [Solucao] |
+```
+
+### Padrao 3: Skill de Referencia
+
+```markdown
+---
+name: referencia-de-api
+description: Referencia rapida para [API/Biblioteca].
+---
+
+# Referencia de [API/Biblioteca]
+
+## Quando Ativar
+
+- Usando [API/Biblioteca]
+- Consultando sintaxe de [API/Biblioteca]
+
+## Operacoes Comuns
+
+### Operacao 1
+
+\`\`\`typescript
+// Uso basico
+\`\`\`
+
+### Operacao 2
+
+\`\`\`typescript
+// Uso avancado
+\`\`\`
+
+## Configuracao
+
+[Inclua exemplos de configuracao]
+
+## Tratamento de Erros
+
+[Inclua padroes de erro]
+```
+
+---
+
+## Testando Sua Skill
+
+### Teste Local
+
+1. **Copie para o diretorio de skills do Gemini Code**:
+   ```bash
+   cp -r skills/nome-da-sua-skill ~/.gemini/skills/
+   ```
+
+2. **Teste com o Gemini Code**:
+   ```
+   Voce: "Preciso fazer [tarefa que deveria ativar sua skill]"
+
+   O Gemini deve referenciar os padroes da sua skill.
+   ```
+
+3. **Verifique a ativacao**:
+   - Peca ao Gemini para explicar um conceito da sua skill
+   - Verifique se ele usa seus exemplos e padroes
+   - Garanta que ele segue suas diretrizes
+
+### Checklist de Validacao
+
+- [ ] **Frontmatter YAML valido** - Sem erros de sintaxe
+- [ ] **Nome segue a convencao** - minusculo-com-hifens
+- [ ] **Descricao e clara** - Diz quando usar
+- [ ] **Exemplos funcionam** - Codigo compila e executa
+- [ ] **Links validos** - Skills relacionadas existem
+- [ ] **Sem dados sensiveis** - Sem chaves de API, tokens, caminhos
+
+### Testando Exemplos de Codigo
+
+```bash
+# Da raiz do repositorio
+npx tsc --noEmit skills/nome-da-sua-skill/examples/*.ts
+
+# Ou de dentro do diretorio da skill
+npx tsc --noEmit examples/*.ts
+
+# Da raiz do repositorio
+python -m py_compile skills/nome-da-sua-skill/examples/*.py
+
+# Ou de dentro do diretorio da skill
+python -m py_compile examples/*.py
+
+# Da raiz do repositorio
+go build ./skills/nome-da-sua-skill/examples/...
+
+# Ou de dentro do diretorio da skill
+go build ./examples/...
+```
+
+---
+
+## Submetendo Sua Skill
+
+### 1. Faca Fork e Clone
+
+```bash
+gh repo fork Fmarzochi/EGC --clone
+cd EGC
+```
+
+### 2. Crie uma Branch
+
+```bash
+git checkout -b feat/skill-nome-da-sua-skill
+```
+
+### 3. Adicione Sua Skill
+
+```bash
+mkdir -p skills/nome-da-sua-skill
+# Crie o SKILL.md
+```
+
+### 4. Valide
+
+```bash
+# Verifique o frontmatter YAML
+head -10 skills/nome-da-sua-skill/SKILL.md
+
+# Verifique a estrutura
+ls -la skills/nome-da-sua-skill/
+
+# Execute os testes se disponiveis
+npm test
+```
+
+### 5. Commit e Push
+
+```bash
+git add skills/nome-da-sua-skill/
+git commit -s -m "feat(skills): adiciona skill nome-da-sua-skill"
+git push -u origin feat/skill-nome-da-sua-skill
+```
+
+### 6. Crie o Pull Request
+
+Use este template de PR:
+
+```markdown
+## Resumo
+
+Descricao breve da skill e por que ela e valiosa.
+
+## Tipo de Skill
+
+- [ ] Padroes de linguagem
+- [ ] Padroes de framework
+- [ ] Fluxo de trabalho
+- [ ] Conhecimento de dominio
+- [ ] Integracao de ferramentas
+
+## Testes
+
+Como testei esta skill localmente.
+
+## Checklist
+
+- [ ] Frontmatter YAML valido
+- [ ] Exemplos de codigo testados
+- [ ] Segue as diretrizes de skills
+- [ ] Sem dados sensiveis
+- [ ] Gatilhos de ativacao claros
+```
+
+---
+
+## Galeria de Exemplos
+
+### Exemplo 1: Padroes de Linguagem
+
+**Arquivo:** `skills/rust-patterns/SKILL.md`
+
+```markdown
+---
+name: rust-patterns
+description: Idiomas Rust, padroes de ownership e boas praticas para codigo seguro e idiomatico.
+origin: egc
+---
+
+# Padroes Rust
+
+## Quando Ativar
+
+- Escrevendo codigo Rust
+- Tratando ownership e borrowing
+- Tratamento de erros com Result/Option
+- Implementando traits
+
+## Padroes de Ownership
+
+### Regras de Borrowing
+
+\`\`\`rust
+// BOM: Empreste quando nao precisar de ownership
+fn process_data(data: &str) -> usize {
+    data.len()
+}
+
+// BOM: Tome ownership quando precisar modificar ou consumir
+fn consume_data(data: Vec<u8>) -> String {
+    String::from_utf8(data).unwrap()
+}
+\`\`\`
+
+## Tratamento de Erros
+
+### Padrao Result
+
+\`\`\`rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Parse error: {0}")]
+    Parse(#[from] std::num::ParseIntError),
+}
+
+pub type AppResult<T> = Result<T, AppError>;
+\`\`\`
+
+## Skills Relacionadas
+
+- `rust-testing`
+- `rust-security`
+```
+
+### Exemplo 2: Padroes de Framework
+
+**Arquivo:** `skills/fastapi-patterns/SKILL.md`
+
+```markdown
+---
+name: fastapi-patterns
+description: Padroes FastAPI para roteamento, injecao de dependencia, validacao e operacoes async.
+origin: egc
+---
+
+# Padroes FastAPI
+
+## Quando Ativar
+
+- Construindo aplicacoes FastAPI
+- Criando endpoints de API
+- Implementando injecao de dependencia
+- Lidando com operacoes async de banco de dados
+
+## Estrutura do Projeto
+
+\`\`\`
+app/
++-- main.py              # Entrypoint da aplicacao FastAPI
++-- routers/             # Handlers de rota
+|   +-- users.py
+|   +-- items.py
++-- models/              # Modelos Pydantic
+|   +-- user.py
+|   +-- item.py
++-- services/            # Logica de negocio
+|   +-- user_service.py
++-- dependencies.py      # Dependencias compartilhadas
+\`\`\`
+
+## Injecao de Dependencia
+
+\`\`\`python
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+async def get_db() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session
+
+@router.get("/users/{user_id}")
+async def get_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_db)
+):
+    pass
+\`\`\`
+
+## Skills Relacionadas
+
+- `python-patterns`
+- `pydantic-validation`
+```
+
+### Exemplo 3: Skill de Fluxo de Trabalho
+
+**Arquivo:** `skills/refactoring-workflow/SKILL.md`
+
+```markdown
+---
+name: refactoring-workflow
+description: Fluxo de trabalho sistematico de refatoracao para melhorar a qualidade do codigo sem alterar o comportamento.
+origin: egc
+---
+
+# Fluxo de Trabalho de Refatoracao
+
+## Quando Ativar
+
+- Melhorando estrutura de codigo
+- Reduzindo divida tecnica
+- Simplificando codigo complexo
+- Extraindo componentes reutilizaveis
+
+## Pre-requisitos
+
+- Todos os testes passando
+- Diretorio de trabalho Git limpo
+- Branch de feature criada
+
+## Etapas do Fluxo de Trabalho
+
+### Etapa 1: Identifique o Alvo da Refatoracao
+
+- Procure code smells (metodos longos, codigo duplicado, classes grandes)
+- Verifique a cobertura de testes para a area alvo
+- Documente o comportamento atual
+
+### Etapa 2: Garanta que Existem Testes
+
+\`\`\`bash
+# Execute os testes para verificar o comportamento atual
+npm test
+
+# Verifique a cobertura para os arquivos alvo
+npm run test:coverage
+\`\`\`
+
+### Etapa 3: Faca Pequenas Mudancas
+
+- Uma refatoracao por vez
+- Execute testes apos cada mudanca
+- Commit frequentemente
+
+### Etapa 4: Verifique que o Comportamento Nao Mudou
+
+\`\`\`bash
+# Execute o suite completo de testes
+npm test
+
+# Execute testes E2E
+npm run test:e2e
+\`\`\`
+
+## Refatoracoes Comuns
+
+| Smell | Refatoracao |
+|-------|-------------|
+| Metodo longo | Extrair metodo |
+| Codigo duplicado | Extrair para funcao compartilhada |
+| Classe grande | Extrair classe |
+| Lista longa de parametros | Introduzir objeto de parametro |
+
+## Checklist
+
+- [ ] Testes existem para o codigo alvo
+- [ ] Fiz mudancas pequenas e focadas
+- [ ] Testes passam apos cada mudanca
+- [ ] Comportamento nao mudou
+- [ ] Commit feito com mensagem clara
+```
+
+---
+
+## Recursos Adicionais
+
+- [CONTRIBUTING.md](../../.github/CONTRIBUTING.md) - Diretrizes gerais de contribuicao
+- [project-guidelines-template](./examples/project-guidelines-template.md) - Template de skill especifica de projeto
+- [coding-standards](../skills/coding-standards/SKILL.md) - Exemplo de skill de padroes
+- [tdd-workflow](../skills/tdd-workflow/SKILL.md) - Exemplo de skill de fluxo de trabalho
+- [security-review](../skills/security-review/SKILL.md) - Exemplo de skill de conhecimento de dominio
+
+---
+
+**Lembre-se**: Uma boa skill e focada, acionavel e imediatamente util. Escreva skills que voce mesmo gostaria de usar.

--- a/translations/pt/docs/guides/TROUBLESHOOTING.md
+++ b/translations/pt/docs/guides/TROUBLESHOOTING.md
@@ -1,0 +1,75 @@
+# Solucao de Problemas
+
+Solucoes de contorno relatadas pela comunidade para bugs atuais do Gemini Code que podem afetar usuarios do egc.
+
+Esses sao comportamentos do Gemini Code upstream, nao bugs do egc. As entradas abaixo resumem as solucoes testadas em producao coletadas na [issue #644](https://github.com/Fmarzochi/EGC-code/issues/644) no Gemini Code `v2.1.79` (macOS, uso intenso de hooks, conectores MCP habilitados). Trate-as como solucoes temporarias pragmaticas ate que as correcoes upstream cheguem.
+
+## Solucoes de Contorno da Comunidade para Bugs Abertos do Gemini Code
+
+### Rotulos falsos de "Hook Error" em hooks que funcionaram com sucesso
+
+**Sintomas:** O hook e executado com sucesso, mas o Gemini Code ainda mostra `Hook Error` no transcript.
+
+**O que ajuda:**
+
+- Consumir stdin no inicio do hook (`input=$(cat)` em hooks shell) para que o processo pai nao veja um pipe nao consumido.
+- Para hooks simples de permitir/bloquear, enviar diagnosticos legiveis por humanos para stderr e manter stdout silencioso, a menos que sua implementacao de hook exija explicitamente stdout estruturado.
+- Redirecionar stderr de processos filhos barulhentos quando nao e acionavel.
+- Usar os codigos de saida corretos: `0` permite, `2` bloqueia, outros valores nao-zero sao tratados como erros.
+
+**Exemplo:**
+
+```bash
+# Bom: bloquear com mensagem no stderr e sair com 2
+input=$(cat)
+echo "[BLOCKED] Motivo aqui" >&2
+exit 2
+```
+
+### Compactacao mais cedo do que o esperado com `gemini_AUTOCOMPACT_PCT_OVERRIDE`
+
+**Sintomas:** Diminuir `gemini_AUTOCOMPACT_PCT_OVERRIDE` faz a compactacao acontecer mais cedo, nao mais tarde.
+
+**O que ajuda:**
+
+- Em algumas versoes atuais do Gemini Code, valores menores podem reduzir o limite de compactacao em vez de extende-lo.
+- Se voce quer mais espaco de trabalho, remova `gemini_AUTOCOMPACT_PCT_OVERRIDE` e prefira `/compact` manual em limites logicos de tarefas.
+- Use o guia `strategic-compact` do egc em vez de forcar um limite menor de auto-compactacao.
+
+### Conectores MCP parecem conectados mas falham apos compactacao
+
+**Sintomas:** Ferramentas MCP do Gmail ou Google Drive falham apos compactacao mesmo que o conector ainda apareca autenticado na UI.
+
+**O que ajuda:**
+
+- Desative e reative o conector afetado apos a compactacao.
+- Se sua versao do Gemini Code suportar, adicione um hook de lembrete `PostCompact` que avisa para verificar a autenticacao do conector apos a compactacao.
+- Trate isso como uma etapa de recuperacao de estado de autenticacao, nao uma correcao permanente.
+
+### Edicoes de hook nao recarregam automaticamente
+
+**Sintomas:** Mudancas nos hooks de `settings.json` nao entram em vigor ate a sessao ser reiniciada.
+
+**O que ajuda:**
+
+- Reinicie a sessao do Gemini Code apos alterar hooks.
+- Usuarios avancados as vezes criam um comando local `/reload` em torno de `kill -HUP $PPID`, mas o egc nao o inclui porque e dependente de shell e nao universalmente confiavel.
+
+### Respostas `529 Overloaded` repetidas
+
+**Sintomas:** O Gemini Code comeca a falhar sob alta pressao de hook/ferramenta/contexto.
+
+**O que ajuda:**
+
+- Reduza a pressao de definicao de ferramentas com `ENABLE_TOOL_SEARCH=auto:5` se sua configuracao suportar.
+- Diminua `MAX_THINKING_TOKENS` para trabalho de rotina.
+- Direcione trabalho de subagente para um modelo mais barato como `gemini_CODE_SUBAGENT_MODEL=haiku` se sua configuracao expoe esse controle.
+- Desabilite servidores MCP nao utilizados por projeto.
+- Compacte manualmente em pontos naturais em vez de esperar pela auto-compactacao.
+
+## Documentacao Relacionada do egc
+
+- [hook-bug-workarounds.md](./hook-bug-workarounds.md) para o checklist resumido de hook/compactacao/recuperacao MCP.
+- [hooks/README.md](../hooks/README.md) para o ciclo de vida documentado de hooks e comportamento de codigos de saida do egc.
+- [token-optimization.md](./token-optimization.md) para configuracoes de custo e gerenciamento de contexto.
+- [issue #644](https://github.com/Fmarzochi/EGC-code/issues/644) para o relatorio original e ambiente testado.

--- a/translations/pt/docs/guides/examples/product-capability-template.md
+++ b/translations/pt/docs/guides/examples/product-capability-template.md
@@ -1,0 +1,84 @@
+# Template de Capacidade de Produto
+
+Use este template quando existe intencao de produto mas as restricoes de implementacao ainda sao implicitas.
+
+O objetivo e criar um contrato de capacidade duravel, nao mais um documento de planejamento vago.
+
+## Capacidade
+
+- **Nome da capacidade:**
+- **Fonte:** PRD / issue / discussao / roadmap / nota do fundador
+- **Ator principal:**
+- **Resultado apos lancamento:**
+- **Sinal de sucesso:**
+
+## Intencao do Produto
+
+Descreva a promessa visivel ao usuario em um curto paragrafo.
+
+## Restricoes
+
+Liste as regras que devem ser verdadeiras antes do inicio da implementacao:
+
+- regras de negocio
+- limites de escopo
+- invariantes
+- restricoes de rollout
+- restricoes de migracao
+- restricoes de compatibilidade retroativa
+- restricoes de billing / autenticacao / conformidade
+
+## Atores e Superficies
+
+- ator(es)
+- superficies de UI
+- superficies de API
+- superficies de automacao / operador
+- superficies de relatorios / dashboard
+
+## Estados e Transicoes
+
+Descreva o ciclo de vida em termos de estados explicitos e transicoes permitidas.
+
+Exemplo:
+
+- `rascunho -> ativo -> pausado -> concluido`
+- `pendente -> aprovado -> provisionado -> revogado`
+
+## Contrato de Interface
+
+- entradas
+- saidas
+- efeitos colaterais necessarios
+- estados de falha
+- tentativas / recuperacao
+- expectativas de idempotencia
+
+## Implicacoes de Dados
+
+- fonte de verdade
+- novas entidades ou campos
+- limites de propriedade
+- expectativas de retencao / exclusao
+
+## Seguranca e Politica
+
+- limites de confianca
+- requisitos de permissao
+- caminhos de abuso
+- requisitos de politica / governanca
+
+## Nao-Objetivos
+
+Liste o que esta capacidade explicitamente nao possui.
+
+## Questoes em Aberto
+
+Capture as decisoes nao resolvidas que bloqueiam a implementacao.
+
+## Entrega
+
+- **Pronto para implementacao?**
+- **Precisa de revisao arquitetural?**
+- **Precisa de esclarecimento de produto?**
+- **Proximo lane egc:** `project-flow-ops` / `tdd-workflow` / `verification-loop` / outro

--- a/translations/pt/docs/guides/examples/project-guidelines-template.md
+++ b/translations/pt/docs/guides/examples/project-guidelines-template.md
@@ -1,0 +1,346 @@
+# Template de Diretrizes de Projeto
+
+Este e um template de skill especifico de projeto que foi anteriormente publicado como uma skill ativa do egc.
+
+Agora vive em `docs/examples/` porque e material de referencia, nao uma skill reutilizavel entre projetos.
+
+Este e um exemplo de skill especifica de projeto. Use como template para seus proprios projetos.
+
+Baseado em uma aplicacao real de producao: [Zenith](https://zenith.chat) - Plataforma de descoberta de clientes com IA.
+
+## Quando Usar
+
+Referencie esta skill quando trabalhar no projeto especifico para o qual foi projetada. Skills de projeto contem:
+- Visao geral da arquitetura
+- Estrutura de arquivos
+- Padroes de codigo
+- Requisitos de teste
+- Fluxo de trabalho de deploy
+
+---
+
+## Visao Geral da Arquitetura
+
+**Stack Tecnologica:**
+- **Frontend**: Next.js 15 (App Router), TypeScript, React
+- **Backend**: FastAPI (Python), modelos Pydantic
+- **Banco de Dados**: Supabase (PostgreSQL)
+- **IA**: API Gemini com chamada de ferramentas e saida estruturada
+- **Deploy**: Google Cloud Run
+- **Testes**: Playwright (E2E), pytest (backend), React Testing Library
+
+**Servicos:**
+```
++---------------------------------------------------------+
+|                         Frontend                        |
+|  Next.js 15 + TypeScript + TailwindCSS                  |
+|  Deploy: Vercel / Cloud Run                             |
++---------------------------------------------------------+
+                              |
+                              v
++---------------------------------------------------------+
+|                         Backend                         |
+|  FastAPI + Python 3.11 + Pydantic                       |
+|  Deploy: Cloud Run                                      |
++---------------------------------------------------------+
+                              |
+              +---------------+---------------+
+              v               v               v
+        +----------+   +----------+   +----------+
+        | Supabase |   |  Gemini  |   |  Redis   |
+        | Database |   |   API    |   |  Cache   |
+        +----------+   +----------+   +----------+
+```
+
+---
+
+## Estrutura de Arquivos
+
+```
+project/
++-- frontend/
+|   +-- src/
+|       +-- app/              # Paginas do app router do Next.js
+|       |   +-- api/          # Rotas de API
+|       |   +-- (auth)/       # Rotas protegidas por autenticacao
+|       |   +-- workspace/    # Workspace principal da aplicacao
+|       +-- components/       # Componentes React
+|       |   +-- ui/           # Componentes base de UI
+|       |   +-- forms/        # Componentes de formulario
+|       |   +-- layouts/      # Componentes de layout
+|       +-- hooks/            # Custom React hooks
+|       +-- lib/              # Utilitarios
+|       +-- types/            # Definicoes TypeScript
+|       +-- config/           # Configuracao
+|
++-- backend/
+|   +-- routers/              # Handlers de rota FastAPI
+|   +-- models.py             # Modelos Pydantic
+|   +-- main.py               # Entrypoint FastAPI
+|   +-- auth_system.py        # Autenticacao
+|   +-- database.py           # Operacoes de banco de dados
+|   +-- services/             # Logica de negocio
+|   +-- tests/                # Testes pytest
+|
++-- deploy/                   # Configuracoes de deploy
++-- docs/                     # Documentacao
++-- scripts/                  # Scripts utilitarios
+```
+
+---
+
+## Padroes de Codigo
+
+### Formato de Resposta de API (FastAPI)
+
+```python
+from pydantic import BaseModel
+from typing import Generic, TypeVar, Optional
+
+T = TypeVar('T')
+
+class ApiResponse(BaseModel, Generic[T]):
+    success: bool
+    data: Optional[T] = None
+    error: Optional[str] = None
+
+    @classmethod
+    def ok(cls, data: T) -> "ApiResponse[T]":
+        return cls(success=True, data=data)
+
+    @classmethod
+    def fail(cls, error: str) -> "ApiResponse[T]":
+        return cls(success=False, error=error)
+```
+
+### Chamadas de API no Frontend (TypeScript)
+
+```typescript
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+async function fetchApi<T>(
+  endpoint: string,
+  options?: RequestInit
+): Promise<ApiResponse<T>> {
+  try {
+    const response = await fetch(`/api${endpoint}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...options?.headers,
+      },
+    })
+
+    if (!response.ok) {
+      return { success: false, error: `HTTP ${response.status}` }
+    }
+
+    return await response.json()
+  } catch (error) {
+    return { success: false, error: String(error) }
+  }
+}
+```
+
+### Integracao com IA Gemini (Saida Estruturada)
+
+```python
+from anthropic import Anthropic
+from pydantic import BaseModel
+
+class AnalysisResult(BaseModel):
+    summary: str
+    key_points: list[str]
+    confidence: float
+
+async def analyze_with_gemini(content: str) -> AnalysisResult:
+    client = Anthropic()
+
+    response = client.messages.create(
+        model="gemini-sonnet-4-5-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": content}],
+        tools=[{
+            "name": "provide_analysis",
+            "description": "Provide structured analysis",
+            "input_schema": AnalysisResult.model_json_schema()
+        }],
+        tool_choice={"type": "tool", "name": "provide_analysis"}
+    )
+
+    tool_use = next(
+        block for block in response.content
+        if block.type == "tool_use"
+    )
+
+    return AnalysisResult(**tool_use.input)
+```
+
+### Custom Hooks (React)
+
+```typescript
+import { useState, useCallback } from 'react'
+
+interface UseApiState<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+}
+
+export function useApi<T>(
+  fetchFn: () => Promise<ApiResponse<T>>
+) {
+  const [state, setState] = useState<UseApiState<T>>({
+    data: null,
+    loading: false,
+    error: null,
+  })
+
+  const execute = useCallback(async () => {
+    setState(prev => ({ ...prev, loading: true, error: null }))
+
+    const result = await fetchFn()
+
+    if (result.success) {
+      setState({ data: result.data!, loading: false, error: null })
+    } else {
+      setState({ data: null, loading: false, error: result.error! })
+    }
+  }, [fetchFn])
+
+  return { ...state, execute }
+}
+```
+
+---
+
+## Requisitos de Teste
+
+### Backend (pytest)
+
+```bash
+# Executar todos os testes
+poetry run pytest tests/
+
+# Executar com cobertura
+poetry run pytest tests/ --cov=. --cov-report=html
+
+# Executar arquivo de teste especifico
+poetry run pytest tests/test_auth.py -v
+```
+
+**Estrutura de teste:**
+```python
+import pytest
+from httpx import AsyncClient
+from main import app
+
+@pytest.fixture
+async def client():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
+
+@pytest.mark.asyncio
+async def test_health_check(client: AsyncClient):
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+```
+
+### Frontend (React Testing Library)
+
+```bash
+# Executar testes
+npm run test
+
+# Executar com cobertura
+npm run test -- --coverage
+
+# Executar testes E2E
+npm run test:e2e
+```
+
+**Estrutura de teste:**
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WorkspacePanel } from './WorkspacePanel'
+
+describe('WorkspacePanel', () => {
+  it('renderiza o workspace corretamente', () => {
+    render(<WorkspacePanel />)
+    expect(screen.getByRole('main')).toBeInTheDocument()
+  })
+
+  it('trata a criacao de sessao', async () => {
+    render(<WorkspacePanel />)
+    fireEvent.click(screen.getByText('Nova Sessao'))
+    expect(await screen.findByText('Sessao criada')).toBeInTheDocument()
+  })
+})
+```
+
+---
+
+## Fluxo de Trabalho de Deploy
+
+### Checklist Pre-Deploy
+
+- [ ] Todos os testes passando localmente
+- [ ] `npm run build` bem-sucedido (frontend)
+- [ ] `poetry run pytest` aprovado (backend)
+- [ ] Nenhum segredo hardcoded
+- [ ] Variaveis de ambiente documentadas
+- [ ] Migracoes de banco de dados prontas
+
+### Comandos de Deploy
+
+```bash
+# Build e deploy do frontend
+cd frontend && npm run build
+gcloud run deploy frontend --source .
+
+# Build e deploy do backend
+cd backend
+gcloud run deploy backend --source .
+```
+
+### Variaveis de Ambiente
+
+```bash
+# Frontend (.env.local)
+NEXT_PUBLIC_API_URL=https://api.example.com
+NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+
+# Backend (.env)
+DATABASE_URL=postgresql://...
+ANTHROPIC_API_KEY=sk-ant-...
+SUPABASE_URL=https://xxx.supabase.co
+SUPABASE_KEY=eyJ...
+```
+
+---
+
+## Regras Criticas
+
+1. **Sem emojis** em codigo, comentarios ou documentacao
+2. **Imutabilidade** - nunca mute objetos ou arrays
+3. **TDD** - escreva testes antes da implementacao
+4. **80% de cobertura** minimo
+5. **Muitos arquivos pequenos** - 200 a 400 linhas tipico, 800 maximo
+6. **Sem console.log** em codigo de producao
+7. **Tratamento adequado de erros** com try/catch
+8. **Validacao de entrada** com Pydantic/Zod
+
+---
+
+## Skills Relacionadas
+
+- `coding-standards.md` - Boas praticas gerais de codificacao
+- `backend-patterns.md` - Padroes de API e banco de dados
+- `frontend-patterns.md` - Padroes React e Next.js
+- `tdd-workflow/` - Metodologia de desenvolvimento orientado a testes

--- a/translations/pt/docs/guides/hook-bug-workarounds.md
+++ b/translations/pt/docs/guides/hook-bug-workarounds.md
@@ -1,0 +1,74 @@
+# Solucoes de Contorno para Bugs de Hook
+
+Solucoes de contorno testadas pela comunidade para bugs atuais do Gemini Code que podem afetar configuracoes pesadas de hooks do egc.
+
+Esta pagina e intencionalmente restrita: coleta as correcoes operacionais de maior sinal da superficie mais ampla de solucao de problemas sem repetir conselhos de configuracao especulativos ou sem suporte. Esses sao comportamentos do Gemini Code upstream, nao bugs do egc.
+
+## Quando Usar Esta Pagina
+
+Use esta pagina quando estiver depurando especificamente:
+
+- rotulos falsos de `Hook Error` em execucoes de hook que funcionaram com sucesso
+- compactacao mais cedo do que o esperado
+- conectores MCP que parecem autenticados mas falham apos compactacao
+- edicoes de hook que nao recarregam automaticamente
+- respostas `529 Overloaded` repetidas sob alta pressao de hook/ferramenta
+
+Para a superficie mais completa de solucao de problemas do egc, use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
+
+## Solucoes de Contorno de Alto Sinal
+
+### Rotulos falsos de `Hook Error`
+
+O que ajuda:
+
+- Consumir stdin no inicio de hooks shell (`input=$(cat)`).
+- Manter stdout silencioso para hooks simples de permitir/bloquear, a menos que seu hook exija explicitamente stdout estruturado.
+- Enviar diagnosticos legiveis por humanos para stderr.
+- Usar os codigos de saida corretos: `0` permite, `2` bloqueia, outros valores nao-zero sao tratados como erros.
+
+```bash
+input=$(cat)
+echo "[BLOCKED] Motivo aqui" >&2
+exit 2
+```
+
+### Compactacao mais cedo do que o esperado
+
+O que ajuda:
+
+- Remova `gemini_AUTOCOMPACT_PCT_OVERRIDE` se diminuir o valor causar compactacao mais cedo em sua versao.
+- Prefira `/compact` manual em limites naturais de tarefas.
+- Use o guia `strategic-compact` do egc em vez de forcar um limite menor.
+
+### Autenticacao MCP parece ativa mas falha apos compactacao
+
+O que ajuda:
+
+- Desative e reative o conector afetado apos a compactacao.
+- Se sua versao do Gemini Code suportar, adicione um hook leve de lembrete `PostCompact` que avisa para verificar a autenticacao do conector.
+- Trate isso como um lembrete de recuperacao, nao uma correcao permanente.
+
+### Edicoes de hook nao recarregam automaticamente
+
+O que ajuda:
+
+- Reinicie a sessao do Gemini Code apos alterar hooks.
+- Usuarios avancados as vezes usam helpers de reload locais em shell, mas o egc nao inclui um porque essas abordagens sao dependentes de shell e plataforma.
+
+### `529 Overloaded` repetido
+
+O que ajuda:
+
+- Reduza a pressao de definicao de ferramentas com `ENABLE_TOOL_SEARCH=auto:5` se sua configuracao suportar.
+- Diminua `MAX_THINKING_TOKENS` para trabalho de rotina.
+- Direcione trabalho de subagente para um modelo mais barato como `gemini_CODE_SUBAGENT_MODEL=haiku` se sua configuracao expoe esse controle.
+- Desabilite servidores MCP nao utilizados por projeto.
+- Compacte manualmente em pontos naturais em vez de esperar pela auto-compactacao.
+
+## Documentacao Relacionada do egc
+
+- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
+- [token-optimization.md](./token-optimization.md)
+- [hooks/README.md](../hooks/README.md)
+- [issue #644](https://github.com/Fmarzochi/EGC-code/issues/644)

--- a/translations/pt/docs/guides/token-optimization.md
+++ b/translations/pt/docs/guides/token-optimization.md
@@ -1,0 +1,151 @@
+# Guia de Otimizacao de Tokens
+
+Configuracoes e habitos praticos para reduzir o consumo de tokens, estender a qualidade da sessao e fazer mais dentro dos limites diarios.
+
+> Veja tambem: `rules/common/performance.md` para estrategia de selecao de modelo, `skills/strategic-compact/` para sugestoes automaticas de compactacao.
+
+---
+
+## Configuracoes Recomendadas
+
+Essas sao as configuracoes padrao recomendadas para a maioria dos usuarios. Usuarios avancados podem ajustar os valores com base em sua carga de trabalho: por exemplo, definindo `MAX_THINKING_TOKENS` menor para tarefas simples ou maior para trabalho arquitetural complexo.
+
+Adicione ao seu `~/.gemini/settings.json`:
+
+```json
+{
+  "model": "sonnet",
+  "env": {
+    "MAX_THINKING_TOKENS": "10000",
+    "gemini_CODE_SUBAGENT_MODEL": "haiku"
+  }
+}
+```
+
+### O que cada configuracao faz
+
+| Configuracao | Padrao | Recomendado | Efeito |
+|--------------|--------|-------------|--------|
+| `model` | gemini-2.5-pro | **sonnet** | Sonnet lida bem com ~80% das tarefas de codificacao. Mude para gemini-2.5-pro com `/model gemini-2.5-pro` para raciocinio complexo. Reducao de custo de ~60%. |
+| `MAX_THINKING_TOKENS` | 31.999 | **10.000** | O pensamento estendido reserva ate 31.999 tokens de saida por requisicao para raciocinio interno. Reduzir isso corta o custo oculto em ~70%. Defina como `0` para desabilitar em tarefas triviais. |
+| `gemini_CODE_SUBAGENT_MODEL` | _(herda principal)_ | **haiku** | Subagentes (ferramenta Task) rodam neste modelo. Haiku e ~80% mais barato e suficiente para exploracao, leitura de arquivos e execucao de testes. |
+
+### Nota da comunidade sobre substituicoes de auto-compactacao
+
+Algumas versoes recentes do Gemini Code tem relatos da comunidade de que `gemini_AUTOCOMPACT_PCT_OVERRIDE` pode somente diminuir o limite de compactacao, o que significa que valores abaixo do padrao podem compactar mais cedo em vez de mais tarde. Se isso acontecer na sua configuracao, remova a substituicao e confie no `/compact` manual mais o guia `strategic-compact` do egc. Veja [Solucao de Problemas](./TROUBLESHOOTING.md).
+
+### Alternando pensamento estendido
+
+- **Alt+T** (Windows/Linux) ou **Option+T** (macOS): alternar ligado/desligado
+- **Ctrl+O**: ver saida de pensamento (modo verbose)
+
+---
+
+## Selecao de Modelo
+
+Use o modelo certo para a tarefa:
+
+| Modelo | Melhor para | Custo |
+|--------|-------------|-------|
+| **Haiku** | Exploracao com subagente, leitura de arquivos, buscas simples | Menor |
+| **Sonnet** | Codificacao diaria, revisoes, escrita de testes, implementacao | Medio |
+| **gemini-2.5-pro** | Arquitetura complexa, raciocinio em multiplos passos, depuracao de problemas sutis | Maior |
+
+Mude de modelo durante a sessao:
+
+```
+/model sonnet     # padrao para a maioria dos trabalhos
+/model gemini-2.5-pro       # raciocinio complexo
+/model haiku      # buscas rapidas
+```
+
+---
+
+## Gerenciamento de Contexto
+
+### Comandos
+
+| Comando | Quando usar |
+|---------|-------------|
+| `/clear` | Entre tarefas nao relacionadas. Contexto antigo desperdicao tokens em cada mensagem subsequente. |
+| `/compact` | Em pontos logicos de tarefa (apos planejamento, apos depuracao, antes de mudar de foco). |
+| `/cost` | Verificar gasto de tokens para a sessao atual. |
+
+### Compactacao estrategica
+
+A skill `strategic-compact` (em `skills/strategic-compact/`) sugere `/compact` em intervalos logicos em vez de depender da auto-compactacao, que pode disparar no meio de uma tarefa. Veja o README da skill para instrucoes de configuracao de hook.
+
+**Quando compactar:**
+- Apos exploracao, antes de implementacao
+- Apos concluir um marco
+- Apos depuracao, antes de continuar com novo trabalho
+- Antes de uma mudanca importante de contexto
+
+**Quando NAO compactar:**
+- No meio de implementacao de mudancas relacionadas
+- Enquanto depura um problema ativo
+- Durante refatoracao de multiplos arquivos
+
+### Subagentes protegem seu contexto
+
+Use subagentes (ferramenta Task) para exploracao em vez de ler muitos arquivos na sua sessao principal. O subagente le 20 arquivos mas retorna apenas um resumo: seu contexto principal fica limpo.
+
+---
+
+## Comprimindo Observacoes
+
+O EGC registra eventos brutos de hook (chamadas de ferramentas, edicoes de arquivos, erros) no banco de dados do state-store. Com o tempo, eles se acumulam. A ferramenta MCP `compress_observations` os processa em resumos tipados:
+
+```
+compress_observations({ limit: 50 })
+```
+
+Isso substitui registros brutos verbosos por entradas compactas como `tool_failure`, `tool_success` e `file_edit`, reduzindo drasticamente o custo de tokens de injetar historico em uma nova sessao. Execute-a em pontos logicos de sessao ou quando a contagem de observacoes crescer muito.
+
+---
+
+## Gerenciamento de Servidores MCP
+
+Cada servidor MCP habilitado adiciona definicoes de ferramentas a sua janela de contexto. O README avisa: **mantenha abaixo de 10 habilitados por projeto**.
+
+Dicas:
+- Execute `/mcp` para ver servidores ativos e seu custo de contexto
+- Use `/mcp` para desabilitar servidores MCP do Gemini Code quando quiser uma mudanca ao vivo. O Gemini Code persiste essas desativacoes de runtime em `~/.gemini.json`.
+- Prefira ferramentas CLI quando disponiveis (`gh` em vez de GitHub MCP, `aws` em vez de AWS MCP)
+- Nao confie em `.gemini/settings.json` ou `.gemini/settings.local.json` para desabilitar servidores MCP do Gemini Code ja carregados; use `/mcp` para isso.
+- `EGC_DISABLED_MCPS` afeta apenas a saida de configuracao MCP gerada pelo EGC durante fluxos de instalacao/sincronizacao. Nao e uma alternancia ao vivo do Gemini Code.
+- O servidor MCP `memory` e configurado por padrao mas nao e usado por nenhuma skill, agente ou hook: considere desabilitá-lo.
+
+---
+
+## Aviso de Custo de Equipes de Agentes
+
+[Equipes de Agentes](https://code.gemini.com/docs/en/agent-teams) (experimental) cria multiplas janelas de contexto independentes. Cada membro consome tokens separadamente.
+
+- Use apenas para tarefas onde o paralelismo agrega valor claro (trabalho em multiplos modulos, revisoes paralelas)
+- Para tarefas sequenciais simples, subagentes (ferramenta Task) sao mais eficientes em tokens
+- Habilite com: `gemini_CODE_EXPERIMENTAL_AGENT_TEAMS=1` nas configuracoes
+
+---
+
+## Futuro: Integracao configure-egc
+
+O assistente de instalacao `configure-egc` poderia oferecer a configuracao dessas variaveis de ambiente durante a configuracao, com explicacoes das trocas de custo. Isso ajudaria novos usuarios a otimizar desde o primeiro dia em vez de descobrir essas configuracoes apos atingir limites.
+
+---
+
+## Referencia Rapida
+
+```bash
+# Fluxo de trabalho diario
+/model sonnet              # Comece aqui
+/model gemini-2.5-pro      # Somente para raciocinio complexo
+/clear                     # Entre tarefas nao relacionadas
+/compact                   # Em pontos logicos
+/cost                      # Verificar gasto
+
+# Variaveis de ambiente (adicionar ao bloco "env" de ~/.gemini/settings.json)
+MAX_THINKING_TOKENS=10000
+gemini_CODE_SUBAGENT_MODEL=haiku
+gemini_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+```

--- a/translations/pt/docs/installation.md
+++ b/translations/pt/docs/installation.md
@@ -1,0 +1,80 @@
+# Guia de Instalacao
+
+## Via npm (recomendado)
+
+Requer [Node.js 20 ou superior](https://nodejs.org/en/download).
+
+```bash
+npm install -g @egchq/egc
+egc install
+```
+
+So isso. O instalador detecta quais ferramentas de IA voce tem instaladas e configura todas automaticamente.
+
+---
+
+## Linux / macOS (pelo codigo-fonte)
+
+Nao sabe se tem o Node.js 20? Execute `node --version`. Se mostrar 20 ou superior, voce esta pronto.
+
+```bash
+git clone https://github.com/Fmarzochi/EGC.git
+cd EGC
+sh install.sh
+```
+
+### O que o instalador faz
+
+1. Compila os servidores MCP (`egc-guardian`, `egc-memory`)
+2. Inicializa o banco de dados SQLite local
+3. Executa o bootstrap cognitivo: escreve o protocolo de memoria em `~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md` e arquivos equivalentes para cada ferramenta detectada
+4. Registra ambos os servidores MCP no arquivo de configuracao de cada ferramenta detectada
+5. Pergunta interativamente se deve instalar a biblioteca de prompts (63 agentes, 229 skills, 76 comandos): pulado automaticamente no CI
+
+### Exemplo de saida
+
+```
+EGC install
+  node v22.0.0
+  building egc-guardian...
+  building egc-memory...
+  initializing database...
+  bootstrapping cognitive protocol...
+  ✓ ~/.claude/CLAUDE.md updated
+  ✓ ~/.gemini/GEMINI.md updated
+  registering MCP servers...
+  ✓ registered in Antigravity CLI
+  ✓ registered in Claude Code (global)
+  ✓ registered in Cursor
+
+Install prompt library? (63 agents, 229 skills, 76 commands) [y/N]:
+
+Installation complete.
+Run 'egc doctor' to verify.
+```
+
+---
+
+## Windows
+
+```powershell
+git clone https://github.com/Fmarzochi/EGC.git
+cd EGC
+.\install.ps1
+```
+
+---
+
+## Verificar a instalacao
+
+```bash
+egc doctor
+```
+
+Verifica que ambos os servidores MCP estao compilados, registrados e alcancaveis em cada ferramenta detectada.
+
+---
+
+## Solucao de problemas
+
+Consulte [TROUBLESHOOTING.md](TROUBLESHOOTING.md) para problemas comuns, incluindo erros de permissao, incompatibilidades de versao do Node.js e etapas de registro manual do MCP.

--- a/translations/pt/docs/installation/HERMES-SETUP.md
+++ b/translations/pt/docs/installation/HERMES-SETUP.md
@@ -1,0 +1,125 @@
+# Configuracao Hermes x egc
+
+Hermes e o shell operacional. egc e a base reutilizavel por tras dele.
+
+Este guia e a versao publica e sanitizada da stack do Hermes usada para executar conteudo, alcance, pesquisa, operacoes de vendas, verificacoes financeiras e fluxos de trabalho de engenharia a partir de uma interface nativa de terminal.
+
+## O que e Publicado Publicamente
+
+- Skills, agentes, comandos, hooks e configuracoes MCP do egc deste repositorio
+- Skills de fluxo de trabalho geradas pelo Hermes que sao estaveis o suficiente para reutilizacao
+- Uma topologia de operador documentada para chat, crons, memoria de workspace e fluxos de distribuicao
+- Material de lancamento para compartilhar a stack publicamente
+
+Este guia nao inclui segredos privados, tokens ativos, dados pessoais nem uma exportacao bruta de `~/.hermes`.
+
+## Arquitetura
+
+Use o Hermes como porta de entrada e o egc como substrato de fluxo de trabalho reutilizavel.
+
+```text
+Telegram / CLI / TUI
+        ↓
+      Hermes
+        ↓
+ egc skills + hooks + MCPs + pacotes de fluxo de trabalho gerados
+        ↓
+ Google Drive / GitHub / automacao de navegador / APIs de pesquisa / ferramentas de midia / ferramentas financeiras
+```
+
+## Mapa Publico de Workspace
+
+Use isso como a superficie minima para reproduzir a configuracao sem vazar estado privado.
+
+- `~/.hermes/config.yaml`
+  - roteamento de modelos
+  - registro de servidores MCP
+  - carregamento de plugins
+- `~/.hermes/skills/egc-imports/`
+  - skills do egc copiadas para uso nativo no Hermes
+- `skills/hermes-generated/`
+  - padroes de operador destilados de sessoes repetidas do Hermes
+- `~/.hermes/plugins/`
+  - plugins de bridge para hooks, lembretes e cola de ferramentas especificas de fluxo de trabalho
+- `~/.hermes/cron/jobs.json`
+  - execucoes de automacao agendadas com prompts e canais explicitos
+- `~/.hermes/workspace/`
+  - artefatos de negocios, ops, saude, conteudo e memoria
+
+## Stack de Capacidades Recomendado
+
+### Core
+
+- Hermes para chat, cron, orquestracao e estado de workspace
+- egc para skills, regras, prompts e convencoes entre harnesses
+- GitHub + Context7 + Exa + Firecrawl + Playwright como a camada MCP base
+
+### Conteudo
+
+- FFmpeg para edicao e montagem local
+- Remotion para clipes programaveis
+- fal.ai para geracao de imagem/video
+- ElevenLabs para voz, limpeza e empacotamento de audio
+- CapCut ou VectCutAPI para polimento final para redes sociais
+
+### Operacoes de Negocios
+
+- Google Drive como sistema de registro para docs, planilhas, apresentacoes e dumps de pesquisa
+- Stripe para operacoes de receita e pagamento
+- GitHub para execucao de engenharia
+- Canais estilo Telegram e iMessage para notificacoes urgentes e aprovacoes
+
+## O que ainda Requer Autenticacao Local
+
+Esses ficam locais e devem ser configurados por operador:
+
+- Token OAuth do Google para Drive / Docs / Sheets / Slides
+- Credenciais de distribuicao X / LinkedIn / outbound
+- Chaves Stripe
+- Credenciais de automacao de navegador e configuracoes de stealth/proxy
+- Quaisquer credenciais de CRM ou sistema de projeto como Linear ou Apollo
+- Caminho de exportacao ou ingestao do Apple Health se as automacoes de saude estiverem habilitadas
+
+## Ordem de Inicializacao Sugerida
+
+0. Execute `egc migrate audit --source ~/.hermes` primeiro para inventariar o workspace legado e ver quais partes ja se mapeiam no egc.
+0.5. Planeje e construa artefatos de migracao antes de importar qualquer coisa:
+   - gere planos revisaveis com `egc migrate plan` e `egc migrate scaffold`
+   - construa skills legadas reutilizaveis com `egc migrate import-skills --output-dir migration-artifacts/skills`
+   - construa templates de traducao de ferramentas com `egc migrate import-tools --output-dir migration-artifacts/tools`
+   - construa templates de plugins de bridge com `egc migrate import-plugins --output-dir migration-artifacts/plugins`
+   - visualize jobs recorrentes com `egc migrate import-schedules --dry-run`
+   - visualize despacho de gateway com `egc migrate import-remote --dry-run`
+   - visualize contexto seguro de env/servico com `egc migrate import-env --dry-run`
+   - importe memoria de workspace sanitizada com `egc migrate import-memory`
+1. Instale o egc e verifique a configuracao base do harness com `node tests/run-all.js`; o resultado esperado e um resumo de testes sem falhas.
+2. Instale o Hermes e aponte para skills importadas do egc.
+3. Registre os servidores MCP que voce realmente usa todos os dias.
+4. Autentique o Google Drive primeiro, depois o GitHub, depois os canais de distribuicao.
+5. Comece com uma superficie de cron pequena: verificacao de prontidao, responsabilidade de conteudo, triagem de inbox, monitor de receita.
+6. Somente entao adicione fluxos de trabalho pessoais mais pesados como saude, grafos de relacionamento ou sequenciamento de outbound.
+
+## Documentacao Relacionada
+
+- [Guia de migracao Hermes/OpenClaw](HERMES-OPENCLAW-MIGRATION.md)
+- [Arquitetura entre harnesses](architecture/cross-harness.md)
+
+## Por que Hermes x egc
+
+Esta stack e util quando voce quer:
+
+- um lugar nativo de terminal para executar operacoes de negocios e engenharia
+- skills reutilizaveis em vez de prompts avulsos
+- automacao que pode notificar, auditar e escalar
+- um repositorio publico que mostra a forma do sistema sem expor seu estado privado de operador
+
+## Escopo do Release Candidate Publico
+
+O EGC v1.0.0 documenta a superficie do Hermes e publica material de lancamento agora.
+
+As pecas privadas restantes podem ser adicionadas depois:
+
+- templates sanitizados adicionais
+- exemplos publicos mais ricos
+- mais pacotes de fluxo de trabalho gerados
+- integracoes mais estreitas com CRM e Google Workspace

--- a/translations/pt/docs/security/RELEASE-VERIFICATION.md
+++ b/translations/pt/docs/security/RELEASE-VERIFICATION.md
@@ -1,0 +1,46 @@
+# Verificacao de Release
+
+Cada release do EGC e publicado com atestados de proveniencia de build que permitem verificar a integridade e autenticidade dos ativos do release.
+
+## Verificando a Proveniencia do Pacote npm
+
+O EGC e publicado no npm com `--provenance`, o que gera um atestado de proveniencia assinado vinculado ao workflow do GitHub Actions que o construiu.
+
+Para verificar:
+
+```bash
+npm audit signatures egc-universal
+```
+
+Saida esperada:
+
+```
+audited 1 package in Xs
+1 package has a verified registry signature
+1 package has a verified attestation
+```
+
+## Verificando os Ativos do GitHub Release
+
+A proveniencia de build para tarballs de release e atestada via [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+
+Para verificar um tarball de release:
+
+```bash
+gh attestation verify egc-universal-<version>.tgz \
+  --owner Fmarzochi \
+  --repo EGC
+```
+
+A saida esperada confirma que o artefato foi produzido pelo workflow `release.yml` no repositorio `Fmarzochi/EGC`.
+
+## O Que e Atestado
+
+| Ativo | Tipo de Atestado |
+|-------|-----------------|
+| tarball npm (`egc-universal-*.tgz`) | Proveniencia de build (SLSA Nivel 2) |
+| pacote npm (publicado) | proveniencia npm (flag `--provenance`) |
+
+## Verificacao Criptografica
+
+Todos os atestados usam a infraestrutura de assinatura sem chave do Sigstore. Nenhum gerenciamento manual de chaves e necessario. A verificacao usa o log de transparencia publico do Sigstore (Rekor) para confirmar que a assinatura foi criada durante a execucao do CI no momento do release.

--- a/translations/pt/docs/security/SCA-POLICY.md
+++ b/translations/pt/docs/security/SCA-POLICY.md
@@ -1,0 +1,47 @@
+# Politica de Analise de Composicao de Software (SCA)
+
+## Finalidade
+
+Esta politica define como o EGC identifica, rastreia e remedia vulnerabilidades e problemas de licenca em suas dependencias.
+
+## Ferramentas
+
+| Ferramenta | Funcao |
+|------|----------|
+| Dependabot | Alertas automatizados e PRs para vulnerabilidades de dependencias |
+| `dependency-review.yml` | Bloqueia PRs que introduzem dependencias de severidade alta ou critica |
+| `npm audit` | Executado no CI em cada push; falha em achados de alta/critica severidade |
+
+## Limites de Remediacao de Vulnerabilidades
+
+| Severidade | Tempo Maximo para Remediar |
+|----------|--------------------------|
+| Critica | 7 dias |
+| Alta | 14 dias |
+| Moderada | 90 dias |
+| Baixa / Info | Melhor esforco; tratado em atualizacoes agendadas de dependencias |
+
+## Gate de Release
+
+Nenhum release pode prosseguir se `npm audit` relatar qualquer vulnerabilidade `alta` ou `critica` na arvore de dependencias. O workflow de CI de release aplica essa verificacao automaticamente.
+
+PRs que introduzem novas dependencias com vulnerabilidades conhecidas sao automaticamente bloqueados por `dependency-review.yml` antes de poderem ser mergeados.
+
+## Politica de Licencas
+
+As dependencias devem usar licencas compativeis com MIT (a licenca do projeto). As seguintes familias de licencas sao aceitaveis:
+
+- MIT, ISC, BSD-2-Clause, BSD-3-Clause, Apache-2.0, CC0-1.0, 0BSD
+
+Licencas que exigem propagacao de copyleft (GPL, LGPL, AGPL) nao sao permitidas sem aprovacao explicita do mantenedor.
+
+## Politica de SAST (Teste de Seguranca de Analise Estatica)
+
+| Ferramenta | Escopo | Limite de Falha |
+|------|-------|------------------|
+| CodeQL | Consultas de seguranca JavaScript/TypeScript | Qualquer achado de alta/critica bloqueia o merge |
+| ESLint | Qualidade de codigo e regras adjacentes a seguranca | Qualquer erro bloqueia o merge |
+
+## Conformidade
+
+Todas as mudancas na base de codigo sao automaticamente avaliadas pelas verificacoes de SCA listadas acima. PRs nao podem ser mergeados se a verificacao `dependency-review` falhar.

--- a/translations/pt/docs/security/SECURITY-ASSESSMENT.md
+++ b/translations/pt/docs/security/SECURITY-ASSESSMENT.md
@@ -1,0 +1,54 @@
+# Avaliacao de Seguranca: Extended Global Context (EGC)
+
+## Escopo
+
+Esta avaliacao cobre o runtime do EGC e seus componentes primarios:
+
+- Servidores MCP: `egc-guardian`, `egc-memory`
+- Scripts de instalacao: `install.sh`, `install.ps1`
+- Scripts de hook: `scripts/hooks/`
+- Pontos de entrada CLI: `scripts/egc.js`, `scripts/egc-doctor.js`
+
+## Limites de Confianca
+
+| Limite | Descricao |
+|----------|-------------|
+| Sistema de arquivos local | O EGC le e grava arquivos de estado em `~/.egc/`. Acesso e apenas do usuario local. |
+| Sockets da ferramenta de IA | Servidores MCP se comunicam com ferramentas de IA via stdio ou sockets nomeados. Sem exposicao de rede. |
+| Dependencias externas | Pacotes npm. Fixados via `package-lock.json`, auditados via Dependabot. |
+| GitHub Actions | CI/CD executa em sandboxes efemeras com permissoes minimas. |
+
+## Identificacao de Ameacas
+
+### Alta Probabilidade / Alto Impacto
+
+| Ameaca | Mitigacao |
+|--------|-----------|
+| Cadeia de suprimentos de dependencia maliciosa | Dependencias fixadas via package-lock.json; alertas Dependabot; npm audit no CI |
+| Injecao de comando via entradas MCP | `egc-guardian` valida todas as chamadas de ferramentas via `validate_command` antes da execucao |
+| Vazamento de credenciais em logs de sessao | Sanitizacao do transcript da sessao remove variaveis de ambiente sensiveis da saida de log |
+
+### Media Probabilidade / Medio Impacto
+
+| Ameaca | Mitigacao |
+|--------|-----------|
+| Acesso nao autorizado ao sistema de arquivos | Servidor MCP executa no contexto do usuario; sem escalonamento de privilegios |
+| Adulteracao de arquivo de estado | Arquivos de estado em `~/.egc/` sao texto simples; sem dados sensiveis de seguranca armazenados |
+| Injecao de prompt via transcript | Ferramenta de IA e responsavel pelo tratamento de prompts; EGC fornece apenas dados brutos de sessao |
+
+### Baixa Probabilidade
+
+| Ameaca | Mitigacao |
+|--------|-----------|
+| Negacao de servico via transcript grande | Limite de 1MB de stdin em hooks de sessao |
+| JSON malformado causando falha em hook | Try/catch em todos os parsers JSONL; saida graciosamente em caso de erro |
+
+## Limitacoes Conhecidas
+
+- O EGC e uma ferramenta apenas local; nao tem componente de servidor, autenticacao ou servicos de rede.
+- A postura de seguranca depende da seguranca da maquina host e das integracoes de ferramentas de IA.
+- Injecao de prompt de conteudo externo e uma preocupacao do nivel da ferramenta de IA, nao enderecavel na camada do EGC.
+
+## Data da Avaliacao
+
+2026-06-04

--- a/translations/pt/docs/security/THREAT-MODEL.md
+++ b/translations/pt/docs/security/THREAT-MODEL.md
@@ -1,0 +1,77 @@
+# Modelo de Ameaca: Extended Global Context (EGC)
+
+## Visao Geral do Sistema
+
+O EGC e um runtime de memoria e orquestracao de IA local. Nao tem servicos de rede, superficie de autenticacao nem modelo de acesso multiusuario. A superficie de ataque e limitada a:
+
+1. O pacote npm e suas dependencias
+2. Os servidores MCP executando como processos stdio locais
+3. O pipeline de CI/CD do GitHub Actions
+4. Hooks de sessao que processam dados de transcript
+
+## Atores
+
+| Ator | Nivel de Confianca | Descricao |
+|-------|-------------|-------------|
+| Usuario local | Totalmente confiavel | Executa o EGC em sua propria maquina |
+| Contribuidor | Parcialmente confiavel | Envia PRs; nao pode fazer merge sem revisao |
+| Autor de dependencia | Nao confiavel | Pacotes npm de terceiros |
+| Ferramenta de IA (Claude Code, etc.) | Confiavel em runtime | Chama ferramentas MCP; executa no mesmo contexto de usuario |
+| Runner do GitHub Actions | Confiavel | Ambiente sandbox efemero |
+| Autor de PR (fork) | Nao confiavel | Codigo de forks nao acessa segredos |
+
+## Superficies de Ataque e Mitigacoes
+
+### 1. Injecao de Dependencia / Cadeia de Suprimentos
+
+**Ameaca:** Um pacote npm malicioso ou comprometido e introduzido.
+
+**Mitigacoes:**
+- Todas as dependencias sao bloqueadas via `package-lock.json`
+- Dependabot monitora alertas de vulnerabilidade
+- `dependency-review.yml` bloqueia PRs que introduzem dependencias de alta severidade
+- CI executa `npm audit` em cada push
+
+### 2. Injecao de Comando via Entradas MCP
+
+**Ameaca:** Uma chamada MCP gerada por IA maliciosa tenta executar comandos shell arbitrarios.
+
+**Mitigacoes:**
+- `egc-guardian` valida todas as chamadas de ferramentas antes da execucao via `validate_command`
+- Comandos shell sao construidos a partir de padroes autorizados, nao interpolacao de string bruta
+
+### 3. Vazamento de Credenciais em Logs
+
+**Ameaca:** Valores sensiveis (chaves de API, tokens de sessao) aparecem em arquivos de transcript de sessao.
+
+**Mitigacoes:**
+- Hook de sessao sanitiza o conteudo do transcript antes de gravar no disco
+- Arquivos de estado em `~/.egc/state/` contem apenas metadados estruturados, nao transcritos brutos
+
+### 4. Comprometimento do Pipeline CI/CD
+
+**Ameaca:** Um PR malicioso aciona um workflow que acessa segredos ou modifica o release.
+
+**Mitigacoes:**
+- Eventos `pull_request` de forks nao tem acesso aos segredos do repositorio
+- `pull_request_target` nao e usado em nenhum workflow
+- Workflows usam permissoes minimas por padrao
+- Workflow de release so dispara em tags de versao enviadas pelo mantenedor
+- Todas as acoes de terceiros sao fixadas em SHAs especificos de commit
+
+## Caminhos de Codigo Criticos
+
+| Caminho | Risco | Protecao |
+|------|------|-----------|
+| `scripts/egc-guardian/src/validate_command.ts` | Alto: controla toda execucao shell | Revisado em cada mudanca |
+| `install.sh` / `install.ps1` | Medio: modifica configuracoes globais de ferramentas de IA | Verificado no CI em Linux, macOS, Windows |
+| `scripts/hooks/session-end.js` | Medio: le transcript, grava no disco | Stdin limitado (1MB); tratamento estruturado de erros |
+| `mcp/servers/egc-memory/` | Baixo: apenas le/grava arquivos de estado | Sem execucao shell; E/S de arquivo puro |
+
+## Risco Residual
+
+O EGC e uma ferramenta de desenvolvedor que executa com permissoes totais do usuario local por design. Uma maquina host comprometida, ferramenta de IA comprometida ou pacote npm comprometido poderia afetar o EGC. Esses riscos estao fora do controle do EGC e sao mitigados pelo ambiente host.
+
+## Data de Revisao
+
+2026-06-04: Felipe Marzochi

--- a/translations/pt/docs/security/vex/README.md
+++ b/translations/pt/docs/security/vex/README.md
@@ -1,0 +1,18 @@
+# Documentos VEX
+
+Este diretorio contem documentos de Vulnerability Exploitability eXchange (VEX) para o EGC.
+
+Documentos VEX comunicam o status de explorabilidade de vulnerabilidades conhecidas em dependencias que estao presentes na arvore de dependencias, mas nao sao exploraves no contexto de uso do EGC.
+
+## Status Atual
+
+`npm audit` nao relata vulnerabilidades conhecidas na arvore de dependencias do EGC em 2026-06-04.
+
+Quando vulnerabilidades forem relatadas no futuro que nao afetam o EGC:
+1. Um documento VEX sera criado no formato OpenVEX (`*.openvex.json`)
+2. O documento incluira o identificador CVE, o pacote afetado e a justificativa de nao explorabilidade
+3. O documento sera atualizado quando a vulnerabilidade upstream for resolvida ou quando a avaliacao mudar
+
+## Formato
+
+Os documentos VEX seguem a [especificacao OpenVEX](https://github.com/openvex/spec).

--- a/translations/pt/docs/spec/README.md
+++ b/translations/pt/docs/spec/README.md
@@ -1,0 +1,53 @@
+# Especificacao do EGC
+
+A especificacao do EGC e executavel. Ela vive em JSON Schemas em `schemas/`, em manifestos de instalacao em `scripts/lib/`, e em testes em `tests/spec/`. Este documento e o indice que os une.
+
+## Versao da spec
+
+`SPEC_VERSION = 0.1.0` (declarado em `agent.yaml`)
+
+Semver se aplica: `MAJOR.MINOR.PATCH`.
+
+- `PATCH`: Documentacao, correcao de digitacao, mudancas sem impacto no contrato
+- `MINOR`: Mudancas aditivas nos schemas (novos campos opcionais, novos tiers opcionais)
+- `MAJOR`: Campos removidos, identificadores renomeados, semantica alterada, novos campos obrigatorios
+
+Uma janela de deprecacao de 90 dias se aplica para mudancas `MAJOR` que quebram compatibilidade em superficies publicas (alvos de instalacao, nomes de ferramentas MCP, nomes de eventos de hook).
+
+## O que a spec cobre
+
+| Superficie | Especificado por | Validado por |
+|---------|--------------|--------------|
+| Tiers de integracao | [`integration-tiers.md`](./integration-tiers.md) | `tests/spec/integration-tiers.test.js` |
+| Contrato de hooks | `schemas/hooks.schema.json` | `tests/hooks/hooks.test.js` |
+| Manifesto de plugin | `schemas/plugin.schema.json` | `tests/plugin-manifest.test.js` |
+| Mapa de runtime | `schemas/runtime-map.schema.json` | `tests/test_orchestrator.py` |
+| Perfis de instalacao | `schemas/install-profiles.schema.json` | `tests/lib/install-manifests.test.js` |
+| Modulos de instalacao | `schemas/install-modules.schema.json` | `tests/scripts/doctor.test.js` |
+| Componentes de instalacao | `schemas/install-components.schema.json` | `tests/lib/install-manifests.test.js` |
+| Deteccao de gerenciador de pacotes | `schemas/package-manager.schema.json` | `tests/scripts/auto-update.test.js` |
+| Metadados de proveniencia | `schemas/provenance.schema.json` | `tests/lib/skill-dashboard.test.js` |
+| Armazenamento de estado | `schemas/state-store.schema.json` | `tests/lib/state-store.test.js` |
+| Configuracao de instalacao EGC | `schemas/egc-install-config.schema.json` | `tests/lib/install-targets.test.js` |
+| Estado de instalacao | `schemas/install-state.schema.json` | lacuna: sem teste dedicado (validado indiretamente via fluxo install-apply) |
+| Registro de agentes | `schemas/agents-registry.schema.json` | lacuna: sem validador dedicado |
+| Registro de skills | `schemas/skills-registry.schema.json` | lacuna: sem validador dedicado |
+
+## Pontos de entrada por audiencia
+
+**Adicionando um novo harness?** Leia [`integration-tiers.md`](./integration-tiers.md).
+
+**Implementando um hook personalizado?** Leia `schemas/hooks.schema.json` e `tests/hooks/hooks.test.js` para exemplos funcionais.
+
+**Auditando seu fork?** Execute `node scripts/harness-audit.js`.
+
+**Migrando entre versoes MAJOR?** Leia o changelog mais o ADR relevante em `docs/decisions/` (planejado).
+
+## O que NAO esta especificado ainda
+
+Esta secao e deliberadamente publica. Rastrear lacunas honestamente e melhor que omissoes aspiracionais.
+
+- **Schema de contrato de harness**: `harness-contract.schema.json` ainda nao existe. O contrato e implicito em `install-apply.js`. Este e o proximo passo de maturacao.
+- **Testes de conformidade por harness**: `tests/spec/{target}.smoke.test.js` ainda nao existe.
+- **ADRs**: `docs/decisions/` ainda nao existe. Cerca de 5-7 ADRs retroativos sao necessarios para decisoes ja tomadas.
+- **HARNESS-{target}.md por alvo Tier 1/2**: resumo de uma pagina por alvo com mantenedor, exemplo de instalacao e casos extremos conhecidos.

--- a/translations/pt/docs/spec/integration-tiers.md
+++ b/translations/pt/docs/spec/integration-tiers.md
@@ -1,0 +1,78 @@
+# Niveis de Integracao do EGC
+
+> O mapa honesto de como cada ferramenta de IA suportada se integra com o EGC.
+
+O EGC suporta 13 ferramentas de IA por meio de 3 mecanismos de integracao distintos. Este documento e a fonte de verdade sobre o que esta e nao esta integrado, e em qual profundidade.
+
+## Definicoes de Nivel
+
+| Nivel | Nome | O que e publicado | Pipeline de instalacao |
+|-------|------|-------------------|------------------------|
+| **1** | Unificado completo | Skills, agentes, regras, hooks, MCP, manifesto de instalacao | `scripts/install-apply.js` via `SUPPORTED_INSTALL_TARGETS` |
+| **2** | Script customizado | Ativos especificos da ferramenta via instalador dedicado | `.{ferramenta}/install.sh` chamado por `install.sh` |
+| **3** | Somente protocolo | Registro do servidor MCP + injecao de protocolo de memoria | `scripts/bootstrap-cognitive.js` + registro MCP em `install.sh` |
+
+## Os 13 Harnesses
+
+| # | Ferramenta | Nivel | Target id | Caminho de instalacao | Notas |
+|---|------------|-------|-----------|----------------------|-------|
+| 1 | **Claude Code** | 1 | `claude` | `~/.claude/skills/<nome>/SKILL.md` | Skills instaladas de forma plana; MCP + bootstrap cognitivo via `~/.claude/CLAUDE.md` |
+| 2 | **Antigravity (AGY)** | 1 | `antigravity` | `~/.gemini/` (compartilhado com Gemini CLI) | Reutiliza GEMINI.md do Gemini CLI |
+| 3 | **Gemini CLI** | 1 | `gemini` | `~/.gemini/` | Bootstrap cognitivo em `GEMINI.md` |
+| 4 | **Cursor** | 1 | `cursor` | `~/.cursor/` | Regras injetadas no cursor.rules global |
+| 5 | **Codex CLI** | 1 | `codex` | `~/.agents/skills/<nome>/SKILL.md` | Skills instaladas de forma plana; `persistent_instructions` adicionado |
+| 6 | **OpenCode** | 1 | `opencode` | `~/.config/opencode/skills/<nome>/SKILL.md` | Eventos de plugin nativos para hooks |
+| 7 | **CodeBuddy** | 1 | `codebuddy` | `.codebuddy/skills/<nome>/SKILL.md` | Injecao de contexto |
+| 8 | **Windsurf** | 1 | `windsurf` | `~/.codeium/windsurf/skills/<nome>/SKILL.md` | Skills instaladas de forma plana |
+| 9 | **Amp** | 1 | `amp` | `~/.amp/skills/<nome>/SKILL.md` | Skills instaladas de forma plana |
+| 10 | **VS Code Copilot** | 1 | `copilot` | `~/.github/skills/<nome>/SKILL.md` | Skills instaladas de forma plana |
+| 11 | **Zed** | 1 | `zed` | `~/.config/zed/skills/<nome>/` | Skills instaladas de forma plana (categoria removida); MCP via `context_servers` em `settings.json`; bootstrap cognitivo em `~/.config/zed/AGENTS.md` |
+| 12 | **Kiro** | 2 | (nenhum) | `~/.kiro/` via `.kiro/install.sh` | Hooks de sessao instalados em `~/.kiro/hooks/` |
+| 13 | **Trae** | 2 | (nenhum) | `~/.trae/` (ou `~/.trae-cn/` com `TRAE_ENV=cn`) via `.trae/install.sh` | Protocolo de memoria gravado em `~/.trae/MEMORY.md` |
+
+## Por que tres niveis (historia, nao aspiracao)
+
+O Nivel 1 (unificado) e o pipeline canonico. E o resultado de `install-plan.js` resolvendo manifestos de instalacao contra `SUPPORTED_INSTALL_TARGETS`, depois `install-apply.js` materializando arquivos. O pipeline emite procedencia, suporta dry-run e e coberto por 200+ testes em `tests/`.
+
+O Nivel 2 (script customizado) existe porque Kiro e Trae chegaram ao EGC antes de o pipeline unificado estar estavel. Seus instaladores fazem aproximadamente o mesmo trabalho que o pipeline unificado, mas a forma dos ativos que publicam difere o suficiente para que a retrocompatibilizacao seja nao trivial. Sao de primeira classe, mas tecnicamente isolados.
+
+O Nivel 3 (somente protocolo) e o ponto de entrada para qualquer ferramenta que suporte MCP. O Claude Code era anteriormente Nivel 3, mas agora suporta `~/.claude/skills/<nome>/SKILL.md` como caminho de descoberta de skills, portanto foi promovido ao Nivel 1 com target id `claude`. Windsurf, Amp e VS Code Copilot foram adicionados como targets Nivel 1 na v1.0.2 seguindo o mesmo padrao de descoberta de skills.
+
+## O que "suportado" garante
+
+Para todos os 9 harnesses, o EGC garante:
+
+- O caminho de instalacao esta documentado acima
+- Registro do servidor MCP (se a ferramenta suportar MCP)
+- Injecao do protocolo de memoria (as instrucoes `get_state` / `update_state` chegam a IA)
+- Existe um caminho de desinstalacao
+
+Somente para Nivel 1 e Nivel 2:
+
+- Skills, agentes e regras sao publicados no sistema de arquivos da ferramenta
+- A ferramenta pode invocar workflows definidos pelo EGC diretamente
+
+Somente para Nivel 1:
+
+- Um unico pipeline produz todos os targets
+- Testes de conformidade validam a saida da instalacao (veja `tests/spec/`)
+- Metadados de procedencia sao registrados para cada arquivo materializado
+
+## Lendo a saida do harness-audit
+
+`node scripts/harness-audit.js` produz um relatorio pontuado contra as 7 categorias definidas em `CATEGORIES`. A pontuacao reflete a saude no nivel do repositorio, nao a saude por harness. Uma melhoria futura e o rollup por harness (veja `docs/spec/README.md` Proximos Passos).
+
+## Adicionando um 14o harness
+
+Escolha o nivel com base no que a ferramenta target realmente consome:
+
+1. **Somente MCP e arquivos de instrucoes?** Nivel 3. Adicione o registro MCP em `install.sh` e um nome de target em `scripts/bootstrap-cognitive.js`. ~50 linhas de mudancas.
+2. **Skills/agentes/regras no sistema de arquivos + layout customizado?** Nivel 2. Crie `.{ferramenta}/install.sh` seguindo o formato do Kiro/Trae. ~200 linhas.
+3. **Skills/agentes/regras no sistema de arquivos + layout canonico?** Nivel 1. Adicione a `SUPPORTED_INSTALL_TARGETS` em `scripts/lib/install-manifests.js`, defina as entradas do manifesto. ~50 linhas de configuracao, nenhum novo caminho de codigo.
+
+O Nivel 1 e preferido quando possivel. O Nivel 2 e aceitavel para ferramentas com layouts de ativos nao padrao. O Nivel 3 e a resposta certa para thin clients.
+
+## Lacunas conhecidas (descobertas de auditoria 2026-06-10)
+
+- Kiro e Trae sao Nivel 2 porque sao anteriores ao pipeline unificado. Poderiam ser migrados para o Nivel 1 com ~6 a 8h de trabalho cada
+- `harness-audit` pontua o repositorio, nao os harnesses individuais -- o rollup por harness e o proximo passo de maturacao


### PR DESCRIPTION
## Summary

- Adds Portuguese (pt-BR) translations for all remaining 20 documentation files in `docs/`
- Completes 100% coverage of `docs/` directory under `translations/pt/docs/`

### Files translated

**Architecture** (8 files)
- `docs/architecture/ARCHITECTURE-IMPROVEMENTS.md`
- `docs/architecture/EGC_2.0_BLUEPRINT.md`
- `docs/architecture/EGC_2.0_TECHNICAL_DESIGN.md`
- `docs/architecture/SELECTIVE-INSTALL-ARCHITECTURE.md`
- `docs/architecture/SELECTIVE-INSTALL-DESIGN.md`
- `docs/architecture/SINGLE-AGENT-OPERATIONAL-MODEL.md`
- `docs/architecture/continuous-learning-v2-spec.md`
- `docs/architecture/cross-harness.md`

**Governance** (1 file)
- `docs/governance/SKILL-PLACEMENT-POLICY.md`

**Guides** (7 files)
- `docs/guides/ANTIGRAVITY-GUIDE.md`
- `docs/guides/MANUAL-ADAPTATION-GUIDE.md`
- `docs/guides/SKILL-DEVELOPMENT-GUIDE.md`
- `docs/guides/TROUBLESHOOTING.md`
- `docs/guides/hook-bug-workarounds.md`
- `docs/guides/token-optimization.md`
- `docs/guides/examples/product-capability-template.md`
- `docs/guides/examples/project-guidelines-template.md`

**Installation** (1 file)
- `docs/installation/HERMES-SETUP.md`

**Security** (1 file)
- `docs/security/vex/README.md`

**Spec** (1 file)
- `docs/spec/integration-tiers.md`

## Test plan

- [ ] All translated files present under `translations/pt/docs/`
- [ ] File structure mirrors the original `docs/` directory
- [ ] No English content accidentally omitted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds complete Brazilian Portuguese translations for the entire `docs/` tree, mirroring structure and cross-links to provide full pt-BR documentation coverage. This brings parity with the English originals for architecture, governance, guides, installation, security, and spec.

- **New Features**
  - Added pt-BR translations under `translations/pt/docs/` with the same directory layout as `docs/`.
  - Localized indexes and key guides (architecture, governance, troubleshooting, templates, installation, security, spec).
  - Ensured links, code blocks, and headings match the originals for consistency.

<sup>Written for commit 72de0ebac56ba0a6b22581fdf67e09364a6542cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

