### PR TITLE
fix(egc-memory): prevent recompression of SQLite observations

### DIFF
--- a/mcp/servers/egc-memory/src/compress.ts
+++ b/mcp/servers/egc-memory/src/compress.ts
@@ -123,7 +123,17 @@ function resolveStateStoreDbPath(): string {
   return path.join(homeDir, STATE_STORE_RELATIVE_PATH);
 }
 
+function resolveProjectRoot(projectPath: string): string {
+  let dir = projectPath;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, ".git"))) return dir;
+    dir = path.dirname(dir);
+  }
+  return projectPath;
+}
+
 async function loadRawObservationsFromStateDb(
+  projectPath: string,
   limit: number = 50,
   since?: string
 ): Promise<RawObservation[]> {
@@ -139,40 +149,48 @@ async function loadRawObservationsFromStateDb(
   });
 
   try {
+    try {
+      await db.run("ALTER TABLE events ADD COLUMN compressed_at TEXT");
+    } catch {
+      // column already exists
+    }
+
+    const projectRoot = resolveProjectRoot(projectPath);
     const sinceFilter = since ?? null;
     const query = `
-      SELECT id, payload, timestamp
-      FROM events
-      WHERE (? IS NULL OR timestamp >= ?)
-      ORDER BY timestamp DESC
+      SELECT e.id, e.payload, e.timestamp
+      FROM events e
+      INNER JOIN sessions s ON e.session_id = s.id
+      WHERE e.compressed_at IS NULL
+        AND s.repo_root = ?
+        AND (? IS NULL OR e.timestamp >= ?)
+      ORDER BY e.timestamp DESC
       LIMIT ?
     `;
 
-    const rows = await db.all(query, [sinceFilter, sinceFilter, limit]);
+    const rows = await db.all(query, [projectRoot, sinceFilter, sinceFilter, limit]);
 
-    return rows.map((row: any) => {
-      let payload: any = {};
-
-      try {
-        payload = JSON.parse(row.payload);
-      } catch {
-        payload = {};
-      }
-
-      return {
-        id: row.id,
-        tool: payload.tool,
-        output: payload.output ?? payload.result ?? "",
-        content:
-          payload.input ??
-          payload.output ??
-          payload.result ??
-          "",
-        result: payload.result ?? payload.output ?? "",
-        path: payload.cwd ?? payload.file ?? "",
-        timestamp: row.timestamp,
-      };
-    });
+    return rows
+      .filter((row: any) => {
+        try {
+          const p = JSON.parse(row.payload);
+          return p !== null && typeof p === "object" && (p.tool || p.output || p.result || p.input);
+        } catch {
+          return false;
+        }
+      })
+      .map((row: any) => {
+        const payload = JSON.parse(row.payload);
+        return {
+          id: row.id,
+          tool: payload.tool,
+          output: payload.output ?? payload.result ?? "",
+          content: payload.input ?? payload.output ?? payload.result ?? "",
+          result: payload.result ?? payload.output ?? "",
+          path: payload.cwd ?? payload.file ?? "",
+          timestamp: row.timestamp,
+        };
+      });
   } finally {
     await db.close();
   }
@@ -183,7 +201,7 @@ export async function loadRawObservations(
   limit: number = 50,
   since?: string
 ): Promise<RawObservation[]> {
-  const sqliteObservations = await loadRawObservationsFromStateDb(limit, since);
+  const sqliteObservations = await loadRawObservationsFromStateDb(projectPath, limit, since);
 
   if (sqliteObservations.length > 0) {
     return sqliteObservations;
@@ -242,6 +260,34 @@ function readObsFile(filePath: string, limit: number, since?: string): RawObserv
 
 export async function replaceObservation(projectPath: string, id: string, compressed: CompressedObservation): Promise<void> {
   const { projectDir } = getProjectHash(projectPath);
+  const dbPath = resolveStateStoreDbPath();
+
+  if (fs.existsSync(dbPath)) {
+    const db = await open({
+      filename: dbPath,
+      driver: sqlite3.Database,
+    });
+
+    try {
+      try {
+        await db.run("ALTER TABLE events ADD COLUMN compressed_at TEXT");
+      } catch {
+        // column already exists
+      }
+
+      const result = await db.run(
+        "UPDATE events SET compressed_at = ? WHERE id = ?",
+        [compressed.compressed_at, id]
+      );
+
+      if ((result as any)?.changes > 0) {
+        return;
+      }
+    } finally {
+      await db.close();
+    }
+  }
+
   let obsPath = path.join(projectDir, "observations.jsonl");
   if (!fs.existsSync(obsPath)) {
     const globalObsPath = path.join(os.homedir(), ".gemini", "homunculus", "observations.jsonl");

--- a/scripts/lib/state-store/migrations.js
+++ b/scripts/lib/state-store/migrations.js
@@ -200,6 +200,15 @@ const MIGRATIONS = [
     name: '004_patterns',
     sql: PATTERNS_SQL,
   },
+  {
+    version: 5,
+    name: '005_events_compressed_at',
+    sql: `
+      ALTER TABLE events ADD COLUMN compressed_at TEXT;
+      CREATE INDEX IF NOT EXISTS idx_events_compressed_at_timestamp
+        ON events (compressed_at, timestamp DESC);
+    `,
+  },
 ];
 
 function ensureMigrationTable(db) {

--- a/tests/lib/state-store.test.js
+++ b/tests/lib/state-store.test.js
@@ -269,22 +269,24 @@ async function runTests() {
       const firstMigrations = firstStore.getAppliedMigrations();
       firstStore.close();
 
-      assert.strictEqual(firstMigrations.length, 4);
+      assert.strictEqual(firstMigrations.length, 5);
       assert.strictEqual(firstMigrations[0].version, 1);
       assert.strictEqual(firstMigrations[1].version, 2);
       assert.strictEqual(firstMigrations[2].version, 3);
       assert.strictEqual(firstMigrations[3].version, 4);
+      assert.strictEqual(firstMigrations[4].version, 5);
       assert.ok(fs.existsSync(expectedPath));
 
       const secondStore = await createStateStore({ homeDir });
       const secondMigrations = secondStore.getAppliedMigrations();
       secondStore.close();
 
-      assert.strictEqual(secondMigrations.length, 4);
+      assert.strictEqual(secondMigrations.length, 5);
       assert.strictEqual(secondMigrations[0].version, 1);
       assert.strictEqual(secondMigrations[1].version, 2);
       assert.strictEqual(secondMigrations[2].version, 3);
       assert.strictEqual(secondMigrations[3].version, 4);
+      assert.strictEqual(secondMigrations[4].version, 5);
     } finally {
       cleanupTempDir(homeDir);
     }
@@ -300,7 +302,7 @@ async function runTests() {
 
       const store = await createStateStore({ dbPath: ':memory:' });
       assert.strictEqual(store.dbPath, ':memory:');
-      assert.strictEqual(store.getAppliedMigrations().length, 4);
+      assert.strictEqual(store.getAppliedMigrations().length, 5);
       store.close();
 
       assert.ok(!fs.existsSync(path.join(tempDir, ':memory:')));


### PR DESCRIPTION
This follow-up addresses the remaining recompression issue for observations loaded from the SQLite state store.

Changes:
- Added state-store migration `005_events_compressed_at` to track compression status on events.
- Updated SQLite observation loading to skip events where `compressed_at` is already set.
- Updated `replaceObservation()` to mark SQLite-backed observations as compressed after successful compression while preserving the existing JSONL fallback behavior.

With this change, observations originating from SQLite are no longer reprocessed on subsequent compression runs.

This PR builds upon the work merged in #218.
Closes the remaining recompression issue discussed in #218.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents recompression of SQLite-backed observations by scoping reads to the current repo, filtering invalid payloads, and tracking processed events via `events.compressed_at`. Keeps the JSONL fallback for projects without the state DB.

- **Bug Fixes**
  - Read from `.gemini/egc/state.db` when present; scope to the repo via `sessions.repo_root` (git root); return only `compressed_at IS NULL`; apply `since` in SQL; skip malformed JSON; fall back to JSONL.
  - When compressing, set `events.compressed_at`; run an idempotent `ALTER TABLE ... ADD COLUMN` in read/write for pre-005 DBs; if no row updated, write to JSONL.
  - Resolve the DB via `STATE_STORE_RELATIVE_PATH`; support `EGC_STATE_DB`.
  - Tests updated to assert migration 005.

- **Migration**
  - Add `compressed_at` to `events` and create index `idx_events_compressed_at_timestamp` on `(compressed_at, timestamp DESC)` in `005_events_compressed_at`.

<sup>Written for commit 143a4a760df28bbc31df5fd1093101cc6dc06110. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Observation compression now prioritizes an SQLite-backed state database, loading uncompressed event records with optional time filtering and result limits before falling back to the existing line-based storage.
  * Updates now mark events with a `compressed_at` timestamp to reflect processing status.

* **Chores**
  * Added a schema migration to introduce the `compressed_at` column on events and an index to improve timestamp-based lookups.
  * Compression updates now write to SQLite when available, with a safe fallback to the prior file-based replacement flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->