### PR TITLE
docs(i18n): fix centered language selector title in Arabic and Hindi READMEs

### DIFF
--- a/translations/ar/README.md
+++ b/translations/ar/README.md
@@ -11,7 +11,7 @@
 <!-- CENTERED-LANGUAGE-SELECTOR-START -->
 <div align="center">
 
-**اللغة / Idioma**
+**Language / اللغة / Idioma / भाषा**
 
 [English](../../README.md) | [**العربية**](README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | [हिन्दी](../hi/README.md)
 

--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -11,7 +11,7 @@
 <!-- CENTERED-LANGUAGE-SELECTOR-START -->
 <div align="center">
 
-**Language / भाषा**
+**Language / اللغة / Idioma / भाषा**
 
 [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **हिन्दी**
 


### PR DESCRIPTION
## Summary

Fixes the centered language selector title in translation files to include all languages consistently.

- `translations/ar/README.md`: `اللغة / Idioma` -> `Language / اللغة / Idioma / भाषा`
- `translations/hi/README.md`: `Language / भाषा` -> `Language / اللغة / Idioma / भाषा`

The main README.md title is being updated by the sync workflow in #423.

After this PR, the centered selector title is identical across all files that have a centered selector.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the centered language selector title in the Arabic and Hindi READMEs to "Language / اللغة / Idioma / भाषा" to match other translations and keep the docs consistent.

<sup>Written for commit 00d7dde20a4db6d8e1016f5045dc2e02a927599f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

