### PR TITLE
fix: handle null message/text in Ollama and Claude providers

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -91,7 +91,7 @@ class ClaudeProvider(LLMProvider):
                 tool_calls = None
 
             content = next(
-                (block.text for block in response.content if block.type == "text"),
+                (block.text or "" for block in response.content if block.type == "text"),
                 "",
             )
 

--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -73,17 +73,18 @@ class OllamaProvider(LLMProvider):
             with urllib.request.urlopen(req, timeout=60) as response:
                 result = json.loads(response.read().decode("utf-8"))
 
-            content = result.get("message", {}).get("content", "")
+            message = result.get("message") or {}
+            content = message.get("content", "")
 
             tool_calls = None
-            if result.get("message", {}).get("tool_calls"):
+            if message.get("tool_calls"):
                 tool_calls = [
                     ToolCall(
                         id=tc.get("id", ""),
                         name=tc.get("function", {}).get("name", ""),
                         arguments=tc.get("function", {}).get("arguments", {}),
                     )
-                    for tc in result["message"]["tool_calls"]
+                    for tc in message["tool_calls"]
                 ]
 
             prompt_tokens = result.get("prompt_eval_count", 0)


### PR DESCRIPTION
## Description

- **OllamaProvider**: extract message dict with null-safe fallback to fix AttributeError when API returns `{"message": null}` and reduce cognitive complexity (fixes #427)
- **ClaudeProvider**: add defensive `or ""` for `block.text` to handle null text in streaming/partial responses (fixes #428)

Co-authored-by: vasu-sachdeva <vasu.sachdeva@example.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes when Ollama or Claude return null fields by adding null-safe fallbacks and default empty strings. This stabilizes content parsing and tool call extraction in both providers.

- **Bug Fixes**
  - Ollama: use `message = result.get("message") or {}` and read `content`/`tool_calls` from it to avoid AttributeError when `message` is null (fixes #427).
  - Claude: use `block.text or ""` when assembling content to handle null text in streaming/partial responses (fixes #428).

<sup>Written for commit edf62d2f3b2e992c9e08b18ff084a9b5fdb56904. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in Claude provider for incomplete text responses.
  * Enhanced Ollama provider resilience when processing responses with missing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->