### PR TITLE
fix(gemini): replace bare except with specific exceptions

### DIFF
--- a/src/llm/providers/gemini.py
+++ b/src/llm/providers/gemini.py
@@ -155,7 +155,7 @@ class GeminiProvider(LLMProvider):
                 if role == "tool" and msg.tool_call_id:
                     try:
                         resp_data = json.loads(msg.content)
-                    except:
+                    except (json.JSONDecodeError, ValueError):
                         resp_data = {"result": msg.content}
                     parts.append(types.Part.from_function_response(
                         name=msg.name or "unknown_tool",


### PR DESCRIPTION
Fixes #409 

## What Changed
- Replaced bare `except:` with `except (json.JSONDecodeError, ValueError)`

## Why
- Catches only JSON-related errors
- Allows KeyboardInterrupt to pass through
- Improves error visibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the bare `except:` in the Gemini provider with explicit handling for `json.JSONDecodeError` and `ValueError` when parsing tool responses. This prevents swallowing unrelated exceptions (e.g., KeyboardInterrupt) and improves JSON error visibility.

<sup>Written for commit 231945f9ac3be0f02e4c700053165e5fd30ea983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when parsing JSON responses from AI models to increase reliability and reduce unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->