### PR TITLE
fix(dashboard): use resolved path in static file handler to close CodeQL path-injection alerts

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -309,10 +309,10 @@ const grandTotal = Object.values(byIde).reduce(
     res.end();
     return;
   }
-  if (fs.existsSync(file) && fs.statSync(file).isFile()) {
-    const ext = path.extname(file);
+  if (fs.existsSync(resolvedFilePath) && fs.statSync(resolvedFilePath).isFile()) {
+    const ext = path.extname(resolvedFilePath);
     res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
-    res.end(fs.readFileSync(file));
+    res.end(fs.readFileSync(resolvedFilePath));
   } else {
     res.writeHead(404); res.end('Not found');
   }

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -24,6 +24,24 @@ const MIME = {
 
 const SERVER_START = Date.now();
 
+function buildStaticManifest(dir) {
+  const manifest = new Map();
+  if (!fs.existsSync(dir)) return manifest;
+  function scan(current, base) {
+    for (const name of fs.readdirSync(current)) {
+      const abs = path.join(current, name);
+      const rel  = base + '/' + name;
+      try {
+        if (fs.statSync(abs).isDirectory()) scan(abs, rel);
+        else manifest.set(rel, abs);
+      } catch (_) {}
+    }
+  }
+  scan(dir, '');
+  return manifest;
+}
+const STATIC_FILES = buildStaticManifest(PUBLIC);
+
 function detectModel() {
   const candidates = [
     path.join(os.homedir(), '.claude', 'settings.json'),
@@ -301,18 +319,12 @@ const grandTotal = Object.values(byIde).reduce(
   }
 
   // ── Static files ─────────────────────────────────────────
-  const urlPath = req.url === '/' ? '/index.html' : req.url;
-  const file    = path.join(PUBLIC, urlPath.split('?')[0]);
-  const resolvedFilePath = path.resolve(file);
-  if (resolvedFilePath !== PUBLIC && !resolvedFilePath.startsWith(PUBLIC + path.sep)) {
-    res.writeHead(403);
-    res.end();
-    return;
-  }
-  if (fs.existsSync(resolvedFilePath) && fs.statSync(resolvedFilePath).isFile()) {
-    const ext = path.extname(resolvedFilePath);
+  const segment = (req.url === '/' ? '/index.html' : req.url).split('?')[0];
+  const filePath = STATIC_FILES.get(segment);
+  if (filePath && fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+    const ext = path.extname(filePath);
     res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
-    res.end(fs.readFileSync(resolvedFilePath));
+    res.end(fs.readFileSync(filePath));
   } else {
     res.writeHead(404); res.end('Not found');
   }


### PR DESCRIPTION
## Summary

Closes 3 open CodeQL `js/path-injection` alerts (#257, #258, #259) in `dashboard/server.js`.

The path traversal guard (lines 307-310) already validates `resolvedFilePath = path.resolve(file)` and rejects any path outside `PUBLIC`. However, the subsequent `fs.existsSync`, `fs.statSync`, `path.extname`, and `fs.readFileSync` calls still used the original `file` variable (derived directly from `req.url`), which CodeQL correctly identifies as uncontrolled user data flowing into a path expression.

**Fix:** use `resolvedFilePath` (the sanitized, resolved path) for all file system operations after the guard passes.

```js
// before
if (fs.existsSync(file) && fs.statSync(file).isFile()) {
  const ext = path.extname(file);
  res.end(fs.readFileSync(file));

// after
if (fs.existsSync(resolvedFilePath) && fs.statSync(resolvedFilePath).isFile()) {
  const ext = path.extname(resolvedFilePath);
  res.end(fs.readFileSync(resolvedFilePath));
```

No behavior change -- the resolved path points to the same file. The guard already ensures it is within `PUBLIC`.

## Test plan

- [ ] Verify `GET /` still serves `index.html`
- [ ] Verify `GET /index.html` returns 200
- [ ] Verify `GET /../package.json` returns 403 (path traversal blocked)
- [ ] CodeQL scan should close alerts #257, #258, #259

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve dashboard static files from a prebuilt manifest to remove user-controlled paths from filesystem calls and close CodeQL `js/path-injection` alerts #257, #258, #259.

- **Bug Fixes**
  - Build `STATIC_FILES` by scanning `PUBLIC` at startup; only files in this map are served.
  - Replace dynamic path resolution and guards with manifest lookup, using `filePath` for `fs.existsSync`, `fs.statSync`, `path.extname`, and `fs.readFileSync`; traversal and unknown paths return 404.

<sup>Written for commit 042bc4517b6b2206dbd009df7e6cf71f14137d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

