### PR TITLE
fix: handle json.JSONDecodeError in tool_calls arguments parsing

### DIFF
--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -85,14 +85,19 @@ class OpenAIProvider(LLMProvider):
 
             tool_calls = None
             if choice.message.tool_calls:
-                tool_calls = [
-                    ToolCall(
-                        id=tc.id or "",
-                        name=tc.function.name,
-                        arguments={} if not tc.function.arguments else json.loads(tc.function.arguments),
+                tool_calls = []
+                for tc in choice.message.tool_calls:
+                    try:
+                        args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+                    except json.JSONDecodeError:
+                        args = {}
+                    tool_calls.append(
+                        ToolCall(
+                            id=tc.id or "",
+                            name=tc.function.name,
+                            arguments=args,
+                        )
                     )
-                    for tc in choice.message.tool_calls
-                ]
 
             return LLMOutput(
                 content=choice.message.content or "",


### PR DESCRIPTION
## Summary

Fixes #393: `OpenAIProvider.generate()` raises unhandled `json.JSONDecodeError` when the API returns malformed JSON in `function.arguments`. This affects `OpenRouterProvider` via inheritance.

## Change

Wrap `json.loads(tc.function.arguments)` in `try/except json.JSONDecodeError` and fall back to `{}` gracefully. Same pattern as the fix in #388.

## Files changed

- `src/llm/providers/openai.py`: Convert list comprehension to explicit loop with error handling (lines 87-100)

## Verification

Manual verification of the error-handling logic confirmed that malformed JSON arguments now fall back to `{}` instead of propagating as `json.JSONDecodeError`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when the API returns malformed JSON in tool call arguments. We now safely parse arguments in `OpenAIProvider.generate()`, which also covers `OpenRouterProvider` via inheritance.

- **Bug Fixes**
  - Parse `tool_calls[].function.arguments` with try/except; fallback to `{}` on `json.JSONDecodeError`.
  - Replaced the list comprehension with a loop to enable the error handling.

<sup>Written for commit 1293cd1c4ec979a3865e0320e2962fffe9a1509d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for tool-call argument parsing to prevent application crashes when invalid JSON is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->