### PR TITLE
chore(glama): add auto_learn tool to marketplace listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -48,6 +48,10 @@
     {
       "name": "orchestrate_task",
       "description": "Routes a prompt with optional agent/skill lists and file payloads. Returns routing context and context-reduction metrics. Agent/skill selection is pass-through; provide explicit lists for deterministic routing."
+    },
+    {
+      "name": "auto_learn",
+      "description": "Mines recent tool failures from the EGC session database and writes ranked recommendations to CLAUDE.md between managed markers. Subsequent calls replace the block in-place. Skips gracefully when no session database exists."
     }
   ],
   "tags": [


### PR DESCRIPTION
## Summary

- Adds `auto_learn` tool entry to `glama.json` now that PR #299 is merged
- Keeps the Glama marketplace listing in sync with the actual server capabilities

## Test plan

- [ ] Verify `glama.json` validates against schema

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `auto_learn` tool to `glama.json` so the Glama marketplace listing matches current server capabilities. The entry explains that it mines recent tool failures and writes ranked recommendations to CLAUDE.md between managed markers.

<sup>Written for commit f4f55becdcfe375ae4446384b20718fe5553b00e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

