### PR TITLE
fix: handle empty OpenAI choices

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    unit: marks unit tests

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -15,6 +15,7 @@ except ImportError:
 from llm.core.interface import (
     AuthenticationError,
     ContextLengthError,
+    LLMError,
     LLMProvider,
     RateLimitError,
 )
@@ -81,6 +82,11 @@ class OpenAIProvider(LLMProvider):
                 params["tools"] = [tool.to_dict() for tool in input.tools]
 
             response = self.client.chat.completions.create(**params)
+            if not response.choices:
+                raise LLMError(
+                    "OpenAI returned an empty choices list",
+                    provider=ProviderType.OPENAI,
+                )
             choice = response.choices[0]
 
             tool_calls = None

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,0 +1,37 @@
+"""Tests for OpenAIProvider response handling."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from llm.core.interface import LLMError
+from llm.core.types import LLMInput, Message, ProviderType, Role
+from llm.providers.openai import OpenAIProvider
+
+
+def _simple_input():
+    return LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="gpt-4o-mini",
+    )
+
+
+class TestOpenAIProviderResponseHandling(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider.__new__(OpenAIProvider)
+        self.provider.client = MagicMock()
+        self.provider._models = []
+
+    def test_empty_choices_raise_llm_error(self):
+        response = MagicMock()
+        response.choices = []
+        self.provider.client.chat.completions.create.return_value = response
+
+        with self.assertRaises(LLMError) as exc:
+            self.provider.generate(_simple_input())
+
+        self.assertEqual(exc.exception.provider, ProviderType.OPENAI)
+        self.assertIn("empty choices", str(exc.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,37 +1,37 @@
 """Tests for OpenAIProvider response handling."""
 
-import unittest
 from unittest.mock import MagicMock
+
+import pytest
 
 from llm.core.interface import LLMError
 from llm.core.types import LLMInput, Message, ProviderType, Role
 from llm.providers.openai import OpenAIProvider
 
 
-def _simple_input():
+def _simple_input() -> LLMInput:
     return LLMInput(
         messages=[Message(role=Role.USER, content="hi")],
         model="gpt-4o-mini",
     )
 
 
-class TestOpenAIProviderResponseHandling(unittest.TestCase):
-    def setUp(self):
-        self.provider = OpenAIProvider.__new__(OpenAIProvider)
-        self.provider.client = MagicMock()
-        self.provider._models = []
-
-    def test_empty_choices_raise_llm_error(self):
-        response = MagicMock()
-        response.choices = []
-        self.provider.client.chat.completions.create.return_value = response
-
-        with self.assertRaises(LLMError) as exc:
-            self.provider.generate(_simple_input())
-
-        self.assertEqual(exc.exception.provider, ProviderType.OPENAI)
-        self.assertIn("empty choices", str(exc.exception))
+@pytest.fixture
+def provider() -> OpenAIProvider:
+    provider = OpenAIProvider.__new__(OpenAIProvider)
+    provider.client = MagicMock()
+    provider._models = []
+    return provider
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.unit
+def test_empty_choices_raise_llm_error(provider: OpenAIProvider) -> None:
+    response = MagicMock()
+    response.choices = []
+    provider.client.chat.completions.create.return_value = response
+
+    with pytest.raises(LLMError) as exc:
+        provider.generate(_simple_input())
+
+    assert exc.value.provider == ProviderType.OPENAI
+    assert "empty choices" in str(exc.value)


### PR DESCRIPTION
## Summary
- raise an LLMError when OpenAI returns an empty choices list
- add a unit test covering the empty-choices path

Fixes #396

## Tests
- python -m pytest tests/test_openai_provider.py tests/test_claude_provider.py -q
- python -m compileall src/llm/providers/openai.py tests/test_openai_provider.py
- git diff --check

## Notes
- python -m pytest tests -q currently fails on an existing hooks test expecting INSAITS_MODEL=egc-custom while the monitor sends gemini-2.5-pro; this is unrelated to the OpenAI provider change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `LLMError` when OpenAI returns an empty `choices` list so callers get a clear provider-tagged error instead of indexing `choices[0]`. Adds a unit test and defines a `unit` marker in `pytest.ini` to align tests with `pytest` (fixes #396).

<sup>Written for commit f30f2c121f85922f20af5dfbeffdce00284ae0ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for OpenAI API responses. The system now gracefully handles edge cases when the API returns empty data, providing clear error messages instead of unexpected system failures. This enhancement ensures better stability and debugging visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->