### PR TITLE
chore(i18n): reorder Korean before Português in language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Language:** English | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [हिन्दी](translations/hi/README.md) | [Português (Brasil)](translations/pt/README.md) | [한국어](translations/ko/README.md)
+**Language:** English | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [हिन्दी](translations/hi/README.md) | [한국어](translations/ko/README.md) | [Português (Brasil)](translations/pt/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -13,7 +13,7 @@
 
 **Language / اللغة / Idioma / भाषा / 언어**
 
-[**English**](README.md) | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [हिन्दी](translations/hi/README.md) | [Português (Brasil)](translations/pt/README.md) | [한국어](translations/ko/README.md)
+[**English**](README.md) | [العربية](translations/ar/README.md) | [Español](translations/es/README.md) | [हिन्दी](translations/hi/README.md) | [한국어](translations/ko/README.md) | [Português (Brasil)](translations/pt/README.md)
 
 </div>
 <!-- CENTERED-LANGUAGE-SELECTOR-END -->


### PR DESCRIPTION
Applies the alphabetical ISO-code ordering generated by `scripts/update-readme-languages.js`.

The bot-created PRs #519, #521, and #523 were all trying to apply this same fix. Merging this PR will stop the sync workflow from opening new PRs on every translation push.

Order after this change: `ar, es, hi, ko, pt` (sorted by ISO code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the README language selector to follow ISO code alphabetical order, placing Korean before Portuguese. This matches `scripts/update-readme-languages.js` and prevents the sync workflow from opening repeated PRs.

<sup>Written for commit 086d144fe8139ff4df9f8d4c95542e2264de2686. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

