### PR TITLE
fix: use process.execPath instead of bare node in hook commands

### DIFF
--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -21,7 +21,7 @@ function isPlainObject(value) {
 }
 
 function buildHookCommand(hookScriptPath) {
-  return `node "${hookScriptPath}"`;
+  return `"${process.execPath}" "${hookScriptPath}"`;
 }
 
 function buildSessionStartCommand(hookScriptPath) {


### PR DESCRIPTION
## Root cause

`buildHookCommand` in `scripts/lib/claude-settings-hooks.js` generates hook entries for Claude Code `settings.json` using the bare `node` binary. This resolves via `PATH` at hook execution time, which breaks when:

- The user's `PATH` inside Claude Code does not include their Node.js installation (common with GUI app launchers on macOS/Linux)
- Multiple Node.js versions are installed via version managers (`nvm`, `mise`, `fnm`) and the wrong one resolves

## Fix

Replace `node` with `process.execPath`, which is the absolute path to the Node.js binary currently running the install script. This guarantees the hook uses the same runtime that installed EGC.

Closes #248

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `process.execPath` instead of `node` when generating Claude Code hook commands, ensuring hooks run with the same Node.js binary as the installer. Prevents PATH-dependent failures and wrong-version selection in GUI launches or multi-version setups.

<sup>Written for commit 71449553aa341a6b089d9eb350cd67e544ef1324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

