### PR TITLE
fix: use secrets.NODE_AUTH_TOKEN in republish workflow

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Unpublish existing version
         run: npm unpublish "@egchq/egc@${{ github.event.inputs.version }}" --force || true
         env:
-          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Wait for unpublish to propagate
         run: |
@@ -58,3 +58,5 @@ jobs:
 
       - name: Publish
         run: npm publish --access public --provenance --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- `env.NODE_AUTH_TOKEN` evaluates to empty string (no such env var exists in the runner)
- Fixed in both the **Unpublish** step and the **Publish** step
- This was causing `workflow file issue` failures on every push to main, generating email spam

## Root cause

`${{ env.NODE_AUTH_TOKEN }}` reads from the `env` context (environment variables), not from `secrets`. The correct reference for npm auth tokens stored as GitHub Secrets is `${{ secrets.NODE_AUTH_TOKEN }}`.

## Test plan

- [ ] Trigger `republish.yml` via `workflow_dispatch` with a test version
- [ ] Confirm no more "workflow file issue" emails on push to main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the republish workflow by using `secrets.NODE_AUTH_TOKEN` for npm auth, preventing failures and email spam on pushes to main. Applies to both Unpublish and Publish steps to ensure end-to-end auth.

- **Bug Fixes**
  - Replace `env.NODE_AUTH_TOKEN` with `secrets.NODE_AUTH_TOKEN` in Unpublish and Publish.
  - Add an env block to Publish to pass `NODE_AUTH_TOKEN`.

<sup>Written for commit 024083aa928562cba5bd6b1c0c5e7ebeb4e3f284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package republishing process to use a more secure token source for publishing and unpublishing.
  * Improved consistency in how release authentication is handled during npm publish steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->