### PR TITLE
feat(guardian): add Headroom Phase 2 optional deep compression

### DIFF
--- a/mcp/servers/egc-guardian/src/headroom-client.ts
+++ b/mcp/servers/egc-guardian/src/headroom-client.ts
@@ -1,0 +1,90 @@
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+
+const PROBE_TIMEOUT_MS = 3_000;
+
+function resolveBaseUrl(): string {
+  const env = process.env.HEADROOM_URL;
+  if (env) return env.replace(/\/$/, '');
+
+  const cfgPath = path.join(os.homedir(), '.headroom', 'config.json');
+  if (fs.existsSync(cfgPath)) {
+    try {
+      const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+      if (cfg.proxy_url) return String(cfg.proxy_url).replace(/\/$/, '');
+    } catch {
+      // malformed config — fall through to default
+    }
+  }
+
+  return 'http://localhost:8787';
+}
+
+export interface HeadroomResult {
+  text: string;
+  bytes_before: number;
+  bytes_after: number;
+  compression_ratio: number;
+  transforms_applied: string[];
+}
+
+export async function compressViaHeadroom(
+  chunks: string[],
+  baseUrl: string = resolveBaseUrl(),
+): Promise<HeadroomResult | null> {
+  if (chunks.length === 0) return null;
+
+  const bytesBefore = chunks.reduce((a, c) => a + Buffer.byteLength(c, 'utf8'), 0);
+
+  const messages = chunks.map((chunk) => ({ role: 'user', content: chunk }));
+
+  let res: Response;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+    res = await fetch(`${baseUrl}/v1/compress`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Headroom-Stack': 'egc-guardian' },
+      body: JSON.stringify({ messages, model: 'claude-sonnet-4-6' }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timer);
+  } catch {
+    return null;
+  }
+
+  if (!res.ok) return null;
+
+  let data: {
+    messages: Array<{ role: string; content?: string }>;
+    tokens_before?: number;
+    tokens_after?: number;
+    compression_ratio?: number;
+    transforms_applied?: string[];
+  };
+  try {
+    data = await res.json() as typeof data;
+  } catch {
+    return null;
+  }
+
+  const compressedText = (data.messages ?? [])
+    .map((m) => m.content ?? '')
+    .filter(Boolean)
+    .join('\n\n');
+
+  const bytesAfter = Buffer.byteLength(compressedText, 'utf8');
+
+  if (bytesAfter >= bytesBefore) return null;
+
+  return {
+    text: compressedText,
+    bytes_before: bytesBefore,
+    bytes_after: bytesAfter,
+    compression_ratio: data.compression_ratio ?? (bytesBefore === 0 ? 1 : bytesAfter / bytesBefore),
+    transforms_applied: data.transforms_applied ?? [],
+  };
+}

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -22,6 +22,7 @@ import { detectVolatile } from './cache-aligner.js';
 import { detectContentType } from './content-router.js';
 import { crushJsonArray } from './smart-crusher.js';
 import { autoLearn } from './learn-writer.js';
+import { compressViaHeadroom } from './headroom-client.js';
 
 interface PipelineResult {
   chunks: string[];
@@ -242,26 +243,49 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         
         const pipeline = runCompressionPipeline(rawPayloads);
 
+        // Phase 2: optional Headroom deep compression (falls back silently if proxy not running)
+        let finalContent = pipeline.chunks.join('\n\n');
+        let headroomSavingsPct = 0;
+        let headroomTransforms: string[] = [];
+        if (pipeline.chunks.length > 0) {
+          const hr = await compressViaHeadroom(pipeline.chunks);
+          if (hr !== null) {
+            finalContent = hr.text;
+            headroomSavingsPct = Math.round((1 - hr.bytes_after / hr.bytes_before) * 100);
+            headroomTransforms = hr.transforms_applied;
+          }
+        }
+
+        const finalBytes = Buffer.byteLength(finalContent, 'utf8');
+        const totalSavingsPct = pipeline.bytes_before === 0
+          ? 0
+          : Math.round((1 - finalBytes / pipeline.bytes_before) * 100);
+
         auditLog('PAYLOAD_MUTATION', 'MUTATED', {
           mode,
           files_requested: filepaths.length,
           raw_chunks: rawPayloads.length,
           reduced_chunks: pipeline.chunks.length,
           bytes_before: pipeline.bytes_before,
-          bytes_after: pipeline.bytes_after,
-          savings_pct: pipeline.savings_pct,
+          bytes_after: finalBytes,
+          savings_pct: totalSavingsPct,
           volatile_findings: pipeline.volatile_findings,
           chunks_crushed: pipeline.chunks_crushed,
+          headroom_savings_pct: headroomSavingsPct,
+          headroom_transforms: headroomTransforms.length,
         });
 
-        const header = [
-          `[reduce_context] ${pipeline.savings_pct}% saved`,
-          `(${pipeline.bytes_before} -> ${pipeline.bytes_after} bytes,`,
+        const headerParts = [
+          `[reduce_context] ${totalSavingsPct}% saved`,
+          `(${pipeline.bytes_before} -> ${finalBytes} bytes,`,
           `${pipeline.chunks_crushed} JSON chunks crushed,`,
-          `${pipeline.volatile_findings} volatile tokens detected)`,
-        ].join(' ');
+          `${pipeline.volatile_findings} volatile tokens detected`,
+        ];
+        if (headroomSavingsPct > 0) {
+          headerParts.push(`, headroom: ${headroomSavingsPct}% extra via ${headroomTransforms.length} transforms`);
+        }
+        const header = headerParts.join(' ') + ')';
 
-        const finalContent = pipeline.chunks.join('\n\n');
         return { content: [{ type: "text", text: `${header}\n\n${finalContent}` }] };
       }
 

--- a/tests/guardian-headroom-client.test.js
+++ b/tests/guardian-headroom-client.test.js
@@ -1,0 +1,69 @@
+/**
+ * Tests for HeadroomClient (compressViaHeadroom).
+ * Run with: node tests/guardian-headroom-client.test.js
+ */
+
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+async function testAsync(name, fn) {
+  try {
+    await fn();
+    console.log(`  ok ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+const buildPath = path.join(__dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'headroom-client.js');
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  process.exit(0);
+}
+
+const { compressViaHeadroom } = require(buildPath);
+
+async function run() {
+  // Headroom proxy almost certainly not running in CI — expect graceful null
+  if (await testAsync('returns null when Headroom proxy is not reachable', async () => {
+    const result = await compressViaHeadroom(['hello world'], 'http://localhost:19999');
+    assert.strictEqual(result, null, 'should return null when proxy is down');
+  })) passed++; else failed++;
+
+  if (await testAsync('returns null for empty chunk list', async () => {
+    const result = await compressViaHeadroom([], 'http://localhost:19999');
+    assert.strictEqual(result, null, 'should return null for empty input');
+  })) passed++; else failed++;
+
+  if (test('module exports compressViaHeadroom as a function', () => {
+    assert.strictEqual(typeof compressViaHeadroom, 'function', 'compressViaHeadroom should be a function');
+  })) passed++; else failed++;
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `headroom-client.ts`: HTTP client for Headroom's `/v1/compress` endpoint
- Integrates as an **optional** second-pass after the Phase 1 pipeline in `reduce_context`
- Falls back silently (3s timeout) if the Headroom proxy is not running — zero impact for users without Headroom
- When active, extra savings and transforms are surfaced in the `reduce_context` header

## How it works

```
Phase 1: CacheAligner → ContentRouter → SmartCrusher → dedup  (native TS, always runs)
Phase 2: Headroom /v1/compress                                 (optional, if proxy is up)
```

URL resolution: `HEADROOM_URL` env var → `~/.headroom/config.json` → `http://localhost:8787`

## Test plan

- [ ] 3 tests in `tests/guardian-headroom-client.test.js` pass (graceful fallback, empty input, module contract)
- [ ] Build compiles cleanly
- [ ] `reduce_context` header includes `headroom: X% extra via N transforms` when proxy is active

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Headroom deep compression (Phase 2) to `reduce_context` to squeeze more bytes after the existing pipeline. If the Headroom proxy isn’t available, it falls back silently with no change to behavior.

- **New Features**
  - Added `headroom-client.ts` for `/v1/compress`.
  - Runs as an optional second pass after CacheAligner → ContentRouter → SmartCrusher → dedup; 3s timeout fallback.
  - Surfaces extra savings in the `reduce_context` header and audit log.
  - URL resolution: `HEADROOM_URL` → `~/.headroom/config.json` → `http://localhost:8787`.
  - Tests cover graceful fallback, empty input, and export contract.

<sup>Written for commit 2064d07753f222d9ac9b6a05894675afeaa02d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

