### PR TITLE
feat(i18n): add language selector to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<div align="right">
+  <a href="README.md">English</a> |
+  <a href="translations/pt/README.md">Português do Brasil</a>
+</div>
+
 <div align="center">
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-<div align="right">
-  <a href="README.md">English</a> |
+<div align="center">
+  <b>Language / Idioma</b>
+  <br/>
+  <a href="README.md"><b>English</b></a> |
   <a href="translations/pt/README.md">Português do Brasil</a>
 </div>
 


### PR DESCRIPTION
Adds a language selector in the top-right corner of the README, following the convention used by large repositories (Electron, Vue, etc.).

Clicking the language name navigates directly to the full translated README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a centered language selector at the top of the README so readers can switch languages quickly. Links to English and Brazilian Portuguese open the full translated README.

<sup>Written for commit ca11feb717e013bba050594168cb5c1e1f321aa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a language selector to the README with links for English and Brazilian Portuguese translation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->