### PR TITLE
fix(memory): fix Copilot propagation guard and add SessionStart propagation

### DIFF
--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -12,6 +12,9 @@ export interface PropagateResult {
   cursor: string | null;
   copilot: string | null;
   gemini: string | null;
+  windsurf: string | null;
+  agents: string | null;
+  llms: string | null;
 }
 
 const EGC_START = '<!-- egc:start -->';
@@ -99,11 +102,61 @@ function writeGeminiContext(projectPath: string, block: string): string | null {
   return filePath;
 }
 
+function writeWindsurfContext(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, '.windsurfrules');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeAgentsContext(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, 'AGENTS.md');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeLlmsTxt(projectPath: string, args: PropagateArgs): string | null {
+  const filePath = path.join(projectPath, 'llms.txt');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const lines: string[] = ['# EGC Project Memory'];
+  if (args.context) lines.push('', args.context);
+  const next = args.next?.slice(0, MAX_ITEMS) ?? [];
+  if (next.length > 0) {
+    lines.push('', '## Next session');
+    for (const n of next) lines.push(`- ${n}`);
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, lines.join('\n')), 'utf-8');
+  return filePath;
+}
+
 export function propagateStateToTools(args: PropagateArgs): PropagateResult {
   const block = buildSummaryBlock(args);
   return {
     cursor: writeCursorContext(args.projectPath, block),
     copilot: writeCopilotContext(args.projectPath, block),
     gemini: writeGeminiContext(args.projectPath, block),
+    windsurf: writeWindsurfContext(args.projectPath, block),
+    agents: writeAgentsContext(args.projectPath, block),
+    llms: writeLlmsTxt(args.projectPath, args),
   };
 }

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -13,6 +13,11 @@ export interface PropagateResult {
   copilot: string | null;
   gemini: string | null;
   windsurf: string | null;
+  trae: string | null;
+  zed: string | null;
+  cline: string | null;
+  aider: string | null;
+  cursorrules: string | null;
   agents: string | null;
   llms: string | null;
 }
@@ -103,7 +108,80 @@ function writeGeminiContext(projectPath: string, block: string): string | null {
 }
 
 function writeWindsurfContext(projectPath: string, block: string): string | null {
-  const filePath = path.join(projectPath, '.windsurfrules');
+  const windsurfDir = path.join(projectPath, '.windsurf');
+  try {
+    if (!fs.existsSync(windsurfDir) || !fs.statSync(windsurfDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const rulesDir = path.join(windsurfDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeTraeContext(projectPath: string, block: string): string | null {
+  const traeDir = path.join(projectPath, '.trae');
+  try {
+    if (!fs.existsSync(traeDir) || !fs.statSync(traeDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const rulesDir = path.join(traeDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeZedContext(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, '.rules');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeClineContext(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, '.clinerules');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeAiderContext(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, 'CONVENTIONS.md');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeLegacyCursorRules(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, '.cursorrules');
   try {
     if (!fs.existsSync(filePath)) return null;
   } catch {
@@ -156,6 +234,11 @@ export function propagateStateToTools(args: PropagateArgs): PropagateResult {
     copilot: writeCopilotContext(args.projectPath, block),
     gemini: writeGeminiContext(args.projectPath, block),
     windsurf: writeWindsurfContext(args.projectPath, block),
+    trae: writeTraeContext(args.projectPath, block),
+    zed: writeZedContext(args.projectPath, block),
+    cline: writeClineContext(args.projectPath, block),
+    aider: writeAiderContext(args.projectPath, block),
+    cursorrules: writeLegacyCursorRules(args.projectPath, block),
     agents: writeAgentsContext(args.projectPath, block),
     llms: writeLlmsTxt(args.projectPath, args),
   };

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -9,6 +9,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { propagateStateContent } = require('../lib/propagate-state');
 
 function readStdinJson() {
   try {
@@ -53,6 +54,12 @@ function main() {
     const content = fs.readFileSync(stateFile, 'utf8');
     if (!content.trim()) {
       process.exit(0);
+    }
+
+    try {
+      propagateStateContent(projectPath, content);
+    } catch (_) {
+      // Propagation is best-effort; never block session startup.
     }
 
     process.stdout.write(

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -103,6 +103,53 @@ function writeGeminiContext(projectPath, block) {
   return filePath;
 }
 
+function writeWindsurfContext(projectPath, block) {
+  const filePath = path.join(projectPath, '.windsurfrules');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeAgentsContext(projectPath, block) {
+  const filePath = path.join(projectPath, 'AGENTS.md');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeLlmsTxt(projectPath, parsed) {
+  const filePath = path.join(projectPath, 'llms.txt');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const lines = ['# EGC Project Memory'];
+  if (parsed.context) lines.push('', parsed.context);
+  if (parsed.next.length > 0) {
+    lines.push('', '## Next session');
+    for (const n of parsed.next.slice(0, MAX_ITEMS)) lines.push(`- ${n}`);
+  }
+  const block = lines.join('\n');
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
 function propagateStateContent(projectPath, stateContent) {
   const parsed = parseStateContent(stateContent);
   const block = buildSummaryBlock(parsed);
@@ -111,6 +158,9 @@ function propagateStateContent(projectPath, stateContent) {
     cursor: writeCursorContext(projectPath, block),
     copilot: writeCopilotContext(projectPath, block),
     gemini: writeGeminiContext(projectPath, block),
+    windsurf: writeWindsurfContext(projectPath, block),
+    agents: writeAgentsContext(projectPath, block),
+    llms: writeLlmsTxt(projectPath, parsed),
   };
 }
 

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -104,7 +104,80 @@ function writeGeminiContext(projectPath, block) {
 }
 
 function writeWindsurfContext(projectPath, block) {
-  const filePath = path.join(projectPath, '.windsurfrules');
+  const windsurfDir = path.join(projectPath, '.windsurf');
+  try {
+    if (!fs.existsSync(windsurfDir) || !fs.statSync(windsurfDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const rulesDir = path.join(windsurfDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeTraeContext(projectPath, block) {
+  const traeDir = path.join(projectPath, '.trae');
+  try {
+    if (!fs.existsSync(traeDir) || !fs.statSync(traeDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const rulesDir = path.join(traeDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeZedContext(projectPath, block) {
+  const filePath = path.join(projectPath, '.rules');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeClineContext(projectPath, block) {
+  const filePath = path.join(projectPath, '.clinerules');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeAiderContext(projectPath, block) {
+  const filePath = path.join(projectPath, 'CONVENTIONS.md');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeLegacyCursorRules(projectPath, block) {
+  const filePath = path.join(projectPath, '.cursorrules');
   try {
     if (!fs.existsSync(filePath)) return null;
   } catch {
@@ -159,6 +232,11 @@ function propagateStateContent(projectPath, stateContent) {
     copilot: writeCopilotContext(projectPath, block),
     gemini: writeGeminiContext(projectPath, block),
     windsurf: writeWindsurfContext(projectPath, block),
+    trae: writeTraeContext(projectPath, block),
+    zed: writeZedContext(projectPath, block),
+    cline: writeClineContext(projectPath, block),
+    aider: writeAiderContext(projectPath, block),
+    cursorrules: writeLegacyCursorRules(projectPath, block),
     agents: writeAgentsContext(projectPath, block),
     llms: writeLlmsTxt(projectPath, parsed),
   };

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -1,50 +1,54 @@
-import fs from 'node:fs';
-import path from 'node:path';
+'use strict';
 
-export interface PropagateArgs {
-  projectPath: string;
-  context?: string;
-  decisions?: { what: string; why?: string }[];
-  next?: string[];
-}
-
-export interface PropagateResult {
-  cursor: string | null;
-  copilot: string | null;
-  gemini: string | null;
-}
+const fs = require('node:fs');
+const path = require('node:path');
 
 const EGC_START = '<!-- egc:start -->';
 const EGC_END = '<!-- egc:end -->';
 const MAX_ITEMS = 5;
 
-function buildSummaryBlock(args: PropagateArgs): string {
-  const lines: string[] = ['## EGC Project Memory'];
+function parseStateContent(content) {
+  const result = { context: '', decisions: [], next: [] };
+  let section = '';
 
-  if (args.context) {
-    lines.push('', `**Context:** ${args.context}`);
+  for (const line of content.split('\n')) {
+    const h2 = line.match(/^## (.+)/);
+    if (h2) { section = h2[1].trim(); continue; }
+
+    const item = line.replace(/^- /, '').trim();
+    if (!item) continue;
+
+    if (section === 'Context') result.context = item;
+    if (section === 'Active Decisions') result.decisions.push(item);
+    if (section === 'Next Session') result.next.push(item);
   }
 
-  const decisions = args.decisions?.slice(0, MAX_ITEMS) ?? [];
+  return result;
+}
+
+function buildSummaryBlock(parsed) {
+  const lines = ['## EGC Project Memory'];
+
+  if (parsed.context) {
+    lines.push('', `**Context:** ${parsed.context}`);
+  }
+
+  const decisions = parsed.decisions.slice(0, MAX_ITEMS);
   if (decisions.length > 0) {
     lines.push('', '**Active decisions:**');
-    for (const d of decisions) {
-      lines.push(`- ${d.what}`);
-    }
+    for (const d of decisions) lines.push(`- ${d}`);
   }
 
-  const next = args.next?.slice(0, MAX_ITEMS) ?? [];
+  const next = parsed.next.slice(0, MAX_ITEMS);
   if (next.length > 0) {
     lines.push('', '**Next session:**');
-    for (const n of next) {
-      lines.push(`- ${n}`);
-    }
+    for (const n of next) lines.push(`- ${n}`);
   }
 
   return lines.join('\n');
 }
 
-function upsertEgcSection(existing: string, block: string): string {
+function upsertEgcSection(existing, block) {
   const section = `${EGC_START}\n${block}\n${EGC_END}`;
   const startIdx = existing.indexOf(EGC_START);
   const endIdx = existing.indexOf(EGC_END);
@@ -56,7 +60,7 @@ function upsertEgcSection(existing: string, block: string): string {
   return existing ? `${existing.trimEnd()}\n\n${section}\n` : `${section}\n`;
 }
 
-function writeCursorContext(projectPath: string, block: string): string | null {
+function writeCursorContext(projectPath, block) {
   const cursorDir = path.join(projectPath, '.cursor');
   try {
     if (!fs.existsSync(cursorDir) || !fs.statSync(cursorDir).isDirectory()) return null;
@@ -68,12 +72,12 @@ function writeCursorContext(projectPath: string, block: string): string | null {
   fs.mkdirSync(rulesDir, { recursive: true });
 
   const filePath = path.join(rulesDir, 'egc-context.mdc');
-  const content = `---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n${block}\n`;
+  const content = `---\ndescription: EGC project memory (auto-updated)\nalwaysApply: true\n---\n\n${block}\n`;
   fs.writeFileSync(filePath, content, 'utf-8');
   return filePath;
 }
 
-function writeCopilotContext(projectPath: string, block: string): string | null {
+function writeCopilotContext(projectPath, block) {
   const filePath = path.join(projectPath, '.github', 'copilot-instructions.md');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -86,7 +90,7 @@ function writeCopilotContext(projectPath: string, block: string): string | null 
   return filePath;
 }
 
-function writeGeminiContext(projectPath: string, block: string): string | null {
+function writeGeminiContext(projectPath, block) {
   const filePath = path.join(projectPath, 'GEMINI.md');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -99,11 +103,15 @@ function writeGeminiContext(projectPath: string, block: string): string | null {
   return filePath;
 }
 
-export function propagateStateToTools(args: PropagateArgs): PropagateResult {
-  const block = buildSummaryBlock(args);
+function propagateStateContent(projectPath, stateContent) {
+  const parsed = parseStateContent(stateContent);
+  const block = buildSummaryBlock(parsed);
+
   return {
-    cursor: writeCursorContext(args.projectPath, block),
-    copilot: writeCopilotContext(args.projectPath, block),
-    gemini: writeGeminiContext(args.projectPath, block),
+    cursor: writeCursorContext(projectPath, block),
+    copilot: writeCopilotContext(projectPath, block),
+    gemini: writeGeminiContext(projectPath, block),
   };
 }
+
+module.exports = { propagateStateContent };

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -79,27 +79,44 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
-  if (await test('writes to .github/copilot-instructions.md when .github/ exists', () => {
+  if (await test('does NOT create copilot-instructions.md when only .github/ exists (bug fix)', () => {
     const dir = mktemp();
     try {
       fs.mkdirSync(path.join(dir, '.github'));
       const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.strictEqual(result.copilot, null, 'copilot should be null when file does not exist');
+      assert.ok(
+        !fs.existsSync(path.join(dir, '.github', 'copilot-instructions.md')),
+        'file must not be created'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes to copilot-instructions.md only when file already exists', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.github'));
+      const filePath = path.join(dir, '.github', 'copilot-instructions.md');
+      fs.writeFileSync(filePath, '# My Copilot rules\n', 'utf-8');
+      const result = propagateStateToTools({ projectPath: dir, ...args });
       assert.ok(result.copilot, 'copilot path should be returned');
       const content = fs.readFileSync(result.copilot, 'utf-8');
       assert.ok(content.includes('<!-- egc:start -->'), 'should have egc sentinel start');
-      assert.ok(content.includes('<!-- egc:end -->'), 'should have egc sentinel end');
       assert.ok(content.includes('EGC Project Memory'), 'should have section header');
     } finally {
       cleanup(dir);
     }
   })) passed++; else failed++;
 
-  if (await test('upserts egc section in existing copilot-instructions.md without destroying user content', () => {
+  if (await test('upserts egc section in copilot-instructions.md without destroying user content', () => {
     const dir = mktemp();
     try {
       fs.mkdirSync(path.join(dir, '.github'));
       const filePath = path.join(dir, '.github', 'copilot-instructions.md');
       fs.writeFileSync(filePath, '# User instructions\n\nDo not use var.\n', 'utf-8');
+
 
       propagateStateToTools({ projectPath: dir, ...args });
       const first = fs.readFileSync(filePath, 'utf-8');

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { propagateStateContent } = require('../../scripts/lib/propagate-state');
+
+function mktemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-propagate-state-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+const SAMPLE_STATE = `# Project State
+project: /home/user/myproject
+updated: 2026-06-20T00:00:00.000Z
+
+## Context
+EGC v1.1.1 stable on npm.
+
+## Active Decisions
+- Use sql.js instead of better-sqlite3: Pure JS, no native module required
+- DCO sign-off mandatory: Legal requirement
+
+## Do Not Repeat
+- Bump version without authorization: Breaks release flow
+
+## Preferences
+- Delete branch after merge
+
+## Next Session
+- Fix propagation hooks
+- Open issue for bidirectional sync
+`;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/propagate-state.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (test('propagates to cursor when .cursor/ exists', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'));
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.cursor, 'cursor path should be returned');
+      const mdc = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(mdc.includes('alwaysApply: true'), 'frontmatter present');
+      assert.ok(mdc.includes('EGC v1.1.1 stable'), 'context included');
+      assert.ok(mdc.includes('sql.js'), 'decision included');
+      assert.ok(mdc.includes('Fix propagation hooks'), 'next item included');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create copilot-instructions.md when only .github/ exists', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.github'));
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.copilot, null);
+      assert.ok(!fs.existsSync(path.join(dir, '.github', 'copilot-instructions.md')));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('updates copilot-instructions.md when it already exists', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.github'));
+      fs.writeFileSync(path.join(dir, '.github', 'copilot-instructions.md'), '# Rules\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.copilot, 'copilot path returned');
+      const content = fs.readFileSync(result.copilot, 'utf-8');
+      assert.ok(content.includes('# Rules'), 'user content preserved');
+      assert.ok(content.includes('<!-- egc:start -->'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to GEMINI.md when it exists', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'GEMINI.md'), '# Gemini config\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.gemini);
+      const content = fs.readFileSync(result.gemini, 'utf-8');
+      assert.ok(content.includes('# Gemini config'));
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('returns all null when no tool configs exist', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.cursor, null);
+      assert.strictEqual(result.copilot, null);
+      assert.strictEqual(result.gemini, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('handles empty state content gracefully', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'));
+      const result = propagateStateContent(dir, '');
+      assert.ok(result.cursor, 'cursor still written');
+      const mdc = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(mdc.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -111,14 +111,14 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('propagates to .windsurfrules when it exists (Windsurf)', () => {
+  if (test('propagates to .windsurf/rules/egc-context.md when .windsurf/ dir exists', () => {
     const dir = mktemp();
     try {
-      fs.writeFileSync(path.join(dir, '.windsurfrules'), '# Windsurf rules\n');
+      fs.mkdirSync(path.join(dir, '.windsurf'));
       const result = propagateStateContent(dir, SAMPLE_STATE);
       assert.ok(result.windsurf, 'windsurf path returned');
+      assert.ok(result.windsurf.includes(path.join('.windsurf', 'rules', 'egc-context.md')));
       const content = fs.readFileSync(result.windsurf, 'utf-8');
-      assert.ok(content.includes('# Windsurf rules'), 'original content preserved');
       assert.ok(content.includes('<!-- egc:start -->'));
       assert.ok(content.includes('EGC Project Memory'));
     } finally {
@@ -126,11 +126,131 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('does not create .windsurfrules when absent', () => {
+  if (test('does not create windsurf context when .windsurf/ dir absent', () => {
     const dir = mktemp();
     try {
       const result = propagateStateContent(dir, SAMPLE_STATE);
       assert.strictEqual(result.windsurf, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to .trae/rules/egc-context.md when .trae/ dir exists (Trae)', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.trae'));
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.trae, 'trae path returned');
+      assert.ok(result.trae.includes(path.join('.trae', 'rules', 'egc-context.md')));
+      const content = fs.readFileSync(result.trae, 'utf-8');
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create trae context when .trae/ dir absent', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.trae, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to .rules when it exists (Zed)', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, '.rules'), '# Zed rules\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.zed, 'zed path returned');
+      const content = fs.readFileSync(result.zed, 'utf-8');
+      assert.ok(content.includes('# Zed rules'), 'original content preserved');
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create .rules when absent (Zed)', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.zed, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to .clinerules when it exists (Cline/Roo)', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, '.clinerules'), '# Cline rules\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.cline, 'cline path returned');
+      const content = fs.readFileSync(result.cline, 'utf-8');
+      assert.ok(content.includes('# Cline rules'), 'original content preserved');
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create .clinerules when absent', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.cline, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to CONVENTIONS.md when it exists (Aider)', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'CONVENTIONS.md'), '# Conventions\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.aider, 'aider path returned');
+      const content = fs.readFileSync(result.aider, 'utf-8');
+      assert.ok(content.includes('# Conventions'), 'original content preserved');
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create CONVENTIONS.md when absent (Aider)', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.aider, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to .cursorrules when it exists (legacy Cursor)', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, '.cursorrules'), '# Legacy rules\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.cursorrules, 'cursorrules path returned');
+      const content = fs.readFileSync(result.cursorrules, 'utf-8');
+      assert.ok(content.includes('# Legacy rules'), 'original content preserved');
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create .cursorrules when absent', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.cursorrules, null);
     } finally {
       cleanup(dir);
     }
@@ -193,6 +313,11 @@ function runTests() {
       assert.strictEqual(result.copilot, null);
       assert.strictEqual(result.gemini, null);
       assert.strictEqual(result.windsurf, null);
+      assert.strictEqual(result.trae, null);
+      assert.strictEqual(result.zed, null);
+      assert.strictEqual(result.cline, null);
+      assert.strictEqual(result.aider, null);
+      assert.strictEqual(result.cursorrules, null);
       assert.strictEqual(result.agents, null);
       assert.strictEqual(result.llms, null);
     } finally {

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -111,6 +111,80 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('propagates to .windsurfrules when it exists (Windsurf)', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, '.windsurfrules'), '# Windsurf rules\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.windsurf, 'windsurf path returned');
+      const content = fs.readFileSync(result.windsurf, 'utf-8');
+      assert.ok(content.includes('# Windsurf rules'), 'original content preserved');
+      assert.ok(content.includes('<!-- egc:start -->'));
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create .windsurfrules when absent', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.windsurf, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to AGENTS.md when it exists (Codex, OpenCode, Amp, Kiro)', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n\nDo not run tests in watch mode.\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.agents, 'agents path returned');
+      const content = fs.readFileSync(result.agents, 'utf-8');
+      assert.ok(content.includes('Do not run tests in watch mode'), 'original content preserved');
+      assert.ok(content.includes('EGC Project Memory'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create AGENTS.md when absent', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.agents, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('propagates to llms.txt when it exists', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'llms.txt'), '# Project context\n\nThis is a Node.js CLI tool.\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.llms, 'llms path returned');
+      const content = fs.readFileSync(result.llms, 'utf-8');
+      assert.ok(content.includes('This is a Node.js CLI tool'), 'original content preserved');
+      assert.ok(content.includes('EGC Project Memory'));
+      assert.ok(content.includes('Fix propagation hooks'), 'next item present');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not create llms.txt when absent', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.llms, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('returns all null when no tool configs exist', () => {
     const dir = mktemp();
     try {
@@ -118,6 +192,9 @@ function runTests() {
       assert.strictEqual(result.cursor, null);
       assert.strictEqual(result.copilot, null);
       assert.strictEqual(result.gemini, null);
+      assert.strictEqual(result.windsurf, null);
+      assert.strictEqual(result.agents, null);
+      assert.strictEqual(result.llms, null);
     } finally {
       cleanup(dir);
     }


### PR DESCRIPTION
## Summary

Two fixes for propagation bugs introduced in #313:

**Bug fix: Copilot guard was too permissive**
`writeCopilotContext` was checking for `.github/` directory existence, which is true in essentially every GitHub repo. It was creating `copilot-instructions.md` in projects that don't use Copilot at all. Now it only writes when `copilot-instructions.md` already exists, matching the same file-presence guard used for `GEMINI.md`.

**SessionStart propagation: last saved state syncs to all tools at startup**
Extracted propagation logic into `scripts/lib/propagate-state.js` (plain CommonJS, no build step required) and called it from the `SessionStart` hook. This means:
- Every time a Claude Code session starts, the last known EGC state is synced to `.cursor/rules/egc-context.mdc`, `GEMINI.md`, and `copilot-instructions.md` (where they exist)
- This closes the gap where a user could open Cursor before calling `update_state` in Claude Code and find stale or missing context
- Propagation is best-effort and never blocks session startup

## Test plan

- [ ] `tests/scripts/propagate-state.test.js`: 6 new cases for the shared CommonJS module
- [ ] `tests/scripts/egc-memory-propagate.test.js`: updated to assert corrected Copilot guard (8 cases, all passing)
- [ ] All tests run locally: 14/14 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Copilot propagation guard and adds startup propagation so the last EGC state syncs at session start across more tools, including Trae, Zed, Cline, Aider, and legacy Cursor, with the correct Windsurf path.

- **New Features**
  - Propagate on Claude Code SessionStart via `scripts/lib/propagate-state.js`; best-effort and never blocks startup.
  - Writes EGC section to existing tool configs only: `.cursor/rules/egc-context.mdc`, `GEMINI.md`, `.github/copilot-instructions.md`, `.windsurf/rules/egc-context.md`, `.trae/rules/egc-context.md`, `.rules` (Zed), `.clinerules`, `CONVENTIONS.md` (Aider), `.cursorrules`, `AGENTS.md`, `llms.txt`.

- **Bug Fixes**
  - Copilot guard only writes when `.github/copilot-instructions.md` already exists.

<sup>Written for commit 7bf21fcb11359936b6266fcbe0f3dcea971bd1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended project memory context propagation to support multiple development tools: Windsurf, Trae, Zed, Cline, Aider, and others.
  * Enhanced context state integration during session initialization for seamless updates.

* **Tests**
  * Added comprehensive test coverage for multi-tool context propagation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->