### PR TITLE
ci(gitlab): add GitLab CI pipeline with lint and tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,33 @@
+stages:
+  - test
+
+variables:
+  NODE_VERSION: "22"
+
+.node_base:
+  image: node:${NODE_VERSION}
+  before_script:
+    - npm ci
+
+lint:
+  extends: .node_base
+  stage: test
+  script:
+    - npm run lint
+
+test:
+  extends: .node_base
+  stage: test
+  parallel:
+    matrix:
+      - NODE_VERSION: ["20", "22"]
+  script:
+    - npm test
+  coverage: '/Lines\s*:\s*(\d+\.?\d*)%/'
+  artifacts:
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/cobertura-coverage.xml
+    when: always
+    expire_in: 7 days


### PR DESCRIPTION
## Summary

- Adds `.gitlab-ci.yml` so contributors who use GitLab can run lint and tests via GitLab CI
- Two stages: lint + test (Node 20 and 22)
- Enables Option 2: GitLab as a functional mirror with its own CI

## Test plan
- [ ] Verify GitLab CI runs on the mirrored repo after merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitLab CI pipeline to run lint and tests on the mirrored repository. Runs on Node 20 and 22 and publishes Cobertura coverage.

- **New Features**
  - Adds `.gitlab-ci.yml` with a single `test` stage containing `lint` and `test` jobs.
  - Uses a shared Node Docker base (`npm ci` in `before_script`).
  - Executes tests in a matrix for Node 20 and 22; lints on Node 22.
  - Extracts line coverage from test output and uploads `coverage/cobertura-coverage.xml`; keeps artifacts for 7 days and always uploads.

<sup>Written for commit 83f4065098a49906a2200303dadeb1e09f0f4a91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated continuous integration pipeline for code quality assurance, including linting and testing stages.
  * Enabled testing across multiple Node.js versions (20 and 22) to ensure broad compatibility.
  * Integrated code coverage tracking with automated reporting and artifact retention to monitor test coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->