### PR TITLE
feat: intelligent session start with per-project stack briefing

### DIFF
--- a/agents/a11y-architect.md
+++ b/agents/a11y-architect.md
@@ -3,6 +3,7 @@ name: a11y-architect
 description: Accessibility Architect specializing in WCAG 2.2 compliance for Web and Native platforms. Use PROACTIVELY when designing UI components, establishing design systems, or auditing code for inclusive user experiences.
 model: gemini-2.5-pro
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+stack: ["*"]
 ---
 
 You are a Senior Accessibility Architect. Your goal is to ensure that every digital product is Perceivable, Operable, Understandable, and Robust (POUR) for all users, including those with visual, auditory, motor, or cognitive disabilities.

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -3,6 +3,7 @@ name: architect
 description: REPO-OWNED ARCHITECT for system design, scalability, and technical decision-making. Use PROACTIVELY when planning new features, refactoring large systems, or making architectural decisions.
 tools: ["Read", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 You are a senior software architect specializing in scalable, maintainable system design.

--- a/agents/build-error-resolver.md
+++ b/agents/build-error-resolver.md
@@ -3,6 +3,7 @@ name: build-error-resolver
 description: Build and TypeScript error resolution specialist. Use PROACTIVELY when build fails or type errors occur. Fixes build/type errors only with minimal diffs, no architectural edits. Focuses on getting the build green quickly.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Build Error Resolver

--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -3,6 +3,7 @@ name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 You are a personal chief of staff that manages all communication channels: email, Slack, LINE, Messenger, and calendar: through a unified triage pipeline.

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -3,6 +3,7 @@ name: code-architect
 description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing implementation blueprints with concrete files, interfaces, data flow, and build order.
 model: gemini-2.5-pro
 tools: [Read, Grep, Glob, Bash]
+stack: ["*"]
 ---
 
 # Code Architect Agent

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -3,6 +3,7 @@ name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, and documenting dependencies to inform new development.
 model: gemini-2.5-pro
 tools: [Read, Grep, Glob, Bash]
+stack: ["*"]
 ---
 
 # Code Explorer Agent

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -3,6 +3,7 @@ name: code-reviewer
 description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code. MUST BE USED for all code changes.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 You are a senior code reviewer ensuring high standards of code quality and security.

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -3,6 +3,7 @@ name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving behavior. Focus on recently modified code unless instructed otherwise.
 model: gemini-2.5-pro
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+stack: ["*"]
 ---
 
 # Code Simplifier Agent

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -3,6 +3,7 @@ name: comment-analyzer
 description: Analyze code comments for accuracy, completeness, maintainability, and comment rot risk.
 model: gemini-2.5-pro
 tools: [Read, Grep, Glob, Bash]
+stack: ["*"]
 ---
 
 # Comment Analyzer Agent

--- a/agents/conversation-analyzer.md
+++ b/agents/conversation-analyzer.md
@@ -3,6 +3,7 @@ name: conversation-analyzer
 description: Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Triggered by /hookify without arguments.
 model: gemini-2.5-pro
 tools: [Read, Grep]
+stack: ["*"]
 ---
 
 # Conversation Analyzer Agent

--- a/agents/cpp-build-resolver.md
+++ b/agents/cpp-build-resolver.md
@@ -3,6 +3,7 @@ name: cpp-build-resolver
 description: C++ build, CMake, and compilation error resolution specialist. Fixes build errors, linker issues, and template errors with minimal changes. Use when C++ builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["cpp"]
 ---
 
 # C++ Build Error Resolver

--- a/agents/cpp-reviewer.md
+++ b/agents/cpp-reviewer.md
@@ -3,6 +3,7 @@ name: cpp-reviewer
 description: Expert C++ code reviewer specializing in memory safety, modern C++ idioms, concurrency, and performance. Use for all C++ code changes. MUST BE USED for C++ projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["cpp"]
 ---
 
 You are a senior C++ code reviewer ensuring high standards of modern C++ and best practices.

--- a/agents/csharp-reviewer.md
+++ b/agents/csharp-reviewer.md
@@ -3,6 +3,7 @@ name: csharp-reviewer
 description: Expert C# code reviewer specializing in .NET conventions, async patterns, security, nullable reference types, and performance. Use for all C# code changes. MUST BE USED for C# projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["csharp"]
 ---
 
 You are a senior C# code reviewer ensuring high standards of idiomatic .NET code and best practices.

--- a/agents/dart-build-resolver.md
+++ b/agents/dart-build-resolver.md
@@ -3,6 +3,7 @@ name: dart-build-resolver
 description: Dart/Flutter build, analysis, and dependency error resolution specialist. Fixes `dart analyze` errors, Flutter compilation failures, pub dependency conflicts, and build_runner issues with minimal, surgical changes. Use when Dart/Flutter builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["dart"]
 ---
 
 # Dart/Flutter Build Error Resolver

--- a/agents/database-reviewer.md
+++ b/agents/database-reviewer.md
@@ -3,6 +3,7 @@ name: database-reviewer
 description: PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance. Incorporates Supabase best practices.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Database Reviewer

--- a/agents/django-build-resolver.md
+++ b/agents/django-build-resolver.md
@@ -3,6 +3,7 @@ name: django-build-resolver
 description: Django/Python build, migration, and dependency error resolution specialist. Fixes pip/Poetry errors, migration conflicts, import errors, Django configuration issues, and collectstatic failures with minimal changes. Use when Django setup or startup fails.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: sonnet
+stack: ["python", "django"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/django-reviewer.md
+++ b/agents/django-reviewer.md
@@ -3,6 +3,7 @@ name: django-reviewer
 description: Expert Django code reviewer specializing in ORM correctness, DRF patterns, migration safety, security misconfigurations, and production-grade Django practices. Use for all Django code changes. MUST BE USED for Django projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
+stack: ["python", "django"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -3,6 +3,7 @@ name: doc-updater
 description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.0-flash
+stack: ["*"]
 ---
 
 # Documentation & Codemap Specialist

--- a/agents/docs-lookup.md
+++ b/agents/docs-lookup.md
@@ -3,6 +3,7 @@ name: docs-lookup
 description: When the user asks how to use a library, framework, or API or needs up-to-date code examples, use Context7 MCP to fetch current documentation and return answers with examples. Invoke for docs/API/setup questions.
 tools: ["Read", "Grep", "mcp__context7__resolve-library-id", "mcp__context7__query-docs"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 You are a documentation specialist. You answer questions about libraries, frameworks, and APIs using current documentation fetched via the Context7 MCP (resolve-library-id and query-docs), not training data.

--- a/agents/e2e-runner.md
+++ b/agents/e2e-runner.md
@@ -3,6 +3,7 @@ name: e2e-runner
 description: End-to-end testing specialist using Vercel Agent Browser (preferred) with Playwright fallback. Use PROACTIVELY for generating, maintaining, and running E2E tests. Manages test journeys, quarantines flaky tests, uploads artifacts (screenshots, videos, traces), and ensures critical user flows work.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # E2E Test Runner

--- a/agents/engineering-auditor.md
+++ b/agents/engineering-auditor.md
@@ -3,6 +3,7 @@ name: engineering-auditor
 description: Full-spectrum engineering health auditor. Evaluates Cyclomatic Complexity, Cognitive Complexity, Nesting Depth, Function Length, File Length, Maintainability, Code Smells, Duplicate Code, Technical Debt, Type Safety, Test Coverage, Test Quality, Security Findings, Dependency Risk, Build Health, Lint Health, Documentation Coverage, and Architectural Smells. Produces a ranked issue list, an Engineering Score, and a concrete remediation plan. NEVER modifies files: audit and plan only.
 tools: ["Read", "Bash", "Grep", "Glob"]
 model: sonnet
+stack: ["*"]
 ---
 
 You are the engineering health authority for this project. Your job is to measure, score, and plan: never to modify files.

--- a/agents/fastapi-reviewer.md
+++ b/agents/fastapi-reviewer.md
@@ -3,6 +3,7 @@ name: fastapi-reviewer
 description: Reviews FastAPI applications for async correctness, dependency injection, Pydantic schemas, security, OpenAPI quality, testing, and production readiness.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
+stack: ["python", "fastapi"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/flutter-reviewer.md
+++ b/agents/flutter-reviewer.md
@@ -3,6 +3,7 @@ name: flutter-reviewer
 description: Flutter and Dart code reviewer. Reviews Flutter code for widget best practices, state management patterns, Dart idioms, performance pitfalls, accessibility, and clean architecture violations. Library-agnostic: works with any state management solution and tooling.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["dart"]
 ---
 
 You are a senior Flutter and Dart code reviewer ensuring idiomatic, performant, and maintainable code.

--- a/agents/fsharp-reviewer.md
+++ b/agents/fsharp-reviewer.md
@@ -3,6 +3,7 @@ name: fsharp-reviewer
 description: Expert F# code reviewer specializing in functional idioms, type safety, pattern matching, computation expressions, and performance. Use for all F# code changes. MUST BE USED for F# projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
+stack: ["fsharp"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/gan-evaluator.md
+++ b/agents/gan-evaluator.md
@@ -4,6 +4,7 @@ description: "GAN Harness: Evaluator agent. Tests the live running application v
 tools: ["Read", "Write", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
 color: red
+stack: ["*"]
 ---
 
 You are the **Evaluator** in a GAN-style multi-agent harness .

--- a/agents/gan-generator.md
+++ b/agents/gan-generator.md
@@ -4,6 +4,7 @@ description: "GAN Harness: Generator agent. Implements features according to the
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
 color: green
+stack: ["*"]
 ---
 
 You are the **Generator** in a GAN-style multi-agent harness .

--- a/agents/gan-planner.md
+++ b/agents/gan-planner.md
@@ -4,6 +4,7 @@ description: "GAN Harness: Planner agent. Expands a one-line prompt into a full 
 tools: ["Read", "Write", "Grep", "Glob"]
 model: gemini-2.5-pro
 color: purple
+stack: ["*"]
 ---
 
 You are the **Planner** in a GAN-style multi-agent harness .

--- a/agents/go-build-resolver.md
+++ b/agents/go-build-resolver.md
@@ -3,6 +3,7 @@ name: go-build-resolver
 description: Go build, vet, and compilation error resolution specialist. Fixes build errors, go vet issues, and linter warnings with minimal changes. Use when Go builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["golang"]
 ---
 
 # Go Build Error Resolver

--- a/agents/go-reviewer.md
+++ b/agents/go-reviewer.md
@@ -3,6 +3,7 @@ name: go-reviewer
 description: Expert Go code reviewer specializing in idiomatic Go, concurrency patterns, error handling, and performance. Use for all Go code changes. MUST BE USED for Go projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["golang"]
 ---
 
 You are a senior Go code reviewer ensuring high standards of idiomatic Go and best practices.

--- a/agents/harmonyos-app-resolver.md
+++ b/agents/harmonyos-app-resolver.md
@@ -3,6 +3,7 @@ name: harmonyos-app-resolver
 description: HarmonyOS application development expert specializing in ArkTS and ArkUI. Reviews code for V2 state management compliance, Navigation routing patterns, API usage, and performance best practices. Use for HarmonyOS/OpenHarmony projects.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: sonnet
+stack: ["arkts"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/harness-optimizer.md
+++ b/agents/harness-optimizer.md
@@ -4,6 +4,7 @@ description: Analyze and improve the local agent harness configuration for relia
 tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
 model: gemini-2.5-pro
 color: teal
+stack: ["*"]
 ---
 
 You are the harness optimizer.

--- a/agents/healthcare-reviewer.md
+++ b/agents/healthcare-reviewer.md
@@ -3,6 +3,7 @@ name: healthcare-reviewer
 description: Reviews healthcare application code for clinical safety, CDSS accuracy, PHI compliance, and medical data integrity. Specialized for EMR/EHR, clinical decision support, and health information systems.
 tools: ["Read", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["python", "*"]
 ---
 
 # Healthcare Reviewer: Clinical Safety & PHI Compliance

--- a/agents/homelab-architect.md
+++ b/agents/homelab-architect.md
@@ -3,6 +3,7 @@ name: homelab-architect
 description: Designs home and small-lab network plans from hardware inventory, goals, and operator experience level, with safe staged changes and rollback guidance.
 tools: ["Read", "Grep"]
 model: sonnet
+stack: ["*"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/java-build-resolver.md
+++ b/agents/java-build-resolver.md
@@ -3,6 +3,7 @@ name: java-build-resolver
 description: Java/Maven/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Java compiler errors, and Maven/Gradle issues with minimal changes. Use when Java or Spring Boot builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["java"]
 ---
 
 # Java Build Error Resolver

--- a/agents/java-reviewer.md
+++ b/agents/java-reviewer.md
@@ -3,6 +3,7 @@ name: java-reviewer
 description: Expert Java and Spring Boot code reviewer specializing in layered architecture, JPA patterns, security, and concurrency. Use for all Java code changes. MUST BE USED for Spring Boot projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["java"]
 ---
 You are a senior Java engineer ensuring high standards of idiomatic Java and Spring Boot best practices.
 When invoked:

--- a/agents/kotlin-build-resolver.md
+++ b/agents/kotlin-build-resolver.md
@@ -3,6 +3,7 @@ name: kotlin-build-resolver
 description: Kotlin/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Kotlin compiler errors, and Gradle issues with minimal changes. Use when Kotlin builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["kotlin"]
 ---
 
 # Kotlin Build Error Resolver

--- a/agents/kotlin-reviewer.md
+++ b/agents/kotlin-reviewer.md
@@ -3,6 +3,7 @@ name: kotlin-reviewer
 description: Kotlin and Android/KMP code reviewer. Reviews Kotlin code for idiomatic patterns, coroutine safety, Compose best practices, clean architecture violations, and common Android pitfalls.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["kotlin"]
 ---
 
 You are a senior Kotlin and Android/KMP code reviewer ensuring idiomatic, safe, and maintainable code.

--- a/agents/loop-operator.md
+++ b/agents/loop-operator.md
@@ -4,6 +4,7 @@ description: Operate autonomous agent loops, monitor progress, and intervene saf
 tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
 model: gemini-2.5-pro
 color: orange
+stack: ["*"]
 ---
 
 You are the loop operator.

--- a/agents/mle-reviewer.md
+++ b/agents/mle-reviewer.md
@@ -3,6 +3,7 @@ name: mle-reviewer
 description: Production machine-learning engineering reviewer for data contracts, feature pipelines, training reproducibility, offline/online evaluation, model serving, monitoring, and rollback. Use when ML, MLOps, model training, inference, feature store, or evaluation code changes.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
+stack: ["python", "*"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/network-architect.md
+++ b/agents/network-architect.md
@@ -3,6 +3,7 @@ name: network-architect
 description: Designs enterprise or multi-site network architecture from requirements, using existing network skills for focused routing, validation, automation, and troubleshooting detail.
 tools: ["Read", "Grep"]
 model: sonnet
+stack: ["*"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/network-config-reviewer.md
+++ b/agents/network-config-reviewer.md
@@ -3,6 +3,7 @@ name: network-config-reviewer
 description: Reviews router and switch configurations for security, correctness, stale references, risky change-window commands, and missing operational guardrails.
 tools: ["Read", "Grep"]
 model: sonnet
+stack: ["*"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/network-troubleshooter.md
+++ b/agents/network-troubleshooter.md
@@ -3,6 +3,7 @@ name: network-troubleshooter
 description: Diagnoses network connectivity, routing, DNS, interface, and policy symptoms with a read-only OSI-layer workflow and evidence-backed root cause summary.
 tools: ["Read", "Bash", "Grep"]
 model: sonnet
+stack: ["*"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/opensource-forker.md
+++ b/agents/opensource-forker.md
@@ -3,6 +3,7 @@ name: opensource-forker
 description: Fork any project for open-sourcing. Copies files, strips secrets and credentials (20+ patterns), replaces internal references with placeholders, generates .env.example, and cleans git history. First stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Open-Source Forker

--- a/agents/opensource-packager.md
+++ b/agents/opensource-packager.md
@@ -3,6 +3,7 @@ name: opensource-packager
 description: Generate complete open-source packaging for a sanitized project. Produces GEMINI.md, setup.sh, README.md, LICENSE, CONTRIBUTING.md, and GitHub issue templates. Makes any repo immediately usable with Gemini Code. Third stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Open-Source Packager

--- a/agents/opensource-sanitizer.md
+++ b/agents/opensource-sanitizer.md
@@ -3,6 +3,7 @@ name: opensource-sanitizer
 description: Verify an open-source fork is fully sanitized before release. Scans for leaked secrets, PII, internal references, and dangerous files using 20+ regex patterns. Generates a PASS/FAIL/PASS-WITH-WARNINGS report. Second stage of the opensource-pipeline skill. Use PROACTIVELY before any public release.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Open-Source Sanitizer

--- a/agents/performance-optimizer.md
+++ b/agents/performance-optimizer.md
@@ -3,6 +3,7 @@ name: performance-optimizer
 description: Performance analysis and optimization specialist. Use PROACTIVELY for identifying bottlenecks, optimizing slow code, reducing bundle sizes, and improving runtime performance. Profiling, memory leaks, render optimization, and algorithmic improvements.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Performance Optimizer

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -3,6 +3,7 @@ name: planner
 description: Expert planning specialist for complex features and refactoring. Use PROACTIVELY when users request feature implementation, architectural changes, or complex refactoring. Automatically activated for planning tasks.
 tools: ["Read", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 You are an expert planning specialist focused on creating comprehensive, actionable implementation plans.

--- a/agents/pr-test-analyzer.md
+++ b/agents/pr-test-analyzer.md
@@ -3,6 +3,7 @@ name: pr-test-analyzer
 description: Review pull request test coverage quality and completeness, with emphasis on behavioral coverage and real bug prevention.
 model: gemini-2.5-pro
 tools: [Read, Grep, Glob, Bash]
+stack: ["*"]
 ---
 
 # PR Test Analyzer Agent

--- a/agents/python-reviewer.md
+++ b/agents/python-reviewer.md
@@ -3,6 +3,7 @@ name: python-reviewer
 description: Expert Python code reviewer specializing in PEP 8 compliance, Pythonic idioms, type hints, security, and performance. Use for all Python code changes. MUST BE USED for Python projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["python"]
 ---
 
 You are a senior Python code reviewer ensuring high standards of Pythonic code and best practices.

--- a/agents/pytorch-build-resolver.md
+++ b/agents/pytorch-build-resolver.md
@@ -3,6 +3,7 @@ name: pytorch-build-resolver
 description: PyTorch runtime, CUDA, and training error resolution specialist. Fixes tensor shape mismatches, device errors, gradient issues, DataLoader problems, and mixed precision failures with minimal changes. Use when PyTorch training or inference crashes.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["python"]
 ---
 
 # PyTorch Build/Runtime Error Resolver

--- a/agents/refactor-cleaner.md
+++ b/agents/refactor-cleaner.md
@@ -3,6 +3,7 @@ name: refactor-cleaner
 description: Dead code cleanup and consolidation specialist. Use PROACTIVELY for removing unused code, duplicates, and refactoring. Runs analysis tools (knip, depcheck, ts-prune) to identify dead code and safely removes it.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Refactor & Dead Code Cleaner

--- a/agents/reproduce-me.md
+++ b/agents/reproduce-me.md
@@ -3,6 +3,7 @@ name: reproduce-me
 description: Reproduce me please.
 tools: ["run_shell_command"]
 model: gemini-2.5-flash
+stack: ["*"]
 ---
 # Reproduce Me Agent
 Success.

--- a/agents/researcher-test.md
+++ b/agents/researcher-test.md
@@ -3,6 +3,7 @@ name: researcher-test
 description: A simple test agent for native delegation experiments.
 tools: ["run_shell_command"]
 model: gemini-2.5-flash
+stack: ["*"]
 ---
 # Researcher Test Agent
 I am a test agent created to verify native delegation.

--- a/agents/rust-build-resolver.md
+++ b/agents/rust-build-resolver.md
@@ -3,6 +3,7 @@ name: rust-build-resolver
 description: Rust build, compilation, and dependency error resolution specialist. Fixes cargo build errors, borrow checker issues, and Cargo.toml problems with minimal changes. Use when Rust builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["rust"]
 ---
 
 # Rust Build Error Resolver

--- a/agents/rust-reviewer.md
+++ b/agents/rust-reviewer.md
@@ -3,6 +3,7 @@ name: rust-reviewer
 description: Expert Rust code reviewer specializing in ownership, lifetimes, error handling, unsafe usage, and idiomatic patterns. Use for all Rust code changes. MUST BE USED for Rust projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["rust"]
 ---
 
 You are a senior Rust code reviewer ensuring high standards of safety, idiomatic patterns, and performance.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -3,6 +3,7 @@ name: security-reviewer
 description: Security vulnerability detection and remediation specialist. Use PROACTIVELY after writing code that handles user input, authentication, API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe crypto, and OWASP Top 10 vulnerabilities.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 # Security Reviewer

--- a/agents/seo-specialist.md
+++ b/agents/seo-specialist.md
@@ -3,6 +3,7 @@ name: seo-specialist
 description: SEO specialist for technical SEO audits, on-page optimization, structured data, Core Web Vitals, and content/keyword mapping. Use for site audits, meta tag reviews, schema markup, sitemap and robots issues, and SEO remediation plans.
 tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 You are a senior SEO specialist focused on technical SEO, search visibility, and sustainable ranking improvements.

--- a/agents/silent-failure-hunter.md
+++ b/agents/silent-failure-hunter.md
@@ -3,6 +3,7 @@ name: silent-failure-hunter
 description: Review code for silent failures, swallowed errors, bad fallbacks, and missing error propagation.
 model: gemini-2.5-pro
 tools: [Read, Grep, Glob, Bash]
+stack: ["*"]
 ---
 
 # Silent Failure Hunter Agent

--- a/agents/swift-build-resolver.md
+++ b/agents/swift-build-resolver.md
@@ -3,6 +3,7 @@ name: swift-build-resolver
 description: Swift/Xcode build, compilation, and dependency error resolution specialist. Fixes swift build errors, Xcode build failures, SPM dependency issues, and code signing problems with minimal changes. Use when Swift builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: sonnet
+stack: ["swift"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/swift-reviewer.md
+++ b/agents/swift-reviewer.md
@@ -3,6 +3,7 @@ name: swift-reviewer
 description: Expert Swift code reviewer specializing in protocol-oriented design, value semantics, ARC memory management, Swift Concurrency, and idiomatic patterns. Use for all Swift code changes. MUST BE USED for Swift projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
+stack: ["swift"]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/tdd-guide.md
+++ b/agents/tdd-guide.md
@@ -3,6 +3,7 @@ name: tdd-guide
 description: Test-Driven Development specialist enforcing write-tests-first methodology. Use PROACTIVELY when writing new features, fixing bugs, or refactoring code. Ensures 80%+ test coverage.
 tools: ["Read", "Write", "Edit", "Bash", "Grep"]
 model: gemini-2.5-pro
+stack: ["*"]
 ---
 
 You are a Test-Driven Development (TDD) specialist who ensures all code is developed test-first with comprehensive coverage.

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -3,6 +3,7 @@ name: type-design-analyzer
 description: Analyze type design for encapsulation, invariant expression, usefulness, and enforcement.
 model: gemini-2.5-pro
 tools: [Read, Grep, Glob, Bash]
+stack: ["*"]
 ---
 
 # Type Design Analyzer Agent

--- a/agents/typescript-reviewer.md
+++ b/agents/typescript-reviewer.md
@@ -3,6 +3,7 @@ name: typescript-reviewer
 description: Expert TypeScript/JavaScript code reviewer specializing in type safety, async correctness, Node/web security, and idiomatic patterns. Use for all TypeScript and JavaScript code changes. MUST BE USED for TypeScript/JavaScript projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
 model: gemini-2.5-pro
+stack: ["typescript", "javascript"]
 ---
 
 You are a senior TypeScript engineer ensuring high standards of type-safe, idiomatic TypeScript and JavaScript.

--- a/rules/web/coding-style.md
+++ b/rules/web/coding-style.md
@@ -1,3 +1,19 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
 > This file extends [common/coding-style.md](../common/coding-style.md) with web-specific frontend content.
 
 # Web Coding Style

--- a/rules/web/design-quality.md
+++ b/rules/web/design-quality.md
@@ -1,3 +1,19 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
 > This file extends [common/patterns.md](../common/patterns.md) with web-specific design-quality guidance.
 
 # Web Design Quality Standards

--- a/rules/web/hooks.md
+++ b/rules/web/hooks.md
@@ -1,3 +1,19 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
 > This file extends [common/hooks.md](../common/hooks.md) with web-specific hook recommendations.
 
 # Web Hooks

--- a/rules/web/patterns.md
+++ b/rules/web/patterns.md
@@ -1,3 +1,19 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
 > This file extends [common/patterns.md](../common/patterns.md) with web-specific patterns.
 
 # Web Patterns

--- a/rules/web/performance.md
+++ b/rules/web/performance.md
@@ -1,3 +1,19 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
 > This file extends [common/performance.md](../common/performance.md) with web-specific performance content.
 
 # Web Performance Rules

--- a/rules/web/security.md
+++ b/rules/web/security.md
@@ -1,3 +1,19 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
 > This file extends [common/security.md](../common/security.md) with web-specific security content.
 
 # Web Security Rules

--- a/rules/web/testing.md
+++ b/rules/web/testing.md
@@ -1,3 +1,19 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
 > This file extends [common/testing.md](../common/testing.md) with web-specific testing content.
 
 # Web Testing Rules

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -12,6 +12,13 @@ const os = require('os');
 const path = require('path');
 const { propagateStateContent } = require('../lib/propagate-state');
 
+let projectDetect = null;
+try {
+  projectDetect = require('../lib/project-detect');
+} catch (_) {
+  // Optional module -- minimal installations without project-detect skip the briefing.
+}
+
 function readStdinJson() {
   try {
     const raw = fs.readFileSync(0, 'utf8');
@@ -37,6 +44,15 @@ function projectSlug(projectPath) {
   return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 
+function parseFrontmatterValue(val) {
+  if (!val.startsWith('[')) return val;
+  try {
+    return JSON.parse(val);
+  } catch (_) {
+    return val;
+  }
+}
+
 function parseFrontmatter(content) {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return {};
@@ -45,29 +61,43 @@ function parseFrontmatter(content) {
     const colonIdx = line.indexOf(':');
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
-    const val = line.slice(colonIdx + 1).trim();
-    if (val.startsWith('[')) {
-      try { result[key] = JSON.parse(val); } catch (_) { result[key] = val; }
-    } else {
-      result[key] = val;
-    }
+    result[key] = parseFrontmatterValue(line.slice(colonIdx + 1).trim());
   }
   return result;
+}
+
+function agentMatchesStack(agentStack, languages, frameworks, knownFrameworkNames) {
+  if (agentStack.includes('*')) return 'generic';
+
+  const agentFrameworks = agentStack.filter(s => knownFrameworkNames.has(s));
+  const agentLanguages = agentStack.filter(s => !knownFrameworkNames.has(s));
+
+  if (agentFrameworks.length > 0) {
+    const allFrameworksPresent = agentFrameworks.every(f => frameworks.includes(f));
+    const languageMatches = agentLanguages.length === 0 || agentLanguages.some(l => languages.includes(l));
+    return allFrameworksPresent && languageMatches ? 'specific' : 'none';
+  }
+
+  return agentLanguages.some(l => languages.includes(l)) ? 'specific' : 'none';
+}
+
+function readAgentFiles(agentsDir) {
+  try {
+    return fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
+  } catch (_) {
+    return null;
+  }
 }
 
 function loadRelevantAgents(languages, frameworks, knownFrameworkNames) {
   const agentsDir = path.join(__dirname, '..', '..', 'agents');
   if (!fs.existsSync(agentsDir)) return { stackSpecific: [], generic: [], missing: true };
 
+  const files = readAgentFiles(agentsDir);
+  if (!files) return { stackSpecific: [], generic: [], missing: false };
+
   const stackSpecific = [];
   const generic = [];
-
-  let files;
-  try {
-    files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
-  } catch (_) {
-    return { stackSpecific: [], generic: [], missing: false };
-  }
 
   for (const file of files) {
     try {
@@ -75,27 +105,9 @@ function loadRelevantAgents(languages, frameworks, knownFrameworkNames) {
       const fm = parseFrontmatter(content);
       if (!fm.name) continue;
       const agentStack = Array.isArray(fm.stack) ? fm.stack : ['*'];
-
-      if (agentStack.includes('*')) {
-        generic.push(fm.name);
-        continue;
-      }
-
-      // Split agent's stack entries into frameworks and languages.
-      const agentFrameworks = agentStack.filter(s => knownFrameworkNames.has(s));
-      const agentLanguages = agentStack.filter(s => !knownFrameworkNames.has(s));
-
-      let matches = false;
-      if (agentFrameworks.length > 0) {
-        // Framework-specific agent: requires all declared frameworks to be detected.
-        matches = agentFrameworks.every(f => frameworks.includes(f)) &&
-          (agentLanguages.length === 0 || agentLanguages.some(l => languages.includes(l)));
-      } else {
-        // Language-only agent: OR semantics -- matches if any language is detected.
-        matches = agentLanguages.some(l => languages.includes(l));
-      }
-
-      if (matches) stackSpecific.push(fm.name);
+      const match = agentMatchesStack(agentStack, languages, frameworks, knownFrameworkNames);
+      if (match === 'generic') generic.push(fm.name);
+      else if (match === 'specific') stackSpecific.push(fm.name);
     } catch (_) {
       // skip unreadable agent
     }
@@ -104,24 +116,7 @@ function loadRelevantAgents(languages, frameworks, knownFrameworkNames) {
   return { stackSpecific, generic, missing: false };
 }
 
-function emitStackBriefing(projectPath) {
-  let detected;
-  let FRAMEWORK_RULES;
-  try {
-    const projectDetect = require('../lib/project-detect');
-    detected = projectDetect.detectProjectType(projectPath);
-    FRAMEWORK_RULES = projectDetect.FRAMEWORK_RULES || [];
-  } catch (_) {
-    return;
-  }
-
-  const { languages, frameworks } = detected;
-  if (languages.length === 0 && frameworks.length === 0) return;
-
-  const knownFrameworkNames = new Set((FRAMEWORK_RULES).map(r => r.framework));
-  const stack = [...new Set([...frameworks, ...languages])];
-  const { stackSpecific, generic, missing } = loadRelevantAgents(languages, frameworks, knownFrameworkNames);
-
+function buildBriefingLines(stack, stackSpecific, generic, missing) {
   const lines = ['', '=== EGC Stack Briefing ==='];
   lines.push(`Stack: ${stack.slice(0, 6).join(', ')}`);
 
@@ -131,9 +126,8 @@ function emitStackBriefing(projectPath) {
     if (stackSpecific.length > 0) {
       lines.push(`Stack agents: ${stackSpecific.slice(0, 6).join(', ')}`);
     }
-    const alwaysUse = generic.filter(n => n === 'code-reviewer').concat(
-      generic.filter(n => n !== 'code-reviewer').slice(0, 2)
-    );
+    const alwaysUse = generic.filter(n => n === 'code-reviewer')
+      .concat(generic.filter(n => n !== 'code-reviewer').slice(0, 2));
     if (alwaysUse.length > 0) {
       lines.push(`Always use: ${alwaysUse.join(', ')}`);
     }
@@ -142,37 +136,45 @@ function emitStackBriefing(projectPath) {
   lines.push('Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session');
   lines.push('===');
   lines.push('');
+  return lines;
+}
 
-  process.stdout.write(lines.join('\n'));
+function emitStackBriefing(projectPath) {
+  if (!projectDetect) return;
+
+  const detected = projectDetect.detectProjectType(projectPath);
+  const { languages, frameworks } = detected;
+  if (languages.length === 0 && frameworks.length === 0) return;
+
+  const FRAMEWORK_RULES = projectDetect.FRAMEWORK_RULES || [];
+  const knownFrameworkNames = new Set(FRAMEWORK_RULES.map(r => r.framework));
+  const stack = [...new Set([...frameworks, ...languages])];
+  const { stackSpecific, generic, missing } = loadRelevantAgents(languages, frameworks, knownFrameworkNames);
+
+  process.stdout.write(buildBriefingLines(stack, stackSpecific, generic, missing).join('\n'));
+}
+
+function loadAndPrintState(projectPath) {
+  const stateFile = path.join(os.homedir(), '.egc', 'state', `${projectSlug(projectPath)}.md`);
+  if (!fs.existsSync(stateFile)) return;
+
+  const content = fs.readFileSync(stateFile, 'utf8');
+  if (!content.trim()) return;
+
+  try {
+    propagateStateContent(projectPath, content);
+  } catch (_) {
+    // Propagation is best-effort; never block session startup.
+  }
+
+  process.stdout.write('EGC persistent memory for this project (restored automatically):\n\n' + content);
 }
 
 function main() {
   try {
     const input = readStdinJson();
     const projectPath = resolveProjectPath(input);
-    const stateFile = path.join(
-      os.homedir(),
-      '.egc',
-      'state',
-      `${projectSlug(projectPath)}.md`
-    );
-
-    if (fs.existsSync(stateFile)) {
-      const content = fs.readFileSync(stateFile, 'utf8');
-      if (content.trim()) {
-        try {
-          propagateStateContent(projectPath, content);
-        } catch (_) {
-          // Propagation is best-effort; never block session startup.
-        }
-
-        process.stdout.write(
-          'EGC persistent memory for this project (restored automatically):\n\n'
-          + content
-        );
-      }
-    }
-
+    loadAndPrintState(projectPath);
     emitStackBriefing(projectPath);
   } catch (_error) {
     // Never break session startup because of memory loading.

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -2,7 +2,8 @@
 'use strict';
 
 // Claude Code SessionStart hook. Prints the EGC state file for the current
-// project so the session always starts with persistent memory loaded.
+// project so the session always starts with persistent memory loaded, then
+// emits a stack briefing with relevant agents for the detected project type.
 // Read-only by design: it never executes project code and never fails the
 // session. Missing or unreadable state exits silently with code 0.
 
@@ -36,6 +37,115 @@ function projectSlug(projectPath) {
   return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const result = {};
+  for (const line of match[1].split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const val = line.slice(colonIdx + 1).trim();
+    if (val.startsWith('[')) {
+      try { result[key] = JSON.parse(val); } catch (_) { result[key] = val; }
+    } else {
+      result[key] = val;
+    }
+  }
+  return result;
+}
+
+function loadRelevantAgents(languages, frameworks, knownFrameworkNames) {
+  const agentsDir = path.join(__dirname, '..', '..', 'agents');
+  if (!fs.existsSync(agentsDir)) return { stackSpecific: [], generic: [], missing: true };
+
+  const stackSpecific = [];
+  const generic = [];
+
+  let files;
+  try {
+    files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
+  } catch (_) {
+    return { stackSpecific: [], generic: [], missing: false };
+  }
+
+  for (const file of files) {
+    try {
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf8');
+      const fm = parseFrontmatter(content);
+      if (!fm.name) continue;
+      const agentStack = Array.isArray(fm.stack) ? fm.stack : ['*'];
+
+      if (agentStack.includes('*')) {
+        generic.push(fm.name);
+        continue;
+      }
+
+      // Split agent's stack entries into frameworks and languages.
+      const agentFrameworks = agentStack.filter(s => knownFrameworkNames.has(s));
+      const agentLanguages = agentStack.filter(s => !knownFrameworkNames.has(s));
+
+      let matches = false;
+      if (agentFrameworks.length > 0) {
+        // Framework-specific agent: requires all declared frameworks to be detected.
+        matches = agentFrameworks.every(f => frameworks.includes(f)) &&
+          (agentLanguages.length === 0 || agentLanguages.some(l => languages.includes(l)));
+      } else {
+        // Language-only agent: OR semantics -- matches if any language is detected.
+        matches = agentLanguages.some(l => languages.includes(l));
+      }
+
+      if (matches) stackSpecific.push(fm.name);
+    } catch (_) {
+      // skip unreadable agent
+    }
+  }
+
+  return { stackSpecific, generic, missing: false };
+}
+
+function emitStackBriefing(projectPath) {
+  let detected;
+  let FRAMEWORK_RULES;
+  try {
+    const projectDetect = require('../lib/project-detect');
+    detected = projectDetect.detectProjectType(projectPath);
+    FRAMEWORK_RULES = projectDetect.FRAMEWORK_RULES || [];
+  } catch (_) {
+    return;
+  }
+
+  const { languages, frameworks } = detected;
+  if (languages.length === 0 && frameworks.length === 0) return;
+
+  const knownFrameworkNames = new Set((FRAMEWORK_RULES).map(r => r.framework));
+  const stack = [...new Set([...frameworks, ...languages])];
+  const { stackSpecific, generic, missing } = loadRelevantAgents(languages, frameworks, knownFrameworkNames);
+
+  const lines = ['', '=== EGC Stack Briefing ==='];
+  lines.push(`Stack: ${stack.slice(0, 6).join(', ')}`);
+
+  if (missing) {
+    lines.push('Agents: none installed -- run: egc install --profile full');
+  } else {
+    if (stackSpecific.length > 0) {
+      lines.push(`Stack agents: ${stackSpecific.slice(0, 6).join(', ')}`);
+    }
+    const alwaysUse = generic.filter(n => n === 'code-reviewer').concat(
+      generic.filter(n => n !== 'code-reviewer').slice(0, 2)
+    );
+    if (alwaysUse.length > 0) {
+      lines.push(`Always use: ${alwaysUse.join(', ')}`);
+    }
+  }
+
+  lines.push('Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session');
+  lines.push('===');
+  lines.push('');
+
+  process.stdout.write(lines.join('\n'));
+}
+
 function main() {
   try {
     const input = readStdinJson();
@@ -47,25 +157,23 @@ function main() {
       `${projectSlug(projectPath)}.md`
     );
 
-    if (!fs.existsSync(stateFile)) {
-      process.exit(0);
+    if (fs.existsSync(stateFile)) {
+      const content = fs.readFileSync(stateFile, 'utf8');
+      if (content.trim()) {
+        try {
+          propagateStateContent(projectPath, content);
+        } catch (_) {
+          // Propagation is best-effort; never block session startup.
+        }
+
+        process.stdout.write(
+          'EGC persistent memory for this project (restored automatically):\n\n'
+          + content
+        );
+      }
     }
 
-    const content = fs.readFileSync(stateFile, 'utf8');
-    if (!content.trim()) {
-      process.exit(0);
-    }
-
-    try {
-      propagateStateContent(projectPath, content);
-    } catch (_) {
-      // Propagation is best-effort; never block session startup.
-    }
-
-    process.stdout.write(
-      'EGC persistent memory for this project (restored automatically):\n\n'
-      + content
-    );
+    emitStackBriefing(projectPath);
   } catch (_error) {
     // Never break session startup because of memory loading.
   }

--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -369,12 +369,11 @@ function getDartDeps(projectDir) {
     if (!fs.existsSync(pubspecPath)) return [];
     const content = fs.readFileSync(pubspecPath, 'utf8');
     const deps = [];
-    const depMatches = content.match(/^(\s+)(\w[\w_-]*):/gm);
-    if (depMatches) {
-      depMatches.forEach(m => {
-        const name = m.trim().replace(/:$/, '');
-        if (name) deps.push(name);
-      });
+    for (const line of content.split('\n')) {
+      const trimmed = line.trimStart();
+      if (!trimmed || line[0] === trimmed[0]) continue;
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx > 0) deps.push(trimmed.slice(0, colonIdx).trim());
     }
     return deps;
   } catch {

--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -79,6 +79,31 @@ const LANGUAGE_RULES = [
     type: 'php',
     markers: ['composer.json', 'composer.lock'],
     extensions: ['.php']
+  },
+  {
+    type: 'dart',
+    markers: ['pubspec.yaml', 'pubspec.lock'],
+    extensions: ['.dart']
+  },
+  {
+    type: 'cpp',
+    markers: ['CMakeLists.txt', 'Makefile', 'configure.ac'],
+    extensions: ['.cpp', '.cc', '.cxx', '.hpp', '.hxx', '.h']
+  },
+  {
+    type: 'fsharp',
+    markers: [],
+    extensions: ['.fs', '.fsx', '.fsi']
+  },
+  {
+    type: 'perl',
+    markers: ['Makefile.PL', 'Build.PL', 'cpanfile'],
+    extensions: ['.pl', '.pm', '.t']
+  },
+  {
+    type: 'arkts',
+    markers: ['build-profile.json5', 'oh-package.json5'],
+    extensions: ['.ets', '.ats']
   }
 ];
 
@@ -124,7 +149,13 @@ const FRAMEWORK_RULES = [
   { framework: 'symfony', language: 'php', markers: ['symfony.lock'], packageKeys: ['symfony/framework-bundle'] },
 
   // Elixir frameworks
-  { framework: 'phoenix', language: 'elixir', markers: [], packageKeys: ['phoenix'] }
+  { framework: 'phoenix', language: 'elixir', markers: [], packageKeys: ['phoenix'] },
+
+  // Dart frameworks
+  { framework: 'flutter', language: 'dart', markers: [], packageKeys: ['flutter'] },
+
+  // C++ frameworks
+  { framework: 'qt', language: 'cpp', markers: ['.qmake.conf'], packageKeys: ['qt5', 'qt6', 'qt'] }
 ];
 
 /**
@@ -301,6 +332,57 @@ function getComposerDeps(projectDir) {
 }
 
 /**
+ * Read CMakeLists.txt for C++ library references (simple keyword extraction)
+ * @param {string} projectDir - Project root directory
+ * @returns {string[]} Array of library/package names (lowercase)
+ */
+function getCppDeps(projectDir) {
+  try {
+    const cmakePath = path.join(projectDir, 'CMakeLists.txt');
+    if (!fs.existsSync(cmakePath)) return [];
+    const content = fs.readFileSync(cmakePath, 'utf8').toLowerCase();
+    const deps = [];
+    const patterns = [
+      /find_package\s*\(\s*(\w+)/g,
+      /target_link_libraries\s*\(\s*\S+\s+([\w:]+)/g
+    ];
+    for (const re of patterns) {
+      let m;
+      while ((m = re.exec(content)) !== null) {
+        if (m[1]) deps.push(m[1].toLowerCase());
+      }
+    }
+    return deps;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read pubspec.yaml for Dart/Flutter package dependencies
+ * @param {string} projectDir - Project root directory
+ * @returns {string[]} Array of package names
+ */
+function getDartDeps(projectDir) {
+  try {
+    const pubspecPath = path.join(projectDir, 'pubspec.yaml');
+    if (!fs.existsSync(pubspecPath)) return [];
+    const content = fs.readFileSync(pubspecPath, 'utf8');
+    const deps = [];
+    const depMatches = content.match(/^(\s+)(\w[\w_-]*):/gm);
+    if (depMatches) {
+      depMatches.forEach(m => {
+        const name = m.trim().replace(/:$/, '');
+        if (name) deps.push(name);
+      });
+    }
+    return deps;
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Read mix.exs for Elixir dependencies (simple pattern match)
  * @param {string} projectDir - Project root directory
  * @returns {string[]} Array of dependency atom names
@@ -354,6 +436,8 @@ function detectProjectType(projectDir) {
   const rustDeps = getRustDeps(projectDir);
   const composerDeps = getComposerDeps(projectDir);
   const elixirDeps = getElixirDeps(projectDir);
+  const dartDeps = getDartDeps(projectDir);
+  const cppDeps = getCppDeps(projectDir);
 
   for (const rule of FRAMEWORK_RULES) {
     const hasMarker = rule.markers.some(m => fileExists(projectDir, m));
@@ -380,6 +464,12 @@ function detectProjectType(projectDir) {
           break;
         case 'elixir':
           depList = elixirDeps;
+          break;
+        case 'dart':
+          depList = dartDeps;
+          break;
+        case 'cpp':
+          depList = cppDeps;
           break;
       }
       hasDep = rule.packageKeys.some(key => depList.some(dep => dep.toLowerCase().includes(key.toLowerCase())));
@@ -425,5 +515,7 @@ module.exports = {
   getGoDeps,
   getRustDeps,
   getComposerDeps,
-  getElixirDeps
+  getElixirDeps,
+  getDartDeps,
+  getCppDeps
 };

--- a/tests/hooks/claude-session-start.test.js
+++ b/tests/hooks/claude-session-start.test.js
@@ -141,6 +141,63 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('emits stack briefing for detectable project (JavaScript)', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    const projectDir = createTempDir('claude-session-start-project-');
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'test', version: '1.0.0' })
+      );
+
+      const result = runHook(homeDir, JSON.stringify({ cwd: projectDir }));
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('=== EGC Stack Briefing ==='), 'briefing header missing');
+      assert.ok(result.stdout.includes('Stack:'), 'stack line missing');
+      assert.ok(result.stdout.includes('coding-standards'), 'coding-standards reminder missing');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('briefing and state are both printed when state exists', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    const projectDir = createTempDir('claude-session-start-project-');
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'test', version: '1.0.0' })
+      );
+
+      const slug = path.basename(os.tmpdir()) + '--' + path.basename(projectDir);
+      const sanitized = slug.replace(/[^a-zA-Z0-9-_]/g, '_');
+      writeStateFile(homeDir, sanitized, '# My Project State\n- resume task A\n');
+
+      const result = runHook(homeDir, JSON.stringify({ cwd: projectDir }));
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('EGC persistent memory'), 'state header missing');
+      assert.ok(result.stdout.includes('=== EGC Stack Briefing ==='), 'briefing missing');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('no briefing emitted for unrecognized project type', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      const result = runHook(homeDir, JSON.stringify({ cwd: '/workspace/empty' }));
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(!result.stdout.includes('EGC Stack Briefing'), 'unexpected briefing');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary

- **Part 1 (detect):** Expanded `project-detect.js` with 5 new languages (Dart, C++, F#, Perl, ArkTS) and 2 frameworks (Flutter, Qt)
- **Part 2 (agents):** Added machine-readable `stack:` field to all 63 agent frontmatter files, enabling runtime stack-based filtering
- **Part 3 (rules):** Fixed `rules/web/*.md` -- 7 files were missing the `paths:` frontmatter that controls auto-activation in web/frontend projects
- **Part 4 (hook):** Enhanced `claude-session-start.js` to emit a per-session stack briefing after loading project state

## How it works

On every new Claude Code session, the hook now:
1. Detects the project stack via `project-detect.js` (languages + frameworks)
2. Reads installed agents and filters by `stack:` field using smart AND/OR semantics
   - Framework agents (e.g. `django-reviewer`): all declared frameworks must be present
   - Language agents (e.g. `python-reviewer`): any matching language triggers inclusion
   - Generic agents (`stack: ["*"]`): always listed under "Always use"
3. Emits a concise briefing so the AI knows which agents to use and is reminded to apply `coding-standards` (cyclomatic complexity) to all code

## Example output (Django project)

```
=== EGC Stack Briefing ===
Stack: django, python
Stack agents: django-build-resolver, django-reviewer, python-reviewer
Always use: code-reviewer, a11y-architect, architect
Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session
===
```

## Test plan

- [ ] `tests/lib/project-detect.test.js` -- 30 tests pass
- [ ] `tests/hooks/claude-session-start.test.js` -- 5 tests pass
- [ ] Manual: Python pure shows only python agents, not django agents
- [ ] Manual: Django project shows both python and django agents
- [ ] Manual: Unknown project type (`/tmp`) produces no briefing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects each project's tech stack on session start and prints a short briefing with relevant agents, so you use the right reviewers and tools per project. Also expands stack detection, fixes web rule auto-activation, and hardens the hook/detector with new tests.

- New Features
  - Expanded `scripts/lib/project-detect.js` with Dart, C++, F#, Perl, ArkTS and frameworks Flutter, Qt.
  - Added `stack:` frontmatter to all agents for runtime filtering (`["*"]` for generic, e.g., `code-reviewer`).
  - Updated `scripts/hooks/claude-session-start.js` to emit a stack briefing (stack, matched agents, “Always use”, coding-standards reminder).
  - Matching: framework agents require all declared frameworks; language agents match any language.

- Bug Fixes
  - Added `paths:` frontmatter to 7 `rules/web/*` files so web rules auto-activate in frontend projects.
  - Hardened `claude-session-start` and `project-detect` to satisfy SonarCloud (top‑level require, helper extraction, safe `pubspec.yaml` parsing) and added 3 stack-briefing tests.

<sup>Written for commit c3e2223f2d8040683711dba82cb24d697421c590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

