### PR TITLE
fix: close accumulateEvent and pin repository-dispatch action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         run: npm publish --access public --provenance --tag "${{ steps.npm_publish_state.outputs.dist_tag }}"
 
       - name: Trigger EGCSite rebuild
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.EGCSITE_DISPATCH_TOKEN }}
           repository: Fmarzochi/EGCSite

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -125,6 +125,8 @@ if (ev.usage) {
   p.tokens.cacheRead += (ev.usage.cache_read_input_tokens || 0);
   p.tokens.cacheWrite += (ev.usage.cache_creation_input_tokens || 0);
 }
+}
+
 // Mark providers offline after 90 s without events
 setInterval(() => {
   const now = Date.now();

--- a/package.json
+++ b/package.json
@@ -107,13 +107,10 @@
     "js-yaml": "^4.2.0",
     "markdown-it": "^14.2.0"
   },
-  "resolutions": {
-    "markdownlint-cli/js-yaml": "^4.2.0",
-    "markdown-it": "^14.2.0"
-  },
   "pnpm": {
     "overrides": {
       "js-yaml": "^4.2.0",
+      "markdownlint-cli>js-yaml": "^4.2.0",
       "markdown-it": "^14.2.0"
     }
   }


### PR DESCRIPTION
## Summary

- `dashboard/server.js`: missing closing brace caused `setInterval`, `const clients`, `const server`, and the entire HTTP server to be declared inside `accumulateEvent`. The `setInterval` inside the function created a new 15-second timer on every incoming event (unbounded memory leak). Added the missing `}` to restore correct module-level scope. This also resolves the CodeQL parse error ("Unexpected token").
- `.github/workflows/release.yml`: pinned `peter-evans/repository-dispatch` to commit hash to satisfy Scorecard Pinned-Dependencies check (#256).

## Test plan

- [ ] CodeQL javascript-typescript scan passes without syntax warnings
- [ ] Scorecard Pinned-Dependencies alert #256 resolves after merge
- [ ] Dashboard server starts without errors: `node dashboard/server.js`
- [ ] Glama build recovers after re-index

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a scoping bug in `dashboard/server.js` that leaked timers and broke CodeQL; also pins `peter-evans/repository-dispatch` and switches to a `pnpm`-compatible override for `js-yaml`.

- **Bug Fixes**
  - Closed `accumulateEvent` properly to restore module scope and stop spawning a new 15s timer per event; resolves CodeQL parsing.

- **Dependencies**
  - Pinned `peter-evans/repository-dispatch` to a specific commit in `release.yml` to satisfy the Scorecard pinned-dependencies check (addresses #256).
  - Removed Yarn `resolutions` and added `pnpm.overrides` for `markdownlint-cli>js-yaml` to fix `ERR_PNPM_INVALID_SELECTOR`.

<sup>Written for commit 8acbf96daf66371ab8e61df05574bc2c79001b11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation by locking an external GitHub Action to a specific revision for more consistent and reliable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->