### PR TITLE
docs: align Guardian Protocol wording across all IDE instruction files

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -4,11 +4,11 @@
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- **Start of every task:** call `orchestrate_task({ prompt: "<task>" })`
-- **Before every shell command:** call `validate_command({ command: "<cmd>" })`
-- **Before every new file write:** call `validate_write({ filepath: "<path>" })`
+- **Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+- **Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+- **Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
 
-Skipping any of these breaks the EGC contract. There are no exceptions.
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 
 ## Output Restrictions
 - NEVER use em dashes (—) in any output: Do not use them in code, commit messages, comments, files, emails, or chat responses. Use regular hyphens (-) instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@ Run `sh install.sh` to build the servers. Run `egc doctor` to verify they are re
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
 **Start of every task (non-trivial):** call `orchestrate_task({ prompt: "<task>" })`
-**Before every shell command:** call `validate_command({ command: "<cmd>" })`
+**Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
 **Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
 
-Skipping any of these breaks the EGC contract. There are no exceptions.
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ These calls are automatic and non-negotiable. Never wait for the user to ask.
 orchestrate_task({ prompt: "<task description>" })
 ```
 
-**Before every Bash command:**
+**Before every shell/Bash command:**
 ```
 validate_command({ command: "<command>" })
 ```


### PR DESCRIPTION
Fixes minor wording inconsistencies in the EGC Guardian Protocol section across all IDE instruction files.

## Changes

- `validate_command`: "Bash command" -> "shell/Bash command" in AGENTS.md and CLAUDE.md (GEMINI.md already had this)
- `AGENTS.md` / `.agents/AGENTS.md`: "There are no exceptions." -> "There are no exceptions for 'simple' tasks." (stronger emphasis)
- `.agents/AGENTS.md` (user-facing): added "non-trivial" to orchestrate_task trigger; added "Write or Edit on a file not yet read" to validate_write

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Guardian Protocol wording across `AGENTS.md`, `.agents/AGENTS.md`, and `CLAUDE.md` for consistency and clarity. Clarifies the non-trivial trigger for `orchestrate_task`, standardizes `validate_command` to "shell/Bash," expands `validate_write` to include "Write or Edit on a file not yet read," and states that the "no exceptions" rule applies even to simple tasks.

<sup>Written for commit 37bea38dafe4a3bfb5dbbf892622241d9cc632cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

