### PR TITLE
fix: preserve Claude tool call arguments

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -78,11 +78,12 @@ class ClaudeProvider(LLMProvider):
             tool_calls = None
             if response.content and hasattr(response.content[0], "type"):
                 if response.content[0].type == "tool_use":
+                    tool_input = getattr(response.content[0], "input", {})
                     tool_calls = [
                         ToolCall(
                             id=getattr(response.content[0], "id", ""),
                             name=getattr(response.content[0], "name", ""),
-                            arguments=getattr(response.content[0].input, "__dict__", {}),
+                            arguments=dict(tool_input) if isinstance(tool_input, dict) else {},
                         )
                     ]
 

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -48,16 +48,11 @@ class TestClaudeProviderContentExtraction(unittest.TestCase):
         return block
 
     def _tool_block(self, name="some_tool", tool_id="call_1"):
-        class _Input:
-            pass
-        inp = _Input()
-        inp.__dict__ = {"key": "value"}
-
         block = MagicMock()
         block.type = "tool_use"
         block.id = tool_id
         block.name = name
-        block.configure_mock(input=inp)
+        block.configure_mock(input={"key": "value"})
         return block
 
     def test_text_block_returns_text_content(self):
@@ -75,6 +70,7 @@ class TestClaudeProviderContentExtraction(unittest.TestCase):
         result = self.provider.generate(_simple_input())
         self.assertEqual(result.content, "")
         self.assertIsNotNone(result.tool_calls)
+        self.assertEqual(result.tool_calls[0].arguments, {"key": "value"})
 
     def test_tool_use_then_text_extracts_text(self):
         """Text after a tool_use block must be returned, not skipped."""


### PR DESCRIPTION
## Summary
- preserve Claude tool call arguments when Anthropic returns dict inputs
- update the Claude provider regression test to use dict input and assert arguments are retained

Fixes #399

## Tests
- `python -m pytest tests/test_claude_provider.py -q`
- `python -m compileall src/llm/providers/claude.py tests/test_claude_provider.py`
- `git diff --check`

## Notes
- `python -m pytest tests -q` still fails in `tests/hooks/test_insaits_security_monitor.py::test_clean_scan_writes_audit_and_uses_environment_options`; it expects `llm_id` from `INSAITS_MODEL=egc-custom`, but the current code sends `gemini-2.5-pro`. This appears unrelated to the Claude provider change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve Claude tool call arguments when Anthropic returns dict inputs, so `ToolCall.arguments` is populated correctly. Updated `tests/test_claude_provider.py` to send a dict and assert the arguments are preserved (fixes #399).

<sup>Written for commit 395966d99565286558135deadb27283ac2aa2912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

