### PR TITLE
fix: handle null message in OllamaProvider content extraction

### DIFF
--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -73,17 +73,18 @@ class OllamaProvider(LLMProvider):
             with urllib.request.urlopen(req, timeout=60) as response:
                 result = json.loads(response.read().decode("utf-8"))
 
-            content = result.get("message", {}).get("content", "")
+            message = result.get("message") or {}
+            content = message.get("content", "")
 
             tool_calls = None
-            if result.get("message", {}).get("tool_calls"):
+            if message.get("tool_calls"):
                 tool_calls = [
                     ToolCall(
                         id=tc.get("id", ""),
                         name=tc.get("function", {}).get("name", ""),
                         arguments=tc.get("function", {}).get("arguments", {}),
                     )
-                    for tc in result["message"]["tool_calls"]
+                    for tc in message["tool_calls"]
                 ]
 
             prompt_tokens = result.get("prompt_eval_count", 0)


### PR DESCRIPTION
## Description

When Ollama API returns `{"message": null}`, `result.get("message", {})` returns `None` (not `{}`) because the key exists but its value is `null`. This caused `AttributeError` on subsequent `.get()` calls for both content and tool_calls.

## Fix

Extract `message` once with a null-safe fallback and reuse it, which also brings cognitive complexity back within the SonarCloud limit (15).

Fixes #427

---

Credit: this fix was originally submitted by @vasu-sachdeva in #431.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes in the Ollama provider when the API returns {"message": null} by null-safely extracting and reusing the `message` object. Fixes #427.

- **Bug Fixes**
  - Extract `message = result.get("message") or {}` once in `generate`, then read `content` and `tool_calls` from it.
  - Removes the AttributeError and reduces cognitive complexity within SonarCloud limits.

<sup>Written for commit 3e1214a608d2763634f55df2aa3ea9324b222468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

