### PR TITLE
chore(codecov): make patch coverage check informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,8 @@ coverage:
         target: 80%
         # Allow up to 5% miss on patch before failing
         threshold: 5%
+        # Informational only: shows coverage diff without blocking merges
+        informational: true
         if_no_uploads: success
         if_not_found: success
 


### PR DESCRIPTION
## Summary

- Adds `informational: true` to the `patch` status check in `codecov.yml`
- The check still runs and reports coverage diff on every PR -- the numbers remain visible
- It no longer blocks merges; coverage decisions stay with the PR author

## Why

The `codecov/patch` check was appearing as a failing required check even though `require_ci_to_pass: false` was set. This is because GitHub treats any check that posts a failure status as blocking, regardless of Codecov's own non-blocking config. `informational: true` makes Codecov post a neutral/informational status instead of a failure, which is the correct way to keep the data visible without gating merges.

## Test plan

- [ ] CI passes
- [ ] Codecov comment still appears on PRs with coverage diff
- [ ] `codecov/patch` no longer shows as a failing check after this merges

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `coverage.status.patch.informational: true` in `codecov.yml` to keep coverage diffs visible without blocking merges.

<sup>Written for commit d4143a67288b46d452b720c5370919b44ca3af45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

