### PR TITLE
fix(ci): enable GitLab pipeline on push events

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,3 @@
-workflow:
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-      when: always
-    - when: never
-
 stages:
   - test
 


### PR DESCRIPTION
## Summary

- Removes the restrictive `workflow:rules` block that blocked all pipelines except those triggered via the GitLab web UI
- The rule `when: never` as fallback caused every GitHub mirror push to create a pipeline with 0 jobs, which GitLab reported as a failed pipeline
- With this fix, the CI jobs (lint, test) run normally on every push to main

## Root Cause

```yaml
workflow:
  rules:
    - if: '$CI_PIPELINE_SOURCE == "web"'
      when: always
    - when: never   # blocked all mirror/push pipelines
```

## Test Plan

- [ ] Push to main triggers a GitLab pipeline with actual jobs
- [ ] lint and test jobs run on Node 20 and 22
- [ ] No more "Pipeline has failed with 0 failed jobs" emails

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable GitLab pipelines on push by removing the restrictive `workflow:rules`. This fixes "failed pipeline with 0 jobs" on mirrored pushes; lint and test now run on every push to `main`.

<sup>Written for commit b99c24ac518e98ebfd0cfc1f195e003440e30a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

