### PR TITLE
fix(watch): address CodeRabbit review -- atomic-save, context merge, path validation

### DIFF
--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -213,7 +213,7 @@ class StateWatcher {
       const watcher = fs.watch(filePath, (eventType) => {
         if (eventType === 'rename') {
           setTimeout(() => {
-            try { watcher.close(); } catch (_) {}
+            try { watcher.close(); } catch (_) { /* watcher already replaced on rename */ }
             this._watchers.delete(tool);
             this._watchFile(tool, filePath);
             this._schedule(tool, filePath);
@@ -222,6 +222,14 @@ class StateWatcher {
         }
         if (eventType !== 'change') return;
         this._schedule(tool, filePath);
+      });
+      // Windows emits 'error' (EPERM) instead of 'rename' on atomic file replacement
+      watcher.on('error', () => {
+        this._watchers.delete(tool);
+        setTimeout(() => {
+          this._watchFile(tool, filePath);
+          this._schedule(tool, filePath);
+        }, 150);
       });
       this._watchers.set(tool, watcher);
     } catch (_) {

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -121,9 +121,10 @@ function resolveStateFilePath(projectPath) {
   if (branch) {
     const branchFile = path.join(stateDir, slug, `${sanitizeBranchName(branch)}.md`);
     if (fs.existsSync(branchFile)) return branchFile;
-    const defaultFile = path.join(stateDir, slug, 'main.md');
-    if (fs.existsSync(defaultFile)) return defaultFile;
   }
+
+  const defaultFile = path.join(stateDir, slug, 'main.md');
+  if (fs.existsSync(defaultFile)) return defaultFile;
 
   const flatFile = path.join(stateDir, `${slug}.md`);
   if (fs.existsSync(flatFile)) return flatFile;
@@ -148,7 +149,7 @@ function mergeBlockIntoStateFile(stateFilePath, block) {
   if (contextMatch) {
     const newCtx = contextMatch[1].trim();
     if (updated.includes('## Context\n')) {
-      updated = updated.replace(/^## Context\n.+/m, `## Context\n${newCtx}`);
+      updated = updated.replace(/## Context\n[\s\S]*?(?=\n##|$)/, `## Context\n${newCtx}\n`);
     }
   }
 
@@ -184,7 +185,7 @@ class StateWatcher {
     for (const [tool, filePath] of files) {
       this._watchFile(tool, filePath);
     }
-    return files.size;
+    return this._watchers.size;
   }
 
   stop() {
@@ -210,6 +211,15 @@ class StateWatcher {
   _watchFile(tool, filePath) {
     try {
       const watcher = fs.watch(filePath, (eventType) => {
+        if (eventType === 'rename') {
+          setTimeout(() => {
+            try { watcher.close(); } catch (_) {}
+            this._watchers.delete(tool);
+            this._watchFile(tool, filePath);
+            this._schedule(tool, filePath);
+          }, 150);
+          return;
+        }
         if (eventType !== 'change') return;
         this._schedule(tool, filePath);
       });
@@ -240,10 +250,10 @@ class StateWatcher {
     }
 
     const block = extractEgcBlock(content);
-    if (!block) return;
+    if (!block || !block.trim()) return;
 
     const stateContent = parseBlockToStateContent(block);
-    if (!stateContent.trim()) return;
+    if (!stateContent.includes('## Context') && !stateContent.includes('## Active Decisions')) return;
 
     // Propagate to all other tools
     const written = propagateStateContent(this._projectPath, stateContent);
@@ -272,4 +282,4 @@ class StateWatcher {
   }
 }
 
-module.exports = { StateWatcher, extractEgcBlock, parseBlockToStateContent };
+module.exports = { StateWatcher, extractEgcBlock, parseBlockToStateContent, mergeBlockIntoStateFile, resolveStateFilePath };

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -208,32 +208,28 @@ class StateWatcher {
     return found;
   }
 
+  _reattach(tool, filePath, oldWatcher) {
+    if (oldWatcher) { try { oldWatcher.close(); } catch (e) { void e; } }
+    this._watchers.delete(tool);
+    this._watchFile(tool, filePath);
+    this._schedule(tool, filePath);
+  }
+
   _watchFile(tool, filePath) {
     try {
       const watcher = fs.watch(filePath, (eventType) => {
         if (eventType === 'rename') {
-          setTimeout(() => {
-            try { watcher.close(); } catch (_) { /* watcher already replaced on rename */ }
-            this._watchers.delete(tool);
-            this._watchFile(tool, filePath);
-            this._schedule(tool, filePath);
-          }, 150);
+          setTimeout(() => this._reattach(tool, filePath, watcher), 150);
           return;
         }
         if (eventType !== 'change') return;
         this._schedule(tool, filePath);
       });
       // Windows emits 'error' (EPERM) instead of 'rename' on atomic file replacement
-      watcher.on('error', () => {
-        this._watchers.delete(tool);
-        setTimeout(() => {
-          this._watchFile(tool, filePath);
-          this._schedule(tool, filePath);
-        }, 150);
-      });
+      watcher.on('error', () => setTimeout(() => this._reattach(tool, filePath, null), 150));
       this._watchers.set(tool, watcher);
-    } catch (_) {
-      // File may have been deleted -- skip silently
+    } catch (e) {
+      void e; // File may have been deleted -- skip silently
     }
   }
 
@@ -258,7 +254,7 @@ class StateWatcher {
     }
 
     const block = extractEgcBlock(content);
-    if (!block || !block.trim()) return;
+    if (!block) return;
 
     const stateContent = parseBlockToStateContent(block);
     if (!stateContent.includes('## Context') && !stateContent.includes('## Active Decisions')) return;

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -55,6 +55,12 @@ function main() {
     process.exit(0);
   }
 
+  const fs = require('node:fs');
+  if (!fs.existsSync(opts.projectPath)) {
+    console.error(`[egc watch] error: path does not exist: ${opts.projectPath}`);
+    process.exit(1);
+  }
+
   const watcher = new StateWatcher(opts.projectPath, {
     onSync({ sourceTool, syncedTools, stateUpdated }) {
       if (opts.quiet) return;

--- a/tests/scripts/watch-state.test.js
+++ b/tests/scripts/watch-state.test.js
@@ -253,9 +253,9 @@ async function runTests() {
       const result = resolveStateFilePath(projectDir);
       assert.strictEqual(result, mainMd, 'should resolve to main.md when no branch (detached HEAD or non-git dir)');
     } finally {
-      try { fs.unlinkSync(mainMd); } catch (_) {}
+      try { fs.unlinkSync(mainMd); } catch (_) { /* may not exist if test failed early */ }
       if (createdSlugDir) {
-        try { fs.rmdirSync(slugDir); } catch (_) {}
+        try { fs.rmdirSync(slugDir); } catch (_) { /* may fail if dir still has files */ }
       }
       cleanup(projectDir);
     }

--- a/tests/scripts/watch-state.test.js
+++ b/tests/scripts/watch-state.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { extractEgcBlock, parseBlockToStateContent, StateWatcher } = require('../../scripts/lib/watch-state');
+const { extractEgcBlock, parseBlockToStateContent, StateWatcher, mergeBlockIntoStateFile, resolveStateFilePath } = require('../../scripts/lib/watch-state');
 
 function mktemp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-watch-state-'));
@@ -169,6 +169,146 @@ async function runTests() {
     } finally {
       cleanup(dir);
     }
+  })) passed++; else failed++;
+
+  if (await test('StateWatcher fires onSync after atomic rename (editor save)', () => {
+    return new Promise((resolve, reject) => {
+      const dir = mktemp();
+      let watcher;
+
+      try {
+        const targetPath = path.join(dir, 'GEMINI.md');
+        fs.writeFileSync(targetPath, `# Gemini\n\n${SAMPLE_MDC}`);
+
+        watcher = new StateWatcher(dir, {
+          onSync({ sourceTool }) {
+            try {
+              assert.strictEqual(sourceTool, 'gemini');
+              watcher.stop();
+              cleanup(dir);
+              resolve();
+            } catch (err) {
+              watcher.stop();
+              cleanup(dir);
+              reject(err);
+            }
+          },
+        });
+        watcher.start();
+
+        setTimeout(() => {
+          const tmpPath = targetPath + '.tmp';
+          const updated = `# Gemini\n\n<!-- egc:start -->\n${SAMPLE_BLOCK}\n- Atomic save item\n<!-- egc:end -->\n`;
+          fs.writeFileSync(tmpPath, updated);
+          fs.renameSync(tmpPath, targetPath);
+        }, 50);
+
+        setTimeout(() => {
+          watcher.stop();
+          cleanup(dir);
+          reject(new Error('onSync did not fire within 2s after atomic rename'));
+        }, 2000);
+      } catch (err) {
+        if (watcher) watcher.stop();
+        cleanup(dir);
+        reject(err);
+      }
+    });
+  })) passed++; else failed++;
+
+  if (await test('mergeBlockIntoStateFile replaces multi-line Context correctly', () => {
+    const dir = mktemp();
+    try {
+      const stateFilePath = path.join(dir, 'state.md');
+      const initial = '# Project State\n\n## Context\nOld line one\nOld line two\nOld line three\n\n## Active Decisions\n- Some decision\n';
+      fs.writeFileSync(stateFilePath, initial);
+
+      const block = `**Context:** New single-line context\n\n**Active decisions:**\n- Some decision`;
+      mergeBlockIntoStateFile(stateFilePath, block);
+
+      const result = fs.readFileSync(stateFilePath, 'utf-8');
+      assert.ok(result.includes('New single-line context'), 'should contain new context');
+      assert.ok(!result.includes('Old line one'), 'should not contain old context first line');
+      assert.ok(!result.includes('Old line two'), 'should not contain old context second line');
+      assert.ok(!result.includes('Old line three'), 'should not contain old context third line');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('resolveStateFilePath without branch finds main.md', () => {
+    const projectDir = mktemp();
+    const stateDir = path.join(os.homedir(), '.egc', 'state');
+    const slug = require('../../scripts/lib/branch-state').projectSlug(projectDir);
+    const slugDir = path.join(stateDir, slug);
+    let createdSlugDir = false;
+    const mainMd = path.join(slugDir, 'main.md');
+
+    try {
+      if (!fs.existsSync(slugDir)) {
+        fs.mkdirSync(slugDir, { recursive: true });
+        createdSlugDir = true;
+      }
+      fs.writeFileSync(mainMd, '# State\n');
+      const result = resolveStateFilePath(projectDir);
+      assert.strictEqual(result, mainMd, 'should resolve to main.md when no branch (detached HEAD or non-git dir)');
+    } finally {
+      try { fs.unlinkSync(mainMd); } catch (_) {}
+      if (createdSlugDir) {
+        try { fs.rmdirSync(slugDir); } catch (_) {}
+      }
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('StateWatcher.start returns count of successful watchers only', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'GEMINI.md'), SAMPLE_MDC);
+      const watcher = new StateWatcher(dir);
+      const count = watcher.start();
+      assert.strictEqual(count, 1, 'only GEMINI.md exists and should be watched');
+      watcher.stop();
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('_handleChange skips empty egc block without propagating', () => {
+    return new Promise((resolve, reject) => {
+      const dir = mktemp();
+      let watcher;
+
+      try {
+        const emptyBlock = `<!-- egc:start -->\n   \n<!-- egc:end -->\n`;
+        fs.writeFileSync(path.join(dir, 'GEMINI.md'), `# Gemini\n\n${emptyBlock}`);
+
+        let synced = false;
+        watcher = new StateWatcher(dir, {
+          onSync() { synced = true; },
+        });
+        watcher.start();
+
+        setTimeout(() => {
+          const emptyContent = `# Gemini\n\n<!-- egc:start -->\n   \n<!-- egc:end -->\n`;
+          fs.writeFileSync(path.join(dir, 'GEMINI.md'), emptyContent);
+        }, 50);
+
+        setTimeout(() => {
+          watcher.stop();
+          cleanup(dir);
+          if (synced) {
+            reject(new Error('onSync should not fire for empty block'));
+          } else {
+            resolve();
+          }
+        }, 800);
+      } catch (err) {
+        if (watcher) watcher.stop();
+        cleanup(dir);
+        reject(err);
+      }
+    });
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Summary

Fixes 6 bugs identified in CodeRabbit's review of PR #317 and adds 5 new tests for previously uncovered paths.

### Fixes

**Bug 1 -- `resolveStateFilePath` missing `main.md` fallback on detached HEAD** (`watch-state.js`)
When `detectBranch` returns null (detached HEAD, non-git dir), the original code skipped `main.md` entirely and jumped to the flat file. Now `main.md` is always tried before the flat file, regardless of whether a branch was detected.

**Bug 2 -- `mergeBlockIntoStateFile` partial Context replacement** (`watch-state.js`)
The regex `/^## Context\n.+/m` only replaced the first line of a multi-line Context block. Fixed to use a greedy match that consumes everything up to the next `##` heading or end of file, matching the existing pattern used for Next Session.

**Bug 3 -- Watcher dies on atomic saves (VS Code, Cursor, Windsurf)** (`watch-state.js`)
Modern editors write to a temp file then rename it over the target. `fs.watch` emits a `rename` event and the watcher becomes stale (wrong inode). The watcher now detects `rename` events, waits 150ms for the rename to complete, closes the dead watcher, and re-attaches to the file path.

**Bug 4 -- `start()` returns discovered file count instead of watcher count** (`watch-state.js`)
`_watchFile` silently swallows errors, so `files.size` could overcount. Changed to `this._watchers.size` which reflects only successfully created watchers.

**Bug 5 -- Ineffective guard against empty EGC blocks** (`watch-state.js`)
`parseBlockToStateContent('')` always returns at least `"# Project State\n"`, so `!stateContent.trim()` never triggered. The guard now checks the raw block before parsing, and verifies the parsed output actually contains `## Context` or `## Active Decisions` before propagating.

**Bug 6 -- No validation of `projectPath` existence** (`watch.js`)
Added an `fs.existsSync` check after argument parsing. If the path does not exist, the CLI exits with a clear error message instead of silently starting a watcher on a non-existent directory.

### Tests added (`tests/scripts/watch-state.test.js`)

- Atomic rename triggers `onSync` (editor save simulation via `fs.renameSync`)
- Multi-line Context block is fully replaced by `mergeBlockIntoStateFile`
- `resolveStateFilePath` finds `main.md` when `detectBranch` returns null
- `start()` returns count of successful watchers (not discovered files)
- Empty EGC block does not trigger propagation

### Exports added

`mergeBlockIntoStateFile` and `resolveStateFilePath` are now exported from `watch-state.js` to support the new tests.

## References

Closes CodeRabbit comments from PR #317.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six watcher bugs and adds five tests. Saves from modern editors now sync across platforms, context blocks merge correctly, the CLI validates paths before starting, and watcher code is simpler and more reliable.

- **Bug Fixes**
  - Always try `main.md` before flat file when no branch is detected.
  - Replace the entire multi-line Context section during merges.
  - Handle atomic editor saves by re-watching on `rename` events (150ms delay) and Windows `error` (EPERM) events.
  - `start()` returns the number of active watchers, not discovered files.
  - Skip empty EGC blocks and only propagate when Context or Active Decisions exist.
  - Validate `projectPath` in the CLI and exit with a clear error if it does not exist.

- **Refactors**
  - Extracted `_reattach` to unify rename/error handling and reduce complexity in `_watchFile`; removed a redundant empty-block trim check.

<sup>Written for commit 32720bef3b4c27c04076349702d3eb2d405d3091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

