### PR TITLE
fix(security): upgrade undici to 6.27.0 in MCP servers

### DIFF
--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -1521,7 +1521,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "@types/node": "^25.9.3",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "undici": "^6.27.0"
   }
 }

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -1799,9 +1799,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -19,5 +19,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "overrides": {
+    "undici": "^6.27.0"
   }
 }


### PR DESCRIPTION
## Summary

- `undici@6.26.0` was pulled as a transitive dependency of `node-gyp` (via `sqlite3`) in both MCP servers
- This version falls in the vulnerable range `< 6.27.0`, triggering 4 Scorecard alerts (GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m, GHSA-p88m-4jfj-68fv, GHSA-vxpw-j846-p89q)
- Added `overrides.undici: "^6.27.0"` to both `egc-memory` and `egc-guardian` package.json
- Regenerated both `package-lock.json` — `undici` now resolves to `6.27.0`

## Test plan

- [ ] CI passes (no breaking changes — only a transitive dep bump in build tooling)
- [ ] Scorecard Vulnerabilities alert closes after merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `undici` to 6.27.0 in both MCP servers to resolve security advisories from the transitive `node-gyp` → `sqlite3` chain. Prevents installation of vulnerable versions (<6.27.0).

- **Dependencies**
  - Added `overrides` to force `undici@^6.27.0` in `egc-memory` and `egc-guardian`.
  - Regenerated lockfiles; `undici` now resolves to `6.27.0`.
  - Fixes GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m, GHSA-p88m-4jfj-68fv, GHSA-vxpw-j846-p89q.
  - No runtime changes.

<sup>Written for commit 079f88ea6ffbb12535a47617ada74daa50ca75e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal dependency version specifications across server modules to maintain consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->