### PR TITLE
docs(ru): add Vile93 translator credit to Russian README backers

### DIFF
--- a/translations/ru/README.md
+++ b/translations/ru/README.md
@@ -176,6 +176,7 @@ EGC создан одним разработчиком, поддерживает
 #### Сторонники
 
 <a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="52" height="52" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
+<a href="https://github.com/Vile93"><img src="https://avatars.githubusercontent.com/u/107775351?v=4" width="52" height="52" alt="@Vile93" title="@Vile93" /></a>
 
 #### Ежемесячные спонсоры · _станьте первым_
 


### PR DESCRIPTION
Add @Vile93 avatar to the backers section of the Russian translation, next to @chizormaangel-commits. Per project policy: translator credit appears only in the translated file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@Vile93` to the Backers section of the Russian README, displaying their avatar alongside `@chizormaangel-commits`. Translator credit appears only in the translated file, per policy.

<sup>Written for commit 0e1ddc3ac01e883e8649882fc956ab539206ae4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

