### PR TITLE
chore(cla): add Kunall7890 to CLA allowlist as established contributor

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/Fmarzochi/EGC/blob/main/.github/CLA.md
           branch: cla-signatures
-          allowlist: Fmarzochi,dependabot[bot],github-actions[bot],renovate[bot],coderabbitai[bot],sonarqubecloud[bot],cubic-dev-ai[bot]
+          allowlist: Fmarzochi,Kunall7890,dependabot[bot],github-actions[bot],renovate[bot],coderabbitai[bot],sonarqubecloud[bot],cubic-dev-ai[bot]
           create-file-commit-message: "chore(cla): initialize signatures file"
           signed-commit-message: "chore(cla): add @$contributorName signature"
           custom-notsigned-prcomment: |


### PR DESCRIPTION
Kunall7890 is a long-standing contributor whose previous PRs predate the CLA workflow (added 2026-06-20). Adding to allowlist so future contributions are not blocked by this check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Kunall7890` to the CLA allowlist in `.github/workflows/cla.yml` so future PRs pass the CLA check. They are an established contributor whose earlier PRs predate the CLA workflow.

<sup>Written for commit ff1104c3d8cf56d9122bc74bc8ddd2290cc89017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contribution workflow settings to allow an additional approved contributor account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->