### PR TITLE
ci: deprecate broken version before republish

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -53,5 +53,8 @@ jobs:
           TARBALL=$(npm pack --json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'))[0].filename")
           echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
 
+      - name: Deprecate broken version if still present
+        run: npm deprecate "@egchq/egc@${{ github.event.inputs.version }}" "BROKEN: dashboard/ missing. Republish in progress -- reinstall once fixed." || true
+
       - name: Publish
         run: npm publish --access public --provenance --tag latest


### PR DESCRIPTION
Adds npm deprecate step in republish.yml to warn users about the broken version while the republish is in progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the broken `@egchq/egc` version in the republish workflow to warn users during republish and avoid fresh installs of the bad build. The step runs `npm deprecate "@egchq/egc@${{ github.event.inputs.version }}" "BROKEN: dashboard/ missing. Republish in progress -- reinstall once fixed."` and is non-blocking so publish still proceeds.

<sup>Written for commit 9112fb7158b4492c910001332d7a97d72dd5621c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package releases that are known to be broken are now marked as deprecated, helping users avoid reinstalling problematic versions.
  * Publishing continues even if the deprecation step can’t be applied, reducing the chance of release interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->