### PR TITLE
fix(hooks): replace prompt injection with direct disk write in egc-memory-save

### DIFF
--- a/scripts/hooks/egc-memory-save.js
+++ b/scripts/hooks/egc-memory-save.js
@@ -45,7 +45,7 @@ function buildSkeleton(projectPath, branch, ts) {
 function writeSnapshotToDisk() {
   const projectPath = process.env.PWD || process.cwd();
   const branch = detectBranch(projectPath);
-  const stateDir = getStateDir();
+  const stateDir = getStateDir(process.env.HOME);
   const resolved = resolveStateRead(stateDir, projectPath, branch);
   const filePath = resolveStateWrite(stateDir, projectPath, branch);
   const ts = new Date().toISOString();
@@ -71,7 +71,7 @@ function main() {
 
   // Direct write: guaranteed snapshot regardless of AI or tool availability.
   // Non-fatal: a write failure must never block the session from stopping.
-  try { writeSnapshotToDisk(); } catch (_) {}
+  try { writeSnapshotToDisk(); } catch (_) { /* non-fatal */ }
 
   // Prompt: lets a cooperative AI enrich the snapshot with synthesized
   // decisions, preferences, and next steps via update_state.

--- a/scripts/hooks/egc-memory-save.js
+++ b/scripts/hooks/egc-memory-save.js
@@ -1,29 +1,86 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
+const { getStateDir, detectBranch, resolveStateRead, resolveStateWrite } = require('../lib/branch-state');
+
+const MARKER_RE = /^- \[session-snapshot [^\]]+\]\n?/gm;
+
+function updateTimestamp(content, ts) {
+  if (/^updated: /m.test(content)) {
+    return content.replace(/^updated: .*/m, `updated: ${ts}`);
+  }
+  return content.replace(/^(project: [^\n]*\n(?:branch: [^\n]*\n)?)/m, `$1updated: ${ts}\n`);
+}
+
+function injectSessionMarker(content, ts) {
+  const marker = `- [session-snapshot ${ts}]`;
+  const withoutStale = content.replace(MARKER_RE, '');
+  if (/^## Next Session$/m.test(withoutStale)) {
+    return withoutStale.replace(/^(## Next Session\n)/m, `$1${marker}\n`);
+  }
+  return withoutStale + `\n## Next Session\n${marker}\n`;
+}
+
+function buildSkeleton(projectPath, branch, ts) {
+  return [
+    '# Project State',
+    `project: ${projectPath}`,
+    ...(branch ? [`branch: ${branch}`] : []),
+    `updated: ${ts}`,
+    '',
+    '## Context',
+    '',
+    '## Active Decisions',
+    '',
+    '## Do Not Repeat',
+    '',
+    '## Preferences',
+    '',
+    '## Next Session',
+    '',
+  ].join('\n');
+}
+
+function writeSnapshotToDisk() {
+  const projectPath = process.env.PWD || process.cwd();
+  const branch = detectBranch(projectPath);
+  const stateDir = getStateDir();
+  const resolved = resolveStateRead(stateDir, projectPath, branch);
+  const filePath = resolveStateWrite(stateDir, projectPath, branch);
+  const ts = new Date().toISOString();
+
+  let content = (resolved.source !== 'none' && fs.existsSync(resolved.filePath))
+    ? fs.readFileSync(resolved.filePath, 'utf-8')
+    : buildSkeleton(projectPath, branch, ts);
+
+  content = updateTimestamp(content, ts);
+  content = injectSessionMarker(content, ts);
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+  try { fs.chmodSync(filePath, 0o600); } catch { /* chmod not supported on Windows */ }
+}
 
 function main() {
   let raw = '';
-  try {
-    raw = fs.readFileSync(0, 'utf8');
-  } catch (_) {
-    process.stdout.write('{}');
-    process.exit(0);
-  }
+  try { raw = fs.readFileSync(0, 'utf8'); } catch (_) { process.stdout.write('{}'); process.exit(0); }
 
   let input = {};
-  try {
-    input = JSON.parse(raw);
-  } catch (_) {
-    process.stdout.write(raw);
-    process.exit(0);
-  }
+  try { input = JSON.parse(raw); } catch (_) { process.stdout.write(raw); process.exit(0); }
 
+  // Direct write: guaranteed snapshot regardless of AI or tool availability.
+  // Non-fatal: a write failure must never block the session from stopping.
+  try { writeSnapshotToDisk(); } catch (_) {}
+
+  // Prompt: lets a cooperative AI enrich the snapshot with synthesized
+  // decisions, preferences, and next steps via update_state.
   const prompt =
-    'Call update_state via the egc-memory MCP tool with the decisions, preferences, and next steps from this session. project_path is optional: omit it and it uses PWD automatically.';
+    'Call update_state via the egc-memory MCP tool with the decisions, '
+    + 'preferences, and next steps from this session. '
+    + 'project_path is optional: omit it and it uses PWD automatically.';
 
-  const output = Object.assign({}, input, { promptForAssistant: prompt });
-  process.stdout.write(JSON.stringify(output));
+  process.stdout.write(JSON.stringify(Object.assign({}, input, { promptForAssistant: prompt })));
   process.exit(0);
 }
 

--- a/tests/hooks/egc-memory-save.test.js
+++ b/tests/hooks/egc-memory-save.test.js
@@ -1,0 +1,258 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const script = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'egc-memory-save.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    return false;
+  }
+}
+
+function runScript(input, env = {}) {
+  const result = spawnSync('node', [script], {
+    encoding: 'utf8',
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    timeout: 10000,
+    env: Object.assign({}, process.env, env),
+  });
+  return {
+    code: result.status ?? 0,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function withTmpDir(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-save-test-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+function stateFileFor(stateDir, projectPath) {
+  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  const slug = parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+  return path.join(stateDir, `${slug}.md`);
+}
+
+function runTests() {
+  console.log('\n=== Testing egc-memory-save.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+  const run = (name, fn) => (test(name, fn) ? passed++ : failed++);
+
+  console.log('Output contract:');
+
+  run('passes through input fields', () => {
+    const result = runScript({ foo: 'bar' });
+    assert.strictEqual(result.code, 0);
+    const out = JSON.parse(result.stdout);
+    assert.strictEqual(out.foo, 'bar');
+  });
+
+  run('emits promptForAssistant', () => {
+    const result = runScript({});
+    assert.strictEqual(result.code, 0);
+    const out = JSON.parse(result.stdout);
+    assert.ok(typeof out.promptForAssistant === 'string' && out.promptForAssistant.length > 0);
+    assert.ok(out.promptForAssistant.includes('update_state'));
+  });
+
+  run('exits 0 on empty stdin', () => {
+    const result = runScript('{}');
+    assert.strictEqual(result.code, 0);
+  });
+
+  run('exits 0 on malformed stdin', () => {
+    const result = runScript('not-json');
+    assert.strictEqual(result.code, 0);
+  });
+
+  console.log('\nDirect disk write -- new state file:');
+
+  run('creates state file when none exists', () => {
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        const stateDir = path.join(home, '.egc', 'state');
+        const filePath = stateFileFor(stateDir, projectPath);
+        assert.ok(!fs.existsSync(filePath), 'file should not exist before run');
+        runScript({}, { PWD: projectPath, HOME: home });
+        assert.ok(fs.existsSync(filePath), 'file should be created');
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  run('new file contains project path', () => {
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        runScript({}, { PWD: projectPath, HOME: home });
+        const filePath = stateFileFor(path.join(home, '.egc', 'state'), projectPath);
+        const content = fs.readFileSync(filePath, 'utf-8');
+        assert.ok(content.includes(`project: ${projectPath}`));
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  run('new file contains updated timestamp', () => {
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        const before = Date.now();
+        runScript({}, { PWD: projectPath, HOME: home });
+        const filePath = stateFileFor(path.join(home, '.egc', 'state'), projectPath);
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const match = content.match(/^updated: (.+)$/m);
+        assert.ok(match, 'updated line must exist');
+        assert.ok(new Date(match[1]).getTime() >= before);
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  run('new file contains session-snapshot marker under Next Session', () => {
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        runScript({}, { PWD: projectPath, HOME: home });
+        const filePath = stateFileFor(path.join(home, '.egc', 'state'), projectPath);
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const nextIdx = content.indexOf('## Next Session');
+        assert.ok(nextIdx >= 0, '## Next Session section must exist');
+        const afterNext = content.slice(nextIdx);
+        assert.ok(afterNext.includes('[session-snapshot '), 'marker must be present');
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  console.log('\nDirect disk write -- existing state file:');
+
+  run('updates updated timestamp in existing file', () => {
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        const stateDir = path.join(home, '.egc', 'state');
+        fs.mkdirSync(stateDir, { recursive: true });
+        const filePath = stateFileFor(stateDir, projectPath);
+        const oldTs = '2020-01-01T00:00:00.000Z';
+        fs.writeFileSync(filePath, [
+          '# Project State',
+          `project: ${projectPath}`,
+          `updated: ${oldTs}`,
+          '',
+          '## Context',
+          'old context',
+          '',
+          '## Next Session',
+          '',
+        ].join('\n'));
+
+        runScript({}, { PWD: projectPath, HOME: home });
+        const content = fs.readFileSync(filePath, 'utf-8');
+        assert.ok(!content.includes(oldTs), 'old timestamp must be replaced');
+        assert.ok(/^updated: \d{4}-/m.test(content), 'new timestamp must exist');
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  run('preserves existing decisions and context', () => {
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        const stateDir = path.join(home, '.egc', 'state');
+        fs.mkdirSync(stateDir, { recursive: true });
+        const filePath = stateFileFor(stateDir, projectPath);
+        fs.writeFileSync(filePath, [
+          '# Project State',
+          `project: ${projectPath}`,
+          `updated: 2020-01-01T00:00:00.000Z`,
+          '',
+          '## Context',
+          'This is the project context.',
+          '',
+          '## Active Decisions',
+          '- use squash merges',
+          '',
+          '## Next Session',
+          '',
+        ].join('\n'));
+
+        runScript({}, { PWD: projectPath, HOME: home });
+        const content = fs.readFileSync(filePath, 'utf-8');
+        assert.ok(content.includes('This is the project context.'));
+        assert.ok(content.includes('- use squash merges'));
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  run('removes stale session markers before inserting fresh one', () => {
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        const stateDir = path.join(home, '.egc', 'state');
+        fs.mkdirSync(stateDir, { recursive: true });
+        const filePath = stateFileFor(stateDir, projectPath);
+        fs.writeFileSync(filePath, [
+          '# Project State',
+          `project: ${projectPath}`,
+          `updated: 2020-01-01T00:00:00.000Z`,
+          '',
+          '## Next Session',
+          '- [session-snapshot 2020-01-01T00:00:00.000Z]',
+          '- [session-snapshot 2020-06-01T00:00:00.000Z]',
+          '',
+        ].join('\n'));
+
+        runScript({}, { PWD: projectPath, HOME: home });
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const markers = (content.match(/\[session-snapshot /g) || []).length;
+        assert.strictEqual(markers, 1, 'exactly one fresh marker must remain');
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  run('state file is chmod 600 on non-Windows', () => {
+    if (process.platform === 'win32') { console.log('      (skipped on Windows)'); passed++; return; }
+    withTmpDir(projectPath => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-home-'));
+      try {
+        runScript({}, { PWD: projectPath, HOME: home });
+        const filePath = stateFileFor(path.join(home, '.egc', 'state'), projectPath);
+        const mode = fs.statSync(filePath).mode & 0o777;
+        assert.strictEqual(mode, 0o600);
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

Fixes #539.

The previous `egc-memory-save.js` hook injected a `promptForAssistant` asking the AI to call `update_state`. This had two failure modes:

1. **Tool-specific**: `promptForAssistant` is a Claude Code concept. Gemini CLI, Cursor, Codex, OpenCode, Trae, and Kiro ignore it entirely -- on those tools the Stop hook fired and saved nothing.
2. **AI-dependent**: even on Claude Code, the save would be skipped if the session ended abruptly, the context was heavy, or the AI was busy.

## What changed

`egc-memory-save.js` now writes a guaranteed state snapshot directly to disk at session end:

- Reads the existing state file via the same `branch-state.js` resolution logic that `egc-memory-load.js` uses on the read side
- Updates the `updated:` timestamp in-place
- Injects a `[session-snapshot <iso>]` marker under `## Next Session` (stale markers from previous sessions are removed first)
- Preserves all existing decisions, preferences, and context without re-serializing
- `chmod 600` applied; `mkdirSync` creates missing parent dirs

The `promptForAssistant` call is kept as an **enrichment path**: when the AI responds, `update_state` overwrites the snapshot with synthesized decisions and next steps. Direct write = reliability floor. AI call = ceiling.

## Testing

12 new tests in `tests/hooks/egc-memory-save.test.js`:

- Output contract: passthrough, `promptForAssistant` presence, graceful handling of empty/malformed stdin
- New file: creates file, writes project path, timestamp, and session marker
- Existing file: updates timestamp, preserves decisions and context, removes stale markers, enforces `chmod 600`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the prompt-based save with a direct disk snapshot in `egc-memory-save.js` to ensure session state is always persisted across tools. Fixes #539.

- **Bug Fixes**
  - Write a guaranteed snapshot at session end using `branch-state.js` resolution (mirrors `egc-memory-load.js`).
  - Update the `updated:` timestamp and inject one `- [session-snapshot <iso>]` under `## Next Session` (removes stale markers).
  - Preserve existing decisions/context; create parent dirs and set mode `600`.
  - Keep `promptForAssistant` as an optional enrichment path via `update_state`; write failures never block the stop hook.
  - Respect `HOME` overrides by calling `getStateDir(process.env.HOME)` (fixes Windows path issues); add comments to catch blocks for lint compliance.
  - Add 12 tests for passthrough, empty/malformed stdin, new/existing file behavior, marker cleanup, and permissions.

<sup>Written for commit 6b6fa48e9c80f9a5867f6138acecd89d91157400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant sessions now save a project state snapshot automatically before responding, helping preserve session context and next-step notes.
  * Existing state files are updated with the latest timestamp and session snapshot marker, keeping ongoing work easier to resume.

* **Tests**
  * Added coverage for snapshot creation, updates, marker replacement, permissions, and graceful handling of empty or invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->