### PR TITLE
feat(dashboard): add provider usage comparison

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -532,14 +532,12 @@ body.minimized footer{display:none!important;}
 
 </div>
 
-<div class="rcard" id="costCard">
-  <span class="eye">💰 Cost Comparison</span>
-  <div class="cost-grand">
+<div class="cost-grand">
   <span class="cost-grand-val" id="costGrandTotal">$0.0000</span>
   <span class="cost-grand-lbl">total spend</span>
-
-  <div id="providerHighlight" class="provider-highlight"></div>
 </div>
+
+<div id="providerHighlight" class="provider-highlight"></div>
   <div class="cost-range-wrap">
     <button class="cost-range-btn active" data-range="all"   id="crAll"   onclick="setCostRange('all')">All time</button>
     <button class="cost-range-btn"        data-range="today" id="crToday" onclick="setCostRange('today')">Today</button>
@@ -1288,7 +1286,7 @@ if (data.mostUsedProvider && data.byIde[data.mostUsedProvider]) {
           const total   = (v.totalInputTokens + v.totalOutputTokens) || 1;
           const inpPct  = Math.round((v.totalInputTokens  / total) * 100);
           const outPct  = Math.round((v.totalOutputTokens / total) * 100);
-          const inpTok  = fmtTokens(v.totalInputTokens);
+          
           const inpTok = fmtTokens(v.totalInputTokens);
           const outTok = fmtTokens(v.totalOutputTokens);
           const totalTok = fmtTokens(v.totalTokens);

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -323,6 +323,16 @@ body.minimized footer{display:none!important;}
 .cost-grand{display:flex;align-items:baseline;gap:6px;margin-bottom:4px;}
 .cost-grand-val{font-size:22px;font-weight:700;color:var(--primary);font-variant-numeric:tabular-nums;}
 .cost-grand-lbl{font-size:10px;color:var(--muted);font-weight:600;letter-spacing:1px;text-transform:uppercase;}
+.provider-highlight{
+  margin-top:6px;
+  font-size:11px;
+  color:var(--muted);
+  font-weight:500;
+}
+
+.provider-highlight strong{
+  color:var(--primary);
+}
 .cost-bars{display:flex;flex-direction:column;gap:8px;margin:4px 0;}
 .cost-bar-row{display:flex;flex-direction:column;gap:3px;}
 .cost-bar-head{display:flex;justify-content:space-between;align-items:baseline;}
@@ -525,9 +535,11 @@ body.minimized footer{display:none!important;}
 <div class="rcard" id="costCard">
   <span class="eye">💰 Cost Comparison</span>
   <div class="cost-grand">
-    <span class="cost-grand-val" id="costGrandTotal">$0.0000</span>
-    <span class="cost-grand-lbl">total spend</span>
-  </div>
+  <span class="cost-grand-val" id="costGrandTotal">$0.0000</span>
+  <span class="cost-grand-lbl">total spend</span>
+
+  <div id="providerHighlight" class="provider-highlight"></div>
+</div>
   <div class="cost-range-wrap">
     <button class="cost-range-btn active" data-range="all"   id="crAll"   onclick="setCostRange('all')">All time</button>
     <button class="cost-range-btn"        data-range="today" id="crToday" onclick="setCostRange('today')">Today</button>
@@ -1252,6 +1264,17 @@ async function loadCostSummary() {
     const data = await r.json();
 
     document.getElementById('costGrandTotal').textContent = fmtCost(data.grandTotal);
+    const highlightEl = document.getElementById('providerHighlight');
+
+if (data.mostUsedProvider && data.byIde[data.mostUsedProvider]) {
+  const provider = data.byIde[data.mostUsedProvider];
+
+  highlightEl.innerHTML =
+    `🏆 Most Used: <strong>${data.mostUsedProvider}</strong> (${provider.usagePercentage}% of total tokens)`;
+} else {
+  highlightEl.innerHTML =
+  '<span style="opacity:.7">No provider usage available yet.</span>';
+}
 
     const barsEl = document.getElementById('costBars');
     const ideEntries = Object.entries(data.byIde);
@@ -1259,21 +1282,32 @@ async function loadCostSummary() {
       barsEl.innerHTML = '<div class="cost-empty">No session data yet.</div>';
     } else {
       barsEl.innerHTML = ideEntries
-        .sort(([, a], [, b]) => b.totalCost - a.totalCost)
+       .sort(([, a], [, b]) => b.totalTokens - a.totalTokens)
         .map(([ide, v]) => {
           const col     = IDE_COLORS[ide] || '#8b949e';
           const total   = (v.totalInputTokens + v.totalOutputTokens) || 1;
           const inpPct  = Math.round((v.totalInputTokens  / total) * 100);
           const outPct  = Math.round((v.totalOutputTokens / total) * 100);
           const inpTok  = fmtTokens(v.totalInputTokens);
-          const outTok  = fmtTokens(v.totalOutputTokens);
-          const costStr = (v.totalCost === 0 && v.costSupported === false)
-            ? `<span style="color:#777;font-size:11px;margin-left:4px;">N/A</span>`
-            : `<strong style="color:${col}">${fmtCost(v.totalCost)}</strong>`;
+          const inpTok = fmtTokens(v.totalInputTokens);
+          const outTok = fmtTokens(v.totalOutputTokens);
+          const totalTok = fmtTokens(v.totalTokens);
+          const usagePct = `${v.usagePercentage}%`;
+
+const costStr =
+  (v.totalCost === 0 && v.costSupported === false)
+    ? `<span style="color:#777;font-size:11px;margin-left:4px;">N/A</span>`
+    : `<strong style="color:${col}">${fmtCost(v.totalCost)}</strong>`;
           return `<div class="cost-bar-row">
             <div class="cost-bar-head">
               <span class="cost-bar-ide" style="color:${col}">${ide}</span>
-              <span class="cost-bar-meta">${inpTok}↑ ${outTok}↓ · ${v.sessions} sess · ${costStr}</span>
+             <span class="cost-bar-meta">
+  ${inpTok}↑ ${outTok}↓ ·
+  ${totalTok} total ·
+  ${v.sessions} sess ·
+  ${usagePct} ·
+  ${costStr}
+</span>
             </div>
             <div class="cost-bar-stack">
               <div class="cost-bar-inp" style="width:${inpPct}%;background:${col}"></div>

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -274,10 +274,10 @@ for (const s of filtered) {
     };
   }
 
-  byIde[s.ide].totalCost += s.cost || 0;
-  byIde[s.ide].totalInputTokens += s.input_tokens || 0;
-  byIde[s.ide].totalOutputTokens += s.output_tokens || 0;
-  byIde[s.ide].sessions += 1;
+  byIde[s.ide].totalCost += Number(s.cost) || 0;
+byIde[s.ide].totalInputTokens += Number(s.input_tokens) || 0;
+byIde[s.ide].totalOutputTokens += Number(s.output_tokens) || 0;
+byIde[s.ide].sessions += 1;
 }
 
 const totalTokens = Object.values(byIde).reduce(
@@ -298,10 +298,10 @@ for (const [ide, provider] of Object.entries(byIde)) {
       ? Number(((provider.totalTokens / totalTokens) * 100).toFixed(1))
       : 0;
 
-  if (provider.totalTokens > maxTokens) {
-    maxTokens = provider.totalTokens;
-    mostUsedProvider = ide;
-  }
+ if (provider.totalTokens > 0 && provider.totalTokens > maxTokens) {
+  maxTokens = provider.totalTokens;
+  mostUsedProvider = ide;
+}
 }
 
 const grandTotal = Object.values(byIde).reduce(

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -260,25 +260,62 @@ if (req.method === 'GET' && req.url === '/session-history') {
     const filtered = cutoff
       ? sessionHistory.filter(s => s.timestamp >= cutoff)
       : sessionHistory;
+const byIde = {};
 
-    const byIde = {};
-    for (const s of filtered) {
-      if (!byIde[s.ide]) {
-        const cap = CAPABILITIES[s.ide] || {};
-        byIde[s.ide] = { totalCost: 0, totalInputTokens: 0, totalOutputTokens: 0, sessions: 0, costSupported: cap.cost === true };
-      }
-      byIde[s.ide].totalCost         += s.cost          || 0;
-      byIde[s.ide].totalInputTokens  += s.input_tokens  || 0;
-      byIde[s.ide].totalOutputTokens += s.output_tokens || 0;
-      byIde[s.ide].sessions          += 1;
-    }
-    const grandTotal = Object.values(byIde).reduce((acc, v) => acc + (v.costSupported ? v.totalCost : 0), 0);
+for (const s of filtered) {
+  if (!byIde[s.ide]) {
+    const cap = CAPABILITIES[s.ide] || {};
+    byIde[s.ide] = {
+      totalCost: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      sessions: 0,
+      costSupported: cap.cost === true,
+    };
+  }
+
+  byIde[s.ide].totalCost += s.cost || 0;
+  byIde[s.ide].totalInputTokens += s.input_tokens || 0;
+  byIde[s.ide].totalOutputTokens += s.output_tokens || 0;
+  byIde[s.ide].sessions += 1;
+}
+
+const totalTokens = Object.values(byIde).reduce(
+  (sum, provider) =>
+    sum + provider.totalInputTokens + provider.totalOutputTokens,
+  0
+);
+
+let mostUsedProvider = null;
+let maxTokens = -1;
+
+for (const [ide, provider] of Object.entries(byIde)) {
+  provider.totalTokens =
+    provider.totalInputTokens + provider.totalOutputTokens;
+
+  provider.usagePercentage =
+    totalTokens > 0
+      ? Number(((provider.totalTokens / totalTokens) * 100).toFixed(1))
+      : 0;
+
+  if (provider.totalTokens > maxTokens) {
+    maxTokens = provider.totalTokens;
+    mostUsedProvider = ide;
+  }
+}
+
+const grandTotal = Object.values(byIde).reduce(
+  (acc, v) => acc + (v.costSupported ? v.totalCost : 0),
+  0
+);
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({
-      grandTotal,
-      byIde,
-      recentSessions: filtered.slice(-50).reverse(),
-    }));
+   res.end(JSON.stringify({ 
+  grandTotal,
+  totalTokens,
+  mostUsedProvider,
+  byIde,
+  recentSessions: filtered.slice(-50).reverse(),
+}));
     return;
   }
 


### PR DESCRIPTION
## Summary

Extends the existing Cost Summary widget with provider usage insights while keeping the dashboard compact.

### Changes

- Added provider usage percentage based on total token usage
- Added total token count for each provider
- Added a "Most Used Provider" highlight
- Sorted providers by total token usage
- Reused the existing Cost Summary widget instead of adding a new dashboard section

### Testing

- Verified `/cost-summary` returns:
  - `totalTokens`
  - `usagePercentage`
  - `mostUsedProvider`
- Verified the dashboard handles empty session history gracefully
- Ran the project test suite

> Note: One local test (`guardian-learn-writer.test.js`) reports a missing `sqlite3` dependency (`ERR_MODULE_NOT_FOUND`), which is unrelated to these dashboard changes.

Closes #529

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider usage comparison to the Cost Comparison widget. The dashboard shows each provider’s token share and highlights the most used provider, with clear empty states. Closes #529.

- **New Features**
  - Extend `/session-history` to return `totalTokens`, `mostUsedProvider`, and per-provider `totalTokens` and `usagePercentage`.
  - Sort provider rows by `totalTokens`; show input/output tokens, total tokens, sessions, usage percent, and cost.

- **Bug Fixes**
  - Graceful empty state when no usage; ensure numeric token/cost values are parsed reliably.

<sup>Written for commit 390b56c69d1724521bf2555a91d849fd83fcbd6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

