### PR TITLE
feat(watch): add egc watch command for bidirectional state sync

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -5,11 +5,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -75,6 +75,10 @@ const COMMANDS = {
     script: 'uninstall.js',
     description: 'Remove EGC-managed files recorded in install-state',
   },
+  watch: {
+    script: 'watch.js',
+    description: 'Watch tool config files and sync state changes bidirectionally',
+  },
 };
 
 const PRIMARY_COMMANDS = [
@@ -93,6 +97,7 @@ const PRIMARY_COMMANDS = [
   'session-inspect',
   'loop-status',
   'uninstall',
+  'watch',
 ];
 
 function showHelp(exitCode = 0) {
@@ -136,6 +141,8 @@ Examples:
   egc session-inspect egc:latest
   egc loop-status --json
   egc uninstall --target antigravity --dry-run
+  egc watch
+  egc watch --project /path/to/project --quiet
 `);
 
   process.exit(exitCode);

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -1,0 +1,275 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { propagateStateContent } = require('./propagate-state');
+const { projectSlug, sanitizeBranchName, detectBranch } = require('./branch-state');
+
+const EGC_START = '<!-- egc:start -->';
+const EGC_END = '<!-- egc:end -->';
+
+const DEBOUNCE_MS = 400;
+
+// Files that EGC manages, keyed by tool name.
+// Each entry is a function (projectPath) -> filePath | null.
+const TOOL_FILE_RESOLVERS = {
+  cursor: (p) => {
+    const f = path.join(p, '.cursor', 'rules', 'egc-context.mdc');
+    return fs.existsSync(f) ? f : null;
+  },
+  copilot: (p) => {
+    const f = path.join(p, '.github', 'copilot-instructions.md');
+    return fs.existsSync(f) ? f : null;
+  },
+  gemini: (p) => {
+    const f = path.join(p, 'GEMINI.md');
+    return fs.existsSync(f) ? f : null;
+  },
+  windsurf: (p) => {
+    const f = path.join(p, '.windsurf', 'rules', 'egc-context.md');
+    return fs.existsSync(f) ? f : null;
+  },
+  trae: (p) => {
+    const f = path.join(p, '.trae', 'rules', 'egc-context.md');
+    return fs.existsSync(f) ? f : null;
+  },
+  zed: (p) => {
+    const f = path.join(p, '.rules');
+    return fs.existsSync(f) ? f : null;
+  },
+  cline: (p) => {
+    const f = path.join(p, '.clinerules');
+    return fs.existsSync(f) ? f : null;
+  },
+  aider: (p) => {
+    const f = path.join(p, 'CONVENTIONS.md');
+    return fs.existsSync(f) ? f : null;
+  },
+  cursorrules: (p) => {
+    const f = path.join(p, '.cursorrules');
+    return fs.existsSync(f) ? f : null;
+  },
+  agents: (p) => {
+    const f = path.join(p, 'AGENTS.md');
+    return fs.existsSync(f) ? f : null;
+  },
+  llms: (p) => {
+    const f = path.join(p, 'llms.txt');
+    return fs.existsSync(f) ? f : null;
+  },
+};
+
+function extractEgcBlock(content) {
+  const start = content.indexOf(EGC_START);
+  const end = content.indexOf(EGC_END);
+  if (start === -1 || end === -1 || end <= start) return null;
+  return content.slice(start + EGC_START.length, end).trim();
+}
+
+function parseBlockToStateContent(block) {
+  const lines = ['# Project State', ''];
+  let context = '';
+  const decisions = [];
+  const next = [];
+
+  let section = '';
+  for (const line of block.split('\n')) {
+    const h2 = line.match(/^\*\*(.+?):\*\*\s*(.*)/);
+    if (h2) {
+      const key = h2[1].trim();
+      const val = h2[2].trim();
+      if (key === 'Context') { context = val; section = 'context'; continue; }
+      if (key === 'Active decisions') { section = 'decisions'; continue; }
+      if (key === 'Next session') { section = 'next'; continue; }
+    }
+    if (section === 'context' && !context && line.trim()) {
+      context = line.trim();
+      continue;
+    }
+    const item = line.replace(/^-\s*/, '').trim();
+    if (!item) continue;
+    if (section === 'decisions') decisions.push(item);
+    if (section === 'next') next.push(item);
+  }
+
+  if (context) {
+    lines.push('## Context');
+    lines.push(context);
+    lines.push('');
+  }
+  if (decisions.length > 0) {
+    lines.push('## Active Decisions');
+    for (const d of decisions) lines.push(`- ${d}`);
+    lines.push('');
+  }
+  if (next.length > 0) {
+    lines.push('## Next Session');
+    for (const n of next) lines.push(`- ${n}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function resolveStateFilePath(projectPath) {
+  const stateDir = path.join(os.homedir(), '.egc', 'state');
+  const slug = projectSlug(projectPath);
+  const branch = detectBranch(projectPath);
+
+  if (branch) {
+    const branchFile = path.join(stateDir, slug, `${sanitizeBranchName(branch)}.md`);
+    if (fs.existsSync(branchFile)) return branchFile;
+    const defaultFile = path.join(stateDir, slug, 'main.md');
+    if (fs.existsSync(defaultFile)) return defaultFile;
+  }
+
+  const flatFile = path.join(stateDir, `${slug}.md`);
+  if (fs.existsSync(flatFile)) return flatFile;
+
+  return null;
+}
+
+function mergeBlockIntoStateFile(stateFilePath, block) {
+  const parsed = parseBlockToStateContent(block);
+  if (!parsed.trim()) return false;
+
+  const existing = fs.readFileSync(stateFilePath, 'utf-8');
+
+  // Only update Context and Next Session sections if they differ
+  const contextMatch = parsed.match(/## Context\n([^\n]+)/);
+  const nextMatch = parsed.match(/## Next Session\n([\s\S]*?)(?=\n##|$)/);
+
+  if (!contextMatch && !nextMatch) return false;
+
+  let updated = existing;
+
+  if (contextMatch) {
+    const newCtx = contextMatch[1].trim();
+    if (updated.includes('## Context\n')) {
+      updated = updated.replace(/^## Context\n.+/m, `## Context\n${newCtx}`);
+    }
+  }
+
+  if (nextMatch) {
+    const newNext = nextMatch[1].trim();
+    const nextSection = `## Next Session\n${newNext}`;
+    if (updated.includes('## Next Session\n')) {
+      updated = updated.replace(/## Next Session\n[\s\S]*?(?=\n##|$)/, `${nextSection}\n`);
+    } else {
+      updated = `${updated.trimEnd()}\n\n${nextSection}\n`;
+    }
+  }
+
+  if (updated === existing) return false;
+
+  fs.writeFileSync(stateFilePath, updated, 'utf-8');
+  return true;
+}
+
+class StateWatcher {
+  constructor(projectPath, { onSync, onError } = {}) {
+    this._projectPath = path.resolve(projectPath);
+    this._onSync = onSync || (() => {});
+    this._onError = onError || (() => {});
+    this._watchers = new Map();
+    this._timers = new Map();
+    // Track last write time per file to skip our own propagations
+    this._lastWriteMs = new Map();
+  }
+
+  start() {
+    const files = this._discoverFiles();
+    for (const [tool, filePath] of files) {
+      this._watchFile(tool, filePath);
+    }
+    return files.size;
+  }
+
+  stop() {
+    for (const watcher of this._watchers.values()) {
+      try { watcher.close(); } catch (_) { /* ignore */ }
+    }
+    this._watchers.clear();
+    for (const timer of this._timers.values()) {
+      clearTimeout(timer);
+    }
+    this._timers.clear();
+  }
+
+  _discoverFiles() {
+    const found = new Map();
+    for (const [tool, resolve] of Object.entries(TOOL_FILE_RESOLVERS)) {
+      const filePath = resolve(this._projectPath);
+      if (filePath) found.set(tool, filePath);
+    }
+    return found;
+  }
+
+  _watchFile(tool, filePath) {
+    try {
+      const watcher = fs.watch(filePath, (eventType) => {
+        if (eventType !== 'change') return;
+        this._schedule(tool, filePath);
+      });
+      this._watchers.set(tool, watcher);
+    } catch (_) {
+      // File may have been deleted -- skip silently
+    }
+  }
+
+  _schedule(tool, filePath) {
+    if (this._timers.has(tool)) clearTimeout(this._timers.get(tool));
+    this._timers.set(tool, setTimeout(() => {
+      this._timers.delete(tool);
+      this._handleChange(tool, filePath);
+    }, DEBOUNCE_MS));
+  }
+
+  _handleChange(tool, filePath) {
+    // Skip if we wrote this file recently (within 2s -- our own propagation)
+    const lastWrite = this._lastWriteMs.get(filePath) || 0;
+    if (Date.now() - lastWrite < 2000) return;
+
+    let content;
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch (_) {
+      return;
+    }
+
+    const block = extractEgcBlock(content);
+    if (!block) return;
+
+    const stateContent = parseBlockToStateContent(block);
+    if (!stateContent.trim()) return;
+
+    // Propagate to all other tools
+    const written = propagateStateContent(this._projectPath, stateContent);
+
+    // Track our own writes to avoid loop-back
+    for (const fp of Object.values(written)) {
+      if (fp) this._lastWriteMs.set(fp, Date.now());
+    }
+
+    // Update state file if found
+    let stateUpdated = false;
+    const stateFilePath = resolveStateFilePath(this._projectPath);
+    if (stateFilePath) {
+      try {
+        stateUpdated = mergeBlockIntoStateFile(stateFilePath, block);
+        if (stateUpdated) this._lastWriteMs.set(stateFilePath, Date.now());
+      } catch (_) { /* non-critical */ }
+    }
+
+    const syncedTools = Object.entries(written)
+      .filter(([, fp]) => fp)
+      .map(([t]) => t)
+      .filter((t) => t !== tool);
+
+    this._onSync({ sourceTool: tool, sourceFile: filePath, syncedTools, stateUpdated });
+  }
+}
+
+module.exports = { StateWatcher, extractEgcBlock, parseBlockToStateContent };

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('node:path');
+const { StateWatcher } = require('./lib/watch-state');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = { projectPath: process.cwd(), quiet: false, help: false };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--help' || args[i] === '-h') { opts.help = true; continue; }
+    if (args[i] === '--quiet' || args[i] === '-q') { opts.quiet = true; continue; }
+    if ((args[i] === '--project' || args[i] === '-p') && args[i + 1]) {
+      opts.projectPath = path.resolve(args[++i]);
+      continue;
+    }
+    if (!args[i].startsWith('-')) {
+      opts.projectPath = path.resolve(args[i]);
+    }
+  }
+
+  return opts;
+}
+
+function showHelp() {
+  console.log(`
+egc watch -- bidirectional state sync daemon
+
+Watches all EGC-managed tool config files in the project. When any file
+is modified outside of EGC's own propagation cycle, the change is synced
+to all other tools automatically.
+
+Usage:
+  egc watch [project-path] [options]
+
+Options:
+  --project, -p <path>  Project root to watch (default: cwd)
+  --quiet, -q           Suppress sync notifications
+  --help, -h            Show this help
+
+Supported tools:
+  Cursor, Copilot, Gemini CLI, Windsurf, Trae, Zed, Cline, Aider,
+  .cursorrules (legacy Cursor), AGENTS.md, llms.txt
+
+Exit: Ctrl+C
+`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  const watcher = new StateWatcher(opts.projectPath, {
+    onSync({ sourceTool, syncedTools, stateUpdated }) {
+      if (opts.quiet) return;
+      const targets = syncedTools.length > 0 ? syncedTools.join(', ') : 'none';
+      const stateNote = stateUpdated ? ' + state file' : '';
+      console.log(`[egc watch] ${sourceTool} changed -> synced to: ${targets}${stateNote}`);
+    },
+    onError(err) {
+      console.error(`[egc watch] error: ${err.message}`);
+    },
+  });
+
+  const count = watcher.start();
+
+  if (count === 0) {
+    console.log('[egc watch] No EGC-managed tool config files found in this project.');
+    console.log('            Run egc install --target <tool> to set up a target first.');
+    process.exit(0);
+  }
+
+  if (!opts.quiet) {
+    console.log(`[egc watch] Watching ${count} tool config file(s) in ${opts.projectPath}`);
+    console.log('[egc watch] Press Ctrl+C to stop.');
+  }
+
+  process.on('SIGINT', () => {
+    watcher.stop();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', () => {
+    watcher.stop();
+    process.exit(0);
+  });
+}
+
+main();

--- a/tests/lib/pattern-detection.test.js
+++ b/tests/lib/pattern-detection.test.js
@@ -236,7 +236,7 @@ async function runTests() {
   // Acceptance test: verifies the patched detect_patterns reads events from the state-store DB,
   // the same file where hooks write runtime events, not the server memory DB.
   if (await test('detect_patterns reads events from state-store DB (same path hooks use)', async () => {
-    const BetterSqlite3 = require('better-sqlite3');
+    const { openDatabase } = require('../../scripts/lib/state-store/db-adapter');
 
     const testDir = createTempDir('egc-patterns-acceptance-');
     const stateDbPath = path.join(testDir, 'state.db');
@@ -270,7 +270,7 @@ async function runTests() {
       store.close();
 
       // Replicate exactly what the patched detect_patterns handler does:
-      // open the state-store DB via better-sqlite3, query events, run detection,
+      // open the state-store DB via sql.js, query events, run detection,
       // persist patterns back to the same DB.
       const windowDays = 7;
       const minOccurrences = 3;
@@ -278,9 +278,7 @@ async function runTests() {
 
       let ssDb;
       try {
-        ssDb = new BetterSqlite3(stateDbPath, { readonly: false });
-        ssDb.pragma('journal_mode = WAL');
-        ssDb.pragma('busy_timeout = 5000');
+        ssDb = await openDatabase(stateDbPath);
 
         const rawRows = ssDb.prepare(
           'SELECT id, session_id, event_type, payload, timestamp FROM events WHERE timestamp >= ? ORDER BY timestamp ASC'

--- a/tests/scripts/watch-state.test.js
+++ b/tests/scripts/watch-state.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { extractEgcBlock, parseBlockToStateContent, StateWatcher } = require('../../scripts/lib/watch-state');
+
+function mktemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-watch-state-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+const SAMPLE_BLOCK = `## EGC Project Memory
+
+**Context:** EGC v1.1.1 stable on npm.
+
+**Active decisions:**
+- Use sql.js instead of better-sqlite3: Pure JS, no native module required
+- DCO sign-off mandatory: Legal requirement
+
+**Next session:**
+- Implement bidirectional sync
+- Fix propagation hooks`;
+
+const SAMPLE_MDC = `---
+description: EGC project memory (auto-updated)
+alwaysApply: true
+---
+
+<!-- egc:start -->
+${SAMPLE_BLOCK}
+<!-- egc:end -->
+`;
+
+async function runTests() {
+  console.log('\n=== Testing scripts/lib/watch-state.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('extractEgcBlock returns block between markers', () => {
+    const content = `# Header\n\n${SAMPLE_MDC}`;
+    const block = extractEgcBlock(content);
+    assert.ok(block, 'block should be returned');
+    assert.ok(block.includes('EGC Project Memory'), 'should include heading');
+    assert.ok(block.includes('sql.js'), 'should include decision');
+  })) passed++; else failed++;
+
+  if (await test('extractEgcBlock returns null when no markers', () => {
+    const block = extractEgcBlock('# Just a plain file\n\nNo EGC markers here.');
+    assert.strictEqual(block, null);
+  })) passed++; else failed++;
+
+  if (await test('extractEgcBlock returns null when only start marker present', () => {
+    const block = extractEgcBlock('<!-- egc:start -->\nSome content');
+    assert.strictEqual(block, null);
+  })) passed++; else failed++;
+
+  if (await test('parseBlockToStateContent produces parseable state content', () => {
+    const state = parseBlockToStateContent(SAMPLE_BLOCK);
+    assert.ok(state.includes('## Context'), 'should have Context section');
+    assert.ok(state.includes('EGC v1.1.1'), 'should include context text');
+  })) passed++; else failed++;
+
+  if (await test('parseBlockToStateContent handles empty block gracefully', () => {
+    const state = parseBlockToStateContent('');
+    assert.ok(typeof state === 'string', 'should return string');
+  })) passed++; else failed++;
+
+  if (await test('StateWatcher.start returns 0 when no tool files exist', () => {
+    const dir = mktemp();
+    try {
+      const watcher = new StateWatcher(dir);
+      const count = watcher.start();
+      assert.strictEqual(count, 0, 'no files to watch in empty dir');
+      watcher.stop();
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('StateWatcher.start returns count of discovered tool files', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, '.cursor', 'rules', 'egc-context.mdc'),
+        SAMPLE_MDC
+      );
+      fs.writeFileSync(path.join(dir, 'GEMINI.md'), `# Gemini\n\n${SAMPLE_MDC}`);
+
+      const watcher = new StateWatcher(dir);
+      const count = watcher.start();
+      assert.ok(count >= 2, `expected at least 2 watched files, got ${count}`);
+      watcher.stop();
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('StateWatcher fires onSync and propagates when watched file changes', () => {
+    return new Promise((resolve, reject) => {
+      const dir = mktemp();
+      let watcher;
+
+      try {
+        fs.writeFileSync(path.join(dir, 'GEMINI.md'), `# Gemini\n\n${SAMPLE_MDC}`);
+        fs.writeFileSync(path.join(dir, 'CONVENTIONS.md'), '# Conventions\n');
+
+        watcher = new StateWatcher(dir, {
+          onSync({ sourceTool, syncedTools }) {
+            try {
+              assert.strictEqual(sourceTool, 'gemini', 'source tool should be gemini');
+              assert.ok(syncedTools.includes('aider'), 'should sync to aider (CONVENTIONS.md)');
+              watcher.stop();
+              cleanup(dir);
+              resolve();
+            } catch (err) {
+              watcher.stop();
+              cleanup(dir);
+              reject(err);
+            }
+          },
+        });
+        watcher.start();
+
+        setTimeout(() => {
+          const updated = `# Gemini\n\n<!-- egc:start -->\n${SAMPLE_BLOCK}\n- New next item\n<!-- egc:end -->\n`;
+          fs.writeFileSync(path.join(dir, 'GEMINI.md'), updated);
+        }, 50);
+
+        // Timeout guard in case the event never fires
+        setTimeout(() => {
+          watcher.stop();
+          cleanup(dir);
+          reject(new Error('onSync did not fire within 2s after file change'));
+        }, 2000);
+      } catch (err) {
+        if (watcher) watcher.stop();
+        cleanup(dir);
+        reject(err);
+      }
+    });
+  })) passed++; else failed++;
+
+  if (await test('StateWatcher.stop closes all watchers cleanly', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'GEMINI.md'), SAMPLE_MDC);
+      const watcher = new StateWatcher(dir);
+      watcher.start();
+      assert.doesNotThrow(() => watcher.stop(), 'stop should not throw');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

Implements bidirectional state sync (closes #315) via a new \`egc watch\` daemon.

**How it works:**
- \`StateWatcher\` discovers all EGC-managed tool config files present in the project
- \`fs.watch()\` monitors each file for changes with a 400ms debounce
- A 2-second write-lock guard prevents loop-back propagation from EGC's own writes
- When a tool file changes, the EGC block (\`<!-- egc:start -->\` / \`<!-- egc:end -->\`) is extracted and propagated to all other tools
- Context changes are optionally merged back into \`~/.egc/state/\` for full round-trip sync

**Supported tools:**
Cursor, Copilot, Gemini CLI, Windsurf, Trae, Zed, Cline, Aider, .cursorrules (legacy), AGENTS.md, llms.txt

**Usage:**
\`\`\`
egc watch                       # watch cwd
egc watch /path/to/project      # watch specific project
egc watch --quiet               # suppress notifications
\`\`\`

## Test plan

- [x] 9/9 new tests in \`tests/scripts/watch-state.test.js\` passing
- [x] \`npm test\` -- 2459/2459 passing (includes the pattern-detection fix from #316 cherry-picked here)
- [x] Manual smoke test: editing GEMINI.md while \`egc watch\` is running propagates to .cursor/rules/egc-context.mdc
- [x] DCO signed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `egc watch` command that runs a daemon to sync EGC context changes across tool config files and (optionally) back to `~/.egc/state/` for round‑trip sync.

- **New Features**
  - Introduces `egc watch` to discover EGC-managed files and sync changes bidirectionally across tools (Cursor, Copilot, Gemini CLI, Windsurf, Trae, Zed, Cline, Aider, `.cursorrules`, `AGENTS.md`, `llms.txt`).
  - Uses `fs.watch()` with a 400ms debounce and a 2s write-lock to prevent loop-back from EGC's own writes; extracts `<!-- egc:start --> ... <!-- egc:end -->` and propagates via `propagateStateContent`.
  - CLI: `egc watch [path]`, `--project/-p`, `--quiet/-q`, `--help/-h`.

- **Bug Fixes**
  - Test: swap direct `better-sqlite3` usage for `openDatabase` (sql.js) in pattern-detection acceptance test.
  - CI: pin `actions/checkout` by SHA and set workflow `permissions: {}` in `gitlab-mirror.yml`.

<sup>Written for commit f0d08bb3da1b11e81620748fa0b46c3b11623574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new `watch` command that continuously monitors and synchronizes project state changes across integrated development tools.

* **Chores**
  * Enhanced GitHub Actions workflow with explicit permission declarations and pinned dependency versions for improved security.
  * Added comprehensive test suite for the new watch functionality and state detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->