### PR TITLE
fix(gemini): replace bare except with specific exceptions

### DIFF
--- a/src/llm/providers/gemini.py
+++ b/src/llm/providers/gemini.py
@@ -155,7 +155,7 @@ class GeminiProvider(LLMProvider):
                 if role == "tool" and msg.tool_call_id:
                     try:
                         resp_data = json.loads(msg.content)
-                    except:
+                    except (json.JSONDecodeError, ValueError):
                         resp_data = {"result": msg.content}
                     parts.append(types.Part.from_function_response(
                         name=msg.name or "unknown_tool",


### PR DESCRIPTION
Replaces bare `except:` with `except (json.JSONDecodeError, ValueError):` in `GeminiProvider` tool result parsing to avoid silently swallowing `KeyboardInterrupt` and `SystemExit`.

Closes #409

Co-authored-by: ayushikaul <ayushikaul555@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit exception handling when parsing tool responses in `GeminiProvider` to `json.JSONDecodeError` and `ValueError`. This prevents swallowing `KeyboardInterrupt` and `SystemExit`, keeping interrupts and exits working as expected.

<sup>Written for commit 5028995407aa14d87e1988170d106bab52ff82e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

