### PR TITLE
fix: copy propagate-state and project-detect libs alongside Claude session hook

### DIFF
--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -10,7 +10,12 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { propagateStateContent } = require('../lib/propagate-state');
+let propagateStateContent = null;
+try {
+  propagateStateContent = require('../lib/propagate-state').propagateStateContent;
+} catch (_) {
+  // Lib not installed yet; run `egc repair` to restore it.
+}
 
 let projectDetect = null;
 try {
@@ -161,10 +166,12 @@ function loadAndPrintState(projectPath) {
   const content = fs.readFileSync(stateFile, 'utf8');
   if (!content.trim()) return;
 
-  try {
-    propagateStateContent(projectPath, content);
-  } catch (_) {
-    // Propagation is best-effort; never block session startup.
+  if (propagateStateContent) {
+    try {
+      propagateStateContent(projectPath, content);
+    } catch (_) {
+      // Propagation is best-effort; never block session startup.
+    }
   }
 
   process.stdout.write('EGC persistent memory for this project (restored automatically):\n\n' + content);

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -30,7 +30,23 @@ const {
   resolveStopHookScriptDestination,
 } = require('../claude-settings-hooks');
 
+const HOOK_LIB_SOURCES = [
+  'scripts/lib/propagate-state.js',
+  'scripts/lib/project-detect.js',
+];
+
 function createSessionStateHookOperations(adapter, targetRoot) {
+  const libDestDir = path.join(targetRoot, 'egc', 'lib');
+  const libOperations = HOOK_LIB_SOURCES.map(src =>
+    createRemappedOperation(
+      adapter,
+      HOOK_MODULE_ID,
+      src,
+      path.join(libDestDir, path.basename(src)),
+      { strategy: 'preserve-relative-path' }
+    )
+  );
+
   return [
     createRemappedOperation(
       adapter,
@@ -39,6 +55,7 @@ function createSessionStateHookOperations(adapter, targetRoot) {
       resolveHookScriptDestination(targetRoot),
       { strategy: 'preserve-relative-path' }
     ),
+    ...libOperations,
     createSessionStartHookMergeOperation(targetRoot),
     createRemappedOperation(
       adapter,


### PR DESCRIPTION
## Problem

The SessionStart hook (`claude-session-start.js`) requires `../lib/propagate-state` and `../lib/project-detect` at runtime, but the install plan only copied the hook script itself to `~/.claude/egc/hooks/` without the lib dependencies.

This caused a `MODULE_NOT_FOUND` crash on every Claude Code session start since #314 introduced the propagation call:

```
node:internal/modules/cjs/loader:1215
  throw err;
Error: Cannot find module '../lib/propagate-state'
Require stack:
- /home/user/.claude/egc/hooks/claude-session-start.js
```

## Fix

**`claude-home.js`**: add copy operations for `scripts/lib/propagate-state.js` and `scripts/lib/project-detect.js` into `~/.claude/egc/lib/` as part of the Claude install plan. Both files are pure Node.js with no external dependencies.

**`claude-session-start.js`**: wrap both lib `require()` calls in `try/catch` so that existing installs (without the lib files) degrade gracefully -- state is still printed to stdout, only propagation is skipped until `egc repair` runs.

## Existing installs

Users with the bug can fix immediately without reinstalling:
```
mkdir -p ~/.claude/egc/lib
cp "$(npm root -g)/@egchq/egc/scripts/lib/propagate-state.js" ~/.claude/egc/lib/
cp "$(npm root -g)/@egchq/egc/scripts/lib/project-detect.js" ~/.claude/egc/lib/
```

Or just run `egc repair` after updating to the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a MODULE_NOT_FOUND crash on Claude session start by copying required libs and making the hook tolerate missing libs. Sessions no longer fail if the lib files are missing.

- **Bug Fixes**
  - Installer now copies `scripts/lib/propagate-state.js` and `scripts/lib/project-detect.js` to `~/.claude/egc/lib/`.
  - `claude-session-start.js` wraps both `require()` calls in try/catch and skips propagation if libs are absent, without blocking startup.

- **Migration**
  - For existing installs, run `egc repair` to restore the lib files.

<sup>Written for commit b053c1982688ed184b52e3f3139a535c82de810d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

