### PR TITLE
docs(contributing): add DCO, CI checks table, and fix Quick Start

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,8 @@ Because EGC operates as a structured engineering platform, contributions must al
 
 - [Governance Philosophy](#governance-philosophy)
 - [Quick Start](#quick-start)
+- [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
+- [CI Checks](#ci-checks)
 - [Orchestrators & Runtime Core](#orchestrators--runtime-core)
 - [Contributing Skills](#contributing-skills)
 - [Skill Adaptation Policy](#skill-adaptation-policy)
@@ -51,12 +53,70 @@ git checkout -b feat/my-contribution
 
 # 3. Add your contribution following the architectural standards below
 
-# 4. Verify locally
-sh install.sh && egc doctor
+# 4. Verify locally (all of these must pass before you open a PR)
+npm ci
+node tests/run-all.js              # full test suite (runs on Linux, macOS, Windows)
+npm audit --audit-level=high       # must show 0 high/critical vulnerabilities
 
-# 5. Submit PR
-git add . && git commit -m "feat: add my-feature" && git push -u origin feat/my-contribution
+# 5. Submit PR (note: -s adds the required DCO sign-off to your commit)
+git add . && git commit -s -m "feat: add my-feature" && git push -u origin feat/my-contribution
 ```
+
+---
+
+## Developer Certificate of Origin (DCO)
+
+Every commit in your pull request **must** include a `Signed-off-by` line. This certifies that you wrote the code and have the right to contribute it under the project's MIT license. The `dco.yml` workflow checks every commit in every PR and blocks the merge if any commit is missing the signature.
+
+**For new commits, always use the `-s` flag:**
+
+```bash
+git commit -s -m "feat: add my-feature"
+```
+
+This automatically appends the required line to your commit message:
+
+```
+Signed-off-by: Your Full Name <your@email.com>
+```
+
+**To sign an existing unsigned commit:**
+
+```bash
+git commit --amend -s
+git push --force-with-lease
+```
+
+**To sign all commits in a branch at once:**
+
+```bash
+git rebase --signoff main
+git push --force-with-lease
+```
+
+> The `Signed-off-by` line must use the same name and email as your Git identity (`git config user.name` and `git config user.email`).
+
+---
+
+## CI Checks
+
+Every pull request runs the following automated checks. Your PR must pass all of them before it can be merged.
+
+| Check | What it validates | How to pass |
+|---|---|---|
+| **DCO** | Every commit has `Signed-off-by` | Use `git commit -s` on every commit |
+| **CI / test** | `node tests/run-all.js` on Linux, macOS, Windows with Node 20 and 22, using npm, yarn, and bun | Run `node tests/run-all.js` locally before opening a PR |
+| **CI / lint** | ESLint on `scripts/` and `tests/`; markdownlint on all `.md` files in `agents/`, `skills/`, `commands/`, `rules/` | Run `npx markdownlint "agents/**/*.md"` if you added or edited Markdown files |
+| **CI / validate** | Structure validators: agents, hooks, skills, commands, install manifests, rules, unicode safety | Run `node scripts/ci/validate-skills.js` (or the equivalent for your component type) |
+| **CI / security** | `npm audit --audit-level=high` | Run `npm audit --audit-level=high` locally; do not introduce packages with known high or critical vulnerabilities |
+| **Dependency Review** | Blocks dependencies with incompatible licenses or known CVEs | Check the license of any package you add |
+| **SonarCloud** | Static analysis: code smells, bugs, security hotspots | Review the SonarCloud report linked in your PR |
+| **CodeRabbit** | AI code review | Read and address CodeRabbit's findings in your PR comments |
+| **PR Size** | Fails if your PR changes more than 150 code files | Keep PRs focused; split large changes into smaller ones |
+
+### CI on fork pull requests
+
+If this is your first contribution from a fork, GitHub requires a maintainer to approve the CI run by clicking **"Approve and run"** in the Actions tab. Your PR will show checks as "Waiting" until a maintainer approves. This is expected: do not close and reopen your PR. A maintainer will approve the run during review.
 
 ---
 
@@ -394,7 +454,12 @@ What architectural gap this fills or what capability this adds to EGC.
 How you ensured this maintains Runtime Integrity and Cross-Platform stability.
 
 ## Checklist
-- [ ] Tested on Linux/macOS/Windows (if applicable)
+- [ ] All commits are signed off with `git commit -s` (required by DCO check)
+- [ ] `node tests/run-all.js` passes locally with zero failures
+- [ ] `npm audit --audit-level=high` shows no high or critical vulnerabilities
+- [ ] Markdownlint passes on all `.md` files you created or modified (agents, skills, commands, rules)
+- [ ] PR changes fewer than 150 code files
+- [ ] Tested on Linux/macOS/Windows (if applicable to your change)
 - [ ] Preserves EGC identity and formatting
 - [ ] No sensitive data committed
 - [ ] Doesn't break the `runtime-map.json` registry
@@ -456,7 +521,7 @@ npm ci
 npm run build
 
 # Run tests
-npm test
+node tests/run-all.js
 ```
 
 The MCP servers (`egc-guardian`, `egc-memory`) are TypeScript projects compiled with `tsc`. Build output goes to `dist/` inside each server directory.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npx @egchq/egc install
 
 ## What the MCP server gives your AI
 
-EGC ships `egc-memory`, an MCP server that exposes 13 tools your AI can call during a session:
+EGC ships `egc-memory`, an MCP server that exposes 14 tools your AI can call during a session:
 
 | Tool | What it does |
 |---|---|
@@ -83,14 +83,15 @@ EGC ships `egc-memory`, an MCP server that exposes 13 tools your AI can call dur
 | `store_decision` | Persists a single decision to SQLite |
 | `query_history` | Returns past decisions by timestamp |
 | `search_history` | Full-text search with BM25 ranking |
-| `set_working_memory` | Stores transient context with a TTL |
-| `get_working_memory` | Reads a transient key |
-| `delete_working_memory` | Removes a transient key |
-| `add_lesson` | Records cross-session knowledge with confidence decay |
-| `list_lessons` | Retrieves active lessons above a confidence threshold |
-| `forget_lesson` | Removes a lesson permanently |
+| `working_memory_set` | Stores transient context with a TTL |
+| `working_memory_get` | Reads a transient key |
+| `working_memory_list` | Lists all live transient entries for the current project |
+| `lesson_save` | Records cross-session knowledge with confidence decay |
+| `lesson_recall` | Retrieves active lessons above a confidence threshold |
+| `lesson_reinforce` | Boosts confidence on a lesson when the same pattern repeats |
 | `detect_patterns` | Surfaces repeated commands and recurring errors from hook events |
 | `compress_observations` | Compresses raw hook observations into typed summaries to reduce token usage |
+| `get_project_state` | Returns server health metadata and storage engine status |
 
 State files live at `~/.egc/state/<project-slug>.md`. One file per project, plain Markdown, human-readable.
 
@@ -155,6 +156,6 @@ Support from the community keeps this project alive and independent.
 
 <a href="https://bestpractices.dev/projects/13099"><img src="assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices" width="110" /></a>
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-<a href="https://linkedin.com/in/felipemarzochi"><img src="assets/images/egc-logo.png" alt="EGC" width="110" /></a>
+<a href="https://www.linkedin.com/in/felipemarzochi"><img src="assets/images/egc-logo.png" alt="EGC" width="110" /></a>
 
 </div>


### PR DESCRIPTION
## Summary

The CONTRIBUTING.md did not document any of the automated CI checks that block PRs. Contributors had no way to know about DCO sign-off, the test suite, markdownlint, or the fork PR approval flow before submitting.

This PR closes that gap.

## What changed

- Added DCO section with step-by-step sign-off instructions (new commits, amend, bulk rebase)
- Added CI Checks table listing all 9 automated checks, what each validates, and how to pass
- Added note explaining that fork PRs show checks as "Waiting" until a maintainer approves
- Fixed Quick Start step 4: replaced `sh install.sh && egc doctor` with `node tests/run-all.js` and `npm audit`
- Fixed Quick Start step 5: added `-s` flag to the `git commit` example
- Fixed PR checklist: added DCO, tests, audit, markdownlint, and PR size limit items
- Fixed Build Instructions: changed `npm test` to `node tests/run-all.js`

## Component Type
- [x] docs

## Validation

No code changed. Documentation only. CI lint and validate jobs will confirm the Markdown is valid.

## Checklist
- [x] All commits are signed off with `git commit -s` (required by DCO check)
- [x] No sensitive data committed
- [x] Documentation only, no runtime changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DCO section and a CI checks table to improve contributor guidance, plus fixes to Quick Start and build steps. Updates `README.md` to reflect renamed `egc-memory` tools, adds `get_project_state`, and corrects the tool count to 14.

- **New Features**
  - Added DCO section with sign-off instructions (new commits, amend, bulk rebase).
  - Added CI Checks table listing all checks and how to pass them.
  - Noted that first-time fork PRs need maintainer approval to run CI.

- **Bug Fixes**
  - Quick Start: replaced `sh install.sh && egc doctor` with `npm ci`, `node tests/run-all.js`, and `npm audit --audit-level=high`; added `-s` to the commit example.
  - Build instructions: use `node tests/run-all.js` instead of `npm test`.
  - PR checklist: added DCO, tests, audit, markdownlint, and PR size limit items.
  - README: updated `egc-memory` tools (e.g., `working_memory_*`, `lesson_*`), added `get_project_state`, and updated count from 13 to 14; fixed LinkedIn link.

<sup>Written for commit 1c348eaf798afe8534013d5f258abb0127fca6dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added working memory management tools (`set`, `get`, `list`) to the MCP server.
  * Added lesson management tools (`save`, `recall`, `reinforce`) for persistent knowledge storage.
  * Added project state reporting to display server health and storage engine status.
  * MCP server now provides 14 tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->