### PR TITLE
fix: collect all Claude tool calls

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -75,17 +75,20 @@ class ClaudeProvider(LLMProvider):
 
             response = self.client.messages.create(**params)
 
-            tool_calls = None
-            if response.content and hasattr(response.content[0], "type"):
-                if response.content[0].type == "tool_use":
-                    tool_input = getattr(response.content[0], "input", {})
-                    tool_calls = [
-                        ToolCall(
-                            id=getattr(response.content[0], "id", ""),
-                            name=getattr(response.content[0], "name", ""),
-                            arguments=dict(tool_input) if isinstance(tool_input, dict) else {},
-                        )
-                    ]
+            tool_calls = []
+            for block in response.content:
+                if getattr(block, "type", None) != "tool_use":
+                    continue
+                tool_input = getattr(block, "input", {})
+                tool_calls.append(
+                    ToolCall(
+                        id=getattr(block, "id", ""),
+                        name=getattr(block, "name", ""),
+                        arguments=dict(tool_input) if isinstance(tool_input, dict) else {},
+                    )
+                )
+            if not tool_calls:
+                tool_calls = None
 
             content = next(
                 (block.text for block in response.content if block.type == "text"),

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -47,12 +47,12 @@ class TestClaudeProviderContentExtraction(unittest.TestCase):
         block.text = text
         return block
 
-    def _tool_block(self, name="some_tool", tool_id="call_1"):
+    def _tool_block(self, name="some_tool", tool_id="call_1", arguments=None):
         block = MagicMock()
         block.type = "tool_use"
         block.id = tool_id
         block.name = name
-        block.configure_mock(input={"key": "value"})
+        block.configure_mock(input=arguments or {"key": "value"})
         return block
 
     def test_text_block_returns_text_content(self):
@@ -79,6 +79,25 @@ class TestClaudeProviderContentExtraction(unittest.TestCase):
         )
         result = self.provider.generate(_simple_input())
         self.assertEqual(result.content, "done")
+
+    def test_multiple_tool_use_blocks_are_collected(self):
+        self.provider.client.messages.create.return_value = self._make_response(
+            [
+                self._tool_block("first_tool", "call_1", {"first": "value"}),
+                self._tool_block("second_tool", "call_2", {"second": "value"}),
+            ],
+            stop_reason="tool_use",
+        )
+        result = self.provider.generate(_simple_input())
+        self.assertIsNotNone(result.tool_calls)
+        self.assertEqual(
+            [tc.name for tc in result.tool_calls],
+            ["first_tool", "second_tool"],
+        )
+        self.assertEqual(
+            [tc.arguments for tc in result.tool_calls],
+            [{"first": "value"}, {"second": "value"}],
+        )
 
     def test_empty_content_returns_empty_string(self):
         self.provider.client.messages.create.return_value = self._make_response([])


### PR DESCRIPTION
## Summary
- collect every Claude `tool_use` block instead of only inspecting `response.content[0]`
- keep dict-based tool arguments from the Anthropic SDK response shape
- add a regression test for two consecutive Claude tool calls

Fixes #397

## Tests
- `python -m pytest tests/test_claude_provider.py -q`
- `python -m compileall src/llm/providers/claude.py tests/test_claude_provider.py`
- `git diff --check`

## Notes
- `python -m pytest tests -q` still fails in `tests/hooks/test_insaits_security_monitor.py::test_clean_scan_writes_audit_and_uses_environment_options`; it expects `llm_id` from `INSAITS_MODEL=egc-custom`, but the current code sends `gemini-2.5-pro`. This appears unrelated to the Claude provider change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collect all Claude `tool_use` blocks and return them as multiple tool calls. Prevents missed calls when Claude emits more than one; fixes #397.

- **Bug Fixes**
  - Iterate over all `response.content` blocks and append each `tool_use` to `tool_calls`; set to None when none found.
  - Preserve dict-shaped tool arguments from the SDK.
  - Add a regression test for two consecutive tool calls.

<sup>Written for commit d4a28763a2c1aed861084ce0e47cc25eed062b7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

