### PR TITLE
ci: add republish workflow and always run npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,5 +105,4 @@ jobs:
           files: ${{ steps.pack.outputs.tarball }}
 
       - name: Publish npm package
-        if: steps.npm_publish_state.outputs.already_published != 'true'
         run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,49 @@
+name: Republish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to republish (e.g. 1.1.3)'
+        required: true
+
+permissions: {}
+
+jobs:
+  republish:
+    name: Unpublish and republish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: 'v${{ github.event.inputs.version }}'
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unpublish existing version
+        run: npm unpublish "@egchq/egc@${{ github.event.inputs.version }}" --force || true
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+
+      - name: Wait for unpublish to propagate
+        run: sleep 20
+
+      - name: Pack tarball
+        id: pack
+        run: |
+          TARBALL=$(npm pack --json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'))[0].filename")
+          echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish
+        run: npm publish --access public --provenance --tag latest


### PR DESCRIPTION
Emergency fix: adds republish.yml workflow_dispatch and removes the already_published guard from release.yml so it always attempts npm publish.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual republish workflow and makes the release job always run `npm publish` so releases of `@egchq/egc` don’t get stuck and can be recovered fast.

- New Features
  - Added `republish.yml`: manual `workflow_dispatch` to unpublish and republish a specific version of `@egchq/egc`. Checks out `v<version>`, runs `npm unpublish`, waits, packs, and publishes with provenance to `latest`.
  - Updated `release.yml`: removed the published guard so `npm publish` always runs with the computed dist-tag.

<sup>Written for commit bfae3ca0d96eb0fd0fc76ff4cba2aa0122e06ba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

