### PR TITLE
feat(hooks): enforce guardian validation and routing at the harness level

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -36,6 +36,8 @@ That installs resolved hooks to `~/.gemini/hooks/hooks.json`. On Windows, the Ge
 
 | Hook | Matcher | Behavior | Exit Code |
 |------|---------|----------|-----------|
+| **Guardian command enforcement** | `Bash` | Validates every command with the egc-guardian validator before it runs; splits compound commands into segments so destructive commands cannot hide behind chaining or sudo. Blocks destructive commands, protected paths, and forbidden git flags; allowlist misses are advisory. Fails open if the validator is unavailable | 2 (blocks) |
+| **Guardian write enforcement** | `Write\|Edit\|MultiEdit` | Validates the target path with the egc-guardian validator; blocks writes to protected paths (credential stores, key files). Fails open if the validator is unavailable | 2 (blocks) |
 | **Dev server blocker** | `Bash` | Blocks `npm run dev` etc. outside tmux: ensures log access | 2 (blocks) |
 | **Tmux reminder** | `Bash` | Suggests tmux for long-running commands (npm test, cargo build, docker) | 0 (warns) |
 | **Git push reminder** | `Bash` | Reminds to review changes before `git push` | 0 (warns) |
@@ -59,6 +61,7 @@ That installs resolved hooks to `~/.gemini/hooks/hooks.json`. On Windows, the Ge
 
 | Hook | Event | What It Does |
 |------|-------|-------------|
+| **Prompt router** | `UserPromptSubmit` | Routes every prompt through the guardian catalog and injects recommended skills and agents into context. Keyword routing by default; set `EGC_ROUTING_LLM=1` for semantic LLM routing when a provider key is available. Never blocks |
 | **Session start** | `SessionStart` | Loads previous project state and emits a stack briefing with relevant agents for the detected project type |
 | **Pre-compact** | `PreCompact` | Saves state before context compaction |
 | **Console.log audit** | `Stop` | Checks all modified files for `console.log` after each response |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -3,6 +3,18 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js pre:write-guardian-validate scripts/hooks/pre-write-guardian-validate.js minimal,standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Block modifications to linter/formatter config files. Steers agent to fix code instead of weakening configs.",
+        "id": "pre:config-protection"
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -406,6 +418,20 @@
         ],
         "description": "EGC cross-runtime session lifecycle bridge (SessionEnd)",
         "id": "sessionend:egc-session-bridge"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js prompt:router scripts/hooks/prompt-router.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Block modifications to linter/formatter config files. Steers agent to fix code instead of weakening configs.",
+        "id": "pre:config-protection"
       }
     ]
   }

--- a/mcp/servers/egc-guardian/src/guardian-cli.ts
+++ b/mcp/servers/egc-guardian/src/guardian-cli.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { validateCommand, validateWrite } from './validator.js';
+import { llmRoute, keywordRoute } from './llm-router.js';
+
+// Thin CLI over the guardian engine so harness hooks can enforce the same
+// rules the MCP tools expose, without requiring the MCP server to be running.
+// Output is a single JSON line on stdout; the process always exits 0 and the
+// caller decides how to act on the verdict.
+
+const MAX_ROUTE_ITEMS = { agents: 3, skills: 5 };
+
+async function main() {
+  const mode = process.argv[2];
+  const payload = process.argv[3] ?? '';
+
+  if (mode === 'command') {
+    const result = validateCommand(payload);
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  if (mode === 'command-batch') {
+    let commands: string[] = [];
+    try {
+      const parsed = JSON.parse(payload);
+      if (Array.isArray(parsed)) commands = parsed.filter((c): c is string => typeof c === 'string');
+    } catch { /* malformed batch payload: validate nothing, return empty */ }
+    process.stdout.write(JSON.stringify(commands.map(c => validateCommand(c))));
+    return;
+  }
+
+  if (mode === 'write') {
+    const result = validateWrite(payload);
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  if (mode === 'route') {
+    const useLlm = process.argv.includes('--llm');
+    let routed: { agents: string[]; skills: string[]; provider: string } | null = null;
+    if (useLlm) routed = await llmRoute(payload);
+    if (!routed) {
+      const kw = keywordRoute(payload);
+      routed = { agents: kw.agents, skills: kw.skills, provider: 'keyword' };
+    }
+    process.stdout.write(JSON.stringify({
+      agents: routed.agents.slice(0, MAX_ROUTE_ITEMS.agents),
+      skills: routed.skills.slice(0, MAX_ROUTE_ITEMS.skills),
+      provider: routed.provider,
+    }));
+    return;
+  }
+
+  process.stdout.write(JSON.stringify({ error: `unknown mode: ${String(mode)}` }));
+}
+
+main().catch(err => {
+  process.stdout.write(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+});

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -184,7 +184,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "orchestrate_task",
-        description: "Routes a prompt with optional agent/skill lists and file payloads. Returns routing context and context-reduction metrics. Agent/skill selection is pass-through; provide explicit lists for deterministic routing.",
+        description: "Routes a prompt against the EGC catalog of skills, agents, and rules. Uses semantic LLM routing when a provider API key is available (ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY) and falls back to local keyword scoring otherwise. Also returns context-reduction metrics for any file payloads.",
         inputSchema: {
           type: "object",
           properties: {

--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -4,6 +4,7 @@
 const { isHookEnabled } = require('../lib/hook-flags');
 const { trace } = require('../lib/utils');
 
+const { run: runGuardianValidate } = require('./pre-bash-guardian-validate');
 const { run: runBlockNoVerify } = require('./block-no-verify');
 const { run: runAutoTmuxDev } = require('./auto-tmux-dev');
 const { run: runTmuxReminder } = require('./pre-bash-tmux-reminder');
@@ -17,6 +18,11 @@ const { run: runBuildComplete } = require('./post-bash-build-complete');
 const MAX_STDIN = 1024 * 1024;
 
 const PRE_BASH_HOOKS = [
+  {
+    id: 'pre:bash:guardian-validate',
+    profiles: 'minimal,standard,strict',
+    run: rawInput => runGuardianValidate(rawInput),
+  },
   {
     id: 'pre:bash:block-no-verify',
     profiles: 'minimal,standard,strict',

--- a/scripts/hooks/pre-bash-guardian-validate.js
+++ b/scripts/hooks/pre-bash-guardian-validate.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Guardian Command Enforcement Hook
+ *
+ * Validates every Bash command with the egc-guardian validator before it
+ * executes. Compound commands are split into segments so destructive
+ * commands cannot hide behind chaining or wrappers like sudo.
+ *
+ * Blocking policy: only hard denials block (destructive commands,
+ * protected paths, forbidden git flags). Allowlist misses and shell
+ * metacharacter denials are advisory and never block, otherwise any
+ * command outside the guardian allowlist would break the session.
+ *
+ * Fails open: if the guardian CLI is missing or errors, the command is
+ * allowed and a warning is emitted.
+ *
+ * Exit codes:
+ *   0 = allow
+ *   2 = block
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const { resolveGuardianCli } = require('../lib/guardian-bin');
+
+const MAX_STDIN = 1024 * 1024;
+const VALIDATE_TIMEOUT_MS = 4000;
+
+const SEGMENT_SEPARATORS = /[&|;<>$`\n\r]+/;
+const LEADING_WRAPPERS = new Set(['sudo', 'env', 'nohup', 'time', 'command']);
+
+const ADVISORY_REASONS = [
+  'Shell chaining/metacharacters are forbidden',
+  'is not in the allowlist',
+];
+
+function parseInput(inputOrRaw) {
+  if (typeof inputOrRaw === 'string') {
+    try {
+      return inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {};
+    } catch {
+      return {};
+    }
+  }
+  return inputOrRaw && typeof inputOrRaw === 'object' ? inputOrRaw : {};
+}
+
+function extractSegments(command) {
+  const segments = [];
+  for (const rawSegment of command.split(SEGMENT_SEPARATORS)) {
+    let tokens = rawSegment.trim().split(/\s+/).filter(Boolean);
+    while (tokens.length > 0 && (LEADING_WRAPPERS.has(tokens[0]) || /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]))) {
+      tokens = tokens.slice(1);
+    }
+    if (tokens.length > 0) segments.push(tokens.join(' '));
+  }
+  return segments;
+}
+
+function isAdvisory(verdict) {
+  const reason = String(verdict.reason || '');
+  return ADVISORY_REASONS.some(marker => reason.includes(marker));
+}
+
+function run(inputOrRaw) {
+  const input = parseInput(inputOrRaw);
+  const command = input?.tool_input?.command;
+  if (!command || typeof command !== 'string') return { exitCode: 0 };
+
+  const segments = extractSegments(command);
+  if (segments.length === 0) return { exitCode: 0 };
+
+  const cli = resolveGuardianCli();
+  if (!cli) {
+    return {
+      exitCode: 0,
+      stderr: '[EGC Guardian] validator CLI not found; command allowed unchecked. Run egc doctor.',
+    };
+  }
+
+  const result = spawnSync(
+    process.execPath,
+    [cli, 'command-batch', JSON.stringify(segments)],
+    { encoding: 'utf8', timeout: VALIDATE_TIMEOUT_MS },
+  );
+
+  if (result.error || result.status !== 0 || !result.stdout) {
+    return {
+      exitCode: 0,
+      stderr: '[EGC Guardian] validator unavailable; command allowed unchecked.',
+    };
+  }
+
+  let verdicts;
+  try {
+    verdicts = JSON.parse(result.stdout);
+  } catch {
+    return {
+      exitCode: 0,
+      stderr: '[EGC Guardian] validator returned malformed output; command allowed unchecked.',
+    };
+  }
+  if (!Array.isArray(verdicts)) return { exitCode: 0 };
+
+  for (let i = 0; i < verdicts.length; i++) {
+    const verdict = verdicts[i] || {};
+    if (verdict.allowed === false && !isAdvisory(verdict)) {
+      return {
+        exitCode: 2,
+        stderr:
+          `EGC Guardian BLOCKED this command: ${verdict.reason || 'denied by policy'} ` +
+          `(segment: ${segments[i]}). Adjust the command to comply with the project safety rules.`,
+      };
+    }
+  }
+
+  return { exitCode: 0 };
+}
+
+module.exports = { run, extractSegments };
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    const result = run(raw);
+    if (result.stderr) process.stderr.write(result.stderr + '\n');
+    if (result.exitCode === 2) process.exit(2);
+    process.stdout.write(raw);
+  });
+}

--- a/scripts/hooks/pre-write-guardian-validate.js
+++ b/scripts/hooks/pre-write-guardian-validate.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Guardian Write Enforcement Hook
+ *
+ * Validates the target path of every Write/Edit/MultiEdit with the
+ * egc-guardian validator before the write executes. Blocks writes to
+ * protected paths (credential stores, key files, system directories).
+ *
+ * Fails open: if the guardian CLI is missing or errors, the write is
+ * allowed and a warning is emitted.
+ *
+ * Exit codes:
+ *   0 = allow
+ *   2 = block
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const { resolveGuardianCli } = require('../lib/guardian-bin');
+
+const MAX_STDIN = 1024 * 1024;
+const VALIDATE_TIMEOUT_MS = 4000;
+
+function parseInput(inputOrRaw) {
+  if (typeof inputOrRaw === 'string') {
+    try {
+      return inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {};
+    } catch {
+      return {};
+    }
+  }
+  return inputOrRaw && typeof inputOrRaw === 'object' ? inputOrRaw : {};
+}
+
+function run(inputOrRaw) {
+  const input = parseInput(inputOrRaw);
+  const filePath = input?.tool_input?.file_path || input?.tool_input?.file || '';
+  if (!filePath || typeof filePath !== 'string') return { exitCode: 0 };
+
+  const cli = resolveGuardianCli();
+  if (!cli) {
+    return {
+      exitCode: 0,
+      stderr: '[EGC Guardian] validator CLI not found; write allowed unchecked. Run egc doctor.',
+    };
+  }
+
+  const result = spawnSync(process.execPath, [cli, 'write', filePath], {
+    encoding: 'utf8',
+    timeout: VALIDATE_TIMEOUT_MS,
+  });
+
+  if (result.error || result.status !== 0 || !result.stdout) {
+    return {
+      exitCode: 0,
+      stderr: '[EGC Guardian] validator unavailable; write allowed unchecked.',
+    };
+  }
+
+  let verdict;
+  try {
+    verdict = JSON.parse(result.stdout);
+  } catch {
+    return {
+      exitCode: 0,
+      stderr: '[EGC Guardian] validator returned malformed output; write allowed unchecked.',
+    };
+  }
+
+  if (verdict.allowed === false) {
+    return {
+      exitCode: 2,
+      stderr:
+        `EGC Guardian BLOCKED this write: ${verdict.reason || 'denied by policy'}. ` +
+        'Writes to protected paths are not permitted.',
+    };
+  }
+
+  return { exitCode: 0 };
+}
+
+module.exports = { run };
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    const result = run(raw);
+    if (result.stderr) process.stderr.write(result.stderr + '\n');
+    if (result.exitCode === 2) process.exit(2);
+    process.stdout.write(raw);
+  });
+}

--- a/scripts/hooks/prompt-router.js
+++ b/scripts/hooks/prompt-router.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Guardian Prompt Router Hook (UserPromptSubmit)
+ *
+ * Routes every user prompt through the guardian catalog and injects the
+ * recommended skills and agents into context, so component selection
+ * happens on every prompt at the harness level.
+ *
+ * Keyword routing runs by default (local, no network). Set
+ * EGC_ROUTING_LLM=1 to use semantic LLM routing when a provider key is
+ * available; without a key it falls back to keyword automatically.
+ *
+ * Never blocks: on any failure the hook stays silent and exits 0.
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const { resolveGuardianCli } = require('../lib/guardian-bin');
+
+const MAX_STDIN = 1024 * 1024;
+const KEYWORD_TIMEOUT_MS = 3000;
+const LLM_TIMEOUT_MS = 8000;
+const MIN_PROMPT_LENGTH = 12;
+
+function parseInput(inputOrRaw) {
+  if (typeof inputOrRaw === 'string') {
+    try {
+      return inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {};
+    } catch {
+      return {};
+    }
+  }
+  return inputOrRaw && typeof inputOrRaw === 'object' ? inputOrRaw : {};
+}
+
+function routeViaCli(cli, prompt) {
+  const useLlm = /^(1|true|yes)$/i.test(String(process.env.EGC_ROUTING_LLM || ''));
+  const args = [cli, 'route', prompt];
+  if (useLlm) args.push('--llm');
+
+  const result = spawnSync(process.execPath, args, {
+    encoding: 'utf8',
+    timeout: useLlm ? LLM_TIMEOUT_MS : KEYWORD_TIMEOUT_MS,
+  });
+
+  if (result.error || result.status !== 0 || !result.stdout) return null;
+
+  try {
+    const routing = JSON.parse(result.stdout);
+    return {
+      agents: Array.isArray(routing.agents) ? routing.agents : [],
+      skills: Array.isArray(routing.skills) ? routing.skills : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function run(inputOrRaw) {
+  const input = parseInput(inputOrRaw);
+  const prompt = input?.prompt || input?.user_prompt || '';
+  if (typeof prompt !== 'string' || prompt.trim().length < MIN_PROMPT_LENGTH) {
+    return { exitCode: 0, stdout: '' };
+  }
+
+  const cli = resolveGuardianCli();
+  if (!cli) return { exitCode: 0, stdout: '' };
+
+  const routing = routeViaCli(cli, prompt);
+  if (!routing || (routing.agents.length === 0 && routing.skills.length === 0)) {
+    return { exitCode: 0, stdout: '' };
+  }
+
+  const lines = ['=== EGC Routing ==='];
+  if (routing.skills.length > 0) lines.push(`Skills: ${routing.skills.join(', ')}`);
+  if (routing.agents.length > 0) lines.push(`Agents: ${routing.agents.join(', ')}`);
+  lines.push('Apply the matching components above if they fit this task.');
+
+  return { exitCode: 0, stdout: lines.join('\n') };
+}
+
+module.exports = { run };
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    const result = run(raw);
+    if (result.stdout) process.stdout.write(result.stdout + '\n');
+    process.exit(0);
+  });
+}

--- a/scripts/lib/guardian-bin.js
+++ b/scripts/lib/guardian-bin.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Locates the compiled guardian CLI so hooks can enforce validation without
+// the MCP server running. Resolution order: explicit env override, the
+// package-relative layout (repo checkout and npm install share it), then the
+// egc-guardian entry in the MCP configs the user already registered.
+
+function fromEnv() {
+  const explicit = process.env.EGC_GUARDIAN_CLI;
+  if (explicit && explicit.trim() && fs.existsSync(explicit.trim())) return explicit.trim();
+  return null;
+}
+
+function fromPackageLayout() {
+  const candidate = path.join(
+    __dirname, '..', '..',
+    'mcp', 'servers', 'egc-guardian', 'build', 'guardian-cli.js',
+  );
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+function fromMcpConfigs() {
+  const configPaths = [
+    path.join(process.env.PWD || process.cwd(), '.mcp.json'),
+    path.join(os.homedir(), '.claude.json'),
+    path.join(os.homedir(), '.gemini', 'settings.json'),
+  ];
+
+  for (const configPath of configPaths) {
+    try {
+      const data = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      const server = data?.mcpServers?.['egc-guardian'];
+      const args = Array.isArray(server?.args) ? server.args : [];
+      const indexJs = [server?.command, ...args].find(
+        a => typeof a === 'string' && a.endsWith(path.join('egc-guardian', 'build', 'index.js')),
+      );
+      if (!indexJs) continue;
+      const candidate = path.join(path.dirname(indexJs), 'guardian-cli.js');
+      if (fs.existsSync(candidate)) return candidate;
+    } catch (_) { /* unreadable or malformed config: try the next one */ }
+  }
+
+  return null;
+}
+
+function resolveGuardianCli() {
+  return fromEnv() || fromPackageLayout() || fromMcpConfigs();
+}
+
+module.exports = { resolveGuardianCli };

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -1,0 +1,123 @@
+/**
+ * Tests for scripts/hooks/pre-bash-guardian-validate.js via run-with-flags.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runHook(command, env = {}) {
+  const rawInput = JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+  const result = spawnSync('node', [runner, 'pre:bash:guardian-validate', 'scripts/hooks/pre-bash-guardian-validate.js', 'minimal,standard,strict'], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing pre-bash-guardian-validate ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('allows a safe allowlisted command', () => {
+    const result = runHook('git status');
+    assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('allows a compound command of safe segments', () => {
+    const result = runHook('cd /tmp && npm run build');
+    assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('allows a non-allowlisted command (advisory, never blocks)', () => {
+    const result = runHook('python3 script.py');
+    assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('blocks a destructive command', () => {
+    const result = runHook('rm -rf /');
+    assert.strictEqual(result.code, 2, 'Expected rm to be blocked');
+    assert.ok(result.stderr.includes('destructive command'), `Expected reason, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('blocks a destructive command hidden behind chaining', () => {
+    const result = runHook('git status && rm -rf ~');
+    assert.strictEqual(result.code, 2, 'Expected chained rm to be blocked');
+  })) passed++; else failed++;
+
+  if (test('blocks a destructive command behind sudo', () => {
+    const result = runHook('sudo rm -rf /etc');
+    assert.strictEqual(result.code, 2, 'Expected sudo rm to be blocked');
+  })) passed++; else failed++;
+
+  if (test('blocks reads of protected paths', () => {
+    const result = runHook('cat ~/.ssh/id_rsa');
+    assert.strictEqual(result.code, 2, 'Expected protected path read to be blocked');
+    assert.ok(result.stderr.includes('protected path'), `Expected reason, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('blocks git force-push', () => {
+    const result = runHook('git push --force origin main');
+    assert.strictEqual(result.code, 2, 'Expected force-push to be blocked');
+  })) passed++; else failed++;
+
+  if (test('fails open with a warning when the validator crashes', () => {
+    const brokenCli = path.join(os.tmpdir(), `egc-broken-cli-${Date.now()}.js`);
+    fs.writeFileSync(brokenCli, 'process.exit(1);\n');
+    try {
+      const result = runHook('rm -rf /', { EGC_GUARDIAN_CLI: brokenCli });
+      assert.strictEqual(result.code, 0, 'Expected fail-open on validator crash');
+      assert.ok(result.stderr.includes('validator unavailable'), `Expected warning, got: ${result.stderr}`);
+    } finally {
+      try { fs.rmSync(brokenCli, { force: true }); } catch { /* best-effort cleanup */ }
+    }
+  })) passed++; else failed++;
+
+  if (test('passes through input without a command field', () => {
+    const rawInput = JSON.stringify({ tool_name: 'Bash', tool_input: {} });
+    const result = spawnSync('node', [runner, 'pre:bash:guardian-validate', 'scripts/hooks/pre-bash-guardian-validate.js', 'minimal,standard,strict'], {
+      input: rawInput,
+      encoding: 'utf8',
+      env: { ...process.env, ECC_HOOK_PROFILE: 'standard' },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    assert.strictEqual(result.status, 0, 'Expected pass for missing command');
+    assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough');
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/pre-write-guardian-validate.test.js
+++ b/tests/hooks/pre-write-guardian-validate.test.js
@@ -1,0 +1,97 @@
+/**
+ * Tests for scripts/hooks/pre-write-guardian-validate.js via run-with-flags.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runHook(filePath, env = {}) {
+  const rawInput = JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath, content: 'x' } });
+  const result = spawnSync('node', [runner, 'pre:write-guardian-validate', 'scripts/hooks/pre-write-guardian-validate.js', 'minimal,standard,strict'], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing pre-write-guardian-validate ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('blocks writes to protected credential paths', () => {
+    const result = runHook(path.join(os.homedir(), '.ssh', 'id_rsa'));
+    assert.strictEqual(result.code, 2, 'Expected protected write to be blocked');
+    assert.ok(result.stderr.includes('protected'), `Expected reason, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('blocks writes to key files by pattern', () => {
+    const result = runHook('/tmp/deploy.pem');
+    assert.strictEqual(result.code, 2, 'Expected key file write to be blocked');
+  })) passed++; else failed++;
+
+  if (test('allows writes to normal project paths', () => {
+    const result = runHook('/tmp/egc-test-output.txt');
+    assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('fails open with a warning when the validator crashes', () => {
+    const brokenCli = path.join(os.tmpdir(), `egc-broken-cli-${Date.now()}.js`);
+    fs.writeFileSync(brokenCli, 'process.exit(1);\n');
+    try {
+      const result = runHook(path.join(os.homedir(), '.ssh', 'id_rsa'), { EGC_GUARDIAN_CLI: brokenCli });
+      assert.strictEqual(result.code, 0, 'Expected fail-open on validator crash');
+      assert.ok(result.stderr.includes('validator unavailable'), `Expected warning, got: ${result.stderr}`);
+    } finally {
+      try { fs.rmSync(brokenCli, { force: true }); } catch { /* best-effort cleanup */ }
+    }
+  })) passed++; else failed++;
+
+  if (test('passes through input without a file path', () => {
+    const rawInput = JSON.stringify({ tool_name: 'Write', tool_input: {} });
+    const result = spawnSync('node', [runner, 'pre:write-guardian-validate', 'scripts/hooks/pre-write-guardian-validate.js', 'minimal,standard,strict'], {
+      input: rawInput,
+      encoding: 'utf8',
+      env: { ...process.env, ECC_HOOK_PROFILE: 'standard' },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    assert.strictEqual(result.status, 0, 'Expected pass for missing file path');
+    assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough');
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/prompt-router.test.js
+++ b/tests/hooks/prompt-router.test.js
@@ -1,0 +1,86 @@
+/**
+ * Tests for scripts/hooks/prompt-router.js via run-with-flags.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runHook(prompt, env = {}) {
+  const rawInput = JSON.stringify({ prompt });
+  const result = spawnSync('node', [runner, 'prompt:router', 'scripts/hooks/prompt-router.js', 'standard,strict'], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing prompt-router ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('injects routing context for a task-shaped prompt', () => {
+    const result = runHook('review this typescript pull request for security issues');
+    assert.strictEqual(result.code, 0, `Expected exit 0, got stderr: ${result.stderr}`);
+    assert.ok(result.stdout.includes('=== EGC Routing ==='), `Expected routing header, got: ${result.stdout}`);
+    assert.ok(result.stdout.includes('Skills:'), `Expected skills line, got: ${result.stdout}`);
+  })) passed++; else failed++;
+
+  if (test('stays silent for prompts below the minimum length', () => {
+    const result = runHook('oi');
+    assert.strictEqual(result.code, 0, 'Expected exit 0');
+    assert.strictEqual(result.stdout, '', `Expected empty stdout, got: ${result.stdout}`);
+  })) passed++; else failed++;
+
+  if (test('never echoes the raw input JSON into context', () => {
+    const result = runHook('review this typescript pull request for security issues');
+    assert.ok(!result.stdout.includes('"prompt"'), `Raw input leaked into stdout: ${result.stdout}`);
+  })) passed++; else failed++;
+
+  if (test('stays silent when the router crashes', () => {
+    const brokenCli = path.join(os.tmpdir(), `egc-broken-cli-${Date.now()}.js`);
+    fs.writeFileSync(brokenCli, 'process.exit(1);\n');
+    try {
+      const result = runHook('review this typescript pull request for security issues', { EGC_GUARDIAN_CLI: brokenCli });
+      assert.strictEqual(result.code, 0, 'Expected exit 0 on router crash');
+      assert.strictEqual(result.stdout, '', `Expected empty stdout, got: ${result.stdout}`);
+    } finally {
+      try { fs.rmSync(brokenCli, { force: true }); } catch { /* best-effort cleanup */ }
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## What Changed

The README states that every shell command and every file write is checked before it executes. Until now that depended on the model voluntarily calling `validate_command`/`validate_write`. This PR moves enforcement to the harness hook level, where the model cannot skip it.

- **`pre-bash-guardian-validate`** (PreToolUse, `Bash`): validates every command with the egc-guardian validator. Compound commands are split into segments so destructive commands cannot hide behind `&&`, `|`, `sudo`, `env`, or inline variable assignments. Blocks hard denials (destructive commands, protected paths, forbidden git flags) with exit 2; allowlist misses and shell metacharacter denials stay advisory so normal workflows keep working.
- **`pre-write-guardian-validate`** (PreToolUse, `Write|Edit|MultiEdit`): validates the target path; blocks writes to protected paths (credential stores, key files).
- **`prompt-router`** (UserPromptSubmit): routes every prompt through the component catalog (432 entries) and injects recommended skills and agents into context. Keyword routing by default with no network; `EGC_ROUTING_LLM=1` enables semantic LLM routing when a provider key is available. Never blocks and never leaks the raw input into context.
- **`guardian-cli.js`**: thin CLI over the existing validator and router so hooks enforce the same rules the MCP tools expose without needing the MCP server running. Resolution order: `EGC_GUARDIAN_CLI` env, package layout, registered MCP configs.
- All guards fail open with a warning when the validator is unavailable, so a broken install never locks the user out of their own tool.
- Corrects the `orchestrate_task` tool description, which still claimed pass-through selection after #566 made routing real.

## Why This Change

Closes the gap between what the README promises and what the runtime enforces. Validation and routing now happen by code on every call instead of depending on protocol obedience.

## Testing Done

- [x] Manual testing completed (policy matrix: legitimate commands pass, rm/sudo rm/chained rm/protected paths/force-push block)
- [x] Automated tests pass locally (`node tests/run-all.js`) - 2487/2487, including 19 new hook tests
- [x] Edge cases considered and tested (compound commands, wrapper commands, missing CLI fail-open, crashing validator fail-open, raw input never injected into context, prompts below minimum length)

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation (hooks/README.md hook inventory)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `egc-guardian` validation for every Bash command and file write at the harness level, and adds prompt routing on submit. Blocks destructive actions and protected paths while failing open if the validator is unavailable.

- **New Features**
  - PreToolUse Bash guard: validates each segment of compound commands; blocks destructive commands, protected paths, and forbidden git flags (exit 2). Allowlist misses and shell metacharacter denials are advisory.
  - PreToolUse write guard: validates target paths for `Write|Edit|MultiEdit`; blocks writes to protected paths (exit 2).
  - UserPromptSubmit router: routes prompts through the catalog and prints recommended skills/agents. Keyword routing by default; set EGC_ROUTING_LLM=1 to enable semantic LLM routing when a provider key is available. Never blocks and never injects raw input.
  - Thin guardian CLI: exposes validator/router for hooks without the MCP server. Resolution order: EGC_GUARDIAN_CLI env, package layout, registered MCP configs. All guards fail open with a warning if the validator is unavailable.
  - Updated `orchestrate_task` tool description to reflect real routing behavior.

<sup>Written for commit 70cb4e43e815a1905a8cbceb3d3335cf7ed408da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

