### PR TITLE
feat(security): apply chmod 600 to audit.log on creation (#531)

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -112,7 +112,16 @@ function writeSecurityAuditLog(action: string, details: Record<string, unknown>)
   const entry = JSON.stringify({ timestamp: new Date().toISOString(), action, ...details });
   try {
     fs.mkdirSync(auditLogDir, { recursive: true, mode: 0o700 });
-    fs.chmodSync(auditLogDir, 0o700);
+  } catch (err) {
+    sysLogger.log('ERROR', 'AUDIT_LOG_WRITE_FAILED', 'FATAL', { error: String(err) });
+    return;
+  }
+  // Best-effort hardening for the case where auditLogDir already existed with
+  // looser permissions (mkdirSync's mode option is a no-op then). Kept out of
+  // the write's critical path so a chmod failure here (e.g. EPERM on a
+  // directory owned by another user) can never cause a DENIED event to be lost.
+  try { fs.chmodSync(auditLogDir, 0o700); } catch { /* non-critical */ }
+  try {
     fs.appendFileSync(auditLogPath, entry + '\n', { encoding: 'utf-8', mode: 0o600 });
     fs.chmodSync(auditLogPath, 0o600);
   } catch (err) {

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -106,10 +106,15 @@ class PersistentLogger {
 
 const sysLogger = new PersistentLogger('egc-guardian-router');
 
-const auditLogPath = path.join(os.homedir(), '.egc', 'audit.log');
+const auditLogDir = path.join(os.homedir(), '.egc');
+const auditLogPath = path.join(auditLogDir, 'audit.log');
 function writeSecurityAuditLog(action: string, details: Record<string, unknown>) {
   const entry = JSON.stringify({ timestamp: new Date().toISOString(), action, ...details });
-  try { fs.appendFileSync(auditLogPath, entry + '\n', 'utf-8'); } catch { /* non-critical */ }
+  try {
+    fs.mkdirSync(auditLogDir, { recursive: true, mode: 0o700 });
+    fs.appendFileSync(auditLogPath, entry + '\n', { encoding: 'utf-8', mode: 0o600 });
+    fs.chmodSync(auditLogPath, 0o600);
+  } catch { /* non-critical */ }
 }
 
 function auditLog(action: string, status: 'ALLOWED'|'DENIED'|'MUTATED'|'ONLINE'|'SHUTDOWN'|'FATAL', details: Record<string, unknown> = {}) {

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -112,9 +112,12 @@ function writeSecurityAuditLog(action: string, details: Record<string, unknown>)
   const entry = JSON.stringify({ timestamp: new Date().toISOString(), action, ...details });
   try {
     fs.mkdirSync(auditLogDir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(auditLogDir, 0o700);
     fs.appendFileSync(auditLogPath, entry + '\n', { encoding: 'utf-8', mode: 0o600 });
     fs.chmodSync(auditLogPath, 0o600);
-  } catch { /* non-critical */ }
+  } catch (err) {
+    sysLogger.log('ERROR', 'AUDIT_LOG_WRITE_FAILED', 'FATAL', { error: String(err) });
+  }
 }
 
 function auditLog(action: string, status: 'ALLOWED'|'DENIED'|'MUTATED'|'ONLINE'|'SHUTDOWN'|'FATAL', details: Record<string, unknown> = {}) {


### PR DESCRIPTION
audit.log was written via appendFileSync with no explicit mode, so new files inherited the process umask (typically 644) — readable by all local users on the same machine. The log contains sensitive security events: blocked commands, denied writes, rate-limit hits.

Also closes a second gap: appendFileSync alone would silently drop every DENIED event if ~/.egc didn't exist yet (e.g. fresh install, no prior state-file write).

Fix: create ~/.egc with mode 0700 if missing, write audit.log with mode 0600 at creation time, and chmodSync as a backstop for the case where the file already existed before this fix shipped.

Verified locally: file created at mode 600 on first write, content correct.

Fixes #531

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down `audit.log` to 0600 and `~/.egc` to 0700, ensures first-run audit logging, and surfaces write failures via the system logger. Also isolates dir permission fixes from the write path so DENIED events are never lost (fixes #531).

- **Bug Fixes**
  - Ensure `~/.egc` exists and is 0700; force 0700 on pre-existing dirs, with chmod backstop moved outside the write path (best-effort).
  - Create `audit.log` with 0600; backstop existing files with `chmodSync`.
  - Log audit write failures via `sysLogger` as non-fatal ERRORs instead of swallowing errors.

<sup>Written for commit bd68d5b161210b8012afb3df6dc68ef5878f660e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security audit logging by writing logs to a dedicated hidden application directory with tighter permissions.
  * Added safer handling to ensure the log directory exists and audit files are created/updated with restricted access.
  * If audit log writing fails, it is reported but does not interrupt normal app behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->