### PR TITLE
Fix HOME env var fallback to support Windows (USERPROFILE)

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -30,7 +30,7 @@ function resolveStateStoreDbPath(): string {
   if (envOverride) {
     return path.resolve(envOverride);
   }
-  const homeDir = process.env.HOME || os.homedir();
+  const homeDir = process.env.HOME || process.env.USERPROFILE || os.homedir();
   return path.join(homeDir, STATE_STORE_RELATIVE_PATH);
 }
 

--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -162,7 +162,7 @@ function runExternalCommand(command, args, options = {}) {
 function runAutoUpdate(options = {}, dependencies = {}) {
   const discover = dependencies.discoverInstalledStates || discoverInstalledStates;
   const execute = dependencies.runExternalCommand || runExternalCommand;
-  const homeDir = options.homeDir || process.env.HOME || os.homedir();
+  const homeDir = options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
   const projectRoot = options.projectRoot || process.cwd();
   const requestedRepoRoot = options.repoRoot ? validateRepoRoot(options.repoRoot) : null;
   const records = discover({
@@ -341,7 +341,7 @@ function main() {
     }
 
     const result = runAutoUpdate({
-      homeDir: process.env.HOME || os.homedir(),
+      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
       repoRoot: options.repoRoot,

--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -133,7 +133,7 @@ function main() {
       showHelp(0);
     }
 
-    const homeDir = process.env.HOME || os.homedir();
+    const homeDir = process.env.HOME || process.env.USERPROFILE || os.homedir();
     const project = path.resolve(options.project || process.cwd());
     const stateFile = stateFilePath(homeDir, project);
     const threshold = resolveThreshold(options);

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -89,7 +89,7 @@ function main() {
 
     const report = buildDoctorReport({
       repoRoot: require('path').join(__dirname, '..'),
-      homeDir: process.env.HOME || os.homedir(),
+      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
     });

--- a/scripts/hooks/state-db-writer.js
+++ b/scripts/hooks/state-db-writer.js
@@ -7,7 +7,7 @@ const crypto = require('crypto');
 const os = require('os');
 
 function resolveStateDbPath() {
-  const home = process.env.HOME || os.homedir();
+  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
   return path.join(home, '.gemini', 'egc', 'state.db');
 }
 

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -133,7 +133,7 @@ function main() {
     });
     const plan = createInstallPlanFromRequest(request, {
       projectRoot: process.cwd(),
-      homeDir: process.env.HOME || os.homedir(),
+      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       claudeRulesDir: process.env.GEMINI_RULES_DIR || null,
     });
 

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -488,7 +488,7 @@ function planAntigravityLegacyInstall(context) {
 function createLegacyInstallPlan(options = {}) {
   const sourceRoot = options.sourceRoot || getSourceRoot();
   const projectRoot = options.projectRoot || process.cwd();
-  const homeDir = options.homeDir || process.env.HOME || os.homedir();
+  const homeDir = options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
   const target = options.target || 'egc';
 
   validateLegacyTarget(target);

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -650,7 +650,7 @@ function buildDiscoveryRecord(adapter, context) {
 
 function discoverInstalledStates(options = {}) {
   const context = {
-    homeDir: options.homeDir || process.env.HOME || os.homedir(),
+    homeDir: options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir(),
     projectRoot: options.projectRoot || process.cwd(),
   };
   const targets = normalizeTargets(options.targets);
@@ -858,7 +858,7 @@ function buildDoctorReport(options = {}) {
   }).filter(record => record.exists);
   const context = {
     repoRoot,
-    homeDir: options.homeDir || process.env.HOME || os.homedir(),
+    homeDir: options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir(),
     projectRoot: options.projectRoot || process.cwd(),
     manifestVersion: manifests.modulesVersion,
     packageVersion: readPackageVersion(repoRoot),
@@ -942,7 +942,7 @@ function repairInstalledStates(options = {}) {
   const manifests = loadInstallManifests({ repoRoot });
   const context = {
     repoRoot,
-    homeDir: options.homeDir || process.env.HOME || os.homedir(),
+    homeDir: options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir(),
     projectRoot: options.projectRoot || process.cwd(),
     manifestVersion: manifests.modulesVersion,
     packageVersion: readPackageVersion(repoRoot),

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -75,7 +75,7 @@ function main() {
 
     const result = repairInstalledStates({
       repoRoot: require('path').join(__dirname, '..'),
-      homeDir: process.env.HOME || os.homedir(),
+      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
       dryRun: options.dryRun,

--- a/scripts/sessions-cli.js
+++ b/scripts/sessions-cli.js
@@ -138,7 +138,7 @@ async function main() {
 
     store = await createStateStore({
       dbPath: options.dbPath,
-      homeDir: process.env.HOME || os.homedir(),
+      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
     });
 
     if (!options.sessionId) {

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -177,7 +177,7 @@ async function main() {
 
     store = await createStateStore({
       dbPath: options.dbPath,
-      homeDir: process.env.HOME || os.homedir(),
+      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
     });
 
     const payload = {
@@ -189,7 +189,7 @@ async function main() {
       }),
       memoryState: collectMemoryState(
         process.env.PWD || process.cwd(),
-        process.env.HOME || os.homedir()
+        process.env.HOME || process.env.USERPROFILE || os.homedir()
       ),
     };
 

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -74,7 +74,7 @@ function main() {
     }
 
     const result = uninstallInstalledStates({
-      homeDir: process.env.HOME || os.homedir(),
+      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
       dryRun: options.dryRun,


### PR DESCRIPTION
## What Changed
Adds a `process.env.USERPROFILE` fallback alongside `process.env.HOME` in every place this codebase resolves the user's home directory, before finally falling back to `os.homedir()`.

Files updated (12):
- scripts/install-apply.js
- scripts/repair.js
- scripts/uninstall.js
- scripts/consolidate.js
- scripts/auto-update.js
- scripts/sessions-cli.js
- scripts/doctor.js
- scripts/status.js
- scripts/lib/install-executor.js
- scripts/lib/install-lifecycle.js
- scripts/hooks/state-db-writer.js
- mcp/servers/egc-memory/src/index.ts

## Why This Change
Fixes #249. On Windows, `process.env.HOME` is frequently unset (Windows sets `USERPROFILE` instead), so the existing `process.env.HOME || os.homedir()` check silently falls through to `os.homedir()` on a stock Windows shell, ignoring any user-supplied `HOME`/`USERPROFILE` override and behaving inconsistently in sandboxed/CI environments where `os.homedir()` can throw or return an unexpected path while `USERPROFILE` is set correctly. Adding the `USERPROFILE` check preserves existing POSIX behavior while making resolution correct and explicit on Windows.

## Testing Done
- [x] Manual testing completed (verified each occurrence resolves to the same value as before on POSIX, and now correctly prefers USERPROFILE over os.homedir() on Windows-style env)
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested (HOME unset + USERPROFILE set; both unset falls back to os.homedir() unchanged)

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the user's home directory in the order `HOME` → `USERPROFILE` → `os.homedir()` to fix incorrect paths on Windows. Applied to CLI tools (`install-apply`, `repair`, `uninstall`, `consolidate`, `auto-update`, `sessions-cli`, `doctor`, `status`), hooks (`state-db-writer`), install lifecycle/executor, and `mcp/servers/egc-memory`, preserving POSIX behavior and honoring Windows overrides.

<sup>Written for commit 4971a2716e2f9debef978de1290a40a049191c13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home directory resolution across system scripts for better cross-platform behavior. The app now prefers `HOME`, then falls back to `USERPROFILE`, and finally uses the OS home directory. This makes state and configuration discovery more reliable—especially in environments (such as Windows setups) where `HOME` may be unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->