### PR TITLE
fix(cla): store signatures on unprotected cla-signatures branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/Fmarzochi/EGC/blob/main/.github/CLA.md
-          branch: main
+          branch: cla-signatures
           allowlist: Fmarzochi,dependabot[bot],github-actions[bot],renovate[bot],coderabbitai[bot],sonarqubecloud[bot],cubic-dev-ai[bot]
           create-file-commit-message: "chore(cla): initialize signatures file"
           signed-commit-message: "chore(cla): add @$contributorName signature"


### PR DESCRIPTION
## Summary

- Changes the CLA signatures storage branch from `main` to `cla-signatures`
- `main` is protected (requires PR + CodeQL scan) so the contributor-assistant bot cannot commit directly to it
- The `cla-signatures` branch was created and is unprotected, allowing the bot to write `signatures/version1/cla.json` directly

## Root Cause

The CLA workflow was failing with:
```
Error occurred when creating the signed contributors file: Repository rule violations found
Changes must be made through a pull request.
Make sure the branch where signatures are stored is NOT protected.
```

## Test Plan

- [ ] First PR from a new contributor triggers bot comment
- [ ] Contributor replies with the sign comment
- [ ] Bot commits signature to `cla-signatures` branch without error
- [ ] CLA check passes on the PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update .github/workflows/cla.yml to store CLA signatures on the unprotected cla-signatures branch instead of main. This avoids repository rule violations and restores the CLA check for new contributors.

<sup>Written for commit 780bb6ee09c1e6fb329a91917d850d2500e7a85f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

