### PR TITLE
fix(cla): skip workflow on comments posted to closed or merged PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   cla:
-    if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.issue.state == 'open')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- The CLA workflow was re-triggering on `issue_comment` events posted to already-merged PRs (e.g. by SonarQube or CodeRabbit after merge)
- When a committer's git identity does not link to their GitHub account, the bot fails with \"Committers of PR N have to sign the CLA\" even if the PR is already merged
- Adding `github.event.issue.state == 'open'` to the job condition prevents the check from running on closed or merged PRs

## Root cause

PR #497 had a commit where the author's git email did not map to a GitHub account (`invalid-email-address`). After the squash merge, SonarQube posted a follow-up comment on the closed PR, which triggered the CLA bot. The bot re-evaluated the original PR commits, found an unresolved identity, and reported a failure.

## Test plan

- [ ] Open a new PR from a contributor, confirm CLA bot still runs normally
- [ ] After merging, have a bot post a comment on the merged PR, confirm CLA workflow does not trigger

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the CLA workflow on `issue_comment` events for closed or merged PRs to prevent false failures from post-merge bot comments.

- **Bug Fixes**
  - Added `github.event.issue.state == 'open'` to the job condition so CLA runs only for open PRs (still runs on `pull_request_target`).

<sup>Written for commit 72e543e88cc8fb6992c485efe85667b745b05c2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated contribution-check handling so it only runs comment-based checks for open pull requests, reducing unnecessary workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->