### PR TITLE
fix: handle null text in ClaudeProvider content extraction

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -91,7 +91,7 @@ class ClaudeProvider(LLMProvider):
                 tool_calls = None
 
             content = next(
-                (block.text for block in response.content if block.type == "text"),
+                (block.text or "" for block in response.content if block.type == "text"),
                 "",
             )
 


### PR DESCRIPTION
﻿## Description

When the Anthropic SDK returns a text block with 	ext=None in edge cases (empty streaming responses, partial responses), content was set to None instead of an empty string. This breaks downstream code that expects a string.

## Fix

Changed lock.text to lock.text or "" on line 94 of src/llm/providers/claude.py, following the same defensive pattern already used on lines 85-86 (getattr(block, "id", "")).

## Testing

All 5 existing tests pass.

Closes #428

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes content extraction in `ClaudeProvider` by treating null text blocks from the Anthropic SDK as empty strings. Prevents crashes when downstream code expects a string.

- **Bug Fixes**
  - Use `(block.text or "")` when selecting the first text block (covers empty streaming/partial responses).

<sup>Written for commit 6698c33e4a0932419246b94f53b1bc872355a707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing text content in API responses, ensuring empty strings are returned consistently instead of null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->