### PR TITLE
chore: update IDE context memory to v1.1.6 and PR #474

### DIFF
--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -5,16 +5,14 @@ alwaysApply: true
 
 ## EGC Project Memory
 
-**Context:** EGC v1.1.5 lançado e publicado no npm. Trabalhando em fixes pós-release enquanto Felipe dorme.
+**Context:** EGC v1.1.6 em produção. PR #474 mergeado (a442023f): três fixes críticos -- server.js brace, release.yml hash pin, package.json pnpm selector.
 
 **Active decisions:**
-- republish.yml usa env.NODE_AUTH_TOKEN (linha 37) em vez de secrets.NODE_AUTH_TOKEN
-- README.md não menciona o dashboard em nenhuma seção
-- Glama mostra tools:[] para o servidor EGC
+- PR #474 mergeado (a442023f): fecha accumulateEvent em server.js, pina peter-evans/repository-dispatch@ff45666b, remove resolutions Yarn e adiciona markdownlint-cli>js-yaml em pnpm.overrides
+- Glama build falhou em 24/06 e 25/06 por ERR_PNPM_INVALID_SELECTOR no campo resolutions.markdownlint-cli/js-yaml
+- CodeQL javascript-typescript estava falhando com 'Unexpected token' no commit 89488b63
 
 **Next session:**
-- republish.yml: corrigir env.NODE_AUTH_TOKEN -> secrets.NODE_AUTH_TOKEN nos steps Unpublish e Publish
-- README.md: adicionar secao Dashboard apos 'Always in sync'
-- Atualizar traducoes do README (ar, es, hi, pt) com secao Dashboard
-- Verificar Glama -- Felipe precisa logar para ver logs do build failure
-- Atualizar local EGC para v1.1.5 e testar egc init abre browser
+- Verificar se Glama rebuild passou após merge do PR #474 em main -- acessar https://glama.ai/mcp/servers/Fmarzochi/EGC/admin
+- Commitar os arquivos unstaged (.cursor/rules/egc-context.mdc, .trae/rules/egc-context.md, AGENTS.md, GEMINI.md) quando houver contexto do que mudou
+- Scorecard alert #256 (Pinned-Dependencies) deve fechar automaticamente após merge -- verificar em Security > Code scanning


### PR DESCRIPTION
Update IDE agent context files (.cursor/rules, AGENTS.md, GEMINI.md, .trae/rules) to reflect current project state after PR #474.

- Context updated to v1.1.6 in production
- Removed stale v1.1.5 references
- Added PR #474 fix summary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update IDE context memory to EGC v1.1.6 and align with PR #474, removing outdated v1.1.5 references to keep dev tooling accurate.
Edits `.cursor/rules/egc-context.mdc` to capture the server.js brace fix, pin `peter-evans/repository-dispatch`, move the `markdownlint-cli` → `js-yaml` override under `pnpm`, and add follow-ups for Glama rebuild and CodeQL status.

<sup>Written for commit c90ce65873ca78346c3361607e414963d5e7c344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

