### PR TITLE
fix(readme): replace em dashes with hyphens in all READMEs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -389,7 +389,8 @@ EGC uses [Crowdin](https://crowdin.com/project/egc) for community translations. 
 | Language | Progress | File |
 |---|---|---|
 | English | Source | [README.md](../README.md) |
-| Portugues do Brasil | 100% | [translations/pt/README.md](../translations/pt/README.md) |
+| Español | 100% | [translations/es/README.md](../translations/es/README.md) |
+| Português (Brasil) | 100% | [translations/pt/README.md](../translations/pt/README.md) |
 
 ---
 
@@ -418,6 +419,7 @@ O EGC usa o [Crowdin](https://crowdin.com/project/egc) para traducoes feitas pel
 | Idioma | Progresso | Arquivo |
 |---|---|---|
 | Ingles | Fonte | [README.md](../README.md) |
+| Español | 100% | [translations/es/README.md](../translations/es/README.md) |
 | Portugues do Brasil | 100% | [translations/pt/README.md](../translations/pt/README.md) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npx @egchq/egc install
 
 EGC ships two MCP servers that work together during every session.
 
-**`egc-memory`** — 14 tools for persistent memory:
+**`egc-memory`** - 14 tools for persistent memory:
 
 | Tool | What it does |
 |---|---|
@@ -97,7 +97,7 @@ EGC ships two MCP servers that work together during every session.
 
 State files live at `~/.egc/state/<project-slug>.md`. One file per project, plain Markdown, human-readable.
 
-**`egc-guardian`** — 5 tools for context and safety:
+**`egc-guardian`** - 5 tools for context and safety:
 
 | Tool | What it does |
 |---|---|

--- a/docs/installation/HERMES-SETUP.md
+++ b/docs/installation/HERMES-SETUP.md
@@ -101,7 +101,7 @@ These stay local and should be configured per operator:
 
 ## Related Docs
 
-- [Hermes/OpenClaw migration guide](HERMES-OPENCLAW-MIGRATION.md)
+- Hermes/OpenClaw migration guide (coming soon)
 - [Cross-harness architecture](architecture/cross-harness.md)
 
 ## Why Hermes x egc

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -62,7 +62,7 @@ npx @egchq/egc install
 
 EGC incluye dos servidores MCP que trabajan juntos durante cada sesión.
 
-**`egc-memory`** — 14 herramientas para memoria persistente:
+**`egc-memory`** - 14 herramientas para memoria persistente:
 
 | Herramienta | Qué hace |
 |---|---|
@@ -83,7 +83,7 @@ EGC incluye dos servidores MCP que trabajan juntos durante cada sesión.
 
 Los archivos de estado se almacenan en `~/.egc/state/<project-slug>.md`. Un archivo por proyecto, en Markdown simple y legible para humanos.
 
-**`egc-guardian`** — 5 herramientas para contexto y seguridad:
+**`egc-guardian`** - 5 herramientas para contexto y seguridad:
 
 | Herramienta | Qué hace |
 |---|---|

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -62,7 +62,7 @@ npx @egchq/egc install
 
 O EGC inclui dois servidores MCP que trabalham juntos durante cada sessão.
 
-**`egc-memory`** — 14 ferramentas para memória persistente:
+**`egc-memory`** - 14 ferramentas para memória persistente:
 
 | Ferramenta | O que faz |
 |---|---|
@@ -83,7 +83,7 @@ O EGC inclui dois servidores MCP que trabalham juntos durante cada sessão.
 
 Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por projeto, Markdown simples, legível por humanos.
 
-**`egc-guardian`** — 5 ferramentas para contexto e segurança:
+**`egc-guardian`** - 5 ferramentas para contexto e segurança:
 
 | Ferramenta | O que faz |
 |---|---|


### PR DESCRIPTION
## Summary
- Replace `—` (em dash) with `-` (hyphen) in README.md, translations/es/README.md, and translations/pt/README.md
- Affects the egc-memory and egc-guardian section headers in all three files

## Test plan
- [ ] No em dashes remain in README files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced em dashes with hyphens in README headers and cleaned up docs for accuracy and consistency.

- **Bug Fixes**
  - Updated `README.md`, `translations/es/README.md`, and `translations/pt/README.md` headers for `egc-memory` and `egc-guardian` to use hyphens.
  - Added Español (100%) to translation tables and corrected the label to "Português (Brasil)" in `.github/CONTRIBUTING.md`.
  - Replaced a dead link in `docs/installation/HERMES-SETUP.md` by marking the Hermes/OpenClaw migration guide as “coming soon.”

<sup>Written for commit 593f9b0412f1cb13a0aef86b58815458d6712e66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

