### PR TITLE
docs(changelog): add unreleased entry for codebuddy-adapter hybrid debounce (#562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to EGC are documented here.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **codebuddy-adapter: hybrid debounce and extension filter for `fs.watch`**: the watcher now fires `pre_tool/running` immediately on the first event (leading edge) and coalesces rapid follow-ups, emitting `post_tool/success` only after 200 ms of silence (trailing edge). Also filters out temp files (`.tmp`, `.swp`, `.lock`, `.bak`, `.orig`) and restricts emissions to recognized log extensions (`.log`, `.jsonl`, `.json`, `.txt`). Closes #506. (by @Maqbool61)
+
 ## [1.1.5] - 2026-06-24
 
 ### Bug Fixes


### PR DESCRIPTION
Documents the fix landed in #562 in the Unreleased section.

## Summary
- Adds `[Unreleased]` section to CHANGELOG.md describing the hybrid debounce and extension filter fix in `codebuddy-adapter.js`

## Test plan
- [ ] No code changed -- docs only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Unreleased entry to the changelog documenting the `codebuddy-adapter` fix: hybrid leading/trailing debounce for `fs.watch` and stricter temp/log file filtering.

<sup>Written for commit e3fab10439d0aa408e566f2b57779ef33fee12c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watcher responsiveness so updates are reported immediately on the first change and grouped more cleanly during rapid activity.
  * Reduced noise by ignoring temporary files and limiting updates to supported log-related file types.
  * Closed a tracked issue related to watcher behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->