### PR TITLE
docs(i18n): fix translator avatars side by side, restore es translator

### DIFF
--- a/translations/ar/README.md
+++ b/translations/ar/README.md
@@ -127,11 +127,7 @@ npx @egchq/egc install
 
 **الداعمون**
 
-<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="48" height="48" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
-
-**المترجم**
-
-<a href="https://github.com/muhammadhasnain3031"><img src="https://avatars.githubusercontent.com/u/262106526?v=4" width="48" height="48" alt="@muhammadhasnain3031" title="@muhammadhasnain3031 — Arabic translation" /></a>
+<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="48" height="48" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a> <a href="https://github.com/muhammadhasnain3031"><img src="https://avatars.githubusercontent.com/u/262106526?v=4" width="48" height="48" alt="@muhammadhasnain3031" title="@muhammadhasnain3031 — Arabic translation" /></a>
 
 **الرعاة الشهريون** · _كن الأول_
 

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -137,7 +137,7 @@ El apoyo de la comunidad mantiene este proyecto vivo e independiente.
 
 **Colaboradores**
 
-<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="48" height="48" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
+<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="48" height="48" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a> <a href="https://github.com/ayushikaul02"><img src="https://avatars.githubusercontent.com/u/212903502?v=4" width="48" height="48" alt="@ayushikaul02" title="@ayushikaul02 — Spanish translation" /></a>
 
 **Patrocinadores mensuales** · _sé el primero_
 


### PR DESCRIPTION
- Arabic README: sponsor and translator avatars now side by side on same line (removed separate heading)
- Spanish README: restore @ayushikaul02 avatar next to sponsor (was wrongly removed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned sponsor and translator avatars side by side in the Arabic README and restored the Spanish translator avatar next to the sponsor for a consistent docs layout across i18n pages.

<sup>Written for commit beb79c17d166467c1e1df73f238d12f0a4006c69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

