### PR TITLE
docs: clean README Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,19 +110,6 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 
 ---
 
-## Contributing
-
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the full contributing guide.
-
-**Translations** are managed via [Crowdin](https://crowdin.com/project/egc). [![Crowdin](https://badges.crowdin.net/egc/localized.svg)](https://crowdin.com/project/egc) A pull request is opened automatically when a language reaches **100%** completion. To contribute a translation, see [Contributing Translations](.github/CONTRIBUTING.md#contributing-translations).
-
-| Language | Progress | File |
-|---|---|---|
-| English | Source | [README.md](README.md) |
-| Portugues do Brasil | 100% | [translations/pt/README.md](translations/pt/README.md) |
-
----
-
 ## Support EGC
 
 EGC is built by one developer, maintained in the open, and free.


### PR DESCRIPTION
## Summary

- Removes the `## Contributing` section from `README.md` entirely (Crowdin badge, language table, translation link, and CONTRIBUTING.md pointer)
- GitHub automatically surfaces the Contributing tab via the root `CONTRIBUTING.md` file -- no manual link needed in the README
- The full translation guide already lives in `.github/CONTRIBUTING.md` under **Contributing Translations** (rules, step-by-step, language table)

## Test plan

- [ ] Verify README.md no longer shows a Contributing section
- [ ] Verify the GitHub Contributing tab (https://github.com/Fmarzochi/EGC?tab=contributing-ov-file) still links to CONTRIBUTING.md correctly
- [ ] Verify `.github/CONTRIBUTING.md` Contributing Translations section is intact

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `## Contributing` section from `README.md` (Crowdin badge, language table, and link) to avoid duplication. GitHub surfaces the Contributing tab from `.github/CONTRIBUTING.md`, which contains the full translation guide.

<sup>Written for commit 9a551d1530ba27491edcc8b02f46da0ce1ae74f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Contributing" section from the README, including translation information and language progress details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->