### PR TITLE
docs(readme): add website link to support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ egc watch --quiet      # suppress output
 
 EGC is built by one developer, maintained in the open, and free.
 
+- **[Website](https://fmarzochi.github.io/EGCSite)**: full docs, feature overview, and live demo
 - **[Join the Discord](https://discord.gg/AtazrtxJ)**: ask questions, share feedback
 - **[Sponsor on GitHub](https://github.com/sponsors/Fmarzochi)**: any amount
 - **[Donate via PayPal](https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD)**: no GitHub account needed


### PR DESCRIPTION
## Summary

- Adds `https://fmarzochi.github.io/EGCSite` as the first item in the Support EGC section
- Gives visitors a direct link to full docs, feature overview, and live demo from the README

## Test plan
- [ ] Click the link and confirm it opens the EGCSite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Website link (https://fmarzochi.github.io/EGCSite) as the first item in the Support EGC section of the README to give readers quick access to docs, feature overview, and a live demo.

<sup>Written for commit 1f5b4bf426b2b46e63fe9204ac88ea6fb4a90cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the project website in the Support section for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->