### PR TITLE
feat(install): add Continue.dev MCP registration (#550)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "egc-memory": "mcp/servers/egc-memory/build/index.js"
       },
       "devDependencies": {
+        "@continuedev/config-yaml": "^1.42.0",
         "@eslint/js": "^10.0.1",
         "@iarna/toml": "^2.2.5",
         "@jazzer.js/core": "4.0.0",
@@ -294,6 +295,31 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@continuedev/config-types": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@continuedev/config-types/-/config-types-1.0.14.tgz",
+      "integrity": "sha512-PVHyHPyRXd2QsaNgnCpiKYU3uHFTlyuQSkqE8OwrBmQqO6/TXUVIr/2EGtyIZGrml4Y+rGMSH40WU4/0t4SGpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@continuedev/config-yaml": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@continuedev/config-yaml/-/config-yaml-1.42.0.tgz",
+      "integrity": "sha512-31Px5wYwIIftOOLoJnKbJF0Sx0fjtLdC6ce5EZrd8/JoefpzWwJ4/+vjZA+/O2vda6xi/jI7ROfFcl0G0X7pFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@continuedev/config-types": "^1.0.14",
+        "yaml": "^2.8.2",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "config-yaml": "dist/cli.js"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3423,6 +3449,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -3501,6 +3543,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "mcp"
   ],
   "devDependencies": {
+    "@continuedev/config-yaml": "^1.42.0",
     "@eslint/js": "^10.0.1",
     "@iarna/toml": "^2.2.5",
     "@jazzer.js/core": "4.0.0",

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -29,6 +29,7 @@ const { spawnSync, spawn } = require('child_process');
 const os = require('os');
 
 const { version: PKG_VERSION } = require('../package.json');
+const { registerMcpServers: runMcpRegistration } = require('./lib/mcp-register');
 
 const isTTY = process.stdout.isTTY;
 const c = {
@@ -133,70 +134,16 @@ function registerMcpServers() {
   logAction('detecting tools...');
   const HOME = os.homedir();
 
-  const targets = [
-    { name: 'Antigravity CLI', path: path.join(HOME, '.gemini', 'antigravity-cli', 'mcp_config.json'), gate: () => fs.existsSync(path.join(HOME, '.gemini', 'antigravity-cli')), format: 'json' },
-    { name: 'Gemini CLI', path: path.join(HOME, '.gemini', 'config', 'mcp_config.json'), gate: () => fs.existsSync(path.join(HOME, '.gemini', 'config')), format: 'json' },
-    { name: 'Claude Code (global)', path: path.join(HOME, '.claude', 'claude_desktop_config.json'), gate: () => fs.existsSync(path.join(HOME, '.claude')), format: 'json' },
-    { name: 'Cursor', path: path.join(HOME, '.cursor', 'mcp.json'), gate: () => fs.existsSync(path.join(HOME, '.cursor')), format: 'json' },
-    { name: 'Kiro', path: path.join(HOME, '.kiro', 'settings', 'mcp.json'), gate: () => fs.existsSync(path.join(HOME, '.kiro')), format: 'json' },
-    { name: 'Codex CLI', path: path.join(HOME, '.codex', 'config.toml'), gate: () => fs.existsSync(path.join(HOME, '.codex', 'config.toml')), format: 'toml' },
-    { name: 'OpenCode', path: path.join(HOME, '.config', 'opencode', 'config.json'), gate: () => fs.existsSync(path.join(HOME, '.config', 'opencode', 'config.json')), format: 'json' },
-  ];
-
-  for (const target of targets) {
-    if (!target.gate()) continue;
-    if (flags.dryRun) {
-      logDry(`would register in ${target.name} (${target.path})`);
-      continue;
+  runMcpRegistration(
+    HOME,
+    { guardianBin: GUARDIAN_BIN, memoryBin: MEMORY_BIN },
+    {
+      dryRun: flags.dryRun,
+      onSkip: (target) => logDry(`would register in ${target.name} (${target.path})`),
+      onRegister: (target) => ok(target.name),
+      onWarn: (target, err) => warn(target.name, err.message),
     }
-    try {
-      if (target.format === 'json') {
-        registerJson(target.path);
-        ok(target.name);
-      } else if (target.format === 'toml') {
-        registerToml(target.path);
-        ok(target.name);
-      }
-    } catch (err) {
-      warn(target.name, err.message);
-    }
-  }
-}
-
-function registerJson(target) {
-  let obj = { mcpServers: {} };
-  if (fs.existsSync(target)) {
-    try { obj = JSON.parse(fs.readFileSync(target, 'utf8')); } catch (_) { return; }
-  }
-  if (!obj.mcpServers) obj.mcpServers = {};
-  let changed = false;
-  if (!obj.mcpServers['egc-guardian']) {
-    obj.mcpServers['egc-guardian'] = { command: 'node', args: [GUARDIAN_BIN] };
-    changed = true;
-  }
-  if (!obj.mcpServers['egc-memory']) {
-    obj.mcpServers['egc-memory'] = { command: 'node', args: [MEMORY_BIN] };
-    changed = true;
-  }
-  if (!changed) return;
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-  fs.writeFileSync(target, JSON.stringify(obj, null, 2) + '\n');
-}
-
-function registerToml(target) {
-  let content = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : '';
-  let appended = false;
-  if (!content.includes('"egc-guardian"') && !content.includes("'egc-guardian'")) {
-    content += `\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["${GUARDIAN_BIN}"]\n`;
-    appended = true;
-  }
-  if (!content.includes('"egc-memory"') && !content.includes("'egc-memory'")) {
-    content += `\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["${MEMORY_BIN}"]\n`;
-    appended = true;
-  }
-  if (!appended) return;
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-  fs.writeFileSync(target, content);
+  );
 }
 
 function runStateDbBootstrap() {

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -109,7 +109,7 @@ function registerJson(targetPath, bins) {
       obj = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
     } catch (err) {
       if (err instanceof SyntaxError) {
-        throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`);
+        throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
       }
       throw err;
     }

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -1,0 +1,246 @@
+'use strict';
+
+/**
+ * MCP server registration for `egc init`.
+ *
+ * Extracted from scripts/init.js so the registration logic (which tool
+ * configs get egc-guardian / egc-memory written into) can be unit tested
+ * without running the full init CLI, which executes top-to-bottom on
+ * require() and has no exports of its own.
+ *
+ * scripts/init.js remains the only caller in production; it supplies the
+ * real HOME dir, real bin paths, and wires the callbacks to its own
+ * colorized console output. Tests supply a temp dir and inert bin paths
+ * instead.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Tool configs that get egc-guardian / egc-memory registered into them,
+ * relative to a given home directory. Each target is only written to if
+ * `gate()` returns true, so we don't create config files for tools the
+ * person doesn't have installed.
+ */
+function buildMcpRegistrationTargets(homeDir) {
+  return [
+    {
+      name: 'Antigravity CLI',
+      path: path.join(homeDir, '.gemini', 'antigravity-cli', 'mcp_config.json'),
+      gate: () => fs.existsSync(path.join(homeDir, '.gemini', 'antigravity-cli')),
+      format: 'json',
+    },
+    {
+      name: 'Gemini CLI',
+      path: path.join(homeDir, '.gemini', 'config', 'mcp_config.json'),
+      gate: () => fs.existsSync(path.join(homeDir, '.gemini', 'config')),
+      format: 'json',
+    },
+    {
+      name: 'Claude Code (global)',
+      path: path.join(homeDir, '.claude', 'claude_desktop_config.json'),
+      gate: () => fs.existsSync(path.join(homeDir, '.claude')),
+      format: 'json',
+    },
+    {
+      name: 'Cursor',
+      path: path.join(homeDir, '.cursor', 'mcp.json'),
+      gate: () => fs.existsSync(path.join(homeDir, '.cursor')),
+      format: 'json',
+    },
+    {
+      name: 'Continue.dev',
+      // Continue's config.json is deprecated in favor of config.yaml, and
+      // editing either directly risks clobbering unrelated model/prompt
+      // config, so this doesn't touch either. It also doesn't use the
+      // plain-JSON drop-in some docs mention for .continue/mcpServers/,
+      // because that claim isn't scoped to global vs. workspace anywhere
+      // official. What *is* confirmed at the source level: loadYaml.ts
+      // calls getAllDotContinueDefinitionFiles(ide, { includeGlobal: true,
+      // includeWorkspace: true, fileExtType: "yaml" }, blockType) for every
+      // block type, and mcpServers is confirmed (via the published
+      // @continuedev/config-yaml package's BLOCK_TYPES export) to be one of
+      // them. So this writes standalone YAML block files instead - same
+      // drop-in folder, format Continue's own loader is confirmed to scan
+      // globally. path is the directory itself: registerContinueYaml
+      // writes two files into it (one server per file - a single block's
+      // mcpServers array is capped at one entry by Continue's own schema).
+      // See https://docs.continue.dev/customize/deep-dives/mcp
+      path: path.join(homeDir, '.continue', 'mcpServers'),
+      gate: () => fs.existsSync(path.join(homeDir, '.continue')),
+      format: 'continue-yaml',
+    },
+    {
+      name: 'Kiro',
+      path: path.join(homeDir, '.kiro', 'settings', 'mcp.json'),
+      gate: () => fs.existsSync(path.join(homeDir, '.kiro')),
+      format: 'json',
+    },
+    {
+      name: 'Codex CLI',
+      path: path.join(homeDir, '.codex', 'config.toml'),
+      gate: () => fs.existsSync(path.join(homeDir, '.codex', 'config.toml')),
+      format: 'toml',
+    },
+    {
+      name: 'OpenCode',
+      path: path.join(homeDir, '.config', 'opencode', 'config.json'),
+      gate: () => fs.existsSync(path.join(homeDir, '.config', 'opencode', 'config.json')),
+      format: 'json',
+    },
+  ];
+}
+
+/**
+ * Merges egc-guardian / egc-memory into a JSON mcpServers config, preserving
+ * whatever else is already in the file. Returns true if the file was
+ * created/changed, false if both entries were already present.
+ */
+function registerJson(targetPath, bins) {
+  const { guardianBin, memoryBin } = bins;
+  let obj = { mcpServers: {} };
+  if (fs.existsSync(targetPath)) {
+    try {
+      obj = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
+    } catch (_) {
+      return false;
+    }
+  }
+  if (!obj.mcpServers) obj.mcpServers = {};
+  let changed = false;
+  if (!obj.mcpServers['egc-guardian']) {
+    obj.mcpServers['egc-guardian'] = { command: 'node', args: [guardianBin] };
+    changed = true;
+  }
+  if (!obj.mcpServers['egc-memory']) {
+    obj.mcpServers['egc-memory'] = { command: 'node', args: [memoryBin] };
+    changed = true;
+  }
+  if (!changed) return false;
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, JSON.stringify(obj, null, 2) + '\n');
+  return true;
+}
+
+/**
+ * Same idea as registerJson but for TOML configs (Codex CLI). Returns true
+ * if the file was appended to, false if both entries were already present.
+ */
+function registerToml(targetPath, bins) {
+  const { guardianBin, memoryBin } = bins;
+  let content = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf8') : '';
+  let appended = false;
+  if (!content.includes('"egc-guardian"') && !content.includes("'egc-guardian'")) {
+    content += `\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["${guardianBin}"]\n`;
+    appended = true;
+  }
+  if (!content.includes('"egc-memory"') && !content.includes("'egc-memory'")) {
+    content += `\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["${memoryBin}"]\n`;
+    appended = true;
+  }
+  if (!appended) return false;
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, content);
+  return true;
+}
+
+/**
+ * Writes standalone Continue.dev YAML block files (the format documented
+ * at https://docs.continue.dev/customize/deep-dives/mcp, with required
+ * name/version/schema metadata) registering egc-guardian and egc-memory.
+ *
+ * IMPORTANT: Continue's real schema (verified against the published
+ * @continuedev/config-yaml package's parseBlock/blockSchema, not just
+ * eyeballed) rejects a single block file whose mcpServers array has more
+ * than one entry - "Array must contain exactly 1 element(s)". So this
+ * writes two files, one server each, rather than one file with both.
+ *
+ * targetDir is the .continue/mcpServers/ folder itself, not a single file.
+ * Unlike registerJson/registerToml this doesn't merge into files that
+ * might hold unrelated user content - these are dedicated, EGC-owned
+ * filenames, so each is just regenerated wholesale. Returns true if either
+ * file was created or changed, false if both already matched exactly
+ * (idempotent no-op).
+ */
+function registerContinueYaml(targetDir, bins) {
+  const { guardianBin, memoryBin } = bins;
+  const files = {
+    'egc-guardian.yaml': [
+      'name: EGC Guardian',
+      'version: 0.0.1',
+      'schema: v1',
+      'mcpServers:',
+      '  - name: egc-guardian',
+      '    command: node',
+      '    args:',
+      `      - ${guardianBin}`,
+      '',
+    ].join('\n'),
+    'egc-memory.yaml': [
+      'name: EGC Memory',
+      'version: 0.0.1',
+      'schema: v1',
+      'mcpServers:',
+      '  - name: egc-memory',
+      '    command: node',
+      '    args:',
+      `      - ${memoryBin}`,
+      '',
+    ].join('\n'),
+  };
+
+  let changed = false;
+  for (const [filename, desired] of Object.entries(files)) {
+    const targetPath = path.join(targetDir, filename);
+    if (fs.existsSync(targetPath)) {
+      const existing = fs.readFileSync(targetPath, 'utf8');
+      if (existing === desired) continue;
+    }
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(targetPath, desired);
+    changed = true;
+  }
+  return changed;
+}
+
+/**
+ * Walks every gated target for homeDir and registers egc-guardian /
+ * egc-memory into whichever tools are actually installed. Callbacks let the
+ * caller (scripts/init.js) drive its own console output without this module
+ * needing to know about colors or dry-run formatting.
+ */
+function registerMcpServers(homeDir, bins, callbacks = {}) {
+  const { dryRun = false, onSkip, onRegister, onWarn } = callbacks;
+  const targets = buildMcpRegistrationTargets(homeDir);
+
+  for (const target of targets) {
+    if (!target.gate()) continue;
+    if (dryRun) {
+      if (onSkip) onSkip(target);
+      continue;
+    }
+    try {
+      if (target.format === 'json') {
+        registerJson(target.path, bins);
+      } else if (target.format === 'toml') {
+        registerToml(target.path, bins);
+      } else if (target.format === 'continue-yaml') {
+        registerContinueYaml(target.path, bins);
+      }
+      if (onRegister) onRegister(target);
+    } catch (err) {
+      if (onWarn) onWarn(target, err);
+    }
+  }
+
+  return targets;
+}
+
+module.exports = {
+  buildMcpRegistrationTargets,
+  registerJson,
+  registerToml,
+  registerContinueYaml,
+  registerMcpServers,
+};

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -107,8 +107,11 @@ function registerJson(targetPath, bins) {
   if (fs.existsSync(targetPath)) {
     try {
       obj = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
-    } catch (_) {
-      throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched`);
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`);
+      }
+      throw err;
     }
   }
   if (!obj.mcpServers) obj.mcpServers = {};

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -95,7 +95,11 @@ function buildMcpRegistrationTargets(homeDir) {
 /**
  * Merges egc-guardian / egc-memory into a JSON mcpServers config, preserving
  * whatever else is already in the file. Returns true if the file was
- * created/changed, false if both entries were already present.
+ * created/changed, false if both entries were already present (a legitimate,
+ * silent no-op). Throws if the existing file can't be parsed as JSON -
+ * that's not a no-op, it's a reason the config wasn't touched, and the two
+ * need to stay distinguishable so a caller can warn on one and stay quiet
+ * on the other.
  */
 function registerJson(targetPath, bins) {
   const { guardianBin, memoryBin } = bins;
@@ -104,7 +108,7 @@ function registerJson(targetPath, bins) {
     try {
       obj = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
     } catch (_) {
-      return false;
+      throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched`);
     }
   }
   if (!obj.mcpServers) obj.mcpServers = {};
@@ -124,6 +128,19 @@ function registerJson(targetPath, bins) {
 }
 
 /**
+ * Escapes a path for use inside a TOML basic (double-quoted) string.
+ * Backslashes are the only character we need to worry about here since
+ * bin paths never contain control characters or unescaped quotes - but an
+ * unescaped backslash matters a lot: TOML reserves "\U" for an 8-hex-digit
+ * Unicode escape, so a raw Windows path like C:\Users\... silently corrupts
+ * the file (or fails to parse) the moment a backslash happens to precede a
+ * hex-ish character.
+ */
+function tomlEscape(p) {
+  return p.replace(/\\/g, '\\\\');
+}
+
+/**
  * Same idea as registerJson but for TOML configs (Codex CLI). Returns true
  * if the file was appended to, false if both entries were already present.
  */
@@ -132,11 +149,11 @@ function registerToml(targetPath, bins) {
   let content = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf8') : '';
   let appended = false;
   if (!content.includes('"egc-guardian"') && !content.includes("'egc-guardian'")) {
-    content += `\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["${guardianBin}"]\n`;
+    content += `\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["${tomlEscape(guardianBin)}"]\n`;
     appended = true;
   }
   if (!content.includes('"egc-memory"') && !content.includes("'egc-memory'")) {
-    content += `\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["${memoryBin}"]\n`;
+    content += `\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["${tomlEscape(memoryBin)}"]\n`;
     appended = true;
   }
   if (!appended) return false;
@@ -174,7 +191,11 @@ function registerContinueYaml(targetDir, bins) {
       '  - name: egc-guardian',
       '    command: node',
       '    args:',
-      `      - ${guardianBin}`,
+      // JSON.stringify produces a double-quoted scalar with the backslash/
+      // quote escaping YAML expects. Needed because a bare scalar breaks on
+      // paths containing "#" (starts a comment) or ": " (a mapping
+      // separator) - both legal in a directory name.
+      `      - ${JSON.stringify(guardianBin)}`,
       '',
     ].join('\n'),
     'egc-memory.yaml': [
@@ -185,7 +206,7 @@ function registerContinueYaml(targetDir, bins) {
       '  - name: egc-memory',
       '    command: node',
       '    args:',
-      `      - ${memoryBin}`,
+      `      - ${JSON.stringify(memoryBin)}`,
       '',
     ].join('\n'),
   };
@@ -221,14 +242,15 @@ function registerMcpServers(homeDir, bins, callbacks = {}) {
       continue;
     }
     try {
+      let registered = false;
       if (target.format === 'json') {
-        registerJson(target.path, bins);
+        registered = registerJson(target.path, bins);
       } else if (target.format === 'toml') {
-        registerToml(target.path, bins);
+        registered = registerToml(target.path, bins);
       } else if (target.format === 'continue-yaml') {
-        registerContinueYaml(target.path, bins);
+        registered = registerContinueYaml(target.path, bins);
       }
-      if (onRegister) onRegister(target);
+      if (registered && onRegister) onRegister(target);
     } catch (err) {
       if (onWarn) onWarn(target, err);
     }

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -138,16 +138,18 @@ function runTests() {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
 
-  (test('registerJson leaves the file untouched if it contains invalid JSON', () => {
+  (test('registerJson throws (not returns false) on unparseable existing content', () => {
     const tmpHome = makeTempDir();
     const dir = path.join(tmpHome, '.cursor');
     fs.mkdirSync(dir, { recursive: true });
     const target = path.join(dir, 'mcp.json');
     fs.writeFileSync(target, 'not valid json {{{');
 
-    const changed = registerJson(target, bins);
-
-    assert.strictEqual(changed, false, 'should not report a change on unparseable existing file');
+    // Throwing (rather than quietly returning false) matters: false is
+    // also the return value for "already fully registered, nothing to do",
+    // and the orchestrator needs to tell those two apart to know whether
+    // to warn.
+    assert.throws(() => registerJson(target, bins), /not valid JSON/);
     assert.strictEqual(fs.readFileSync(target, 'utf8'), 'not valid json {{{', 'existing content should be untouched, not clobbered');
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
@@ -167,6 +169,51 @@ function runTests() {
     const content = fs.readFileSync(target, 'utf8');
     assert.ok(content.includes('name = "egc-guardian"'));
     assert.ok(content.includes('name = "egc-memory"'));
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerToml escapes backslashes in Windows-style bin paths', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, '');
+    const winPath = 'C:\\Users\\person\\egc\\mcp\\servers\\egc-guardian\\build\\index.js';
+
+    registerToml(target, { guardianBin: winPath, memoryBin: bins.memoryBin });
+
+    const content = fs.readFileSync(target, 'utf8');
+    // "\U" is reserved in TOML for an 8-hex-digit Unicode escape - a raw,
+    // unescaped backslash from a Windows path breaks the string the moment
+    // it's followed by a hex-ish character (as "\Users" would be here).
+    assert.ok(
+      content.includes('C:\\\\Users\\\\person\\\\egc\\\\mcp\\\\servers\\\\egc-guardian\\\\build\\\\index.js'),
+      'backslashes should be doubled for a valid TOML basic string'
+    );
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerToml output (including Windows paths) parses with a real TOML parser', () => {
+    let TOML;
+    try {
+      TOML = require('@iarna/toml');
+    } catch (_) {
+      console.log('    (skipped: @iarna/toml not installed)');
+      return;
+    }
+
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, '');
+    const winPath = 'C:\\Users\\person\\egc-guardian\\index.js';
+
+    registerToml(target, { guardianBin: winPath, memoryBin: bins.memoryBin });
+
+    const parsed = TOML.parse(fs.readFileSync(target, 'utf8'));
+    const guardianEntry = parsed.mcp_servers.find(s => s.name === 'egc-guardian');
+    assert.strictEqual(guardianEntry.args[0], winPath, 'path should round-trip exactly through a real TOML parser');
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
@@ -225,6 +272,51 @@ function runTests() {
     assert.strictEqual(changed, true, 'a changed bin path should be treated as a real change');
     const guardianContent = fs.readFileSync(path.join(targetDir, 'egc-guardian.yaml'), 'utf8');
     assert.ok(guardianContent.includes('/new/path/egc-guardian/index.js'));
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerContinueYaml double-quotes bin paths with YAML-special characters', () => {
+    const tmpHome = makeTempDir();
+    const targetDir = path.join(tmpHome, '.continue', 'mcpServers');
+    // "#" starts a YAML comment, ": " is a mapping key/value separator -
+    // both are legal in a real directory name and both break a bare
+    // (unquoted) scalar.
+    const trickyPath = '/home/person/my #projects/egc: guardian/index.js';
+
+    registerContinueYaml(targetDir, { guardianBin: trickyPath, memoryBin: bins.memoryBin });
+
+    const content = fs.readFileSync(path.join(targetDir, 'egc-guardian.yaml'), 'utf8');
+    assert.ok(
+      content.includes(`      - ${JSON.stringify(trickyPath)}`),
+      'path should be wrapped in a double-quoted scalar, not inserted bare'
+    );
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerContinueYaml output with tricky characters round-trips through the real Continue parser', () => {
+    let parseBlock;
+    try {
+      parseBlock = require('@continuedev/config-yaml').parseBlock;
+    } catch (_) {
+      console.log('    (skipped: @continuedev/config-yaml not installed)');
+      return;
+    }
+
+    const tmpHome = makeTempDir();
+    const targetDir = path.join(tmpHome, '.continue', 'mcpServers');
+    const trickyPath = '/home/person/my #projects/egc: guardian/index.js';
+
+    registerContinueYaml(targetDir, { guardianBin: trickyPath, memoryBin: bins.memoryBin });
+
+    const content = fs.readFileSync(path.join(targetDir, 'egc-guardian.yaml'), 'utf8');
+    const parsed = parseBlock(content);
+    assert.strictEqual(
+      parsed.mcpServers[0].args[0],
+      trickyPath,
+      'path should round-trip exactly through the real block schema parser'
+    );
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
@@ -305,6 +397,61 @@ function runTests() {
 
     assert.ok(skipped.includes('Continue.dev'));
     assert.ok(!fs.existsSync(path.join(tmpHome, '.continue', 'mcpServers')), 'dry-run must not write any files');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // Regression guard for the P1 fix: onRegister must never fire when
+  // nothing was actually written. A gated target (Cursor) whose existing
+  // config is unparseable should report through onWarn instead, and the
+  // file must be left alone rather than overwritten.
+  (test('registerMcpServers calls onWarn (not onRegister) when an existing JSON target is broken', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.cursor');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'mcp.json'), 'not valid json {{{');
+
+    const registered = [];
+    const warned = [];
+    registerMcpServers(tmpHome, bins, {
+      dryRun: false,
+      onRegister: (target) => registered.push(target.name),
+      onWarn: (target) => warned.push(target.name),
+    });
+
+    assert.ok(!registered.includes('Cursor'), 'onRegister must not fire when nothing was written');
+    assert.ok(warned.includes('Cursor'), 'onWarn should fire so the failure is not silent');
+    assert.strictEqual(
+      fs.readFileSync(path.join(dir, 'mcp.json'), 'utf8'),
+      'not valid json {{{',
+      'broken file must be left untouched, not overwritten'
+    );
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // The other side of the same fix: a target that's already fully
+  // registered is a legitimate no-op, not a failure, and must stay
+  // silent - re-running `egc init` on an already-set-up machine shouldn't
+  // print a warning for every tool that's already correctly configured.
+  (test('registerMcpServers stays silent (no onRegister, no onWarn) on an already-registered target', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.cursor');
+    fs.mkdirSync(dir, { recursive: true });
+    // Pre-register by calling registerJson directly, simulating a second
+    // `egc init` run on a machine that's already set up.
+    registerJson(path.join(dir, 'mcp.json'), bins);
+
+    const registered = [];
+    const warned = [];
+    registerMcpServers(tmpHome, bins, {
+      dryRun: false,
+      onRegister: (target) => registered.push(target.name),
+      onWarn: (target) => warned.push(target.name),
+    });
+
+    assert.ok(!registered.includes('Cursor'), 'nothing changed, so onRegister should not fire again');
+    assert.ok(!warned.includes('Cursor'), 'an already-registered target is not an error and should not warn');
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -1,0 +1,316 @@
+/**
+ * Tests for scripts/lib/mcp-register.js (issue #550)
+ *
+ * Covers the target list (including the new Continue.dev entry, which
+ * writes a Continue YAML block file rather than JSON), the JSON/TOML merge
+ * behavior, and the registerMcpServers() orchestrator that scripts/init.js
+ * delegates to.
+ *
+ * Run with: node tests/lib/mcp-register.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  buildMcpRegistrationTargets,
+  registerJson,
+  registerToml,
+  registerContinueYaml,
+  registerMcpServers,
+} = require('../../scripts/lib/mcp-register');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${err.message}`);
+    return false;
+  }
+}
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-register-test-'));
+}
+
+const bins = {
+  guardianBin: '/fake/mcp/servers/egc-guardian/build/index.js',
+  memoryBin: '/fake/mcp/servers/egc-memory/build/index.js',
+};
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/mcp-register.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  // ── buildMcpRegistrationTargets ──────────────────────────────────
+
+  (test('includes a Continue.dev target pointed at the mcpServers directory', () => {
+    const targets = buildMcpRegistrationTargets('/home/person');
+    const continueTarget = targets.find(t => t.name === 'Continue.dev');
+    assert.ok(continueTarget, 'Continue.dev target should exist');
+    assert.strictEqual(
+      continueTarget.path,
+      path.join('/home/person', '.continue', 'mcpServers'),
+      'Continue.dev should write into the mcpServers folder, not a single file or config.json'
+    );
+    assert.strictEqual(continueTarget.format, 'continue-yaml');
+  }) ? passed++ : failed++);
+
+  (test('Continue.dev gate is false when ~/.continue does not exist', () => {
+    const tmpHome = makeTempDir();
+    const targets = buildMcpRegistrationTargets(tmpHome);
+    const continueTarget = targets.find(t => t.name === 'Continue.dev');
+    assert.strictEqual(continueTarget.gate(), false);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('Continue.dev gate is true when ~/.continue exists', () => {
+    const tmpHome = makeTempDir();
+    fs.mkdirSync(path.join(tmpHome, '.continue'));
+    const targets = buildMcpRegistrationTargets(tmpHome);
+    const continueTarget = targets.find(t => t.name === 'Continue.dev');
+    assert.strictEqual(continueTarget.gate(), true);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('does not drop any of the pre-existing targets', () => {
+    const targets = buildMcpRegistrationTargets('/home/person');
+    const names = targets.map(t => t.name);
+    for (const expected of [
+      'Antigravity CLI', 'Gemini CLI', 'Claude Code (global)', 'Cursor',
+      'Kiro', 'Codex CLI', 'OpenCode',
+    ]) {
+      assert.ok(names.includes(expected), `${expected} should still be a target`);
+    }
+  }) ? passed++ : failed++);
+
+  // ── registerJson (generic - used by Cursor, Claude, Gemini, Kiro, etc.) ──
+
+  (test('registerJson creates a fresh file with both mcp servers', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.cursor', 'mcp.json');
+    const changed = registerJson(target, bins);
+
+    assert.strictEqual(changed, true);
+    const written = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.deepStrictEqual(written.mcpServers['egc-guardian'], { command: 'node', args: [bins.guardianBin] });
+    assert.deepStrictEqual(written.mcpServers['egc-memory'], { command: 'node', args: [bins.memoryBin] });
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerJson preserves unrelated existing mcpServers entries', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.cursor');
+    fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, 'mcp.json');
+    fs.writeFileSync(target, JSON.stringify({
+      mcpServers: { 'some-other-server': { command: 'npx', args: ['-y', 'other'] } },
+    }, null, 2));
+
+    registerJson(target, bins);
+
+    const written = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.ok(written.mcpServers['some-other-server'], 'pre-existing unrelated server should survive the merge');
+    assert.ok(written.mcpServers['egc-guardian'], 'egc-guardian should be added');
+    assert.ok(written.mcpServers['egc-memory'], 'egc-memory should be added');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerJson is idempotent: second run reports no change', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.cursor', 'mcp.json');
+
+    const firstRun = registerJson(target, bins);
+    const secondRun = registerJson(target, bins);
+
+    assert.strictEqual(firstRun, true, 'first run should report a change');
+    assert.strictEqual(secondRun, false, 'second run should report no change (already registered)');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerJson leaves the file untouched if it contains invalid JSON', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.cursor');
+    fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, 'mcp.json');
+    fs.writeFileSync(target, 'not valid json {{{');
+
+    const changed = registerJson(target, bins);
+
+    assert.strictEqual(changed, false, 'should not report a change on unparseable existing file');
+    assert.strictEqual(fs.readFileSync(target, 'utf8'), 'not valid json {{{', 'existing content should be untouched, not clobbered');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // ── registerToml (unchanged behavior, guards against regressions) ──
+
+  (test('registerToml appends both mcp_servers blocks to a fresh file', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, '');
+
+    const changed = registerToml(target, bins);
+
+    assert.strictEqual(changed, true);
+    const content = fs.readFileSync(target, 'utf8');
+    assert.ok(content.includes('name = "egc-guardian"'));
+    assert.ok(content.includes('name = "egc-memory"'));
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // ── registerContinueYaml ─────────────────────────────────────────
+
+  (test('registerContinueYaml writes two files, one server each', () => {
+    const tmpHome = makeTempDir();
+    const targetDir = path.join(tmpHome, '.continue', 'mcpServers');
+    const changed = registerContinueYaml(targetDir, bins);
+
+    assert.strictEqual(changed, true);
+    const guardianContent = fs.readFileSync(path.join(targetDir, 'egc-guardian.yaml'), 'utf8');
+    const memoryContent = fs.readFileSync(path.join(targetDir, 'egc-memory.yaml'), 'utf8');
+
+    // Required top-level block metadata per Continue's docs
+    assert.ok(/^name: .+/m.test(guardianContent) && /^version: .+/m.test(guardianContent) && /^schema: v1$/m.test(guardianContent));
+    assert.ok(/^name: .+/m.test(memoryContent) && /^version: .+/m.test(memoryContent) && /^schema: v1$/m.test(memoryContent));
+
+    // Each file defines exactly one server - Continue's real schema rejects
+    // a block file with more than one mcpServers entry, confirmed against
+    // the actual @continuedev/config-yaml package below.
+    assert.ok(guardianContent.includes('- name: egc-guardian'));
+    assert.ok(!guardianContent.includes('egc-memory'), 'guardian file should not also define memory');
+    assert.ok(memoryContent.includes('- name: egc-memory'));
+    assert.ok(!memoryContent.includes('egc-guardian'), 'memory file should not also define guardian');
+    assert.ok(guardianContent.includes(bins.guardianBin));
+    assert.ok(memoryContent.includes(bins.memoryBin));
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerContinueYaml is idempotent: second run reports no change', () => {
+    const tmpHome = makeTempDir();
+    const targetDir = path.join(tmpHome, '.continue', 'mcpServers');
+
+    const firstRun = registerContinueYaml(targetDir, bins);
+    const secondRun = registerContinueYaml(targetDir, bins);
+
+    assert.strictEqual(firstRun, true, 'first run should report a change');
+    assert.strictEqual(secondRun, false, 'second run should report no change (content identical)');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerContinueYaml regenerates a file if its bin path changes', () => {
+    const tmpHome = makeTempDir();
+    const targetDir = path.join(tmpHome, '.continue', 'mcpServers');
+
+    registerContinueYaml(targetDir, bins);
+    const changed = registerContinueYaml(targetDir, {
+      guardianBin: '/new/path/egc-guardian/index.js',
+      memoryBin: bins.memoryBin,
+    });
+
+    assert.strictEqual(changed, true, 'a changed bin path should be treated as a real change');
+    const guardianContent = fs.readFileSync(path.join(targetDir, 'egc-guardian.yaml'), 'utf8');
+    assert.ok(guardianContent.includes('/new/path/egc-guardian/index.js'));
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // Real schema validation, not just "is this valid YAML" - uses the
+  // actual published @continuedev/config-yaml package (the same one
+  // Continue's own core imports) to parse what we generate. Skips itself
+  // gracefully if the package isn't installed, e.g. offline CI, rather
+  // than failing the whole suite over an optional cross-check.
+  (test('registerContinueYaml output validates against the real Continue block schema', () => {
+    let parseBlock;
+    try {
+      parseBlock = require('@continuedev/config-yaml').parseBlock;
+    } catch (_) {
+      console.log('    (skipped: @continuedev/config-yaml not installed)');
+      return;
+    }
+
+    const tmpHome = makeTempDir();
+    const targetDir = path.join(tmpHome, '.continue', 'mcpServers');
+    registerContinueYaml(targetDir, bins);
+
+    const guardianContent = fs.readFileSync(path.join(targetDir, 'egc-guardian.yaml'), 'utf8');
+    const memoryContent = fs.readFileSync(path.join(targetDir, 'egc-memory.yaml'), 'utf8');
+
+    const guardianParsed = parseBlock(guardianContent);
+    const memoryParsed = parseBlock(memoryContent);
+    assert.strictEqual(guardianParsed.mcpServers[0].name, 'egc-guardian');
+    assert.strictEqual(memoryParsed.mcpServers[0].name, 'egc-memory');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // ── registerMcpServers orchestrator ─────────────────────────────
+
+  (test('registerMcpServers writes Continue.dev config when ~/.continue exists', () => {
+    const tmpHome = makeTempDir();
+    fs.mkdirSync(path.join(tmpHome, '.continue'));
+
+    const registered = [];
+    registerMcpServers(tmpHome, bins, {
+      dryRun: false,
+      onRegister: (target) => registered.push(target.name),
+    });
+
+    assert.ok(registered.includes('Continue.dev'), 'Continue.dev should be reported as registered');
+    const dir = path.join(tmpHome, '.continue', 'mcpServers');
+    assert.ok(fs.readFileSync(path.join(dir, 'egc-guardian.yaml'), 'utf8').includes('- name: egc-guardian'));
+    assert.ok(fs.readFileSync(path.join(dir, 'egc-memory.yaml'), 'utf8').includes('- name: egc-memory'));
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerMcpServers skips Continue.dev entirely when ~/.continue is absent', () => {
+    const tmpHome = makeTempDir();
+
+    const registered = [];
+    registerMcpServers(tmpHome, bins, {
+      dryRun: false,
+      onRegister: (target) => registered.push(target.name),
+    });
+
+    assert.ok(!registered.includes('Continue.dev'), 'Continue.dev should not be touched when not installed');
+    assert.ok(!fs.existsSync(path.join(tmpHome, '.continue')), 'no .continue dir should be created as a side effect');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerMcpServers in dry-run mode writes nothing', () => {
+    const tmpHome = makeTempDir();
+    fs.mkdirSync(path.join(tmpHome, '.continue'));
+
+    const skipped = [];
+    registerMcpServers(tmpHome, bins, {
+      dryRun: true,
+      onSkip: (target) => skipped.push(target.name),
+    });
+
+    assert.ok(skipped.includes('Continue.dev'));
+    assert.ok(!fs.existsSync(path.join(tmpHome, '.continue', 'mcpServers')), 'dry-run must not write any files');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

This pull request adds support for automatically registering the MCP server with Continue.dev during installation.

## Changes

* Added a dedicated `mcp-register` module for Continue.dev integration.
* Integrated MCP registration into the installation workflow.
* Added tests covering the registration logic and expected behavior.
* Preserved existing installation behavior while extending support for Continue.dev.

## Testing

* ✅ Verified the installation flow with the new registration logic.
* ✅ Ran the MCP registration test suite successfully.
* ✅ Confirmed that existing functionality continues to work as expected.

## Related Issue

Closes #550.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically registers EGC MCP servers with Continue.dev during install by writing per-server YAML blocks in ~/.continue/mcpServers, and hardens the overall MCP registration flow with safer, idempotent behavior. Addresses #550.

- **New Features**
  - Continue.dev: auto-registers `egc-guardian` and `egc-memory` via per-server YAML in `~/.continue/mcpServers` (validated by `@continuedev/config-yaml`), integrated into `egc init` via `scripts/lib/mcp-register.js`.
  - Unified registration: single orchestrator for JSON/TOML/Continue targets with dry-run and callbacks; replaces inline logic in `scripts/init.js`.

- **Bug Fixes**
  - Safer, idempotent writes: skip already-registered configs; don’t overwrite invalid JSON; escape Windows paths in TOML; quote YAML args for special characters; suppress onRegister on no-ops.
  - Clearer errors: only warn on JSON parse `SyntaxError` and attach the original error as the cause for better diagnostics.

<sup>Written for commit e37477970e30a7fafd543dd51eed1e80ef292cb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader setup support for MCP server configuration across more editor and CLI tools.
  * Continue.dev setup now uses dedicated per-server config files, with safer updates and fewer unnecessary rewrites.

* **Bug Fixes**
  * Improved setup reliability by preserving existing settings, avoiding duplicate entries, and handling invalid config files more safely.
  * Added dry-run behavior and better error handling so one failed config target won’t stop other updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->