### PR TITLE
test(hooks): add coverage for missing agents path in briefing

### DIFF
--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -90,7 +90,7 @@ function readAgentFiles(agentsDir) {
 }
 
 function loadRelevantAgents(languages, frameworks, knownFrameworkNames) {
-  const agentsDir = path.join(__dirname, '..', '..', 'agents');
+  const agentsDir = process.env.EGC_AGENTS_DIR || path.join(__dirname, '..', '..', 'agents');
   if (!fs.existsSync(agentsDir)) return { stackSpecific: [], generic: [], missing: true };
 
   const files = readAgentFiles(agentsDir);

--- a/src/llm/cli/selector.py
+++ b/src/llm/cli/selector.py
@@ -26,7 +26,7 @@ def print_banner() -> None:
 ╔════════════════════════════════════════════════════════════╗
 ║   EGC — Everything Gemini Code                             ║
 ║   Desenvolvido por Felipe Marzochi  -  @FEMARZOCHI         ║
-║   https://github.com/Fmarzochi/EGC           ║
+║   https://github.com/Fmarzochi/EGC                         ║
 ║   © Todos os direitos reservados                           ║
 ╚════════════════════════════════════════════════════════════╝{Color.RESET}"""
     print(banner)

--- a/tests/hooks/claude-session-start.test.js
+++ b/tests/hooks/claude-session-start.test.js
@@ -198,6 +198,29 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('briefing shows install hint when agents directory is missing', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    const projectDir = createTempDir('claude-session-start-project-');
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'test', version: '1.0.0' })
+      );
+
+      const result = runHook(homeDir, JSON.stringify({ cwd: projectDir }), {
+        EGC_AGENTS_DIR: path.join(homeDir, 'nonexistent-agents'),
+      });
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('=== EGC Stack Briefing ==='), 'briefing header missing');
+      assert.ok(result.stdout.includes('none installed'), 'install hint missing');
+      assert.ok(result.stdout.includes('coding-standards'), 'coding-standards reminder missing');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What

Commit `1fec1a5` changed text in the `missing` branch of `buildBriefingLines` but that branch had no test, leaving `codecov/patch` at 50% on main.

## How

- Added `EGC_AGENTS_DIR` env override to `loadRelevantAgents` so the missing-agents path is reachable in tests without touching the real `agents/` directory.
- Added one test: detectable project (JS) + nonexistent agents dir → briefing shows the install hint and `coding-standards` reminder.

## Result

All 9 hook tests pass. Patch coverage on the changed lines goes above the 80% target.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test coverage for the “missing agents” path in the session-start briefing by allowing tests to set `EGC_AGENTS_DIR`, and fixes the CLI banner URL alignment. Patch coverage on the changed lines now exceeds 80%, and all hook tests pass.

<sup>Written for commit 491f0b8ad101b86991df3df02b5279995bded88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the agents directory location via configuration.

* **Bug Fixes**
  * Improved banner alignment in command-line output.

* **Tests**
  * Added test coverage for handling missing agents directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->