### PR TITLE
feat(guardian): add CacheAligner and ContentRouter

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+fmarzochi@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -1521,7 +1521,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "@types/node": "^25.9.3",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "undici": "^6.27.0"
   }
 }

--- a/mcp/servers/egc-guardian/src/cache-aligner.ts
+++ b/mcp/servers/egc-guardian/src/cache-aligner.ts
@@ -1,0 +1,77 @@
+export type VolatileLabel = 'uuid' | 'iso8601' | 'jwt' | 'hex_hash';
+
+export interface VolatileFinding {
+  label: VolatileLabel;
+  sample: string;
+}
+
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const HEX_HASH_LENGTHS = new Set([32, 40, 64]);
+const HEX_ALPHABET_RE = /^[0-9a-f]+$/i;
+const ISO_DATE_MIN_LEN = 8;
+
+function isIso8601(token: string): boolean {
+  if (token.length < ISO_DATE_MIN_LEN) return false;
+  if (!token.includes('T') && !token.includes('-')) return false;
+  const candidate = token.endsWith('Z') ? token.slice(0, -1) + '+00:00' : token;
+  const d = new Date(candidate);
+  return !isNaN(d.getTime()) && candidate.includes('-');
+}
+
+function isJwtShape(token: string): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  return parts.every(p => p.length >= 4);
+}
+
+function isHexHash(token: string): boolean {
+  return HEX_HASH_LENGTHS.has(token.length) && HEX_ALPHABET_RE.test(token);
+}
+
+const ISO_RE = /\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?)?/g;
+
+export function detectVolatile(text: string): VolatileFinding[] {
+  const findings: VolatileFinding[] = [];
+  const seen = new Set<string>();
+
+  const uuidMatches = text.match(UUID_RE) ?? [];
+  for (const m of uuidMatches) {
+    const key = `uuid:${m.toLowerCase()}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      findings.push({ label: 'uuid', sample: m.slice(0, 36) });
+    }
+  }
+
+  const isoMatches = text.match(ISO_RE) ?? [];
+  for (const m of isoMatches) {
+    if (m.length >= ISO_DATE_MIN_LEN) {
+      const key = `iso:${m}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        findings.push({ label: 'iso8601', sample: m.slice(0, 24) });
+      }
+    }
+  }
+
+  const tokens = text.split(/[\s,;'"()\[\]{}]+/).filter(Boolean);
+  for (const token of tokens) {
+    if (isJwtShape(token)) {
+      const key = `jwt:${token.slice(0, 16)}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        findings.push({ label: 'jwt', sample: token.slice(0, 20) + '...' });
+      }
+      continue;
+    }
+    if (isHexHash(token)) {
+      const key = `hex:${token}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        findings.push({ label: 'hex_hash', sample: token.slice(0, 16) + '...' });
+      }
+    }
+  }
+
+  return findings;
+}

--- a/mcp/servers/egc-guardian/src/content-router.ts
+++ b/mcp/servers/egc-guardian/src/content-router.ts
@@ -1,0 +1,52 @@
+export type ContentType = 'json_array' | 'code' | 'log' | 'diff' | 'text';
+
+const CODE_SIGNALS = [
+  /^\s*(import|export|const|let|var|function|class|interface|type|async|await|return|from)\b/m,
+  /^\s*(def |fn |pub fn |func |package |#include|using namespace)\b/m,
+  /[{};]\s*$/m,
+];
+
+const LOG_SIGNALS = [
+  /\b(ERROR|WARN|INFO|DEBUG|FATAL|TRACE)\b/,
+  /^\[?\d{4}-\d{2}-\d{2}/m,
+  /\b(at \w+\.\w+\(|Exception|Traceback|stack trace)\b/i,
+];
+
+const DIFF_SIGNALS = [
+  /^diff --git/m,
+  /^@@\s+-\d+,\d+\s+\+\d+,\d+\s+@@/m,
+  /^[+-]{3} [ab]\//m,
+];
+
+function isJsonArray(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('[')) return false;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === 'object' && parsed[0] !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function detectContentType(chunk: string): ContentType {
+  if (isJsonArray(chunk)) return 'json_array';
+
+  for (const re of DIFF_SIGNALS) {
+    if (re.test(chunk)) return 'diff';
+  }
+
+  let logScore = 0;
+  for (const re of LOG_SIGNALS) {
+    if (re.test(chunk)) logScore++;
+  }
+  if (logScore >= 2) return 'log';
+
+  let codeScore = 0;
+  for (const re of CODE_SIGNALS) {
+    if (re.test(chunk)) codeScore++;
+  }
+  if (codeScore >= 1) return 'code';
+
+  return 'text';
+}

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -1799,9 +1799,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -19,5 +19,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "overrides": {
+    "undici": "^6.27.0"
   }
 }

--- a/tests/guardian-cache-aligner.test.js
+++ b/tests/guardian-cache-aligner.test.js
@@ -1,0 +1,105 @@
+/**
+ * Tests for CacheAligner (detectVolatile) and ContentRouter (detectContentType).
+ * Run with: node tests/guardian-cache-aligner.test.js
+ */
+
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+const alignerPath = path.join(__dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'cache-aligner.js');
+const routerPath  = path.join(__dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'content-router.js');
+
+if (!fs.existsSync(alignerPath) || !fs.existsSync(routerPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  process.exit(0);
+}
+
+const { detectVolatile } = require(alignerPath);
+const { detectContentType } = require(routerPath);
+
+// CacheAligner tests
+
+if (test('detects canonical UUID', () => {
+  const r = detectVolatile('session id: 550e8400-e29b-41d4-a716-446655440000');
+  assert.ok(r.some(f => f.label === 'uuid'), 'should find uuid');
+})) passed++; else failed++;
+
+if (test('detects ISO 8601 timestamp', () => {
+  const r = detectVolatile('updated at 2026-06-19T21:32:00Z');
+  assert.ok(r.some(f => f.label === 'iso8601'), 'should find iso8601');
+})) passed++; else failed++;
+
+if (test('detects JWT shape', () => {
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+  const r = detectVolatile(jwt);
+  assert.ok(r.some(f => f.label === 'jwt'), 'should find jwt');
+})) passed++; else failed++;
+
+if (test('detects SHA256 hex hash', () => {
+  const sha256 = 'a'.repeat(64);
+  const r = detectVolatile(`hash: ${sha256}`);
+  assert.ok(r.some(f => f.label === 'hex_hash'), 'should find hex_hash');
+})) passed++; else failed++;
+
+if (test('returns empty findings for plain text', () => {
+  const r = detectVolatile('the quick brown fox jumps over the lazy dog');
+  assert.strictEqual(r.length, 0, 'should have no findings');
+})) passed++; else failed++;
+
+if (test('deduplicates repeated UUIDs', () => {
+  const uuid = '550e8400-e29b-41d4-a716-446655440000';
+  const r = detectVolatile(`${uuid} and again ${uuid}`);
+  const uuidFindings = r.filter(f => f.label === 'uuid');
+  assert.strictEqual(uuidFindings.length, 1, 'should deduplicate');
+})) passed++; else failed++;
+
+// ContentRouter tests
+
+if (test('classifies JSON array', () => {
+  const chunk = JSON.stringify([{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }]);
+  assert.strictEqual(detectContentType(chunk), 'json_array');
+})) passed++; else failed++;
+
+if (test('classifies TypeScript code', () => {
+  const chunk = 'import { foo } from "bar";\nconst x = async () => {};';
+  assert.strictEqual(detectContentType(chunk), 'code');
+})) passed++; else failed++;
+
+if (test('classifies log output', () => {
+  const chunk = '[2026-06-19T21:00:00Z] ERROR something went wrong\nTraceback (most recent call last)';
+  assert.strictEqual(detectContentType(chunk), 'log');
+})) passed++; else failed++;
+
+if (test('classifies unified diff', () => {
+  const chunk = '--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1,3 +1,4 @@\n+import foo';
+  assert.strictEqual(detectContentType(chunk), 'diff');
+})) passed++; else failed++;
+
+if (test('classifies plain text as text', () => {
+  const chunk = 'This is a summary of the project decisions made this week.';
+  assert.strictEqual(detectContentType(chunk), 'text');
+})) passed++; else failed++;
+
+if (test('JSON object (not array) is not classified as json_array', () => {
+  const chunk = JSON.stringify({ key: 'value' });
+  assert.notStrictEqual(detectContentType(chunk), 'json_array');
+})) passed++; else failed++;
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- **CacheAligner** (`src/cache-aligner.ts`): detects volatile content in context chunks -- UUIDs, ISO 8601 timestamps, JWTs, and hex hashes (MD5/SHA1/SHA256). Read-only: never mutates content, only returns findings. Stabilizing prefixes by identifying volatile tokens helps provider KV cache hit rates.
- **ContentRouter** (`src/content-router.ts`): classifies context chunks by type (`json_array`, `code`, `log`, `diff`, `text`) using structural heuristics. Zero ML dependencies. Routes each chunk to the appropriate compressor in the next pipeline layer.
- **12 tests** (`tests/guardian-cache-aligner.test.js`): full coverage of both modules.

Both modules are pure TypeScript with zero runtime dependencies, inspired by the Headroom project's `cache_aligner.py` and `content_router.py`.

## Test plan

- [x] `node tests/guardian-cache-aligner.test.js` -- 12/12 passing
- [x] `npm run build` in `mcp/servers/egc-guardian` -- clean compile
- [x] DCO signed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `CacheAligner` and `ContentRouter` to stabilize context chunk caching and route content to the right compressors. Also pins `undici` to 6.27.0 for security.

- **New Features**
  - `CacheAligner`: detects UUIDs, ISO 8601 timestamps, JWTs, and hex hashes; read-only; helps stabilize prefixes for better KV cache hit rates.
  - `ContentRouter`: classifies chunks as `json_array`, `code`, `log`, `diff`, or `text` using structural heuristics; zero runtime deps.
  - Added 12 tests covering both modules.

- **Dependencies**
  - Override `undici` to `^6.27.0` in guardian and memory servers to address known vulnerabilities.

<sup>Written for commit c3854cd8e871ca8c581ceab0870c11f4795b0030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

