### PR TITLE
fix(state): prevent local project memory from leaking into git commits

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/Fmarzochi/EGC/blob/main/.github/CLA.md
-          branch: main
+          branch: cla-signatures
           allowlist: Fmarzochi,dependabot[bot],github-actions[bot],renovate[bot],coderabbitai[bot],sonarqubecloud[bot],cubic-dev-ai[bot]
           create-file-commit-message: "chore(cla): initialize signatures file"
           signed-commit-message: "chore(cla): add @$contributorName signature"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,4 @@ The EGC runtime routes tasks to the appropriate agent using the execution orches
 - `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`
 
 Run `sh install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -55,3 +55,4 @@ Both servers must be registered in your MCP config (`.mcp.json`):
 - `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`
 
 Run `sh install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.
+

--- a/install.sh
+++ b/install.sh
@@ -372,6 +372,23 @@ if [ -n "$obsidian_block" ]; then
 fi
 set -e
 
+# Install git pre-commit hook (strips egc:state blocks before commits)
+if [ -d "$ROOT_DIR/.git" ] && [ "$DRY_RUN" = false ]; then
+  GIT_HOOK="$ROOT_DIR/.git/hooks/pre-commit"
+  STRIP_SCRIPT="$ROOT_DIR/scripts/hooks/git-pre-commit.sh"
+  if [ ! -f "$GIT_HOOK" ]; then
+    printf '#!/usr/bin/env bash\nROOT="$(git rev-parse --show-toplevel)"\nbash "$ROOT/scripts/hooks/git-pre-commit.sh"\n' > "$GIT_HOOK"
+    chmod +x "$GIT_HOOK"
+    echo "  ✓ git pre-commit hook installed"
+  elif ! grep -q "git-pre-commit.sh" "$GIT_HOOK" 2>/dev/null; then
+    printf '\nROOT="$(git rev-parse --show-toplevel)"\nbash "$ROOT/scripts/hooks/git-pre-commit.sh"\n' >> "$GIT_HOOK"
+    chmod +x "$GIT_HOOK"
+    echo "  ✓ git pre-commit hook updated"
+  else
+    echo "  ✓ git pre-commit hook already installed"
+  fi
+fi
+
 echo ""
 echo "Installation complete."
 echo "Run 'egc doctor' to verify."

--- a/scripts/hooks/git-pre-commit.sh
+++ b/scripts/hooks/git-pre-commit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+    MODE=$(git ls-files --stage "$FILE" | awk '{print $1}')
+    git update-index --cacheinfo "${MODE},${CLEAN_HASH},${FILE}"
+    echo "[egc] stripped local state block from $FILE"
+  fi
+done <<< "$STAGED"
+
+exit 0

--- a/scripts/hooks/git-pre-commit.sh
+++ b/scripts/hooks/git-pre-commit.sh
@@ -1,4 +1,31 @@
 #!/usr/bin/env bash
+# Strips egc:state blocks from staged markdown files before commit.
+# The working tree is left untouched — IDEs continue reading local project memory normally.
+
+set -euo pipefail
+
+if [[ "${EGC_SKIP_GIT_HOOKS:-0}" == "1" || "${EGC_SKIP_PRECOMMIT:-0}" == "1" ]]; then
+  exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null) || true
+[ -z "$STAGED" ] && exit 0
+
+EGC_START='<!-- egc:start -->'
+EGC_END='<!-- egc:end -->'
+
+while IFS= read -r FILE; do
+  [ -z "$FILE" ] && continue
+  case "$FILE" in
+    *.md|*.mdx|*.mdc) ;;
+    *) continue ;;
+  esac
+  if git show ":$FILE" 2>/dev/null | grep -qF "$EGC_START"; then
+    CLEAN_HASH=$(git show ":$FILE" | sed "/^${EGC_START}$/,/^${EGC_END}$/d" | git hash-object -w --stdin)
     MODE=$(git ls-files --stage "$FILE" | awk '{print $1}')
     git update-index --cacheinfo "${MODE},${CLEAN_HASH},${FILE}"
     echo "[egc] stripped local state block from $FILE"


### PR DESCRIPTION
## Bug

When `egc-memory` calls `update_state`, the `propagate-state` mechanism injects an `<!-- egc:start -->...<!-- egc:end -->` block into `AGENTS.md` and `GEMINI.md` so that all IDEs on the same machine can read the current project context without calling `get_state`.

These files are version-controlled. If the maintainer ran `git commit` with these local state blocks present, personal workflow data (next-session notes, in-flight PR names, strategy decisions) would be committed to the public repository and become visible to anyone who clones or forks EGC.

## Fix

**`scripts/hooks/git-pre-commit.sh`** — new pre-commit hook that:
- Scans staged `*.md` / `*.mdx` / `*.mdc` files for `<!-- egc:start -->` blocks
- Strips those blocks from the **git index** using `git hash-object` + `git update-index`
- Leaves the **working tree untouched** — IDEs continue reading local context normally
- Respects `EGC_SKIP_GIT_HOOKS=1` and `EGC_SKIP_PRECOMMIT=1` escape hatches

**`install.sh`** — registers the hook automatically into `.git/hooks/pre-commit` when run inside a git repository. npm users are unaffected (`AGENTS.md` and `GEMINI.md` are not in the published package `files` list).

## Test

```
git add AGENTS.md   # file has <!-- egc:start --> block on disk
git commit          # hook runs, strips block from index
git show HEAD:AGENTS.md | grep egc:start  # → no output (clean)
grep egc:start AGENTS.md                  # → still present on disk (IDEs happy)
```

## Impact

- Zero impact on cross-IDE memory sharing (blocks remain on disk)
- Zero impact on npm users (hook only installs in git repos)
- Contributors who clone and run `install.sh` get the protection automatically

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents accidental commits of local EGC project memory by stripping `<!-- egc:start -->...<!-- egc:end -->` blocks from staged Markdown while leaving files on disk unchanged. Also updates the CLA workflow to store signatures on the `cla-signatures` branch.

- **Bug Fixes**
  - Added `scripts/hooks/git-pre-commit.sh` to remove EGC state blocks from staged `.md` / `.mdx` / `.mdc`.
  - Working tree is untouched; IDEs continue to read local context.
  - Honors `EGC_SKIP_GIT_HOOKS=1` and `EGC_SKIP_PRECOMMIT=1`.
  - `install.sh` auto-installs or updates `.git/hooks/pre-commit`.
  - CLA workflow now writes signatures to `cla-signatures`.

<sup>Written for commit 48e5236d8451c58e133d5bcdce8a3f3869f95078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic pre-commit hook installation that processes Markdown files during commits.

* **Chores**
  * Updated CLA workflow to use dedicated branch for storing signatures.
  * Minor documentation formatting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->