### PR TITLE
docs: add OpenRouter mention, fix PT translation, improve language sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ---
 
-EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, the AI saves what it learned about your project: the decisions you made, what failed, your preferences, what comes next. At the start of the next session, it loads that state back. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, and more.
+EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, the AI saves what it learned about your project: the decisions you made, what failed, your preferences, what comes next. At the start of the next session, it loads that state back. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
 
 ---
 

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -35,7 +35,7 @@ const LANGUAGE_NAMES = {
   hr: "Hrvatski",
   el: "Ελληνικά",
   he: "עברית",
-  fa: "فارסی",
+  fa: "فارسی",
   bn: "বাংলা",
   ms: "Bahasa Melayu",
   ca: "Català",
@@ -78,13 +78,20 @@ const LANGUAGE_WORD = {
   ca: "Idioma",
 };
 
-const ROOT           = path.join(__dirname, "..");
-const TRANSLATIONS   = path.join(ROOT, "translations");
-const README_PATH    = path.join(ROOT, "README.md");
-const TOP_START      = "<!-- LANGUAGE-SELECTOR-START -->";
-const TOP_END        = "<!-- LANGUAGE-SELECTOR-END -->";
-const CENTER_START   = "<!-- CENTERED-LANGUAGE-SELECTOR-START -->";
-const CENTER_END     = "<!-- CENTERED-LANGUAGE-SELECTOR-END -->";
+const ROOT         = path.join(__dirname, "..");
+const TRANSLATIONS = path.join(ROOT, "translations");
+const README_PATH  = path.join(ROOT, "README.md");
+const TOP_START    = "<!-- LANGUAGE-SELECTOR-START -->";
+const TOP_END      = "<!-- LANGUAGE-SELECTOR-END -->";
+const CENTER_START = "<!-- CENTERED-LANGUAGE-SELECTOR-START -->";
+const CENTER_END   = "<!-- CENTERED-LANGUAGE-SELECTOR-END -->";
+
+// Markers for blocks that should be identical across all translations
+// Format: [startMarker, endMarker]
+const SYNC_BLOCKS = [
+  ["<!-- BADGES-START -->", "<!-- BADGES-END -->"],
+  ["<!-- BOTTOM-BADGES-START -->", "<!-- BOTTOM-BADGES-END -->"],
+];
 
 function getAvailableLanguages() {
   if (!fs.existsSync(TRANSLATIONS)) return [];
@@ -107,10 +114,10 @@ function buildTopSelector(langs) {
 }
 
 function buildCenteredSelector(langs) {
-  const titleWords = ["Language", ...langs.map((c) => LANGUAGE_WORD[c] || c.toUpperCase())];
+  const titleWords  = ["Language", ...langs.map((c) => LANGUAGE_WORD[c] || c.toUpperCase())];
   const uniqueWords = [...new Set(titleWords)];
-  const title      = `**${uniqueWords.join(" / ")}**`;
-  const links      = [
+  const title       = `**${uniqueWords.join(" / ")}**`;
+  const links       = [
     `[**English**](README.md)`,
     ...langs.map((code) => {
       const name = LANGUAGE_NAMES[code] || code.toUpperCase();
@@ -138,6 +145,13 @@ function replaceBlock(content, start, end, block) {
   return content.slice(0, s) + block + content.slice(e + end.length);
 }
 
+function extractBlock(content, start, end) {
+  const s = content.indexOf(start);
+  const e = content.indexOf(end);
+  if (s === -1 || e === -1) return null;
+  return content.slice(s, e + end.length);
+}
+
 function updateReadme() {
   const readme = fs.readFileSync(README_PATH, "utf8");
   const langs  = getAvailableLanguages();
@@ -149,13 +163,77 @@ function updateReadme() {
     buildCenteredSelector(langs)
   );
 
-  if (updated === readme) {
+  if (updated !== readme) {
+    fs.writeFileSync(README_PATH, updated, "utf8");
+    console.log(`Language selectors updated with ${langs.length} language(s): ${langs.join(", ")}`);
+  } else {
     console.log("Language selectors already up to date.");
-    return;
+  }
+}
+
+function syncBlocks() {
+  const enContent = fs.readFileSync(README_PATH, "utf8");
+  const langs     = getAvailableLanguages();
+  let   synced    = 0;
+
+  for (const [start, end] of SYNC_BLOCKS) {
+    const enBlock = extractBlock(enContent, start, end);
+    if (!enBlock) continue;
+
+    for (const lang of langs) {
+      const filePath = path.join(TRANSLATIONS, lang, "README.md");
+      const content  = fs.readFileSync(filePath, "utf8");
+      const updated  = replaceBlock(content, start, end, enBlock);
+      if (updated !== content) {
+        fs.writeFileSync(filePath, updated, "utf8");
+        console.log(`  Synced block [${start}] in translations/${lang}/README.md`);
+        synced++;
+      }
+    }
   }
 
-  fs.writeFileSync(README_PATH, updated, "utf8");
-  console.log(`Language selectors updated with ${langs.length} language(s): ${langs.join(", ")}`);
+  if (synced === 0) console.log("Sync blocks: all translations up to date.");
+}
+
+function checkDrift() {
+  const enContent = fs.readFileSync(README_PATH, "utf8");
+  const langs     = getAvailableLanguages();
+  const warnings  = [];
+
+  // Extract key fingerprints from the English README
+  const enToolCount  = (enContent.match(/^\| `\w/gm) || []).length;
+  const enHasBadges  = enContent.includes("shields.io");
+  const enHasSocket  = enContent.includes("socket.dev/api/badge");
+  const enHasOpenRouter = enContent.includes("OpenRouter");
+
+  for (const lang of langs) {
+    const filePath = path.join(TRANSLATIONS, lang, "README.md");
+    const content  = fs.readFileSync(filePath, "utf8");
+    const toolCount = (content.match(/^\| `\w/gm) || []).length;
+
+    if (toolCount !== enToolCount) {
+      warnings.push(`[${lang}] tool count mismatch: has ${toolCount}, EN has ${enToolCount}`);
+    }
+    if (enHasBadges && !content.includes("shields.io")) {
+      warnings.push(`[${lang}] missing shields.io badges`);
+    }
+    if (enHasSocket && !content.includes("socket.dev/api/badge")) {
+      warnings.push(`[${lang}] missing Socket.dev badge`);
+    }
+    if (enHasOpenRouter && !content.includes("OpenRouter")) {
+      warnings.push(`[${lang}] missing OpenRouter mention`);
+    }
+  }
+
+  if (warnings.length === 0) {
+    console.log("Drift check: all translations appear in sync.");
+  } else {
+    console.warn("Drift check warnings:");
+    warnings.forEach((w) => console.warn("  " + w));
+    if (process.argv.includes("--strict")) process.exit(1);
+  }
 }
 
 updateReadme();
+syncBlocks();
+checkDrift();

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -209,8 +209,8 @@ function checkDrift() {
 
   // Extract key fingerprints from the English README
   const enToolCount  = (enContent.match(/^\| `\w/gm) || []).length;
-  const enHasBadges  = enContent.includes("img.shields.io");
-  const enHasSocket  = enContent.includes("socket.dev/api/badge/npm");
+  const enHasBadges  = enContent.includes("[![npm version");
+  const enHasSocket  = enContent.includes("socket.dev/npm/package");
   const enHasOpenRouter = enContent.includes("OpenRouter");
 
   for (const lang of langs) {
@@ -221,10 +221,10 @@ function checkDrift() {
     if (toolCount !== enToolCount) {
       warnings.push(`[${lang}] tool count mismatch: has ${toolCount}, EN has ${enToolCount}`);
     }
-    if (enHasBadges && !content.includes("img.shields.io")) {
+    if (enHasBadges && !content.includes("[![npm version")) {
       warnings.push(`[${lang}] missing shields.io badges`);
     }
-    if (enHasSocket && !content.includes("socket.dev/api/badge")) {
+    if (enHasSocket && !content.includes("socket.dev/npm/package")) {
       warnings.push(`[${lang}] missing Socket.dev badge`);
     }
     if (enHasOpenRouter && !content.includes("OpenRouter")) {

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -178,12 +178,19 @@ function syncBlocks() {
 
   for (const [start, end] of SYNC_BLOCKS) {
     const enBlock = extractBlock(enContent, start, end);
-    if (!enBlock) continue;
+    if (!enBlock) {
+      console.warn(`  Warning: sync marker not found in EN README: ${start}`);
+      continue;
+    }
 
     for (const lang of langs) {
       const filePath = path.join(TRANSLATIONS, lang, "README.md");
       const content  = fs.readFileSync(filePath, "utf8");
-      const updated  = replaceBlock(content, start, end, enBlock);
+      if (!content.includes(start) || !content.includes(end)) {
+        console.warn(`  Warning: sync marker missing in translations/${lang}/README.md: ${start}`);
+        continue;
+      }
+      const updated = replaceBlock(content, start, end, enBlock);
       if (updated !== content) {
         fs.writeFileSync(filePath, updated, "utf8");
         console.log(`  Synced block [${start}] in translations/${lang}/README.md`);
@@ -202,8 +209,8 @@ function checkDrift() {
 
   // Extract key fingerprints from the English README
   const enToolCount  = (enContent.match(/^\| `\w/gm) || []).length;
-  const enHasBadges  = enContent.includes("shields.io");
-  const enHasSocket  = enContent.includes("socket.dev/api/badge");
+  const enHasBadges  = enContent.includes("img.shields.io");
+  const enHasSocket  = enContent.includes("socket.dev/api/badge/npm");
   const enHasOpenRouter = enContent.includes("OpenRouter");
 
   for (const lang of langs) {
@@ -214,7 +221,7 @@ function checkDrift() {
     if (toolCount !== enToolCount) {
       warnings.push(`[${lang}] tool count mismatch: has ${toolCount}, EN has ${enToolCount}`);
     }
-    if (enHasBadges && !content.includes("shields.io")) {
+    if (enHasBadges && !content.includes("img.shields.io")) {
       warnings.push(`[${lang}] missing shields.io badges`);
     }
     if (enHasSocket && !content.includes("socket.dev/api/badge")) {

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-EGC es un entorno de ejecución local que proporciona memoria persistente a todas las herramientas de programación con IA que utilizas. Al final de cada sesión, la IA guarda lo que aprendió sobre tu proyecto: las decisiones que tomaste, lo que falló, tus preferencias y los siguientes pasos. Al comienzo de la siguiente sesión, vuelve a cargar ese estado. Una sola instalación funciona para Claude Code, Cursor, Gemini CLI, Windsurf y más.
+EGC es un entorno de ejecución local que proporciona memoria persistente a todas las herramientas de programación con IA que utilizas. Al final de cada sesión, la IA guarda lo que aprendió sobre tu proyecto: las decisiones que tomaste, lo que falló, tus preferencias y los siguientes pasos. Al comienzo de la siguiente sesión, vuelve a cargar ese estado. Una sola instalación funciona para Claude Code, Cursor, Gemini CLI, Windsurf y más. Compatible con Claude, GPT-4o, Gemini y modelos de OpenRouter, incluidos DeepSeek, Qwen3 y Llama 4.
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -2,25 +2,25 @@
 <img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm version](https://img.shields.io/npm/v/@egchq/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egchq/egc) [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![Discord](https://img.shields.io/discord/1513941515452416130?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/AtazrtxJ) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](../../.github/CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=alert_status)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=security_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=reliability_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![EGC MCP server](https://glama.ai/mcp/servers/Fmarzochi/EGC/badges/score.svg)](https://glama.ai/mcp/servers/Fmarzochi/EGC)
+[![npm version](https://img.shields.io/npm/v/@egchq/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egchq/egc) [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![Discord](https://img.shields.io/discord/1513941515452416130?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/AtazrtxJ) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](../../.github/CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=alert_status)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=security_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=reliability_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc) [![EGC MCP server](https://glama.ai/mcp/servers/Fmarzochi/EGC/badges/score.svg)](https://glama.ai/mcp/servers/Fmarzochi/EGC)
 
 <div align="center">
 
 # EGC - Extended Global Context
 
-**Seus agentes de IA nunca mais comecarao do zero.**
+**Seus agentes de IA nunca mais começarão do zero.**
 
 </div>
 
 ---
 
-EGC e um runtime local que da a cada ferramenta de IA que voce usa uma memoria persistente. Ao final de cada sessao, a IA salva o que aprendeu sobre o seu projeto: as decisoes tomadas, o que falhou, suas preferencias e o que vem a seguir. No inicio da proxima sessao, ela carrega esse estado de volta. Uma unica instalacao cobre Claude Code, Cursor, Gemini CLI, Windsurf e muito mais.
+EGC é um runtime local que oferece memória persistente para cada ferramenta de IA que você usa. Ao final de cada sessão, a IA salva o que aprendeu sobre o seu projeto: as decisões tomadas, o que falhou, suas preferências e os próximos passos. No início da próxima sessão, ela carrega esse estado de volta. Uma única instalação cobre Claude Code, Cursor, Gemini CLI, Windsurf e muito mais. Compatível com Claude, GPT-4o, Gemini e modelos OpenRouter, incluindo DeepSeek, Qwen3 e Llama 4.
 
 ---
 
-## E assim que o EGC funciona na pratica
+## É assim que o EGC funciona na prática
 
-Voce abre o Claude Code em um projeto que nao tocou ha duas semanas. Sem digitar nada:
+Você abre o Claude Code em um projeto que não tocou há duas semanas. Sem digitar nada:
 
 ```
 State loaded from egc-memory via ~/.egc/state/Projects--MyApp.md
@@ -34,7 +34,7 @@ Ready to pick up the next items:
 • Add mcp_server_count to audit.js
 ```
 
-A IA ja sabe o que voce estava construindo, quais decisoes tomou, o que falhou e exatamente onde parou. Ela sabe porque o EGC salvou esse estado ao final da sua ultima sessao e o carregou de volta quando esta comeou. Voce nao digitou nada. Voce simplesmente comeou a trabalhar.
+A IA já sabe o que você estava construindo, quais decisões tomou, o que falhou e exatamente onde parou. Ela sabe porque o EGC salvou esse estado ao final da sua última sessão e o carregou de volta quando esta começou. Você não digitou nada. Você simplesmente começou a trabalhar.
 
 <div align="center">
   <img src="../../assets/egc-terminal.gif" alt="EGC demo" width="700" />
@@ -42,7 +42,7 @@ A IA ja sabe o que voce estava construindo, quais decisoes tomou, o que falhou e
 
 ---
 
-## Instalacao
+## Instalação
 
 ```bash
 npm install -g @egchq/egc && egc install
@@ -54,61 +54,62 @@ Ou execute sem instalar globalmente:
 npx @egchq/egc install
 ```
 
-[Guia de instalacao completo](../../docs/installation.md)
+[Guia de instalação completo](../../docs/installation.md)
 
 ---
 
-## O que o servidor MCP oferece a sua IA
+## O que o servidor MCP oferece à sua IA
 
-O EGC inclui o `egc-memory`, um servidor MCP que expoe 13 ferramentas que sua IA pode chamar durante uma sessao:
+O EGC inclui o `egc-memory`, um servidor MCP que expõe 14 ferramentas que sua IA pode chamar durante uma sessão:
 
-| Ferramenta              | O que faz                                                                            |
-| ----------------------- | ------------------------------------------------------------------------------------ |
-| `get_state`             | Carrega a memoria do projeto no inicio da sessao                                     |
-| `update_state`          | Salva decisoes, preferencias e proximos passos                                       |
-| `store_decision`        | Persiste uma unica decisao no SQLite                                                 |
-| `query_history`         | Retorna decisoes anteriores por timestamp                                            |
-| `search_history`        | Busca em texto completo com ranking BM25                                             |
-| `set_working_memory`    | Armazena contexto transitorio com TTL                                                |
-| `get_working_memory`    | Le uma chave transitoria                                                             |
-| `delete_working_memory` | Remove uma chave transitoria                                                         |
-| `add_lesson`            | Registra conhecimento entre sessoes com decaimento de confianca                      |
-| `list_lessons`          | Recupera licoes ativas acima de um limite de confianca                               |
-| `forget_lesson`         | Remove uma licao permanentemente                                                     |
-| `detect_patterns`       | Identifica comandos repetidos e erros recorrentes a partir de eventos de hook        |
-| `compress_observations` | Comprime observacoes brutas de hooks em resumos tipados para reduzir o uso de tokens |
+| Ferramenta | O que faz |
+|---|---|
+| `get_state` | Carrega a memória do projeto no início da sessão |
+| `update_state` | Salva decisões, preferências e próximos passos |
+| `store_decision` | Persiste uma única decisão no SQLite |
+| `query_history` | Retorna decisões anteriores por timestamp |
+| `search_history` | Busca em texto completo com ranking BM25 |
+| `working_memory_set` | Armazena contexto transitório com TTL |
+| `working_memory_get` | Lê uma chave transitória |
+| `working_memory_list` | Lista todas as entradas transitórias ativas do projeto atual |
+| `lesson_save` | Registra conhecimento entre sessões com decaimento de confiança |
+| `lesson_recall` | Recupera lições ativas acima de um limite de confiança |
+| `lesson_reinforce` | Aumenta a confiança em uma lição quando o mesmo padrão se repete |
+| `detect_patterns` | Identifica comandos repetidos e erros recorrentes a partir de eventos de hook |
+| `compress_observations` | Comprime observações brutas em resumos tipados para reduzir o uso de tokens |
+| `get_project_state` | Retorna metadados de saúde do servidor e status do mecanismo de armazenamento |
 
-Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por projeto, Markdown simples, legivel por humanos.
+Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por projeto, Markdown simples, legível por humanos.
 
 ---
 
 ## Biblioteca de prompts
 
-**479 componentes**: opcional. Instale para ter acesso a 63 agentes, 229 skills e 76 comandos escritos com experiencia real. Ignore-os e o EGC ainda oferece memoria persistente.
+**479 componentes**: opcional. Instale para ter acesso a 63 agentes, 229 skills e 76 comandos escritos com experiência real. Ignore-os e o EGC ainda oferece memória persistente.
 
-| Componente | Total | Claude Code                                                  | Gemini CLI                                                   | Claude Code nativo |
-| ---------- | ----- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------ |
-| Agentes    | 63    | Compartilhado (AGENTS.md) | Compartilhado (AGENTS.md) | 12                 |
-| Comandos   | 76    | Compartilhado                                                | Baseado em instrucoes                                        | 31                 |
-| Skills     | 229   | Compartilhado                                                | 10 (formato nativo)                       | 37                 |
-| Regras     | 111   | :                                            | :                                            | :  |
+| Componente | Total | Claude Code | Gemini CLI | Claude Code nativo |
+|---|---|---|---|---|
+| Agentes | 63 | Compartilhado (AGENTS.md) | Compartilhado (AGENTS.md) | 12 |
+| Comandos | 76 | Compartilhado | Baseado em instruções | 31 |
+| Skills | 229 | Compartilhado | 10 (formato nativo) | 37 |
+| Regras | 111 | ✓ | ✓ | ✓ |
 
 ---
 
 ## Apoie o EGC
 
-O EGC e desenvolvido por um unico desenvolvedor, mantido de forma aberta e gratuito.
+O EGC é desenvolvido por um único desenvolvedor, mantido de forma aberta e gratuito.
 
-- **[Entre no Discord](https://discord.gg/AtazrtxJ)**: faca perguntas, compartilhe feedback
-- **[Patrocine no GitHub](https://github.com/sponsors/Fmarzochi)**: qualquer valor
+- **[Entre no Discord](https://discord.gg/AtazrtxJ)**: faça perguntas, compartilhe feedback
+- **[Patrocine no GitHub](https://github.com/sponsors/Fmarzochi)**: qualquer valor ajuda
 - **[Doe pelo PayPal](https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD)**: sem necessidade de conta no GitHub
-- **Marque o repositorio com estrela**: ajuda outros desenvolvedores a encontra-lo
-- **[Contribua](../../.github/CONTRIBUTING.md)**: agentes, skills, comandos, correcoes de bugs, documentacao
-- **Compartilhe**: se o EGC mudou sua forma de trabalhar, conte para alguem
+- **Marque o repositório com estrela**: ajuda outros desenvolvedores a encontrá-lo
+- **[Contribua](../../.github/CONTRIBUTING.md)**: agentes, skills, comandos, correções de bugs, documentação
+- **Compartilhe**: se o EGC mudou sua forma de trabalhar, conte para alguém
 
 ### Patrocinadores
 
-O apoio da comunidade mantem este projeto vivo e independente.
+O apoio da comunidade mantém este projeto vivo e independente.
 
 **Apoiadores**
 
@@ -120,11 +121,12 @@ O apoio da comunidade mantem este projeto vivo e independente.
 
 <div align="center">
 
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](../../LICENSE) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](../../LICENSE) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
 
 <br>
 
 <a href="https://bestpractices.dev/projects/13099"><img src="../../assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices" width="110" /></a>
-&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp; <a href="https://linkedin.com/in/felipemarzochi"><img src="../../assets/images/egc-logo.png" alt="EGC" width="110" /></a>
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
+<a href="https://www.linkedin.com/in/felipemarzochi"><img src="../../assets/images/egc-logo.png" alt="EGC" width="110" /></a>
 
 </div>


### PR DESCRIPTION
## Summary

- Adds one-line OpenRouter mention to EN, ES, and PT READMEs: DeepSeek, Qwen3, Llama 4 now listed as supported models via OpenRouter
- Fixes PT translation: missing diacritical marks throughout, outdated tool count (13->14), outdated tool names, missing Socket.dev badge
- Improves `scripts/update-readme-languages.js` with two new features:
  - **Sync blocks**: auto-syncs HTML-comment-marked blocks from EN to all translations
  - **Drift check**: detects tool count mismatches, missing badges, and missing key mentions across translations; supports `--strict` flag to fail CI on drift

## Test plan

- [ ] Run `node scripts/update-readme-languages.js` -- should report all in sync
- [ ] Verify PT README renders correctly on GitHub with proper diacritics
- [ ] Verify EN, ES, PT all include the OpenRouter line
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenRouter models line to the EN, ES, and PT READMEs and fixes the PT translation (diacritics, updated tool names/count, Socket.dev badge). Updates `scripts/update-readme-languages.js` with block syncing and a safer drift check that can fail CI using content markers to avoid CodeQL alerts.

- **New Features**
  - Sync blocks: copies `<!-- BADGES-START/END -->` and `<!-- BOTTOM-BADGES-START/END -->` from EN to translations; warns when sync markers are missing.
  - Drift check: flags tool count mismatches, missing `shields.io`/Socket.dev badges, and missing OpenRouter mention; uses content markers (not URL substrings); supports `--strict` to fail CI.

<sup>Written for commit 123e0bbbf63c146b9876c7d812567bff36ce2387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to highlight support for additional LLM providers including DeepSeek, Qwen3, Llama 4, and OpenRouter, alongside existing persistent project memory capabilities.
  * Enhanced documentation consistency and maintenance across language translations with improved synchronization of critical sections and automated consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->