### PR TITLE
fix(i18n): remove dead code from selector script and fix workflow push

### DIFF
--- a/.github/workflows/update-readme-languages.yml
+++ b/.github/workflows/update-readme-languages.yml
@@ -3,6 +3,8 @@ name: Update README Language Selector
 on:
   push:
     branches: [main]
+    paths:
+      - translations/**/README.md
   workflow_dispatch:
 
 permissions: {}
@@ -13,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -23,15 +26,23 @@ jobs:
       - name: Update language selector
         run: node scripts/update-readme-languages.js
 
-      - name: Commit if changed
+      - name: Open PR if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           if git diff --cached --quiet; then
-            echo "No changes to commit."
-          else
-            MSG=$'chore(i18n): sync language selector in README\n\nSigned-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
-            git commit -m "$MSG"
-            git push
+            echo "Language selector already up to date."
+            exit 0
           fi
+          BRANCH="chore/sync-language-selector-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$BRANCH"
+          git commit -m $'chore(i18n): sync language selector in README\n\nSigned-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(i18n): sync language selector in README" \
+            --body "Language selector updated automatically to reflect available translations." \
+            --base main \
+            --head "$BRANCH"

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -41,48 +41,9 @@ const LANGUAGE_NAMES = {
   ca: "Català",
 };
 
-const LANGUAGE_WORD = {
-  pt: "Idioma",
-  es: "Idioma",
-  fr: "Langue",
-  de: "Sprache",
-  it: "Lingua",
-  nl: "Taal",
-  pl: "Język",
-  ru: "Язык",
-  uk: "Мова",
-  tr: "Dil",
-  ar: "اللغة",
-  hi: "भाषा",
-  zh: "语言",
-  ja: "言語",
-  ko: "언어",
-  vi: "Ngôn ngữ",
-  th: "ภาษา",
-  id: "Bahasa",
-  sv: "Språk",
-  da: "Sprog",
-  no: "Språk",
-  fi: "Kieli",
-  cs: "Jazyk",
-  sk: "Jazyk",
-  ro: "Limbă",
-  hu: "Nyelv",
-  bg: "Език",
-  hr: "Jezik",
-  el: "Γλώσσα",
-  he: "שפה",
-  fa: "زبان",
-  bn: "ভাষা",
-  ms: "Bahasa",
-  ca: "Idioma",
-};
-
 const ROOT           = path.join(__dirname, "..");
 const TRANSLATIONS   = path.join(ROOT, "translations");
 const README_PATH    = path.join(ROOT, "README.md");
-const TOP_START      = "<!-- LANGUAGE-SELECTOR-START -->";
-const TOP_END        = "<!-- LANGUAGE-SELECTOR-END -->";
 const CENTER_START   = "<!-- CENTERED-LANGUAGE-SELECTOR-START -->";
 const CENTER_END     = "<!-- CENTERED-LANGUAGE-SELECTOR-END -->";
 
@@ -98,17 +59,8 @@ function getAvailableLanguages() {
     .sort();
 }
 
-function buildTopSelector(langs) {
-  const links = langs.map((code) => {
-    const name = LANGUAGE_NAMES[code] || code.toUpperCase();
-    return `[${name}](translations/${code}/README.md)`;
-  });
-  return `${TOP_START}\n**Language:** English | ${links.join(" | ")}\n${TOP_END}`;
-}
-
 function buildCenteredSelector(langs) {
-  const titleWords = ["Language", ...langs.map((c) => LANGUAGE_WORD[c] || c.toUpperCase())];
-  const title      = `**${titleWords.join(" / ")}**`;
+  const title = `**Language**`;
   const links      = [
     `[**English**](README.md)`,
     ...langs.map((code) => {
@@ -141,20 +93,15 @@ function updateReadme() {
   const readme = fs.readFileSync(README_PATH, "utf8");
   const langs  = getAvailableLanguages();
 
-  const updated = replaceBlock(
-    replaceBlock(readme, TOP_START, TOP_END, buildTopSelector(langs)),
-    CENTER_START,
-    CENTER_END,
-    buildCenteredSelector(langs)
-  );
+  const updated = replaceBlock(readme, CENTER_START, CENTER_END, buildCenteredSelector(langs));
 
   if (updated === readme) {
-    console.log("Language selectors already up to date.");
+    console.log("Language selector already up to date.");
     return;
   }
 
   fs.writeFileSync(README_PATH, updated, "utf8");
-  console.log(`Language selectors updated with ${langs.length} language(s): ${langs.join(", ")}`);
+  console.log(`Language selector updated with ${langs.length} language(s): ${langs.join(", ")}`);
 }
 
 updateReadme();


### PR DESCRIPTION
## Summary

- Removes `buildTopSelector`, `TOP_START`, `TOP_END`, and `LANGUAGE_WORD` from `scripts/update-readme-languages.js` — all dead code after the top selector block was removed from README in #260
- Title in the centered selector is now always `**Language**` — no more multilingual concatenation
- Fixes `update-readme-languages.yml`: the workflow was trying to push directly to main on every commit, which branch protection always rejects. It now creates a PR when the selector is out of sync
- Narrows the workflow trigger to `translations/**/README.md` paths so it only fires when a new translation actually appears, not on every push to main

## Root cause

After #260 was merged, the `Update README Language Selector` workflow ran and failed immediately because `git push` to main is blocked by the CodeQL branch protection rule. This PR fixes the workflow so it can never fail that way again.

## Test plan

- [ ] Verify script runs cleanly: `node scripts/update-readme-languages.js` reports "already up to date"
- [ ] CI passes on this PR
- [ ] After merge, the `Update README Language Selector` workflow does not trigger (trigger is now scoped to `translations/**/README.md`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the README language selector script and fixed the workflow to open a PR instead of pushing to `main`. This avoids branch protection failures and only runs when a new translation README is added.

- **Bug Fixes**
  - `update-readme-languages.yml` creates a PR using `GITHUB_TOKEN` (adds `pull-requests: write`), no direct push to `main`.
  - Workflow triggers only on `translations/**/README.md`.

- **Refactors**
  - Removed unused `buildTopSelector`, `TOP_START`, `TOP_END`, and `LANGUAGE_WORD` from `scripts/update-readme-languages.js`.
  - Centered selector title is now always `**Language**`.

<sup>Written for commit 1f21f5c8ec49531dc23ad5637262d1e6cc2af3ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

