### PR TITLE
Fix content extraction in Claude tool_use response

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -87,7 +87,9 @@ class ClaudeProvider(LLMProvider):
                     ]
 
             return LLMOutput(
-                content=response.content[0].text if response.content else "",
+                content=next(
+                    (block.text for block in response.content if block.type == "text"), "",
+                ),
                 tool_calls=tool_calls,
                 model=response.model,
                 usage={


### PR DESCRIPTION
## Summary

Fix an `AttributeError` in the Claude provider when a response starts with a `tool_use` block.

The previous implementation assumed that `response.content[0]` always contained a text block and accessed its `text` attribute directly. However, Claude can return a `tool_use` block as the first (or only) content item, which does not have a `text` attribute.

This change updates the content extraction logic to safely retrieve the first available text block from the response and fall back to an empty string when no text block is present.

Fixes #<issue-number>

## Changes

* Replace direct access to `response.content[0].text`
* Extract the first text block from `response.content`
* Return an empty string when the response contains only tool calls

## Testing

* Ran the project test suite successfully
* Verified that text responses continue to work as expected
* Verified that responses beginning with `tool_use` blocks no longer raise an `AttributeError`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an AttributeError in the Claude provider when a response starts with a `tool_use` block by safely extracting the first `text` block from `response.content`, or returning an empty string if none exists. Prevents crashes on tool-only responses and keeps normal text responses unchanged.

<sup>Written for commit b98d6b1befe64f9b5519026b30b11c1874e8cd7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



