### PR TITLE
fix(dashboard): guard accumulateEvent against missing ide field

### DIFF
--- a/dashboard/accumulator.js
+++ b/dashboard/accumulator.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Shared accumulator factory used by dashboard/server.js and tests.
+ *
+ * createAccumulator(prices) returns a fresh accumulator with its own
+ * providerState and sessionHistory so every caller (including each test)
+ * gets an isolated instance that exercises the same production code path.
+ *
+ * @param {object} [externalPrices] — mutable container for calcCost lookups
+ *   (e.g. the server's MODEL_PRICES object).  When omitted all cost
+ *   calculations return null.
+ */
+function createAccumulator(externalPrices) {
+  const providerState = {};
+  const sessionHistory = [];
+  const MAX_SESSION_HISTORY = 1000;
+
+  const CAPABILITIES = {
+    claude:    { tokenUsage:true,  model:true,  cost:true,  session:true,  workspace:true  },
+    gemini:    { tokenUsage:true,  model:true,  cost:false, session:true,  workspace:false },
+    cursor:    { tokenUsage:false, model:false, cost:false, session:true,  workspace:true  },
+    codex:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+    vscode:    { tokenUsage:false, model:false, cost:false, session:false, workspace:true  },
+    kiro:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+    trae:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+    opencode:  { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+    codebuddy: { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+    aider:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  };
+
+  const IDE_PRICE_KEY = {
+    claude:   '_default_claude',
+    gemini:   '_default_gemini',
+    codex:    '_default_codex',
+    opencode: '_default_opencode',
+  };
+
+  // externalPrices is the same object reference the server mutates via
+  // Object.assign when prices.json changes — calcCost always sees fresh data.
+  const prices = externalPrices || {};
+
+  function calcCost(ide, tokens, model) {
+    const pricing = prices[model] || prices[IDE_PRICE_KEY[ide]];
+    if (!pricing) return null;
+    const inp = (tokens.input      || 0) * (pricing.input      || 0) / 1e6;
+    const out = (tokens.output     || 0) * (pricing.output     || 0) / 1e6;
+    const cr  = (tokens.cacheRead  || 0) * (pricing.cacheRead  || 0) / 1e6;
+    const cw  = (tokens.cacheWrite || 0) * (pricing.cacheWrite || 0) / 1e6;
+    return inp + out + cr + cw;
+  }
+
+  function getProvider(ide) {
+    if (!providerState[ide]) {
+      providerState[ide] = {
+        ide,
+        lastSeen:  null,
+        running:   false,
+        toolCalls: 0,
+        sessions:  0,
+        lastModel: null,
+        tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      };
+    }
+    return providerState[ide];
+  }
+
+  /**
+   * Process a telemetry event.
+   * @returns {boolean} true if the event was accepted and state was updated;
+   *                    false if the event was rejected (missing/invalid ide).
+   */
+  function accumulateEvent(ev) {
+    if (!ev || typeof ev.ide !== 'string' || !ev.ide) return false;
+
+    const p = getProvider(ev.ide);
+    p.lastSeen = Date.now();
+    p.running  = true;
+    if (ev.model) p.lastModel = ev.model;
+
+    if (ev.event === 'pre_tool') p.toolCalls++;
+
+    if (ev.event === 'session_end') {
+      const usage = ev.usage || {};
+      const sessionTokens = {
+        input:      usage.input_tokens                || 0,
+        output:     usage.output_tokens               || 0,
+        cacheRead:  usage.cache_read_input_tokens     || 0,
+        cacheWrite: usage.cache_creation_input_tokens || 0,
+      };
+      const sessionModel = ev.model || p.lastModel || null;
+      const ideCap       = CAPABILITIES[ev.ide] || {};
+      const sessionCost  = ideCap.cost === true ? calcCost(ev.ide, sessionTokens, sessionModel) : null;
+
+      sessionHistory.push({
+        timestamp:    Date.now(),
+        ide:          ev.ide,
+        model:        sessionModel,
+        input_tokens:  sessionTokens.input,
+        output_tokens: sessionTokens.output,
+        total_tokens:  sessionTokens.input + sessionTokens.output,
+        cost:          sessionCost,
+      });
+
+      if (sessionHistory.length > MAX_SESSION_HISTORY) sessionHistory.shift();
+    }
+
+    if (ev.usage) {
+      p.sessions++;
+      p.tokens.input += (ev.usage.input_tokens || 0);
+      p.tokens.output += (ev.usage.output_tokens || 0);
+      p.tokens.cacheRead += (ev.usage.cache_read_input_tokens || 0);
+      p.tokens.cacheWrite += (ev.usage.cache_creation_input_tokens || 0);
+    }
+
+    return true;
+  }
+
+  return { providerState, sessionHistory, getProvider, accumulateEvent, calcCost, CAPABILITIES };
+}
+
+module.exports = { createAccumulator };

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -6,6 +6,7 @@ const path    = require('path');
 const fs      = require('fs');
 const os      = require('os');
 const { execSync } = require('child_process');
+const { createAccumulator } = require('./accumulator');
 
 const PORT   = 7890;
 const PUBLIC = path.join(__dirname, 'public');
@@ -46,119 +47,27 @@ function detectOperator() {
 }
 const OPERATOR = detectOperator();
 
-// What each provider can actually expose — honest contract
-const CAPABILITIES = {
-  claude:    { tokenUsage:true,  model:true,  cost:true,  session:true,  workspace:true  },
-  gemini:    { tokenUsage:true,  model:true,  cost:false, session:true,  workspace:false },
-  cursor:    { tokenUsage:false, model:false, cost:false, session:true,  workspace:true  },
-  codex:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-  vscode:    { tokenUsage:false, model:false, cost:false, session:false, workspace:true  },
-  kiro:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-  trae:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-  opencode:  { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-  codebuddy: { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-  aider:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-};
-
 // Pricing per 1M tokens — loaded from prices.json (configurable)
 const PRICES_PATH = path.join(__dirname, 'prices.json');
-let MODEL_PRICES = {};
+const MODEL_PRICES = {};
 function loadPrices() {
   try {
-    MODEL_PRICES = JSON.parse(fs.readFileSync(PRICES_PATH, 'utf8'));
+    const data = JSON.parse(fs.readFileSync(PRICES_PATH, 'utf8'));
+    Object.assign(MODEL_PRICES, data);
   } catch (_) {
-    MODEL_PRICES = {
+    Object.assign(MODEL_PRICES, {
       '_default_claude': { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
       '_default_gemini': { input: 0.10, output: 0.40,  cacheRead: 0.025, cacheWrite: 0.00 },
       '_default_codex':  { input: 2.50, output: 10.00, cacheRead: 1.25, cacheWrite: 0.00 },
-    };
+    });
   }
 }
 loadPrices();
 fs.watchFile(PRICES_PATH, () => loadPrices());
 
-const IDE_PRICE_KEY = {
-  claude: '_default_claude',
-  gemini: '_default_gemini',
-  codex:  '_default_codex',
-  opencode: '_default_opencode',
-};
-
-function calcCost(ide, tokens, model) {
-  const pricing = MODEL_PRICES[model] || MODEL_PRICES[IDE_PRICE_KEY[ide]];
-  if (!pricing) return null;
-  const inp = (tokens.input      || 0) * (pricing.input      || 0) / 1e6;
-  const out = (tokens.output     || 0) * (pricing.output     || 0) / 1e6;
-  const cr  = (tokens.cacheRead  || 0) * (pricing.cacheRead  || 0) / 1e6;
-  const cw  = (tokens.cacheWrite || 0) * (pricing.cacheWrite || 0) / 1e6;
-  return inp + out + cr + cw;
-}
-
-// Runtime telemetry accumulated from real events
-const providerState = {};
-// Store recent completed sessions for dashboard analytics
-const sessionHistory = [];
-const MAX_SESSION_HISTORY = 1000;
-
-function getProvider(ide) {
-  if (!providerState[ide]) {
-    providerState[ide] = {
-      ide,
-      lastSeen:  null,
-      running:   false,
-      toolCalls: 0,
-      sessions:  0,
-      lastModel: null,          // ← add this line
-      tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    };
-  }
-  return providerState[ide];
-}
-
-function accumulateEvent(ev) {
-  
-
-  const p = getProvider(ev.ide);
-  p.lastSeen = Date.now();
-  p.running  = true;
-  if (ev.model) p.lastModel = ev.model;   // ← add this line
-
-if (ev.event === 'pre_tool') p.toolCalls++;
-
-if (ev.event === 'session_end') {
-  const usage = ev.usage || {};
-  const sessionTokens = {
-    input:      usage.input_tokens                || 0,
-    output:     usage.output_tokens               || 0,
-    cacheRead:  usage.cache_read_input_tokens     || 0,
-    cacheWrite: usage.cache_creation_input_tokens || 0,
-  };
-  const sessionModel = ev.model || p.lastModel || null;
-  const ideCap       = CAPABILITIES[ev.ide] || {};
-  const sessionCost  = ideCap.cost === true ? calcCost(ev.ide, sessionTokens, sessionModel) : null;
-
-  sessionHistory.push({
-    timestamp:    Date.now(),
-    ide:          ev.ide,
-    model:        sessionModel,
-    input_tokens:  sessionTokens.input,
-    output_tokens: sessionTokens.output,
-    total_tokens:  sessionTokens.input + sessionTokens.output,
-    cost:          sessionCost,
-  });
-
-  if (sessionHistory.length > MAX_SESSION_HISTORY) sessionHistory.shift();
-}
-
-if (ev.usage) {
-  p.sessions++;
-
-  p.tokens.input += (ev.usage.input_tokens || 0);
-  p.tokens.output += (ev.usage.output_tokens || 0);
-  p.tokens.cacheRead += (ev.usage.cache_read_input_tokens || 0);
-  p.tokens.cacheWrite += (ev.usage.cache_creation_input_tokens || 0);
-}
-}
+// Shared accumulator — fresh state, production logic
+const ACC = createAccumulator(MODEL_PRICES);
+const { providerState, sessionHistory, getProvider, accumulateEvent, calcCost, CAPABILITIES } = ACC;
 
 // Mark providers offline after 90 s without events
 setInterval(() => {
@@ -189,9 +98,10 @@ const server = http.createServer((req, res) => {
     req.on('end', () => {
       try {
         const ev = JSON.parse(body);
-        accumulateEvent(ev);
-        const msg = JSON.stringify(ev);
-        for (const ws of clients) { if (ws.readyState === 1) ws.send(msg); }
+        if (accumulateEvent(ev)) {
+          const msg = JSON.stringify(ev);
+          for (const ws of clients) { if (ws.readyState === 1) ws.send(msg); }
+        }
       } catch (_) {}
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end('{"ok":true}');

--- a/tests/dashboard-server.test.js
+++ b/tests/dashboard-server.test.js
@@ -1,0 +1,89 @@
+'use strict';
+/**
+ * Regression tests for Fmarzochi/EGC#500
+ *
+ * Exercises the real createAccumulator() factory shared with
+ * dashboard/server.js so these tests guard the production fix.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createAccumulator } = require('../dashboard/accumulator');
+
+// ---------------------------------------------------------------------------
+// Tests — every scenario that should be caught by the guard clause
+// ---------------------------------------------------------------------------
+
+test('valid event with ide string creates provider state and counts tool calls', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+  assert.equal(Object.keys(providerState).length, 0);
+
+  accumulateEvent({ ide: 'claude', event: 'pre_tool' });
+
+  assert.ok(providerState.claude, 'provider state should exist for claude');
+  assert.equal(providerState.claude.ide, 'claude');
+  assert.equal(providerState.claude.toolCalls, 1);
+  assert.ok(providerState.claude.running, 'provider should be marked running');
+});
+
+test('event without ide property does not create provider state', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+  accumulateEvent({ event: 'pre_tool' });
+  assert.equal(Object.keys(providerState).length, 0);
+});
+
+test('event with explicitly undefined ide does not create provider state', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+  accumulateEvent({ ide: undefined, event: 'pre_tool' });
+  assert.equal(Object.keys(providerState).length, 0);
+});
+
+test('event with empty string ide does not create provider state', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+  accumulateEvent({ ide: '', event: 'pre_tool' });
+  assert.equal(Object.keys(providerState).length, 0);
+});
+
+test('event with numeric ide does not create provider state (typeof check)', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+  accumulateEvent({ ide: 42, event: 'pre_tool' });
+  assert.equal(Object.keys(providerState).length, 0);
+});
+
+test('null event argument does not crash and creates no state', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+  accumulateEvent(null);
+  assert.equal(Object.keys(providerState).length, 0);
+});
+
+test('undefined event argument does not crash and creates no state', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+  accumulateEvent(undefined);
+  assert.equal(Object.keys(providerState).length, 0);
+});
+
+test('multiple valid events accumulate on the same provider', () => {
+  const { providerState, accumulateEvent } = createAccumulator();
+
+  accumulateEvent({ ide: 'claude', event: 'pre_tool' });
+  accumulateEvent({ ide: 'claude', event: 'pre_tool' });
+  accumulateEvent({ ide: 'claude', event: 'pre_tool' });
+
+  assert.equal(providerState.claude.toolCalls, 3);
+  assert.equal(Object.keys(providerState).length, 1,
+    'only one provider should exist');
+});
+
+test('valid event returns true', () => {
+  const { accumulateEvent } = createAccumulator();
+  assert.equal(accumulateEvent({ ide: 'gemini', event: 'pre_tool' }), true);
+});
+
+test('invalid event returns false (broadcast guard)', () => {
+  const { accumulateEvent } = createAccumulator();
+  assert.equal(accumulateEvent({ event: 'pre_tool' }), false);
+  assert.equal(accumulateEvent(null), false);
+  assert.equal(accumulateEvent(undefined), false);
+  assert.equal(accumulateEvent({ ide: '' }), false);
+  assert.equal(accumulateEvent({ ide: 42 }), false);
+});


### PR DESCRIPTION
## What Changed

Added an early-return guard clause in `accumulateEvent()` in `dashboard/server.js`:

`if (!ev || typeof ev.ide !== 'string' || !ev.ide) return;`

When a telemetry event arrives without a valid `ide` field, the function now exits immediately instead of calling `getProvider(undefined)`, which previously created a phantom provider entry under the key `undefined` in the `providerState` map.

## Why This Change

Telemetry events with a missing `ide` field silently corrupted the dashboard state. A single malformed event added a bogus `undefined` IDE entry visible in every dashboard view (`/telemetry`, `/cost-summary`, `/session-history`), polluting the analytics and cost data. This is a data-integrity bug: invalid input should be silently ignored, not silently recorded.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (\`node tests/run-all.js\`)
- [x] Edge cases considered and tested

New regression test file \`tests/dashboard-server.test.js\` (8 tests) covers:
1. Valid event with ide string → normal processing
2. Event without \`ide\` property → guard catches it
3. Event with explicitly \`undefined\` ide → guard catches it
4. Event with empty string \`ide\` → guard catches it
5. Event with numeric \`ide\` (typeof check) → guard catches it
6. \`null\` event argument → guard catches it
7. \`undefined\` event argument → guard catches it
8. Multiple valid events accumulate correctly on one provider

All 8 tests pass and the existing test suite continues to pass.

## Type of Change

- [x] \`fix:\` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] Follows conventional commits format
- [x] All commits signed off with \`git commit -s\` (DCO)
- [x] \`npm audit --audit-level=high\` shows 0 vulnerabilities
- [x] PR changes fewer than 150 code files

## Documentation

- [ ] Updated relevant documentation (not needed — self-explanatory guard clause)
- [x] Added comments for complex logic (guard clause self-documents)
- [ ] README updated (not needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `accumulateEvent()` against missing/invalid `ide`, extracted a shared accumulator, and gated WebSocket broadcasts to valid events. This removes the phantom `undefined` provider and keeps `/telemetry`, `/cost-summary`, and `/session-history` clean.

- **Bug Fixes**
  - Early-return in `accumulateEvent()` when `ev` is falsy or `ev.ide` is not a non-empty string; added regression tests for invalid `ide` and normal accumulation.
  - `accumulateEvent()` now returns a boolean; `POST /event` only broadcasts accepted events.

- **Refactors**
  - Moved accumulation logic to `dashboard/accumulator.js` (`createAccumulator(prices)`), shared by server and tests.
  - Kept `MODEL_PRICES` as a mutable object and update via `Object.assign` so price reloads propagate to the accumulator.

<sup>Written for commit 7bcd096cc869283ff6e98e8b0f4969eab638732d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for dashboard server event handling.
  * Ensured invalid or missing event data is safely ignored (no state is created and no errors are thrown).
  * Confirmed valid events initialize provider state correctly and that repeated events for the same ID accumulate counts while keeping a single provider entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->