### PR TITLE
fix(glama): add Dockerfile to prevent pnpm build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:24-slim
+
+WORKDIR /app
+
+RUN npm install -g mcp-proxy@6.4.3
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+CMD ["mcp-proxy", "--", "node", "mcp/servers/egc-memory/build/index.js"]


### PR DESCRIPTION
## Problem

Glama auto-generates a Dockerfile for EGC using \`pnpm install\`. pnpm 10 reads the \`resolutions\` field in \`package.json\` for Yarn compatibility and cannot parse the \`markdownlint-cli/js-yaml\` nested selector (Yarn syntax).

Error from Glama build logs:
\`\`\`
ERR_PNPM_INVALID_SELECTOR  Cannot parse the "markdownlint-cli/js-yaml" selector
process "/bin/sh -c (pnpm install) && (pnpm run build)" did not complete successfully: exit code: 1
\`\`\`

This caused EGC to fail Glama's Docker build test and disappear from search results.

## Fix

Add an explicit \`Dockerfile\` at the repo root. Glama uses it instead of auto-generating one. The Dockerfile uses \`npm ci\` (not pnpm), avoiding the \`resolutions\` incompatibility entirely.

## Test plan

- [ ] CI passes (CodeQL + lint)
- [ ] Glama re-triggers build after merge and succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a repo `Dockerfile` so Glama builds succeed by using `npm ci` instead of `pnpm install`, fixing the `resolutions` parsing error and restoring EGC to search.

- **Bug Fixes**
  - Force Glama to use the provided `Dockerfile` instead of its auto-generated one.
  - Switch to `npm ci` to avoid `pnpm` 10 `ERR_PNPM_INVALID_SELECTOR` on `resolutions` (`markdownlint-cli/js-yaml`).
  - Install `mcp-proxy@6.4.3` and run the built server via `mcp-proxy -- node mcp/servers/egc-memory/build/index.js`.

<sup>Written for commit dced5cfa52de8041995acb7a871ee43fccb7035e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

