### PR TITLE
fix: spawn dashboard with shell:true on Windows in egc init

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -268,7 +268,9 @@ if (!flags.dryRun) {
         return;
       }
       const child = spawn(process.execPath, [dashboardScript], {
-        detached: true, stdio: 'ignore',
+        detached: true,
+        stdio: 'ignore',
+        ...(process.platform === 'win32' && { shell: true }),
       });
       child.unref();
       console.log(`\n  ${c.cyan}EGC Dashboard starting at http://localhost:7890${c.reset}`);


### PR DESCRIPTION
Fixes dashboard auto-launch on Windows. Node's `spawn()` requires `shell: true` on Windows to locate and execute scripts correctly.

Credit: fix originally contributed by @Kunall7890 in #455.

## Changes
- `scripts/init.js`: add `shell: true` to spawn options when running on Windows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard auto-launch on Windows by spawning it with `shell: true` in `egc init` (Windows-only), so Node can locate and run the script. This makes the EGC Dashboard start reliably after init without affecting other platforms.

<sup>Written for commit 3691a57fa9ac26479267b3433fd217591ea9ea85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

