### PR TITLE
docs: update all docs to reflect session start stack briefing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -252,7 +252,8 @@ agents/your-agent-name.md
 name: your-agent-name
 description: What this agent does and when the orchestrator should invoke it. Be specific!
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: claude-sonnet-4-6
+stack: ["*"]
 ---
 
 You are a [role] specialist operating within the EGC runtime.
@@ -286,7 +287,8 @@ What you return to the runtime queue or user.
 | `name` | Lowercase, hyphenated | `code-reviewer` |
 | `description` | Used for routing decisions | Be specific! |
 | `tools` | Only what's needed | `Read`, `Write`, `Bash`, `Task` (for delegation) |
-| `model` | Capability target | `gemini-1.5-flash` (fast), `gemini-2.5-pro` (complex) |
+| `model` | Capability target | `claude-haiku-4-5` (fast), `claude-sonnet-4-6` (complex) |
+| `stack` | Project types this agent targets | `["*"]` (all), `["python"]`, `["python", "django"]` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to EGC are documented here.
 - Fixed `StateWatcher.start()` to return the count of successfully attached watchers rather than the count of discovered files.
 - Fixed `egc doctor` to remove stale `better-sqlite3` references after the sql.js migration.
 - Pinned `undici` to 6.27.0 in both MCP servers, patching a known CVE.
+- Fixed session start hook: the AI had no way to know which agents applied to each project. Session start now detects the project stack and emits a briefing with relevant agents at the start of every session, closing the gap between what EGC promised and what it actually delivered.
 
 ## [1.1.1] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Ready to pick up the next items:
 • Add GEMINI.md with session memory protocol
 • Publish v1.0.1 fix to npm after clean install test passes
 • Add mcp_server_count to audit.js
+
+=== EGC Stack Briefing ===
+Stack: typescript, javascript
+Stack agents: typescript-reviewer, javascript-reviewer
+Always use: code-reviewer
+Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session
+===
 ```
 
 The AI already knows what you were building, what decisions you made, what failed, and exactly where you stopped. It knows because EGC saved that state at the end of your last session and loaded it back when this one started -- on its own, without you asking. You didn't type anything. You just started working.
@@ -153,7 +160,7 @@ egc telemetry status
 
 ## Prompt library
 
-**479 components** included as a bonus. Install to get access to 63 agents, 229 skills, and 76 commands written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.
+**481 components** included as a bonus. Install to get access to 64 agents, 229 skills, 77 commands, and 111 rules written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ egc telemetry status
 
 ## Prompt library
 
-**481 components** included as a bonus. Install to get access to 64 agents, 229 skills, 77 commands, and 111 rules written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.
+**479 components** included as a bonus. Install to get access to 63 agents, 229 skills, and 76 commands, plus 111 rules, all written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,11 +2,21 @@
 
 This document describes the planned development direction for EGC (Extended Global Context).
 
-## v1.1.1: Bidirectional Sync (In progress)
+## v1.1.2: Bidirectional Sync (Released 2026-06-20)
 
-- `egc watch`: bidirectional sync daemon -- edits in any tool config file propagate to all others and back to `~/.egc/state/` automatically (issues #302, #303)
-- `update_state` now propagates context to all 13 supported tool config files in one call (issue #313)
-- Handles atomic saves (VS Code, Cursor, Windsurf rename-based writes) and Windows EPERM events (issue #320)
+- `egc watch`: bidirectional sync daemon - edits in any tool config file propagate to all others and back to `~/.egc/state/` automatically (issues #302, #303)
+- `update_state` now propagates context to 11 supported tool config files in one call (issue #313)
+- Guardian pipeline: CacheAligner, ContentRouter, SmartCrusher, Headroom Phase 2 wired into `reduce_context`
+- `sql.js` replaces `better-sqlite3`: pure-JavaScript/WebAssembly SQLite, no native compilation required
+- `auto_learn`: new `egc-guardian` tool that mines session failures and writes actionable lessons automatically
+- Stack briefing: session start now detects the project stack and emits a briefing with relevant agents
+
+## v1.1.1: BM25 Search and Bug Fixes (Released 2026-06-19)
+
+- `lesson_recall` upgraded to BM25 full-text search via FTS5 virtual table
+- Fixed state DB path resolution across all harnesses
+- Fixed hook commands to use `process.execPath` for reliable PATH resolution
+- Added 7 OpenRouter model mappings (community contribution)
 
 ## v1.1.0: Memory Expansion (Released 2026-06-13)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,9 +43,9 @@ EGC install
   ✓ ~/.claude/CLAUDE.md updated
   ✓ ~/.gemini/GEMINI.md updated
   registering MCP servers...
-  ✓ registered in Antigravity CLI
   ✓ registered in Claude Code (global)
   ✓ registered in Cursor
+  ✓ registered in Gemini CLI
 
 Install prompt library? (63 agents, 229 skills, 76 commands) [y/N]:
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Hooks are event-driven automations that fire before or after Gemini Code tool executions. They enforce code quality, catch mistakes early, and automate repetitive checks.
+Hooks are event-driven automations that fire before or after AI tool executions. They enforce code quality, catch mistakes early, and automate repetitive checks.
 
 ## How Hooks Work
 
@@ -59,7 +59,7 @@ That installs resolved hooks to `~/.gemini/hooks/hooks.json`. On Windows, the Ge
 
 | Hook | Event | What It Does |
 |------|-------|-------------|
-| **Session start** | `SessionStart` | Loads previous context and detects package manager |
+| **Session start** | `SessionStart` | Loads previous project state and emits a stack briefing with relevant agents for the detected project type |
 | **Pre-compact** | `PreCompact` | Saves state before context compaction |
 | **Console.log audit** | `Stop` | Checks all modified files for `console.log` after each response |
 | **Session summary** | `Stop` | Persists session state when transcript path is available |

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -134,7 +134,7 @@ egc telemetry status
 
 ## Biblioteca de prompts
 
-**481 componentes** incluidos como bonus: 64 agentes, 229 habilidades, 77 comandos y 111 reglas escritos en sesiones de ingeniería reales. Ignóralos por completo y EGC seguirá dándote memoria persistente.
+**479 componentes** incluidos como bonus: 63 agentes, 229 habilidades, 76 comandos y 111 reglas escritos en sesiones de ingeniería reales. Ignóralos por completo y EGC seguirá dándote memoria persistente.
 
 ---
 

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -32,6 +32,13 @@ Ready to pick up the next items:
 • Add GEMINI.md with session memory protocol
 • Publish v1.0.1 fix to npm after clean install test passes
 • Add mcp_server_count to audit.js
+
+=== EGC Stack Briefing ===
+Stack: typescript, javascript
+Stack agents: typescript-reviewer, javascript-reviewer
+Always use: code-reviewer
+Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session
+===
 ```
 
 La IA ya sabe qué estabas construyendo, qué decisiones tomaste, qué falló y exactamente dónde te detuviste. Lo sabe porque EGC guardó ese estado al final de tu última sesión y lo cargó nuevamente cuando esta comenzó. No escribiste nada. Simplemente empezaste a trabajar.
@@ -127,7 +134,7 @@ egc telemetry status
 
 ## Biblioteca de prompts
 
-**479 componentes** incluidos como bonus: 63 agentes, 229 habilidades, 76 comandos y 111 reglas escritos en sesiones de ingeniería reales. Ignóralos por completo y EGC seguirá dándote memoria persistente.
+**481 componentes** incluidos como bonus: 64 agentes, 229 habilidades, 77 comandos y 111 reglas escritos en sesiones de ingeniería reales. Ignóralos por completo y EGC seguirá dándote memoria persistente.
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -134,7 +134,7 @@ egc telemetry status
 
 ## Biblioteca de prompts
 
-**481 componentes** inclusos como brinde: 64 agentes, 229 skills, 77 comandos e 111 regras escritos em sessoes reais de engenharia. Ignore-os completamente e o EGC ainda oferece memoria persistente.
+**479 componentes** inclusos como brinde: 63 agentes, 229 skills, 76 comandos e 111 regras escritos em sessoes reais de engenharia. Ignore-os completamente e o EGC ainda oferece memoria persistente.
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -32,6 +32,13 @@ Ready to pick up the next items:
 • Add GEMINI.md with session memory protocol
 • Publish v1.0.1 fix to npm after clean install test passes
 • Add mcp_server_count to audit.js
+
+=== EGC Stack Briefing ===
+Stack: typescript, javascript
+Stack agents: typescript-reviewer, javascript-reviewer
+Always use: code-reviewer
+Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session
+===
 ```
 
 A IA já sabe o que você estava construindo, quais decisões tomou, o que falhou e exatamente onde parou. Ela sabe porque o EGC salvou esse estado ao final da sua última sessão e o carregou de volta quando esta começou. Você não digitou nada. Você simplesmente começou a trabalhar.
@@ -127,7 +134,7 @@ egc telemetry status
 
 ## Biblioteca de prompts
 
-**479 componentes** inclusos como brinde: 63 agentes, 229 skills, 76 comandos e 111 regras escritos em sessoes reais de engenharia. Ignore-os completamente e o EGC ainda oferece memoria persistente.
+**481 componentes** inclusos como brinde: 64 agentes, 229 skills, 77 comandos e 111 regras escritos em sessoes reais de engenharia. Ignore-os completamente e o EGC ainda oferece memoria persistente.
 
 ---
 


### PR DESCRIPTION
## Summary

- README (EN/PT/ES): adds the stack briefing block to the session demo output so the marketing copy matches what EGC actually delivers; updates component count to 481 (64 agents, 229 skills, 77 commands, 111 rules); fixes EN README which was missing the rules breakdown
- CHANGELOG [1.1.2]: adds bug fix entry for session start briefing (the core fix from PR #382)
- ROADMAP: marks v1.1.1 and v1.1.2 as released with accurate feature lists; removes stale "In progress" label
- hooks/README: updates SessionStart description to mention stack briefing; replaces "Gemini Code" with vendor-neutral "AI tool"
- docs/installation.md: replaces fictional "Antigravity CLI" with "Gemini CLI" in example output
- .github/CONTRIBUTING.md: adds `stack` field to agent template and field table; updates model examples from Gemini-specific to Claude (vendor-neutral, matching current agents)

## Test plan

- [ ] README renders correctly on GitHub (EN, PT, ES)
- [ ] Demo code block shows both state output and stack briefing
- [ ] Component counts are consistent across all three READMEs (481 total)
- [ ] ROADMAP no longer has "In progress" for released versions
- [ ] CONTRIBUTING agent template includes `stack` field

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh docs for the new session start stack briefing and the 1.1.1/1.1.2 releases. READMEs (EN/PT/ES) now show the briefing; CHANGELOG notes the v1.1.2 stack‑briefing fix; ROADMAP marks both releases; hooks/installation use vendor‑neutral wording; CONTRIBUTING adds a `stack` field and Claude model examples.

- **Bug Fixes**
  - Restored catalog‑compatible component count format in all READMEs and corrected totals to 479 (63 agents, 229 skills, 76 commands); 111 rules are listed outside the validated segment.

<sup>Written for commit 0bd2a0d053def696b2d3f716602b8aa181359df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now support a `stack` field for specifying project type compatibility.
  * Session start hook now detects project stack and emits a briefing with relevant agents.

* **Documentation**
  * Updated contribution guidelines with current agent configuration examples.
  * Generalized documentation from AI-specific to broader AI terminology.
  * Updated release roadmap and MCP server registration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->