### PR TITLE
feat(i18n): match ECC language selector format exactly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 
 [![npm version](https://img.shields.io/npm/v/@egchq/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egchq/egc) [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![Discord](https://img.shields.io/discord/1513941515452416130?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/AtazrtxJ) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](.github/CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=alert_status)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=security_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=reliability_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![EGC MCP server](https://glama.ai/mcp/servers/Fmarzochi/EGC/badges/score.svg)](https://glama.ai/mcp/servers/Fmarzochi/EGC)
 
+<!-- CENTERED-LANGUAGE-SELECTOR-START -->
+<div align="center">
+
+**Language / Idioma**
+
+[**English**](README.md) | [Português do Brasil](translations/pt/README.md)
+
+</div>
+<!-- CENTERED-LANGUAGE-SELECTOR-END -->
+
 <div align="center">
 
 # EGC - Extended Global Context

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -35,65 +35,126 @@ const LANGUAGE_NAMES = {
   hr: "Hrvatski",
   el: "Ελληνικά",
   he: "עברית",
-  fa: "فارسی",
+  fa: "فارסی",
   bn: "বাংলা",
   ms: "Bahasa Melayu",
   ca: "Català",
 };
 
-const ROOT             = path.join(__dirname, "..");
-const TRANSLATIONS_DIR = path.join(ROOT, "translations");
-const README_PATH      = path.join(ROOT, "README.md");
-const SELECTOR_START   = "<!-- LANGUAGE-SELECTOR-START -->";
-const SELECTOR_END     = "<!-- LANGUAGE-SELECTOR-END -->";
+const LANGUAGE_WORD = {
+  pt: "Idioma",
+  es: "Idioma",
+  fr: "Langue",
+  de: "Sprache",
+  it: "Lingua",
+  nl: "Taal",
+  pl: "Język",
+  ru: "Язык",
+  uk: "Мова",
+  tr: "Dil",
+  ar: "اللغة",
+  hi: "भाषा",
+  zh: "语言",
+  ja: "言語",
+  ko: "언어",
+  vi: "Ngôn ngữ",
+  th: "ภาษา",
+  id: "Bahasa",
+  sv: "Språk",
+  da: "Sprog",
+  no: "Språk",
+  fi: "Kieli",
+  cs: "Jazyk",
+  sk: "Jazyk",
+  ro: "Limbă",
+  hu: "Nyelv",
+  bg: "Език",
+  hr: "Jezik",
+  el: "Γλώσσα",
+  he: "שפה",
+  fa: "زبان",
+  bn: "ভাষা",
+  ms: "Bahasa",
+  ca: "Idioma",
+};
+
+const ROOT           = path.join(__dirname, "..");
+const TRANSLATIONS   = path.join(ROOT, "translations");
+const README_PATH    = path.join(ROOT, "README.md");
+const TOP_START      = "<!-- LANGUAGE-SELECTOR-START -->";
+const TOP_END        = "<!-- LANGUAGE-SELECTOR-END -->";
+const CENTER_START   = "<!-- CENTERED-LANGUAGE-SELECTOR-START -->";
+const CENTER_END     = "<!-- CENTERED-LANGUAGE-SELECTOR-END -->";
 
 function getAvailableLanguages() {
-  if (!fs.existsSync(TRANSLATIONS_DIR)) return [];
-
+  if (!fs.existsSync(TRANSLATIONS)) return [];
   return fs
-    .readdirSync(TRANSLATIONS_DIR)
+    .readdirSync(TRANSLATIONS)
     .filter((code) => {
-      const stat = fs.statSync(path.join(TRANSLATIONS_DIR, code));
-      const readme = path.join(TRANSLATIONS_DIR, code, "README.md");
+      const stat   = fs.statSync(path.join(TRANSLATIONS, code));
+      const readme = path.join(TRANSLATIONS, code, "README.md");
       return stat.isDirectory() && fs.existsSync(readme);
     })
     .sort();
 }
 
-function buildSelector(langs) {
-  const langLinks = langs.map((code) => {
+function buildTopSelector(langs) {
+  const links = langs.map((code) => {
     const name = LANGUAGE_NAMES[code] || code.toUpperCase();
     return `[${name}](translations/${code}/README.md)`;
   });
+  return `${TOP_START}\n**Language:** English | ${links.join(" | ")}\n${TOP_END}`;
+}
 
-  const parts = ["English", ...langLinks];
-  return `${SELECTOR_START}\n**Language:** ${parts.join(" | ")}\n${SELECTOR_END}`;
+function buildCenteredSelector(langs) {
+  const titleWords = ["Language", ...langs.map((c) => LANGUAGE_WORD[c] || c.toUpperCase())];
+  const title      = `**${titleWords.join(" / ")}**`;
+  const links      = [
+    `[**English**](README.md)`,
+    ...langs.map((code) => {
+      const name = LANGUAGE_NAMES[code] || code.toUpperCase();
+      return `[${name}](translations/${code}/README.md)`;
+    }),
+  ].join(" | ");
+
+  return [
+    CENTER_START,
+    '<div align="center">',
+    "",
+    title,
+    "",
+    links,
+    "",
+    "</div>",
+    CENTER_END,
+  ].join("\n");
+}
+
+function replaceBlock(content, start, end, block) {
+  const s = content.indexOf(start);
+  const e = content.indexOf(end);
+  if (s === -1 || e === -1) return content;
+  return content.slice(0, s) + block + content.slice(e + end.length);
 }
 
 function updateReadme() {
   const readme = fs.readFileSync(README_PATH, "utf8");
+  const langs  = getAvailableLanguages();
 
-  const startIdx = readme.indexOf(SELECTOR_START);
-  const endIdx   = readme.indexOf(SELECTOR_END);
-
-  if (startIdx === -1 || endIdx === -1) {
-    console.error("Language selector sentinels not found in README.md");
-    process.exit(1);
-  }
-
-  const langs       = getAvailableLanguages();
-  const newSelector = buildSelector(langs);
-  const updated     = readme.slice(0, startIdx)
-    + newSelector
-    + readme.slice(endIdx + SELECTOR_END.length);
+  const updated = replaceBlock(
+    replaceBlock(readme, TOP_START, TOP_END, buildTopSelector(langs)),
+    CENTER_START,
+    CENTER_END,
+    buildCenteredSelector(langs)
+  );
 
   if (updated === readme) {
-    console.log("Language selector already up to date.");
+    console.log("Language selectors already up to date.");
     return;
   }
 
   fs.writeFileSync(README_PATH, updated, "utf8");
-  console.log(`Language selector updated with ${langs.length} language(s): ${langs.join(", ")}`);
+  console.log(`Language selectors updated with ${langs.length} language(s): ${langs.join(", ")}`);
 }
 
 updateReadme();


### PR DESCRIPTION
## What this does

Adds the centered language selector after the badges, matching the exact structure of affaan-m/ECC.

**Before:** only a plain line at the top.

**After:**

Top (line 1, plain markdown):
```
**Language:** English | [Português do Brasil](translations/pt/README.md)
```

After badges (centered div):
```html
<div align="center">

**Language / Idioma**

[**English**](README.md) | [Português do Brasil](translations/pt/README.md)

</div>
```

When a new language is added, both selectors update automatically. The centered title grows too: `Language / Idioma / 언어` when Korean arrives.

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a centered language selector in the README after badges to match `affaan-m/ECC`, and updates the script to auto-maintain both the top and centered selectors. This improves i18n navigation and keeps selectors in sync as new translations are added.

- New Features
  - README: add a centered selector block with a multi-language title (e.g., Language / Idioma), bold English link, and native-name links for translations; keep the top inline selector; both are wrapped in sentinel comments and update automatically.
  - Script: `scripts/update-readme-languages.js` now discovers `translations/*/README.md` and rebuilds/replaces both selector blocks in place.

<sup>Written for commit 52c8133abbe23f8c69df7c7bbbe481099f9dbbba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered language selector in README with links to English and Portuguese (Brazil) translation versions for users to choose their preferred language.

* **Chores**
  * Enhanced the automated process for managing README language selectors with improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->