### PR TITLE
fix(license): remove extra lines so GitHub detects MIT correctly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,5 @@
 MIT License
 
-Extended Global Context (EGC)
-Production Runtime Framework
-
 Copyright (c) 2026 Felipe Marzochi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Problem

GitHub's license detector was showing the EGC license as "Other" instead of "MIT" because two extra lines ("Extended Global Context (EGC)" and "Production Runtime Framework") were placed between "MIT License" and the copyright notice.

GitHub expects the standard format:
```
MIT License

Copyright (c) YEAR AUTHOR
```

## Fix

Removed the two extra lines so GitHub can auto-detect the MIT license correctly.

This also unblocks PR rohitg00/awesome-claude-code-toolkit#573 where CodeRabbit flagged this discrepancy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed two non-standard lines from LICENSE so GitHub detects MIT correctly. Restores the standard MIT header format for proper license display.

<sup>Written for commit e7f1b10fb58c769743306c154e2df82798ad782d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

