### PR TITLE
fix(dashboard): gate sessionCost by CAPABILITIES.cost in accumulateEv…

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -134,7 +134,8 @@ if (ev.event === 'session_end') {
     cacheWrite: usage.cache_creation_input_tokens || 0,
   };
   const sessionModel = ev.model || p.lastModel || null;
-  const sessionCost  = calcCost(ev.ide, sessionTokens, sessionModel);
+  const ideCap       = CAPABILITIES[ev.ide] || {};
+  const sessionCost  = ideCap.cost === true ? calcCost(ev.ide, sessionTokens, sessionModel) : null;
 
   sessionHistory.push({
     timestamp:    Date.now(),
@@ -271,7 +272,7 @@ if (req.method === 'GET' && req.url === '/session-history') {
       byIde[s.ide].totalOutputTokens += s.output_tokens || 0;
       byIde[s.ide].sessions          += 1;
     }
-    const grandTotal = Object.values(byIde).reduce((acc, v) => acc + v.totalCost, 0);
+    const grandTotal = Object.values(byIde).reduce((acc, v) => acc + (v.costSupported ? v.totalCost : 0), 0);
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({
       grandTotal,


### PR DESCRIPTION
…ent (#501)

accumulateEvent called calcCost() for every IDE unconditionally, storing a non-null cost for gemini (cost:false) because it has an IDE_PRICE_KEY entry. /telemetry correctly gated on cap.cost; /cost-summary didn't.

Fix 1: gate sessionCost in session_end by CAPABILITIES[ide].cost === true
Fix 2: gate grandTotal reduce by costSupported flag in /cost-summary

Fixes #501

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect cost totals for IDEs without cost support. Costs are now gated by `CAPABILITIES[ide].cost`, preventing false charges for `gemini` (Fixes #501).

- **Bug Fixes**
  - On `session_end`, compute `sessionCost` only when `CAPABILITIES[ide].cost === true`.
  - In the cost summary, `grandTotal` only sums IDEs with `costSupported`.

<sup>Written for commit fb35b7c99be55e0fd222fda4310d8bf93144a62d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

