### PR TITLE
feat(guardian): add SmartCrusher for JSON array compression

### DIFF
--- a/mcp/servers/egc-guardian/src/smart-crusher.ts
+++ b/mcp/servers/egc-guardian/src/smart-crusher.ts
@@ -1,0 +1,76 @@
+export interface CrushResult {
+  crushed: string;
+  rows_before: number;
+  rows_after: number;
+  savings_pct: number;
+}
+
+const MIN_ROWS_TO_ANALYZE = 5;
+const MAX_ROWS_AFTER_CRUSH = 10;
+const VARIANCE_THRESHOLD = 0.15;
+
+function columnCardinality(rows: Record<string, unknown>[], key: string): number {
+  const values = new Set<string>();
+  for (const row of rows) {
+    const v = row[key];
+    values.add(v === null || v === undefined ? '__null__' : String(v));
+  }
+  return values.size / rows.length;
+}
+
+function rowSignature(row: Record<string, unknown>, keys: string[]): string {
+  return keys.map(k => {
+    const v = row[k];
+    return v === null || v === undefined ? '' : String(v).slice(0, 32);
+  }).join('|');
+}
+
+export function crushJsonArray(text: string): CrushResult | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.trim());
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed)) return null;
+  const rows = parsed.filter(r => r !== null && typeof r === 'object') as Record<string, unknown>[];
+  if (rows.length < MIN_ROWS_TO_ANALYZE) return null;
+
+  const allKeys = [...new Set(rows.flatMap(r => Object.keys(r)))];
+
+  // Keep columns with meaningful variance (high cardinality = important)
+  const importantKeys = allKeys.filter(k => columnCardinality(rows, k) >= VARIANCE_THRESHOLD);
+  const scoreKeys = importantKeys.length > 0 ? importantKeys : allKeys;
+
+  // Deduplicate by signature on important keys
+  const seen = new Set<string>();
+  const unique: Record<string, unknown>[] = [];
+  for (const row of rows) {
+    const sig = rowSignature(row, scoreKeys);
+    if (!seen.has(sig)) {
+      seen.add(sig);
+      unique.push(row);
+    }
+  }
+
+  // Cap at MAX_ROWS_AFTER_CRUSH, keeping first and last items for context
+  let final = unique;
+  if (unique.length > MAX_ROWS_AFTER_CRUSH) {
+    const head = unique.slice(0, Math.floor(MAX_ROWS_AFTER_CRUSH / 2));
+    const tail = unique.slice(-(MAX_ROWS_AFTER_CRUSH - head.length));
+    final = [...head, ...tail];
+  }
+
+  if (final.length >= rows.length) return null;
+
+  const crushed = JSON.stringify(final, null, 2);
+  const savingsPct = Math.round((1 - final.length / rows.length) * 100);
+
+  return {
+    crushed,
+    rows_before: rows.length,
+    rows_after: final.length,
+    savings_pct: savingsPct,
+  };
+}

--- a/tests/guardian-smart-crusher.test.js
+++ b/tests/guardian-smart-crusher.test.js
@@ -1,0 +1,89 @@
+/**
+ * Tests for SmartCrusher (crushJsonArray).
+ * Run with: node tests/guardian-smart-crusher.test.js
+ */
+
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+const buildPath = path.join(__dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'smart-crusher.js');
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  process.exit(0);
+}
+
+const { crushJsonArray } = require(buildPath);
+
+function makeRows(n, valueFn) {
+  return JSON.stringify(Array.from({ length: n }, (_, i) => valueFn(i)));
+}
+
+if (test('returns null for non-JSON input', () => {
+  assert.strictEqual(crushJsonArray('not json at all'), null);
+})) passed++; else failed++;
+
+if (test('returns null for JSON object (not array)', () => {
+  assert.strictEqual(crushJsonArray('{"key":"value"}'), null);
+})) passed++; else failed++;
+
+if (test('returns null for array smaller than MIN_ROWS', () => {
+  const small = JSON.stringify([{ a: 1 }, { a: 2 }, { a: 3 }]);
+  assert.strictEqual(crushJsonArray(small), null);
+})) passed++; else failed++;
+
+if (test('deduplicates identical rows', () => {
+  const rows = makeRows(10, () => ({ status: 'ok', code: 200 }));
+  const result = crushJsonArray(rows);
+  assert.ok(result !== null, 'should return a result');
+  assert.strictEqual(result.rows_after, 1, 'all identical rows collapse to 1');
+  assert.ok(result.savings_pct > 0, 'should have savings');
+})) passed++; else failed++;
+
+if (test('caps output at MAX_ROWS_AFTER_CRUSH', () => {
+  const rows = makeRows(50, i => ({ id: i, name: `item-${i}`, value: Math.random() }));
+  const result = crushJsonArray(rows);
+  assert.ok(result !== null, 'should return result for 50 unique rows');
+  assert.ok(result.rows_after <= 10, `rows_after ${result.rows_after} should be <= 10`);
+})) passed++; else failed++;
+
+if (test('preserves all rows when all are unique and under cap', () => {
+  const rows = makeRows(7, i => ({ id: i, name: `unique-${i}` }));
+  const result = crushJsonArray(rows);
+  // 7 unique rows under cap of 10, no dups => null (no savings possible)
+  assert.strictEqual(result, null, 'no savings if all unique and under cap');
+})) passed++; else failed++;
+
+if (test('returns valid JSON in crushed output', () => {
+  const rows = makeRows(20, i => ({ id: i % 5, type: 'event', payload: `data-${i % 3}` }));
+  const result = crushJsonArray(rows);
+  assert.ok(result !== null, 'should crush repeated patterns');
+  const reparsed = JSON.parse(result.crushed);
+  assert.ok(Array.isArray(reparsed), 'crushed output must be valid JSON array');
+})) passed++; else failed++;
+
+if (test('savings_pct is between 0 and 100', () => {
+  const rows = makeRows(20, i => ({ id: i % 5, label: 'same' }));
+  const result = crushJsonArray(rows);
+  assert.ok(result !== null, 'should have result');
+  assert.ok(result.savings_pct >= 0 && result.savings_pct <= 100);
+})) passed++; else failed++;
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Adds `SmartCrusher` (`src/smart-crusher.ts`) to `egc-guardian`: a pure TypeScript JSON array compressor that reduces token usage when `reduce_context` loads files containing large JSON arrays (e.g. `query_history`, `get_state` responses, tool output logs).

**Algorithm:**
1. Parses the input as a JSON array of objects
2. Identifies high-variance columns (cardinality >= 15% of total rows)
3. Deduplicates rows with identical signatures on those columns
4. Caps output at 10 rows (head + tail) when unique rows still exceed the limit
5. Returns `null` if no savings are possible (array too small or all rows unique and under cap)

**Safety:** always returns `null` instead of inflating output. The caller decides whether to use the crushed or original content.

## Test plan

- [x] `node tests/guardian-smart-crusher.test.js` -- 8/8 passing
- [x] `npm run build` -- clean compile
- [x] DCO signed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SmartCrusher` to `egc-guardian` to compress large JSON arrays in `reduce_context` (e.g., `query_history`, `get_state`, tool logs) and cut token usage. Returns `null` when no savings are possible.

- **New Features**
  - Adds `crushJsonArray(text)` that deduplicates rows using high-variance columns (>=15% cardinality) and trims with head+tail.
  - Caps output at 10 rows; skips arrays <5 rows; never inflates content (returns `null` if no savings).
  - Returns a `CrushResult` with `crushed`, `rows_before`, `rows_after`, and `savings_pct`.

<sup>Written for commit ea2aa19003cb702d5a6be16e1a6ac723e603b845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

