### PR TITLE
ci: add GitLab mirror workflow

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -1,0 +1,19 @@
+name: GitLab Mirror
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to GitLab
+        run: |
+          git remote add gitlab https://oauth2:${{ secrets.GITLAB_TOKEN }}@gitlab.com/Fmarzochi/EGC.git
+          git push gitlab main --force


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow that automatically pushes to GitLab on every merge to main
- Uses `GITLAB_TOKEN` secret (already configured in repo settings)
- Keeps `https://gitlab.com/Fmarzochi/EGC` in sync as a public mirror

## Test plan
- [ ] Merge this PR and verify the GitLab repo receives the push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow that mirrors the `main` branch to GitLab on every push, keeping `https://gitlab.com/Fmarzochi/EGC` in sync. Uses the `GITLAB_TOKEN` secret to authenticate and force-push updates.

<sup>Written for commit bbb6d8028649a157b440ba1e4741f4b326d6af2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

