### PR TITLE
fix: handle null message in OllamaProvider content extraction

### DIFF
--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -73,10 +73,10 @@ class OllamaProvider(LLMProvider):
             with urllib.request.urlopen(req, timeout=60) as response:
                 result = json.loads(response.read().decode("utf-8"))
 
-            content = result.get("message", {}).get("content", "")
+            content = (result.get("message") or {}).get("content", "")
 
             tool_calls = None
-            if result.get("message", {}).get("tool_calls"):
+            if (result.get("message") or {}).get("tool_calls"):
                 tool_calls = [
                     ToolCall(
                         id=tc.get("id", ""),


### PR DESCRIPTION
﻿## Description

When the Ollama API returns {"message": null}, esult.get("message", {}) returns None instead of {} because the key *exists* but is null. This causes AttributeError: 'NoneType' has no attribute 'get' on both:

1. Line 76 - content extraction: .get("content", "")
2. Line 79 - tool_calls check: .get("tool_calls")

## Fix

Changed both lines from esult.get("message", {}) to (result.get("message") or {}), which safely falls back to an empty dict even when the value is None.

## Testing

Existing test passes:
`
tests/test_ollama_provider.py::TestOllamaProviderPayload::test_none_temperature_omits_options PASSED
`

Closes #427


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `OllamaProvider.generate` when the API returns `{"message": null}` by defaulting `message` to `{}`. Content and `tool_calls` extraction now safely handle a null `message` without raising `AttributeError`.

<sup>Written for commit 30d34d94a918f10e1f40cebd56f32661fbc8c275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of LLM provider response handling to gracefully manage edge cases in result data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->