### PR TITLE
fix(ci): skip CLA job on plain issue comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   cla:
+    if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The CLA workflow triggers on all `issue_comment` events, including comments on plain issues (not PRs). When the event targets an issue without an associated pull request, the bot fails with:

> Could not resolve to a PullRequest with the number of N.

This produces false-positive failure emails on every issue comment.

## Fix

Added an `if` condition to the job so it only runs when:
- the event is `pull_request_target`, OR
- the event is `issue_comment` **and** the comment belongs to a PR (`github.event.issue.pull_request` is set)

## Test

Close any plain issue with a comment -- the CLA job should be skipped (no run, no failure email).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the CLA workflow on plain issue comments to eliminate false failure emails. Adds an `if` guard to the `cla` job to run only on `pull_request_target` events or `issue_comment` events where `github.event.issue.pull_request` exists.

<sup>Written for commit 2e710d3925f7d5366f31f7cd7999ed0713d83821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated contributor agreement checks so they only run for relevant pull request-related events, helping reduce unnecessary job runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->