### PR TITLE
feat(i18n): remove duplicate language selector and add Crowdin MT pre-translation

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -24,6 +24,76 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Upload sources to Crowdin
+        uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          create_pull_request: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Pre-translate via Machine Translation
+        id: pretranslate
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+        run: |
+          engines=$(curl -sf \
+            -H "Authorization: Bearer $CROWDIN_PERSONAL_TOKEN" \
+            "https://api.crowdin.com/api/v2/mts?limit=1" || echo '{}')
+          engine_id=$(echo "$engines" | jq -r '.data[0].data.id // empty')
+          if [ -z "$engine_id" ]; then
+            echo "::notice::No MT engine configured. Skipping pre-translation."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "MT engine: $engine_id"
+          lang_response=$(curl -sf \
+            -H "Authorization: Bearer $CROWDIN_PERSONAL_TOKEN" \
+            "https://api.crowdin.com/api/v2/projects/${CROWDIN_PROJECT_ID}/languages/progress?limit=500")
+          lang_ids=$(echo "$lang_response" | jq -r '[.data[].data.languageId] | @json')
+          pt_response=$(curl -sf -X POST \
+            -H "Authorization: Bearer $CROWDIN_PERSONAL_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.crowdin.com/api/v2/projects/${CROWDIN_PROJECT_ID}/pre-translations" \
+            -d "{\"method\":\"mt\",\"engineId\":${engine_id},\"languageIds\":${lang_ids},\"autoApproveOption\":\"all\",\"translateUntranslatedOnly\":true,\"duplicateTranslations\":false}" \
+            || echo '{}')
+          pre_id=$(echo "$pt_response" | jq -r '.data.identifier // empty')
+          if [ -z "$pre_id" ]; then
+            echo "::warning::Pre-translation request failed. Skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Pre-translation started: $pre_id"
+          echo "pre_id=${pre_id}" >> "$GITHUB_OUTPUT"
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for pre-translation to finish
+        if: steps.pretranslate.outputs.skipped != 'true'
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          PRE_ID: ${{ steps.pretranslate.outputs.pre_id }}
+        run: |
+          for i in $(seq 1 36); do
+            result=$(curl -sf \
+              -H "Authorization: Bearer $CROWDIN_PERSONAL_TOKEN" \
+              "https://api.crowdin.com/api/v2/projects/${CROWDIN_PROJECT_ID}/pre-translations/${PRE_ID}")
+            status=$(echo "$result" | jq -r '.data.status')
+            echo "Status: $status (attempt $i/36)"
+            if [ "$status" = "finished" ]; then
+              break
+            elif [ "$status" = "failed" ]; then
+              echo "::warning::Pre-translation failed. Proceeding with existing translations."
+              break
+            fi
+            sleep 10
+          done
+
       - name: Check translation progress
         id: progress
         env:
@@ -40,29 +110,16 @@ jobs:
           echo "complete_count=${count}" >> "$GITHUB_OUTPUT"
           echo "total_count=${total}" >> "$GITHUB_OUTPUT"
           if [ "${min}" -lt 100 ]; then
-            echo "::notice::Minimum translation progress: ${min}%. Uploading sources only. A PR will be created automatically when all languages reach 100%."
+            echo "::notice::Minimum translation progress: ${min}%. A PR will be created when all languages reach 100%."
           else
-            echo "::notice::All ${total} language(s) at 100%. Proceeding with download and PR creation."
+            echo "::notice::All ${total} language(s) at 100%. Proceeding with download."
           fi
 
-      - name: Upload sources to Crowdin (below 100%)
-        if: steps.progress.outputs.min_progress != '100'
-        uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2
-        with:
-          upload_sources: true
-          upload_translations: false
-          download_translations: false
-          create_pull_request: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-
-      - name: Crowdin full sync (100% complete)
+      - name: Download translations and create PR
         if: steps.progress.outputs.min_progress == '100'
         uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2
         with:
-          upload_sources: true
+          upload_sources: false
           upload_translations: false
           download_translations: true
           create_pull_request: true

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -52,15 +52,18 @@ jobs:
             exit 0
           fi
           echo "MT engine: $engine_id"
-          lang_response=$(curl -sf \
-            -H "Authorization: Bearer $CROWDIN_PERSONAL_TOKEN" \
-            "https://api.crowdin.com/api/v2/projects/${CROWDIN_PROJECT_ID}/languages/progress?limit=500")
-          lang_ids=$(echo "$lang_response" | jq -r '[.data[].data.languageId] | @json')
+          supported=$(echo "$engines" | jq -r '.data[0].data.supportedLanguagePairs.en // [] | @json')
+          if [ "$supported" = "[]" ]; then
+            echo "::notice::MT engine has no en->X pairs. Skipping pre-translation."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Supported target languages: $supported"
           pt_response=$(curl -sf -X POST \
             -H "Authorization: Bearer $CROWDIN_PERSONAL_TOKEN" \
             -H "Content-Type: application/json" \
             "https://api.crowdin.com/api/v2/projects/${CROWDIN_PROJECT_ID}/pre-translations" \
-            -d "{\"method\":\"mt\",\"engineId\":${engine_id},\"languageIds\":${lang_ids},\"autoApproveOption\":\"all\",\"translateUntranslatedOnly\":true,\"duplicateTranslations\":false}" \
+            -d "{\"method\":\"mt\",\"engineId\":${engine_id},\"languageIds\":${supported},\"autoApproveOption\":\"all\",\"translateUntranslatedOnly\":true,\"duplicateTranslations\":false}" \
             || echo '{}')
           pre_id=$(echo "$pt_response" | jq -r '.data.identifier // empty')
           if [ -z "$pre_id" ]; then
@@ -94,44 +97,20 @@ jobs:
             sleep 10
           done
 
-      - name: Check translation progress
-        id: progress
-        env:
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-        run: |
-          response=$(curl -sf \
-            -H "Authorization: Bearer $CROWDIN_PERSONAL_TOKEN" \
-            "https://api.crowdin.com/api/v2/projects/${CROWDIN_PROJECT_ID}/languages/progress?limit=500")
-          min=$(echo "$response" | jq '[.data[].data.translationProgress] | min // 0')
-          count=$(echo "$response" | jq '[.data[].data | select(.translationProgress == 100)] | length')
-          total=$(echo "$response" | jq '.data | length')
-          echo "min_progress=${min}" >> "$GITHUB_OUTPUT"
-          echo "complete_count=${count}" >> "$GITHUB_OUTPUT"
-          echo "total_count=${total}" >> "$GITHUB_OUTPUT"
-          if [ "${min}" -lt 100 ]; then
-            echo "::notice::Minimum translation progress: ${min}%. A PR will be created when all languages reach 100%."
-          else
-            echo "::notice::All ${total} language(s) at 100%. Proceeding with download."
-          fi
-
       - name: Download translations and create PR
-        if: steps.progress.outputs.min_progress == '100'
         uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2
         with:
           upload_sources: false
           upload_translations: false
           download_translations: true
           create_pull_request: true
-          pull_request_title: "chore: sync translations from Crowdin (${{ steps.progress.outputs.complete_count }}/${{ steps.progress.outputs.total_count }} languages at 100%)"
+          pull_request_title: "chore: sync translations from Crowdin"
           pull_request_body: |
             Translations synced automatically from [Crowdin](https://crowdin.com/project/egc).
 
-            **Translation progress: ${{ steps.progress.outputs.min_progress }}%** (${{ steps.progress.outputs.complete_count }} of ${{ steps.progress.outputs.total_count }} active language(s) at 100%)
-
             Only fully translated files are included (`skip_untranslated_files: true`).
 
-            > This PR was created automatically. Do not merge unless all checks pass and the progress badge shows 100%.
+            > This PR was created automatically. Do not merge unless all checks pass.
           pull_request_base_branch_name: main
           localization_branch_name: chore/crowdin-translations
           skip_untranslated_files: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<!-- LANGUAGE-SELECTOR-START -->
-**Language:** English | [Português do Brasil](translations/pt/README.md)
-<!-- LANGUAGE-SELECTOR-END -->
-
 <div align="center">
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
@@ -11,7 +7,7 @@
 <!-- CENTERED-LANGUAGE-SELECTOR-START -->
 <div align="center">
 
-**Language / Idioma**
+**Language**
 
 [**English**](README.md) | [Português do Brasil](translations/pt/README.md)
 


### PR DESCRIPTION
## Summary

- Removes the redundant `Language: English | Português do Brasil` block above the hero image -- the centered selector below the badges already handles this
- Renames `Language / Idioma` to `Language` in the centered selector (repository language is English)
- Restructures `crowdin-sync.yml` to add automatic MT pre-translation:
  1. Upload sources to Crowdin (always)
  2. Discover configured MT engine via Crowdin API
  3. If engine found: trigger pre-translation for all active languages, wait up to 6 min for completion
  4. Check progress and download + open PR when all languages reach 100%
  5. Falls back gracefully if no MT engine is configured

## Why

The top language selector was added automatically by a previous workflow and is redundant with the centered one. Having two selectors in the same README pollutes the header.

The MT step enables fully automatic translation updates: when the English README changes, Crowdin pre-translates all configured languages via machine translation and opens a PR automatically without waiting for human translators.

## Test plan

- [ ] README renders with a single language selector below the badges
- [ ] `Language / Idioma` heading is gone, `Language` is shown
- [ ] Hero image is the first element in the page (no selector above it)
- [ ] Crowdin sync workflow runs without errors when no MT engine is configured (notice log, skips gracefully)
- [ ] When MT engine is configured in Crowdin, pre-translation step triggers and waits for completion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate language selector in the README and standardized the label to “Language”. Added automatic Crowdin MT pre-translation in `crowdin-sync.yml` with a simpler download step that only opens a PR when translations change.

- **New Features**
  - Upload sources first, then detect an MT engine via the Crowdin API.
  - If found, pre-translate only MT-supported languages and wait up to 6 minutes.
  - Always run the download step; include only fully translated files (`skip_untranslated_files: true`), so a PR opens only when there are changes.
  - Skip MT gracefully if no engine is available or if pre-translation fails.

<sup>Written for commit 0591f45f76147a316be0713c1733fb896855d717. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned language selector in README with improved visual presentation and clearer "Language" label for better user navigation.

* **Chores**
  * Enhanced translation workflow with optimized source management, improved progress tracking, and refined automation for more efficient localization updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->