### PR TITLE
fix: include dashboard in npm package and add ws dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "ajv": "^8.12.0",
         "argparse": "^2.0.1",
         "js-yaml": "^4.2.0",
-        "sql.js": "^1.14.1"
+        "sql.js": "^1.14.1",
+        "ws": "^8.16.0"
       },
       "bin": {
         "egc": "scripts/egc.js",
@@ -3382,6 +3383,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "files": [
     "scripts/",
+    "dashboard/",
     "src/",
     "agents/",
     "commands/",
@@ -74,7 +75,8 @@
     "ajv": "^8.12.0",
     "argparse": "^2.0.1",
     "js-yaml": "^4.2.0",
-    "sql.js": "^1.14.1"
+    "sql.js": "^1.14.1",
+    "ws": "^8.16.0"
   },
   "keywords": [
     "egc",


### PR DESCRIPTION
Fixes the v1.1.3 npm package: `dashboard/` was missing from the `files` array so `egc dashboard` failed after a global install.

- Add `dashboard/` to `files` in `package.json`
- Add `ws` to `dependencies` so `dashboard/server.js` resolves the WebSocket module without a separate install step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global installs of `egc dashboard`. The package now ships `dashboard/` and declares `ws` so `dashboard/server.js` runs without extra setup.

<sup>Written for commit a19d00ca2c6da84175b7338a06c431b490773be9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

