### PR TITLE
ci(dco): add guidance comment and downgrade to informational

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -39,7 +39,7 @@ jobs:
             echo "Use 'git commit -s' or 'git commit --amend -s' to sign existing commits."
             exit 1
           fi
-          echo "All commits have DCO sign-off."
+          echo "All commits have DCO sign-off. OK"
 
       - name: Post guidance comment
         if: always() && steps.dco.outputs.missing == '1'
@@ -58,7 +58,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `${marker}
-            👋 **DCO sign-off missing**
+            **DCO sign-off missing**
 
             One or more commits in this PR are missing a \`Signed-off-by\` line (Developer Certificate of Origin).
 
@@ -68,10 +68,10 @@ jobs:
             git commit --amend -s
             git push --force-with-lease
 
-            # Multiple commits — replace N with the number of commits in your PR
+            # Multiple commits -- replace N with the number of commits in your PR
             git rebase --signoff HEAD~N
             git push --force-with-lease
             \`\`\`
 
-            > ℹ️ This check is **informational only** — a maintainer can still merge your PR without sign-off.`
+            > Note: This check is **informational only** -- a maintainer can still merge your PR without sign-off.`
             });

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   dco:
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+
       - name: Check DCO sign-off
+        id: dco
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -26,10 +28,11 @@ jobs:
             body=$(git log -1 --format="%B" "$sha")
             if ! echo "$body" | grep -qE "^Signed-off-by: .+ <.+>$"; then
               author=$(git log -1 --format="%an <%ae>" "$sha")
-              echo "::error::Commit $sha ($author) is missing Signed-off-by"
+              echo "::warning::Commit $sha ($author) is missing Signed-off-by"
               missing=1
             fi
           done < <(git log --format="%H" "${BASE_SHA}..${HEAD_SHA}")
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
           if [ "$missing" -eq 1 ]; then
             echo ""
             echo "Add 'Signed-off-by: Name <email>' to commit messages."
@@ -37,3 +40,38 @@ jobs:
             exit 1
           fi
           echo "All commits have DCO sign-off."
+
+      - name: Post guidance comment
+        if: always() && steps.dco.outputs.missing == '1'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const marker = '<!-- dco-guidance -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (comments.some(c => c.body.includes(marker))) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `${marker}
+            👋 **DCO sign-off missing**
+
+            One or more commits in this PR are missing a \`Signed-off-by\` line (Developer Certificate of Origin).
+
+            **How to fix:**
+            \`\`\`bash
+            # Single commit
+            git commit --amend -s
+            git push --force-with-lease
+
+            # Multiple commits — replace N with the number of commits in your PR
+            git rebase --signoff HEAD~N
+            git push --force-with-lease
+            \`\`\`
+
+            > ℹ️ This check is **informational only** — a maintainer can still merge your PR without sign-off.`
+            });


### PR DESCRIPTION
## Summary

- When a PR is missing DCO sign-off, the workflow now posts a single comment (idempotent — won't repeat on re-run) explaining exactly how to fix it with `git commit --amend -s`
- Downgraded annotations from `::error::` to `::warning::` — the check still shows red so contributors know, but DCO is not a required status check and does not block merging
- Added `pull-requests: write` permission so the comment step can post

## Why

Contributors have been submitting valid PRs (CLA signed, tests green) but getting stuck on DCO with no clear guidance. Two recent PRs (#513, #526) had to be merged with `--admin` because of this. DCO is informational in this repo — the CLA covers the legal requirement.

## Behavior after this PR

1. Contributor opens PR without `git commit -s`
2. DCO check runs and shows red
3. Bot posts one comment with the exact commands to fix it
4. Maintainer can merge normally without `--admin` — DCO was never a required check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the DCO check informational and add a one-time guidance comment with exact commands to fix missing sign-off. The check still shows red, but it no longer blocks merges.

- **New Features**
  - Posts a single, idempotent PR comment with fix steps (`git commit --amend -s`, `git rebase --signoff`), using plain text to satisfy the unicode safety check.
  - Downgrades annotations from errors to warnings; status remains failing but non-blocking.
  - Adds `pull-requests: write` permission so the workflow can comment.

<sup>Written for commit 45aac086cbca005300ee1963b6cd357899d89374. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer guidance when a pull request is missing DCO sign-off.
  * The check now highlights each commit without a `Signed-off-by` line and posts a helpful comment with steps to fix it.
  * Existing DCO failures still block the check, but now include more actionable feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->