### PR TITLE
fix: handle missing Ollama temperature

### DIFF
--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -64,7 +64,7 @@ class OllamaProvider(LLMProvider):
                 "messages": [msg.to_dict() for msg in input.messages],
                 "stream": False,
             }
-            if abs(input.temperature - 1.0) > 1e-9:
+            if input.temperature is not None and abs(input.temperature - 1.0) > 1e-9:
                 payload["options"] = {"temperature": input.temperature}
 
             data = json.dumps(payload).encode("utf-8")

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,0 +1,52 @@
+"""Tests for OllamaProvider request payload handling."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from llm.core.types import LLMInput, Message, Role
+from llm.providers.ollama import OllamaProvider
+
+
+class _Response:
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(
+            {
+                "message": {"content": "ok"},
+                "prompt_eval_count": 1,
+                "eval_count": 2,
+                "done_reason": "stop",
+            }
+        ).encode("utf-8")
+
+
+class TestOllamaProviderPayload(unittest.TestCase):
+    def test_none_temperature_omits_options(self) -> None:
+        provider = OllamaProvider(
+            base_url="http://localhost:11434",
+            default_model="llama3",
+        )
+
+        with patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            result = provider.generate(
+                LLMInput(
+                    messages=[Message(role=Role.USER, content="hi")],
+                    model="llama3",
+                    temperature=None,
+                )
+            )
+
+        request = urlopen.call_args.args[0]
+        payload = json.loads(request.data.decode("utf-8"))
+        self.assertNotIn("options", payload)
+        self.assertEqual(result.content, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip the Ollama temperature options block when `LLMInput.temperature` is `None`
- add a focused OllamaProvider regression test that verifies no `options` payload is sent for `temperature=None`

Fixes #391

## Tests
- `python -m pytest tests/test_ollama_provider.py tests/test_claude_provider.py -q`
- `python -m compileall src/llm/providers/ollama.py tests/test_ollama_provider.py`
- `git diff --check`

## Notes
- `python -m pytest tests -q` still fails in `tests/hooks/test_insaits_security_monitor.py::test_clean_scan_writes_audit_and_uses_environment_options`; it expects `llm_id` from `INSAITS_MODEL=egc-custom`, but the current code sends `gemini-2.5-pro`. This appears unrelated to the Ollama provider change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip sending the Ollama `options` block when `LLMInput.temperature` is None to avoid invalid request payloads (fixes #391).

- **Bug Fixes**
  - Guard adding `options` in `OllamaProvider.generate` with `temperature is not None` and `abs(temperature - 1.0) > 1e-9`.
  - Added `tests/test_ollama_provider.py` to assert the payload omits `options` and returns expected content.

<sup>Written for commit df5a7f28aaf71c530e6c71f2d83a29453940475a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

