### PR TITLE
docs: fix Contributing link and simplify Languages section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the full contributing guide.

--- a/README.md
+++ b/README.md
@@ -110,18 +110,16 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 
 ---
 
-## Languages
+## Contributing
 
-[![Crowdin](https://badges.crowdin.net/egc/localized.svg)](https://crowdin.com/project/egc)
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the full contributing guide.
 
-EGC is translated by the community via [Crowdin](https://crowdin.com/project/egc). A pull request is opened automatically when a language reaches **100%** completion.
+**Translations** are managed via [Crowdin](https://crowdin.com/project/egc). [![Crowdin](https://badges.crowdin.net/egc/localized.svg)](https://crowdin.com/project/egc) A pull request is opened automatically when a language reaches **100%** completion. To contribute a translation, see [Contributing Translations](.github/CONTRIBUTING.md#contributing-translations).
 
 | Language | Progress | File |
 |---|---|---|
 | English | Source | [README.md](README.md) |
 | Portugues do Brasil | 100% | [translations/pt/README.md](translations/pt/README.md) |
-
-Want to translate EGC into your language? See [Contributing Translations](.github/CONTRIBUTING.md#contributing-translations).
 
 ---
 


### PR DESCRIPTION
## Summary

- Add root-level `CONTRIBUTING.md` that redirects to `.github/CONTRIBUTING.md`, so GitHub renders the file instead of showing the `.github/` folder when users click contributing links
- Replace the redundant `## Languages` section (which duplicated the header language selector) with a `## Contributing` section that consolidates the contributing guide link, translation info, and Crowdin badge in one place

## Test plan

- [ ] Verify `CONTRIBUTING.md` at repo root renders correctly on GitHub and links through to `.github/CONTRIBUTING.md`
- [ ] Verify the `## Contributing` section in README displays the Crowdin badge and translation table correctly
- [ ] Verify no duplicate language selector content remains (header selector is kept, standalone `## Languages` section is removed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GitHub rendering of the contributing guide by adding a root `CONTRIBUTING.md` that links to `.github/CONTRIBUTING.md`. Simplify the README by replacing the redundant “Languages” section with a “Contributing” section that includes the guide link, translation info, and the Crowdin badge.

<sup>Written for commit fa957bb805161cdc3c970b5881839911cc1a16ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

