### PR TITLE
fix: resolve state DB path via getEGCDir instead of hardcoded .gemini

### DIFF
--- a/scripts/ci/runtime-snapshot.js
+++ b/scripts/ci/runtime-snapshot.js
@@ -2,10 +2,10 @@
 'use strict';
 
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
 const { createStateStore } = require('../lib/state-store');
+const { getEGCDir } = require('../lib/utils');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -106,7 +106,7 @@ function buildTracerBlock(opts) {
 async function buildStateStoreBlock(opts) {
     const dbPath = opts.dbPath
         ? path.resolve(opts.dbPath)
-        : path.join(os.homedir(), '.gemini', 'egc', 'state.db');
+        : path.join(getEGCDir(), 'egc', 'state.db');
     const block = {
         dbPath,
         dbExists: fs.existsSync(dbPath)

--- a/scripts/hooks/state-db-writer.js
+++ b/scripts/hooks/state-db-writer.js
@@ -4,11 +4,10 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const os = require('os');
+const { getEGCDir } = require(path.join(__dirname, '..', 'lib', 'utils.js'));
 
 function resolveStateDbPath() {
-  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
-  return path.join(home, '.gemini', 'egc', 'state.db');
+  return path.join(getEGCDir(), 'egc', 'state.db');
 }
 
 async function main() {


### PR DESCRIPTION
## Root cause

`state-db-writer.js` and `runtime-snapshot.js` both hardcoded `~/.gemini/egc/state.db` as the state database path. This silently breaks every harness that installs EGC outside `~/.gemini` (Claude Code, Cursor, VS Code, and any future harness).

## Fix

Replace the hardcoded path with `getEGCDir()` from `scripts/lib/utils.js`, which resolves the correct base directory for the active harness via environment variables and install-path detection.

Removes the now-unused `os` import from both files.

Closes #247

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the state DB path using `getEGCDir()` instead of the hardcoded ~/.gemini path, so installs outside ~/.gemini work across harnesses (Claude Code, Cursor, VS Code). Also removes the unused `os` import.

<sup>Written for commit 3b2b7fa4ca76dc365ba5ddacc58bd925cafbc749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

