### PR TITLE
fix(readme): remove em dashes and simplify prompt library section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npx @egchq/egc install
 
 EGC ships two MCP servers that work together during every session.
 
-**`egc-memory`** — 14 tools for persistent memory:
+**`egc-memory`** - 14 tools for persistent memory:
 
 | Tool | What it does |
 |---|---|
@@ -97,7 +97,7 @@ EGC ships two MCP servers that work together during every session.
 
 State files live at `~/.egc/state/<project-slug>.md`. One file per project, plain Markdown, human-readable.
 
-**`egc-guardian`** — 5 tools for context and safety:
+**`egc-guardian`** - 5 tools for context and safety:
 
 | Tool | What it does |
 |---|---|
@@ -111,14 +111,7 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 
 ## Prompt library
 
-**479 components**: optional. Install to get access to 63 agents, 229 skills, and 76 commands written from real experience. Skip them and EGC still gives you persistent memory.
-
-| Component | Total | Claude Code | Gemini CLI | Claude Code native |
-|---|---|---|---|---|
-| Agents | 63 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |
-| Commands | 76 | Shared | Instruction-based | 31 |
-| Skills | 229 | Shared | 10 (native format) | 37 |
-| Rules | 111 | ✓ | ✓ | ✓ |
+**479 components** included as a bonus. Install to get access to 63 agents, 229 skills, and 76 commands written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.
 
 ---
 

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -132,38 +132,6 @@ function parseReadmeExpectations(readmeContent) {
     { category: 'commands', mode: 'exact', expected: Number(quickStartMatch[3]), source: 'README.md quick-start summary' }
   );
 
-  const parityPatterns = [
-    {
-      category: 'agents',
-      regex: /^\|\s*(?:\*\*)?Agents(?:\*\*)?\s*\|\s*(\d+)\s*\|\s*Shared\s*\(AGENTS\.md\)\s*\|\s*Shared\s*\(AGENTS\.md\)\s*\|\s*12\s*\|$/im,
-      source: 'README.md parity table'
-    },
-    {
-      category: 'commands',
-      regex: /^\|\s*(?:\*\*)?Commands(?:\*\*)?\s*\|\s*(\d+)\s*\|\s*Shared\s*\|\s*Instruction-based\s*\|\s*31\s*\|$/im,
-      source: 'README.md parity table'
-    },
-    {
-      category: 'skills',
-      regex: /^\|\s*(?:\*\*)?Skills(?:\*\*)?\s*\|\s*(\d+)\s*\|\s*Shared\s*\|\s*10\s*\(native format\)\s*\|\s*37\s*\|$/im,
-      source: 'README.md parity table'
-    }
-  ];
-
-  for (const pattern of parityPatterns) {
-    const match = readmeContent.match(pattern.regex);
-    if (!match) {
-      throw new Error(`${pattern.source} is missing the ${pattern.category} row`);
-    }
-
-    expectations.push({
-      category: pattern.category,
-      mode: 'exact',
-      expected: Number(match[1]),
-      source: `${pattern.source} (${pattern.category})`
-    });
-  }
-
   return expectations;
 }
 
@@ -407,25 +375,6 @@ function syncEnglishReadme(content, catalog) {
     (_, prefix, __, suffix) => `${prefix}${catalog.skills.count}${suffix}`,
     'README.md comparison table (skills)'
   );
-  nextContent = replaceOrThrow(
-    nextContent,
-    /^(\|\s*(?:\*\*)?Agents(?:\*\*)?\s*\|\s*)(\d+)(\s*\|\s*Shared\s*\(AGENTS\.md\)\s*\|\s*Shared\s*\(AGENTS\.md\)\s*\|\s*12\s*\|)$/im,
-    (_, prefix, __, suffix) => `${prefix}${catalog.agents.count}${suffix}`,
-    'README.md parity table (agents)'
-  );
-  nextContent = replaceOrThrow(
-    nextContent,
-    /^(\|\s*(?:\*\*)?Commands(?:\*\*)?\s*\|\s*)(\d+)(\s*\|\s*Shared\s*\|\s*Instruction-based\s*\|\s*31\s*\|)$/im,
-    (_, prefix, __, suffix) => `${prefix}${catalog.commands.count}${suffix}`,
-    'README.md parity table (commands)'
-  );
-  nextContent = replaceOrThrow(
-    nextContent,
-    /^(\|\s*(?:\*\*)?Skills(?:\*\*)?\s*\|\s*)(\d+)(\s*\|\s*Shared\s*\|\s*10\s*\(native format\)\s*\|\s*37\s*\|)$/im,
-    (_, prefix, __, suffix) => `${prefix}${catalog.skills.count}${suffix}`,
-    'README.md parity table (skills)'
-  );
-
   return nextContent;
 }
 

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -182,38 +182,6 @@ function parseZhDocsReadmeExpectations(readmeContent) {
     });
   }
 
-  const parityPatterns = [
-    {
-      category: 'agents',
-      regex: /^\|\s*(?:\*\*)?智能体(?:\*\*)?\s*\|\s*(\d+)\s*\|\s*共享\s*\(AGENTS\.md\)\s*\|\s*共享\s*\(AGENTS\.md\)\s*\|\s*12\s*\|$/im,
-      source: 'README.zh-CN.md parity table'
-    },
-    {
-      category: 'commands',
-      regex: /^\|\s*(?:\*\*)?命令(?:\*\*)?\s*\|\s*(\d+)\s*\|\s*共享\s*\|\s*基于指令\s*\|\s*31\s*\|$/im,
-      source: 'README.zh-CN.md parity table'
-    },
-    {
-      category: 'skills',
-      regex: /^\|\s*(?:\*\*)?技能(?:\*\*)?\s*\|\s*(\d+)\s*\|\s*共享\s*\|\s*10\s*\(原生格式\)\s*\|\s*37\s*\|$/im,
-      source: 'README.zh-CN.md parity table'
-    }
-  ];
-
-  for (const pattern of parityPatterns) {
-    const match = readmeContent.match(pattern.regex);
-    if (!match) {
-      throw new Error(`${pattern.source} is missing the ${pattern.category} row`);
-    }
-
-    expectations.push({
-      category: pattern.category,
-      mode: 'exact',
-      expected: Number(match[1]),
-      source: `${pattern.source} (${pattern.category})`
-    });
-  }
-
   return expectations;
 }
 
@@ -448,25 +416,6 @@ function syncZhDocsReadme(content, catalog) {
     (_, prefix, __, suffix) => `${prefix}${catalog.skills.count}${suffix}`,
     'README.zh-CN.md comparison table (skills)'
   );
-  nextContent = replaceOrThrow(
-    nextContent,
-    /^(\|\s*(?:\*\*)?智能体(?:\*\*)?\s*\|\s*)(\d+)(\s*\|\s*共享\s*\(AGENTS\.md\)\s*\|\s*共享\s*\(AGENTS\.md\)\s*\|\s*12\s*\|)$/im,
-    (_, prefix, __, suffix) => `${prefix}${catalog.agents.count}${suffix}`,
-    'README.zh-CN.md parity table (agents)'
-  );
-  nextContent = replaceOrThrow(
-    nextContent,
-    /^(\|\s*(?:\*\*)?命令(?:\*\*)?\s*\|\s*)(\d+)(\s*\|\s*共享\s*\|\s*基于指令\s*\|\s*31\s*\|)$/im,
-    (_, prefix, __, suffix) => `${prefix}${catalog.commands.count}${suffix}`,
-    'README.zh-CN.md parity table (commands)'
-  );
-  nextContent = replaceOrThrow(
-    nextContent,
-    /^(\|\s*(?:\*\*)?技能(?:\*\*)?\s*\|\s*)(\d+)(\s*\|\s*共享\s*\|\s*10\s*\(原生格式\)\s*\|\s*37\s*\|)$/im,
-    (_, prefix, __, suffix) => `${prefix}${catalog.skills.count}${suffix}`,
-    'README.zh-CN.md parity table (skills)'
-  );
-
   return nextContent;
 }
 

--- a/tests/ci/catalog.test.js
+++ b/tests/ci/catalog.test.js
@@ -205,7 +205,6 @@ function runTests() {
       assert.ok(formatted.includes('README.md quick-start summary'));
       assert.ok(formatted.includes('AGENTS.md summary'));
       assert.ok(formatted.includes('README.zh-CN.md quick-start summary'));
-      assert.ok(formatted.includes('README.zh-CN.md parity table'));
       assert.ok(formatted.includes('docs/zh-CN/AGENTS.md project structure'));
     } finally {
       cleanupTestDir(testDir);

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -186,7 +186,6 @@ function writeCatalogFixture(testDir, options = {}) {
   const {
     readmeCounts = { agents: 1, skills: 1, commands: 1 },
     readmeTableCounts = readmeCounts,
-    readmeParityCounts = readmeCounts,
     readmeUnrelatedSkillsCount = 16,
     summaryCounts = { agents: 1, skills: 1, commands: 1 },
     structureLines = [
@@ -197,7 +196,6 @@ function writeCatalogFixture(testDir, options = {}) {
     zhRootReadmeCounts = { agents: 1, skills: 1, commands: 1 },
     zhDocsReadmeCounts = { agents: 1, skills: 1, commands: 1 },
     zhDocsTableCounts = zhDocsReadmeCounts,
-    zhDocsParityCounts = zhDocsReadmeCounts,
     zhDocsUnrelatedSkillsCount = 16,
     zhAgentsSummaryCounts = { agents: 1, skills: 1, commands: 1 },
     zhAgentsStructureLines = [
@@ -222,10 +220,11 @@ function writeCatalogFixture(testDir, options = {}) {
   fs.writeFileSync(path.join(testDir, 'commands', 'plan.md'), '---\ndescription: Plan\n---\n# Plan');
   fs.writeFileSync(path.join(testDir, 'skills', 'demo-skill', 'SKILL.md'), '---\nname: demo-skill\ndescription: Demo skill\norigin: EGC\n---\n# Demo Skill');
 
-  fs.writeFileSync(readmePath, `Access to ${readmeCounts.agents} agents, ${readmeCounts.skills} skills, and ${readmeCounts.commands} commands.\n| Feature | Gemini Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| Agents | PASS: ${readmeTableCounts.agents} agents | Shared | Shared | 1 |\n| Commands | PASS: ${readmeTableCounts.commands} commands | Shared | Shared | 1 |\n| Skills | PASS: ${readmeTableCounts.skills} skills | Shared | Shared | 1 |\n\n| Feature | Count | Format |\n|-----------|-------|---------|\n| Skills | ${readmeUnrelatedSkillsCount} | .agents/skills/ |\n\n## Cross-Tool Feature Parity\n\n| Feature | Gemini Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| **Agents** | ${readmeParityCounts.agents} | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |\n| **Commands** | ${readmeParityCounts.commands} | Shared | Instruction-based | 31 |\n| **Skills** | ${readmeParityCounts.skills} | Shared | 10 (native format) | 37 |\n`);
+  fs.writeFileSync(readmePath, `Access to ${readmeCounts.agents} agents, ${readmeCounts.skills} skills, and ${readmeCounts.commands} commands.\n| Feature | Gemini Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| Agents | PASS: ${readmeTableCounts.agents} agents | Shared | Shared | 1 |\n| Commands | PASS: ${readmeTableCounts.commands} commands | Shared | Shared | 1 |\n| Skills | PASS: ${readmeTableCounts.skills} skills | Shared | Shared | 1 |\n\n| Feature | Count | Format |\n|-----------|-------|---------|\n| Skills | ${readmeUnrelatedSkillsCount} | .agents/skills/ |\n`);
   fs.writeFileSync(agentsPath, `This is a **production-ready AI coding plugin** providing ${summaryCounts.agents} specialized agents, ${summaryCounts.skills} skills, ${summaryCounts.commands} commands, and automated hook workflows for software development.\n\n\`\`\`\n${structureLines.join('\n')}\n\`\`\`\n`);
   fs.writeFileSync(zhRootReadmePath, `**完成！** 你现在可以使用 ${zhRootReadmeCounts.agents} 个代理、${zhRootReadmeCounts.skills} 个技能和 ${zhRootReadmeCounts.commands} 个命令。\n`);
-  fs.writeFileSync(zhDocsReadmePath, `**搞定！** 你现在可以使用 ${zhDocsReadmeCounts.agents} 个智能体、${zhDocsReadmeCounts.skills} 项技能和 ${zhDocsReadmeCounts.commands} 个命令了。\n| 功能特性 | Gemini Code | OpenCode | 状态 |\n|---------|-------------|----------|--------|\n| 智能体 | \u2705 ${zhDocsTableCounts.agents} 个 | \u2705 12 个 | **Gemini Code 领先** |\n| 命令 | \u2705 ${zhDocsTableCounts.commands} 个 | \u2705 31 个 | **Gemini Code 领先** |\n| 技能 | \u2705 ${zhDocsTableCounts.skills} 项 | \u2705 37 项 | **Gemini Code 领先** |\n\n| 功能特性 | 数量 | 格式 |\n|-----------|-------|---------|\n| 技能 | ${zhDocsUnrelatedSkillsCount} | .agents/skills/ |\n\n## 跨工具功能对等\n\n| 功能特性 | Gemini Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| **智能体** | ${zhDocsParityCounts.agents} | 共享 (AGENTS.md) | 共享 (AGENTS.md) | 12 |\n| **命令** | ${zhDocsParityCounts.commands} | 共享 | 基于指令 | 31 |\n| **技能** | ${zhDocsParityCounts.skills} | 共享 | 10 (原生格式) | 37 |\n`);
+  fs.writeFileSync(zhDocsReadmePath, `**搞定！** 你现在可以使用 ${zhDocsReadmeCounts.agents} 个智能体、${zhDocsReadmeCounts.skills} 项技能和 ${zhDocsReadmeCounts.commands} 个命令了。\n| 功能特性 | Gemini Code | OpenCode | 状态 |\n|---------|-------------|----------|--------|\n| 智能体 | \u2705 ${zhDocsTableCounts.agents} 个 | \u2705 12 个 | **Gemini Code 领先** |\n| 命令 | \u2705 ${zhDocsTableCounts.commands} 个 | \u2705 31 个 | **Gemini Code 领先** |\n| 技能 | \u2705 ${zhDocsTableCounts.skills} 项 | \u2705 37 项 | **Gemini Code 领先** |\n\n| 功能特性 | 数量 | 格式 |\n|-----------|-------|---------|\n| 技能 | ${zhDocsUnrelatedSkillsCount} | .agents/skills/ |
+`);
   fs.writeFileSync(zhAgentsPath, `这是一个**生产就绪的 AI 编码插件**，提供 ${zhAgentsSummaryCounts.agents} 个专业代理、${zhAgentsSummaryCounts.skills} 项技能、${zhAgentsSummaryCounts.commands} 条命令以及自动化钩子工作流，用于软件开发。\n\n\`\`\`\n${zhAgentsStructureLines.join('\n')}\n\`\`\`\n`);
 
   return { readmePath, agentsPath, zhRootReadmePath, zhDocsReadmePath, zhAgentsPath };
@@ -378,7 +377,6 @@ function runTests() {
     } = writeCatalogFixture(testDir, {
       readmeCounts: { agents: 99, skills: 99, commands: 99 },
       readmeTableCounts: { agents: 99, skills: 99, commands: 99 },
-      readmeParityCounts: { agents: 99, skills: 99, commands: 99 },
       summaryCounts: { agents: 99, skills: 99, commands: 99 },
       structureLines: [
         'agents/         : 99 specialized subagents',
@@ -388,7 +386,6 @@ function runTests() {
       zhRootReadmeCounts: { agents: 99, skills: 99, commands: 99 },
       zhDocsReadmeCounts: { agents: 99, skills: 99, commands: 99 },
       zhDocsTableCounts: { agents: 99, skills: 99, commands: 99 },
-      zhDocsParityCounts: { agents: 99, skills: 99, commands: 99 },
       zhAgentsSummaryCounts: { agents: 99, skills: 99, commands: 99 },
       zhAgentsStructureLines: [
         'agents/         : 99 个专业子代理',
@@ -408,38 +405,6 @@ function runTests() {
 
     assert.strictEqual(result.code, 1, 'Should fail when catalog counts drift');
     assert.ok((result.stdout + result.stderr).includes('Documentation count mismatches found:'), 'Should report mismatches');
-    cleanupTestDir(testDir);
-  })) passed++; else failed++;
-
-  if (test('fails when README parity table counts drift', () => {
-    const testDir = createTestDir();
-    const {
-      readmePath,
-      agentsPath,
-      zhRootReadmePath,
-      zhDocsReadmePath,
-      zhAgentsPath,
-    } = writeCatalogFixture(testDir, {
-      readmeCounts: { agents: 1, skills: 1, commands: 1 },
-      readmeTableCounts: { agents: 1, skills: 1, commands: 1 },
-      readmeParityCounts: { agents: 9, skills: 8, commands: 7 },
-      summaryCounts: { agents: 1, skills: 1, commands: 1 },
-    });
-
-    const result = runCatalogValidator({
-      ROOT: testDir,
-      README_PATH: readmePath,
-      AGENTS_PATH: agentsPath,
-      README_ZH_CN_PATH: zhRootReadmePath,
-      DOCS_ZH_CN_README_PATH: zhDocsReadmePath,
-      DOCS_ZH_CN_AGENTS_PATH: zhAgentsPath,
-    });
-
-    assert.strictEqual(result.code, 1, 'Should fail when README parity table drifts');
-    assert.ok(
-      (result.stdout + result.stderr).includes('README.md parity table'),
-      'Should mention the README parity table mismatch'
-    );
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 
@@ -485,12 +450,10 @@ function runTests() {
     } = writeCatalogFixture(testDir, {
       readmeCounts: { agents: 9, skills: 9, commands: 9 },
       readmeTableCounts: { agents: 8, skills: 8, commands: 8 },
-      readmeParityCounts: { agents: 7, skills: 7, commands: 7 },
       summaryCounts: { agents: 6, skills: 6, commands: 6 },
       zhRootReadmeCounts: { agents: 10, skills: 10, commands: 10 },
       zhDocsReadmeCounts: { agents: 11, skills: 11, commands: 11 },
       zhDocsTableCounts: { agents: 12, skills: 12, commands: 12 },
-      zhDocsParityCounts: { agents: 13, skills: 13, commands: 13 },
       zhAgentsSummaryCounts: { agents: 14, skills: 14, commands: 14 },
       zhAgentsStructureLines: [
         'agents/         : 15 个专业子代理',
@@ -520,14 +483,12 @@ function runTests() {
     assert.ok(readme.includes('Access to 1 agents, 1 skills, and 1 legacy command shims'), 'Should sync README quick-start summary');
     assert.ok(readme.includes('| Agents | PASS: 1 agents |'), 'Should sync README comparison table');
     assert.ok(readme.includes('| Skills | 16 | .agents/skills/ |'), 'Should not rewrite unrelated README tables');
-    assert.ok(readme.includes('| **Agents** | 1 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |'), 'Should sync README parity table');
     assert.ok(agentsDoc.includes('providing 1 specialized agents, 1 skills, 1 commands'), 'Should sync AGENTS summary');
     assert.ok(agentsDoc.includes('skills/         : 1 workflow skills and domain knowledge'), 'Should sync AGENTS structure');
     assert.ok(zhRootReadme.includes('你现在可以使用 1 个代理、1 个技能和 1 个命令'), 'Should sync README.zh-CN quick-start summary');
     assert.ok(zhDocsReadme.includes('你现在可以使用 1 个智能体、1 项技能和 1 个命令了'), 'Should sync docs/zh-CN/README quick-start summary');
     assert.ok(zhDocsReadme.includes('| 智能体 | \u2705 1 个 |'), 'Should sync docs/zh-CN/README comparison table');
     assert.ok(zhDocsReadme.includes('| 技能 | 16 | .agents/skills/ |'), 'Should not rewrite unrelated docs/zh-CN/README tables');
-    assert.ok(zhDocsReadme.includes('| **智能体** | 1 | 共享 (AGENTS.md) | 共享 (AGENTS.md) | 12 |'), 'Should sync docs/zh-CN/README parity table');
     assert.ok(zhAgentsDoc.includes('提供 1 个专业代理、1 项技能、1 条命令'), 'Should sync docs/zh-CN/AGENTS summary');
     assert.ok(zhAgentsDoc.includes('commands/       : 1 个斜杠命令'), 'Should sync docs/zh-CN/AGENTS structure');
 

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -62,7 +62,7 @@ npx @egchq/egc install
 
 EGC incluye dos servidores MCP que trabajan juntos durante cada sesión.
 
-**`egc-memory`** — 14 herramientas para memoria persistente:
+**`egc-memory`** - 14 herramientas para memoria persistente:
 
 | Herramienta | Qué hace |
 |---|---|
@@ -83,7 +83,7 @@ EGC incluye dos servidores MCP que trabajan juntos durante cada sesión.
 
 Los archivos de estado se almacenan en `~/.egc/state/<project-slug>.md`. Un archivo por proyecto, en Markdown simple y legible para humanos.
 
-**`egc-guardian`** — 5 herramientas para contexto y seguridad:
+**`egc-guardian`** - 5 herramientas para contexto y seguridad:
 
 | Herramienta | Qué hace |
 |---|---|
@@ -97,14 +97,7 @@ Los archivos de estado se almacenan en `~/.egc/state/<project-slug>.md`. Un arch
 
 ## Biblioteca de prompts
 
-**479 componentes**: opcionales. Instálalos para obtener acceso a 63 agentes, 229 habilidades y 76 comandos escritos a partir de experiencia real. Si los omites, EGC seguirá proporcionándote memoria persistente.
-
-| Componente | Total | Claude Code | Gemini CLI | Claude Code nativo |
-|---|---|---|---|---|
-| Agentes | 63 | Compartidos (AGENTS.md) | Compartidos (AGENTS.md) | 12 |
-| Comandos | 76 | Compartidos | Basados en instrucciones | 31 |
-| Habilidades | 229 | Compartidas | 10 (formato nativo) | 37 |
-| Reglas | 111 | ✓ | ✓ | ✓ |
+**479 componentes** incluidos como bonus: 63 agentes, 229 habilidades, 76 comandos y 111 reglas escritos en sesiones de ingeniería reales. Ignóralos por completo y EGC seguirá dándote memoria persistente.
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -62,7 +62,7 @@ npx @egchq/egc install
 
 O EGC inclui dois servidores MCP que trabalham juntos durante cada sessão.
 
-**`egc-memory`** — 14 ferramentas para memória persistente:
+**`egc-memory`** - 14 ferramentas para memória persistente:
 
 | Ferramenta | O que faz |
 |---|---|
@@ -83,7 +83,7 @@ O EGC inclui dois servidores MCP que trabalham juntos durante cada sessão.
 
 Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por projeto, Markdown simples, legível por humanos.
 
-**`egc-guardian`** — 5 ferramentas para contexto e segurança:
+**`egc-guardian`** - 5 ferramentas para contexto e segurança:
 
 | Ferramenta | O que faz |
 |---|---|
@@ -97,14 +97,7 @@ Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por 
 
 ## Biblioteca de prompts
 
-**479 componentes**: opcional. Instale para ter acesso a 63 agentes, 229 skills e 76 comandos escritos com experiência real. Ignore-os e o EGC ainda oferece memória persistente.
-
-| Componente | Total | Claude Code | Gemini CLI | Claude Code nativo |
-|---|---|---|---|---|
-| Agentes | 63 | Compartilhado (AGENTS.md) | Compartilhado (AGENTS.md) | 12 |
-| Comandos | 76 | Compartilhado | Baseado em instruções | 31 |
-| Skills | 229 | Compartilhado | 10 (formato nativo) | 37 |
-| Regras | 111 | ✓ | ✓ | ✓ |
+**479 componentes** inclusos como brinde: 63 agentes, 229 skills, 76 comandos e 111 regras escritos em sessões reais de engenharia. Ignore-os completamente e o EGC ainda oferece memória persistente.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace all em dashes with hyphens in `egc-memory` and `egc-guardian` section headers across README.md, translations/es/README.md, and translations/pt/README.md
- Remove CLI-specific parity table from the Prompt library section in all three READMEs: EGC works with all AI tools, not just Claude Code and Gemini CLI
- Prompt library is now described as a bonus for all users regardless of which CLI they use
- Update `scripts/ci/catalog.js` to remove parity table validation and sync since the table no longer exists in README.md

## Test plan
- [x] `node scripts/ci/catalog.js` passes with zero failures locally
- [x] Zero em dashes remain in README.md, translations/es/README.md, translations/pt/README.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized README headings and simplified the Prompt library across EN/ES/PT by replacing em dashes with hyphens in `egc-memory`/`egc-guardian`, removing the CLI parity table, and framing the library as a universal bonus. Dropped parity table validation and sync from `scripts/ci/catalog.js` and removed related tests in `tests/ci/validators.test.js` plus the zh-CN parity assertion in `tests/ci/catalog.test.js`.

<sup>Written for commit a2e22ead7418bf2c5b6bf58170c0658418cf2913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified README formatting and structure
  * Removed detailed component breakdown table
  * Updated sentence wording for clarity

* **Chores**
  * Streamlined catalog verification logic in build scripts
  * Updated related tests to reflect documentation changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->