### PR TITLE
ci(gitlab): disable automatic pipeline trigger pending identity verification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,9 @@
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+      when: always
+    - when: never
+
 stages:
   - test
 


### PR DESCRIPTION
## Summary

- GitLab requires identity verification (SMS or credit card) for new accounts to run jobs on shared runners
- Until verification is complete, every push triggers a pipeline that fails instantly with `Identity verification is required in order to run CI jobs`
- This generates failure emails on every push

## Change

Added a `workflow: rules:` block at the top of `.gitlab-ci.yml` that:

- Blocks all automatic pipeline triggers (push, merge request, schedule, etc.)
- Allows manual pipelines triggered via the GitLab UI (`CI_PIPELINE_SOURCE == "web"`)

## Re-enabling CI

Once identity verification is complete on the GitLab account, remove the `when: never` rule (or the entire `workflow:` block) to restore automatic pipeline execution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disable automatic GitLab CI pipeline triggers to prevent instant failures and email noise while identity verification is pending. Only manual pipelines from the GitLab UI are allowed via `workflow: rules:` in `.gitlab-ci.yml`.

- **Migration**
  - After verification, remove the `when: never` rule (or the whole `workflow` block) to restore automatic triggers.

<sup>Written for commit 869dc4f86575cdbdc74bf9222a628c4f202b48b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

