### PR TITLE
docs(readme): add egc-guardian MCP tools and fix Rules table formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ npx @egchq/egc install
 
 ---
 
-## What the MCP server gives your AI
+## What EGC gives your AI
 
-EGC ships `egc-memory`, an MCP server that exposes 14 tools your AI can call during a session:
+EGC ships two MCP servers that work together during every session.
+
+**`egc-memory`** — 14 tools for persistent memory:
 
 | Tool | What it does |
 |---|---|
@@ -95,6 +97,16 @@ EGC ships `egc-memory`, an MCP server that exposes 14 tools your AI can call dur
 
 State files live at `~/.egc/state/<project-slug>.md`. One file per project, plain Markdown, human-readable.
 
+**`egc-guardian`** — 5 tools for context and safety:
+
+| Tool | What it does |
+|---|---|
+| `validate_command` | Checks shell commands against project safety rules before execution |
+| `validate_write` | Validates file write paths to prevent unsafe writes |
+| `reduce_context` | Compresses file payloads to save your token budget |
+| `orchestrate_task` | Routes prompts with agent/skill context and returns compression metrics |
+| `auto_learn` | Mines session failures and writes actionable lessons to CLAUDE.md |
+
 ---
 
 ## Prompt library
@@ -106,7 +118,7 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 | Agents | 63 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |
 | Commands | 76 | Shared | Instruction-based | 31 |
 | Skills | 229 | Shared | 10 (native format) | 37 |
-| Rules | 111 |: |: |: |
+| Rules | 111 | ✓ | ✓ | ✓ |
 
 ---
 

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -58,9 +58,11 @@ npx @egchq/egc install
 
 ---
 
-## Lo que el servidor MCP ofrece a tu IA
+## Lo que EGC ofrece a tu IA
 
-EGC incluye `egc-memory`, un servidor MCP que expone 14 herramientas que tu IA puede utilizar durante una sesión:
+EGC incluye dos servidores MCP que trabajan juntos durante cada sesión.
+
+**`egc-memory`** — 14 herramientas para memoria persistente:
 
 | Herramienta | Qué hace |
 |---|---|
@@ -80,6 +82,16 @@ EGC incluye `egc-memory`, un servidor MCP que expone 14 herramientas que tu IA p
 | `get_project_state` | Devuelve metadatos de estado del servidor y del motor de almacenamiento |
 
 Los archivos de estado se almacenan en `~/.egc/state/<project-slug>.md`. Un archivo por proyecto, en Markdown simple y legible para humanos.
+
+**`egc-guardian`** — 5 herramientas para contexto y seguridad:
+
+| Herramienta | Qué hace |
+|---|---|
+| `validate_command` | Verifica comandos de shell contra las reglas de seguridad del proyecto antes de ejecutarlos |
+| `validate_write` | Valida rutas de escritura de archivos para prevenir escrituras inseguras |
+| `reduce_context` | Comprime los archivos del payload para ahorrar tu presupuesto de tokens |
+| `orchestrate_task` | Enruta prompts con contexto de agentes/skills y devuelve métricas de compresión |
+| `auto_learn` | Analiza fallos de sesión y escribe lecciones accionables en CLAUDE.md |
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -58,9 +58,11 @@ npx @egchq/egc install
 
 ---
 
-## O que o servidor MCP oferece à sua IA
+## O que o EGC oferece à sua IA
 
-O EGC inclui o `egc-memory`, um servidor MCP que expõe 14 ferramentas que sua IA pode chamar durante uma sessão:
+O EGC inclui dois servidores MCP que trabalham juntos durante cada sessão.
+
+**`egc-memory`** — 14 ferramentas para memória persistente:
 
 | Ferramenta | O que faz |
 |---|---|
@@ -80,6 +82,16 @@ O EGC inclui o `egc-memory`, um servidor MCP que expõe 14 ferramentas que sua I
 | `get_project_state` | Retorna metadados de saúde do servidor e status do mecanismo de armazenamento |
 
 Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por projeto, Markdown simples, legível por humanos.
+
+**`egc-guardian`** — 5 ferramentas para contexto e segurança:
+
+| Ferramenta | O que faz |
+|---|---|
+| `validate_command` | Verifica comandos de shell contra as regras de segurança do projeto antes da execução |
+| `validate_write` | Valida caminhos de escrita para prevenir gravações inseguras |
+| `reduce_context` | Comprime payloads de arquivos para economizar seu orçamento de tokens |
+| `orchestrate_task` | Roteia prompts com contexto de agentes/skills e retorna métricas de compressão |
+| `auto_learn` | Analisa falhas de sessão e escreve lições acionáveis no CLAUDE.md |
 
 ---
 


### PR DESCRIPTION
## Changes

- Renames the MCP section to **"What EGC gives your AI"** to reflect that two servers ship with EGC, not one
- Adds `egc-guardian` tool table (5 tools: `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task`, `auto_learn`) in EN, ES, and PT
- Fixes broken Rules row in English README: `|: |: |: |` → `| ✓ | ✓ | ✓ |`
- All three language files kept in sync

## Test plan

- [ ] English README renders correctly on GitHub
- [ ] Spanish and Portuguese translations match structure
- [ ] No links broken, assets unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented `egc-guardian` MCP tools and clarified that EGC ships two MCP servers. Fixed the Rules table formatting in the English README and synced ES/PT docs.

- **New Features**
  - Renamed section to "What EGC gives your AI".
  - Added `egc-guardian` tools table (`validate_command`, `validate_write`, `reduce_context`, `orchestrate_task`, `auto_learn`).
  - Mirrored updates in `translations/es/README.md` and `translations/pt/README.md`.

- **Bug Fixes**
  - Fixed the Rules table row in the English README (now shows ✓ ✓ ✓).

<sup>Written for commit 1abd35c21e2c5e7d346626836fcfdce9ee667cd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

