### PR TITLE
style: change Portuguese (Brazil) spelling in README selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Language:** English | [Español](translations/es/README.md) | [Português do Brasil](translations/pt/README.md)
+**Language:** English | [Español](translations/es/README.md) | [Português (Brasil)](translations/pt/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -13,7 +13,7 @@
 
 **Language / Idioma**
 
-[**English**](README.md) | [Español](translations/es/README.md) | [Português do Brasil](translations/pt/README.md)
+[**English**](README.md) | [Español](translations/es/README.md) | [Português (Brasil)](translations/pt/README.md)
 
 </div>
 <!-- CENTERED-LANGUAGE-SELECTOR-END -->

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -5,7 +5,7 @@ const fs   = require("fs");
 const path = require("path");
 
 const LANGUAGE_NAMES = {
-  pt: "Português do Brasil",
+  pt: "Português (Brasil)",
   es: "Español",
   fr: "Français",
   de: "Deutsch",


### PR DESCRIPTION
Changes the spelling of Portuguese language from 'Português do Brasil' to 'Português (Brasil)' in the README selectors, updated via the automated script.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the Brazilian Portuguese label to "Português (Brasil)" across README language selectors (top and centered). Updates `scripts/update-readme-languages.js` so future runs keep this wording.

<sup>Written for commit a23fd39b7098368b63e69eafca19ea8f06b59f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

