### PR TITLE
fix(dashboard): debounce and filter fs.watch events in codebuddy-adapter

### DIFF
--- a/dashboard/codebuddy-adapter.js
+++ b/dashboard/codebuddy-adapter.js
@@ -1,17 +1,19 @@
 #!/usr/bin/env node
 'use strict';
-
 const http = require('http');
 const fs   = require('fs');
 const path = require('path');
 const os   = require('os');
 
 const PORT = 7890;
-
 const WATCH_PATHS = [
   path.join(os.homedir(), '.codebuddy', 'logs'),
   path.join(os.homedir(), '.config', 'codebuddy', 'logs'),
 ];
+
+const LOG_EXTENSIONS     = new Set(['.log', '.jsonl', '.json', '.txt']);
+const IGNORED_EXTENSIONS = new Set(['.tmp', '.swp', '.lock', '.bak', '.orig']);
+const DEBOUNCE_MS = 200;
 
 function post(ev) {
   const body = JSON.stringify(ev);
@@ -28,13 +30,37 @@ function post(ev) {
 
 function watchLogDir(dir) {
   if (!fs.existsSync(dir)) return false;
+
+  const debounceMap = new Map(); // { filename -> { timer, fired } }
+
   fs.watch(dir, { persistent:false }, (evt, filename) => {
     if (!filename) return;
-    try {
-      post({ ide:'codebuddy', event:'pre_tool', tool:'CodeBuddy', agent:'main', detail:filename, status:'running' });
-      setTimeout(()=>{ post({ ide:'codebuddy', event:'post_tool', tool:'CodeBuddy', agent:'main', status:'success' }); }, 400);
-    } catch(_) {}
+
+    const ext = path.extname(filename).toLowerCase();
+    if (IGNORED_EXTENSIONS.has(ext)) return;
+    if (!LOG_EXTENSIONS.has(ext)) return;
+
+    const state = debounceMap.get(filename) || { timer: null, fired: false };
+
+    if (state.timer) clearTimeout(state.timer);
+
+    if (!state.fired) {
+      state.fired = true;
+      try {
+        post({ ide:'codebuddy', event:'pre_tool', tool:'CodeBuddy', agent:'main', detail:filename, status:'running' });
+      } catch(_) {}
+    }
+
+    state.timer = setTimeout(() => {
+      debounceMap.delete(filename);
+      try {
+        post({ ide:'codebuddy', event:'post_tool', tool:'CodeBuddy', agent:'main', status:'success' });
+      } catch(_) {}
+    }, DEBOUNCE_MS);
+
+    debounceMap.set(filename, state);
   });
+
   console.log(`Watching CodeBuddy logs: ${dir}`);
   return true;
 }
@@ -46,6 +72,5 @@ function init() {
   }
   if (!started) console.log('CodeBuddy not found. Adapter will retry.');
 }
-
 init();
 setInterval(()=>{ if (!started) init(); }, 15000);


### PR DESCRIPTION
Fixes #506

- Add 200ms debounce map keyed by filename to coalesce rapid rename+change pairs from fs.watch into a single emission
- Filter out .tmp, .swp, .lock, .bak, .orig files before emitting
- Only emit for recognized log extensions: .log, .jsonl, .json, .txt

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the CodeBuddy dashboard adapter to a per-file, leading+trailing debounce and extension filter to cut duplicate `fs.watch` events and ignore temp files. The dashboard now shows CodeBuddy as active immediately and only emits for valid log files.

- **Bug Fixes**
  - Leading+trailing 200ms per-file debounce: `pre_tool` fires immediately; `post_tool` fires 200ms after quiet (replaces fixed 400ms delay).
  - Per-file state via Map to track active/timer and handle multiple files independently.
  - Filters: ignores `.tmp`, `.swp`, `.lock`, `.bak`, `.orig`; allows `.log`, `.jsonl`, `.json`, `.txt`.

<sup>Written for commit 6442dac454b354a26f1b21be59295d5a88cff598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

