### PR TITLE
fix(docs): update egc-memory tool names and count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npx @egchq/egc install
 
 ## What the MCP server gives your AI
 
-EGC ships `egc-memory`, an MCP server that exposes 13 tools your AI can call during a session:
+EGC ships `egc-memory`, an MCP server that exposes 14 tools your AI can call during a session:
 
 | Tool | What it does |
 |---|---|
@@ -83,14 +83,15 @@ EGC ships `egc-memory`, an MCP server that exposes 13 tools your AI can call dur
 | `store_decision` | Persists a single decision to SQLite |
 | `query_history` | Returns past decisions by timestamp |
 | `search_history` | Full-text search with BM25 ranking |
-| `set_working_memory` | Stores transient context with a TTL |
-| `get_working_memory` | Reads a transient key |
-| `delete_working_memory` | Removes a transient key |
-| `add_lesson` | Records cross-session knowledge with confidence decay |
-| `list_lessons` | Retrieves active lessons above a confidence threshold |
-| `forget_lesson` | Removes a lesson permanently |
+| `working_memory_set` | Stores transient context with a TTL |
+| `working_memory_get` | Reads a transient key |
+| `working_memory_list` | Lists all live transient entries for the current project |
+| `lesson_save` | Records cross-session knowledge with confidence decay |
+| `lesson_recall` | Retrieves active lessons above a confidence threshold |
+| `lesson_reinforce` | Boosts confidence on a lesson when the same pattern repeats |
 | `detect_patterns` | Surfaces repeated commands and recurring errors from hook events |
 | `compress_observations` | Compresses raw hook observations into typed summaries to reduce token usage |
+| `get_project_state` | Returns server health metadata and storage engine status |
 
 State files live at `~/.egc/state/<project-slug>.md`. One file per project, plain Markdown, human-readable.
 
@@ -155,6 +156,6 @@ Support from the community keeps this project alive and independent.
 
 <a href="https://bestpractices.dev/projects/13099"><img src="assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices" width="110" /></a>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-<a href="https://linkedin.com/in/felipemarzochi"><img src="assets/images/egc-logo.png" alt="EGC" width="110" /></a>
+<a href="https://www.linkedin.com/in/felipemarzochi"><img src="assets/images/egc-logo.png" alt="EGC" width="110" /></a>
 
 </div>


### PR DESCRIPTION
## Summary

- Corrects 6 tool names that were renamed in the `egc-memory` server but not updated in the README
- Adds `get_project_state` (new tool, previously omitted)
- Updates tool count from 13 to 14
- Fixes LinkedIn URL to include `www.`

## Tool name changes

| Old name (README) | Correct name (server) |
|---|---|
| `set_working_memory` | `working_memory_set` |
| `get_working_memory` | `working_memory_get` |
| `delete_working_memory` | `working_memory_list` |
| `add_lesson` | `lesson_save` |
| `list_lessons` | `lesson_recall` |
| `forget_lesson` | `lesson_reinforce` |

## Test plan
- [ ] CI passes
- [ ] `node scripts/ci/catalog.js` reports all checks OK (verified locally)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README to match the current `egc-memory` server tools and count, and fixes a broken link. This keeps the docs accurate for anyone calling the MCP tools.

- **Bug Fixes**
  - Updated tool names: `working_memory_set`, `working_memory_get`, `working_memory_list`, `lesson_save`, `lesson_recall`, `lesson_reinforce`.
  - Added `get_project_state`; tool count is now 14.
  - Fixed LinkedIn URL to include `www`.

<sup>Written for commit 1cf443f99fc2e347f8a9f39491ae0a744c8388b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP server tooling documentation with revised tool names and availability
  * Expanded tool suite from 13 to 14 tools
  * Fixed LinkedIn profile link format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->