### PR TITLE
fix(ci): fix YAML block scalar in update-readme-languages commit step

### DIFF
--- a/.github/workflows/update-readme-languages.yml
+++ b/.github/workflows/update-readme-languages.yml
@@ -31,8 +31,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else
-            git commit -m "chore(i18n): sync language selector in README
-
-Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+            MSG=$'chore(i18n): sync language selector in README\n\nSigned-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+            git commit -m "$MSG"
             git push
           fi


### PR DESCRIPTION
## Summary

The `Signed-off-by:` line inside the `git commit -m` call had zero indentation inside the `run: |` YAML block scalar. GitHub Actions terminated the literal block early at that line and treated `Signed-off-by:` as an unexpected top-level YAML key, causing every push-triggered run to fail with:

```
(Line: 36, Col: 1): Unexpected value 'Signed-off-by'
```

The fix replaces the multi-line commit message with a bash `$'...'` string that encodes newlines as `\n` escapes within a single properly-indented line.

## Root cause

The bug was dormant because the workflow previously only had `workflow_dispatch`. Adding the `push` trigger in PR #235 caused the file to be parsed on every main merge and exposed the issue.

## Test plan

- [ ] CI passes (workflow file parses correctly)
- [ ] Trigger via `workflow_dispatch` to confirm no more parse errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes YAML parsing in the update-readme-languages workflow that broke push-triggered runs. Replaces the multi-line commit message with a bash $'...' string using \n escapes so the Signed-off-by line isn’t misread as a top-level YAML key.

<sup>Written for commit ca8b7e7c3c7ec8a228f70687190ab0ebd46637c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

