### PR TITLE
fix(propagate-state): inject EGC_TRIGGERS into llms.txt block

### DIFF
--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -252,6 +252,7 @@ function writeLlmsTxt(projectPath, parsed) {
     lines.push('', '## Next session');
     for (const n of parsed.next.slice(0, MAX_ITEMS)) lines.push(`- ${n}`);
   }
+  lines.push('', EGC_TRIGGERS);
   const block = lines.join('\n');
 
   const existing = fs.readFileSync(filePath, 'utf-8');


### PR DESCRIPTION
## Summary

- `writeLlmsTxt` built its own content block from scratch without `EGC_TRIGGERS`, making `llms.txt` the only target missing the natural language interface section
- Fixes the issue identified by CodeRabbit (critical) and cubic (P2) on PR #322
- One-line fix: `lines.push('', EGC_TRIGGERS)` before joining, consistent with all other IDE context writers

## Root cause

`writeLlmsTxt` receives `parsed` directly and builds its own `lines` array, while every other writer receives the output of `buildSummaryBlock(parsed)` which already includes `EGC_TRIGGERS`. The fix aligns `llms.txt` with all other targets.

## Test plan

- [ ] Verify module loads without errors
- [ ] Verify `llms.txt` block now includes the EGC Natural Language Interface section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `EGC_TRIGGERS` to the `llms.txt` writer so the Natural Language Interface section is included, matching other IDE context writers. Fixes the missing section caused by building the `llms.txt` block from scratch.

<sup>Written for commit 143ca510d755b4d20b0c60055399eed67585f720. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

