### PR TITLE
fix(ollama): populate usage tokens from API response

### DIFF
--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -86,11 +86,19 @@ class OllamaProvider(LLMProvider):
                     for tc in result["message"]["tool_calls"]
                 ]
 
+            prompt_tokens = result.get("prompt_eval_count", 0)
+            completion_tokens = result.get("eval_count", 0)
+
             return LLMOutput(
                 content=content,
                 tool_calls=tool_calls,
                 model=model,
                 stop_reason=result.get("done_reason"),
+                usage={
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
             )
         except Exception as e:
             msg = str(e)


### PR DESCRIPTION
Fixes #398

Maps `prompt_eval_count` and `eval_count` from the Ollama response to `LLMOutput.usage`, consistent with the pattern used in OpenAI, Gemini, and Claude providers.

**Before:** `usage` was always `None` for Ollama responses.
**After:** `usage` contains `prompt_tokens`, `completion_tokens`, and `total_tokens`.

Co-authored-by: vaishnavidesai09 <vaishnavidesai09@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate usage token metrics for the Ollama provider by mapping API response fields to `LLMOutput.usage`. This aligns usage reporting with OpenAI, Gemini, and Claude and fixes cases where usage was missing.

- **Bug Fixes**
  - Map `prompt_eval_count` to `prompt_tokens`, `eval_count` to `completion_tokens`, and set `total_tokens`; defaults to 0 when fields are absent.

<sup>Written for commit 19cc04ab34aff61ea899532f5a841404a022ac35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

