### PR TITLE
fix(ci): use block scalar in republish deprecate step to fix YAML parse error

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -54,7 +54,8 @@ jobs:
           echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
 
       - name: Deprecate broken version if still present
-        run: npm deprecate "@egchq/egc@${{ github.event.inputs.version }}" "BROKEN: dashboard/ missing. Republish in progress -- reinstall once fixed." || true
+        run: |
+          npm deprecate "@egchq/egc@${{ github.event.inputs.version }}" "BROKEN: dashboard/ missing. Republish in progress -- reinstall once fixed." || true
 
       - name: Publish
         run: npm publish --access public --provenance --tag latest


### PR DESCRIPTION
## Problem

The `Deprecate broken version` step in `republish.yml` used an inline `run:` scalar containing `BROKEN: ` (colon-space). GitHub Actions' YAML parser rejected this, causing every push to main to generate a `workflow file issue` failure for `republish.yml` even though the workflow is `workflow_dispatch` only.

## Fix

Wrap the command in a YAML literal block scalar (`|`), which does not have the colon-space ambiguity:

```yaml
run: |
  npm deprecate "..." "BROKEN: ..." || true
```

Verified with `python3 -c "import yaml; yaml.safe_load(...)"` -- YAML is now valid.

## Context

This workflow was created as an emergency tool to republish v1.1.3 after the dashboard was missing from the npm tarball. The root cause was fixed in v1.1.4 (PR #443). The workflow remains useful as an emergency republish mechanism.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a YAML parse error in the `republish` workflow by switching the “Deprecate broken version” step to a block scalar. This stops “workflow file issue” failures on pushes to main and keeps the emergency republish for `@egchq/egc` working.

<sup>Written for commit c6c1fbbede8aea141693310f5c9d0a74f74711b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an automation step to use a cleaner multi-line script format, with no change in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->