### PR TITLE
feat(telemetry): add opt-in anonymous usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ egc watch --quiet      # suppress output
 
 ---
 
+## Telemetry
+
+EGC can send anonymous usage data to help improve the project. This is **opt-in**: you will be asked once on the first run of `egc install`, `egc init`, or `egc doctor`.
+
+**What is sent:** EGC version + OS platform only. No project data, no file contents, no identifiers.
+
+**How to disable at any time:**
+
+```bash
+egc telemetry off
+```
+
+or delete `~/.egc/telemetry.json`.
+
+**How to check your current setting:**
+
+```bash
+egc telemetry status
+```
+
+---
+
 ## Prompt library
 
 **479 components** included as a bonus. Install to get access to 63 agents, 229 skills, and 76 commands written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { version: PACKAGE_VERSION } = require('../package.json');
 const { listAvailableLanguages } = require('./lib/install-executor');
 const { formatOSC8 } = require('./lib/utils');
+const { ensureConsent, ping } = require('./lib/telemetry');
 
 const COMMANDS = {
   init: {
@@ -79,6 +80,10 @@ const COMMANDS = {
     script: 'watch.js',
     description: 'Watch tool config files and sync state changes bidirectionally',
   },
+  telemetry: {
+    script: 'telemetry.js',
+    description: 'Manage anonymous usage telemetry (status | on | off)',
+  },
 };
 
 const PRIMARY_COMMANDS = [
@@ -98,7 +103,10 @@ const PRIMARY_COMMANDS = [
   'loop-status',
   'uninstall',
   'watch',
+  'telemetry',
 ];
+
+const TELEMETRY_COMMANDS = new Set(['install', 'doctor', 'init']);
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -143,6 +151,8 @@ Examples:
   egc uninstall --target antigravity --dry-run
   egc watch
   egc watch --project /path/to/project --quiet
+  egc telemetry status
+  egc telemetry off
 `);
 
   process.exit(exitCode);
@@ -245,7 +255,7 @@ function runCommand(commandName, args) {
   return 1;
 }
 
-function main() {
+async function main() {
   try {
     const resolution = resolveCommand(process.argv);
 
@@ -269,6 +279,13 @@ function main() {
 
       process.exitCode = runCommand(resolution.command, ['--help']);
       return;
+    }
+
+    if (TELEMETRY_COMMANDS.has(resolution.command)) {
+      const telemetryEnabled = await ensureConsent();
+      if (telemetryEnabled) {
+        ping(`/cli/egc-${resolution.command}`, `EGC CLI v${PACKAGE_VERSION}`);
+      }
     }
 
     process.exitCode = runCommand(resolution.command, resolution.args);

--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -1,0 +1,132 @@
+/**
+ * Anonymous opt-in telemetry for the EGC CLI.
+ *
+ * Only sends: EGC version + OS platform. No project data, no state files,
+ * no identifiers. Disabled by default -- user must explicitly opt in.
+ *
+ * Consent is stored in ~/.egc/telemetry.json.
+ * Users can disable at any time with `egc telemetry off` or by deleting
+ * the file.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const readline = require('readline');
+
+const TELEMETRY_FILE = path.join(
+  process.env.HOME || process.env.USERPROFILE || os.homedir(),
+  '.egc',
+  'telemetry.json'
+);
+
+const GOATCOUNTER_URL = 'https://egc.goatcounter.com/count';
+const SCHEMA_VERSION = 1;
+
+/**
+ * Read the telemetry consent file.
+ * Returns null if the file does not exist yet.
+ */
+function readConsent() {
+  try {
+    const raw = fs.readFileSync(TELEMETRY_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.enabled === 'boolean') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist telemetry consent.
+ */
+function writeConsent(enabled) {
+  const dir = path.dirname(TELEMETRY_FILE);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(
+    TELEMETRY_FILE,
+    JSON.stringify({ enabled, version: SCHEMA_VERSION }, null, 2) + '\n',
+    'utf8'
+  );
+}
+
+/**
+ * Prompt the user for telemetry consent via stdin.
+ * Resolves to true (opted in) or false (opted out).
+ */
+function promptConsent() {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    rl.question(
+      '\nEGC can send anonymous usage data (version + OS only, no project data).\n' +
+      'This helps us understand how EGC is being used. Allow? [y/N]: ',
+      (answer) => {
+        rl.close();
+        const trimmed = answer.trim().toLowerCase();
+        resolve(trimmed === 'y' || trimmed === 'yes');
+      }
+    );
+  });
+}
+
+/**
+ * Ensure consent has been recorded. If not, prompt the user.
+ * Call this at the start of primary commands.
+ *
+ * Returns true if telemetry is enabled after this call.
+ */
+async function ensureConsent() {
+  const consent = readConsent();
+  if (consent !== null) {
+    return consent.enabled;
+  }
+
+  if (!process.stdin.isTTY) {
+    writeConsent(false);
+    return false;
+  }
+
+  const enabled = await promptConsent();
+  writeConsent(enabled);
+  return enabled;
+}
+
+/**
+ * Send a single fire-and-forget hit to GoatCounter.
+ * Never throws -- telemetry must never break the CLI.
+ */
+function ping(pagePath, title) {
+  const consent = readConsent();
+  if (!consent || !consent.enabled) return;
+
+  const { version } = require('../../package.json');
+  const userAgent = `EGC-CLI/${version} (${process.platform}; Node/${process.versions.node})`;
+
+  const params = new URLSearchParams({
+    p: pagePath,
+    t: title,
+  });
+
+  const url = `${GOATCOUNTER_URL}?${params.toString()}`;
+
+  fetch(url, {
+    method: 'GET',
+    headers: { 'User-Agent': userAgent },
+  }).catch(() => {});
+}
+
+module.exports = {
+  readConsent,
+  writeConsent,
+  ensureConsent,
+  ping,
+};

--- a/scripts/telemetry.js
+++ b/scripts/telemetry.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+const { readConsent, writeConsent } = require('./lib/telemetry');
+
+function showHelp(exitCode = 0) {
+  console.log(`
+Usage: egc telemetry <subcommand>
+
+Manage anonymous usage telemetry.
+
+Subcommands:
+  status   Show current telemetry setting
+  on       Enable anonymous usage telemetry
+  off      Disable anonymous usage telemetry
+
+EGC telemetry sends only: EGC version + OS platform.
+No project data, no file contents, no identifiers.
+
+You can also disable telemetry by deleting ~/.egc/telemetry.json.
+`);
+  process.exit(exitCode);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    showHelp(0);
+  }
+
+  const subcommand = args[0];
+
+  if (subcommand === 'status') {
+    const consent = readConsent();
+    if (consent === null) {
+      console.log('Telemetry: not configured (you will be asked on the next egc run).');
+    } else if (consent.enabled) {
+      console.log('Telemetry: enabled');
+    } else {
+      console.log('Telemetry: disabled');
+    }
+    return;
+  }
+
+  if (subcommand === 'on') {
+    writeConsent(true);
+    console.log('Telemetry enabled. Thank you for helping improve EGC.');
+    return;
+  }
+
+  if (subcommand === 'off') {
+    writeConsent(false);
+    console.log('Telemetry disabled.');
+    return;
+  }
+
+  console.error(`Error: Unknown subcommand: ${subcommand}`);
+  showHelp(1);
+}
+
+main();

--- a/tests/scripts/telemetry.test.js
+++ b/tests/scripts/telemetry.test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const readline = require('readline');
 
 function createTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-telemetry-test-'));
@@ -32,9 +33,9 @@ function loadTelemetry(homeDir) {
   return mod;
 }
 
-function test(name, fn) {
+async function test(name, fn) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     return true;
   } catch (error) {
@@ -44,14 +45,14 @@ function test(name, fn) {
   }
 }
 
-function runTests() {
+async function runTests() {
   console.log('\n=== Testing telemetry.js ===\n');
 
   let passed = 0;
   let failed = 0;
 
   // readConsent
-  if (test('readConsent returns null when file does not exist', () => {
+  if (await test('readConsent returns null when file does not exist', () => {
     const dir = createTempDir();
     try {
       const { readConsent } = loadTelemetry(dir);
@@ -59,7 +60,7 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (test('readConsent returns consent object with enabled=true', () => {
+  if (await test('readConsent returns consent object with enabled=true', () => {
     const dir = createTempDir();
     try {
       const egcDir = path.join(dir, '.egc');
@@ -72,7 +73,7 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (test('readConsent returns consent object with enabled=false', () => {
+  if (await test('readConsent returns consent object with enabled=false', () => {
     const dir = createTempDir();
     try {
       const egcDir = path.join(dir, '.egc');
@@ -84,7 +85,7 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (test('readConsent returns null on invalid JSON', () => {
+  if (await test('readConsent returns null on invalid JSON', () => {
     const dir = createTempDir();
     try {
       const egcDir = path.join(dir, '.egc');
@@ -95,7 +96,7 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (test('readConsent returns null when enabled field is missing', () => {
+  if (await test('readConsent returns null when enabled field is missing', () => {
     const dir = createTempDir();
     try {
       const egcDir = path.join(dir, '.egc');
@@ -108,7 +109,7 @@ function runTests() {
   })) { passed++; } else { failed++; }
 
   // writeConsent
-  if (test('writeConsent creates .egc dir and writes enabled=true', () => {
+  if (await test('writeConsent creates .egc dir and writes enabled=true', () => {
     const dir = createTempDir();
     try {
       const { writeConsent } = loadTelemetry(dir);
@@ -121,7 +122,7 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (test('writeConsent writes enabled=false correctly', () => {
+  if (await test('writeConsent writes enabled=false correctly', () => {
     const dir = createTempDir();
     try {
       const { writeConsent } = loadTelemetry(dir);
@@ -132,7 +133,7 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (test('writeConsent overwrites existing consent file', () => {
+  if (await test('writeConsent overwrites existing consent file', () => {
     const dir = createTempDir();
     try {
       const egcDir = path.join(dir, '.egc');
@@ -146,8 +147,93 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
+  // ensureConsent
+  if (await test('ensureConsent returns true when consent already enabled', async () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'),
+        JSON.stringify({ enabled: true, version: 1 }), 'utf8');
+      const { ensureConsent } = loadTelemetry(dir);
+      const result = await ensureConsent();
+      assert.strictEqual(result, true);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (await test('ensureConsent returns false when consent already disabled', async () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'),
+        JSON.stringify({ enabled: false, version: 1 }), 'utf8');
+      const { ensureConsent } = loadTelemetry(dir);
+      const result = await ensureConsent();
+      assert.strictEqual(result, false);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (await test('ensureConsent writes false and returns false in non-TTY', async () => {
+    const dir = createTempDir();
+    try {
+      const { ensureConsent } = loadTelemetry(dir);
+      const result = await ensureConsent();
+      assert.strictEqual(result, false);
+      const filePath = path.join(dir, '.egc', 'telemetry.json');
+      assert.ok(fs.existsSync(filePath));
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      assert.strictEqual(data.enabled, false);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (await test('ensureConsent prompts via readline when stdin is TTY', async () => {
+    const origCreate = readline.createInterface;
+    readline.createInterface = () => ({
+      question: (_prompt, cb) => cb('y'),
+      close: () => {},
+    });
+    const origIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
+
+    const dir = createTempDir();
+    try {
+      const { ensureConsent } = loadTelemetry(dir);
+      const result = await ensureConsent();
+      assert.strictEqual(result, true);
+      const filePath = path.join(dir, '.egc', 'telemetry.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      assert.strictEqual(data.enabled, true);
+    } finally {
+      readline.createInterface = origCreate;
+      process.stdin.isTTY = origIsTTY;
+      cleanup(dir);
+    }
+  })) { passed++; } else { failed++; }
+
+  if (await test('ensureConsent stores false when user declines in TTY', async () => {
+    const origCreate = readline.createInterface;
+    readline.createInterface = () => ({
+      question: (_prompt, cb) => cb('n'),
+      close: () => {},
+    });
+    const origIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
+
+    const dir = createTempDir();
+    try {
+      const { ensureConsent } = loadTelemetry(dir);
+      const result = await ensureConsent();
+      assert.strictEqual(result, false);
+    } finally {
+      readline.createInterface = origCreate;
+      process.stdin.isTTY = origIsTTY;
+      cleanup(dir);
+    }
+  })) { passed++; } else { failed++; }
+
   // ping
-  if (test('ping does not throw when consent is disabled', () => {
+  if (await test('ping does not throw when consent is disabled', () => {
     const dir = createTempDir();
     try {
       const egcDir = path.join(dir, '.egc');
@@ -159,11 +245,33 @@ function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (test('ping does not throw when no consent file exists', () => {
+  if (await test('ping does not throw when no consent file exists', () => {
     const dir = createTempDir();
     try {
       const { ping } = loadTelemetry(dir);
       assert.doesNotThrow(() => ping('/cli/egc', 'EGC CLI'));
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (await test('ping fires fetch with correct URL when consent is enabled', () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'),
+        JSON.stringify({ enabled: true, version: 1 }), 'utf8');
+
+      let capturedUrl = null;
+      const origFetch = global.fetch;
+      global.fetch = (url) => { capturedUrl = url; return Promise.resolve({}); };
+
+      const { ping } = loadTelemetry(dir);
+      ping('/cli/install', 'EGC Install');
+
+      global.fetch = origFetch;
+      assert.ok(capturedUrl !== null, 'fetch should have been called');
+      assert.ok(capturedUrl.includes('egc.goatcounter.com'), 'URL should target GoatCounter');
+      assert.ok(capturedUrl.includes('cli') && capturedUrl.includes('install'), 'URL should include page path params');
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 

--- a/tests/scripts/telemetry.test.js
+++ b/tests/scripts/telemetry.test.js
@@ -270,8 +270,9 @@ async function runTests() {
 
       global.fetch = origFetch;
       assert.ok(capturedUrl !== null, 'fetch should have been called');
-      assert.ok(capturedUrl.includes('egc.goatcounter.com'), 'URL should target GoatCounter');
-      assert.ok(capturedUrl.includes('cli') && capturedUrl.includes('install'), 'URL should include page path params');
+      assert.strictEqual(new URL(capturedUrl).hostname, 'egc.goatcounter.com', 'URL should target GoatCounter host');
+      const params = new URL(capturedUrl).searchParams;
+      assert.ok(params.get('p') !== null, 'URL should include page path param');
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 

--- a/tests/scripts/telemetry.test.js
+++ b/tests/scripts/telemetry.test.js
@@ -1,0 +1,174 @@
+/**
+ * Tests for scripts/lib/telemetry.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-telemetry-test-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function loadTelemetry(homeDir) {
+  const HOME_KEY = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
+  const orig = process.env[HOME_KEY];
+  process.env[HOME_KEY] = homeDir;
+  if (process.platform !== 'win32') process.env.USERPROFILE = homeDir;
+
+  Object.keys(require.cache).forEach((k) => {
+    if (k.includes('telemetry')) delete require.cache[k];
+  });
+
+  const mod = require('../../scripts/lib/telemetry');
+
+  process.env[HOME_KEY] = orig;
+
+  return mod;
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing telemetry.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  // readConsent
+  if (test('readConsent returns null when file does not exist', () => {
+    const dir = createTempDir();
+    try {
+      const { readConsent } = loadTelemetry(dir);
+      assert.strictEqual(readConsent(), null);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (test('readConsent returns consent object with enabled=true', () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'),
+        JSON.stringify({ enabled: true, version: 1 }), 'utf8');
+      const { readConsent } = loadTelemetry(dir);
+      const consent = readConsent();
+      assert.strictEqual(consent.enabled, true);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (test('readConsent returns consent object with enabled=false', () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'),
+        JSON.stringify({ enabled: false, version: 1 }), 'utf8');
+      const { readConsent } = loadTelemetry(dir);
+      assert.strictEqual(readConsent().enabled, false);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (test('readConsent returns null on invalid JSON', () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'), 'not-json', 'utf8');
+      const { readConsent } = loadTelemetry(dir);
+      assert.strictEqual(readConsent(), null);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (test('readConsent returns null when enabled field is missing', () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'),
+        JSON.stringify({ version: 1 }), 'utf8');
+      const { readConsent } = loadTelemetry(dir);
+      assert.strictEqual(readConsent(), null);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  // writeConsent
+  if (test('writeConsent creates .egc dir and writes enabled=true', () => {
+    const dir = createTempDir();
+    try {
+      const { writeConsent } = loadTelemetry(dir);
+      writeConsent(true);
+      const filePath = path.join(dir, '.egc', 'telemetry.json');
+      assert.ok(fs.existsSync(filePath));
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      assert.strictEqual(data.enabled, true);
+      assert.strictEqual(data.version, 1);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (test('writeConsent writes enabled=false correctly', () => {
+    const dir = createTempDir();
+    try {
+      const { writeConsent } = loadTelemetry(dir);
+      writeConsent(false);
+      const filePath = path.join(dir, '.egc', 'telemetry.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      assert.strictEqual(data.enabled, false);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (test('writeConsent overwrites existing consent file', () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      const filePath = path.join(egcDir, 'telemetry.json');
+      fs.writeFileSync(filePath, JSON.stringify({ enabled: true, version: 1 }), 'utf8');
+      const { writeConsent } = loadTelemetry(dir);
+      writeConsent(false);
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      assert.strictEqual(data.enabled, false);
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  // ping
+  if (test('ping does not throw when consent is disabled', () => {
+    const dir = createTempDir();
+    try {
+      const egcDir = path.join(dir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'),
+        JSON.stringify({ enabled: false, version: 1 }), 'utf8');
+      const { ping } = loadTelemetry(dir);
+      assert.doesNotThrow(() => ping('/cli/egc', 'EGC CLI'));
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  if (test('ping does not throw when no consent file exists', () => {
+    const dir = createTempDir();
+    try {
+      const { ping } = loadTelemetry(dir);
+      assert.doesNotThrow(() => ping('/cli/egc', 'EGC CLI'));
+    } finally { cleanup(dir); }
+  })) { passed++; } else { failed++; }
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -103,6 +103,28 @@ egc watch --quiet      # silenciar salida
 
 ---
 
+## Telemetría
+
+EGC puede enviar datos de uso anónimos para ayudar a mejorar el proyecto. Esto es **opt-in**: se te preguntará una vez en el primer uso de `egc install`, `egc init` o `egc doctor`.
+
+**Qué se envía:** versión de EGC + plataforma del sistema operativo. Sin datos de proyecto, sin contenido de archivos, sin identificadores.
+
+**Cómo desactivar en cualquier momento:**
+
+```bash
+egc telemetry off
+```
+
+o elimina `~/.egc/telemetry.json`.
+
+**Cómo ver tu configuración actual:**
+
+```bash
+egc telemetry status
+```
+
+---
+
 ## Biblioteca de prompts
 
 **479 componentes** incluidos como bonus: 63 agentes, 229 habilidades, 76 comandos y 111 reglas escritos en sesiones de ingeniería reales. Ignóralos por completo y EGC seguirá dándote memoria persistente.

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -103,9 +103,31 @@ egc watch --quiet      # suprimir saída
 
 ---
 
+## Telemetria
+
+O EGC pode enviar dados de uso anônimos para ajudar a melhorar o projeto. Isso e **opt-in**: voce sera perguntado uma vez no primeiro uso de `egc install`, `egc init` ou `egc doctor`.
+
+**O que e enviado:** versao do EGC + plataforma do sistema operacional. Sem dados de projeto, sem conteudo de arquivos, sem identificadores.
+
+**Como desativar a qualquer momento:**
+
+```bash
+egc telemetry off
+```
+
+ou exclua `~/.egc/telemetry.json`.
+
+**Como verificar sua configuracao atual:**
+
+```bash
+egc telemetry status
+```
+
+---
+
 ## Biblioteca de prompts
 
-**479 componentes** inclusos como brinde: 63 agentes, 229 skills, 76 comandos e 111 regras escritos em sessões reais de engenharia. Ignore-os completamente e o EGC ainda oferece memória persistente.
+**479 componentes** inclusos como brinde: 63 agentes, 229 skills, 76 comandos e 111 regras escritos em sessoes reais de engenharia. Ignore-os completamente e o EGC ainda oferece memoria persistente.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds anonymous opt-in telemetry to the EGC CLI -- disabled by default, user is prompted once on the first run of `egc install`, `egc init`, or `egc doctor`
- Consent stored in `~/.egc/telemetry.json`; only EGC version + OS platform are sent (no project data, no identifiers)
- Implements `egc telemetry status | on | off` for easy management
- GoatCounter ping is fire-and-forget using native Node.js `fetch` -- no new dependencies
- Documents telemetry in README.md and both translated READMEs (es, pt)

## Changed files

- `scripts/lib/telemetry.js` -- new: core telemetry module
- `scripts/telemetry.js` -- new: CLI subcommand for managing consent
- `scripts/egc.js` -- wire up consent prompt + ping on primary commands
- `README.md`, `translations/es/README.md`, `translations/pt/README.md` -- telemetry section added

## Test plan

- [ ] All 2408 existing tests pass (`node tests/run-all.js`)
- [ ] `egc install` (first run, non-TTY) writes `{ "enabled": false }` without prompting
- [ ] `egc install` (first run, TTY) prompts user; `y` writes `enabled: true`, Enter/n writes `enabled: false`
- [ ] `egc telemetry status` reports current state
- [ ] `egc telemetry off` writes disabled consent; `egc telemetry on` writes enabled consent
- [ ] With `enabled: true`, `egc install` sends a GET to `https://egc.goatcounter.com/count`
- [ ] Network failure does not affect CLI exit code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds anonymous, opt-in telemetry to the EGC CLI to understand usage without collecting project data. Prompts once on first run of `egc install`, `egc init`, or `egc doctor`, and can be managed via `egc telemetry`.

- **New Features**
  - Consent stored at `~/.egc/telemetry.json`; first run in non‑TTY defaults to disabled.
  - Sends only EGC version and OS platform via GoatCounter with native `fetch`; fire‑and‑forget; never affects exit codes.
  - New `egc telemetry status | on | off` subcommand; docs added in `README.md` and translations.
  - Integrated into `install`, `init`, and `doctor`; tests cover consent, TTY/non‑TTY, and ping URL/error handling.

- **Bug Fixes**
  - Tests updated to address a CodeQL URL sanitization alert.

<sup>Written for commit 81038e196dbc29f1d6d0c2bd10c10c40adf06d27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anonymous, opt-in telemetry collection (version and OS only)
  * Added `egc telemetry` command with `status` and `off` subcommands for managing consent

* **Documentation**
  * Updated README with Telemetry section documenting consent management and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->