### PR TITLE
fix(dashboard): prevent path traversal via public* sibling directories

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -356,7 +356,12 @@ if (req.method === 'GET' && req.url === '/session-history') {
   // ── Static files ─────────────────────────────────────────
   const urlPath = req.url === '/' ? '/index.html' : req.url;
   const file    = path.join(PUBLIC, urlPath.split('?')[0]);
-  if (!file.startsWith(PUBLIC)) { res.writeHead(403); res.end(); return; }
+  const resolvedFilePath = path.resolve(file);
+  if (resolvedFilePath !== PUBLIC && !resolvedFilePath.startsWith(PUBLIC + path.sep)) {
+    res.writeHead(403);
+    res.end();
+    return;
+  }
   if (fs.existsSync(file) && fs.statSync(file).isFile()) {
     const ext = path.extname(file);
     res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });


### PR DESCRIPTION
Replace insecure startsWith(PUBLIC) with proper boundary check using PUBLIC + path.sep to block access to sibling directories like public-secret/.
Fixes #502

## What Changed
- Added `path.resolve(file)` to resolve any relative directory traversal sequences (`..`).
- Replaced the insecure `!file.startsWith(PUBLIC)` check with a strict comparison (`resolvedFilePath !== PUBLIC`) and a proper boundary check using `PUBLIC + path.sep`.

## Why This Change
Fix issue #502

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened static file access checks to better prevent requests from escaping the public files directory.
  * Requests for files outside the allowed directory now return a forbidden response and stop immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->