### PR TITLE
feat: EGC Dashboard -- window controls, egc dashboard command and egc init auto-start

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -15,7 +15,19 @@
         "description": "Persist session state and evaluate patterns"
       }
     ],
+    "beforeFileEdit": [
+      {
+        "command": "EGC_HOOK_EVENT=pre_tool node .cursor/hooks/dashboard-emit.js",
+        "event": "beforeFileEdit",
+        "description": "Emit pre-edit event to EGC Dashboard"
+      }
+    ],
     "beforeShellExecution": [
+      {
+        "command": "EGC_HOOK_EVENT=pre_tool node .cursor/hooks/dashboard-emit.js",
+        "event": "beforeShellExecution",
+        "description": "Emit pre-bash event to EGC Dashboard"
+      },
       {
         "command": "npx block-no-verify@1.1.2",
         "event": "beforeShellExecution",
@@ -29,12 +41,22 @@
     ],
     "afterShellExecution": [
       {
+        "command": "EGC_HOOK_EVENT=post_tool node .cursor/hooks/dashboard-emit.js",
+        "event": "afterShellExecution",
+        "description": "Emit post-bash event to EGC Dashboard"
+      },
+      {
         "command": "node .cursor/hooks/after-shell-execution.js",
         "event": "afterShellExecution",
         "description": "PR URL logging, build analysis"
       }
     ],
     "afterFileEdit": [
+      {
+        "command": "EGC_HOOK_EVENT=post_tool node .cursor/hooks/dashboard-emit.js",
+        "event": "afterFileEdit",
+        "description": "Emit post-edit event to EGC Dashboard"
+      },
       {
         "command": "node .cursor/hooks/after-file-edit.js",
         "event": "afterFileEdit",

--- a/.cursor/hooks/dashboard-emit.js
+++ b/.cursor/hooks/dashboard-emit.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict';
+
+const { readStdin } = require('./adapter');
+const http = require('http');
+
+readStdin().then(raw => {
+  try {
+    const input = JSON.parse(raw || '{}');
+    const event = process.env.EGC_HOOK_EVENT || 'pre_tool';
+    const tool  = input.tool || input.tool_name || '';
+    const file  = input.path || input.file || input.file_path || input.command || '';
+    const agent = 'main';
+
+    const ev = JSON.stringify({ ide:'cursor', event, tool, agent, detail:file, status: event==='pre_tool'?'running':'success' });
+    const req = http.request(
+      { hostname:'127.0.0.1', port:7890, path:'/event', method:'POST',
+        headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(ev)},
+        timeout:300 },
+      ()=>{}
+    );
+    req.on('error', ()=>{});
+    req.on('timeout', ()=>req.destroy());
+    req.end(ev);
+  } catch(_) {}
+  process.stdout.write(raw || '');
+}).catch(()=>{});

--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -1,0 +1,22 @@
+---
+description: EGC project memory (auto-updated by update_state)
+alwaysApply: true
+---
+
+## EGC Project Memory
+
+**Context:** EGC main estavel. PR #441 feat/dashboard-integration aberto com dashboard completo + botoes min/max/close + egc dashboard command + egc init auto-start. Fix de lint pushado, CI rodando.
+
+**Active decisions:**
+- PR #441 aberto: dashboard no repo EGC com 4 features integradas
+- scripts/dashboard.js: novo comando egc dashboard com start/stop/status
+- scripts/init.js: auto-start do dashboard apos egc init
+- Botoes min/max/close no header do dashboard
+- Fix lint: empty catch blocks em dashboard.js precisam de comentario
+
+**Next session:**
+- Aguardar CI do PR #441 ficar verde e mergear
+- Verificar reviews do CodeRabbit/cubic no PR #441
+- Anunciar dashboard no Discord quando PR #441 mergear
+- Versao 1.1.2 beta: nao publicar no npm sem autorizacao do Felipe
+- Issues #438 #439 #440: aguardar contributors testarem o dashboard

--- a/.kiro/hooks/dashboard-emit.kiro.hook
+++ b/.kiro/hooks/dashboard-emit.kiro.hook
@@ -1,0 +1,15 @@
+{
+  "name": "dashboard-emit-pre",
+  "version": "1.0.0",
+  "enabled": true,
+  "description": "Emit pre-tool events to EGC Dashboard at localhost:7890",
+  "when": {
+    "type": "preToolUse",
+    "toolTypes": ["*"]
+  },
+  "then": {
+    "type": "runCommand",
+    "command": "node -e \"const h=require('http'),b=JSON.stringify({ide:'kiro',event:'pre_tool',tool:process.env.KIRO_TOOL_NAME||'',agent:'main',detail:process.env.KIRO_HOOK_FILE||'',status:'running'});const r=h.request({hostname:'127.0.0.1',port:7890,path:'/event',method:'POST',headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(b)},timeout:300},()=>{});r.on('error',()=>{});r.end(b);\"",
+    "timeout": 1
+  }
+}

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -148,6 +148,16 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
       input: { tool: string; callID?: string; args?: { filePath?: string; file_path?: string; path?: string } },
       output: unknown
     ) => {
+      // Emit to EGC Dashboard
+      try {
+        const http = await import("http")
+        const tool = input.tool.charAt(0).toUpperCase() + input.tool.slice(1)
+        const body = JSON.stringify({ ide:"opencode", event:"post_tool", tool, agent:"main", status:"success" })
+        const req = http.default.request({ hostname:"127.0.0.1", port:7890, path:"/event", method:"POST", headers:{"Content-Type":"application/json","Content-Length":Buffer.byteLength(body)}, timeout:300 }, ()=>{})
+        req.on("error", ()=>{})
+        req.end(body)
+      } catch(_) {}
+
       const filePath = getFilePath(input.args as Record<string, unknown>)
       if (input.tool === "edit" && filePath) {
         recordChange(filePath, "modified")
@@ -203,6 +213,17 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
     "tool.execute.before": async (
       input: { tool: string; callID?: string; args?: Record<string, unknown> }
     ) => {
+      // Emit to EGC Dashboard
+      try {
+        const http = await import("http")
+        const detail = (input.args?.filePath ?? input.args?.file_path ?? input.args?.path ?? input.args?.command ?? "") as string
+        const tool = input.tool.charAt(0).toUpperCase() + input.tool.slice(1)
+        const body = JSON.stringify({ ide:"opencode", event:"pre_tool", tool, agent:"main", detail, status:"running" })
+        const req = http.default.request({ hostname:"127.0.0.1", port:7890, path:"/event", method:"POST", headers:{"Content-Type":"application/json","Content-Length":Buffer.byteLength(body)}, timeout:300 }, ()=>{})
+        req.on("error", ()=>{})
+        req.end(body)
+      } catch(_) {}
+
       if (input.tool === "write") {
         const filePath = getFilePath(input.args)
         if (filePath) {

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+config.json
+*.pid

--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -1,0 +1,521 @@
+---
+version: alpha
+name: Voltagent-design-analysis
+description: An inspired interpretation of Voltagent's design language — a developer-focused AI agent engineering platform whose surface is an unrelenting near-black canvas broken only by a single electric-green brand accent, code-editor mockups inside the hero, and a precise grid of dark feature cards that read like a documentation site dressed as marketing.
+
+colors:
+  primary: "#00d992"
+  primary-soft: "#2fd6a1"
+  primary-deep: "#10b981"
+  on-primary: "#101010"
+  ink: "#f2f2f2"
+  ink-strong: "#ffffff"
+  body: "#bdbdbd"
+  mute: "#8b949e"
+  hairline: "#3d3a39"
+  hairline-soft: "#b8b3b0"
+  canvas: "#101010"
+  canvas-soft: "#1a1a1a"
+  canvas-text-soft: "#f5f6f7"
+
+typography:
+  display-xl:
+    fontFamily: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif
+    fontSize: 60px
+    fontWeight: 400
+    lineHeight: 60px
+    letterSpacing: -0.65px
+  display-lg:
+    fontFamily: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif
+    fontSize: 36px
+    fontWeight: 400
+    lineHeight: 40px
+    letterSpacing: -0.9px
+  display-md:
+    fontFamily: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif
+    fontSize: 24px
+    fontWeight: 700
+    lineHeight: 32px
+    letterSpacing: -0.6px
+  display-sm:
+    fontFamily: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif
+    fontSize: 20px
+    fontWeight: 600
+    lineHeight: 28px
+  eyebrow-mono:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 14px
+    fontWeight: 600
+    lineHeight: 20px
+    letterSpacing: 2.52px
+  eyebrow-uppercase:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 18px
+    fontWeight: 600
+    lineHeight: 28px
+    letterSpacing: 0.45px
+  body-lg:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 28px
+  body-md:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 26px
+  body-md-strong:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 16px
+    fontWeight: 600
+    lineHeight: 24px
+  body-sm:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 20px
+  body-sm-strong:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 14px
+    fontWeight: 600
+    lineHeight: 23px
+  caption:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 16px
+  caption-strong:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 16px
+  code:
+    fontFamily: SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 18px
+  code-strong:
+    fontFamily: SFMono-Regular, Menlo, Monaco, Consolas, monospace
+    fontSize: 13px
+    fontWeight: 550
+    lineHeight: 16px
+  button-md:
+    fontFamily: Inter, system-ui, -apple-system, sans-serif
+    fontSize: 16px
+    fontWeight: 600
+    lineHeight: 24px
+
+rounded:
+  none: 0px
+  xs: 4px
+  sm: 6px
+  md: 8px
+  pill: 9999px
+  full: 9999px
+
+spacing:
+  xxs: 2px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 20px
+  2xl: 24px
+  3xl: 32px
+  4xl: 40px
+  5xl: 48px
+  6xl: 64px
+
+components:
+  nav-bar:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.md} {spacing.3xl}"
+  nav-link:
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md} {spacing.lg}"
+  button-outline-on-dark:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md} {spacing.lg}"
+  button-ghost-green:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.primary-soft}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md} {spacing.lg}"
+  button-pill-tag:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.pill}"
+    padding: "{spacing.xs} {spacing.md}"
+  text-input:
+    backgroundColor: "{colors.canvas-soft}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md} {spacing.lg}"
+  card-feature:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.2xl}"
+  card-feature-emphasized:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.xl}"
+  code-mockup:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    typography: "{typography.code}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.xl}"
+  code-inline-chip:
+    backgroundColor: "{colors.canvas-soft}"
+    textColor: "{colors.canvas-text-soft}"
+    typography: "{typography.code}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.xxs} {spacing.sm}"
+  hero-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-xl}"
+    padding: "{spacing.5xl} {spacing.3xl}"
+  content-band:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.display-lg}"
+    padding: "{spacing.5xl} {spacing.3xl}"
+  green-divider-band:
+    backgroundColor: "{colors.canvas}"
+    borderColor: "{colors.primary}"
+  footer:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.body}"
+    typography: "{typography.body-sm}"
+    padding: "{spacing.4xl} {spacing.3xl}"
+
+  # ─── Examples (illustrative) — auto-derived; resolve any TO_FILL markers below ───
+  ex-pricing-tier:
+    description: "Default Pricing tier card. Re-uses feature-card chrome with brand canvas-soft surface."
+    backgroundColor: "{colors.canvas-soft}"
+    textColor: "{colors.ink}"
+    borderColor: "{colors.hairline}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.2xl}"
+  ex-pricing-tier-featured:
+    description: "Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode)."
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.2xl}"
+  ex-product-selector:
+    description: "What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery)."
+    backgroundColor: "{colors.canvas-soft}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.2xl}"
+  ex-cart-drawer:
+    description: "Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart)."
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.2xl}"
+    item-divider: "{colors.hairline}"
+  ex-app-shell-row:
+    description: "Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator."
+    backgroundColor: "{colors.canvas}"
+    activeIndicator: "{colors.primary}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md} {spacing.lg}"
+  ex-data-table-cell:
+    description: "Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm."
+    headerBackground: "{colors.canvas-soft}"
+    headerTypography: "{typography.caption}"
+    bodyTypography: "{typography.body-sm}"
+    cellPadding: "{spacing.md} {spacing.lg}"
+    rowBorder: "{colors.hairline}"
+  ex-auth-form-card:
+    description: "Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside."
+    backgroundColor: "{colors.canvas-soft}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.2xl}"
+  ex-modal-card:
+    description: "Modal dialog surface — same chrome as feature-card with elevated shadow."
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.2xl}"
+  ex-empty-state-card:
+    description: "Empty-state illustration frame."
+    backgroundColor: "{colors.canvas-soft}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.3xl}"
+    captionTypography: "{typography.body-md}"
+  ex-toast:
+    description: "Toast notification surface — feature-card shape + medium shadow."
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md} {spacing.lg}"
+    typography: "{typography.body-sm}"
+
+---
+
+
+## Overview
+
+Voltagent is an AI agent engineering platform built for developers, and the brand wears that audience proudly: a near-black `{colors.canvas}` (`#101010`) page background that runs edge-to-edge with no light-mode counterpart, a single electric-green accent (`{colors.primary}` `#00d992`) reserved for CTAs, status pills, and the brand lightning glyph, and a typography system that pairs sentence-case Inter with SF Mono for inline code and command snippets. The whole page reads like polished documentation that decided to also sell something.
+
+The decorative system is restrained. There is no gradient mesh, no atmospheric backdrop, no illustration suite. Instead, the brand uses small typographic moments — a green code chip (`npx voltagent ...`), a 3-px outlined feature card sitting against the same near-black canvas, a green hairline divider between section bands — to mark its identity. The result is a page that feels engineered: every card has a hairline border, every snippet has a copy-to-clipboard button, every metric is rendered in a numeric monospace.
+
+Type stays calm. Hero display sits at 60 px in regular weight with `-0.65 px` tracking — not a billboard headline, more like a documentation H1. Section headings step down to 36 px / 24 px in similar weights. Body copy is 16 px Inter at line-height 1.65 for the kind of legibility long-form devs expect. Uppercase eyebrows are common — `EVERYTHING YOU NEED` style mono-cap labels above section headlines — and they use Inter at weight 600 with wide positive tracking (`2.52 px` at 14 px).
+
+**Key Characteristics:**
+- A single electric-green accent `{colors.primary}` (`#00d992`) carries every CTA, every status pill, and the brand's lightning logo. No second accent.
+- Dark canvas (`{colors.canvas}` `#101010`) is the only page surface — there is no light-mode rhythm; the entire site reads as one continuous dark surface broken by feature-card boundaries.
+- Hairline-bordered feature cards (`{colors.hairline}` `#3d3a39`, 1 px solid) are the brand's primary chrome — no shadows, no fills, just precise hairline rectangles.
+- A signature dashed-border accent (`1px dashed rgba(79, 93, 117, 0.4)`) appears between sections as a quiet rhythm cue — the brand's only ornamental line.
+- Inter + SF Mono pair carries every typographic role. SF Mono is reserved for code blocks, inline command snippets, and metric counters.
+- Buttons are tight 6 px rounded rectangles (not pills); only inline status tags use the 9999 px full pill.
+
+## Colors
+
+### Brand & Accent
+- **Electric Green** (`{colors.primary}` — `#00d992`): The single brand accent. Every primary CTA, every status pill, every "live" indicator, the brand's lightning glyph itself. Reserved.
+- **Primary Soft** (`{colors.primary-soft}` — `#2fd6a1`): A slightly more muted green used inside button-ghost variants and tooltip / focus indicators.
+- **Primary Deep** (`{colors.primary-deep}` — `#10b981`): The darker green used for inline link colour in body copy.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#101010`): The default near-black page background. The only surface mode in the brand's marketing system.
+- **Canvas Soft** (`{colors.canvas-soft}` — `#1a1a1a`): A slightly lighter dark fill used inside code blocks and form inputs to mark them visually distinct against the canvas.
+- **Hairline** (`{colors.hairline}` — `#3d3a39`): 1 px solid borders — feature cards, buttons, dividers between rows. The brand's universal "edge" colour.
+- **Hairline Soft** (`{colors.hairline-soft}` — `#b8b3b0`): A lighter divider tint used in rare on-light secondary contexts.
+
+### Text
+- **Ink** (`{colors.ink}` — `#f2f2f2`): Default text colour on the dark canvas — slightly off-white to reduce contrast strain.
+- **Ink Strong** (`{colors.ink-strong}` — `#ffffff`): Pure-white text for hero headlines and high-emphasis copy.
+- **Body** (`{colors.body}` — `#bdbdbd`): Secondary text — supporting copy, body paragraphs in long-form sections.
+- **Mute** (`{colors.mute}` — `#8b949e`): Lowest-priority on-dark text — captions, fine print, footer secondary lines.
+- **Canvas Text Soft** (`{colors.canvas-text-soft}` — `#f5f6f7`): Used inside code mockups to keep code colour just slightly cooler than the surrounding body text.
+
+### Semantic
+The brand doesn't surface a separate error / warning palette in its public marketing pages — the underlying Docusaurus default semantic palette exists in the design system but is reserved for in-product / docs contexts. Validation cues on the marketing surface use the primary green for success and a muted body grey for missing states.
+
+## Typography
+
+### Font Family
+Two faces carry the system:
+1. **Inter** for every display, body, button, and link role. Weights 400 / 500 / 600 / 700 are the working set. Used with OpenType features `"calt"` and `"rlig"` enabled across the page so the geometric Inter ligatures and contextual alternates render correctly.
+2. **SF Mono** (`SFMono-Regular` with Menlo / Monaco / Consolas / Liberation Mono fallbacks) for inline code, command snippets, terminal mockups, and the brand's numeric counters. Weights 400 / 549 / 550 / 700 are present — the unusual 549 / 550 sub-bold weight gives the mono a "slightly heavier than regular" voice for emphasis.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 60px | 400 | 60px | -0.65px | Hero headline ("AI Agent Engineering Platform"). |
+| `{typography.display-lg}` | 36px | 400 | 40px | -0.9px | Section headlines. |
+| `{typography.display-md}` | 24px | 700 | 32px | -0.6px | Sub-section / card-title displays. |
+| `{typography.display-sm}` | 20px | 600 | 28px | 0 | Card titles in dense grids. |
+| `{typography.eyebrow-mono}` | 14px | 600 | 20px | 2.52px | UPPERCASE eyebrow tags ("EVERYTHING YOU NEED"). |
+| `{typography.eyebrow-uppercase}` | 18px | 600 | 28px | 0.45px | Larger uppercase eyebrows above hero subsections. |
+| `{typography.body-lg}` | 18px | 400 | 28px | 0 | Lead paragraphs. |
+| `{typography.body-md}` | 16px | 400 | 26px | 0 | Default body paragraph. |
+| `{typography.body-md-strong}` | 16px | 600 | 24px | 0 | Bolded inline body. |
+| `{typography.body-sm}` | 14px | 400 | 20px | 0 | Secondary body. |
+| `{typography.body-sm-strong}` | 14px | 600 | 23px | 0 | Bold caption / pill-tag labels. |
+| `{typography.caption}` | 12px | 400 | 16px | 0 | Fine print. |
+| `{typography.caption-strong}` | 12px | 500 | 16px | 0 | Bold caption. |
+| `{typography.code}` | 13px | 400 | 18px | 0 | Code blocks, inline command snippets. |
+| `{typography.code-strong}` | 13px | 550 | 16px | 0 | Emphasised inline code (the SF Mono "almost-bold" weight). |
+| `{typography.button-md}` | 16px | 600 | 24px | 0 | Button labels. |
+
+### Principles
+- **Inter regular at 60 px display** is the brand's calming counter to AI marketing's tendency to shout. The light tracking and modest weight read like documentation.
+- **Two-face contrast carries the technical voice.** Inter for narrative; SF Mono for anything that could be typed at a terminal.
+- **Uppercase eyebrow with tracking is the brand's signature label style.** `2.52 px` at 14 px is the documented value.
+
+### Note on Font Substitutes
+- **Sans** — *Inter* is the brand's actual face; substitute is the brand itself when self-hosting is not available.
+- **Mono** — *SF Mono* is Apple-system; *JetBrains Mono* or *Geist Mono* are the best free substitutes.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4 px; small 5 / 6.4 px values appear inside code-mockup line-height compensation.
+- **Tokens**: `{spacing.xxs}` 2 px · `{spacing.xs}` 4 px · `{spacing.sm}` 8 px · `{spacing.md}` 12 px · `{spacing.lg}` 16 px · `{spacing.xl}` 20 px · `{spacing.2xl}` 24 px · `{spacing.3xl}` 32 px · `{spacing.4xl}` 40 px · `{spacing.5xl}` 48 px · `{spacing.6xl}` 64 px.
+- **Section padding**: hero + content bands use `{spacing.5xl}` 48 px top/bottom.
+- **Card interior padding**: feature cards sit at `{spacing.2xl}` 24 px.
+
+### Grid & Container
+- Marketing container centres at roughly 1200 – 1400 px; content stays edge-to-edge in colour with horizontal gutters of `{spacing.3xl}` on desktop.
+- Feature-card grids: 2-up to 3-up at desktop, 1-up at mobile.
+
+### Responsive Strategy
+
+#### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 768px | Hero 60→32 px; cards 1-up; nav hamburger. |
+| Tablet | 768–1023px | Cards 2-up; nav stays horizontal. |
+| Desktop | ≥ 1024px | Full 3-up card grids. |
+
+#### Touch Targets
+Buttons render at ~44 px tall (12 px vertical padding + 24 px line-height). Meet WCAG AAA at all breakpoints.
+
+#### Collapsing Strategy
+Nav collapses to hamburger at mobile; the menu overlay keeps the same green CTA pinned at the bottom. Feature-card grids drop to 1-up; hero typography scales fluidly.
+
+#### Image Behavior
+Code-editor mockups render as image-like cards with copy-to-clipboard affordances. No photography in the brand's marketing surface.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Level 0 — Flat | No shadow, no border. | Full-bleed bands. |
+| Level 1 — Hairline | 1 px solid `{colors.hairline}` border on `{colors.canvas}`. | Default for every feature card and button. |
+| Level 2 — Inset Glow | `0 0 15px rgba(92, 88, 85, 0.2)` subtle outer glow. | Hovering / featured cards. |
+| Level 3 — Modal Stack | `0 20px 60px rgba(0,0,0,0.7), 0 0 0 1px rgba(148,163,184,0.1) inset` heavy drop + inset ring. | Modal / dialog surfaces in-product. |
+
+### Decorative Depth
+- Hairline cards on dark canvas — the brand's only true elevation mode.
+- A 2 px solid `{colors.primary}` green border occasionally marks "featured" or "active" status on a card.
+- A 1 px dashed `rgba(79, 93, 117, 0.4)` divider sits between section bands as a quiet rhythm cue.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Full-bleed bands. |
+| `{rounded.xs}` | 4px | Smallest inline pills, code inline chips. |
+| `{rounded.sm}` | 6px | Default button and input radius. |
+| `{rounded.md}` | 8px | Card chrome, code-block chrome. |
+| `{rounded.pill}` | 9999px | Inline status tags ("Live", "Beta"). |
+| `{rounded.full}` | 9999px | Circular icon containers. |
+
+## Components
+
+### Buttons
+
+**`button-primary`** — the electric-green CTA.
+- Background `{colors.primary}`, text `{colors.on-primary}` (near-black), label `{typography.button-md}`, padding `{spacing.md} {spacing.lg}`, shape `{rounded.sm}` 6 px.
+
+**`button-outline-on-dark`** — the hairline-on-dark secondary button.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.hairline}` border, same typography / padding / shape.
+
+**`button-ghost-green`** — text-only with green label, for tertiary actions.
+- Background `{colors.canvas}`, text `{colors.primary-soft}`, no border.
+
+**`button-pill-tag`** — the inline pill for category tags / status labels.
+- Background `{colors.canvas}`, text `{colors.ink}`, hairline border, body in `{typography.body-sm}`, padding `{spacing.xs} {spacing.md}`, shape `{rounded.pill}` 9999 px.
+
+### Cards & Containers
+
+**`card-feature`** — the default feature card.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.hairline}` border, padding `{spacing.2xl}`, shape `{rounded.md}` 8 px. The brand's most-repeated card chrome.
+
+**`card-feature-emphasized`** — the same card with a 3 px hairline border for emphasis.
+- Same chrome as `card-feature` with 3 px solid `{colors.hairline}`.
+
+**`code-mockup`** — the dark code-editor card with copy-to-clipboard affordance.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.hairline}`, body in `{typography.code}` (SF Mono 13 px), padding `{spacing.xl}`, shape `{rounded.md}`.
+
+**`code-inline-chip`** — the inline command snippet pill.
+- Background `{colors.canvas-soft}`, text `{colors.canvas-text-soft}`, body in `{typography.code}`, padding `{spacing.xxs} {spacing.sm}`, shape `{rounded.sm}`.
+
+### Inputs & Forms
+
+**`text-input`** — the standard text input on dark.
+- Background `{colors.canvas-soft}`, text `{colors.ink}`, 1 px solid `{colors.hairline}`, body in `{typography.body-sm}`, padding `{spacing.md} {spacing.lg}`, shape `{rounded.sm}` 6 px.
+
+### Navigation
+
+**`nav-bar`** — the sticky top nav on dark.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.md} {spacing.3xl}`.
+
+**`nav-link`** — link items in nav.
+- Text `{colors.body}`, set in `{typography.body-sm}`.
+
+**`footer`** — the dark footer band.
+- Background `{colors.canvas}`, text `{colors.body}`, padding `{spacing.4xl} {spacing.3xl}`. Body in `{typography.body-sm}`.
+
+### Signature Components
+
+**`hero-band`** — the dark hero band with the 60-px Inter headline.
+- Background `{colors.canvas}`, text `{colors.ink}` (with the headline at `{colors.ink-strong}` white), padding `{spacing.5xl} {spacing.3xl}`. Headline in `{typography.display-xl}` (60 px / weight 400 / `-0.65 px` tracking). Eyebrow above headline in `{typography.eyebrow-mono}` (uppercase, tracked).
+
+**`content-band`** — the standard content band hosting feature grids.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.5xl} {spacing.3xl}`. Section headline in `{typography.display-lg}`.
+
+**`green-divider-band`** — a thin green-glow band that occasionally separates major sections.
+- Background `{colors.canvas}`, 2 px solid `{colors.primary}` top/bottom border. The brand's only chromatic divider.
+
+### Examples (illustrative)
+
+> Auto-derived kit-mirror demonstration surfaces (`scripts/derive-examples-block.mjs`). Each `ex-*` entry references brand-native primitives so downstream consumers (`/preview-design`, `/generate-kit`) re-skin the same 10 surfaces consistently. `TO_FILL` markers indicate missing primitives — resolve in the LLM judgment pass.
+
+**`ex-pricing-tier`** — Default Pricing tier card. Re-uses feature-card chrome with brand canvas-soft surface.
+- Properties: `backgroundColor`, `textColor`, `borderColor`, `rounded`, `padding`
+
+**`ex-pricing-tier-featured`** — Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode).
+- Properties: `backgroundColor`, `textColor`, `rounded`, `padding`
+
+**`ex-product-selector`** — What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery).
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-cart-drawer`** — Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart).
+- Properties: `backgroundColor`, `rounded`, `padding`, `item-divider`
+
+**`ex-app-shell-row`** — Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator.
+- Properties: `backgroundColor`, `activeIndicator`, `rounded`, `padding`
+
+**`ex-data-table-cell`** — Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm.
+- Properties: `headerBackground`, `headerTypography`, `bodyTypography`, `cellPadding`, `rowBorder`
+
+**`ex-auth-form-card`** — Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-modal-card`** — Modal dialog surface — same chrome as feature-card with elevated shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-empty-state-card`** — Empty-state illustration frame.
+- Properties: `backgroundColor`, `rounded`, `padding`, `captionTypography`
+
+**`ex-toast`** — Toast notification surface — feature-card shape + medium shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`, `typography`
+
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (`#00d992`) for every primary CTA, the lightning logo glyph, and live-status indicators. The green is the brand's centre of gravity.
+- Use the dark `{colors.canvas}` (`#101010`) as the only page surface. There is no light-mode rhythm.
+- Build cards with 1 px `{colors.hairline}` borders, not shadows. Hairlines on dark IS the brand's elevation system.
+- Pair Inter (sentence-case) with SF Mono (inline code, command snippets). Every uppercase moment uses Inter at weight 600 with `2.52 px` tracking — not a separate mono.
+- Use `{rounded.sm}` 6 px for buttons, `{rounded.md}` 8 px for cards, `{rounded.pill}` 9999 px only for inline status tags.
+
+### Don't
+- Don't introduce a light-mode counterpart. The brand is dark-canvas only.
+- Don't use the primary green as a body-text fill. It's CTA-only.
+- Don't drop a soft drop-shadow on cards. The brand uses hairlines + occasional glow, never material shadows.
+- Don't render the hero headline in heavy weight (700+). The brand's display is intentionally calm at weight 400.
+- Don't replace Inter or SF Mono with a different family — both faces are part of the brand's voice and pairing.

--- a/dashboard/aider-watcher.js
+++ b/dashboard/aider-watcher.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const http = require('http');
+const os   = require('os');
+
+const WATCH_PATHS = [
+  path.join(os.homedir(), '.aider.chat.history.md'),
+  path.join(os.homedir(), '.aider.input.history'),
+  path.join(process.cwd(), '.aider.chat.history.md'),
+];
+
+const PORT = 7890;
+let lastSizes = {};
+
+function post(ev) {
+  const body = JSON.stringify(ev);
+  const req = http.request(
+    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
+      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
+      timeout:300 },
+    ()=>{}
+  );
+  req.on('error', ()=>{});
+  req.on('timeout', ()=>req.destroy());
+  req.end(body);
+}
+
+function watchFile(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  lastSizes[filePath] = fs.statSync(filePath).size;
+
+  fs.watch(filePath, { persistent:false }, (evt) => {
+    if (evt !== 'change') return;
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.size <= lastSizes[filePath]) return;
+
+      const fd = fs.openSync(filePath, 'r');
+      const buf = Buffer.alloc(stat.size - lastSizes[filePath]);
+      fs.readSync(fd, buf, 0, buf.length, lastSizes[filePath]);
+      fs.closeSync(fd);
+      lastSizes[filePath] = stat.size;
+
+      const chunk = buf.toString('utf8');
+      const toolMatch = chunk.match(/\b(read|edit|write|bash|run)\b/i);
+      const tool = toolMatch ? toolMatch[1].charAt(0).toUpperCase() + toolMatch[1].slice(1) : 'Aider';
+
+      post({ ide:'aider', event:'pre_tool', tool, agent:'main', detail:chunk.slice(0,80).trim(), status:'running' });
+      setTimeout(()=>{ post({ ide:'aider', event:'post_tool', tool, agent:'main', status:'success' }); }, 500);
+    } catch(_) {}
+  });
+}
+
+WATCH_PATHS.forEach(watchFile);
+
+console.log('EGC Aider watcher running. Watching:', WATCH_PATHS.filter(p=>fs.existsSync(p)));
+
+setInterval(()=>{
+  WATCH_PATHS.forEach(p=>{ if(fs.existsSync(p) && !lastSizes[p]) watchFile(p); });
+}, 5000);

--- a/dashboard/codebuddy-adapter.js
+++ b/dashboard/codebuddy-adapter.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('http');
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+
+const PORT = 7890;
+
+const WATCH_PATHS = [
+  path.join(os.homedir(), '.codebuddy', 'logs'),
+  path.join(os.homedir(), '.config', 'codebuddy', 'logs'),
+];
+
+function post(ev) {
+  const body = JSON.stringify(ev);
+  const req = http.request(
+    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
+      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
+      timeout:300 },
+    ()=>{}
+  );
+  req.on('error', ()=>{});
+  req.on('timeout', ()=>req.destroy());
+  req.end(body);
+}
+
+function watchLogDir(dir) {
+  if (!fs.existsSync(dir)) return false;
+  fs.watch(dir, { persistent:false }, (evt, filename) => {
+    if (!filename) return;
+    try {
+      post({ ide:'codebuddy', event:'pre_tool', tool:'CodeBuddy', agent:'main', detail:filename, status:'running' });
+      setTimeout(()=>{ post({ ide:'codebuddy', event:'post_tool', tool:'CodeBuddy', agent:'main', status:'success' }); }, 400);
+    } catch(_) {}
+  });
+  console.log(`Watching CodeBuddy logs: ${dir}`);
+  return true;
+}
+
+let started = false;
+function init() {
+  for (const dir of WATCH_PATHS) {
+    if (watchLogDir(dir)) { started = true; break; }
+  }
+  if (!started) console.log('CodeBuddy not found. Adapter will retry.');
+}
+
+init();
+setInterval(()=>{ if (!started) init(); }, 15000);

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,0 +1,849 @@
+{
+  "name": "egc-dashboard",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "egc-dashboard",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "ws": "^8.16.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "egc-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "description": "EGC real-time agent monitoring dashboard",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.16.0"
+  }
+}

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -429,6 +429,7 @@ const IDES=[
   {id:'vscode',    label:'VS Code',    c:'#007acc',e:'🔷'},
   {id:'aider',     label:'Aider',      c:'#f57c00',e:'⚡'},
 ];
+function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
 
 const EGC_AGENTS=[
   {id:'memory',    name:'Memory',        icon:'🧠',node:'memory',    c:'#00d992',tools:['Read','Grep','Glob','Search'],   thoughts:{Read:'🧠 Reading memory',Grep:'🔎 Searching history',Glob:'📂 Scanning directory',Search:'🔎 Searching knowledge base'}},
@@ -653,10 +654,10 @@ function renderAgents(){
 
   wrap.innerHTML=EGC_AGENTS.map(ag=>{
     const st=S.agState[ag.id]||'idle';
-    const act=S.agState[ag.id+'_act']||'Standby';
-    const file=S.agState[ag.id+'_file']||'';
+    const act=esc(S.agState[ag.id+'_act']||'Standby');
+    const file=esc(S.agState[ag.id+'_file']||'');
     const elapsed=S.agState[ag.id+'_t']?Math.round((Date.now()-S.agState[ag.id+'_t']))+'ms':'';
-    const prog=S.agState[ag.id+'_prog']||0;
+    const prog=parseFloat(S.agState[ag.id+'_prog'])||0;
     const isActive=st==='active';
     return`<div class="ag-card ${isActive?'active':'idle'}" style="--ag-c:${ag.c}">
       <div class="ag-top">
@@ -851,9 +852,9 @@ function addRow(ev,na){
   r.innerHTML=`
     <span class="tl-time" style="color:var(--muted)">${time}</span>
     <span class="tl-ico" style="color:${col}">${ico}</span>
-    <span class="tl-who" style="color:${ic.c}">${ev.agent||'main'}</span>
-    <span class="tl-what">${what}${file?` <span style="color:var(--muted);font-size:10px">${file}</span>`:''}</span>
-    <span class="tl-dur">${ev.duration_ms?ev.duration_ms+'ms':''}</span>`;
+    <span class="tl-who" style="color:${ic.c}">${esc(ev.agent||'main')}</span>
+    <span class="tl-what">${esc(what)}${file?` <span style="color:var(--muted);font-size:10px">${esc(file)}</span>`:''}</span>
+    <span class="tl-dur">${esc(ev.duration_ms?ev.duration_ms+'ms':'')}</span>`;
   list.insertBefore(r,list.firstChild);
   while(list.children.length>150)list.removeChild(list.lastChild);
 }

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1,0 +1,976 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<title>EGC - Dashboard</title>
+<link rel="icon" type="image/png" href="/egc-logo.png"/>
+<link rel="manifest" href="/manifest.json"/>
+<meta name="theme-color" content="#101010"/>
+<meta name="mobile-web-app-capable" content="yes"/>
+<meta name="apple-mobile-web-app-capable" content="yes"/>
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+<meta name="apple-mobile-web-app-title" content="EGC Dashboard"/>
+<link rel="apple-touch-icon" href="/egc-logo.png"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+:root{
+  --canvas:#101010;--canvas-soft:#1a1a1a;--canvas-mid:#141414;
+  --hairline:#3d3a39;--hairline-2:#252320;
+  --ink:#f2f2f2;--ink-strong:#ffffff;--body:#bdbdbd;--muted:#8b949e;
+  --primary:#00d992;--primary-soft:#2fd6a1;--primary-dim:rgba(0,217,146,.08);--primary-glow:rgba(0,217,146,.16);
+  --red:#f87171;--yellow:#fbbf24;--blue:#60a5fa;--purple:#a78bfa;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+html{-webkit-font-smoothing:antialiased;}
+body{
+  background:var(--canvas);color:var(--ink);
+  font-family:Inter,system-ui,-apple-system,sans-serif;font-size:13px;
+  height:100vh;display:grid;grid-template-rows:88px 1fr 118px;overflow:hidden;
+}
+
+/* ── GREETING ─────────────────────────────────────────── */
+.greeting{position:fixed;inset:0;z-index:200;background:rgba(8,8,8,.95);backdrop-filter:blur(8px);display:flex;align-items:center;justify-content:center;animation:fadein .5s ease-out;}
+.greeting.out{animation:fadeout .4s ease-out forwards;pointer-events:none;}
+@keyframes fadein{from{opacity:0}to{opacity:1}}
+@keyframes fadeout{from{opacity:1}to{opacity:0}}
+.gr-card{background:var(--canvas-soft);border:1px solid var(--hairline);border-radius:14px;padding:44px 52px;max-width:460px;width:90%;display:flex;flex-direction:column;gap:22px;animation:slideup .45s ease-out;}
+@keyframes slideup{from{transform:translateY(18px);opacity:0}to{transform:none;opacity:1}}
+.gr-time{font-size:10px;font-weight:600;letter-spacing:2.52px;text-transform:uppercase;color:var(--muted);}
+.gr-hi{font-size:26px;font-weight:700;color:var(--ink-strong);line-height:1.2;}
+.gr-hi span{color:var(--primary);}
+.gr-div{height:1px;background:var(--hairline);}
+.gr-sub{font-size:9px;font-weight:600;letter-spacing:2.52px;text-transform:uppercase;color:var(--muted);}
+.gr-stats{display:flex;flex-direction:column;gap:9px;}
+.gr-stat{display:flex;align-items:center;gap:10px;font-size:13px;color:var(--body);}
+.gr-check{color:var(--primary);font-size:14px;flex-shrink:0;}
+.gr-foot{display:flex;align-items:center;justify-content:space-between;}
+.gr-ready{font-size:14px;font-weight:600;color:var(--ink);}
+.gr-skip{font-size:11px;color:var(--muted);cursor:pointer;transition:color .15s;}
+.gr-skip:hover{color:var(--body);}
+
+/* ── HEADER ───────────────────────────────────────────── */
+.hd{display:grid;grid-template-columns:auto 1fr auto;align-items:center;padding:0 24px;border-bottom:1px solid var(--hairline);background:var(--canvas);}
+.hd-brand a{display:flex;align-items:center;gap:12px;text-decoration:none;}
+.hd-logo{height:36px;width:auto;filter:drop-shadow(0 0 8px rgba(0,217,146,.5));}
+.hd-logo-svg{width:36px;height:36px;flex-shrink:0;animation:logopulse 4s ease-in-out infinite;}
+@keyframes logopulse{0%,100%{filter:drop-shadow(0 0 4px rgba(0,217,146,.4))}50%{filter:drop-shadow(0 0 10px rgba(0,217,146,.9))}}
+.hd-wm{display:flex;flex-direction:column;gap:1px;}
+.hd-wm-eye{font-size:9px;font-weight:600;letter-spacing:2.52px;text-transform:uppercase;color:var(--primary);}
+.hd-wm-name{font-size:17px;font-weight:700;letter-spacing:.5px;color:var(--ink-strong);}
+.vd{width:1px;height:26px;background:var(--hairline);flex-shrink:0;margin:0 18px;}
+.hd-center{display:flex;align-items:center;min-width:0;flex:1;}
+.hd-block{display:flex;flex-direction:column;gap:2px;flex-shrink:0;}
+.hd-eye{font-size:9px;font-weight:600;letter-spacing:2.52px;text-transform:uppercase;color:var(--muted);}
+.hd-val{font-size:13px;font-weight:500;color:var(--ink);white-space:nowrap;}
+.status-badge{display:flex;align-items:center;gap:6px;padding:4px 12px;border-radius:9999px;border:1px solid rgba(0,217,146,.3);background:rgba(0,217,146,.06);font-size:10px;font-weight:600;letter-spacing:1.5px;color:var(--primary);}
+.status-dot{width:6px;height:6px;border-radius:50%;background:var(--primary);animation:pip 1.4s ease-in-out infinite;}
+.session-time{font-family:SFMono-Regular,Menlo,monospace;font-size:20px;font-weight:500;color:var(--ink-strong);letter-spacing:2px;}
+.hd-right{display:flex;align-items:center;gap:8px;}
+.sys-health{display:flex;align-items:center;gap:6px;padding:5px 12px;background:var(--canvas-soft);border:1px solid var(--hairline);border-radius:8px;}
+.sh-row{display:flex;align-items:center;gap:5px;}
+.sh-item{font-size:10px;font-weight:600;color:var(--muted);letter-spacing:.5px;display:flex;align-items:center;gap:3px;}
+.sh-dot{width:5px;height:5px;border-radius:50%;background:var(--muted);}
+.sh-dot.ok{background:var(--primary);box-shadow:0 0 4px rgba(0,217,146,.5);}
+.sh-dot.err{background:var(--red);}
+.sh-lat{font-size:9px;color:var(--muted);font-variant-numeric:tabular-nums;font-family:SFMono-Regular,monospace;padding-left:8px;border-left:1px solid var(--hairline);}
+.ide-pills{display:flex;gap:2px;align-items:center;}
+.ide-pill{position:relative;display:flex;align-items:center;gap:3px;padding:4px 7px;border-radius:9999px;border:1px solid var(--hairline);font-size:13px;color:var(--muted);cursor:pointer;white-space:nowrap;user-select:none;transition:color .15s,border-color .15s,background .15s,max-width .25s;}
+.ide-pill:hover{color:var(--body);border-color:rgba(255,255,255,.18);}
+.ide-pill:hover .ide-lbl{display:inline;max-width:90px;opacity:1;margin-left:2px;}
+.ide-pill.alive{color:var(--ink);border-color:var(--pill-c);}
+.ide-pill.selected{background:color-mix(in srgb,var(--pill-c,#fff) 14%,transparent);border-color:var(--pill-c);color:var(--ink-strong);}
+.ide-pill.alive .ide-lbl,.ide-pill.selected .ide-lbl{display:inline;max-width:80px;opacity:1;margin-left:2px;font-size:10px;font-weight:600;}
+.ide-dot{width:5px;height:5px;border-radius:50%;background:var(--muted);transition:background .2s;flex-shrink:0;}
+.ide-pill.alive .ide-dot,.ide-pill.selected .ide-dot{background:var(--pill-c);animation:pip 1.6s ease-in-out infinite;}
+.ide-lbl{display:none;font-size:10px;font-weight:500;overflow:hidden;text-overflow:ellipsis;max-width:0;opacity:0;transition:max-width .2s,opacity .2s;}
+.ws-chip{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted);flex-shrink:0;}
+.ws-dot{width:7px;height:7px;border-radius:50%;background:var(--red);transition:background .3s;}
+.ws-dot.on{background:var(--primary);box-shadow:0 0 6px rgba(0,217,146,.5);animation:pip 2s ease-in-out infinite;}
+@keyframes pip{0%,100%{opacity:1}50%{opacity:.25}}
+.win-controls{display:flex;align-items:center;gap:6px;margin-left:14px;flex-shrink:0;}
+.wc-btn{width:13px;height:13px;border-radius:50%;border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:filter .15s;flex-shrink:0;padding:0;}
+.wc-btn:hover{filter:brightness(1.3);}
+.wc-btn svg{opacity:0;transition:opacity .1s;pointer-events:none;}
+.wc-btn:hover svg{opacity:1;}
+.wc-close{background:#ff5f57;}
+.wc-min{background:#febc2e;}
+.wc-max{background:#28c840;}
+body.minimized header{border-bottom:none;}
+body.minimized .main{display:none!important;}
+body.minimized footer{display:none!important;}
+
+/* ── MAIN ─────────────────────────────────────────────── */
+.main{display:grid;grid-template-columns:42fr 26fr 32fr;overflow:hidden;min-height:0;}
+
+/* ── BRAIN PANEL ──────────────────────────────────────── */
+.panel-brain{border-right:1px solid var(--hairline);position:relative;overflow:hidden;}
+#brainCanvas{display:block;width:100%;height:100%;}
+.brain-overlay{position:absolute;top:14px;right:16px;font-size:9px;font-weight:600;letter-spacing:2.52px;text-transform:uppercase;color:var(--muted);display:flex;align-items:center;gap:6px;}
+.brain-label{position:absolute;bottom:14px;left:16px;font-size:9px;font-weight:600;letter-spacing:2.52px;text-transform:uppercase;color:rgba(61,58,57,.6);}
+.live-dot{width:6px;height:6px;border-radius:50%;background:var(--primary);animation:pip 1s ease-in-out infinite;}
+
+/* ── CENTER PANEL ─────────────────────────────────────── */
+.panel-center{border-right:1px solid var(--hairline);display:flex;flex-direction:column;overflow:hidden;min-height:0;}
+.sec-head{display:flex;align-items:center;justify-content:space-between;padding:0 16px;height:36px;border-bottom:1px solid var(--hairline);flex-shrink:0;}
+.eye{font-size:9px;font-weight:600;letter-spacing:2.52px;text-transform:uppercase;color:var(--muted);}
+
+/* Unified agent cards */
+.agents-wrap{flex:1;overflow-y:auto;padding:8px 10px;display:flex;flex-direction:column;gap:6px;}
+.agents-wrap::-webkit-scrollbar{width:2px;}
+.agents-wrap::-webkit-scrollbar-thumb{background:var(--hairline);}
+.ag-card{
+  border-radius:8px;border:1px solid var(--hairline-2);
+  padding:12px 14px;background:var(--canvas-mid);
+  transition:border-color .25s,background .25s,box-shadow .25s;
+}
+.ag-card.active{
+  background:var(--canvas-soft);
+  border-color:var(--ag-c,var(--primary));
+  box-shadow:0 0 12px rgba(0,0,0,.3);
+}
+.ag-card.active::before{
+  content:'';display:block;position:absolute;
+}
+.ag-top{display:flex;align-items:center;gap:10px;margin-bottom:8px;}
+.ag-status-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0;background:var(--hairline);}
+.ag-card.active .ag-status-dot{background:var(--ag-c,var(--primary));box-shadow:0 0 5px var(--ag-c,var(--primary));animation:pip 1.1s ease-in-out infinite;}
+.ag-ico{font-size:18px;flex-shrink:0;}
+.ag-name{font-size:13px;font-weight:700;color:var(--ink-strong);flex:1;}
+.ag-elapsed{font-size:10px;color:var(--muted);font-variant-numeric:tabular-nums;font-family:SFMono-Regular,monospace;}
+.ag-action{font-size:12px;color:var(--body);margin-bottom:5px;display:flex;align-items:center;gap:7px;min-height:18px;}
+.ag-action-ico{font-size:13px;flex-shrink:0;}
+.ag-file{font-size:10px;color:var(--muted);font-family:SFMono-Regular,Menlo,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-bottom:6px;}
+.ag-prog-wrap{height:3px;background:var(--hairline-2);border-radius:2px;overflow:hidden;}
+.ag-prog-fill{height:100%;border-radius:2px;background:var(--ag-c,var(--primary));transition:width .4s ease-out;}
+.ag-prog-fill.indeterminate{width:40%!important;animation:indeterminate 1.4s ease-in-out infinite;}
+@keyframes indeterminate{0%{transform:translateX(-100%)}100%{transform:translateX(350%)}}
+.ag-card.idle .ag-action{color:var(--muted);opacity:.5;}
+.ag-card.idle .ag-file{opacity:.3;}
+
+/* ── RIGHT PANEL ──────────────────────────────────────── */
+.panel-right{overflow-y:auto;display:flex;flex-direction:column;}
+.panel-right::-webkit-scrollbar{width:2px;}
+.panel-right::-webkit-scrollbar-thumb{background:var(--hairline);}
+.rcard{border-bottom:1px solid var(--hairline);padding:14px 18px;display:flex;flex-direction:column;gap:10px;}
+.rc-row{display:flex;justify-content:space-between;align-items:center;gap:8px;}
+.rc-label{font-size:11px;color:var(--muted);flex-shrink:0;}
+.rc-val{font-size:12px;font-weight:500;color:var(--ink);text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px;}
+/* Mission task block */
+.task-block{background:var(--canvas-soft);border:1px solid var(--hairline-2);border-radius:7px;padding:10px 12px;display:flex;flex-direction:column;gap:6px;}
+.task-name{font-size:13px;font-weight:600;color:var(--ink-strong);}
+.task-file{font-size:10px;color:var(--muted);font-family:SFMono-Regular,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.task-prog-wrap{height:4px;background:var(--hairline-2);border-radius:2px;overflow:hidden;}
+.task-prog-fill{height:100%;background:var(--primary);border-radius:2px;transition:width .5s ease-out;}
+.task-pct{font-size:10px;color:var(--primary);font-weight:600;font-variant-numeric:tabular-nums;}
+/* Memory bars */
+.mem-bar-wrap{display:flex;flex-direction:column;gap:3px;}
+.mem-bar-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:3px;}
+.mem-bar-label{font-size:11px;color:var(--body);}
+.mem-bar-pct{font-size:11px;font-weight:600;color:var(--primary);font-variant-numeric:tabular-nums;}
+.mem-bar-track{height:4px;background:var(--canvas-soft);border:1px solid var(--hairline-2);border-radius:2px;overflow:hidden;}
+.mem-bar-fill{height:100%;border-radius:2px;width:0%;transition:width 1.2s ease-out;}
+.mem-counts{display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;margin-top:4px;}
+.mc{display:flex;flex-direction:column;align-items:center;gap:3px;padding:9px 4px;background:var(--canvas-soft);border:1px solid var(--hairline-2);border-radius:7px;}
+.mc-n{font-size:18px;font-weight:700;color:var(--ink-strong);font-variant-numeric:tabular-nums;}
+.mc-l{font-size:8px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--muted);}
+/* Pipeline bars */
+.pipe-list{display:flex;flex-direction:column;gap:6px;}
+.pipe-row{opacity:.2;transition:opacity .4s;}
+.pipe-row.done{opacity:1;}
+.pipe-top{display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;}
+.pipe-ico{font-size:12px;margin-right:7px;}
+.pipe-lbl{font-size:12px;color:var(--body);}
+.pipe-pct{font-size:10px;color:var(--muted);font-variant-numeric:tabular-nums;}
+.pipe-bar-track{height:3px;background:var(--hairline-2);border-radius:2px;overflow:hidden;}
+.pipe-bar-fill{height:100%;border-radius:2px;background:var(--primary);width:0%;transition:width .9s ease-out;}
+/* Economy — real telemetry only */
+.eco-provider{border:1px solid var(--hairline-2);border-radius:7px;padding:10px 12px;margin-bottom:6px;display:flex;flex-direction:column;gap:6px;}
+.eco-provider:last-child{margin-bottom:0;}
+.eco-provider-head{font-size:10px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;}
+.eco-row{display:flex;justify-content:space-between;align-items:baseline;}
+.eco-lbl{font-size:11px;color:var(--muted);}
+.eco-val{font-size:12px;font-weight:600;color:var(--ink);font-variant-numeric:tabular-nums;}
+.eco-val.green{color:var(--primary);}
+.eco-unavail-row{display:flex;flex-direction:column;gap:3px;padding:7px 0;}
+.eco-lbl-na{font-size:11px;color:var(--muted);}
+.eco-val-na{font-size:11px;font-weight:600;color:var(--red);}
+.eco-reason{font-size:9px;color:var(--muted);line-height:1.4;}
+.eco-empty{padding:14px 0;text-align:center;color:var(--muted);font-size:11px;}
+
+/* ── TIMELINE ─────────────────────────────────────────── */
+.timeline{border-top:1px solid var(--hairline);display:flex;flex-direction:column;background:var(--canvas);}
+.tl-head{display:flex;align-items:center;justify-content:space-between;padding:6px 20px 5px;border-bottom:1px solid var(--hairline);flex-shrink:0;}
+.tl-head-l{display:flex;align-items:center;gap:8px;}
+.tl-ct{font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;}
+.btn-sm{font-size:10px;font-weight:500;color:var(--muted);background:none;border:1px solid var(--hairline);border-radius:6px;padding:2px 8px;font-family:inherit;cursor:pointer;transition:color .12s;}
+.btn-sm:hover{color:var(--ink);}
+.tl-list{flex:1;overflow-y:auto;padding:3px 14px;display:flex;flex-direction:column;gap:1px;}
+.tl-list::-webkit-scrollbar{width:2px;}
+.tl-list::-webkit-scrollbar-thumb{background:var(--hairline);}
+.tl-row{display:grid;grid-template-columns:48px 20px 90px 1fr 58px;align-items:center;gap:7px;padding:3px 6px;border-radius:4px;font-size:11px;color:var(--muted);transition:background .1s;}
+.tl-row:not(.na){animation:liup .13s ease-out;}
+@keyframes liup{from{opacity:0;transform:translateY(-2px)}to{opacity:1;transform:none}}
+.tl-row:hover{background:var(--canvas-soft);}
+.tl-time{font-variant-numeric:tabular-nums;font-size:10px;}
+.tl-ico{font-size:13px;text-align:center;}
+.tl-who{font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.tl-what{font-family:SFMono-Regular,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.tl-dur{text-align:right;font-variant-numeric:tabular-nums;font-size:10px;}
+
+/* ── RESPONSIVE ───────────────────────────────────────── */
+@media(max-width:1100px)and(min-width:681px){
+  .main{grid-template-columns:1fr 1fr;}
+  .panel-brain{display:none;}
+  .panel-center{border-right:1px solid var(--hairline);}
+  .sys-health{display:none;}
+  .vd.hd-sh{display:none;}
+}
+@media(max-width:860px)and(min-width:681px){
+  .hd{padding:0 16px;}
+  .hd-block.hd-hide{display:none;}
+  .vd.hd-hide{display:none;}
+  .ide-pills{max-width:180px;}
+}
+@media(max-width:680px){
+  body{grid-template-rows:58px 1fr 72px;padding-bottom:54px;}
+  .hd{padding:0 12px;}
+  .hd-center{display:none;}
+  .sys-health{display:none;}
+  .vd{display:none;}
+  .hd-right{gap:6px;}
+  .ide-pills{display:none;}
+  .main{grid-template-columns:1fr;position:relative;overflow:auto;}
+  .panel-brain,.panel-center,.panel-right{display:none;position:absolute;inset:0;border:none!important;overflow-y:auto;}
+  .panel-brain.ta{display:block;}
+  .panel-center.ta{display:flex;}
+  .panel-right.ta{display:flex;flex-direction:column;}
+  .timeline{height:72px;}
+  .tl-row{grid-template-columns:44px 18px 70px 1fr;}
+  .tl-dur{display:none;}
+  .tab-bar{display:flex!important;}
+}
+.tab-bar{display:none;position:fixed;bottom:0;left:0;right:0;height:54px;z-index:100;background:var(--canvas-soft);border-top:1px solid var(--hairline);}
+.tab-btn{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;font-size:9px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--muted);cursor:pointer;transition:color .15s;user-select:none;-webkit-tap-highlight-color:transparent;}
+.tab-btn.a{color:var(--primary);}
+.tab-ico{font-size:20px;line-height:1;}
+</style>
+</head>
+<body>
+
+<div class="greeting" id="gr">
+  <div class="gr-card">
+    <div><div class="gr-time" id="grT">Good morning</div><div class="gr-hi">Welcome back, <span id="grName">Operator</span>.</div></div>
+    <div class="gr-div"></div>
+    <div class="gr-sub">Yesterday's Session</div>
+    <div class="gr-stats" id="grStats">
+      <div class="gr-stat"><span class="gr-check">◌</span>Loading session data…</div>
+    </div>
+    <div class="gr-foot"><div class="gr-ready">Ready to continue?</div><div class="gr-skip" onclick="dg()">Click to continue →</div></div>
+  </div>
+</div>
+
+<header class="hd">
+  <div class="hd-brand">
+    <a href="https://fmarzochi.github.io/EGCSite/" target="_blank" rel="noopener">
+      <img class="hd-logo" src="/egc-logo.png" alt="EGC"
+        onerror="this.style.display='none';document.getElementById('hsvg').style.display='block'"/>
+      <svg id="hsvg" class="hd-logo-svg" style="display:none" viewBox="0 0 64 64" fill="none">
+        <circle cx="32" cy="18" r="14" fill="#0a4d2e" opacity=".9"/>
+        <circle cx="46" cy="32" r="14" fill="#0a4d2e" opacity=".9"/>
+        <circle cx="32" cy="46" r="14" fill="#0a4d2e" opacity=".9"/>
+        <circle cx="18" cy="32" r="14" fill="#0a4d2e" opacity=".9"/>
+        <circle cx="32" cy="18" r="10" fill="#00d992"/>
+        <circle cx="46" cy="32" r="10" fill="#00d992"/>
+        <circle cx="32" cy="46" r="10" fill="#00d992"/>
+        <circle cx="18" cy="32" r="10" fill="#00d992"/>
+        <circle cx="32" cy="32" r="8" fill="#2fd6a1"/>
+        <rect x="30" y="50" width="4" height="12" rx="2" fill="#0a4d2e"/>
+      </svg>
+      <div class="hd-wm"><span class="hd-wm-name">EGC - Dashboard</span></div>
+    </a>
+  </div>
+  <div class="hd-center">
+    <div class="vd"></div>
+    <div class="hd-block">
+      <span class="hd-eye">Project</span>
+      <span class="hd-val" id="projName" style="max-width:140px;overflow:hidden;text-overflow:ellipsis">--</span>
+    </div>
+    <div class="vd hd-hide"></div>
+    <div class="status-badge" id="activeBadge" style="display:none"><div class="status-dot"></div>ACTIVE</div>
+    <div class="vd"></div>
+    <div class="hd-block">
+      <span class="hd-eye">Session</span>
+      <span class="session-time" id="sTimer">00:00:00</span>
+    </div>
+    <div class="vd hd-hide"></div>
+    <div class="hd-block hd-hide">
+      <span class="hd-eye">Model</span>
+      <span class="hd-val" id="modelName">Claude Sonnet 4</span>
+    </div>
+  </div>
+  <div class="hd-right">
+    <div class="sys-health" id="sysHealth">
+      <div class="sh-row">
+        <div class="sh-item"><div class="sh-dot" id="sh-mem"></div>MEM</div>
+        <div class="sh-item"><div class="sh-dot" id="sh-mcp"></div>MCP</div>
+        <div class="sh-item"><div class="sh-dot" id="sh-guard"></div>GUARD</div>
+        <div class="sh-item"><div class="sh-dot" id="sh-hooks"></div>HOOKS</div>
+      </div>
+      <span class="sh-lat" id="shLat">-- ms</span>
+    </div>
+    <div class="vd hd-sh"></div>
+    <div class="ide-pills" id="idePills"></div>
+    <div class="vd"></div>
+    <div class="ws-chip"><div class="ws-dot" id="wsDot"></div><span id="wsLbl">offline</span></div>
+    <div class="win-controls">
+      <button class="wc-btn wc-min" id="wcMin" title="Minimize">
+        <svg width="8" height="2" viewBox="0 0 8 2"><rect y="0" width="8" height="2" fill="#000" opacity=".5"/></svg>
+      </button>
+      <button class="wc-btn wc-max" id="wcMax" title="Maximize">
+        <svg width="8" height="8" viewBox="0 0 8 8"><rect x="1" y="1" width="6" height="6" fill="none" stroke="#000" stroke-width="1.5" opacity=".5"/></svg>
+      </button>
+      <button class="wc-btn wc-close" id="wcClose" title="Close">
+        <svg width="8" height="8" viewBox="0 0 8 8"><line x1="1" y1="1" x2="7" y2="7" stroke="#000" stroke-width="1.5" opacity=".5"/><line x1="7" y1="1" x2="1" y2="7" stroke="#000" stroke-width="1.5" opacity=".5"/></svg>
+      </button>
+    </div>
+  </div>
+</header>
+
+<main class="main">
+  <section class="panel-brain">
+    <canvas id="brainCanvas"></canvas>
+    <div class="brain-overlay"><div class="live-dot" style="width:5px;height:5px"></div>Neural Graph</div>
+    <div class="brain-label">EGC COGNITIVE PIPELINE</div>
+  </section>
+
+  <section class="panel-center" id="panelCenter">
+    <div class="sec-head">
+      <span class="eye">Live Agents</span>
+      <span class="eye" id="agCt" style="color:var(--primary)">0 active</span>
+    </div>
+    <div class="agents-wrap" id="agWrap"></div>
+  </section>
+
+  <section class="panel-right" id="panelRight">
+    <div class="rcard">
+      <span class="eye">Mission</span>
+      <div class="rc-row"><span class="rc-label">Project</span><span class="rc-val" id="mc-proj">--</span></div>
+      <div class="rc-row"><span class="rc-label">Provider</span><span class="rc-val">Anthropic</span></div>
+      <div class="rc-row"><span class="rc-label">Model</span><span class="rc-val" id="mc-model">Claude Sonnet 4</span></div>
+      <div class="task-block">
+        <span class="rc-label">Current Task</span>
+        <div class="task-name" id="taskName">Waiting for events…</div>
+        <div class="task-file" id="taskFile"></div>
+        <span class="task-pct" id="taskPct" style="display:none"></span>
+        <div class="task-prog-wrap" style="display:none"><div class="task-prog-fill" id="taskBar"></div></div>
+      </div>
+    </div>
+
+    <div class="rcard">
+      <span class="eye">Memory</span>
+      <div class="mem-bar-wrap">
+        <div class="mem-bar-head"><span class="mem-bar-label">Long-term Memory</span><span class="mem-bar-pct" id="ltPct">87%</span></div>
+        <div class="mem-bar-track"><div class="mem-bar-fill" id="ltBar" style="background:var(--primary)"></div></div>
+      </div>
+      <div class="mem-bar-wrap">
+        <div class="mem-bar-head"><span class="mem-bar-label">Working Memory</span><span class="mem-bar-pct" id="wmPct">41%</span></div>
+        <div class="mem-bar-track"><div class="mem-bar-fill" id="wmBar" style="background:var(--primary-soft)"></div></div>
+      </div>
+      <div class="mem-counts">
+        <div class="mc"><span class="mc-n" id="cntL">0</span><span class="mc-l">Lessons</span></div>
+        <div class="mc"><span class="mc-n" id="cntD">0</span><span class="mc-l">Decisions</span></div>
+        <div class="mc"><span class="mc-n" id="cntP">0</span><span class="mc-l">Patterns</span></div>
+      </div>
+    </div>
+
+    <div class="rcard">
+      <span class="eye">AI Pipeline</span>
+      <div class="pipe-list" id="pipeList"></div>
+    </div>
+
+    <div class="rcard">
+      <span class="eye">Economy</span>
+      <div id="ecoContent"><div class="eco-empty">Waiting for provider events…</div></div>
+    </div>
+  </section>
+</main>
+
+<footer class="timeline">
+  <div class="tl-head">
+    <div class="tl-head-l"><div class="live-dot"></div><span class="eye">Live Activity</span></div>
+    <div style="display:flex;align-items:center;gap:10px">
+      <span class="tl-ct" id="tlCt">0 events</span>
+      <button class="btn-sm" onclick="clearLog()">clear</button>
+    </div>
+  </div>
+  <div class="tl-list" id="tlList"></div>
+</footer>
+
+<nav class="tab-bar">
+  <div class="tab-btn a" id="tb-brain" onclick="swTab('brain')"><span class="tab-ico">🧠</span>Brain</div>
+  <div class="tab-btn" id="tb-agents" onclick="swTab('agents')"><span class="tab-ico">🤖</span>Agents</div>
+  <div class="tab-btn" id="tb-mission" onclick="swTab('mission')"><span class="tab-ico">📊</span>Mission</div>
+</nav>
+
+<script>
+/* ── CONSTANTS ─────────────────────────────────────────── */
+const IDES=[
+  {id:'claude',    label:'Claude Code',c:'#7c4dff',e:'🤖'},
+  {id:'gemini',    label:'Gemini CLI', c:'#00d992',e:'✨'},
+  {id:'cursor',    label:'Cursor',     c:'#00bcd4',e:'🔵'},
+  {id:'codex',     label:'Codex',      c:'#10a37f',e:'🟢'},
+  {id:'kiro',      label:'Kiro',       c:'#ff6f00',e:'🟠'},
+  {id:'trae',      label:'Trae',       c:'#e91e63',e:'🎯'},
+  {id:'opencode',  label:'OpenCode',   c:'#2fd6a1',e:'📦'},
+  {id:'codebuddy', label:'CodeBuddy',  c:'#607d8b',e:'🧑‍💻'},
+  {id:'vscode',    label:'VS Code',    c:'#007acc',e:'🔷'},
+  {id:'aider',     label:'Aider',      c:'#f57c00',e:'⚡'},
+];
+
+const EGC_AGENTS=[
+  {id:'memory',    name:'Memory',        icon:'🧠',node:'memory',    c:'#00d992',tools:['Read','Grep','Glob','Search'],   thoughts:{Read:'🧠 Reading memory',Grep:'🔎 Searching history',Glob:'📂 Scanning directory',Search:'🔎 Searching knowledge base'}},
+  {id:'guardian',  name:'Guardian',      icon:'🛡️', node:'guardian',  c:'#00bcd4',tools:['Bash','MCP'],                   thoughts:{Bash:'🛡️ Validating command',MCP:'🔗 Calling MCP pipeline'}},
+  {id:'reviewer',  name:'Code Reviewer', icon:'👁️', node:'reviewer',  c:'#7c4dff',tools:['Edit','Write'],                 thoughts:{Edit:'✍️ Editing file',Write:'💾 Writing file'}},
+  {id:'architect', name:'Architecture',  icon:'🏗️',node:'architect', c:'#ff6f00',tools:['Task'],                         thoughts:{Task:'📋 Orchestrating task'}},
+  {id:'fetcher',   name:'Web Fetcher',   icon:'🌐',node:'fetcher',   c:'#10a37f',tools:['WebFetch'],                     thoughts:{WebFetch:'🌐 Fetching external resource'}},
+  {id:'context',   name:'Context',       icon:'📐',node:'context',   c:'#8b949e',tools:[],                               thoughts:{}},
+];
+
+const BRAIN_NODES=[
+  {id:'claude',   label:'Claude',    x:.50,y:.13,r:32,c:'#7c4dff'},
+  {id:'memory',   label:'Memory',    x:.14,y:.37,r:23,c:'#00d992'},
+  {id:'guardian', label:'Guardian',  x:.86,y:.37,r:23,c:'#00bcd4'},
+  {id:'reviewer', label:'Reviewer',  x:.26,y:.65,r:21,c:'#7c4dff'},
+  {id:'architect',label:'Architect', x:.74,y:.65,r:21,c:'#ff6f00'},
+  {id:'context',  label:'Context',   x:.50,y:.85,r:19,c:'#8b949e'},
+];
+const BRAIN_EDGES=[
+  ['claude','memory'],['claude','guardian'],
+  ['memory','reviewer'],['guardian','architect'],
+  ['reviewer','context'],['architect','context'],
+  ['memory','context'],['guardian','reviewer'],
+];
+
+// Pipeline stages: driven by runtime events, not fake timers
+const PIPELINE=[
+  {id:'state',    label:'Runtime State',    icon:'◌', event:'session_start'},
+  {id:'memory',   label:'Memory',           icon:'◌', event:'MemoryLoaded'},
+  {id:'lessons',  label:'Lessons',          icon:'◌', event:'LessonStored'},
+  {id:'guardian', label:'Guardian',         icon:'◌', event:'pre_tool'},
+  {id:'mcp',      label:'MCP',              icon:'◌', event:'MCP'},
+  {id:'hooks',    label:'Hooks',            icon:'◌', event:'session_start'},
+];
+
+const TL_ICO={
+  Read:'📖',Edit:'✍️',Write:'💾',Bash:'⚡',MCP:'🔗',Grep:'🔎',
+  Glob:'📂',WebFetch:'🌐',Task:'📋',Search:'🔎',
+  pre_tool:'▶',post_tool:'✔',session_start:'🚀',session_end:'🏁',
+};
+const TL_COLOR={
+  Read:'#00d992',Edit:'#7c4dff',Write:'#7c4dff',Bash:'#fbbf24',MCP:'#00bcd4',
+  Grep:'#00d992',Glob:'#00d992',WebFetch:'#10a37f',Task:'#ff6f00',Search:'#00d992',
+};
+
+/* ── STATE ─────────────────────────────────────────────── */
+const S={
+  ws:null,rc:1000,total:0,
+  events:[],logQ:[],logRunning:false,
+  demo:false,realEvents:false,filter:null,
+  agState:{},
+  eco:{tok:0,hitCt:0,lifetok:1482221},
+  mission:{task:'Waiting...',file:'--',pct:0},
+  latencyMs:0,hooksOk:false,
+};
+
+/* ── GREETING ───────────────────────────────────────────── */
+const ghr=new Date().getHours();
+document.getElementById('grT').textContent=ghr<12?'Good morning':ghr<18?'Good afternoon':'Good evening';
+function dg(){const el=document.getElementById('gr');el.classList.add('out');setTimeout(()=>el.remove(),500);}
+setTimeout(dg,7000);
+
+/* ── MOBILE TABS ────────────────────────────────────────── */
+function swTab(name){
+  const map={brain:'panel-brain',agents:'panelCenter',mission:'panelRight'};
+  ['panel-brain','panelCenter','panelRight'].forEach(id=>{
+    const el=document.getElementById(id)||document.querySelector('.'+id);
+    if(el) el.classList.remove('ta');
+  });
+  document.querySelector('.panel-brain')?.classList.remove('ta');
+  document.getElementById('panelCenter')?.classList.remove('ta');
+  document.getElementById('panelRight')?.classList.remove('ta');
+  if(name==='brain') document.querySelector('.panel-brain')?.classList.add('ta');
+  if(name==='agents') document.getElementById('panelCenter')?.classList.add('ta');
+  if(name==='mission') document.getElementById('panelRight')?.classList.add('ta');
+  document.querySelectorAll('.tab-btn').forEach(b=>b.classList.remove('a'));
+  document.getElementById(`tb-${name}`)?.classList.add('a');
+  if(name==='brain') setTimeout(()=>brain?.resize(),50);
+}
+swTab('brain');
+
+/* ── SESSION TIMER — anchored to server start ───────────── */
+let T0=Date.now();
+function startTimer(){
+  clearInterval(S._timerIv);
+  S._timerIv=setInterval(()=>{
+    const e=Date.now()-T0;
+    const h=Math.floor(e/3600000).toString().padStart(2,'0');
+    const m=Math.floor((e%3600000)/60000).toString().padStart(2,'0');
+    const s=Math.floor((e%60000)/1000).toString().padStart(2,'0');
+    document.getElementById('sTimer').textContent=`${h}:${m}:${s}`;
+  },1000);
+}
+startTimer();
+
+/* ── IDE PILLS ──────────────────────────────────────────── */
+function iconf(id){return IDES.find(i=>i.id===id)||{label:id,c:'#888',e:'🔧'};}
+document.getElementById('idePills').innerHTML=IDES.map(i=>
+  `<div class="ide-pill" id="pill-${i.id}" style="--pill-c:${i.c}" onclick="selIde('${i.id}')" title="${i.label}">
+    <div class="ide-dot"></div><span class="ide-ico">${i.e}</span><span class="ide-lbl">${i.label}</span></div>`
+).join('');
+function selIde(id){
+  S.filter=S.filter===id?null:id;
+  document.querySelectorAll('.ide-pill').forEach(e=>e.classList.remove('selected'));
+  if(S.filter)document.getElementById(`pill-${S.filter}`)?.classList.add('selected');
+  replayLog();
+}
+function replayLog(){
+  const list=document.getElementById('tlList');list.innerHTML='';
+  const evs=S.filter?S.events.filter(e=>e.ide===S.filter):S.events;
+  evs.slice(0,100).forEach(ev=>addRow(ev,true));
+}
+
+/* ── BRAIN CANVAS ───────────────────────────────────────── */
+class Brain{
+  constructor(canvas){
+    this.c=canvas;this.ctx=canvas.getContext('2d');
+    this.parts=[];this.active=new Set();this.pulses=[];this.t=0;
+    this.resize();
+    new ResizeObserver(()=>this.resize()).observe(canvas.parentElement);
+    this.loop();
+  }
+  resize(){
+    const dpr=window.devicePixelRatio||1;
+    this.w=this.c.offsetWidth;this.h=this.c.offsetHeight;
+    this.c.width=this.w*dpr;this.c.height=this.h*dpr;
+    this.ctx.setTransform(dpr,0,0,dpr,0,0);
+  }
+  np(n){return{x:n.x*this.w,y:n.y*this.h};}
+  fire(a,b,col){this.parts.push({a,b,t:0,sp:.005+Math.random()*.005,col:col||'#00d992'});}
+  activate(id){
+    this.active.add(id);
+    this.pulses.push({id,t:0,max:100});
+    setTimeout(()=>this.active.delete(id),3500);
+  }
+  draw(){
+    const{ctx,w,h}=this;this.t++;
+    ctx.clearRect(0,0,w,h);
+    // Grid
+    ctx.strokeStyle='rgba(61,58,57,.1)';ctx.lineWidth=.5;
+    for(let x=0;x<w;x+=38){ctx.beginPath();ctx.moveTo(x,0);ctx.lineTo(x,h);ctx.stroke();}
+    for(let y=0;y<h;y+=38){ctx.beginPath();ctx.moveTo(0,y);ctx.lineTo(w,y);ctx.stroke();}
+    // No ambient particles — every particle must correspond to a real event
+    // Edges
+    BRAIN_EDGES.forEach(([a,b])=>{
+      const na=BRAIN_NODES.find(n=>n.id===a),nb=BRAIN_NODES.find(n=>n.id===b);if(!na||!nb)return;
+      const pa=this.np(na),pb=this.np(nb);
+      const on=this.active.has(a)&&this.active.has(b);
+      const either=this.active.has(a)||this.active.has(b);
+      ctx.strokeStyle=on?'rgba(0,217,146,.5)':either?'rgba(61,58,57,.9)':'rgba(61,58,57,.4)';
+      ctx.lineWidth=on?2:either?1:.6;
+      ctx.setLineDash(on?[]:[5,8]);
+      ctx.beginPath();ctx.moveTo(pa.x,pa.y);ctx.lineTo(pb.x,pb.y);ctx.stroke();
+      ctx.setLineDash([]);
+    });
+    // Particles
+    this.parts=this.parts.filter(p=>p.t<1);
+    this.parts.forEach(p=>{
+      p.t=Math.min(1,p.t+p.sp);
+      const na=BRAIN_NODES.find(n=>n.id===p.a),nb=BRAIN_NODES.find(n=>n.id===p.b);if(!na||!nb)return;
+      const pa=this.np(na),pb=this.np(nb);
+      const x=pa.x+(pb.x-pa.x)*p.t,y=pa.y+(pb.y-pa.y)*p.t;
+      const g=ctx.createRadialGradient(x,y,0,x,y,p.ambient?4:9);
+      const c=p.col;
+      g.addColorStop(0,p.ambient?'rgba(61,58,57,.5)':c);
+      g.addColorStop(1,'rgba(0,0,0,0)');
+      ctx.fillStyle=g;ctx.beginPath();ctx.arc(x,y,p.ambient?4:9,0,Math.PI*2);ctx.fill();
+    });
+    // Pulse rings
+    this.pulses=this.pulses.filter(p=>p.t<p.max);
+    this.pulses.forEach(p=>{
+      p.t++;
+      const node=BRAIN_NODES.find(n=>n.id===p.id);if(!node)return;
+      const pos=this.np(node);
+      const r=node.r+(p.t/p.max)*48;
+      ctx.strokeStyle=`rgba(0,217,146,${(1-p.t/p.max)*.38})`;
+      ctx.lineWidth=1;ctx.beginPath();ctx.arc(pos.x,pos.y,r,0,Math.PI*2);ctx.stroke();
+    });
+    // Nodes
+    BRAIN_NODES.forEach(node=>{
+      const pos=this.np(node);
+      const on=this.active.has(node.id);
+      const br=1+Math.sin(this.t*.028+node.x*9)*.022;
+      const r=node.r*br;
+      if(on){
+        const g=ctx.createRadialGradient(pos.x,pos.y,0,pos.x,pos.y,r*3.5);
+        g.addColorStop(0,node.c+'28');g.addColorStop(1,'transparent');
+        ctx.fillStyle=g;ctx.beginPath();ctx.arc(pos.x,pos.y,r*3.5,0,Math.PI*2);ctx.fill();
+      }
+      const bg=ctx.createRadialGradient(pos.x-r*.3,pos.y-r*.3,r*.1,pos.x,pos.y,r);
+      bg.addColorStop(0,'#252525');bg.addColorStop(1,'#181818');
+      ctx.fillStyle=bg;ctx.beginPath();ctx.arc(pos.x,pos.y,r,0,Math.PI*2);ctx.fill();
+      ctx.strokeStyle=on?node.c:'rgba(61,58,57,.8)';ctx.lineWidth=on?2.5:1;
+      ctx.beginPath();ctx.arc(pos.x,pos.y,r,0,Math.PI*2);ctx.stroke();
+      if(on){ctx.strokeStyle=node.c+'40';ctx.lineWidth=4;ctx.beginPath();ctx.arc(pos.x,pos.y,r-5,0,Math.PI*2);ctx.stroke();}
+      // Node label
+      ctx.fillStyle=on?'#ffffff':'#6b7280';
+      ctx.font=`${on?700:400} ${node.id==='claude'?13:10}px Inter,sans-serif`;
+      ctx.textAlign='center';ctx.textBaseline='middle';
+      ctx.fillText(node.label,pos.x,pos.y);
+      // Status label below node (when active)
+      if(on){
+        const ag=EGC_AGENTS.find(a=>a.node===node.id);
+        if(ag&&S.agState[ag.id+'_act']){
+          ctx.font='10px Inter,sans-serif';ctx.fillStyle='rgba(0,217,146,.8)';
+          ctx.fillText(S.agState[ag.id+'_act'].split(' ')[0],pos.x,pos.y+r+12);
+        }
+      }
+    });
+    // Scanlines
+    for(let y=0;y<h;y+=3){ctx.fillStyle='rgba(0,0,0,.06)';ctx.fillRect(0,y,w,1);}
+  }
+  loop(){this.draw();requestAnimationFrame(()=>this.loop());}
+}
+const brain=new Brain(document.getElementById('brainCanvas'));
+
+/* ── UNIFIED AGENT CARDS ────────────────────────────────── */
+function renderAgents(){
+  const wrap=document.getElementById('agWrap');
+  const activeCt=EGC_AGENTS.filter(a=>S.agState[a.id]==='active').length;
+  document.getElementById('agCt').textContent=activeCt+' active';
+
+  wrap.innerHTML=EGC_AGENTS.map(ag=>{
+    const st=S.agState[ag.id]||'idle';
+    const act=S.agState[ag.id+'_act']||'Standby';
+    const file=S.agState[ag.id+'_file']||'';
+    const elapsed=S.agState[ag.id+'_t']?Math.round((Date.now()-S.agState[ag.id+'_t']))+'ms':'';
+    const prog=S.agState[ag.id+'_prog']||0;
+    const isActive=st==='active';
+    return`<div class="ag-card ${isActive?'active':'idle'}" style="--ag-c:${ag.c}">
+      <div class="ag-top">
+        <div class="ag-status-dot"></div>
+        <div class="ag-ico">${ag.icon}</div>
+        <div class="ag-name">${ag.name}</div>
+        <div class="ag-elapsed">${elapsed}</div>
+      </div>
+      <div class="ag-action">
+        <span class="ag-action-ico">${isActive?'':'💤'}</span>
+        <span>${isActive?act:'Standby'}</span>
+      </div>
+      ${file?`<div class="ag-file">📂 ${file}</div>`:''}
+      ${isActive?`<div class="ag-prog-wrap"><div class="ag-prog-fill ${prog<0?'indeterminate':''}" style="${prog>=0?'width:'+prog+'%':''}"></div></div>`:''}
+    </div>`;
+  }).join('');
+}
+renderAgents();
+
+function activateAgent(agId,thought,file){
+  const ag=EGC_AGENTS.find(a=>a.id===agId);if(!ag)return;
+  S.agState[agId]='active';
+  S.agState[agId+'_act']=thought;
+  S.agState[agId+'_file']=file||'';
+  S.agState[agId+'_t']=Date.now();
+  S.agState[agId+'_prog']=-1; // -1 = indeterminate, no fake %
+  renderAgents();
+  // Brain
+  brain.activate(agId==='context'?'context':ag.node);
+  brain.activate('claude');
+  brain.fire('claude',ag.node,ag.c);
+  setTimeout(()=>brain.fire(ag.node,'claude','#00d992'),700);
+  BRAIN_EDGES.filter(([a,b])=>a===ag.node||b===ag.node)
+    .forEach(([a,b])=>setTimeout(()=>brain.fire(a,b,ag.c),300+Math.random()*600));
+  // Health dots: MEM when memory agent fires, GUARD when guardian fires, HOOKS on any event
+  document.getElementById('sh-hooks')?.classList.add('ok');
+  if(agId==='memory')document.getElementById('sh-mem')?.classList.add('ok');
+  if(agId==='guardian')document.getElementById('sh-guard')?.classList.add('ok');
+  // Deactivate
+  clearTimeout(S.agState[agId+'_timer']);
+  S.agState[agId+'_timer']=setTimeout(()=>{
+    S.agState[agId]='idle';S.agState[agId+'_prog']=100;
+    renderAgents();
+  },3500);
+}
+
+/* ── MISSION TASK — real tool events only ───────────────── */
+function updateMission(tool,file){
+  const taskNames={
+    Edit:'Editing file',Write:'Writing file',Read:'Reading file',
+    Bash:'Running command',MCP:'MCP call',Task:'Task created',
+    Grep:'Searching',WebFetch:'Fetching URL',Glob:'Scanning directory',
+    Skill:'Skill delegated',Agent:'Agent spawned',
+  };
+  const label=taskNames[tool]||tool;
+  if(!label)return;
+  document.getElementById('taskName').textContent=label;
+  document.getElementById('taskFile').textContent=file||'--';
+  document.getElementById('taskBar').style.width='0%';
+  document.getElementById('taskPct').textContent='';
+}
+
+/* ── ECONOMY — real telemetry only ─────────────────────── */
+function renderEconomy(telemetry){
+  const wrap=document.getElementById('ecoContent');
+  const active=Object.entries(telemetry).filter(([,p])=>p.running||p.sessions>0);
+  if(!active.length){wrap.innerHTML='<div class="eco-empty">No provider events received yet.</div>';return;}
+  wrap.innerHTML=active.map(([ide,p])=>{
+    const ic=IDES.find(i=>i.id===ide)||{label:ide,c:'#888'};
+    const cap=p.capabilities||{};
+    let tokHtml='';
+    if(cap.tokenUsage&&p.tokens){
+      const hasTok=p.tokens.input>0||p.tokens.output>0;
+      tokHtml=hasTok
+        ?`<div class="eco-row"><span class="eco-lbl">Input Tokens</span><span class="eco-val">${p.tokens.input.toLocaleString()}</span></div>
+          <div class="eco-row"><span class="eco-lbl">Output Tokens</span><span class="eco-val">${p.tokens.output.toLocaleString()}</span></div>
+          ${p.tokens.cacheRead>0?`<div class="eco-row"><span class="eco-lbl">Cache Read</span><span class="eco-val">${p.tokens.cacheRead.toLocaleString()}</span></div>`:''}
+          ${p.cost!==null?`<div class="eco-row"><span class="eco-lbl">Estimated Cost</span><span class="eco-val green">$${p.cost.toFixed(4)}</span></div>`:''}
+        `
+        :'<div class="eco-empty" style="text-align:left;padding:4px 0">Waiting for session end event…</div>';
+    }else{
+      tokHtml=`<div class="eco-unavail-row">
+        <span class="eco-lbl-na">Tokens</span>
+        <span class="eco-val-na">Unavailable</span>
+        <span class="eco-reason">Provider does not expose token telemetry.</span>
+      </div>`;
+    }
+    return`<div class="eco-provider">
+      <div class="eco-provider-head" style="color:${ic.c}">${ic.label}</div>
+      ${tokHtml}
+      <div class="eco-row"><span class="eco-lbl">Tool Calls</span><span class="eco-val">${p.toolCalls}</span></div>
+      <div class="eco-row"><span class="eco-lbl">Sessions</span><span class="eco-val">${p.sessions}</span></div>
+    </div>`;
+  }).join('');
+}
+
+function pollTelemetry(){
+  fetch('/telemetry').then(r=>r.json()).then(t=>{
+    renderEconomy(t);
+    // Update pill alive state from server truth
+    Object.entries(t).forEach(([ide,p])=>{
+      const el=document.getElementById(`pill-${ide}`);
+      if(!el)return;
+      if(p.running)el.classList.add('alive');
+      else el.classList.remove('alive');
+    });
+  }).catch(()=>{});
+}
+setInterval(pollTelemetry,8000);
+pollTelemetry();
+
+/* ── WEBSOCKET ──────────────────────────────────────────── */
+function connect(){
+  try{
+    S.ws=new WebSocket('ws://localhost:7890');
+    S.ws.onopen=()=>{setWs(true);S.rc=1000;pingLatency();};
+    S.ws.onclose=()=>{setWs(false);setTimeout(connect,S.rc);S.rc=Math.min(S.rc*2,10000);};
+    S.ws.onmessage=m=>{
+      try{
+        const t0=performance.now();
+        S.realEvents=true;S.demo=false;
+        handleEv(JSON.parse(m.data));
+        S.latencyMs=Math.round(performance.now()-t0);
+        document.getElementById('shLat').textContent=S.latencyMs+'ms';
+      }catch(e){}
+    };
+  }catch(e){}
+}
+function setWs(on){
+  document.getElementById('wsDot').className='ws-dot'+(on?' on':'');
+  document.getElementById('wsLbl').textContent=on?'live':'offline';
+  document.getElementById('activeBadge').style.display=on?'':'none';
+}
+function pingLatency(){
+  if(!S.ws||S.ws.readyState!==1)return;
+  fetch('/ping').then(r=>r.json()).then(d=>{
+    const lat=Date.now()-d.ts;
+    document.getElementById('shLat').textContent=lat+'ms';
+  }).catch(()=>{});
+  setTimeout(pingLatency,5000);
+}
+
+/* ── EVENT HANDLER ──────────────────────────────────────── */
+function handleEv(ev){
+  ev.at=Date.now();
+  S.events.unshift(ev);if(S.events.length>2000)S.events.pop();
+  S.total++;
+  if(!S.demo)document.getElementById(`pill-${ev.ide}`)?.classList.add('alive');
+  if(ev.event==='session_start'||ev.event==='pre_tool'){
+    pipelineActivate('state');
+    pipelineActivate('hooks');
+  }
+  if(ev.event==='pre_tool'){
+    const tool=ev.tool||'';
+    const file=ev.detail||ev.metadata?.file||'';
+    pipelineActivate('guardian');
+    if(tool==='MCP'||tool.startsWith('mcp')){
+      pipelineActivate('mcp');
+      document.getElementById('sh-mcp')?.classList.add('ok');
+    }
+    const ag=EGC_AGENTS.find(a=>a.tools.includes(tool));
+    if(ag){
+      const thought=ag.thoughts[tool]||`${ag.icon} ${tool}...`;
+      activateAgent(ag.id,thought,file);
+    }
+    updateMission(tool,file);
+  }
+  if(ev.event==='session_end'){
+    pipelineActivate('memory');
+    pipelineActivate('lessons');
+    pollTelemetry();
+  }
+  if(!S.filter||ev.ide===S.filter)enqueueLog(ev);
+  document.getElementById('tlCt').textContent=S.total+' events';
+}
+
+/* ── TIMELINE ───────────────────────────────────────────── */
+function enqueueLog(ev){S.logQ.push(ev);if(!S.logRunning)drainLog();}
+function drainLog(){if(!S.logQ.length){S.logRunning=false;return;}S.logRunning=true;addRow(S.logQ.shift());setTimeout(drainLog,280);}
+function addRow(ev,na){
+  const list=document.getElementById('tlList');
+  const ic=iconf(ev.ide);
+  const time=new Date(ev.at).toLocaleTimeString('en',{hour12:false});
+  const ok=ev.status!=='error';
+  const r=document.createElement('div');
+  r.className=`tl-row${na?' na':''}`;
+  const tool=ev.tool||'';
+  const ico=TL_ICO[tool]||TL_ICO[ev.event]||'▸';
+  const col=ok?(TL_COLOR[tool]||ic.c):ev.status==='error'?'#f87171':'#8b949e';
+  const what=(tool?tool:ev.event)||'?';
+  const file=ev.detail||'';
+  r.innerHTML=`
+    <span class="tl-time" style="color:var(--muted)">${time}</span>
+    <span class="tl-ico" style="color:${col}">${ico}</span>
+    <span class="tl-who" style="color:${ic.c}">${ev.agent||'main'}</span>
+    <span class="tl-what">${what}${file?` <span style="color:var(--muted);font-size:10px">${file}</span>`:''}</span>
+    <span class="tl-dur">${ev.duration_ms?ev.duration_ms+'ms':''}</span>`;
+  list.insertBefore(r,list.firstChild);
+  while(list.children.length>150)list.removeChild(list.lastChild);
+}
+function clearLog(){document.getElementById('tlList').innerHTML='';S.events=[];S.total=0;document.getElementById('tlCt').textContent='0 events';}
+
+/* ── PIPELINE — driven by real events ───────────────────── */
+document.getElementById('pipeList').innerHTML=PIPELINE.map(p=>
+  `<div class="pipe-row" id="pp-${p.id}">
+    <div class="pipe-top">
+      <div><span class="pipe-ico" id="pico-${p.id}">${p.icon}</span><span class="pipe-lbl">${p.label}</span></div>
+      <span class="pipe-pct" id="ppct-${p.id}">Waiting</span>
+    </div>
+  </div>`
+).join('');
+
+function pipelineActivate(id){
+  const row=document.getElementById(`pp-${id}`);
+  const pct=document.getElementById(`ppct-${id}`);
+  const ico=document.getElementById(`pico-${id}`);
+  if(!row)return;
+  row.classList.add('done');
+  if(pct)pct.textContent='Active';
+  if(ico)ico.textContent='✔';
+}
+// Hooks and runtime state fire on first connection
+pipelineActivate('hooks');
+
+/* ── STATS — real data only ─────────────────────────────── */
+fetch('/stats').then(r=>r.json()).then(st=>{
+  const proj=st.project||'--';
+  document.getElementById('projName').textContent=proj;
+  document.getElementById('mc-proj').textContent=proj;
+  const model=st.model||'Unknown';
+  document.getElementById('modelName').textContent=model;
+  document.getElementById('mc-model').textContent=model;
+  // Anchor timer to server start so browser refresh doesn't reset it
+  if(st.serverStart){T0=st.serverStart;startTimer();}
+  if(st.operator)document.getElementById('grName').textContent=st.operator.split(' ')[0];
+  // Show ACTIVE badge only when WS is live
+  document.getElementById('activeBadge').style.display='';
+
+  // Greeting: show only what we actually know
+  const grLines=[];
+  if(st.decisions>0)grLines.push(`✔ ${st.decisions} decisions in long-term memory`);
+  if(st.lessons>0)grLines.push(`✔ ${st.lessons} lessons loaded`);
+  if(st.patterns>0)grLines.push(`✔ ${st.patterns} patterns detected`);
+  if(!grLines.length)grLines.push('No prior session data found.');
+  document.getElementById('grStats').innerHTML=grLines
+    .map(l=>`<div class="gr-stat"><span class="gr-check">${l.startsWith('✔')?'✔':'◌'}</span>${l.replace('✔ ','')}</div>`)
+    .join('');
+
+  // Memory counts — real numbers or 0
+  const anim=(id,v)=>{
+    let n=0;const step=Math.max(1,Math.ceil(v/40));
+    const iv=setInterval(()=>{n=Math.min(n+step,v);document.getElementById(id).textContent=n;if(n>=v)clearInterval(iv);},45);
+  };
+  anim('cntL',st.lessons||0);
+  anim('cntD',st.decisions||0);
+  anim('cntP',st.patterns||0);
+
+  // Memory bars: only show if data exists
+  if(st.longTermPct!=null){
+    document.getElementById('ltBar').style.width=st.longTermPct+'%';
+    document.getElementById('ltPct').textContent=st.longTermPct+'%';
+  } else {
+    document.getElementById('ltPct').textContent='Unknown';
+  }
+  if(st.workingPct!=null){
+    document.getElementById('wmBar').style.width=st.workingPct+'%';
+    document.getElementById('wmPct').textContent=st.workingPct+'%';
+  } else {
+    document.getElementById('wmPct').textContent='Unknown';
+  }
+}).catch(()=>{
+  document.getElementById('grStats').innerHTML=
+    '<div class="gr-stat"><span class="gr-check">◌</span>Server unavailable — running offline.</div>';
+});
+
+connect();
+
+if('serviceWorker' in navigator){
+  navigator.serviceWorker.register('/sw.js').catch(()=>{});
+}
+
+/* ── WINDOW CONTROLS ─────────────────────────────────── */
+(function(){
+  let minimized=false;
+
+  document.getElementById('wcMin').addEventListener('click',()=>{
+    minimized=!minimized;
+    document.body.classList.toggle('minimized',minimized);
+    document.getElementById('wcMin').title=minimized?'Restore':'Minimize';
+  });
+
+  document.getElementById('wcMax').addEventListener('click',()=>{
+    if(!document.fullscreenElement){
+      document.documentElement.requestFullscreen().catch(()=>{});
+      document.getElementById('wcMax').title='Exit Fullscreen';
+    } else {
+      document.exitFullscreen().catch(()=>{});
+      document.getElementById('wcMax').title='Maximize';
+    }
+  });
+
+  document.addEventListener('fullscreenchange',()=>{
+    const btn=document.getElementById('wcMax');
+    btn.title=document.fullscreenElement?'Exit Fullscreen':'Maximize';
+  });
+
+  document.getElementById('wcClose').addEventListener('click',()=>{
+    window.close();
+    // Fallback if window.close() is blocked (tab not opened by script)
+    setTimeout(()=>{
+      document.body.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:Inter,sans-serif;color:#666;font-size:14px;">Dashboard closed. You can close this tab.</div>';
+    },200);
+  });
+})();
+</script>
+</body>
+</html>

--- a/dashboard/public/manifest.json
+++ b/dashboard/public/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "EGC - Extended Global Context · Mission Control",
+  "short_name": "EGC Mission Control",
+  "description": "Real-time runtime observability for the EGC ecosystem",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#101010",
+  "theme_color": "#101010",
+  "orientation": "landscape",
+  "icons": [
+    { "src": "/egc-logo.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "/egc-logo.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
+  ]
+}

--- a/dashboard/public/sw.js
+++ b/dashboard/public/sw.js
@@ -1,0 +1,30 @@
+// EGC Mission Control — Service Worker
+// Serves only the shell offline; all telemetry requires the local server.
+const CACHE = 'egc-mc-v2';
+const SHELL  = ['/', '/index.html'];
+
+self.addEventListener('install', e => {
+  e.waitUntil(
+    caches.open(CACHE).then(c => c.addAll(SHELL)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', e => {
+  // Never cache API calls — always go to network
+  const url = new URL(e.request.url);
+  if (['/event', '/stats', '/telemetry', '/capabilities', '/ping'].includes(url.pathname)) {
+    e.respondWith(fetch(e.request));
+    return;
+  }
+  e.respondWith(
+    caches.match(e.request).then(cached => cached || fetch(e.request))
+  );
+});

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+'use strict';
+
+const http    = require('http');
+const path    = require('path');
+const fs      = require('fs');
+const os      = require('os');
+const { exec, execSync } = require('child_process');
+
+const PORT   = 7890;
+const PUBLIC = path.join(__dirname, 'public');
+const CFG    = path.join(__dirname, 'config.json');
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript',
+  '.css':  'text/css',
+  '.json': 'application/json',
+  '.png':  'image/png',
+  '.svg':  'image/svg+xml',
+  '.ico':  'image/x-icon',
+};
+
+const SERVER_START = Date.now();
+
+function detectModel() {
+  const candidates = [
+    path.join(os.homedir(), '.claude', 'settings.json'),
+    path.join(os.homedir(), '.claude', 'settings.local.json'),
+  ];
+  for (const p of candidates) {
+    try {
+      const s = JSON.parse(fs.readFileSync(p, 'utf8'));
+      if (s.model)        return s.model;
+      if (s.defaultModel) return s.defaultModel;
+    } catch (_) {}
+  }
+  return process.env.ANTHROPIC_MODEL || process.env.EGC_MODEL || null;
+}
+
+const DETECTED_MODEL = detectModel();
+
+function detectOperator() {
+  try { return execSync('git config user.name', { encoding: 'utf8', timeout: 500 }).trim(); } catch (_) {}
+  return process.env.USER || process.env.USERNAME || null;
+}
+const OPERATOR = detectOperator();
+
+// What each provider can actually expose — honest contract
+const CAPABILITIES = {
+  claude:    { tokenUsage:true,  model:true,  cost:true,  session:true,  workspace:true  },
+  gemini:    { tokenUsage:true,  model:true,  cost:false, session:true,  workspace:false },
+  cursor:    { tokenUsage:false, model:false, cost:false, session:true,  workspace:true  },
+  codex:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  vscode:    { tokenUsage:false, model:false, cost:false, session:false, workspace:true  },
+  kiro:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  trae:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  opencode:  { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  codebuddy: { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  aider:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+};
+
+// Pricing per 1M tokens — updated from Anthropic pricing page
+const CLAUDE_PRICING = {
+  input:      3.00,
+  output:    15.00,
+  cacheRead:  0.30,
+  cacheWrite: 3.75,
+};
+
+// Runtime telemetry accumulated from real events
+const providerState = {};
+
+function getProvider(ide) {
+  if (!providerState[ide]) {
+    providerState[ide] = {
+      ide,
+      lastSeen:  null,
+      running:   false,
+      toolCalls: 0,
+      sessions:  0,
+      tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+  }
+  return providerState[ide];
+}
+
+function accumulateEvent(ev) {
+  const p = getProvider(ev.ide);
+  p.lastSeen = Date.now();
+  p.running  = true;
+
+  if (ev.event === 'pre_tool')    p.toolCalls++;
+  if (ev.event === 'session_end' && ev.usage) {
+    p.sessions++;
+    p.tokens.input      += (ev.usage.input_tokens                  || 0);
+    p.tokens.output     += (ev.usage.output_tokens                 || 0);
+    p.tokens.cacheRead  += (ev.usage.cache_read_input_tokens       || 0);
+    p.tokens.cacheWrite += (ev.usage.cache_creation_input_tokens   || 0);
+  }
+}
+
+// Mark providers offline after 90 s without events
+setInterval(() => {
+  const now = Date.now();
+  for (const p of Object.values(providerState)) {
+    if (p.running && p.lastSeen && now - p.lastSeen > 90_000) {
+      p.running = false;
+    }
+  }
+}, 15_000);
+
+// ── WebSocket clients ───────────────────────────────────────
+const clients = new Set();
+
+// ── HTTP server ─────────────────────────────────────────────
+const server = http.createServer((req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+
+  // ── POST /event ─────────────────────────────────────────
+  if (req.method === 'POST' && req.url === '/event') {
+    let body = '';
+    req.on('data', d => body += d);
+    req.on('end', () => {
+      try {
+        const ev = JSON.parse(body);
+        accumulateEvent(ev);
+        const msg = JSON.stringify(ev);
+        for (const ws of clients) { if (ws.readyState === 1) ws.send(msg); }
+      } catch (_) {}
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{"ok":true}');
+    });
+    return;
+  }
+
+  // ── GET /capabilities ────────────────────────────────────
+  if (req.method === 'GET' && req.url === '/capabilities') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(CAPABILITIES));
+    return;
+  }
+
+  // ── GET /telemetry ───────────────────────────────────────
+  if (req.method === 'GET' && req.url === '/telemetry') {
+    const result = {};
+    for (const [ide, p] of Object.entries(providerState)) {
+      const cap = CAPABILITIES[ide] || {};
+      let cost = null;
+      if (ide === 'claude' && cap.cost && p.tokens.input > 0) {
+        cost =
+          p.tokens.input      * CLAUDE_PRICING.input      / 1e6 +
+          p.tokens.output     * CLAUDE_PRICING.output     / 1e6 +
+          p.tokens.cacheRead  * CLAUDE_PRICING.cacheRead  / 1e6 +
+          p.tokens.cacheWrite * CLAUDE_PRICING.cacheWrite / 1e6;
+      }
+      result[ide] = {
+        running:      p.running,
+        toolCalls:    p.toolCalls,
+        sessions:     p.sessions,
+        tokens:       cap.tokenUsage ? p.tokens : null,
+        cost:         (cap.cost && cost !== null) ? cost : null,
+        capabilities: cap,
+      };
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(result));
+    return;
+  }
+
+  // ── GET /stats ───────────────────────────────────────────
+  if (req.method === 'GET' && req.url === '/stats') {
+    const cwd       = process.cwd();
+    const cwdName   = path.basename(cwd);
+    const project   = cwdName === 'dashboard' ? path.basename(path.dirname(cwd)) : cwdName;
+    const workspace = cwdName === 'dashboard' ? path.dirname(cwd) : cwd;
+
+    const stats = {
+      project,
+      workspace,
+      model:       DETECTED_MODEL || 'Unknown',
+      provider:    'Anthropic',
+      serverStart: SERVER_START,
+      operator:    OPERATOR,
+      decisions: 0, lessons: 0, patterns: 0,
+      longTermPct: null, workingPct: null,
+    };
+
+    try {
+      const dir = path.join(os.homedir(), '.egc', 'state');
+      if (fs.existsSync(dir)) {
+        const files = fs.readdirSync(dir).filter(f => f.endsWith('.md')).slice(0, 6);
+        let d = 0, l = 0, p = 0;
+        for (const f of files) {
+          const c = fs.readFileSync(path.join(dir, f), 'utf8');
+          d += (c.match(/^- What:/gm)   || []).length;
+          l += (c.match(/lesson/gi)      || []).length;
+          p += (c.match(/pattern/gi)     || []).length;
+        }
+        stats.decisions = d;
+        stats.lessons   = Math.min(l, 99);
+        stats.patterns  = Math.min(p, 30);
+      }
+    } catch (_) {}
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(stats));
+    return;
+  }
+
+  // ── GET /ping ────────────────────────────────────────────
+  if (req.method === 'GET' && req.url === '/ping') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ts: Date.now() }));
+    return;
+  }
+
+  // ── GET /egc-logo.png ────────────────────────────────────
+  if (req.method === 'GET' && req.url === '/egc-logo.png') {
+    const logo = path.join(__dirname, '..', 'assets', 'images', 'egc-logo.png');
+    if (fs.existsSync(logo)) {
+      res.writeHead(200, { 'Content-Type': 'image/png' });
+      res.end(fs.readFileSync(logo));
+    } else {
+      res.writeHead(404); res.end();
+    }
+    return;
+  }
+
+  // ── GET /config.json ─────────────────────────────────────
+  if (req.method === 'GET' && req.url === '/config.json') {
+    if (fs.existsSync(CFG)) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(fs.readFileSync(CFG));
+    } else {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{"rules":[]}');
+    }
+    return;
+  }
+
+  // ── Static files ─────────────────────────────────────────
+  const urlPath = req.url === '/' ? '/index.html' : req.url;
+  const file    = path.join(PUBLIC, urlPath.split('?')[0]);
+  if (!file.startsWith(PUBLIC)) { res.writeHead(403); res.end(); return; }
+  if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+    const ext = path.extname(file);
+    res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+    res.end(fs.readFileSync(file));
+  } else {
+    res.writeHead(404); res.end('Not found');
+  }
+});
+
+// ── WebSocket ────────────────────────────────────────────────
+try {
+  const { WebSocketServer } = require('ws');
+  const wss = new WebSocketServer({ server });
+  wss.on('connection', ws => {
+    clients.add(ws);
+    ws.on('close', () => clients.delete(ws));
+    ws.on('error', () => clients.delete(ws));
+  });
+} catch (_) {
+  console.error('ws module not found. Run: npm install inside dashboard/');
+  process.exit(1);
+}
+
+server.listen(PORT, '127.0.0.1', () => {
+  const url = `http://localhost:${PORT}`;
+  console.log(`EGC Dashboard running at ${url}`);
+  exec(`xdg-open ${url} 2>/dev/null || open ${url} 2>/dev/null || true`);
+});
+
+server.on('error', err => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`Port ${PORT} already in use. Is the dashboard already running?`);
+  } else {
+    console.error(err.message);
+  }
+  process.exit(1);
+});

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -5,7 +5,7 @@ const http    = require('http');
 const path    = require('path');
 const fs      = require('fs');
 const os      = require('os');
-const { exec, execSync } = require('child_process');
+const { execSync } = require('child_process');
 
 const PORT   = 7890;
 const PUBLIC = path.join(__dirname, 'public');
@@ -115,7 +115,9 @@ const clients = new Set();
 
 // ── HTTP server ─────────────────────────────────────────────
 const server = http.createServer((req, res) => {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  const reqOrigin = req.headers.origin || '';
+  res.setHeader('Access-Control-Allow-Origin',
+    /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(reqOrigin) ? reqOrigin : 'http://localhost:7890');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
@@ -270,9 +272,7 @@ try {
 }
 
 server.listen(PORT, '127.0.0.1', () => {
-  const url = `http://localhost:${PORT}`;
-  console.log(`EGC Dashboard running at ${url}`);
-  exec(`xdg-open ${url} 2>/dev/null || open ${url} 2>/dev/null || true`);
+  console.log(`EGC Dashboard running at http://localhost:${PORT}`);
 });
 
 server.on('error', err => {

--- a/dashboard/shim-session.js
+++ b/dashboard/shim-session.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('http');
+
+const IDE   = process.argv[2] || 'trae';
+const EVENT = process.argv[3] || 'session_start';
+
+function post(ev) {
+  const body = JSON.stringify(ev);
+  const req = http.request(
+    { hostname:'127.0.0.1', port:7890, path:'/event', method:'POST',
+      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
+      timeout:300 },
+    ()=>{}
+  );
+  req.on('error', ()=>{});
+  req.on('timeout', ()=>req.destroy());
+  req.end(body);
+}
+
+post({ ide:IDE, event:EVENT, agent:'main', status:'running', detail:'' });

--- a/dashboard/shim.js
+++ b/dashboard/shim.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('http');
+
+const IDE = process.env.EGC_IDE || process.argv[2] || 'claude';
+
+function post(ev) {
+  const body = JSON.stringify(ev);
+  const req = http.request(
+    { hostname: '127.0.0.1', port: 7890, path: '/event', method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+      timeout: 300 },
+    () => {}
+  );
+  req.on('error', () => {});
+  req.on('timeout', () => req.destroy());
+  req.end(body);
+}
+
+function fileFrom(input) {
+  if (!input) return '';
+  return input.file_path || input.path || input.command || input.url ||
+         input.skill || input.subagent_type || '';
+}
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => raw += d);
+process.stdin.on('end', () => {
+  try {
+    const hook = JSON.parse(raw);
+    const name = hook.hook_event_name;
+
+    if (name === 'Stop') {
+      post({
+        ide:        IDE,
+        event:      'session_end',
+        agent:      'main',
+        session_id: hook.session_id,
+        stop_reason: hook.stop_reason || null,
+        usage:      hook.usage || null,
+      });
+      process.exit(0);
+    }
+
+    const isPre  = name === 'PreToolUse';
+    const isPost = name === 'PostToolUse';
+    if (!isPre && !isPost) process.exit(0);
+
+    post({
+      ide:        IDE,
+      event:      isPre ? 'pre_tool' : 'post_tool',
+      tool:       hook.tool_name || '',
+      agent:      'main',
+      detail:     fileFrom(hook.tool_input),
+      status:     isPre ? 'running' : (hook.tool_response?.is_error ? 'error' : 'success'),
+      session_id: hook.session_id,
+      duration_ms: hook.tool_response?.duration_ms || undefined,
+    });
+  } catch (_) {}
+  process.exit(0);
+});

--- a/dashboard/vscode-adapter.js
+++ b/dashboard/vscode-adapter.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('http');
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+
+const PORT = 7890;
+
+const LOG_PATHS = [
+  path.join(os.homedir(), '.vscode', 'logs'),
+  path.join(os.homedir(), '.vscode-server', 'data', 'logs'),
+];
+
+function post(ev) {
+  const body = JSON.stringify(ev);
+  const req = http.request(
+    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
+      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
+      timeout:300 },
+    ()=>{}
+  );
+  req.on('error', ()=>{});
+  req.on('timeout', ()=>req.destroy());
+  req.end(body);
+}
+
+function findCopilotLog(dir) {
+  if (!fs.existsSync(dir)) return null;
+  try {
+    const entries = fs.readdirSync(dir, {withFileTypes:true});
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        const sub = path.join(dir, e.name);
+        const files = fs.readdirSync(sub).filter(f=>f.includes('copilot') || f.includes('github'));
+        if (files.length) return path.join(sub, files[0]);
+      }
+    }
+  } catch(_) {}
+  return null;
+}
+
+let watching = false;
+let lastSize = 0;
+
+function watch() {
+  for (const logDir of LOG_PATHS) {
+    const logFile = findCopilotLog(logDir);
+    if (!logFile) continue;
+    if (watching) break;
+    watching = true;
+    lastSize = fs.statSync(logFile).size;
+
+    fs.watch(logFile, { persistent:false }, () => {
+      try {
+        const stat = fs.statSync(logFile);
+        if (stat.size <= lastSize) return;
+        const buf = Buffer.alloc(stat.size - lastSize);
+        const fd = fs.openSync(logFile, 'r');
+        fs.readSync(fd, buf, 0, buf.length, lastSize);
+        fs.closeSync(fd);
+        lastSize = stat.size;
+
+        const chunk = buf.toString('utf8');
+        if (chunk.includes('request') || chunk.includes('completion') || chunk.includes('edit')) {
+          post({ ide:'vscode', event:'pre_tool', tool:'Copilot', agent:'main', detail:chunk.slice(0,60).trim(), status:'running' });
+          setTimeout(()=>{ post({ ide:'vscode', event:'post_tool', tool:'Copilot', agent:'main', status:'success' }); }, 400);
+        }
+      } catch(_) {}
+    });
+
+    console.log(`Watching VS Code Copilot log: ${logFile}`);
+    break;
+  }
+}
+
+watch();
+setInterval(()=>{ if (!watching) watch(); }, 10000);
+console.log('EGC VS Code Copilot adapter running');

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -77,11 +77,16 @@ async function start() {
 
   // Wait up to 3s for server to accept connections
   const deadline = Date.now() + 3000;
+  let ready = false;
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, 200));
-    if (await isRunning()) break;
+    if (await isRunning()) { ready = true; break; }
   }
 
+  if (!ready) {
+    console.error('EGC Dashboard failed to start. Check server.js for errors.');
+    process.exit(1);
+  }
   console.log(`EGC Dashboard running at http://localhost:${PORT}`);
   openBrowser();
 }
@@ -91,6 +96,14 @@ async function stop() {
   if (!pid) {
     const already = await isRunning();
     if (!already) { console.log('Dashboard is not running.'); return; }
+    console.error('No PID file found. Stop the server manually.');
+    return;
+  }
+  try {
+    process.kill(pid, 0);
+  } catch (_) {
+    try { fs.unlinkSync(PID_FILE); } catch (__) { /* pid file is optional */ }
+    if (!await isRunning()) { console.log('Dashboard is not running (stale PID cleaned up).'); return; }
     console.error('No PID file found. Stop the server manually.');
     return;
   }

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync, spawn } = require('child_process');
+const path = require('path');
+const http = require('http');
+const fs = require('fs');
+
+const PORT = 7890;
+const DASHBOARD_DIR = path.join(__dirname, '..', 'dashboard');
+const SERVER_SCRIPT = path.join(DASHBOARD_DIR, 'server.js');
+const PID_FILE = path.join(require('os').homedir(), '.egc', 'dashboard.pid');
+
+const args = process.argv.slice(2);
+const flag = args[0];
+
+function isRunning() {
+  return new Promise(resolve => {
+    const req = http.get(`http://localhost:${PORT}/ping`, res => {
+      res.resume();
+      resolve(res.statusCode === 200);
+    });
+    req.on('error', () => resolve(false));
+    req.setTimeout(800, () => { req.destroy(); resolve(false); });
+  });
+}
+
+function openBrowser() {
+  const url = `http://localhost:${PORT}`;
+  const cmd = process.platform === 'win32' ? 'start' :
+               process.platform === 'darwin' ? 'open' : 'xdg-open';
+  try {
+    spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' });
+  } catch (_) {}
+}
+
+function writePid(pid) {
+  try {
+    fs.mkdirSync(path.dirname(PID_FILE), { recursive: true });
+    fs.writeFileSync(PID_FILE, String(pid));
+  } catch (_) {}
+}
+
+function readPid() {
+  try { return parseInt(fs.readFileSync(PID_FILE, 'utf8').trim(), 10); } catch (_) { return null; }
+}
+
+async function start() {
+  if (!fs.existsSync(SERVER_SCRIPT)) {
+    console.error('EGC Dashboard not found. Expected: ' + SERVER_SCRIPT);
+    process.exit(1);
+  }
+
+  const nmDir = path.join(DASHBOARD_DIR, 'node_modules');
+  if (!fs.existsSync(nmDir)) {
+    console.log('Installing dashboard dependencies...');
+    const r = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['install'], {
+      cwd: DASHBOARD_DIR, stdio: 'inherit',
+    });
+    if (r.status !== 0) { console.error('npm install failed.'); process.exit(1); }
+  }
+
+  const already = await isRunning();
+  if (already) {
+    console.log(`EGC Dashboard already running at http://localhost:${PORT}`);
+    openBrowser();
+    return;
+  }
+
+  const child = spawn(process.execPath, [SERVER_SCRIPT], {
+    cwd: DASHBOARD_DIR,
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+  writePid(child.pid);
+
+  // Wait up to 3s for server to accept connections
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 200));
+    if (await isRunning()) break;
+  }
+
+  console.log(`EGC Dashboard running at http://localhost:${PORT}`);
+  openBrowser();
+}
+
+async function stop() {
+  const pid = readPid();
+  if (!pid) {
+    const already = await isRunning();
+    if (!already) { console.log('Dashboard is not running.'); return; }
+    console.error('No PID file found. Stop the server manually.');
+    return;
+  }
+  try {
+    process.kill(pid, 'SIGTERM');
+    fs.unlinkSync(PID_FILE);
+    console.log(`Dashboard stopped (pid ${pid}).`);
+  } catch (e) {
+    console.error('Failed to stop dashboard:', e.message);
+  }
+}
+
+async function status() {
+  const running = await isRunning();
+  const pid = readPid();
+  if (running) {
+    console.log(`running  http://localhost:${PORT}${pid ? `  (pid ${pid})` : ''}`);
+  } else {
+    console.log('stopped');
+  }
+}
+
+(async () => {
+  if (flag === '--stop' || flag === 'stop') return stop();
+  if (flag === '--status' || flag === 'status') return status();
+  if (flag === '--help' || flag === '-h') {
+    console.log('Usage: egc dashboard [stop|status]');
+    console.log('  (no args)  Start dashboard and open browser');
+    console.log('  stop       Stop the background server');
+    console.log('  status     Show whether the server is running');
+    return;
+  }
+  await start();
+})();

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -31,14 +31,14 @@ function openBrowser() {
                process.platform === 'darwin' ? 'open' : 'xdg-open';
   try {
     spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' });
-  } catch (_) {}
+  } catch (_) { /* browser open is best-effort */ }
 }
 
 function writePid(pid) {
   try {
     fs.mkdirSync(path.dirname(PID_FILE), { recursive: true });
     fs.writeFileSync(PID_FILE, String(pid));
-  } catch (_) {}
+  } catch (_) { /* pid file is optional */ }
 }
 
 function readPid() {

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -84,6 +84,10 @@ const COMMANDS = {
     script: 'telemetry.js',
     description: 'Manage anonymous usage telemetry (status | on | off)',
   },
+  dashboard: {
+    script: 'dashboard.js',
+    description: 'Start the EGC Dashboard (localhost:7890). Use "stop" or "status" as sub-args.',
+  },
 };
 
 const PRIMARY_COMMANDS = [
@@ -104,6 +108,7 @@ const PRIMARY_COMMANDS = [
   'uninstall',
   'watch',
   'telemetry',
+  'dashboard',
 ];
 
 const TELEMETRY_COMMANDS = new Set(['install', 'doctor', 'init']);

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -24,7 +24,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const http = require('http');
+const { spawnSync, spawn } = require('child_process');
 const os = require('os');
 
 const { version: PKG_VERSION } = require('../package.json');
@@ -245,3 +246,26 @@ runDoctor();
 console.log('');
 console.log(`  ${c.green}${c.bold}Installation complete.${c.reset}`);
 console.log(`  ${c.dim}Run \`egc doctor\` anytime to verify.${c.reset}`);
+
+if (!flags.dryRun) {
+  const dashboardScript = path.join(ROOT_DIR, 'scripts', 'dashboard.js');
+  if (fs.existsSync(dashboardScript)) {
+    const dashPing = new Promise(resolve => {
+      const req = http.get('http://localhost:7890/ping', res => { res.resume(); resolve(res.statusCode === 200); });
+      req.on('error', () => resolve(false));
+      req.setTimeout(500, () => { req.destroy(); resolve(false); });
+    });
+    dashPing.then(already => {
+      if (already) {
+        console.log(`\n  ${c.cyan}Dashboard already running at http://localhost:7890${c.reset}`);
+        return;
+      }
+      const child = spawn(process.execPath, [dashboardScript], {
+        detached: true, stdio: 'ignore',
+      });
+      child.unref();
+      console.log(`\n  ${c.cyan}EGC Dashboard starting at http://localhost:7890${c.reset}`);
+      console.log(`  ${c.dim}Minimize it to keep working. Run \`egc dashboard stop\` to close.${c.reset}`);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Adds the EGC Mission Control Dashboard to the repository and integrates it into the CLI lifecycle.

### What's included

- **`dashboard/`** -- full Mission Control dashboard
  - `server.js`: Node.js HTTP + WebSocket server on port 7890
  - `shim.js`: Claude Code hook bridge (PreToolUse, PostToolUse, Stop)
  - `public/index.html`: real-time UI -- zero fake data, all telemetry from live events
  - `public/manifest.json` + `public/sw.js`: PWA support (installable, offline shell)
  - Adapters for all supported IDEs: Cursor, VS Code, Aider, CodeBuddy, etc.

- **Window controls in header** (this PR's main UI addition)
  - Minimize button: collapses dashboard to header bar only
  - Maximize button: toggles fullscreen
  - Close button: closes the window
  - Works in browser mode and PWA standalone mode

- **`egc dashboard` CLI command** (`scripts/dashboard.js`)
  - Starts server in background (detached), opens browser automatically
  - Idempotent: if already running, just opens browser
  - Sub-commands: `egc dashboard stop`, `egc dashboard status`
  - Auto-installs `dashboard/node_modules` on first run

- **`egc init` auto-start**
  - After installation completes, dashboard starts automatically in background
  - User can minimize it and start working immediately
  - Message shown: "Minimize it to keep working. Run `egc dashboard stop` to close."

## Test plan

- [ ] `egc init` completes and dashboard opens automatically
- [ ] Minimize button collapses dashboard to header bar; clicking again restores
- [ ] Maximize button toggles fullscreen
- [ ] Close button closes the window (or shows "close this tab" fallback)
- [ ] `egc dashboard` opens dashboard if not running
- [ ] `egc dashboard` is idempotent (safe to run twice)
- [ ] `egc dashboard stop` kills the background server
- [ ] `egc dashboard status` reports running/stopped
- [ ] `config.json` is gitignored and not committed
- [ ] PWA install prompt appears in Chrome/Edge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the EGC Mission Control dashboard with window controls, a new `egc dashboard` CLI, and auto-start after `egc init` for real-time telemetry on localhost:7890. Adds IDE hook emitters (Cursor, OpenCode, Kiro) and hardens security (XSS escaping, localhost-only CORS, safer stop).

- **New Features**
  - `dashboard/` app with Node HTTP + WebSocket server, real-time UI, and PWA shell.
  - Header window controls: minimize, maximize, close.
  - `egc dashboard` command: background start, opens browser, `stop` and `status`, idempotent; installs deps on first run.
  - IDE hooks: Cursor, OpenCode, and Kiro emit pre/post-tool events to the dashboard.

- **Bug Fixes**
  - Escape user-controlled values in the UI to prevent XSS via WebSocket data.
  - Restrict CORS to localhost/127.0.0.1; remove redundant browser open in server.
  - CLI: fail if server isn’t reachable within 3s; verify PID is live before sending SIGTERM.

<sup>Written for commit 844a37f5546ea5ae26b95341110559aae903d53f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

