### PR TITLE
fix(ci): trigger update-readme-languages on push to main

### DIFF
--- a/.github/workflows/update-readme-languages.yml
+++ b/.github/workflows/update-readme-languages.yml
@@ -1,6 +1,8 @@
 name: Update README Language Selector
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

- Adds `push: branches: [main]` trigger to `update-readme-languages.yml`
- The workflow was configured for `workflow_dispatch` only, but GitHub was creating failed runs on every push with "No jobs were run", sending failure notifications on every merge

## Root cause

The workflow responds to `workflow_dispatch` only, but runs were being queued on push events and immediately failing with zero jobs. Adding the proper push trigger makes the workflow execute its actual job (check if README language selector needs updating after each push to main).

## Checklist
- [x] All commits are signed off with `git commit -s` (required by DCO check)
- [x] `node tests/run-all.js` passes locally with zero failures
- [x] `npm audit --audit-level=high` shows no high or critical vulnerabilities
- [x] PR changes fewer than 150 code files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the `update-readme-languages` workflow on pushes to `main` so the README language selector check runs after merges and stops noisy "No jobs were run" failures. Adds a `push: branches: [main]` trigger alongside `workflow_dispatch`.

<sup>Written for commit c01a13af7633807483348056b254cad2acea364a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow trigger configuration to enable automated execution on main branch commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->