### PR TITLE
fix: open browser automatically after egc init starts dashboard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,8 @@ module.exports = [
         ignores: [
             '.opencode/dist/**',
             '.cursor/**',
+            '.claude/**',
+            'dashboard/**',
             'node_modules/**',
             'mcp/servers/*/build/**'
         ]

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -259,7 +259,7 @@ if (!flags.dryRun) {
       const url = 'http://localhost:7890';
       const cmd = process.platform === 'win32' ? 'start' :
                   process.platform === 'darwin' ? 'open' : 'xdg-open';
-      try { require('child_process').spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) {}
+      try { require('child_process').spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) { /* best-effort */ }
     };
     dashPing.then(already => {
       if (already) {

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -255,9 +255,16 @@ if (!flags.dryRun) {
       req.on('error', () => resolve(false));
       req.setTimeout(500, () => { req.destroy(); resolve(false); });
     });
+    const openBrowser = () => {
+      const url = 'http://localhost:7890';
+      const cmd = process.platform === 'win32' ? 'start' :
+                  process.platform === 'darwin' ? 'open' : 'xdg-open';
+      try { require('child_process').spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) {}
+    };
     dashPing.then(already => {
       if (already) {
         console.log(`\n  ${c.cyan}Dashboard already running at http://localhost:7890${c.reset}`);
+        openBrowser();
         return;
       }
       const child = spawn(process.execPath, [dashboardScript], {
@@ -266,6 +273,7 @@ if (!flags.dryRun) {
       child.unref();
       console.log(`\n  ${c.cyan}EGC Dashboard starting at http://localhost:7890${c.reset}`);
       console.log(`  ${c.dim}Minimize it to keep working. Run \`egc dashboard stop\` to close.${c.reset}`);
+      setTimeout(openBrowser, 1500);
     });
   }
 }


### PR DESCRIPTION
`egc init` was starting the dashboard server but not opening the browser. Users had to manually navigate to http://localhost:7890.

`egc dashboard` already called `openBrowser()` correctly. This fix adds the same call to `init.js`:
- Already running: opens browser immediately
- Just started: opens browser after 1.5s to allow server to bind

Fixes the auto-open behavior described in the CLI reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `egc init` to automatically open the dashboard at http://localhost:7890, matching `egc dashboard` behavior. Opens immediately if running or after 1.5s; also updates ESLint ignores for `.claude/**` and `dashboard/**`, and annotates the catch to satisfy lint.

<sup>Written for commit 5f6e640d1cb1373fb1f2ebb34e458a0a21516e1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

