### PR TITLE
fix(claude): handle AttributeError when response starts with tool_use block

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -86,8 +86,13 @@ class ClaudeProvider(LLMProvider):
                         )
                     ]
 
+            content = next(
+                (block.text for block in response.content if block.type == "text"),
+                "",
+            )
+
             return LLMOutput(
-                content=response.content[0].text if response.content else "",
+                content=content,
                 tool_calls=tool_calls,
                 model=response.model,
                 usage={

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -1,0 +1,94 @@
+"""Tests for ClaudeProvider content extraction."""
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _make_anthropic_stub():
+    stub = types.ModuleType("anthropic")
+    stub.Anthropic = MagicMock
+    return stub
+
+
+def _simple_input():
+    from llm.core.types import LLMInput, Message, Role
+    return LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="claude-sonnet-4-7",
+    )
+
+
+class TestClaudeProviderContentExtraction(unittest.TestCase):
+    def setUp(self):
+        self._patch = patch.dict(sys.modules, {"anthropic": _make_anthropic_stub()})
+        self._patch.start()
+        from llm.providers.claude import ClaudeProvider
+        self.provider = ClaudeProvider.__new__(ClaudeProvider)
+        self.provider.client = MagicMock()
+        self.provider._models = []
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def _make_response(self, blocks, stop_reason="end_turn"):
+        response = MagicMock()
+        response.content = blocks
+        response.model = "claude-sonnet-4-7"
+        response.stop_reason = stop_reason
+        response.usage.input_tokens = 10
+        response.usage.output_tokens = 5
+        return response
+
+    def _text_block(self, text):
+        block = MagicMock()
+        block.type = "text"
+        block.text = text
+        return block
+
+    def _tool_block(self, name="some_tool", tool_id="call_1"):
+        class _Input:
+            pass
+        inp = _Input()
+        inp.__dict__ = {"key": "value"}
+
+        block = MagicMock()
+        block.type = "tool_use"
+        block.id = tool_id
+        block.name = name
+        block.configure_mock(input=inp)
+        return block
+
+    def test_text_block_returns_text_content(self):
+        self.provider.client.messages.create.return_value = self._make_response(
+            [self._text_block("hello")]
+        )
+        result = self.provider.generate(_simple_input())
+        self.assertEqual(result.content, "hello")
+
+    def test_tool_use_first_returns_empty_content(self):
+        """Regression: tool_use block has no .text — must not raise AttributeError."""
+        self.provider.client.messages.create.return_value = self._make_response(
+            [self._tool_block()], stop_reason="tool_use"
+        )
+        result = self.provider.generate(_simple_input())
+        self.assertEqual(result.content, "")
+        self.assertIsNotNone(result.tool_calls)
+
+    def test_tool_use_then_text_extracts_text(self):
+        """Text after a tool_use block must be returned, not skipped."""
+        self.provider.client.messages.create.return_value = self._make_response(
+            [self._tool_block(), self._text_block("done")]
+        )
+        result = self.provider.generate(_simple_input())
+        self.assertEqual(result.content, "done")
+
+    def test_empty_content_returns_empty_string(self):
+        self.provider.client.messages.create.return_value = self._make_response([])
+        result = self.provider.generate(_simple_input())
+        self.assertEqual(result.content, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`src/llm/providers/claude.py` line 90 unconditionally read `response.content[0].text`. When Claude responds with only a `tool_use` block and no preceding text, that block has no `.text` attribute, raising `AttributeError`.

Closes #386

## Fix

Replace the unconditional access with `next()` over content blocks filtered by `type == "text"`, returning `""` when no text block is present:

```python
content = next(
    (block.text for block in response.content if block.type == "text"),
    "",
)
```

## Tests

Added `tests/test_claude_provider.py` covering:
- Normal text response
- `tool_use` first, no text — returns `""` without crashing
- `tool_use` then `text` — returns the text correctly
- Empty content list — returns `""`

## Credit

Fix authored by @krishna3554, who identified and resolved this issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an AttributeError when Claude returns a leading `tool_use` block by extracting the first `text` block and defaulting to an empty string. Keeps tool call handling intact.

- **Bug Fixes**
  - Replace `response.content[0].text` with a safe `next()` over `text` blocks; fallback to "".
  - Add tests for text-only, tool_use-only, tool_use-then-text, and empty content.

<sup>Written for commit 15ef0460de3605758963f0f18519353d90f47238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

