### PR TITLE
fix(security): state file permissions, path traversal guard, audit log, rate limiter

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -106,9 +106,16 @@ class PersistentLogger {
 
 const sysLogger = new PersistentLogger('egc-guardian-router');
 
+const auditLogPath = path.join(os.homedir(), '.egc', 'audit.log');
+function writeSecurityAuditLog(action: string, details: Record<string, unknown>) {
+  const entry = JSON.stringify({ timestamp: new Date().toISOString(), action, ...details });
+  try { fs.appendFileSync(auditLogPath, entry + '\n', 'utf-8'); } catch { /* non-critical */ }
+}
+
 function auditLog(action: string, status: 'ALLOWED'|'DENIED'|'MUTATED'|'ONLINE'|'SHUTDOWN'|'FATAL', details: Record<string, unknown> = {}) {
   const level = (status === 'FATAL' || status === 'DENIED') ? 'ERROR' : (status === 'ONLINE' || status === 'SHUTDOWN' ? 'INFO' : 'AUDIT');
   sysLogger.log(level, action, status, details);
+  if (status === 'DENIED') writeSecurityAuditLog(action, details);
 }
 
 const server = new Server({ name: "egc-guardian-router", version: "3.0.0" }, { capabilities: { tools: {} } });
@@ -184,8 +191,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX_CALLS = 60;
+const rateLimitMap = new Map<string, number[]>();
+
+function checkRateLimit(tool: string): boolean {
+  const now = Date.now();
+  const timestamps = (rateLimitMap.get(tool) ?? []).filter(t => now - t < RATE_WINDOW_MS);
+  timestamps.push(now);
+  rateLimitMap.set(tool, timestamps);
+  return timestamps.length <= RATE_MAX_CALLS;
+}
+
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
+    const tool = request.params.name;
+    if (!checkRateLimit(tool)) {
+      auditLog('RATE_LIMIT_EXCEEDED', 'DENIED', { tool, limit: RATE_MAX_CALLS, window_ms: RATE_WINDOW_MS });
+      return { content: [{ type: "text", text: `[DENIED] Rate limit exceeded for tool '${tool}': max ${RATE_MAX_CALLS} calls per ${RATE_WINDOW_MS / 1000}s` }] };
+    }
     switch (request.params.name) {
       case "validate_command": {
         const { command } = ValidateCommandSchema.parse(request.params.arguments);

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -336,7 +336,11 @@ function getStateDir(): string {
 }
 
 function resolveProjectPath(provided?: string): string {
-  return provided || process.env.EGC_PROJECT || process.env.PWD || os.homedir();
+  const raw = provided || process.env.EGC_PROJECT || process.env.PWD || os.homedir();
+  if (provided && provided.split(/[/\\]/).some(s => s === '..')) {
+    throw new Error(`project_path must not contain path traversal sequences: ${provided}`);
+  }
+  return path.resolve(raw);
 }
 
 function readStateDoc(filePath: string): Record<string, string[]|string> {
@@ -406,6 +410,7 @@ function writeStateDoc(filePath: string, projectPath: string, data: {
   ];
 
   fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
+  try { fs.chmodSync(filePath, 0o600); } catch { /* chmod not supported on Windows */ }
 }
 
 const LESSON_REINFORCE_DELTA = 0.15;


### PR DESCRIPTION
## Summary

Four security hardening fixes implementing the ideas proposed by @Ap-0007 in PRs #514, #515, #516, #517. The original PRs modified stub `.js` files instead of the real `.ts` sources and had implementation issues, so the fixes were applied correctly with co-authorship credited.

- **#514 — State file permissions**: `chmodSync(0o600)` after every `writeFileSync` in `egc-memory`, preventing other local users from reading project memory files. No-op on Windows (try/catch).
- **#515 — Path traversal guard**: `resolveProjectPath` now rejects any `project_path` containing `..` segments before resolving, closing a potential escape from `~/.egc/state/`.
- **#516 — Dedicated security audit log**: DENIED events are now written synchronously to `~/.egc/audit.log` (separate from the general service log), making security monitoring straightforward.
- **#517 — Rate limiter for MCP tool calls**: Map-based sliding-window limiter (60 calls / 60 s per tool), no external dependencies. Excess calls return `[DENIED]` and are logged to the audit log.

Closes #514, #515, #516, #517
Fixes #509, #510, #511

## Test plan
- [x] All existing tests pass (`node tests/run-all.js` exit 0)
- [x] TypeScript compiles cleanly in both `egc-memory` and `egc-guardian`
- [x] Co-authorship: `Co-authored-by: vanta.nox <Ap-0007@users.noreply.github.com>`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens security in `egc-memory` and `egc-guardian` by locking state file permissions, blocking path traversal, adding a dedicated audit log, and rate-limiting tool calls. Protects local data, prevents directory escapes, and improves monitoring.

- **Bug Fixes**
  - State files: set permissions to 0o600 after each write in `egc-memory` (no-op on Windows).
  - Path traversal: reject `project_path` containing `..` before resolving; prevents escapes from `~/.egc/state/`.
  - Audit log: write DENIED events to `~/.egc/audit.log`, separate from service logs.
  - Rate limiting: per-tool sliding window (60 calls / 60s) for MCP tool calls; extra calls return `[DENIED]` and are audited.

<sup>Written for commit a12f45861d9e82d7ea9078ed453f9eca1a1eb416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request rate limiting for tool actions, with clear feedback when limits are exceeded.
  * Added security audit logging for denied actions.

* **Bug Fixes**
  * Improved project path handling to block unsafe path traversal inputs.
  * Tightened state file permissions for better local data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->