### PR TITLE
fix(fuzzing): replace invalid sanitizer 'none' with 'address' in ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -5,4 +5,4 @@ main_repo: https://github.com/Fmarzochi/EGC
 fuzzing_engines:
   - libfuzzer
 sanitizers:
-  - none
+  - address

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -22,7 +22,7 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
         with:
           language: javascript
-          sanitizer: none
+          sanitizer: address
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Fuzzers
@@ -32,7 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 1800
           mode: batch
-          sanitizer: none
+          sanitizer: address
           output-sarif: true
 
       - name: Upload SARIF

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -22,7 +22,7 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
         with:
           language: javascript
-          sanitizer: none
+          sanitizer: address
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Fuzzers
@@ -32,7 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 600
           mode: prune
-          sanitizer: none
+          sanitizer: address
           output-sarif: true
 
       - name: Upload SARIF

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -20,7 +20,7 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
         with:
           language: javascript
-          sanitizer: none
+          sanitizer: address
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Fuzzers
@@ -30,7 +30,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 300
           mode: code-change
-          sanitizer: none
+          sanitizer: address
           output-sarif: true
 
       - name: Upload SARIF


### PR DESCRIPTION
## Problem

All three ClusterFuzzLite workflows (`cflite_batch.yml`, `cflite_cron.yml`, `cflite_pr.yml`) and `.clusterfuzzlite/project.yaml` used `sanitizer: none`. ClusterFuzzLite rejects this value outright:

```
Invalid SANITIZER: none. Must be one of: ['address', 'memory', 'undefined', 'coverage'].
config_utils.ConfigError: Invalid Configuration.
```

The fuzzer never ran. As a secondary consequence, the `upload-sarif` step also failed because `cifuzz-sarif/results.sarif` was never created.

## Fix

Replace `none` with `address` in all four files. `address` (AddressSanitizer) is the standard sanitizer for ClusterFuzzLite JavaScript projects and is explicitly listed as a valid option.

## Files changed

- `.clusterfuzzlite/project.yaml`
- `.github/workflows/cflite_batch.yml`
- `.github/workflows/cflite_cron.yml`
- `.github/workflows/cflite_pr.yml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced invalid sanitizer value 'none' with 'address' in ClusterFuzzLite config and all three workflows so fuzzers run and generate SARIF. This fixes immediate job failures and unblocks batch, cron, and PR runs.

<sup>Written for commit ae53f3b43bc70274e4c71e505351610ec438eff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration fuzzing workflows to use AddressSanitizer for improved memory safety detection during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->