### PR TITLE
fix: resolve state-store DB path using harness detection in detect_patterns

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -22,16 +22,46 @@ import {
 import { detectPatternsFromEvents, patternToStoreEntry } from './patterns.js';
 import { ruleBasedCompress, llmCompress, loadRawObservations, replaceObservation } from './compress.js';
 
-// Mirrors DEFAULT_STATE_STORE_RELATIVE_PATH from scripts/lib/state-store/index.js
-const STATE_STORE_RELATIVE_PATH = path.join('.gemini', 'egc', 'state.db');
-
 function resolveStateStoreDbPath(): string {
   const envOverride = process.env.EGC_STATE_DB;
-  if (envOverride) {
-    return path.resolve(envOverride);
-  }
+  if (envOverride) return path.resolve(envOverride);
+
   const homeDir = process.env.HOME || process.env.USERPROFILE || os.homedir();
-  return path.join(homeDir, STATE_STORE_RELATIVE_PATH);
+  const env = process.env;
+
+  // Tier 1: harness-specific env vars injected at hook time (and sometimes at MCP launch).
+  if (env.GEMINI_PROJECT_DIR || env.GEMINI_PLUGIN_ROOT) {
+    return path.join(homeDir, '.gemini', 'egc', 'state.db');
+  }
+  if (env.CLAUDE_PROJECT_DIR || env.CLAUDE_PLUGIN_ROOT) {
+    return path.join(homeDir, '.claude', 'egc', 'state.db');
+  }
+  if (env.CODEBUDDY_PROJECT_DIR || env.CODEBUDDY_PLUGIN_ROOT) {
+    return path.join(homeDir, '.codebuddy', 'egc', 'state.db');
+  }
+  if (env.VSCODE_AGENT || env.GITHUB_COPILOT_API_TOKEN) {
+    return path.join(homeDir, '.github', 'egc', 'state.db');
+  }
+  if (env.KIRO_HOOK_FILE || env.KIRO_FILE_PATH) {
+    return path.join(homeDir, '.kiro', 'egc', 'state.db');
+  }
+
+  // Tier 2: probe known harness locations for an existing DB.
+  const candidates = [
+    path.join(homeDir, '.claude', 'egc', 'state.db'),
+    path.join(homeDir, '.gemini', 'egc', 'state.db'),
+    path.join(homeDir, '.cursor', 'egc', 'state.db'),
+    path.join(homeDir, '.github', 'egc', 'state.db'),
+    path.join(homeDir, '.kiro', 'egc', 'state.db'),
+    path.join(homeDir, '.codebuddy', 'egc', 'state.db'),
+    path.join(homeDir, '.egc', 'egc', 'state.db'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  // Fallback: ~/.egc is the harness-agnostic default used by egc init.
+  return path.join(homeDir, '.egc', 'egc', 'state.db');
 }
 
 function hideEgcRootOnWindows(): void {


### PR DESCRIPTION
## Root cause

detect_patterns in the egc-memory MCP server used a hardcoded constant pointing to ~/.gemini/egc/state.db. For any user not on Gemini CLI (Claude Code, Cursor, VS Code, etc.), hooks write events to a harness-specific path, so detect_patterns always queried an empty or non-existent database and returned events_analyzed=0.

## Fix

Replace the hardcoded constant with a two-tier resolver in resolveStateStoreDbPath():

**Tier 1** check harness-specific env vars (GEMINI_PROJECT_DIR, CLAUDE_PROJECT_DIR, CODEBUDDY_PROJECT_DIR, VSCODE_AGENT, KIRO_HOOK_FILE) that some harnesses inject when launching MCP server processes.

**Tier 2** probe the known harness locations in order and return the first DB file that exists on disk. This handles harnesses that do not inject env vars into MCP server processes.

**Fallback** ~/.egc/egc/state.db, the harness-agnostic default used by egc init.

The EGC_STATE_DB env var override is still checked first and takes priority over everything else.

Root cause investigation by @NITESH-DTU.

Closes #212

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes detect_patterns returning events_analyzed=0 on non-Gemini harnesses by resolving the state-store DB path based on the active harness instead of a hardcoded path. This makes pattern detection work across Claude, Cursor, VS Code, and others.

- **Bug Fixes**
  - Replaced hardcoded `~/.gemini/egc/state.db` with resolveStateStoreDbPath()
  - Tier 1: checks harness env vars (GEMINI_*, CLAUDE_*, CODEBUDDY_*, VSCODE_AGENT, KIRO_*)
  - Tier 2: probes known locations (`~/.claude`, `~/.gemini`, `~/.cursor`, `~/.github`, `~/.kiro`, `~/.codebuddy`, `~/.egc`) and uses the first existing DB
  - Fallback: `~/.egc/egc/state.db`
  - `EGC_STATE_DB` env var still overrides all other sources

<sup>Written for commit f5d2430ad5563f3ed7d2f3245523697b7092e607. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

