### PR TITLE
fix(dashboard): pick newest copilot log by modification time (#504)

### DIFF
--- a/dashboard/vscode-adapter.js
+++ b/dashboard/vscode-adapter.js
@@ -29,24 +29,25 @@ function post(ev) {
 function findCopilotLog(dir) {
   if (!fs.existsSync(dir)) return null;
   try {
+    let newestFile = null;
+    let newestMtime = -1;
     const entries = fs.readdirSync(dir, {withFileTypes:true});
     for (const e of entries) {
-      if (e.isDirectory()) {
-        const sub = path.join(dir, e.name);
-        const files = fs.readdirSync(sub).filter(f=>f.includes('copilot') || f.includes('github'));
-        if (files.length) {
-          let newestLogFile = files[0];
-          // Find the newest log file in the directory
-          for(const f of files) {
-            const fStat = fs.statSync(path.join(sub, f));
-            if (fStat.mtimeMs > fs.statSync(path.join(sub, newestLogFile)).mtimeMs) {
-              newestLogFile = f;
-            }
+      if(!e.isDirectory()) continue;
+      const sub = path.join(dir, e.name);
+      const files = fs.readdirSync(sub).filter(f=>f.includes('copilot') || f.includes('github'));
+      for(const f of files) {
+        const fPath = path.join(sub, f);
+        try {
+          const mtimeMs = fs.statSync(path.join(sub, f)).mtimeMs;
+          if (mtimeMs > newestMtime) {
+            newestFile = fPath;
+            newestMtime = mtimeMs;
           }
-          return path.join(sub, newestLogFile);
-        }
+        } catch (_) {}    
       }
     }
+    return newestFile;
   } catch(_) {}
   return null;
 }

--- a/dashboard/vscode-adapter.js
+++ b/dashboard/vscode-adapter.js
@@ -34,7 +34,17 @@ function findCopilotLog(dir) {
       if (e.isDirectory()) {
         const sub = path.join(dir, e.name);
         const files = fs.readdirSync(sub).filter(f=>f.includes('copilot') || f.includes('github'));
-        if (files.length) return path.join(sub, files[0]);
+        if (files.length) {
+          let newestLogFile = files[0];
+          // Find the newest log file in the directory
+          for(const f of files) {
+            const fStat = fs.statSync(path.join(sub, f));
+            if (fStat.mtimeMs > fs.statSync(path.join(sub, newestLogFile)).mtimeMs) {
+              newestLogFile = f;
+            }
+          }
+          return path.join(sub, newestLogFile);
+        }
       }
     }
   } catch(_) {}


### PR DESCRIPTION
## What Changed
Find the newest log file by checking modification time instead of picking files[0]

## Why This Change
Fix issue #504 

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the VS Code dashboard adapter to scan all log subfolders and return the newest Copilot/GitHub log by modification time, instead of the first match. Fixes #504 and avoids stale log reads when multiple files are present.

<sup>Written for commit 6cc54e707b999ee1879a337c5e5332661057b232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

