### PR TITLE
ci: trigger EGCSite rebuild after each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,3 +106,10 @@ jobs:
 
       - name: Publish npm package
         run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"
+
+      - name: Trigger EGCSite rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EGCSITE_DISPATCH_TOKEN }}
+          repository: Fmarzochi/EGCSite
+          event-type: egc-release


### PR DESCRIPTION
## Summary

- Adds a step to `release.yml` that dispatches a `repository_dispatch` event (`egc-release`) to the EGCSite repo after each npm publish
- EGCSite's `deploy.yml` listens for this event and triggers a full rebuild, which fetches fresh contributor data from the GitHub API

## How it works

1. A new EGC version is tagged and released
2. `release.yml` publishes to npm, then calls `peter-evans/repository-dispatch` with `event-type: egc-release`
3. EGCSite rebuilds and the `/contributors` page automatically reflects the latest contributor list

## Secret required

Add `EGCSITE_DISPATCH_TOKEN` to EGC repository secrets: a GitHub Personal Access Token (classic) with `repo` scope on the `Fmarzochi/EGCSite` repository. This token authorizes the cross-repo dispatch call.

## Test plan

- [ ] Merge this PR
- [ ] Create `EGCSITE_DISPATCH_TOKEN` secret in EGC repo settings
- [ ] Tag a new release and confirm EGCSite rebuild triggers automatically

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Triggers an EGCSite rebuild after each EGC release by dispatching an `egc-release` event from `release.yml` after npm publish. Uses `peter-evans/repository-dispatch@v3` to call `Fmarzochi/EGCSite`, so the site pulls fresh contributor data.

- **Migration**
  - Add `EGCSITE_DISPATCH_TOKEN` as a repo secret in EGC: a PAT (classic) with `repo` scope on `Fmarzochi/EGCSite` to authorize the dispatch.

<sup>Written for commit 54e6e419d64a86c0925c46d3891b5e5491a0448c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automatic post-release step that triggers a site rebuild after publishing.
  * Release publishing now kicks off a fresh update for the public site, helping changes appear faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->