### PR TITLE
fix(doctor): remove stale better-sqlite3 references from error messages

### DIFF
--- a/scripts/bootstrap-state-db.js
+++ b/scripts/bootstrap-state-db.js
@@ -20,10 +20,9 @@ if (require.main === module) {
   bootstrap()
     .then(result => {
       if (!result.ok) {
-        process.stderr.write('[bootstrap-state-db] WARNING: better-sqlite3 native module unavailable.\n');
+        process.stderr.write('[bootstrap-state-db] WARNING: state store could not be initialized.\n');
         process.stderr.write('  The EGC state store was not created. Hook-level memory persistence is disabled.\n');
-        process.stderr.write('  On Windows: install Visual Studio Build Tools, then run: npm rebuild better-sqlite3\n');
-        process.stderr.write('  On Linux/macOS: ensure build-essential and python3 are installed, then run: npm rebuild better-sqlite3\n');
+        process.stderr.write('  Run: egc init  to retry initialization.\n');
         process.exit(0);
       }
       process.stderr.write(`[bootstrap-state-db] OK ${result.dbPath} (${result.migrations.length} migrations)\n`);

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -113,7 +113,7 @@ function main() {
       if (stateDb) {
         console.log('\nState store:');
         console.log('  WARNING: state.db not found at ' + stateDb.dbPath);
-        console.log('  Run: egc init  to create the state store (requires better-sqlite3 native module)');
+        console.log('  Run: egc init  to create the state store');
       }
     }
 


### PR DESCRIPTION
## Summary

- `scripts/doctor.js`: removed "(requires better-sqlite3 native module)" from the warning shown when `state.db` is missing
- `scripts/bootstrap-state-db.js`: replaced the three-line block that told users to install Visual Studio Build Tools and run `npm rebuild better-sqlite3` with a generic "run egc init to retry" message

## Why

EGC migrated from `better-sqlite3` to `sql.js` in v1.1.1 (PR #303). `sql.js` is pure JavaScript and requires no native compilation. The old error messages were misleading users into installing build tools that are no longer needed.

Discovered during a clean install test on Ubuntu 24.04 Docker.

## Test plan

- [ ] Run `npm install -g @egchq/egc` on a clean machine
- [ ] Run `egc doctor` before `egc init` — message should no longer mention better-sqlite3
- [ ] Run `egc init` — should succeed with sql.js
- [ ] Run `egc doctor` after init

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale `better-sqlite3` mentions in doctor and bootstrap warnings after the move to `sql.js`, so users aren’t told to install native build tools. Messages now tell users to run egc init to create the state store.

- **Bug Fixes**
  - scripts/doctor.js: shortened state.db missing message; removed `better-sqlite3` requirement.
  - scripts/bootstrap-state-db.js: replaced native build guidance with a simple “state store could not be initialized; run egc init to retry.”

<sup>Written for commit 166f407121718f31ab1588f70f4f7ccf1e7ebe13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

