### PR TITLE
feat(cla): add lightweight CLA via contributor-assistant

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,13 @@
+# Contributor License Agreement
+
+By contributing to EGC (Extended Global Context), you agree to the following terms:
+
+1. **Grant of License** - You grant Felipe Marzochi and the EGC project a perpetual, worldwide, non-exclusive, royalty-free license to use, reproduce, modify, distribute, and sublicense your contribution as part of the EGC project, under the same license as the project (MIT).
+
+2. **Original Work** - Your contribution is your original creation. You have the right to submit it and grant the license above.
+
+3. **No Warranty** - You provide your contribution as-is, without warranties of any kind.
+
+4. **Patent Grant** - You grant a license under any patents you hold that are necessarily infringed by your contribution.
+
+This agreement covers all past and future contributions to the Fmarzochi/EGC repository.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,12 +98,29 @@ git push --force-with-lease
 
 ---
 
+## Contributor License Agreement (CLA)
+
+Every contributor must sign the CLA once before their first PR can be merged.
+
+**How to sign:** When you open your first PR, the CLA bot will post a comment. Reply with:
+
+```
+I have read the CLA Document and I hereby sign the CLA.
+```
+
+That is it. One comment, one time. Future PRs are merged without any extra steps.
+
+Read the full agreement at [.github/CLA.md](CLA.md). It is short (4 clauses) and written in plain English.
+
+---
+
 ## CI Checks
 
 Every pull request runs the following automated checks. Your PR must pass all of them before it can be merged.
 
 | Check | What it validates | How to pass |
 |---|---|---|
+| **CLA** | First-time contributors have signed the CLA | Post the sign comment when the bot asks |
 | **DCO** | Every commit has `Signed-off-by` | Use `git commit -s` on every commit |
 | **CI / test** | `node tests/run-all.js` on Linux, macOS, Windows with Node 20 and 22, using npm, yarn, and bun | Run `node tests/run-all.js` locally before opening a PR |
 | **CI / lint** | ESLint on `scripts/` and `tests/`; markdownlint on all `.md` files in `agents/`, `skills/`, `commands/`, `rules/` | Run `npx markdownlint "agents/**/*.md"` if you added or edited Markdown files |
@@ -456,6 +473,7 @@ What architectural gap this fills or what capability this adds to EGC.
 How you ensured this maintains Runtime Integrity and Cross-Platform stability.
 
 ## Checklist
+- [ ] CLA signed (first contribution only - reply to the bot comment)
 - [ ] All commits are signed off with `git commit -s` (required by DCO check)
 - [ ] `node tests/run-all.js` passes locally with zero failures
 - [ ] `npm audit --audit-level=high` shows no high or critical vulnerabilities

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,40 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/Fmarzochi/EGC/blob/main/.github/CLA.md
+          branch: main
+          allowlist: Fmarzochi,dependabot[bot],github-actions[bot],renovate[bot],coderabbitai[bot],sonarqubecloud[bot],cubic-dev-ai[bot]
+          create-file-commit-message: "chore(cla): initialize signatures file"
+          signed-commit-message: "chore(cla): add @$contributorName signature"
+          custom-notsigned-prcomment: |
+            Thank you for your contribution to EGC!
+
+            Please sign our Contributor License Agreement to get this PR merged.
+
+            **[Sign the CLA](https://github.com/Fmarzochi/EGC/blob/main/.github/CLA.md)** - read it, then post the comment below:
+
+            > I have read the CLA Document and I hereby sign the CLA.
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA."
+          custom-allsigned-prcomment: "All contributors have signed the CLA. Thank you!"
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
## Summary

Adds a lightweight Contributor License Agreement using `contributor-assistant/github-action`.

**How it works:**
- When someone opens their first PR, the bot posts a comment with instructions
- The contributor posts: "I have read the CLA Document and I hereby sign the CLA."
- Signature is stored in `signatures/version1/cla.json` in this repo
- Never asked again on future PRs

**What it is NOT:**
- No PDF, no email, no external service
- No OAuth redirect outside GitHub
- No manual process for maintainers

**Allowlist (skip signing):** Fmarzochi, dependabot, github-actions, renovate, coderabbitai, sonarqubecloud, cubic-dev-ai

**CLA document:** `.github/CLA.md` - short, plain English, 4 clauses

**Secret added:** `CLA_ASSISTANT_TOKEN` (repo write access to commit signatures)

## Test plan

- [ ] Open a test PR from a fork account
- [ ] Confirm bot comments asking for signature
- [ ] Post the sign comment
- [ ] Confirm check turns green and signature appears in `signatures/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a lightweight CLA flow using `contributor-assistant/github-action`. First‑time contributors sign by commenting on their PR; signatures are committed to `signatures/version1/cla.json` and not requested again, and CONTRIBUTING docs now cover the flow and CI check.

- **New Features**
  - Added `.github/CLA.md` (plain‑English, 4 clauses).
  - Added `.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.6.1` to gate PRs.
  - Updated `.github/CONTRIBUTING.md` with signing steps, CI table entry, and a checklist item.
  - Allowlisted maintainers and common bots to skip.

- **Migration**
  - Set repo secret `CLA_ASSISTANT_TOKEN` with write access (used to commit signatures).

<sup>Written for commit 9e55d21f45d3db330cda743dc9180c251db75f4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Contributor License Agreement (CLA) for project contributions
  * Implemented automated CLA verification through GitHub Actions workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->