### PR TITLE
feat(memory): improve tool descriptions for TDQS A rating on Glama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to EGC are documented here.
 
+## [1.1.1] - 2026-06-20
+
+### New Features
+
+- **`egc watch`** — bidirectional sync daemon. Watches all EGC-managed tool config files in the project. When context is edited directly in any tool file (Cursor, Gemini CLI, GitHub Copilot, Windsurf, etc.), the change is extracted from the EGC block and synced to all other tools and back to `~/.egc/state/` automatically. Handles atomic saves (VS Code, Cursor, Windsurf rename-based writes) and Windows EPERM events.
+
+### Memory Improvements
+
+- **`update_state` propagates to 11 tool config files** — calling `update_state` now writes the new context to every EGC-managed file found in the project: `.cursor/rules/egc-context.mdc`, `.github/copilot-instructions.md`, `GEMINI.md`, `.windsurf/rules/egc-context.md`, `.trae/rules/egc-context.md`, `.rules` (Zed), `.clinerules` (Cline), `CONVENTIONS.md` (Aider), `.cursorrules`, `AGENTS.md`, and `llms.txt`. No extra calls needed — one `update_state` keeps every tool in sync.
+
+### Bug Fixes
+
+- Fixed `update_state` propagation to GitHub Copilot: guard now correctly detects the existing EGC block before inserting.
+- Fixed multi-line Context section replacement in bidirectional sync merge.
+- Fixed state file path resolution in detached HEAD / non-git directories.
+- Fixed `StateWatcher.start()` to return the count of successfully attached watchers rather than the count of discovered files.
+
 ## [1.1.0] - 2026-06-13
 
 ### New Tools
@@ -10,9 +27,9 @@ All notable changes to EGC are documented here.
 
 - **`detect_patterns`** - Analyzes runtime events from the state-store database to surface repeated commands and recurring errors across sessions. Helps identify automation candidates and structural issues that persist between conversations.
 
-- **`working_memory`** - Stores transient context within a session with configurable TTL. Entries expire automatically so the memory store does not accumulate stale data across sessions. Exposed as `set_working_memory`, `get_working_memory`, and `delete_working_memory`.
+- **`working_memory`** - Stores transient context within a session with configurable TTL. Entries expire automatically so the memory store does not accumulate stale data across sessions. Exposed as `working_memory_set`, `working_memory_get`, and `working_memory_list`.
 
-- **`lessons`** - Records cross-session knowledge with confidence decay. Each lesson tracks how many times it was reinforced and when it was last seen; confidence degrades over time so stale lessons surface for review rather than being applied forever. Exposed as `add_lesson`, `list_lessons`, and `forget_lesson`.
+- **`lessons`** - Records cross-session knowledge with confidence decay. Each lesson tracks how many times it was reinforced and when it was last seen; confidence degrades over time so stale lessons surface for review rather than being applied forever. Exposed as `lesson_save`, `lesson_recall`, and `lesson_reinforce`.
 
 - **`search_history`** - Full-text search over stored observations using FTS5 with BM25 ranking. Returns results ordered by relevance rather than recency.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 | `orchestrate_task` | Routes prompts with agent/skill context and returns compression metrics |
 | `auto_learn` | Mines session failures and writes actionable lessons to CLAUDE.md |
 
+**`egc watch`** — bidirectional sync daemon. Watches all EGC-managed tool config files in the project. When you edit context directly in any tool file (Cursor, Gemini CLI, Copilot, etc.), the change is extracted from the EGC block and synced to all other tools and back to `~/.egc/state/` automatically.
+
+```
+egc watch              # watch current project
+egc watch /path/proj   # watch a specific project
+egc watch --quiet      # suppress output
+```
+
 ---
 
 ## Prompt library

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,12 @@
 
 This document describes the planned development direction for EGC (Extended Global Context).
 
+## v1.1.1: Bidirectional Sync (In progress)
+
+- `egc watch`: bidirectional sync daemon -- edits in any tool config file propagate to all others and back to `~/.egc/state/` automatically (issues #302, #303)
+- `update_state` now propagates context to all 13 supported tool config files in one call (issue #313)
+- Handles atomic saves (VS Code, Cursor, Windsurf rename-based writes) and Windows EPERM events (issue #320)
+
 ## v1.1.0: Memory Expansion (Released 2026-06-13)
 
 - `working_memory`: transient key-value store with TTL (issue #138)
@@ -15,9 +21,10 @@ This document describes the planned development direction for EGC (Extended Glob
 
 ## v1.2.0: Ecosystem Expansion
 
-- Support for additional AI harnesses (Zed, Windsurf, Continue)
+- `egc install --target <tool>`: create context stubs for individual tools on first install
 - Plugin system for community-contributed agents and skills
 - Per-project skill profiles and overrides
+- Shared state between team members (multi-user installations)
 
 ## v1.3.0: Governance and Security
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/servers/schema.json",
   "name": "EGC",
-  "description": "Local MCP runtime that gives persistent cross-session memory to 12 AI coding agents (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Amp, and more). SQLite-backed state survives context resets. Install: npm install -g @egchq/egc",
+  "description": "Local MCP runtime that gives persistent cross-session memory to 13 AI coding tools (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Amp, Kiro, VS Code Copilot, and more). SQLite-backed state survives context resets. Bidirectional sync keeps all tool config files in sync. Install: npm install -g @egchq/egc",
   "license": "MIT",
   "homepage": "https://github.com/Fmarzochi/EGC",
   "repository": "https://github.com/Fmarzochi/EGC",
@@ -75,7 +75,13 @@
     "gemini-cli",
     "codex",
     "windsurf",
-    "coding-assistant"
+    "amp",
+    "kiro",
+    "coding-assistant",
+    "cross-session",
+    "bidirectional-sync",
+    "sqlite",
+    "session-memory"
   ],
   "authors": [
     {

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -636,7 +636,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "lesson_recall",
-        description: "Search active lessons by keyword across content, context, and tags. Only lessons at or above min_confidence (default 0.2) are returned; lower-confidence lessons are archived and hidden. Updates the last_recalled timestamp on matched lessons, which factors into reinforcement decay. Returns results ranked by confidence score descending. Call at session start to surface relevant patterns before beginning work on a known problem area.",
+        description: "Search active lessons by keyword across content, context, and tags. Only lessons at or above min_confidence (default 0.2) are returned; lower-confidence lessons are archived and hidden. Updates the last_recalled timestamp on matched lessons (decay is driven by last_reinforced, not last_recalled). Returns results ranked by confidence score descending. Call at session start to surface relevant patterns before beginning work on a known problem area.",
         inputSchema: {
           type: "object",
           properties: {
@@ -671,7 +671,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "compress_observations",
-        description: "Compress recent raw hook observations into structured typed summaries (tool_failure, tool_success, file_edit, shell_command) using rule-based analysis. Reduces token count when injecting session history into context. Does not delete raw observations — only marks them as compressed. Call before get_state or at session start to ensure hook data is compact before loading project memory. Returns the count of compressed items and a human-readable summary of what was processed.",
+        description: "Compress recent raw hook observations into structured typed summaries (tool_failure, tool_success, file_edit, generic) using rule-based analysis. Reduces token count when injecting session history into context. Does not delete raw observations — only marks them as compressed. Call before get_state or at session start to ensure hook data is compact before loading project memory. Returns the count of compressed items and a human-readable summary of what was processed.",
         inputSchema: {
           type: "object",
           properties: {

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -586,7 +586,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "working_memory_set",
-        description: "Store a transient key-value entry scoped to the current project. The entry expires automatically after ttl_seconds (default: end-of-session). Use this for debug flags, temporary task context, or any value that should not pollute long-term project state.",
+        description: "Store a transient key-value entry scoped to the current project. Expires automatically after ttl_seconds (default 86400s). Overwrites any existing entry with the same key without error. Use for debug flags, temporary task context, or values that must not pollute long-term state in update_state. Do not use for data that must survive a session restart — use update_state instead.",
         inputSchema: {
           type: "object",
           properties: {
@@ -600,7 +600,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "working_memory_get",
-        description: "Retrieve a single transient entry by key for the current project. Returns null if the entry does not exist or has expired.",
+        description: "Retrieve a single transient entry by key for the current project. Returns null if the key does not exist or has expired — does not throw. Does not modify the entry or extend its TTL. Use working_memory_list when the key is unknown or to audit all active entries.",
         inputSchema: {
           type: "object",
           properties: {
@@ -612,7 +612,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "working_memory_list",
-        description: "List all live transient entries for the current project, ordered by key. Expired entries are excluded.",
+        description: "List all live transient key-value entries for the current project, ordered by key. Expired entries are excluded automatically. Returns an empty array when no live entries exist. Each entry includes key, value, and expires_at. Use to audit active transient state or to check whether a key exists before calling working_memory_get.",
         inputSchema: {
           type: "object",
           properties: {
@@ -622,7 +622,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "lesson_save",
-        description: "Persist a new lesson learned during this session. Lessons are stored with a confidence score and decay over time when not reinforced. Use this to record patterns, rules, or observations the AI should remember across sessions.",
+        description: "Persist a new lesson learned during this session with an initial confidence score (default 0.7). Confidence decays over time when the lesson is not reinforced. Does not deduplicate — call lesson_recall first to check whether a similar lesson already exists. Use to record patterns, heuristics, or observations the AI should carry forward across sessions.",
         inputSchema: {
           type: "object",
           properties: {
@@ -636,7 +636,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "lesson_recall",
-        description: "Search active lessons above a confidence threshold. Lessons below 0.2 confidence are archived and not returned by default. Returns lessons ranked by confidence score.",
+        description: "Search active lessons by keyword across content, context, and tags. Only lessons at or above min_confidence (default 0.2) are returned; lower-confidence lessons are archived and hidden. Updates the last_recalled timestamp on matched lessons, which factors into reinforcement decay. Returns results ranked by confidence score descending. Call at session start to surface relevant patterns before beginning work on a known problem area.",
         inputSchema: {
           type: "object",
           properties: {
@@ -649,7 +649,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "lesson_reinforce",
-        description: "Reinforce an existing lesson when the same pattern is observed again. Increases confidence by 0.15, capped at 1.0. Call this when a previously stored lesson proves relevant or a mistake is repeated.",
+        description: "Reinforce an existing lesson when the same pattern is observed again. Increases confidence by 0.15, capped at 1.0. Unarchives lessons that had decayed below the threshold. Call this when a lesson recalled via lesson_recall proves relevant to the current task, or when the same mistake recurs. Returns the updated lesson with its new confidence score.",
         inputSchema: {
           type: "object",
           properties: {
@@ -660,7 +660,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "detect_patterns",
-        description: "Analyzes captured runtime events and surfaces recurring behaviors across sessions. Detects repeated commands and recurring errors using frequency analysis. Patterns are persisted to SQLite with frequency, last_seen, and suggested_automation fields. Returns patterns with type, description, occurrence count, and an actionable suggestion.",
+        description: "Analyze captured runtime hook events and surface recurring behaviors across sessions. Detects repeated shell commands and recurring error signatures using frequency analysis. Patterns are stored with frequency, last_seen, and suggested_automation fields. Returns an array of pattern objects with type, description, occurrence count, and an actionable automation suggestion. Call after several sessions of work to identify tasks worth automating or formalizing as a hook.",
         inputSchema: {
           type: "object",
           properties: {
@@ -671,7 +671,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "compress_observations",
-        description: "Compress recent raw hook observations into structured typed summaries. Reduces token usage for context injection. Returns count + summary of compressed items.",
+        description: "Compress recent raw hook observations into structured typed summaries (tool_failure, tool_success, file_edit, shell_command) using rule-based analysis. Reduces token count when injecting session history into context. Does not delete raw observations — only marks them as compressed. Call before get_state or at session start to ensure hook data is compact before loading project memory. Returns the count of compressed items and a human-readable summary of what was processed.",
         inputSchema: {
           type: "object",
           properties: {

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -93,6 +93,14 @@ Los archivos de estado se almacenan en `~/.egc/state/<project-slug>.md`. Un arch
 | `orchestrate_task` | Enruta prompts con contexto de agentes/skills y devuelve métricas de compresión |
 | `auto_learn` | Analiza fallos de sesión y escribe lecciones accionables en CLAUDE.md |
 
+**`egc watch`** — daemon de sincronización bidireccional. Monitorea todos los archivos de configuración de herramientas gestionados por EGC en el proyecto. Cuando editas el contexto directamente en cualquier archivo de herramienta (Cursor, Gemini CLI, Copilot, etc.), el cambio se extrae del bloque EGC y se sincroniza con todas las demás herramientas y de vuelta a `~/.egc/state/` automáticamente.
+
+```
+egc watch              # monitorear proyecto actual
+egc watch /ruta/proj   # monitorear proyecto específico
+egc watch --quiet      # silenciar salida
+```
+
 ---
 
 ## Biblioteca de prompts

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -93,6 +93,14 @@ Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por 
 | `orchestrate_task` | Roteia prompts com contexto de agentes/skills e retorna métricas de compressão |
 | `auto_learn` | Analisa falhas de sessão e escreve lições acionáveis no CLAUDE.md |
 
+**`egc watch`** — daemon de sincronização bidirecional. Monitora todos os arquivos de configuração de ferramentas gerenciados pelo EGC no projeto. Quando você edita o contexto diretamente em qualquer arquivo de ferramenta (Cursor, Gemini CLI, Copilot, etc.), a mudança é extraída do bloco EGC e sincronizada com todas as outras ferramentas e de volta para `~/.egc/state/` automaticamente.
+
+```
+egc watch              # monitorar projeto atual
+egc watch /caminho     # monitorar projeto específico
+egc watch --quiet      # suprimir saída
+```
+
 ---
 
 ## Biblioteca de prompts


### PR DESCRIPTION
## Summary

- Improve descriptions for the 9 egc-memory tools added in v1.1.1 (working_memory_set/get/list, lesson_save/recall/reinforce, detect_patterns, compress_observations)
- All 6 TDQS dimensions now covered: Purpose Clarity, Usage Guidelines, Behavioral Transparency, Parameter Semantics, Conciseness, Contextual Completeness
- Existing 5 tools (get_state, update_state, store_decision, query_history, get_project_state) already score A and are unchanged

## Motivation

Glama's TDQS pipeline runs the actual MCP server and scores every tool description it discovers via `tools/list`. The 9 new tools were added in PR #317 without descriptions optimized for TDQS. This PR brings them to the same standard as the existing tools, all of which score A.

Key improvements:
- **working_memory_get/list**: added output shape, null behavior, TTL behavior
- **lesson_save**: deduplication warning, contrast with lesson_recall
- **lesson_recall**: documented side-effect on last_recalled timestamp; clarified decay is driven by last_reinforced (not last_recalled)
- **lesson_reinforce**: documented unarchive behavior and return shape
- **detect_patterns**: clarified output fields, added usage timing guidance
- **compress_observations**: added typed-summary examples (tool_failure, tool_success, file_edit, generic), idempotency note, return shape
- **glama.json**: updated tool count to 13, added tags (amp, kiro, cross-session, bidirectional-sync, sqlite, session-memory)
- **README/translations**: added egc watch section to EN, PT, and ES READMEs
- **CHANGELOG**: added v1.1.1 entry, fixed tool names in v1.1.0
- **ROADMAP**: added v1.1.1 entry, updated v1.2.0 goals

## Test plan

- [ ] CI lint and tests pass
- [ ] No changes to tool behavior, only descriptions
- [ ] After merge, Glama re-index shows 14 tools all with A scores