### PR TITLE
ci: enforce npm audit as a blocking check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,6 @@ jobs:
 
       - name: Run npm audit
         run: npm audit --audit-level=high
-        continue-on-error: true  # Allows PR to proceed, but marks job as failed if vulnerabilities found
 
   lint:
     name: Lint


### PR DESCRIPTION
## Problem

`npm audit --audit-level=high` was running in CI with `continue-on-error: true`, which meant a PR introducing a high-severity vulnerability in the dependency tree would show a failed job but **never be blocked from merging**.

The comment said "marks job as failed" -- but a failed job with `continue-on-error: true` does not block the merge gate. The SCA policy (`docs/security/SCA-POLICY.md`) states high-severity vulnerabilities must block merges; the workflow was not enforcing it.

## Fix

Remove `continue-on-error: true` from the `npm audit` step. The step now fails the job and blocks the PR if any high or critical vulnerability is found.

## Safety check

Current state: `npm audit` exits 0 -- zero vulnerabilities in the dependency tree. This change does not break any existing PR or workflow run.

## Related

Identified during security posture review (`docs/security/SCA-POLICY.md` already required this behavior).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce `npm audit --audit-level=high` as a blocking CI check by removing `continue-on-error`, so PRs with high/critical vulnerabilities cannot merge. This aligns with our SCA policy; current runs pass with zero issues.

<sup>Written for commit 5208a3c0ea868a2ecab2171297b257d8ee2951b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

