### PR TITLE
docs: restructure roadmap and add Where to start to CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,22 @@ EGC operates under a philosophy of **Stability over Expansion** and **Passive Ma
 
 ---
 
+## Where to start
+
+Not sure where to begin? Here are the best entry points:
+
+**Fix a real bug (code):** Issues labeled [`good first issue`](https://github.com/Fmarzochi/EGC/issues?q=is%3Aopen+label%3A%22good+first+issue%22) are small, self-contained, and come with a suggested fix and the exact file and line range. Start here if you want to write code.
+
+**Translate the README:** Open issues exist for [German](https://github.com/Fmarzochi/EGC/issues/486), [French](https://github.com/Fmarzochi/EGC/issues/480), [Japanese](https://github.com/Fmarzochi/EGC/issues/482), [Chinese Simplified](https://github.com/Fmarzochi/EGC/issues/483), [Russian](https://github.com/Fmarzochi/EGC/issues/487), [Italian](https://github.com/Fmarzochi/EGC/issues/481), [Turkish](https://github.com/Fmarzochi/EGC/issues/484), [Ukrainian](https://github.com/Fmarzochi/EGC/issues/479), and [Malay](https://github.com/Fmarzochi/EGC/issues/488). Translation is done on [Crowdin](https://crowdin.com/project/egc) -- no code required.
+
+**Test on your platform:** If you are on [Windows](https://github.com/Fmarzochi/EGC/issues/476) or [macOS](https://github.com/Fmarzochi/EGC/issues/477), install EGC and report what works and what does not. No code required.
+
+**Add an agent or skill:** Look at existing files in `agents/` and `skills/` for examples. The format is documented below and the CI validator will tell you exactly what is wrong if your file has a structural issue.
+
+For all contributions, the two hard requirements are `git commit -s` (DCO) and signing the CLA when the bot asks. Both are explained in the sections below.
+
+---
+
 ## Quick Start
 
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,26 +29,37 @@ This document describes the planned development direction for EGC (Extended Glob
 - State consolidation pipeline on each `update_state` call (issue #143)
 - SessionStart hook runs idempotently across harness reinstalls
 
-## v1.2.0: Ecosystem Expansion
+## v1.2.0: Stability
 
+Fix what is broken before growing further.
+
+- Fix dashboard adapters: CodeBuddy noisy events (#506), VS Code wrong Copilot log (#504), Aider stops after log rotation (#503), POST /event body size cap (#499)
+- True automatic session save: eliminate dependency on AI following a prompt to call `update_state`
+- Validated Windows install experience with documented troubleshooting
+- Contributor pipeline: structured `good first issue` backlog, "Where to start" in CONTRIBUTING.md
 - `egc install --target <tool>`: create context stubs for individual tools on first install
+
+## v1.3.0: Growth
+
+- Community translations: German, French, Japanese, Chinese Simplified, Russian, Italian, Turkish, Ukrainian, Malay
 - Plugin system for community-contributed agents and skills
 - Per-project skill profiles and overrides
+- `egc install --target <tool>`: expanded target coverage
+
+## v2.0.0: Teams
+
 - Shared state between team members (multi-user installations)
-
-## v1.3.0: Governance and Security
-
-- Formal security review by an independent party
-- Assurance case documenting security properties
-- Contribution from at least two active maintainers (bus factor >= 2)
-- SBOM (Software Bill of Materials) generation
-
-## v2.0.0: Production Runtime
-
+- Team and organization-level installations
+- Cross-project memory federation
 - Stable MCP server API with versioned interfaces
 - egc-guardian and egc-memory promoted to GA
-- Cross-project memory federation
-- Team and organization-level installations
+
+## v3.0.0: Enterprise
+
+- Formal security review by an independent party
+- SBOM (Software Bill of Materials) generation
+- Assurance case documenting security properties
+- Contribution from at least two active maintainers (bus factor >= 2)
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

- Reorganize ROADMAP.md into four clear phases: Stability (v1.2.0), Growth (v1.3.0), Teams (v2.0.0), Enterprise (v3.0.0)
- Governance and security goals moved to v3.0.0 -- after community and team features, not before
- Add Where to start section to CONTRIBUTING.md with direct links to good first issues, translation issues, and platform validation tasks

## Motivation

The previous roadmap mixed contributor pipeline goals with enterprise governance goals at the same version. The new structure is honest: you build community before you build governance, not the other way around.

The Where to start section removes the biggest friction for new contributors: not knowing which issue to pick.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructures the roadmap into four phases (v1.2.0 Stability, v1.3.0 Growth, v2.0.0 Teams, v3.0.0 Enterprise) and moves governance/security to Enterprise. Adds a "Where to start" section in CONTRIBUTING with links to good first issues, translations, and Windows/macOS validation to help new contributors get started fast.

- **Refactors**
  - Roadmap goals reorganized into four clear phases.
  - Governance and security moved to v3.0.0, after community and team features.

- **New Features**
  - CONTRIBUTING now includes "Where to start" with direct links to labeled issues and Crowdin translations (German, French, Japanese, Chinese Simplified, Russian, Italian, Turkish, Ukrainian, Malay).
  - Links to platform validation tasks for Windows and macOS.

<sup>Written for commit 0e461368eaa2d9c484a8aad8007c3aac3691f377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

