### PR TITLE
docs(changelog): add unreleased entry for orchestrate_task routing (#566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to EGC are documented here.
 
 ## [Unreleased]
 
+### New Features
+
+- **`orchestrate_task` now performs real skill/agent/rule routing**: a build-time generator indexes the full component catalog (260 skills, 63 agents, 109 rules) and the guardian classifies each task prompt against it. With an `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`/`GOOGLE_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY` (model configurable via `OPENROUTER_MODEL`) in the environment, routing is semantic via the corresponding LLM; without any key it falls back to a local keyword scorer and keeps working, adding a `routing_hint` that explains how to enable semantic routing. LLM responses are validated against the catalog so models cannot invent component names, and every provider call has a 5s timeout. (#566)
+
 ### Bug Fixes
 
 - **codebuddy-adapter: hybrid debounce and extension filter for `fs.watch`**: the watcher now fires `pre_tool/running` immediately on the first event (leading edge) and coalesces rapid follow-ups, emitting `post_tool/success` only after 200 ms of silence (trailing edge). Also filters out temp files (`.tmp`, `.swp`, `.lock`, `.bak`, `.orig`) and restricts emissions to recognized log extensions (`.log`, `.jsonl`, `.json`, `.txt`). Closes #506. (by @Maqbool61)


### PR DESCRIPTION
## What Changed

Adds the Unreleased changelog entry for the orchestrate_task semantic routing feature merged in #566.

## Why This Change

Keeps CHANGELOG.md in sync with merged features, following the same pattern used for #562/#563.

## Type of Change

- [x] `docs:` Documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Unreleased CHANGELOG entry for `orchestrate_task` semantic routing. It documents catalog indexing, LLM-based routing and required env keys, local fallback with a routing hint, catalog validation to prevent invented names, and 5s timeouts.

<sup>Written for commit 4796d346f96ae0ba94633bb9d2feb16f10bb4f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

