### PR TITLE
fix(egc-memory): load observations from state store

### DIFF
--- a/mcp/servers/egc-memory/src/compress.ts
+++ b/mcp/servers/egc-memory/src/compress.ts
@@ -6,6 +6,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { z } from "zod";
+import sqlite3 from "sqlite3";
+import { open } from "sqlite";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -108,12 +110,81 @@ export function getProjectHash(projectPath: string): { projectId: string; projec
 }
 
 // ─── Loader & Replacer for observations.jsonl ──────────────────────────────────
+function resolveStateStoreDbPath(): string {
+  const envOverride = process.env.EGC_STATE_DB;
+  if (envOverride) {
+    return path.resolve(envOverride);
+  }
 
+  const homeDir = process.env.HOME || os.homedir();
+  return path.join(homeDir, ".gemini", "egc", "state.db");
+}
+async function loadRawObservationsFromStateDb(
+  limit: number = 50,
+  since?: string
+): Promise<RawObservation[]> {
+  const dbPath = resolveStateStoreDbPath();
+
+  if (!fs.existsSync(dbPath)) {
+    return [];
+  }
+
+  const db = await open({
+    filename: dbPath,
+    driver: sqlite3.Database,
+  });
+
+  try {
+    const query = `
+      SELECT id, payload, timestamp
+      FROM events
+      ORDER BY timestamp DESC
+      LIMIT ?
+    `;
+
+    const rows = await db.all(query, [limit]);
+
+    return rows.map((row: any) => {
+      let payload: any = {};
+
+      try {
+        payload = JSON.parse(row.payload);
+      } catch {
+        payload = {};
+      }
+
+      return {
+        id: row.id,
+        tool: payload.tool,
+        output: payload.output ?? payload.result ?? "",
+        content:
+          payload.input ??
+          payload.output ??
+          payload.result ??
+          "",
+        result: payload.result ?? payload.output ?? "",
+        path: payload.cwd ?? payload.file ?? "",
+        timestamp: row.timestamp,
+      };
+    });
+  } finally {
+    await db.close();
+  }
+}
 export async function loadRawObservations(
   projectPath: string,
   limit: number = 50,
   since?: string
 ): Promise<RawObservation[]> {
+  const sqliteObservations = await loadRawObservationsFromStateDb(
+  limit,
+  since
+);
+
+if (sqliteObservations.length > 0) {
+  return sqliteObservations;
+}
+
   const { projectDir } = getProjectHash(projectPath);
   const obsPath = path.join(projectDir, "observations.jsonl");
 

--- a/mcp/servers/egc-memory/src/compress.ts
+++ b/mcp/servers/egc-memory/src/compress.ts
@@ -110,15 +110,19 @@ export function getProjectHash(projectPath: string): { projectId: string; projec
 }
 
 // ─── Loader & Replacer for observations.jsonl ──────────────────────────────────
+
+// Mirrors STATE_STORE_RELATIVE_PATH from mcp/servers/egc-memory/src/index.ts
+const STATE_STORE_RELATIVE_PATH = path.join(".gemini", "egc", "state.db");
+
 function resolveStateStoreDbPath(): string {
   const envOverride = process.env.EGC_STATE_DB;
   if (envOverride) {
     return path.resolve(envOverride);
   }
-
   const homeDir = process.env.HOME || os.homedir();
-  return path.join(homeDir, ".gemini", "egc", "state.db");
+  return path.join(homeDir, STATE_STORE_RELATIVE_PATH);
 }
+
 async function loadRawObservationsFromStateDb(
   limit: number = 50,
   since?: string
@@ -135,14 +139,16 @@ async function loadRawObservationsFromStateDb(
   });
 
   try {
+    const sinceFilter = since ?? null;
     const query = `
       SELECT id, payload, timestamp
       FROM events
+      WHERE (? IS NULL OR timestamp >= ?)
       ORDER BY timestamp DESC
       LIMIT ?
     `;
 
-    const rows = await db.all(query, [limit]);
+    const rows = await db.all(query, [sinceFilter, sinceFilter, limit]);
 
     return rows.map((row: any) => {
       let payload: any = {};
@@ -171,19 +177,17 @@ async function loadRawObservationsFromStateDb(
     await db.close();
   }
 }
+
 export async function loadRawObservations(
   projectPath: string,
   limit: number = 50,
   since?: string
 ): Promise<RawObservation[]> {
-  const sqliteObservations = await loadRawObservationsFromStateDb(
-  limit,
-  since
-);
+  const sqliteObservations = await loadRawObservationsFromStateDb(limit, since);
 
-if (sqliteObservations.length > 0) {
-  return sqliteObservations;
-}
+  if (sqliteObservations.length > 0) {
+    return sqliteObservations;
+  }
 
   const { projectDir } = getProjectHash(projectPath);
   const obsPath = path.join(projectDir, "observations.jsonl");


### PR DESCRIPTION
## What Changed

This PR addresses an issue where `compress_observations` could return `No raw observations found to compress.` even when hook events were actively being generated.

During investigation, I found that:

* `compress_observations` reads observations via `loadRawObservations()`, which currently only consults `observations.jsonl`.
* The active hook pipeline (`observe-runner.js` → `state-db-writer.js`) persists runtime events into the SQLite state store (`state.db`).

As a result, fresh installs may accumulate events in SQLite without ever populating `observations.jsonl`, causing compression to find no observations.

This PR:

* Adds SQLite-backed observation loading from the `events` table.
* Updates `loadRawObservations()` to attempt SQLite loading first.
* Falls back to the existing JSONL implementation when no SQLite observations are found.

This preserves backward compatibility while restoring expected behavior on fresh installs.

## Why This Change

Producer path:

```text
observe-runner.js
    ↓
teeEventToStateDb()
    ↓
state-db-writer.js
    ↓
insertRuntimeEvent()
    ↓
SQLite events table
```

Consumer path before this change:

```text
compress_observations
    ↓
loadRawObservations()
    ↓
observations.jsonl only
```

This PR attempts to reconnect those paths.

## Testing Done

* [x] Traced the observation producer and consumer paths to identify the source mismatch.
* [x] Verified that the active hook pipeline writes runtime events to the SQLite state store.
* [x] Confirmed that `compress_observations` only consulted `observations.jsonl` before this change.
* [x] Implemented SQLite-backed observation loading with JSONL fallback.
* [x] Verified that the modified TypeScript code compiled successfully before reaching the existing Windows-specific `chmod` build issue.
* [x] Preserved the legacy JSONL path to maintain backward compatibility.
* [ ] Full automated test suite execution on Windows (blocked by the existing `chmod` build script issue unrelated to this change).

## Notes

I intentionally kept this change minimal and backward-compatible.

Potential follow-ups may include:

* Applying `since` filtering to the SQLite query.
* Aligning SQLite observation filtering with the existing JSONL filtering logic.
* Clarifying whether JSONL should remain a supported observation source going forward.

I am happy to make follow-up changes if maintainers would prefer a different approach.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing observations during compression by reading from the SQLite state store first, with a fallback to `observations.jsonl`. Applies the `since` filter, respects `limit`, and aligns the state DB path with `index.ts` for fresh installs while keeping backward compatibility.

- **Bug Fixes**
  - `loadRawObservations()` now queries the `events` table in `state.db` (resolved via `STATE_STORE_RELATIVE_PATH` or `EGC_STATE_DB`) before `observations.jsonl`.
  - SQL applies the `since` filter and respects `limit`; results are ordered by timestamp desc.
  - Uses `sqlite3` + `sqlite` to load events and maps payloads into `RawObservation` fields.

<sup>Written for commit fd3a27d703fd66171b6d4189e1ea9d0d671a8f01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

