### PR TITLE
fix(selector): only catch ImportError when importing ModelResolver

### DIFF
--- a/src/llm/cli/selector.py
+++ b/src/llm/cli/selector.py
@@ -8,9 +8,8 @@ from enum import Enum
 
 try:
     from llm.core.model_resolver import ModelResolver
-except Exception:  # pragma: no cover - selector still works standalone
+except ImportError:  # pragma: no cover - selector still works standalone
     ModelResolver = None  # type: ignore[assignment]
-
 
 class Color(str, Enum):
     RESET = "\033[0m"


### PR DESCRIPTION
## What Changed
- Replaced the broad `except Exception` guard when importing `ModelResolver` with `except ImportError`.
- Preserved the existing fallback behavior when `ModelResolver` is unavailable.
- Prevented unrelated runtime/import errors from being silently swallowed.

## Why This Change
The selector is intended to work standalone when `ModelResolver` is not installed. However, using `except Exception` also hides genuine errors such as `NameError`, `AttributeError`, and other import-time failures inside `model_resolver.py`.

Restricting the exception handler to `ImportError` ensures that real bugs surface properly while still allowing the standalone fallback behavior.

Fixes #418

## Testing Done
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

Note: `node tests/run-all.js` was executed locally. The repository currently reports existing test failures (`124 failed`) that appear unrelated to this change.
<img width="1920" height="1080" alt="Screenshot (441)" src="https://github.com/user-attachments/assets/1edb405d-6cc5-42e6-8987-fec6e1ae7f08" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit the selector’s import guard to only catch ImportError when importing `ModelResolver`. Preserves the standalone fallback when `ModelResolver` isn’t installed and lets real import-time errors surface instead of being swallowed.

<sup>Written for commit baa37232222f29e08c7f42e07a80901597103166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling to provide more specific feedback when import-related issues occur, enabling better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->