### PR TITLE
ci: poll for unpublish propagation before republishing

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -37,7 +37,15 @@ jobs:
           NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
 
       - name: Wait for unpublish to propagate
-        run: sleep 20
+        run: |
+          for i in $(seq 1 12); do
+            if ! npm view "@egchq/egc@${{ github.event.inputs.version }}" version >/dev/null 2>&1; then
+              echo "Version ${{ github.event.inputs.version }} no longer visible in registry"
+              break
+            fi
+            echo "Attempt $i: version still visible, waiting 10s..."
+            sleep 10
+          done
 
       - name: Pack tarball
         id: pack


### PR DESCRIPTION
Replaces fixed sleep 20 with a poll loop (up to 120s) that waits until the version is no longer visible in the registry before publishing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI republish workflow now polls npm for unpublish propagation (up to 120s) instead of a fixed sleep, ensuring the target version of `@egchq/egc` is no longer visible before republishing. This reduces flaky republish failures caused by registry lag.

<sup>Written for commit 572778550fa0b3f9ce82b5689fd88b38f4028bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

