### PR TITLE
docs(i18n): add Hindi to all language selectors, add translator credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Language:** English | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [Português (Brasil)](translations/pt/README.md)
+**Language:** English | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [Português (Brasil)](translations/pt/README.md) | [हिन्दी](translations/hi/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -13,7 +13,7 @@
 
 **Language / اللغة / Idioma**
 
-[**English**](README.md) | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [Português (Brasil)](translations/pt/README.md)
+[**English**](README.md) | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [Português (Brasil)](translations/pt/README.md) | [हिन्दी](translations/hi/README.md)
 
 </div>
 <!-- CENTERED-LANGUAGE-SELECTOR-END -->

--- a/translations/ar/README.md
+++ b/translations/ar/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**اللغة:** [English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **العربية**
+**اللغة:** [English](../../README.md) | **العربية** | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [हिन्दी](../hi/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -13,7 +13,7 @@
 
 **اللغة / Idioma**
 
-[English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [**العربية**](README.md)
+[English](../../README.md) | [**العربية**](README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [हिन्दी](../hi/README.md)
 
 </div>
 <!-- CENTERED-LANGUAGE-SELECTOR-END -->

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Idioma:** [English](../../README.md) | [العربية](../ar/README.md) | **Español** | [Português (Brasil)](../pt/README.md)
+**Idioma:** [English](../../README.md) | [العربية](../ar/README.md) | **Español** | [Português (Brasil)](../pt/README.md) | [हिन्दी](../hi/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">

--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**भाषा:** [English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [العربية](../ar/README.md) | **हिन्दी**
+**भाषा:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **हिन्दी**
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -13,7 +13,7 @@
 
 **Language / भाषा**
 
-[English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [العربية](../ar/README.md) | **हिन्दी**
+[English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **हिन्दी**
 
 </div>
 <!-- CENTERED-LANGUAGE-SELECTOR-END -->

--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**भाषा:** [English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **हिन्दी**
+**भाषा:** [English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [العربية](../ar/README.md) | **हिन्दी**
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -13,7 +13,7 @@
 
 **Language / भाषा**
 
-[English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **हिन्दी**
+[English](../../README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [العربية](../ar/README.md) | **हिन्दी**
 
 </div>
 <!-- CENTERED-LANGUAGE-SELECTOR-END -->
@@ -127,7 +127,7 @@ EGC एक डेवलपर द्वारा बनाया गया ह�
 
 **समर्थक (Backers)**
 
-<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="48" height="48" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
+<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="48" height="48" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a> <a href="https://github.com/muhammadhasnain3031"><img src="https://avatars.githubusercontent.com/u/262106526?v=4" width="48" height="48" alt="@muhammadhasnain3031" title="@muhammadhasnain3031 — Hindi translation" /></a>
 
 **मासिक प्रायोजक** · _पहले बनें_
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Idioma:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | **Português (Brasil)**
+**Idioma:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | **Português (Brasil)** | [हिन्दी](../hi/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">


### PR DESCRIPTION
## Summary

Follow-up to #419 (Hindi README by @muhammadhasnain3031).

- Added Hindi to language selectors in all files: main README, Arabic, Spanish, and Portuguese translations
- Fixed Arabic selector order (was at the end, now consistent: English | Arabic | Spanish | Portuguese | Hindi)
- Fixed Hindi selector order to match canonical order
- Added @muhammadhasnain3031 translator avatar in the backers section of the Hindi README

## Files changed

- `README.md`: added Hindi to both selectors
- `translations/ar/README.md`: added Hindi, fixed Arabic position in selector
- `translations/es/README.md`: added Hindi
- `translations/pt/README.md`: added Hindi
- `translations/hi/README.md`: fixed selector order + translator credit

## Credit

Translation contributed by @muhammadhasnain3031 in #419.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README language support by adding English as an available option and including a Hindi translation link in the language selector sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->