### PR TITLE
Fix Claude response bug

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -86,8 +86,12 @@ class ClaudeProvider(LLMProvider):
                         )
                     ]
 
+                        if response.content and hasattr(response.content[0], 'text'):
+                text = response.content[0].text
+            else:
+                text = ''
             return LLMOutput(
-                content=response.content[0].text if response.content else "",
+                content=text,
                 tool_calls=tool_calls,
                 model=response.model,
                 usage={


### PR DESCRIPTION
## What was broken
AttributeError when Claude response starts with a tool_use block
## What changed
Added check for tool_use block before accessing text attribute
## How to test
Test with a Claude response starting with a tool_use block

---
_Opened by autonomous agent. Human review required before merge._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash (AttributeError) when Claude responses start with a tool_use block by checking for a text attribute before reading it. If no text exists, we return an empty content string while preserving tool_calls, model, usage, and stop_reason.

<sup>Written for commit 0017102db7eb23bb148ad3fa582b20e89d253893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of Claude provider by adding defensive checks when processing API responses, ensuring the system gracefully handles edge cases where response content may be missing or malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->