### PR TITLE
feat(memory): propagate state to tool config files on update_state

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
+import { propagateStateToTools } from './propagate';
 import {
   createWorkingMemoryTable,
   sweepExpired,
@@ -844,9 +845,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         fs.mkdirSync(path.dirname(filePath), { recursive: true });
         writeStateDoc(filePath, projPath, args, existing, branch);
 
-        log('INFO', 'Project state updated', { project: projPath, branch: branch || 'none', decisions: args.decisions?.length || 0 });
+        const propagated = propagateStateToTools({
+          projectPath: projPath,
+          context: args.context,
+          decisions: args.decisions,
+          next: args.next,
+        });
+        const propagatedTools = Object.entries(propagated)
+          .filter(([, p]) => p !== null)
+          .map(([tool]) => tool);
+
+        log('INFO', 'Project state updated', { project: projPath, branch: branch || 'none', decisions: args.decisions?.length || 0, propagated: propagatedTools });
         const branchLine = branch ? `Branch: ${branch}\n` : '';
-        return { content: [{ type: "text", text: `Project memory updated.\n${branchLine}File: ${filePath}\nDecisions saved: ${args.decisions?.length || 0}\nNext session items: ${args.next?.length || 0}` }] };
+        const toolsLine = propagatedTools.length > 0 ? `Tools updated: ${propagatedTools.join(', ')}\n` : '';
+        return { content: [{ type: "text", text: `Project memory updated.\n${branchLine}${toolsLine}File: ${filePath}\nDecisions saved: ${args.decisions?.length || 0}\nNext session items: ${args.next?.length || 0}` }] };
       }
 
       case "working_memory_set": {

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface PropagateArgs {
+  projectPath: string;
+  context?: string;
+  decisions?: { what: string; why?: string }[];
+  next?: string[];
+}
+
+export interface PropagateResult {
+  cursor: string | null;
+  copilot: string | null;
+  gemini: string | null;
+}
+
+const EGC_START = '<!-- egc:start -->';
+const EGC_END = '<!-- egc:end -->';
+const MAX_ITEMS = 5;
+
+function buildSummaryBlock(args: PropagateArgs): string {
+  const lines: string[] = ['## EGC Project Memory'];
+
+  if (args.context) {
+    lines.push('', `**Context:** ${args.context}`);
+  }
+
+  const decisions = args.decisions?.slice(0, MAX_ITEMS) ?? [];
+  if (decisions.length > 0) {
+    lines.push('', '**Active decisions:**');
+    for (const d of decisions) {
+      lines.push(`- ${d.what}`);
+    }
+  }
+
+  const next = args.next?.slice(0, MAX_ITEMS) ?? [];
+  if (next.length > 0) {
+    lines.push('', '**Next session:**');
+    for (const n of next) {
+      lines.push(`- ${n}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function upsertEgcSection(existing: string, block: string): string {
+  const section = `${EGC_START}\n${block}\n${EGC_END}`;
+  const startIdx = existing.indexOf(EGC_START);
+  const endIdx = existing.indexOf(EGC_END);
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    return existing.slice(0, startIdx) + section + existing.slice(endIdx + EGC_END.length);
+  }
+
+  return existing ? `${existing.trimEnd()}\n\n${section}\n` : `${section}\n`;
+}
+
+function writeCursorContext(projectPath: string, block: string): string | null {
+  const cursorDir = path.join(projectPath, '.cursor');
+  try {
+    if (!fs.existsSync(cursorDir) || !fs.statSync(cursorDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const rulesDir = path.join(cursorDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.mdc');
+  const content = `---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n${block}\n`;
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+function writeCopilotContext(projectPath: string, block: string): string | null {
+  const githubDir = path.join(projectPath, '.github');
+  try {
+    if (!fs.existsSync(githubDir) || !fs.statSync(githubDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const filePath = path.join(githubDir, 'copilot-instructions.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeGeminiContext(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, 'GEMINI.md');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+export function propagateStateToTools(args: PropagateArgs): PropagateResult {
+  const block = buildSummaryBlock(args);
+  return {
+    cursor: writeCursorContext(args.projectPath, block),
+    copilot: writeCopilotContext(args.projectPath, block),
+    gemini: writeGeminiContext(args.projectPath, block),
+  };
+}

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SERVER_ROOT = path.join(__dirname, '../../mcp/servers/egc-memory');
+const PROPAGATE_PATH = path.join(SERVER_ROOT, 'build', 'propagate.js');
+
+if (!fs.existsSync(PROPAGATE_PATH)) {
+  console.error(
+    `[SKIP] Missing ${PROPAGATE_PATH}. Run 'npm ci && npm run build' in mcp/servers/egc-memory first.`
+  );
+  process.exit(0);
+}
+
+const { propagateStateToTools } = require(PROPAGATE_PATH);
+
+function mktemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-propagate-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+async function runTests() {
+  console.log('\n=== Testing egc-memory propagate.ts ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  const args = {
+    context: 'Test project in alpha phase.',
+    decisions: [{ what: 'Use TypeScript', why: 'Type safety' }],
+    next: ['Add rate limiting', 'Write integration tests'],
+  };
+
+  if (await test('returns null for all tools when no config dirs exist', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.strictEqual(result.cursor, null, 'cursor should be null');
+      assert.strictEqual(result.copilot, null, 'copilot should be null');
+      assert.strictEqual(result.gemini, null, 'gemini should be null');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes egc-context.mdc when .cursor/ exists', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'));
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.cursor, 'cursor path should be returned');
+      const mdc = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(mdc.includes('alwaysApply: true'), 'should have frontmatter');
+      assert.ok(mdc.includes('EGC Project Memory'), 'should have section header');
+      assert.ok(mdc.includes('Test project in alpha phase'), 'should have context');
+      assert.ok(mdc.includes('Use TypeScript'), 'should have decision');
+      assert.ok(mdc.includes('Add rate limiting'), 'should have next item');
+      assert.strictEqual(result.copilot, null, 'copilot should still be null');
+      assert.strictEqual(result.gemini, null, 'gemini should still be null');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes to .github/copilot-instructions.md when .github/ exists', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.github'));
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.copilot, 'copilot path should be returned');
+      const content = fs.readFileSync(result.copilot, 'utf-8');
+      assert.ok(content.includes('<!-- egc:start -->'), 'should have egc sentinel start');
+      assert.ok(content.includes('<!-- egc:end -->'), 'should have egc sentinel end');
+      assert.ok(content.includes('EGC Project Memory'), 'should have section header');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('upserts egc section in existing copilot-instructions.md without destroying user content', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.github'));
+      const filePath = path.join(dir, '.github', 'copilot-instructions.md');
+      fs.writeFileSync(filePath, '# User instructions\n\nDo not use var.\n', 'utf-8');
+
+      propagateStateToTools({ projectPath: dir, ...args });
+      const first = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(first.includes('Do not use var'), 'original content must be preserved');
+      assert.ok(first.includes('<!-- egc:start -->'), 'egc block must be present');
+
+      propagateStateToTools({
+        projectPath: dir,
+        context: 'Updated context.',
+        decisions: [{ what: 'Use ESM' }],
+        next: ['Deploy to prod'],
+      });
+      const second = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(second.includes('Do not use var'), 'original content preserved after update');
+      assert.ok(second.includes('Updated context'), 'context should be updated');
+      assert.ok(!second.includes('Test project in alpha phase'), 'old context should be gone');
+      assert.strictEqual(
+        (second.match(/<!-- egc:start -->/g) || []).length,
+        1,
+        'only one egc block'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('upserts egc section in existing GEMINI.md', () => {
+    const dir = mktemp();
+    try {
+      const geminiPath = path.join(dir, 'GEMINI.md');
+      fs.writeFileSync(geminiPath, '# Gemini instructions\n\nFollow the style guide.\n', 'utf-8');
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.gemini, 'gemini path should be returned');
+      const content = fs.readFileSync(result.gemini, 'utf-8');
+      assert.ok(content.includes('Follow the style guide'), 'original content preserved');
+      assert.ok(content.includes('<!-- egc:start -->'), 'egc block added');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('skips GEMINI.md when file does not exist', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.strictEqual(result.gemini, null, 'gemini should be null when file absent');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('handles missing context and next gracefully', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'));
+      const result = propagateStateToTools({ projectPath: dir });
+      assert.ok(result.cursor, 'cursor path should be returned');
+      const mdc = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(mdc.includes('EGC Project Memory'), 'header present');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

- Adds `propagate.ts` to the `egc-memory` MCP server: a focused module that writes a condensed EGC context block to the config files of every AI tool detected in the project directory
- Hooks into `update_state`: after the state file is written, `propagateStateToTools` is called automatically with no user action required
- Tool detection is presence-based: a tool's file is only written when its config directory or file already exists in the project, so propagation is zero-config and non-intrusive

**Tools supported:**

| Tool | File written | Condition |
|---|---|---|
| Cursor | `.cursor/rules/egc-context.mdc` | `.cursor/` directory exists |
| GitHub Copilot | `.github/copilot-instructions.md` | `.github/` directory exists |
| Gemini CLI | `GEMINI.md` | file already exists in project root |

EGC sections in Copilot and Gemini files are wrapped in `<!-- egc:start -->` / `<!-- egc:end -->` sentinels so updates are idempotent and never destroy user-authored content.

## Why

A developer switching from Claude Code to Cursor mid-project currently has no shared context: Claude remembers Claude, Cursor remembers Cursor. This PR makes `update_state` the single write that syncs context across all tools simultaneously. The user calls `update_state` at the end of a session and every registered tool picks it up at the start of the next one.

## Test plan

- [ ] New test file `tests/scripts/egc-memory-propagate.test.js` with 7 cases covering all tools, the no-op path, idempotent upsert, and absence handling
- [ ] All 7 new tests pass locally
- [ ] Pre-existing test suite: 2426/2427 (1 failure is pre-existing on main, not introduced here)
- [ ] `npm run build` in `mcp/servers/egc-memory` compiles without errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates EGC project memory to tool config files on `update_state`, keeping Cursor, Copilot, and Gemini in sync with zero extra setup. Detection is presence-based, so projects are not modified unless the tool is already configured.

- **New Features**
  - Added `propagate.ts` to `egc-memory` to write a condensed EGC context block to detected tool files.
  - Auto-runs after `update_state`; no user action needed.
  - Tool targets:
    - Cursor: `.cursor/rules/egc-context.mdc` (created if `.cursor/` exists)
    - GitHub Copilot: `.github/copilot-instructions.md` (EGC section upserted)
    - Gemini CLI: `GEMINI.md` (upserted only if file exists)
  - Copilot and Gemini sections are wrapped with `<!-- egc:start -->` / `<!-- egc:end -->` for idempotent updates and to preserve user content.

<sup>Written for commit 18fbbc4861130af6be758d1ae1276a689de47295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

