### PR TITLE
fix(test): replace better-sqlite3 with sql.js and harden gitlab-mirror workflow

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -5,11 +5,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/tests/lib/pattern-detection.test.js
+++ b/tests/lib/pattern-detection.test.js
@@ -236,7 +236,7 @@ async function runTests() {
   // Acceptance test: verifies the patched detect_patterns reads events from the state-store DB,
   // the same file where hooks write runtime events, not the server memory DB.
   if (await test('detect_patterns reads events from state-store DB (same path hooks use)', async () => {
-    const BetterSqlite3 = require('better-sqlite3');
+    const { openDatabase } = require('../../scripts/lib/state-store/db-adapter');
 
     const testDir = createTempDir('egc-patterns-acceptance-');
     const stateDbPath = path.join(testDir, 'state.db');
@@ -270,7 +270,7 @@ async function runTests() {
       store.close();
 
       // Replicate exactly what the patched detect_patterns handler does:
-      // open the state-store DB via better-sqlite3, query events, run detection,
+      // open the state-store DB via sql.js, query events, run detection,
       // persist patterns back to the same DB.
       const windowDays = 7;
       const minOccurrences = 3;
@@ -278,9 +278,7 @@ async function runTests() {
 
       let ssDb;
       try {
-        ssDb = new BetterSqlite3(stateDbPath, { readonly: false });
-        ssDb.pragma('journal_mode = WAL');
-        ssDb.pragma('busy_timeout = 5000');
+        ssDb = await openDatabase(stateDbPath);
 
         const rawRows = ssDb.prepare(
           'SELECT id, session_id, event_type, payload, timestamp FROM events WHERE timestamp >= ? ORDER BY timestamp ASC'


### PR DESCRIPTION
## Summary

- Fix 1 failing test: \`detect_patterns reads events from state-store DB\` in \`tests/lib/pattern-detection.test.js\` -- was using \`better-sqlite3\` directly after the project migrated to \`sql.js\` in #303
- Fix 3 open security alerts (#243, #246, #247) in \`.github/workflows/gitlab-mirror.yml\`: add \`permissions: {}\` at workflow level, job-level \`contents: read\`, and pin \`actions/checkout\` to a full SHA

## Test plan

- [x] \`node tests/lib/pattern-detection.test.js\` -- 12/12 passing
- [x] \`npm test\` -- 2450/2450 passing (was 2449/2450)
- [x] Workflow YAML valid (no structural changes beyond permissions + SHA pin)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing pattern-detection acceptance test by using the project’s `sql.js` adapter and tightens the GitLab mirror workflow with least-privilege settings and a pinned action to address security alerts.

- **Bug Fixes**
  - Test now opens the state-store via `openDatabase` from `scripts/lib/state-store/db-adapter` (uses `sql.js`), replacing `better-sqlite3`. Restores the failing test and matches app behavior.
  - Hardened `.github/workflows/gitlab-mirror.yml` with `permissions: {}` and job-level `contents: read` to resolve alerts (#243, #246, #247).

- **Dependencies**
  - Pinned `actions/checkout` to a full SHA for supply-chain safety.

<sup>Written for commit 283ef59afe69c140ac74813ffed76f7909e013da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

