### PR TITLE
fix: Node.js version guard, npm auto-update detection, and troubleshooting docs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,8 +1,8 @@
 # .tool-versions — Local development tool versions for asdf / mise
 # This is a LOCAL DEVELOPMENT default only — NOT a runtime requirement.
-# The project supports Node.js >= 18 (see engines in package.json).
+# The project supports Node.js >= 20 (see engines in package.json).
 # asdf: run `asdf install` to get this version locally.
-# mise: run `mise install`. Any 18.x, 20.x, or 22.x release works.
+# mise: run `mise install`. Any 20.x, 22.x, or 24.x release works.
 
-nodejs 20.19.0
+nodejs 24.16.0
 python 3.12.8

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -37,3 +37,64 @@ npm install -g @egchq/egc
 ```
 
 If you prefer not to change your Node installation, the alternative is to [configure a custom npm global prefix](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) under your home directory.
+
+---
+
+## Node.js version conflict with mise / asdf (multiple Node installations)
+
+**Symptom:** `egc auto-update` fails with a confusing git error, or `egc` reports version issues even though it is already up to date. Common when using [mise](https://mise.jdx.dev) or [asdf](https://asdf-vm.com) with multiple Node versions.
+
+**Cause:** EGC was installed globally under one Node version (e.g. 24), but a project's `.tool-versions` activates a different version (e.g. 20). The two global installs each have their own copy of EGC, and they can disagree about where EGC's files came from.
+
+**Fix:** Keep EGC in a single Node version -- the one that is active outside of any project directory.
+
+```bash
+# 1. Check which Node version is your system default
+node --version        # outside any project dir
+
+# 2. Remove EGC from the other Node version (replace 20.x.x with the version to clean)
+/path/to/mise/installs/node/20.x.x/bin/npm uninstall -g @egchq/egc
+
+# 3. Reinstall from the correct version
+npm install -g @egchq/egc@latest
+```
+
+With mise, you can also align the project's `.tool-versions` with your global Node to avoid the split:
+
+```bash
+# In the project directory, update .tool-versions to match your global Node
+echo "nodejs $(node --version | tr -d v)" > .tool-versions
+```
+
+**Verification:** After fixing, run `egc doctor` -- it should report no errors.
+
+---
+
+## `EGC requires Node.js 20 or later`
+
+**Symptom:** Running `egc` prints:
+
+```
+EGC requires Node.js 20 or later (found: v18.x.x).
+Update with:  mise install node@lts  OR  nvm install --lts  OR  https://nodejs.org
+```
+
+**Cause:** The active Node.js version is below the minimum required by EGC.
+
+**Fix:** Install or activate Node.js 20 or later:
+
+```bash
+# With mise
+mise install node@lts
+mise use -g node@lts
+
+# With nvm
+nvm install --lts
+nvm use --lts
+
+# With fnm
+fnm install --lts
+fnm use lts-latest
+```
+
+Then re-run `egc`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Via npm (recommended)
 
-Requires [Node.js 20 or later](https://nodejs.org/en/download).
+Requires [Node.js 20 or later](https://nodejs.org/en/download). Node.js 24 LTS is recommended.
 
 ```bash
 npm install -g @egchq/egc
@@ -10,6 +10,8 @@ egc install
 ```
 
 That's it. The installer detects which AI tools you have installed and configures all of them automatically.
+
+> **Note:** If you use a Node.js version manager (mise, nvm, asdf, fnm), install EGC under your **default** Node version -- the one active outside any project directory. Installing it under multiple Node versions causes version conflicts. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for details.
 
 ---
 

--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { version: PKG_VERSION } = require('../package.json');
 
 const { discoverInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
@@ -54,28 +55,36 @@ function parseArgs(argv) {
 function deriveRepoRootFromState(state) {
   const operations = Array.isArray(state && state.operations) ? state.operations : [];
 
+  // Prefer deriving root from the currently running package (__dirname = <pkg>/scripts)
+  // This works correctly regardless of which Node version is active.
+  const pkgRoot = path.resolve(__dirname, '..');
+  for (const operation of operations) {
+    if (typeof operation.sourceRelativePath !== 'string' || !operation.sourceRelativePath.trim()) {
+      continue;
+    }
+    if (fs.existsSync(path.join(pkgRoot, operation.sourceRelativePath))) {
+      return pkgRoot;
+    }
+  }
+
+  // Fallback: derive from absolute sourcePath (git-clone installs)
   for (const operation of operations) {
     if (typeof operation.sourcePath !== 'string' || !operation.sourcePath.trim()) {
       continue;
     }
-
     if (typeof operation.sourceRelativePath !== 'string' || !operation.sourceRelativePath.trim()) {
       continue;
     }
-
     const relativeParts = operation.sourceRelativePath
       .split(/[\\/]+/)
       .filter(Boolean);
-
     if (relativeParts.length === 0) {
       continue;
     }
-
     let repoRoot = path.resolve(operation.sourcePath);
     for (let index = 0; index < relativeParts.length; index += 1) {
       repoRoot = path.dirname(repoRoot);
     }
-
     return repoRoot;
   }
 
@@ -234,20 +243,28 @@ function runAutoUpdate(options = {}, dependencies = {}) {
   };
 
   if (!options.dryRun) {
-    execute('git', ['fetch', '--all', '--prune'], { cwd: repoRoot, env });
-    try {
-      execute('git', ['pull', '--ff-only'], { cwd: repoRoot, env });
-    } catch (pullError) {
-      const msg = String(pullError.message || '');
-      if (msg.includes('no tracking information') || msg.includes('set-upstream')) {
-        throw new Error(
-          'git pull failed: no upstream tracking branch configured.\n' +
-          'If installed via npm, update with: npm install -g @egchq/egc@latest\n' +
-          'Otherwise: git branch --set-upstream-to=origin/<branch>',
-          { cause: pullError }
-        );
+    const isGitRepo = fs.existsSync(path.join(repoRoot, '.git'));
+    if (!isGitRepo) {
+      // npm-installed: git pull is not applicable. Reinstall from current package.
+      console.log(`EGC is installed via npm (v${PKG_VERSION}).`);
+      console.log('To upgrade to a newer version, run: npm install -g @egchq/egc@latest');
+      console.log('Reinstalling current version into managed targets...\n');
+    } else {
+      execute('git', ['fetch', '--all', '--prune'], { cwd: repoRoot, env });
+      try {
+        execute('git', ['pull', '--ff-only'], { cwd: repoRoot, env });
+      } catch (pullError) {
+        const msg = String(pullError.message || '');
+        if (msg.includes('no tracking information') || msg.includes('set-upstream')) {
+          throw new Error(
+            'git pull failed: no upstream tracking branch configured.\n' +
+            'To update: npm install -g @egchq/egc@latest\n' +
+            'Or set upstream: git branch --set-upstream-to=origin/<branch>',
+            { cause: pullError }
+          );
+        }
+        throw pullError;
       }
-      throw pullError;
     }
   }
 

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
 
+const _nodeMajor = parseInt(process.versions.node, 10);
+if (_nodeMajor < 20) {
+  process.stderr.write(
+    `EGC requires Node.js 20 or later (found: ${process.version}).\n` +
+    'Update with:  mise install node@lts  OR  nvm install --lts  OR  https://nodejs.org\n'
+  );
+  process.exit(1);
+}
+
 const { spawnSync } = require('child_process');
 const path = require('path');
 const { version: PACKAGE_VERSION } = require('../package.json');

--- a/tests/scripts/auto-update.test.js
+++ b/tests/scripts/auto-update.test.js
@@ -73,6 +73,7 @@ function makeRecord({ repoRoot, homeDir, projectRoot, adapter, request, resoluti
 
 function ensureFakeRepo(repoRoot) {
   fs.mkdirSync(path.join(repoRoot, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(repoRoot, '.git'), { recursive: true });
   fs.writeFileSync(
     path.join(repoRoot, 'package.json'),
     JSON.stringify({ name: 'everything-gemini', version: '1.10.0' }, null, 2)
@@ -112,11 +113,13 @@ function runTests() {
   })) passed += 1; else failed += 1;
 
   if (test('deriveRepoRootFromState uses sourcePath and sourceRelativePath', () => {
+    // Use a sourceRelativePath that does not exist in the running EGC package so
+    // the __dirname-based fast path falls through to the absolute-sourcePath fallback.
     const state = {
       operations: [
         {
-          sourcePath: path.join('/tmp', 'egc', 'scripts', 'setup-package-manager.js'),
-          sourceRelativePath: path.join('scripts', 'setup-package-manager.js'),
+          sourcePath: path.join('/tmp', 'egc', 'custom-nonexistent-file.js'),
+          sourceRelativePath: 'custom-nonexistent-file.js',
         },
       ],
     };


### PR DESCRIPTION
## Summary

- **Runtime Node.js guard** (`scripts/egc.js`): EGC now exits immediately with a clear, actionable message if the active Node.js version is below 20, instead of crashing with a confusing stack trace.
- **npm install detection in `auto-update`** (`scripts/auto-update.js`): when EGC is installed via npm (no `.git` in the package directory), `egc auto-update` now skips the git pull and prints a friendly upgrade command instead of failing with a misleading git error.
- **Relative-path repo root resolution** (`scripts/auto-update.js`): `deriveRepoRootFromState` now resolves the EGC package root from `__dirname` (the currently running script) before falling back to the absolute `sourcePath` stored in `install-state.json`. This eliminates version-conflict errors for users who have EGC installed across multiple Node versions via mise or asdf.
- **Troubleshooting docs** (`docs/TROUBLESHOOTING.md`): two new sections covering the Node version conflict scenario and the new runtime guard message.
- **`.tool-versions`**: updated from Node 20.19.0 to 24.16.0 (current LTS), which also resolves the local/global Node split for the maintainer workflow.

## Test plan

- [ ] `egc --version` returns version without error on Node 20+
- [ ] `egc auto-update --dry-run` exits with `errors=0` when installed via npm
- [ ] Running `egc` with Node < 20 prints the guard message and exits 1
- [ ] CI passes (CodeQL, SonarCloud, tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Node 20+ runtime guard, fix npm-installed `auto-update`, and make repo root resolution resilient across multiple Node versions. Docs now include version‑manager install guidance, and `.tool-versions` is updated to Node 24 LTS.

- **Bug Fixes**
  - CLI exits early with a clear message when Node < 20.
  - `auto-update` detects npm installs (no `.git`), skips `git pull`, and prints `npm install -g @egchq/egc@latest`.
  - Repo root is derived from the running package (`__dirname`) before falling back to stored paths, preventing mise/asdf multi-Node conflicts.

<sup>Written for commit 9d45531cb2f8e84d33471f02a9ed0992dbbc19ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

