### PR TITLE
fix(docs): add Spanish to translation tables and fix broken HERMES link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -389,7 +389,8 @@ EGC uses [Crowdin](https://crowdin.com/project/egc) for community translations. 
 | Language | Progress | File |
 |---|---|---|
 | English | Source | [README.md](../README.md) |
-| Portugues do Brasil | 100% | [translations/pt/README.md](../translations/pt/README.md) |
+| Español | 100% | [translations/es/README.md](../translations/es/README.md) |
+| Português (Brasil) | 100% | [translations/pt/README.md](../translations/pt/README.md) |
 
 ---
 
@@ -418,6 +419,7 @@ O EGC usa o [Crowdin](https://crowdin.com/project/egc) para traducoes feitas pel
 | Idioma | Progresso | Arquivo |
 |---|---|---|
 | Ingles | Fonte | [README.md](../README.md) |
+| Español | 100% | [translations/es/README.md](../translations/es/README.md) |
 | Portugues do Brasil | 100% | [translations/pt/README.md](../translations/pt/README.md) |
 
 ---

--- a/docs/installation/HERMES-SETUP.md
+++ b/docs/installation/HERMES-SETUP.md
@@ -101,7 +101,7 @@ These stay local and should be configured per operator:
 
 ## Related Docs
 
-- [Hermes/OpenClaw migration guide](HERMES-OPENCLAW-MIGRATION.md)
+- Hermes/OpenClaw migration guide (coming soon)
 - [Cross-harness architecture](architecture/cross-harness.md)
 
 ## Why Hermes x egc


### PR DESCRIPTION
## Changes

- **CONTRIBUTING.md**: Español (100%) was missing from both the EN and PT translation tables despite `translations/es/README.md` existing and being complete
- **HERMES-SETUP.md**: broken link to `HERMES-OPENCLAW-MIGRATION.md` (file does not exist) replaced with `coming soon` placeholder

## Test plan

- [ ] CONTRIBUTING.md translation tables list EN, ES, PT
- [ ] No broken links in HERMES-SETUP.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Spanish to the translation tables and fix a broken link in the Hermes setup docs. This surfaces the ES docs in both EN and PT tables and replaces the missing Hermes/OpenClaw migration guide link with a “coming soon” note.

<sup>Written for commit 37c8a2f3e83108bcd6b7da1989582defdac5aea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

