### PR TITLE
docs: align Guardian Protocol wording in Cursor, Kiro, Trae and OpenCode

### DIFF
--- a/.cursor/rules/common-development-workflow.md
+++ b/.cursor/rules/common-development-workflow.md
@@ -12,11 +12,11 @@ The Feature Implementation Workflow describes the development pipeline: planning
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- **Start of every task:** call `orchestrate_task({ prompt: "<task>" })`
-- **Before every shell command:** call `validate_command({ command: "<cmd>" })`
-- **Before every new file write:** call `validate_write({ filepath: "<path>" })`
+- **Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+- **Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+- **Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
 
-Skipping any of these breaks the EGC contract. There are no exceptions.
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 
 ## Feature Implementation Workflow
 

--- a/.kiro/steering/development-workflow.md
+++ b/.kiro/steering/development-workflow.md
@@ -13,11 +13,11 @@ The Feature Implementation Workflow describes the development pipeline: planning
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- **Start of every task:** call `orchestrate_task({ prompt: "<task>" })`
-- **Before every shell command:** call `validate_command({ command: "<cmd>" })`
-- **Before every new file write:** call `validate_write({ filepath: "<path>" })`
+- **Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+- **Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+- **Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
 
-Skipping any of these breaks the EGC contract. There are no exceptions.
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 
 ## Feature Implementation Workflow
 

--- a/.opencode/instructions/INSTRUCTIONS.md
+++ b/.opencode/instructions/INSTRUCTIONS.md
@@ -6,11 +6,11 @@ This document consolidates the core rules and guidelines from the Gemini Code co
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- **Start of every task (non-trivial):** call `orchestrate_task({ prompt: "<task>" })`
-- **Before every shell command:** call `validate_command({ command: "<cmd>" })`
-- **Before every new file write:** call `validate_write({ filepath: "<path>" })`
+- **Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+- **Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+- **Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
 
-Skipping any of these breaks the EGC contract. There are no exceptions.
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 
 ## Security Guidelines (CRITICAL)
 

--- a/.trae/rules/egc-context.md
+++ b/.trae/rules/egc-context.md
@@ -2,9 +2,9 @@
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- **Start of every task:** call `orchestrate_task({ prompt: "<task>" })`
-- **Before every shell command:** call `validate_command({ command: "<cmd>" })`
-- **Before every new file write:** call `validate_write({ filepath: "<path>" })`
+- **Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+- **Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+- **Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
 
-Skipping any of these breaks the EGC contract. There are no exceptions.
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 


### PR DESCRIPTION
## Summary

Full audit of the Guardian Protocol section across all IDE/CLI instruction files. Four files had stale wording that diverged from the canonical version.

**Files fixed:**
- `.cursor/rules/common-development-workflow.md`
- `.kiro/steering/development-workflow.md`
- `.opencode/instructions/INSTRUCTIONS.md`
- `.trae/rules/egc-context.md`

**Changes applied consistently to all four files:**
- `Start of every task` -> `Start of every non-trivial task`
- `Before every shell command` -> `Before every shell/Bash command`
- `Before every new file write` -> `Before every new file Write or Edit on a file not yet read`
- `There are no exceptions.` -> `There are no exceptions for "simple" tasks.`

These match the wording already shipped in `.agents/AGENTS.md`, `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` (aligned in PR #461).

## Test plan

- [ ] Verify all four files render correctly in their respective IDEs
- [ ] Confirm no other files in the repo contain the old wording: `grep -r "Before every shell command" .`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned Guardian Protocol wording across Cursor, Kiro, Trae, and OpenCode docs to match the canonical guidance. Clarifies when to run EGC calls and removes ambiguity across IDEs.

- **Refactors**
  - "Start of every task" → "Start of every non-trivial task"
  - "Before every shell command" → "Before every shell/Bash command"
  - "Before every new file write" → "Before every new file Write or Edit on a file not yet read"
  - "There are no exceptions." → "There are no exceptions for "simple" tasks."

<sup>Written for commit cba2989c7ce9123340a63dbe358e4721462cd106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

