### PR TITLE
fix(cla): scope permissions to job level and pin action SHA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,17 +6,17 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
   cla:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
-      - uses: contributor-assistant/github-action@v2.6.1
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
 
             Please sign our Contributor License Agreement to get this PR merged.
 
-            **[Sign the CLA](https://github.com/Fmarzochi/EGC/blob/main/.github/CLA.md)** - read it, then post the comment below:
+            Read [.github/CLA.md](https://github.com/Fmarzochi/EGC/blob/main/.github/CLA.md), then post the comment below:
 
             > I have read the CLA Document and I hereby sign the CLA.
           custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA."


### PR DESCRIPTION
## Summary

Fixes 4 Scorecard code-scanning alerts introduced by PR #371 (CLA workflow).

- **#250 #251 #252** Token-Permissions (High): permissions were set at workflow level instead of job level. Moved to job-level and removed `actions: write` which is not required by contributor-assistant.
- **#253** Pinned-Dependencies (Medium): `contributor-assistant/github-action@v2.6.1` replaced with full SHA `ca4a40a7d1004f18d9960b404b97e5f30a505a08`.

Alerts #244 and #245 (crowdin-sync, update-readme-languages) are pre-existing and already correctly scoped — will be dismissed separately as acceptable risk.

## Test plan

- [ ] CI green
- [ ] Scorecard alerts #250 #251 #252 #253 auto-close after this merges to main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope CLA workflow permissions to the job level and pin the `contributor-assistant/github-action` to a commit SHA to tighten CI security. Fixes Scorecard Token-Permissions and Pinned-Dependencies alerts.

- **Bug Fixes**
  - Move permissions from workflow to `cla` job; keep only `contents`, `pull-requests`, `statuses`; remove `actions: write` (resolves Scorecard #250 #251 #252).
  - Pin `contributor-assistant/github-action` v2.6.1 to a specific commit SHA (resolves Scorecard #253).

<sup>Written for commit 86900882d1c0c0d0a49ba0345dd019c863b99910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security by restricting permission scope and pinning action to a specific version
  * Updated CLA verification message to provide clearer instructions for contributors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->