### PR TITLE
fix(i18n): restore multilingual title in centered language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <!-- CENTERED-LANGUAGE-SELECTOR-START -->
 <div align="center">
 
-**Language**
+**Language / Idioma**
 
 [**English**](README.md) | [Português do Brasil](translations/pt/README.md)
 

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -41,6 +41,43 @@ const LANGUAGE_NAMES = {
   ca: "Català",
 };
 
+const LANGUAGE_WORD = {
+  pt: "Idioma",
+  es: "Idioma",
+  fr: "Langue",
+  de: "Sprache",
+  it: "Lingua",
+  nl: "Taal",
+  pl: "Język",
+  ru: "Язык",
+  uk: "Мова",
+  tr: "Dil",
+  ar: "اللغة",
+  hi: "भाषा",
+  zh: "语言",
+  ja: "言語",
+  ko: "언어",
+  vi: "Ngôn ngữ",
+  th: "ภาษา",
+  id: "Bahasa",
+  sv: "Språk",
+  da: "Sprog",
+  no: "Språk",
+  fi: "Kieli",
+  cs: "Jazyk",
+  sk: "Jazyk",
+  ro: "Limbă",
+  hu: "Nyelv",
+  bg: "Език",
+  hr: "Jezik",
+  el: "Γλώσσα",
+  he: "שפה",
+  fa: "زبان",
+  bn: "ভাষা",
+  ms: "Bahasa",
+  ca: "Idioma",
+};
+
 const ROOT           = path.join(__dirname, "..");
 const TRANSLATIONS   = path.join(ROOT, "translations");
 const README_PATH    = path.join(ROOT, "README.md");
@@ -70,7 +107,8 @@ function buildTopSelector(langs) {
 }
 
 function buildCenteredSelector(langs) {
-  const title = `**Language**`;
+  const titleWords = ["Language", ...langs.map((c) => LANGUAGE_WORD[c] || c.toUpperCase())];
+  const title      = `**${titleWords.join(" / ")}**`;
   const links      = [
     `[**English**](README.md)`,
     ...langs.map((code) => {


### PR DESCRIPTION
Restores `LANGUAGE_WORD` and the dynamic title so the centered selector reads `**Language / Idioma**` (and will grow to `Language / Idioma / Idioma` etc. as more translations land). Matches the convention used by major open-source repositories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the multilingual title in the centered README language selector by reintroducing the `LANGUAGE_WORD` map and dynamic title generation. The selector now shows "Language / Idioma" when Portuguese is available and will expand automatically as more translations are added.

<sup>Written for commit 6a70c4c77647137b5927e51780126860603f0839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

