### PR TITLE
feat(i18n): auto-update README language selector on translation merge

### DIFF
--- a/.github/workflows/update-readme-languages.yml
+++ b/.github/workflows/update-readme-languages.yml
@@ -1,0 +1,41 @@
+name: Update README Language Selector
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "translations/*/README.md"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update-selector:
+    name: Sync language selector
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+
+      - name: Update language selector
+        run: node scripts/update-readme-languages.js
+
+      - name: Commit if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "chore(i18n): sync language selector in README
+
+Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
+<!-- LANGUAGE-SELECTOR-START -->
 <div align="center">
   <b>Language / Idioma</b>
   <br/>
   <a href="README.md"><b>English</b></a> |
   <a href="translations/pt/README.md">Português do Brasil</a>
 </div>
+<!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-<div align="center">
-  <b>Language / Idioma</b>
-  <br/>
-  <a href="README.md"><b>English</b></a> |
-  <a href="translations/pt/README.md">Português do Brasil</a>
-</div>
+**Language:** English | [Português do Brasil](translations/pt/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs   = require("fs");
+const path = require("path");
+
+const LANGUAGE_NAMES = {
+  pt: "Português do Brasil",
+  es: "Español",
+  fr: "Français",
+  de: "Deutsch",
+  it: "Italiano",
+  nl: "Nederlands",
+  pl: "Polski",
+  ru: "Русский",
+  uk: "Українська",
+  tr: "Türkçe",
+  ar: "العربية",
+  hi: "हिन्दी",
+  zh: "中文",
+  ja: "日本語",
+  ko: "한국어",
+  vi: "Tiếng Việt",
+  th: "ภาษาไทย",
+  id: "Bahasa Indonesia",
+  sv: "Svenska",
+  da: "Dansk",
+  no: "Norsk",
+  fi: "Suomi",
+  cs: "Čeština",
+  sk: "Slovenčina",
+  ro: "Română",
+  hu: "Magyar",
+  bg: "Български",
+  hr: "Hrvatski",
+  el: "Ελληνικά",
+  he: "עברית",
+  fa: "فارسی",
+  bn: "বাংলা",
+  ms: "Bahasa Melayu",
+  ca: "Català",
+};
+
+const ROOT              = path.join(__dirname, "..");
+const TRANSLATIONS_DIR  = path.join(ROOT, "translations");
+const README_PATH       = path.join(ROOT, "README.md");
+const SELECTOR_START    = "<!-- LANGUAGE-SELECTOR-START -->";
+const SELECTOR_END      = "<!-- LANGUAGE-SELECTOR-END -->";
+
+function getAvailableLanguages() {
+  if (!fs.existsSync(TRANSLATIONS_DIR)) return [];
+
+  return fs
+    .readdirSync(TRANSLATIONS_DIR)
+    .filter((code) => {
+      const readmePath = path.join(TRANSLATIONS_DIR, code, "README.md");
+      return fs.statSync(path.join(TRANSLATIONS_DIR, code)).isDirectory()
+        && fs.existsSync(readmePath);
+    })
+    .sort();
+}
+
+function buildSelector(langs) {
+  const langLinks = langs.map((code) => {
+    const name = LANGUAGE_NAMES[code] || code.toUpperCase();
+    return `  <a href="translations/${code}/README.md">${name}</a>`;
+  });
+
+  const englishLink = `  <a href="README.md"><b>English</b></a>`;
+  const allLinks    = [englishLink, ...langLinks];
+  const linksLine   = allLinks.join(" |\n");
+
+  return [
+    SELECTOR_START,
+    '<div align="center">',
+    "  <b>Language / Idioma</b>",
+    "  <br/>",
+    linksLine,
+    "</div>",
+    SELECTOR_END,
+  ].join("\n");
+}
+
+function updateReadme() {
+  const readme = fs.readFileSync(README_PATH, "utf8");
+
+  const startIdx = readme.indexOf(SELECTOR_START);
+  const endIdx   = readme.indexOf(SELECTOR_END);
+
+  if (startIdx === -1 || endIdx === -1) {
+    console.error("Language selector sentinels not found in README.md");
+    process.exit(1);
+  }
+
+  const langs       = getAvailableLanguages();
+  const newSelector = buildSelector(langs);
+  const updated     = readme.slice(0, startIdx)
+    + newSelector
+    + readme.slice(endIdx + SELECTOR_END.length);
+
+  if (updated === readme) {
+    console.log("Language selector already up to date.");
+    return;
+  }
+
+  fs.writeFileSync(README_PATH, updated, "utf8");
+  console.log(`Language selector updated with ${langs.length} language(s): ${langs.join(", ")}`);
+}
+
+updateReadme();

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -41,11 +41,11 @@ const LANGUAGE_NAMES = {
   ca: "Català",
 };
 
-const ROOT              = path.join(__dirname, "..");
-const TRANSLATIONS_DIR  = path.join(ROOT, "translations");
-const README_PATH       = path.join(ROOT, "README.md");
-const SELECTOR_START    = "<!-- LANGUAGE-SELECTOR-START -->";
-const SELECTOR_END      = "<!-- LANGUAGE-SELECTOR-END -->";
+const ROOT             = path.join(__dirname, "..");
+const TRANSLATIONS_DIR = path.join(ROOT, "translations");
+const README_PATH      = path.join(ROOT, "README.md");
+const SELECTOR_START   = "<!-- LANGUAGE-SELECTOR-START -->";
+const SELECTOR_END     = "<!-- LANGUAGE-SELECTOR-END -->";
 
 function getAvailableLanguages() {
   if (!fs.existsSync(TRANSLATIONS_DIR)) return [];
@@ -53,9 +53,9 @@ function getAvailableLanguages() {
   return fs
     .readdirSync(TRANSLATIONS_DIR)
     .filter((code) => {
-      const readmePath = path.join(TRANSLATIONS_DIR, code, "README.md");
-      return fs.statSync(path.join(TRANSLATIONS_DIR, code)).isDirectory()
-        && fs.existsSync(readmePath);
+      const stat = fs.statSync(path.join(TRANSLATIONS_DIR, code));
+      const readme = path.join(TRANSLATIONS_DIR, code, "README.md");
+      return stat.isDirectory() && fs.existsSync(readme);
     })
     .sort();
 }
@@ -63,22 +63,11 @@ function getAvailableLanguages() {
 function buildSelector(langs) {
   const langLinks = langs.map((code) => {
     const name = LANGUAGE_NAMES[code] || code.toUpperCase();
-    return `  <a href="translations/${code}/README.md">${name}</a>`;
+    return `[${name}](translations/${code}/README.md)`;
   });
 
-  const englishLink = `  <a href="README.md"><b>English</b></a>`;
-  const allLinks    = [englishLink, ...langLinks];
-  const linksLine   = allLinks.join(" |\n");
-
-  return [
-    SELECTOR_START,
-    '<div align="center">',
-    "  <b>Language / Idioma</b>",
-    "  <br/>",
-    linksLine,
-    "</div>",
-    SELECTOR_END,
-  ].join("\n");
+  const parts = ["English", ...langLinks];
+  return `${SELECTOR_START}\n**Language:** ${parts.join(" | ")}\n${SELECTOR_END}`;
 }
 
 function updateReadme() {


### PR DESCRIPTION
## What this does

When a new translation PR is merged into main, the README language selector updates automatically without any manual edits.

**Flow:**
1. Someone translates the project on Crowdin and reaches 100%
2. The crowdin-sync workflow opens a PR adding `translations/<code>/README.md`
3. That PR is approved and merged
4. This workflow fires, detects the new folder in `translations/`, and commits the updated selector to main

**How it works:**
- `scripts/update-readme-languages.js` scans `translations/*/README.md` and regenerates the selector block
- Sentinel comments (`<!-- LANGUAGE-SELECTOR-START -->` / `<!-- LANGUAGE-SELECTOR-END -->`) mark the block in README.md so the script can replace it precisely
- The workflow (`update-readme-languages.yml`) runs on push to main when any `translations/*/README.md` changes
- If nothing changed, no commit is made

**Language support pre-mapped:** 30+ language codes mapped to their native display names (한국어, 中文, Español, Français, Deutsch, etc.)

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically updates the README language selector when a translation README is merged into `main`. Also switches to a single bold plain‑text selector line, replacing the old centered HTML.

- **New Features**
  - Adds a GitHub Action that runs on push to `main` when `translations/*/README.md` changes and commits the updated README only if needed.
  - Introduces `scripts/update-readme-languages.js` to scan `translations/*/README.md` and rebuild the selector between `<!-- LANGUAGE-SELECTOR-START -->` and `<!-- LANGUAGE-SELECTOR-END -->`.
  - Seeds a map of 30+ language codes to native names.

- **Bug Fixes**
  - Replaces the centered HTML block with a plain‑text line: `**Language:** English | [Português do Brasil](...) | ...`, matching common OSS format.

<sup>Written for commit 4ae19ff164ba8187a303278e4953b0d5d1f4e4c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

