### PR TITLE
fix(tests): add comment to empty catch block in bootstrap-state-db test

### DIFF
--- a/tests/scripts/bootstrap-state-db.test.js
+++ b/tests/scripts/bootstrap-state-db.test.js
@@ -109,7 +109,7 @@ async function runTests() {
         `expected FAILED in stderr, got: ${result.stderr}`
       );
     } finally {
-      try { fs.unlinkSync(tempFile); } catch (_) {}
+      try { fs.unlinkSync(tempFile); } catch (_) { /* cleanup best-effort */ }
     }
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
- Adds `/* cleanup best-effort */` comment inside the empty `catch` block at line 112 of `tests/scripts/bootstrap-state-db.test.js`
- Fixes ESLint `no-empty` error that broke the Lint CI job on main after PR #284 merge

## Root Cause
The `catch (_) {}` block used for cleanup (`fs.unlinkSync`) after the FAILED subprocess test was flagged by ESLint rule `no-empty`. Empty block statements are disallowed; a comment inside the block satisfies the rule.

## Test plan
- [ ] Lint job passes (ESLint: 0 errors)
- [ ] All existing tests continue to pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/* cleanup best-effort */` inside the empty `catch` around `fs.unlinkSync` in `tests/scripts/bootstrap-state-db.test.js` to satisfy ESLint `no-empty`. This fixes the lint CI failure on `main`.

<sup>Written for commit 5d9982691b7cab99778997c851dc4e81fed35278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup robustness by enhancing error handling in test teardown logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->