### PR TITLE
feat(bootstrap): deploy EGC Guardian Protocol to all end users on clean install

### DIFF
--- a/.codebuddy/MEMORY.md
+++ b/.codebuddy/MEMORY.md
@@ -43,3 +43,14 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - Context is heavy or slow → call `reduce_context`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
+
+## EGC Guardian Protocol
+
+These calls are automatic and non-negotiable. Never wait for the user to ask.
+
+- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`
+- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`
+- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`
+- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`
+
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.

--- a/.opencode/instructions/EGC_MEMORY.md
+++ b/.opencode/instructions/EGC_MEMORY.md
@@ -43,3 +43,14 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - Context is heavy or slow → call `reduce_context`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
+
+## EGC Guardian Protocol
+
+These calls are automatic and non-negotiable. Never wait for the user to ask.
+
+- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`
+- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`
+- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`
+- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`
+
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.

--- a/.trae/MEMORY.md
+++ b/.trae/MEMORY.md
@@ -43,3 +43,14 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - Context is heavy or slow → call `reduce_context`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
+
+## EGC Guardian Protocol
+
+These calls are automatic and non-negotiable. Never wait for the user to ask.
+
+- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`
+- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`
+- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`
+- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`
+
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -30,11 +30,22 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - Context is heavy or slow → call \`reduce_context\`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
+
+## EGC Guardian Protocol
+
+These calls are automatic and non-negotiable. Never wait for the user to ask.
+
+**Start of every non-trivial task:** call \`orchestrate_task({ prompt: "<task>" })\`
+**Before every shell/Bash command:** call \`validate_command({ command: "<cmd>" })\`
+**Before every new file Write or Edit on a file not yet read:** call \`validate_write({ filepath: "<path>" })\`
+**At the end of every significant work block:** call \`auto_learn({ project_path: "<cwd>" })\`
+
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 <!-- /egc-memory-protocol -->
 `;
 
-const CODEX_PROTOCOL_SUFFIX = ' At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history. Judge by full context not literal words.';
-const CODEX_PROTOCOL_FULL   = `persistent_instructions = "At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history. Judge by full context not literal words."\n`;
+const CODEX_PROTOCOL_SUFFIX = ' At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn.';
+const CODEX_PROTOCOL_FULL   = `persistent_instructions = "At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn."\n`;
 
 const HOME = os.homedir();
 
@@ -101,7 +112,7 @@ try {
         return;
       }
       const separator = existing.trim() ? '\n\n' : '';
-      obj['cursor.rules'] = existing + separator + '[egc-memory-protocol] At the start of every session call get_state({}) via egc-memory to restore project context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. [egc-auto-intuition] Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents. Judge by full context not literal words.';
+      obj['cursor.rules'] = existing + separator + '[egc-memory-protocol] At the start of every session call get_state({}) via egc-memory to restore project context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. [egc-auto-intuition] Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents. Judge by full context not literal words. [egc-guardian] Before every non-trivial task call orchestrate_task. Before every shell command call validate_command. Before every new file write/edit call validate_write. After every work block call auto_learn.';
       fs.writeFileSync(settingsFile + '.egc.bak', rawContent, 'utf8');
       fs.writeFileSync(settingsFile, JSON.stringify(obj, null, 2) + '\n', 'utf8');
       console.log(`  [cognitive] Cursor: memory protocol installed (${settingsFile.replace(HOME, '~')})`);
@@ -185,7 +196,7 @@ try {
     if (fs.existsSync(src)) {
       fs.copyFileSync(src, target);
     } else {
-      fs.writeFileSync(target, '# EGC Session Memory\n\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr. Judge by full context not literal words.\n');
+      fs.writeFileSync(target, '# EGC Session Memory\n\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr. Judge by full context not literal words.\n\n## EGC Guardian Protocol\n\nThese calls are automatic and non-negotiable. Never wait for the user to ask.\n\n- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`\n- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`\n- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`\n- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`\n\nSkipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.\n');
     }
     console.log(`  [cognitive] OpenCode: memory protocol installed (${target.replace(HOME, '~')})`);
   } catch (e) {
@@ -228,7 +239,7 @@ try {
     if (fs.existsSync(src)) {
       fs.copyFileSync(src, target);
     } else {
-      fs.writeFileSync(target, '# Session Memory\n\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr. Judge by full context not literal words.\n');
+      fs.writeFileSync(target, '# Session Memory\n\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr. Judge by full context not literal words.\n\n## EGC Guardian Protocol\n\nThese calls are automatic and non-negotiable. Never wait for the user to ask.\n\n- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`\n- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`\n- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`\n- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`\n\nSkipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.\n');
     }
     console.log('  [cognitive] CodeBuddy: memory protocol installed (~/.codebuddy/MEMORY.md)');
   } catch (e) {


### PR DESCRIPTION
## Summary

- Add `## EGC Guardian Protocol` section to the `BLOCK` constant in `scripts/bootstrap-cognitive.js` -- injected into `~/.claude/CLAUDE.md` and `~/.gemini/GEMINI.md` on clean install
- Update `CODEX_PROTOCOL_SUFFIX` and `CODEX_PROTOCOL_FULL` (Codex CLI) with Guardian Protocol instructions
- Update the Cursor inline `cursor.rules` string with `[egc-guardian]` tag
- Update fallback strings for OpenCode and CodeBuddy (used when source files are missing)
- Add Guardian Protocol section to source files copied to users: `.trae/MEMORY.md`, `.codebuddy/MEMORY.md`, `.opencode/instructions/EGC_MEMORY.md`

## What changed for users

Previously, `egc-guardian` was registered as an MCP server on install but the AI was never instructed to call its tools. The Guardian Protocol (`orchestrate_task`, `validate_command`, `validate_write`, `auto_learn`) was only in EGC's own project `CLAUDE.md` -- invisible to end users.

After this change, any fresh install deploys the Guardian Protocol to all supported AI tools alongside the memory protocol.

## Test plan

- [ ] Run `node scripts/bootstrap-cognitive.js` on a clean machine and verify `~/.claude/CLAUDE.md` contains `## EGC Guardian Protocol`
- [ ] Verify `~/.gemini/GEMINI.md` receives the same section
- [ ] Verify `~/.trae/MEMORY.md` is copied with Guardian Protocol section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys the EGC Guardian Protocol to all end users on clean install. Tools now get clear, mandatory calls (`orchestrate_task`, `validate_command`, `validate_write`, `auto_learn`) so `egc-guardian` is actually used.

- **New Features**
  - Inject Guardian Protocol into installed memory files for Claude, Gemini, Trae, CodeBuddy, and OpenCode.
  - Update `Codex` protocol strings (`CODEX_PROTOCOL_SUFFIX`/`CODEX_PROTOCOL_FULL`) with Guardian steps.
  - Append `[egc-guardian]` rules to Cursor `cursor.rules`.
  - Add fallback copies that include Guardian content when source files are missing.

<sup>Written for commit f300b3585078a521569c2204650209cdddeadbd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default protocol content injected into supported clients, adding new guidance and required steps for safer task execution and validation.
  * Extended the built-in memory/instructions text used during setup so the latest protocol rules are included across client bootstraps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->