### PR TITLE
docs(readme): add zero-memorization marketing framing to tools sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ EGC ships two MCP servers that work together during every session.
 
 ### Memory -- 14 tools that your AI uses automatically
 
-You never call these tools yourself. When you say "let's pick up where we left off", "save this decision", or "what did we learn last time" -- in any language -- your AI detects the intent and calls the right tool. The commands exist, but you will never need to type them.
+No commands to memorize. Your AI reads this table so you never have to. Say anything in any language -- "continue from yesterday", "remember this decision", "what broke last time?" -- and it calls the right tool. You just work. EGC handles the rest.
 
 **`egc-memory`**
 
@@ -106,6 +106,8 @@ State files live at `~/.egc/state/<project-slug>.md`. One file per project, plai
 ### Context and safety -- 5 tools for when things get heavy
 
 **`egc-guardian`**
+
+These tools run automatically in the background. Every shell command and every file write is checked before it executes. You never invoke them directly.
 
 | Tool | What it does |
 |---|---|


### PR DESCRIPTION
Adds two short paragraphs above the egc-memory and egc-guardian tool tables to communicate that users never need to memorize or type any tool names -- the AI interprets natural language and calls the right tool automatically.

**egc-memory:** "No commands to memorize. Your AI reads this table so you never have to..."
**egc-guardian:** "These tools run automatically in the background..."

This completes the marketing framing started in #324.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates README to add zero‑memorization framing for tool sections. Adds two short intros above the `egc-memory` and `egc-guardian` tables explaining that natural language triggers the right tool and that safety checks run automatically in the background.

<sup>Written for commit 38ce8cb310a9ff930a55a9ebd8f59b24669641c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

