### PR TITLE
fix(egc-memory): add FTS5 index to lesson_recall via Migration 5

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import { randomUUID } from 'crypto';
 import { z } from 'zod';
-import { createSearchIndex, rebuildSearchIndex, searchDecisions } from './search.js';
+import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
 import {
   createWorkingMemoryTable,
@@ -83,6 +83,7 @@ function log(level: 'INFO'|'WARN'|'ERROR'|'AUDIT'|'DEBUG', msg: string, meta: Re
 
 let dbInstance: Database | null = null;
 let searchIndexReady = false;
+let lessonsSearchIndexReady = false;
 
 // ============================================================================
 // SQLite Arbitration & Message Queue (Cross-Runtime Synchronization)
@@ -250,6 +251,22 @@ async function runMigrations(db: Database, dbDir: string) {
           ON lessons (archived, confidence DESC);
       `);
       await db.run('INSERT INTO schema_migrations (version) VALUES (4)');
+    }
+
+    // Migration 5: FTS5 index over lessons for BM25 keyword search.
+    // Mirrors the decisions_fts pattern; triggers keep the index in sync on
+    // every write and a one-time rebuild backfills lessons from Migration 4.
+    const hasV5 = await db.get('SELECT version FROM schema_migrations WHERE version = 5');
+    try {
+      if (!hasV5) {
+        await createLessonsSearchIndex(db);
+        await rebuildLessonsSearchIndex(db);
+        await db.run('INSERT INTO schema_migrations (version) VALUES (5)');
+      }
+      lessonsSearchIndexReady = true;
+    } catch (e) {
+      lessonsSearchIndexReady = false;
+      log('WARN', 'FTS5 unavailable for lessons, lesson_recall falls back to substring matching', { error: String(e) });
     }
   } finally {
     try { fs.unlinkSync(lockFile); } catch(e) {
@@ -663,18 +680,30 @@ async function handleLessonSave(db: Database, args: unknown) {
 
 async function handleLessonRecall(db: Database, args: unknown) {
   const { query, min_confidence, limit } = LessonRecallSchema.parse(args);
-  const lowerQuery = query.toLowerCase();
-  const rows = await db.all<LessonRow[]>(
-    `SELECT * FROM lessons
-     WHERE archived = 0 AND confidence >= ?
-     ORDER BY confidence DESC, created_at DESC
-     LIMIT ?`,
-    [min_confidence, limit * 3]
-  );
-  const matched = rows
-    .filter(r => r.content.toLowerCase().includes(lowerQuery) || r.context.toLowerCase().includes(lowerQuery) || (r.tags?.toLowerCase().includes(lowerQuery) ?? false))
-    .slice(0, limit)
-    .map(mapLessonRow);
+
+  let matched: ReturnType<typeof mapLessonRow>[];
+
+  if (lessonsSearchIndexReady) {
+    const results = await searchLessons(db, query, min_confidence, limit);
+    matched = results.map(r => mapLessonRow({
+      id: r.id, content: r.content, context: r.context, confidence: r.confidence,
+      tags: r.tags ?? null, archived: 0, created_at: r.created_at,
+      last_reinforced: r.last_reinforced ?? null, last_recalled: r.last_recalled ?? null
+    } as LessonRow));
+  } else {
+    const lowerQuery = query.toLowerCase();
+    const rows = await db.all<LessonRow[]>(
+      `SELECT * FROM lessons
+       WHERE archived = 0 AND confidence >= ?
+       ORDER BY confidence DESC, created_at DESC
+       LIMIT ?`,
+      [min_confidence, limit * 3]
+    );
+    matched = rows
+      .filter(r => r.content.toLowerCase().includes(lowerQuery) || r.context.toLowerCase().includes(lowerQuery) || (r.tags?.toLowerCase().includes(lowerQuery) ?? false))
+      .slice(0, limit)
+      .map(mapLessonRow);
+  }
 
   const now = new Date().toISOString();
   if (matched.length > 0) {
@@ -685,7 +714,7 @@ async function handleLessonRecall(db: Database, args: unknown) {
     });
   }
 
-  log('INFO', 'Lessons recalled', { query, count: matched.length });
+  log('INFO', 'Lessons recalled', { query, fts: lessonsSearchIndexReady, count: matched.length });
   return { content: [{ type: "text", text: JSON.stringify({ lessons: matched, meta: { query, min_confidence, limit, count: matched.length } }, null, 2) }] };
 }
 

--- a/mcp/servers/egc-memory/src/search.ts
+++ b/mcp/servers/egc-memory/src/search.ts
@@ -71,6 +71,98 @@ export function rankResults(rows: RawSearchRow[]): RankedDecision[] {
   }));
 }
 
+export interface RankedLesson {
+  id: string;
+  content: string;
+  context: string;
+  confidence: number;
+  tags: string | null;
+  created_at: string;
+  last_reinforced: string | null;
+  last_recalled: string | null;
+  score: number;
+}
+
+interface RawLessonRow {
+  id: string;
+  content: string;
+  context: string;
+  confidence: number;
+  tags: string | null;
+  created_at: string;
+  last_reinforced: string | null;
+  last_recalled: string | null;
+  rawScore: number;
+}
+
+export async function createLessonsSearchIndex(db: Database): Promise<void> {
+  await db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS lessons_fts USING fts5(
+      content,
+      context,
+      tags,
+      content='lessons',
+      content_rowid='rowid'
+    );
+    CREATE TRIGGER IF NOT EXISTS lessons_fts_after_insert AFTER INSERT ON lessons BEGIN
+      INSERT INTO lessons_fts(rowid, content, context, tags)
+        VALUES (new.rowid, new.content, new.context, COALESCE(new.tags, ''));
+    END;
+    CREATE TRIGGER IF NOT EXISTS lessons_fts_after_delete AFTER DELETE ON lessons BEGIN
+      INSERT INTO lessons_fts(lessons_fts, rowid, content, context, tags)
+        VALUES ('delete', old.rowid, old.content, old.context, COALESCE(old.tags, ''));
+    END;
+    CREATE TRIGGER IF NOT EXISTS lessons_fts_after_update AFTER UPDATE ON lessons BEGIN
+      INSERT INTO lessons_fts(lessons_fts, rowid, content, context, tags)
+        VALUES ('delete', old.rowid, old.content, old.context, COALESCE(old.tags, ''));
+      INSERT INTO lessons_fts(rowid, content, context, tags)
+        VALUES (new.rowid, new.content, new.context, COALESCE(new.tags, ''));
+    END;
+  `);
+}
+
+export async function rebuildLessonsSearchIndex(db: Database): Promise<void> {
+  await db.exec(`INSERT INTO lessons_fts(lessons_fts) VALUES ('rebuild')`);
+}
+
+export async function searchLessons(
+  db: Database,
+  query: string,
+  minConfidence: number,
+  limit: number
+): Promise<RankedLesson[]> {
+  const match = sanitizeFtsQuery(query);
+  if (!match) return [];
+
+  const rows: RawLessonRow[] = await db.all(
+    `SELECT l.id, l.content, l.context, l.confidence, l.tags,
+            l.created_at, l.last_reinforced, l.last_recalled,
+            bm25(lessons_fts) AS rawScore
+     FROM lessons_fts
+     JOIN lessons l ON l.rowid = lessons_fts.rowid
+     WHERE lessons_fts MATCH ?
+       AND l.archived = 0
+       AND l.confidence >= ?
+     ORDER BY rawScore
+     LIMIT ?`,
+    [match, minConfidence, limit]
+  );
+
+  if (rows.length === 0) return [];
+  const best = Math.max(...rows.map(r => -r.rawScore));
+  return rows.map(r => ({
+    id: r.id,
+    content: r.content,
+    context: r.context,
+    confidence: r.confidence,
+    tags: r.tags ?? null,
+    created_at: r.created_at,
+    last_reinforced: r.last_reinforced ?? null,
+    last_recalled: r.last_recalled ?? null,
+    score: best > 0 ? Math.round((-r.rawScore / best) * 100) / 100 : 0
+  }));
+}
+
 export async function searchDecisions(
   db: Database,
   query: string,


### PR DESCRIPTION
## Root cause

`lesson_recall` never used FTS5. It ran a plain `SELECT` and filtered results in JavaScript with `.includes()`, requiring exact substring match. Searching for `"testing"` would miss a lesson containing `"test"`. No relevance ranking existed.

The `lessons` table was added in Migration 4 without a search index, unlike `decisions` which has had a BM25 FTS5 index since Migration 2.

## Fix

**Migration 5** adds `lessons_fts`, a FTS5 virtual table over the `lessons` table, using the same content table and trigger pattern already proven by `decisions_fts`:

- `lessons_fts_after_insert` populates the index on every `lesson_save`
- `lessons_fts_after_update` keeps the index in sync when content changes
- `lessons_fts_after_delete` removes stale entries on archival/deletion
- A one-time `rebuild` backfills all lessons created before this migration

`handleLessonRecall` now calls `searchLessons()` (BM25 ranking via `bm25(lessons_fts)`) when the index is available, and falls back to the previous `.includes()` behavior on SQLite builds without FTS5 support.

## Changes

- `search.ts`: added `createLessonsSearchIndex`, `rebuildLessonsSearchIndex`, `searchLessons`, `RankedLesson`
- `index.ts`: Migration 5 block, `lessonsSearchIndexReady` flag, updated `handleLessonRecall`

Closes #211

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches lesson recall to FTS5 with BM25 ranking for better matches and relevance, replacing fragile substring filtering. Migration 5 creates and backfills a `lessons_fts` index with a safe fallback when FTS5 is unavailable. Addresses #211.

- **Bug Fixes**
  - `lesson_recall` now uses `searchLessons()` (FTS5 + BM25) to find partial matches and rank results.
  - Falls back to previous `.includes()` matching if FTS5 isn’t supported.

- **Migration**
  - Migration 5 adds `lessons_fts` with INSERT/UPDATE/DELETE triggers and runs a one-time `rebuild` to backfill existing lessons. No manual steps required.

<sup>Written for commit 6437ace5099495a760d7fda578fdf92128e1010d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Full Text Search for lessons with relevance-based ranking
  * Implemented fallback substring matching when search index is unavailable
  * Enhanced lesson recall with improved search performance and result prioritization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->