### PR TITLE
feat(i18n): restore top language selector in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- LANGUAGE-SELECTOR-START -->
+**Language:** English | [Português do Brasil](translations/pt/README.md)
+<!-- LANGUAGE-SELECTOR-END -->
+
 <div align="center">
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -44,6 +44,8 @@ const LANGUAGE_NAMES = {
 const ROOT           = path.join(__dirname, "..");
 const TRANSLATIONS   = path.join(ROOT, "translations");
 const README_PATH    = path.join(ROOT, "README.md");
+const TOP_START      = "<!-- LANGUAGE-SELECTOR-START -->";
+const TOP_END        = "<!-- LANGUAGE-SELECTOR-END -->";
 const CENTER_START   = "<!-- CENTERED-LANGUAGE-SELECTOR-START -->";
 const CENTER_END     = "<!-- CENTERED-LANGUAGE-SELECTOR-END -->";
 
@@ -57,6 +59,14 @@ function getAvailableLanguages() {
       return stat.isDirectory() && fs.existsSync(readme);
     })
     .sort();
+}
+
+function buildTopSelector(langs) {
+  const links = langs.map((code) => {
+    const name = LANGUAGE_NAMES[code] || code.toUpperCase();
+    return `[${name}](translations/${code}/README.md)`;
+  });
+  return `${TOP_START}\n**Language:** English | ${links.join(" | ")}\n${TOP_END}`;
 }
 
 function buildCenteredSelector(langs) {
@@ -93,15 +103,20 @@ function updateReadme() {
   const readme = fs.readFileSync(README_PATH, "utf8");
   const langs  = getAvailableLanguages();
 
-  const updated = replaceBlock(readme, CENTER_START, CENTER_END, buildCenteredSelector(langs));
+  const updated = replaceBlock(
+    replaceBlock(readme, TOP_START, TOP_END, buildTopSelector(langs)),
+    CENTER_START,
+    CENTER_END,
+    buildCenteredSelector(langs)
+  );
 
   if (updated === readme) {
-    console.log("Language selector already up to date.");
+    console.log("Language selectors already up to date.");
     return;
   }
 
   fs.writeFileSync(README_PATH, updated, "utf8");
-  console.log(`Language selector updated with ${langs.length} language(s): ${langs.join(", ")}`);
+  console.log(`Language selectors updated with ${langs.length} language(s): ${langs.join(", ")}`);
 }
 
 updateReadme();


### PR DESCRIPTION
Restores the `<!-- LANGUAGE-SELECTOR-START -->` block at the top of README (above the logo), which was removed in #260.

Also restores `buildTopSelector` and the `TOP_START`/`TOP_END` constants in the update script so the block stays in sync automatically when new translations are added.

The centered selector below the badges is unchanged and still shows `**Language**` (not "Language / Idioma").

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the top language selector in the README above the logo and makes the update script auto-sync it when translations are added. The centered selector below the badges is unchanged and still shows "Language".

- **Refactors**
  - Restores buildTopSelector and `TOP_START`/`TOP_END` markers in `scripts/update-readme-languages.js`.
  - Script now updates both top and centered selectors and improves log messages.

<sup>Written for commit 76bb695cc2795f9ba1ad5fc50387658014c174f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

