### PR TITLE
fix: auto_learn propagates lessons to all IDE config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
 
 **Your AI agents never start from zero again.**
 
-*No commands to learn. Just work -- EGC handles the rest.*
+*No commands to learn. Just work - EGC handles the rest.*
 
 </div>
 
 ---
 
-EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own -- no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
+EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own - no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
 
 ---
 
@@ -39,7 +39,7 @@ EGC is a local runtime that gives every AI coding tool you use a persistent memo
 You open Claude Code on a project you haven't touched in two weeks. Without typing anything:
 
 ```
-State loaded from egc-memory via ~/.egc/state/Projects--MyApp.md
+State loaded from egc-memory via ~/.egc/state/Projects-MyApp.md
 
 Context and preferences acknowledged (terse responses).
 
@@ -53,11 +53,11 @@ Ready to pick up the next items:
 Stack: typescript, javascript
 Stack agents: typescript-reviewer, javascript-reviewer
 Always use: code-reviewer
-Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session
+Skill: coding-standards (cyclomatic complexity) - apply to all code written this session
 ===
 ```
 
-The AI already knows what you were building, what decisions you made, what failed, and exactly where you stopped. It knows because EGC saved that state at the end of your last session and loaded it back when this one started -- on its own, without you asking. You didn't type anything. You just started working.
+The AI already knows what you were building, what decisions you made, what failed, and exactly where you stopped. It knows because EGC saved that state at the end of your last session and loaded it back when this one started - on its own, without you asking. You didn't type anything. You just started working.
 
 <div align="center">
   <img src="assets/egc-terminal.gif" alt="EGC demo" width="700" />
@@ -87,7 +87,7 @@ EGC ships two MCP servers that work together during every session.
 
 ### Memory - 14 tools that your AI uses automatically
 
-No commands to memorize. Your AI reads this table so you never have to. Say anything in any language -- "continue from yesterday", "remember this decision", "what broke last time?" -- and it calls the right tool. You just work. EGC handles the rest.
+No commands to memorize. Your AI reads this table so you never have to. Say anything in any language - "continue from yesterday", "remember this decision", "what broke last time?" - and it calls the right tool. You just work. EGC handles the rest.
 
 **`egc-memory`**
 
@@ -122,38 +122,16 @@ These tools run automatically in the background. Every shell command and every f
 | `validate_write` | Validates file write paths to prevent unsafe writes |
 | `reduce_context` | Compresses file payloads to save your token budget |
 | `orchestrate_task` | Routes prompts with agent/skill context and returns compression metrics |
-| `auto_learn` | Mines session failures and writes actionable lessons to CLAUDE.md |
+| `auto_learn` | Mines session failures and writes actionable lessons to all AI tool config files in the project |
 
 ### Always in sync - across every tool you use
 
-**`egc watch`** -- run it once and every tool you use stays in sync. Edit context in Cursor and it appears in Gemini CLI, Copilot, Windsurf, and everywhere else automatically. When your state updates, all your tool config files update with it. No manual steps, no stale state.
+**`egc watch`** - run it once and every tool you use stays in sync. Edit context in Cursor and it appears in Gemini CLI, Copilot, Windsurf, and everywhere else automatically. When your state updates, all your tool config files update with it. No manual steps, no stale state.
 
 ```
 egc watch              # watch current project
 egc watch /path/proj   # watch a specific project
 egc watch --quiet      # suppress output
-```
-
----
-
-## Telemetry
-
-EGC can send anonymous usage data to help improve the project. This is **opt-in**: you will be asked once on the first run of `egc install`, `egc init`, or `egc doctor`.
-
-**What is sent:** EGC version + OS platform only. No project data, no file contents, no identifiers.
-
-**How to disable at any time:**
-
-```bash
-egc telemetry off
-```
-
-or delete `~/.egc/telemetry.json`.
-
-**How to check your current setting:**
-
-```bash
-egc telemetry status
 ```
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,6 +75,28 @@ This checks that both MCP servers are built, registered, and reachable in every 
 
 ---
 
+## Telemetry
+
+EGC can send anonymous usage data to help improve the project. This is **opt-in**: you will be asked once on the first run of `egc install`, `egc init`, or `egc doctor`.
+
+**What is sent:** EGC version + OS platform only. No project data, no file contents, no identifiers.
+
+**How to disable at any time:**
+
+```bash
+egc telemetry off
+```
+
+or delete `~/.egc/telemetry.json`.
+
+**How to check your current setting:**
+
+```bash
+egc telemetry status
+```
+
+---
+
 ## Troubleshooting
 
 See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues including permission errors, Node.js version mismatches, and manual MCP registration steps.

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -169,12 +169,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "auto_learn",
-        description: "Mines recent tool failures from session history and writes actionable recommendations to CLAUDE.md between managed markers. Safe to call at any time; skips gracefully if no failures are found.",
+        description: "Mines recent tool failures from session history and writes actionable recommendations to all AI tool config files found in the project (CLAUDE.md, GEMINI.md, AGENTS.md, Cursor, Copilot, Windsurf, and others). Safe to call at any time; skips gracefully if no failures are found.",
         inputSchema: {
           type: "object",
           properties: {
             project_path: { type: "string", description: "Absolute path to the project root." },
-            target_file: { type: "string", description: "Path to write recommendations to. Defaults to CLAUDE.md in the project root." },
+            target_file: { type: "string", description: "Primary file to write recommendations to. Defaults to CLAUDE.md in the project root. Lessons are also propagated to all other AI tool config files found in the project." },
             limit: { type: "number", description: "Max number of failure patterns to surface (default 10)." }
           },
           required: ["project_path"]
@@ -341,9 +341,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           skipped: result.skipped,
         });
 
+        const extraFiles = result.propagated_to?.length ?? 0;
         const summary = result.skipped
           ? `[auto_learn] skipped: ${result.reason}`
-          : `[auto_learn] wrote ${result.recommendations_written} recommendations to ${result.target_file} (${result.patterns_found} failure patterns found)`;
+          : `[auto_learn] wrote ${result.recommendations_written} recommendations to ${result.target_file}${extraFiles > 0 ? ` and ${extraFiles} other AI tool config file(s)` : ''} (${result.patterns_found} failure patterns found)`;
 
         return { content: [{ type: 'text', text: summary }] };
       }

--- a/mcp/servers/egc-guardian/src/learn-writer.ts
+++ b/mcp/servers/egc-guardian/src/learn-writer.ts
@@ -7,6 +7,20 @@ import { open } from 'sqlite';
 const MARKER_START = '<!-- egc:learn:start -->';
 const MARKER_END   = '<!-- egc:learn:end -->';
 
+const PROPAGATION_TARGETS = [
+  'GEMINI.md',
+  'AGENTS.md',
+  '.cursor/rules/egc-context.mdc',
+  '.github/copilot-instructions.md',
+  '.windsurf/rules/egc-context.md',
+  '.trae/rules/egc-context.md',
+  '.rules',
+  '.clinerules',
+  'CONVENTIONS.md',
+  '.cursorrules',
+  'llms.txt',
+];
+
 export interface FailurePattern {
   tool: string;
   count: number;
@@ -19,6 +33,7 @@ export interface LearnResult {
   target_file: string;
   skipped: boolean;
   reason?: string;
+  propagated_to: string[];
 }
 
 function resolveStateDb(): string {
@@ -107,28 +122,42 @@ function writeToFile(filePath: string, content: string): void {
   }
 }
 
+function propagateLearnBlock(projectRoot: string, content: string): string[] {
+  const written: string[] = [];
+  for (const rel of PROPAGATION_TARGETS) {
+    const targetPath = path.join(projectRoot, rel);
+    if (fs.existsSync(targetPath)) {
+      writeToFile(targetPath, content);
+      written.push(rel);
+    }
+  }
+  return written;
+}
+
 export async function autoLearn(opts: {
   project_path: string;
   target_file?: string;
   limit?: number;
 }): Promise<LearnResult> {
   const projectRoot = opts.project_path;
-  const targetFile  = opts.target_file ?? path.join(projectRoot, 'CLAUDE.md');
+  const primaryFile = opts.target_file ?? path.join(projectRoot, 'CLAUDE.md');
   const limit       = opts.limit ?? 10;
 
   const patterns = await loadRecentFailures(projectRoot, limit);
 
   if (patterns.length === 0) {
-    return { patterns_found: 0, recommendations_written: 0, target_file: targetFile, skipped: true, reason: 'no failures found in session history' };
+    return { patterns_found: 0, recommendations_written: 0, target_file: primaryFile, skipped: true, reason: 'no failures found in session history', propagated_to: [] };
   }
 
   const content = buildRecommendations(patterns);
-  writeToFile(targetFile, content);
+  writeToFile(primaryFile, content);
+  const propagated = propagateLearnBlock(projectRoot, content);
 
   return {
     patterns_found: patterns.length,
     recommendations_written: patterns.length,
-    target_file: targetFile,
+    target_file: primaryFile,
     skipped: false,
+    propagated_to: propagated,
   };
 }

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -16,7 +16,7 @@ let projectDetect = null;
 try {
   projectDetect = require('../lib/project-detect');
 } catch (_) {
-  // Optional module -- minimal installations without project-detect skip the briefing.
+  // Optional module - minimal installations without project-detect skip the briefing.
 }
 
 function readStdinJson() {
@@ -41,7 +41,7 @@ function resolveProjectPath(input) {
 
 function projectSlug(projectPath) {
   const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
-  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+  return parts.slice(-2).join('-').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 
 function parseFrontmatterValue(val) {
@@ -121,7 +121,7 @@ function buildBriefingLines(stack, stackSpecific, generic, missing) {
   lines.push(`Stack: ${stack.slice(0, 6).join(', ')}`);
 
   if (missing) {
-    lines.push('Agents: none installed -- run: egc install --profile full');
+    lines.push('Agents: none installed - run: egc install --profile full');
   } else {
     if (stackSpecific.length > 0) {
       lines.push(`Stack agents: ${stackSpecific.slice(0, 6).join(', ')}`);
@@ -133,7 +133,7 @@ function buildBriefingLines(stack, stackSpecific, generic, missing) {
     }
   }
 
-  lines.push('Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session');
+  lines.push('Skill: coding-standards (cyclomatic complexity) - apply to all code written this session');
   lines.push('===');
   lines.push('');
   return lines;

--- a/tests/hooks/claude-session-start.test.js
+++ b/tests/hooks/claude-session-start.test.js
@@ -67,7 +67,7 @@ function runTests() {
   if (test('prints the state file for the cwd received on stdin', () => {
     const homeDir = createTempDir('claude-session-start-home-');
     try {
-      writeStateFile(homeDir, 'workspace--demo', '# Project State\n- resume feature X\n');
+      writeStateFile(homeDir, 'workspace-demo', '# Project State\n- resume feature X\n');
 
       const result = runHook(
         homeDir,
@@ -85,7 +85,7 @@ function runTests() {
   if (test('uses the same slug sanitization as the egc-memory server', () => {
     const homeDir = createTempDir('claude-session-start-home-');
     try {
-      writeStateFile(homeDir, 'My_Projects--app_v2_0', 'sanitized slug state\n');
+      writeStateFile(homeDir, 'My_Projects-app_v2_0', 'sanitized slug state\n');
 
       const result = runHook(
         homeDir,
@@ -114,7 +114,7 @@ function runTests() {
   if (test('exits silently with code 0 when the state file is blank', () => {
     const homeDir = createTempDir('claude-session-start-home-');
     try {
-      writeStateFile(homeDir, 'workspace--blank', '   \n\n');
+      writeStateFile(homeDir, 'workspace-blank', '   \n\n');
 
       const result = runHook(homeDir, JSON.stringify({ cwd: '/workspace/blank' }));
 
@@ -128,7 +128,7 @@ function runTests() {
   if (test('tolerates invalid stdin and falls back to environment paths', () => {
     const homeDir = createTempDir('claude-session-start-home-');
     try {
-      writeStateFile(homeDir, 'env--project', 'state from env fallback\n');
+      writeStateFile(homeDir, 'env-project', 'state from env fallback\n');
 
       const result = runHook(homeDir, 'not json at all', {
         CLAUDE_PROJECT_DIR: '/env/project',
@@ -171,7 +171,7 @@ function runTests() {
         JSON.stringify({ name: 'test', version: '1.0.0' })
       );
 
-      const slug = path.basename(os.tmpdir()) + '--' + path.basename(projectDir);
+      const slug = path.basename(os.tmpdir()) + '-' + path.basename(projectDir);
       const sanitized = slug.replace(/[^a-zA-Z0-9-_]/g, '_');
       writeStateFile(homeDir, sanitized, '# My Project State\n- resume task A\n');
 

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -23,7 +23,7 @@ EGC es un entorno de ejecución local que proporciona memoria persistente a toda
 Abres Claude Code en un proyecto que no has tocado en dos semanas. Sin escribir nada:
 
 ```text
-State loaded from egc-memory via ~/.egc/state/Projects--MyApp.md
+State loaded from egc-memory via ~/.egc/state/Projects-MyApp.md
 
 Context and preferences acknowledged (terse responses).
 
@@ -37,7 +37,7 @@ Ready to pick up the next items:
 Stack: typescript, javascript
 Stack agents: typescript-reviewer, javascript-reviewer
 Always use: code-reviewer
-Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session
+Skill: coding-standards (cyclomatic complexity) - apply to all code written this session
 ===
 ```
 
@@ -98,36 +98,14 @@ Los archivos de estado se almacenan en `~/.egc/state/<project-slug>.md`. Un arch
 | `validate_write` | Valida rutas de escritura de archivos para prevenir escrituras inseguras |
 | `reduce_context` | Comprime los archivos del payload para ahorrar tu presupuesto de tokens |
 | `orchestrate_task` | Enruta prompts con contexto de agentes/skills y devuelve métricas de compresión |
-| `auto_learn` | Analiza fallos de sesión y escribe lecciones accionables en CLAUDE.md |
+| `auto_learn` | Analiza fallos de sesión y escribe lecciones accionables en todos los archivos de configuración de herramientas de IA del proyecto |
 
-**`egc watch`** — daemon de sincronización bidireccional. Monitorea todos los archivos de configuración de herramientas gestionados por EGC en el proyecto. Cuando editas el contexto directamente en cualquier archivo de herramienta (Cursor, Gemini CLI, Copilot, etc.), el cambio se extrae del bloque EGC y se sincroniza con todas las demás herramientas y de vuelta a `~/.egc/state/` automáticamente.
+**`egc watch`** - daemon de sincronización bidireccional. Monitorea todos los archivos de configuración de herramientas gestionados por EGC en el proyecto. Cuando editas el contexto directamente en cualquier archivo de herramienta (Cursor, Gemini CLI, Copilot, etc.), el cambio se extrae del bloque EGC y se sincroniza con todas las demás herramientas y de vuelta a `~/.egc/state/` automáticamente.
 
 ```
 egc watch              # monitorear proyecto actual
 egc watch /ruta/proj   # monitorear proyecto específico
 egc watch --quiet      # silenciar salida
-```
-
----
-
-## Telemetría
-
-EGC puede enviar datos de uso anónimos para ayudar a mejorar el proyecto. Esto es **opt-in**: se te preguntará una vez en el primer uso de `egc install`, `egc init` o `egc doctor`.
-
-**Qué se envía:** versión de EGC + plataforma del sistema operativo. Sin datos de proyecto, sin contenido de archivos, sin identificadores.
-
-**Cómo desactivar en cualquier momento:**
-
-```bash
-egc telemetry off
-```
-
-o elimina `~/.egc/telemetry.json`.
-
-**Cómo ver tu configuración actual:**
-
-```bash
-egc telemetry status
 ```
 
 ---

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -23,7 +23,7 @@ EGC é um runtime local que oferece memória persistente para cada ferramenta de
 Você abre o Claude Code em um projeto que não tocou há duas semanas. Sem digitar nada:
 
 ```
-State loaded from egc-memory via ~/.egc/state/Projects--MyApp.md
+State loaded from egc-memory via ~/.egc/state/Projects-MyApp.md
 
 Context and preferences acknowledged (terse responses).
 
@@ -37,7 +37,7 @@ Ready to pick up the next items:
 Stack: typescript, javascript
 Stack agents: typescript-reviewer, javascript-reviewer
 Always use: code-reviewer
-Skill: coding-standards (cyclomatic complexity) -- apply to all code written this session
+Skill: coding-standards (cyclomatic complexity) - apply to all code written this session
 ===
 ```
 
@@ -98,36 +98,14 @@ Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por 
 | `validate_write` | Valida caminhos de escrita para prevenir gravações inseguras |
 | `reduce_context` | Comprime payloads de arquivos para economizar seu orçamento de tokens |
 | `orchestrate_task` | Roteia prompts com contexto de agentes/skills e retorna métricas de compressão |
-| `auto_learn` | Analisa falhas de sessão e escreve lições acionáveis no CLAUDE.md |
+| `auto_learn` | Analisa falhas de sessão e escreve lições acionáveis em todos os arquivos de configuração de ferramentas de IA do projeto |
 
-**`egc watch`** — daemon de sincronização bidirecional. Monitora todos os arquivos de configuração de ferramentas gerenciados pelo EGC no projeto. Quando você edita o contexto diretamente em qualquer arquivo de ferramenta (Cursor, Gemini CLI, Copilot, etc.), a mudança é extraída do bloco EGC e sincronizada com todas as outras ferramentas e de volta para `~/.egc/state/` automaticamente.
+**`egc watch`** - daemon de sincronização bidirecional. Monitora todos os arquivos de configuração de ferramentas gerenciados pelo EGC no projeto. Quando você edita o contexto diretamente em qualquer arquivo de ferramenta (Cursor, Gemini CLI, Copilot, etc.), a mudança é extraída do bloco EGC e sincronizada com todas as outras ferramentas e de volta para `~/.egc/state/` automaticamente.
 
 ```
 egc watch              # monitorar projeto atual
 egc watch /caminho     # monitorar projeto específico
 egc watch --quiet      # suprimir saída
-```
-
----
-
-## Telemetria
-
-O EGC pode enviar dados de uso anônimos para ajudar a melhorar o projeto. Isso e **opt-in**: voce sera perguntado uma vez no primeiro uso de `egc install`, `egc init` ou `egc doctor`.
-
-**O que e enviado:** versao do EGC + plataforma do sistema operacional. Sem dados de projeto, sem conteudo de arquivos, sem identificadores.
-
-**Como desativar a qualquer momento:**
-
-```bash
-egc telemetry off
-```
-
-ou exclua `~/.egc/telemetry.json`.
-
-**Como verificar sua configuracao atual:**
-
-```bash
-egc telemetry status
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **`auto_learn` bug fix**: the tool was only writing lessons to `CLAUDE.md`. It now propagates to all AI tool config files found in the project: `GEMINI.md`, `AGENTS.md`, `.cursor/rules/egc-context.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/egc-context.md`, `.trae/rules/egc-context.md`, `.rules`, `.clinerules`, `CONVENTIONS.md`, `.cursorrules`, `llms.txt`. Only writes to files that already exist.
- **Double hyphen removal**: all `--` in display text and prose replaced with `-` across EN/PT/ES READMEs and hook output strings. Also fixes `projectSlug` separator.
- **Telemetry moved**: removed telemetry sections from all three READMEs; content is now in `docs/installation.md` where it belongs.
- **Descriptions updated**: `auto_learn` description updated in `egc-guardian/src/index.ts` and all three READMEs to accurately reflect multi-IDE propagation.

## Test plan

- [ ] Run `auto_learn` on a project that has multiple AI tool config files and verify lessons appear in all of them
- [ ] Run `node scripts/ci/catalog.js --text` and confirm counts still match (63/76/229)
- [ ] Confirm no `--` in prose text remains in any README
- [ ] Confirm telemetry section appears in `docs/installation.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `auto_learn` so lessons propagate to all existing tool config files, not just `CLAUDE.md`. Also moves telemetry docs to the installation guide, normalizes hyphen usage, and updates tests for the new slug separator.

- **Bug Fixes**
  - `auto_learn` writes to all existing config files: `GEMINI.md`, `AGENTS.md`, `.cursor/rules/egc-context.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/egc-context.md`, `.trae/rules/egc-context.md`, `.rules`, `.clinerules`, `CONVENTIONS.md`, `.cursorrules`, `llms.txt` (touches only if present).
  - Tool output shows how many extra files were updated; tool description updated to reflect multi-editor propagation.
  - Fixed project slug separator in `claude-session-start.js` from `--` to `-`; tests updated to match.

- **Refactors**
  - Removed telemetry sections from READMEs; added to `docs/installation.md`.
  - Replaced `--` with `-` in EN/PT/ES READMEs and hook strings.
  - Updated `auto_learn` description in `egc-guardian` and READMEs.

<sup>Written for commit 6e0e29d9f4945afb5bbf4c0f96a117b88150bc95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

