### PR TITLE
fix: handle empty Gemini message content

### DIFF
--- a/src/llm/providers/gemini.py
+++ b/src/llm/providers/gemini.py
@@ -168,7 +168,7 @@ class GeminiProvider(LLMProvider):
                             args=tc.arguments
                         ))
                 else:
-                    parts.append(types.Part.from_text(text=msg.content))
+                    parts.append(types.Part.from_text(text=msg.content or ""))
                     
                 if parts:
                     contents.append(types.Content(role=gemini_role, parts=parts))

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,0 +1,64 @@
+"""Tests for GeminiProvider message handling."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from llm.core.types import LLMInput, Message, Role
+from llm.providers import gemini as gemini_module
+from llm.providers.gemini import GeminiProvider
+
+
+class _PartStub:
+    @staticmethod
+    def from_text(text: str | None) -> SimpleNamespace:
+        if text is None:
+            raise TypeError("argument of type 'NoneType' is not iterable")
+        return SimpleNamespace(text=text, function_call=None)
+
+
+class _TypesStub:
+    Part = _PartStub
+    Content = SimpleNamespace
+    GenerateContentConfig = SimpleNamespace
+
+
+def _gemini_response() -> SimpleNamespace:
+    part = SimpleNamespace(text="ok", function_call=None)
+    content = SimpleNamespace(parts=[part])
+    candidate = SimpleNamespace(content=content, finish_reason="STOP")
+    return SimpleNamespace(
+        candidates=[candidate],
+        usage_metadata=None,
+    )
+
+
+class TestGeminiProviderMessageHandling(unittest.TestCase):
+    def setUp(self) -> None:
+        self._patch = patch.object(gemini_module, "types", _TypesStub)
+        self._patch.start()
+        self.provider = GeminiProvider.__new__(GeminiProvider)
+        self.provider.client = MagicMock()
+        self.provider.client.models.generate_content.return_value = _gemini_response()
+        self.provider._fallback_chain = {}
+        self.provider._models = []
+
+    def tearDown(self) -> None:
+        self._patch.stop()
+
+    def test_none_content_is_sent_as_empty_text(self) -> None:
+        result = self.provider.generate(
+            LLMInput(
+                messages=[Message(role=Role.ASSISTANT, content=None)],
+                model="gemini-2.5-pro",
+                temperature=None,
+            )
+        )
+
+        call_kwargs = self.provider.client.models.generate_content.call_args.kwargs
+        self.assertEqual(call_kwargs["contents"][0].parts[0].text, "")
+        self.assertEqual(result.content, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- treat `None` message content as an empty string before building Gemini text parts
- add a focused GeminiProvider regression test for assistant messages with `content=None`

Fixes #392

## Tests
- `python -m pytest tests/test_gemini_provider.py tests/test_claude_provider.py -q`
- `python -m compileall src/llm/providers/gemini.py tests/test_gemini_provider.py`
- `git diff --check`

## Notes
- `python -m pytest tests -q` still fails in `tests/hooks/test_insaits_security_monitor.py::test_clean_scan_writes_audit_and_uses_environment_options`; it expects `llm_id` from `INSAITS_MODEL=egc-custom`, but the current code sends `gemini-2.5-pro`. This appears unrelated to the Gemini provider change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle `None` assistant message content in `GeminiProvider` by sending an empty string to prevent crashes when building text parts. Adds a regression test to ensure `None` content serializes to empty text.

<sup>Written for commit 1d4b5e7480eca7c0738acc937d8ba497ad9db62e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

