### PR TITLE
fix(tests): make guardian hook tests hermetic and fail-open silent

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -36,8 +36,8 @@ That installs resolved hooks to `~/.gemini/hooks/hooks.json`. On Windows, the Ge
 
 | Hook | Matcher | Behavior | Exit Code |
 |------|---------|----------|-----------|
-| **Guardian command enforcement** | `Bash` | Validates every command with the egc-guardian validator before it runs; splits compound commands into segments so destructive commands cannot hide behind chaining or sudo. Blocks destructive commands, protected paths, and forbidden git flags; allowlist misses are advisory. Fails open if the validator is unavailable | 2 (blocks) |
-| **Guardian write enforcement** | `Write\|Edit\|MultiEdit` | Validates the target path with the egc-guardian validator; blocks writes to protected paths (credential stores, key files). Fails open if the validator is unavailable | 2 (blocks) |
+| **Guardian command enforcement** | `Bash` | Validates every command with the egc-guardian validator before it runs; splits compound commands into segments so destructive commands cannot hide behind chaining or sudo. Blocks destructive commands, protected paths, and forbidden git flags; allowlist misses are advisory. Fails open silently if the validator is unavailable | 2 (blocks) |
+| **Guardian write enforcement** | `Write\|Edit\|MultiEdit` | Validates the target path with the egc-guardian validator; blocks writes to protected paths (credential stores, key files). Fails open silently if the validator is unavailable | 2 (blocks) |
 | **Dev server blocker** | `Bash` | Blocks `npm run dev` etc. outside tmux: ensures log access | 2 (blocks) |
 | **Tmux reminder** | `Bash` | Suggests tmux for long-running commands (npm test, cargo build, docker) | 0 (warns) |
 | **Git push reminder** | `Bash` | Reminds to review changes before `git push` | 0 (warns) |

--- a/scripts/hooks/pre-bash-guardian-validate.js
+++ b/scripts/hooks/pre-bash-guardian-validate.js
@@ -73,10 +73,7 @@ function run(inputOrRaw) {
 
   const cli = resolveGuardianCli();
   if (!cli) {
-    return {
-      exitCode: 0,
-      stderr: '[EGC Guardian] validator CLI not found; command allowed unchecked. Run egc doctor.',
-    };
+    return { exitCode: 0 };
   }
 
   const result = spawnSync(
@@ -86,20 +83,14 @@ function run(inputOrRaw) {
   );
 
   if (result.error || result.status !== 0 || !result.stdout) {
-    return {
-      exitCode: 0,
-      stderr: '[EGC Guardian] validator unavailable; command allowed unchecked.',
-    };
+    return { exitCode: 0 };
   }
 
   let verdicts;
   try {
     verdicts = JSON.parse(result.stdout);
   } catch {
-    return {
-      exitCode: 0,
-      stderr: '[EGC Guardian] validator returned malformed output; command allowed unchecked.',
-    };
+    return { exitCode: 0 };
   }
   if (!Array.isArray(verdicts)) return { exitCode: 0 };
 

--- a/scripts/hooks/pre-write-guardian-validate.js
+++ b/scripts/hooks/pre-write-guardian-validate.js
@@ -6,8 +6,8 @@
  * egc-guardian validator before the write executes. Blocks writes to
  * protected paths (credential stores, key files, system directories).
  *
- * Fails open: if the guardian CLI is missing or errors, the write is
- * allowed and a warning is emitted.
+ * Fails open silently: if the guardian CLI is missing or errors, the
+ * write is allowed. Run egc doctor to diagnose a missing validator.
  *
  * Exit codes:
  *   0 = allow
@@ -40,10 +40,7 @@ function run(inputOrRaw) {
 
   const cli = resolveGuardianCli();
   if (!cli) {
-    return {
-      exitCode: 0,
-      stderr: '[EGC Guardian] validator CLI not found; write allowed unchecked. Run egc doctor.',
-    };
+    return { exitCode: 0 };
   }
 
   const result = spawnSync(process.execPath, [cli, 'write', filePath], {
@@ -52,20 +49,14 @@ function run(inputOrRaw) {
   });
 
   if (result.error || result.status !== 0 || !result.stdout) {
-    return {
-      exitCode: 0,
-      stderr: '[EGC Guardian] validator unavailable; write allowed unchecked.',
-    };
+    return { exitCode: 0 };
   }
 
   let verdict;
   try {
     verdict = JSON.parse(result.stdout);
   } catch {
-    return {
-      exitCode: 0,
-      stderr: '[EGC Guardian] validator returned malformed output; write allowed unchecked.',
-    };
+    return { exitCode: 0 };
   }
 
   if (verdict.allowed === false) {

--- a/tests/fixtures/fake-guardian-cli.js
+++ b/tests/fixtures/fake-guardian-cli.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Deterministic stand-in for the compiled guardian CLI, used by hook tests
+ * so they do not depend on the egc-guardian build existing in the test
+ * environment. Mirrors the CLI protocol (mode + payload argv, JSON verdict
+ * on stdout, exit 0); the verdict rules cover only what the hook tests
+ * assert. Validator correctness itself is covered by the guardian tests.
+ */
+
+'use strict';
+
+const PROTECTED_RE = /\.ssh|\.aws|id_rsa|\.pem$|\.key$/;
+
+function verdictForCommand(segment) {
+  const base = segment.trim().split(/\s+/)[0] || '';
+  if (base === 'rm' || base === 'mv') {
+    return { allowed: false, reason: `'${base}' is a destructive command and is always denied`, trust_level: 'DANGEROUS' };
+  }
+  if (PROTECTED_RE.test(segment)) {
+    return { allowed: false, reason: `${base} of protected path is forbidden`, trust_level: 'SAFE_READONLY' };
+  }
+  if (base === 'git' && /\bpush\b/.test(segment) && /(\s--force\b|\s-f\b)/.test(segment)) {
+    return { allowed: false, reason: 'git force-push is forbidden', trust_level: 'SAFE_READONLY' };
+  }
+  return { allowed: true, trust_level: 'SAFE_READONLY' };
+}
+
+const mode = process.argv[2];
+const payload = process.argv[3] || '';
+
+if (mode === 'command') {
+  process.stdout.write(JSON.stringify(verdictForCommand(payload)));
+} else if (mode === 'command-batch') {
+  let segments;
+  try { segments = JSON.parse(payload); } catch { segments = []; }
+  if (!Array.isArray(segments)) segments = [];
+  process.stdout.write(JSON.stringify(segments.map(verdictForCommand)));
+} else if (mode === 'write') {
+  if (PROTECTED_RE.test(payload)) {
+    process.stdout.write(JSON.stringify({ allowed: false, reason: `Path '${payload}' is protected`, trust_level: 'BLOCKED' }));
+  } else {
+    process.stdout.write(JSON.stringify({ allowed: true }));
+  }
+} else if (mode === 'route') {
+  process.stdout.write(JSON.stringify({ agents: ['code-reviewer'], skills: ['security-review'], provider: 'keyword' }));
+} else {
+  process.stdout.write(JSON.stringify({ error: `unknown mode: ${mode}` }));
+}

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
 
 function test(name, fn) {
   try {
@@ -30,6 +31,7 @@ function runHook(command, env = {}) {
     env: {
       ...process.env,
       ECC_HOOK_PROFILE: 'standard',
+      EGC_GUARDIAN_CLI: fakeCli,
       ...env
     },
     timeout: 15000,
@@ -91,13 +93,13 @@ function runTests() {
     assert.strictEqual(result.code, 2, 'Expected force-push to be blocked');
   })) passed++; else failed++;
 
-  if (test('fails open with a warning when the validator crashes', () => {
+  if (test('fails open silently when the validator crashes', () => {
     const brokenCli = path.join(os.tmpdir(), `egc-broken-cli-${Date.now()}.js`);
     fs.writeFileSync(brokenCli, 'process.exit(1);\n');
     try {
       const result = runHook('rm -rf /', { EGC_GUARDIAN_CLI: brokenCli });
       assert.strictEqual(result.code, 0, 'Expected fail-open on validator crash');
-      assert.ok(result.stderr.includes('validator unavailable'), `Expected warning, got: ${result.stderr}`);
+      assert.strictEqual(result.stderr, '', `Expected silent fail-open, got: ${result.stderr}`);
     } finally {
       try { fs.rmSync(brokenCli, { force: true }); } catch { /* best-effort cleanup */ }
     }
@@ -108,7 +110,7 @@ function runTests() {
     const result = spawnSync('node', [runner, 'pre:bash:guardian-validate', 'scripts/hooks/pre-bash-guardian-validate.js', 'minimal,standard,strict'], {
       input: rawInput,
       encoding: 'utf8',
-      env: { ...process.env, ECC_HOOK_PROFILE: 'standard' },
+      env: { ...process.env, ECC_HOOK_PROFILE: 'standard', EGC_GUARDIAN_CLI: fakeCli },
       timeout: 15000,
       stdio: ['pipe', 'pipe', 'pipe']
     });

--- a/tests/hooks/pre-write-guardian-validate.test.js
+++ b/tests/hooks/pre-write-guardian-validate.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
 
 function test(name, fn) {
   try {
@@ -30,6 +31,7 @@ function runHook(filePath, env = {}) {
     env: {
       ...process.env,
       ECC_HOOK_PROFILE: 'standard',
+      EGC_GUARDIAN_CLI: fakeCli,
       ...env
     },
     timeout: 15000,
@@ -65,13 +67,13 @@ function runTests() {
     assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
   })) passed++; else failed++;
 
-  if (test('fails open with a warning when the validator crashes', () => {
+  if (test('fails open silently when the validator crashes', () => {
     const brokenCli = path.join(os.tmpdir(), `egc-broken-cli-${Date.now()}.js`);
     fs.writeFileSync(brokenCli, 'process.exit(1);\n');
     try {
       const result = runHook(path.join(os.homedir(), '.ssh', 'id_rsa'), { EGC_GUARDIAN_CLI: brokenCli });
       assert.strictEqual(result.code, 0, 'Expected fail-open on validator crash');
-      assert.ok(result.stderr.includes('validator unavailable'), `Expected warning, got: ${result.stderr}`);
+      assert.strictEqual(result.stderr, '', `Expected silent fail-open, got: ${result.stderr}`);
     } finally {
       try { fs.rmSync(brokenCli, { force: true }); } catch { /* best-effort cleanup */ }
     }
@@ -82,7 +84,7 @@ function runTests() {
     const result = spawnSync('node', [runner, 'pre:write-guardian-validate', 'scripts/hooks/pre-write-guardian-validate.js', 'minimal,standard,strict'], {
       input: rawInput,
       encoding: 'utf8',
-      env: { ...process.env, ECC_HOOK_PROFILE: 'standard' },
+      env: { ...process.env, ECC_HOOK_PROFILE: 'standard', EGC_GUARDIAN_CLI: fakeCli },
       timeout: 15000,
       stdio: ['pipe', 'pipe', 'pipe']
     });

--- a/tests/hooks/prompt-router.test.js
+++ b/tests/hooks/prompt-router.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
 
 function test(name, fn) {
   try {
@@ -30,6 +31,7 @@ function runHook(prompt, env = {}) {
     env: {
       ...process.env,
       ECC_HOOK_PROFILE: 'standard',
+      EGC_GUARDIAN_CLI: fakeCli,
       ...env
     },
     timeout: 15000,
@@ -53,7 +55,7 @@ function runTests() {
     const result = runHook('review this typescript pull request for security issues');
     assert.strictEqual(result.code, 0, `Expected exit 0, got stderr: ${result.stderr}`);
     assert.ok(result.stdout.includes('=== EGC Routing ==='), `Expected routing header, got: ${result.stdout}`);
-    assert.ok(result.stdout.includes('Skills:'), `Expected skills line, got: ${result.stdout}`);
+    assert.ok(result.stdout.includes('Skills: security-review'), `Expected skills line, got: ${result.stdout}`);
   })) passed++; else failed++;
 
   if (test('stays silent for prompts below the minimum length', () => {


### PR DESCRIPTION
## What Changed

Fixes the 21 failing checks that #568 introduced on main.

- Hook tests now run against a deterministic fixture CLI (`tests/fixtures/fake-guardian-cli.js`) that mirrors the guardian CLI protocol, removing the dependency on the egc-guardian build existing in the test environment. CI test jobs do not build the MCP servers, so the previous tests failed open and every blocking assertion failed across the test matrix.
- Fail-open is now silent: the per-command stderr warning spammed installs without the build and broke the pre-existing dispatcher minimal-profile contract test. `egc doctor` is the diagnostic path for a missing validator.
- hooks/README.md wording updated accordingly.

## Why This Change

Restores main to green. Verified locally by removing the guardian build and running the affected tests (24/24) plus the full suite with the build present (2487/2487).

## Testing Done

- [x] Manual testing completed (simulated CI by removing mcp/servers/egc-guardian/build)
- [x] Automated tests pass locally (`node tests/run-all.js`) - 2487/2487
- [x] Edge cases considered and tested (missing build, crashing validator, malformed fixture payload)

## Type of Change

- [x] `fix:` Bug fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make guardian hook tests hermetic and make fail-open behavior silent. Removes the CI dependency on the `egc-guardian` build and stops stderr noise, fixing failures introduced in #568.

- **Bug Fixes**
  - Added a deterministic fixture CLI at `tests/fixtures/fake-guardian-cli.js` that mirrors the guardian protocol; tests set `EGC_GUARDIAN_CLI` to this binary.
  - Hooks now fail open silently: `pre-bash-guardian-validate.js` and `pre-write-guardian-validate.js` return exit 0 with no stderr when the validator is missing, crashes, or returns malformed output.
  - Updated `hooks/README.md` to note silent fail-open and adjusted tests (including prompt-router) to assert the new behavior.

<sup>Written for commit ab319cb8068a9a94d1589035f41ce00d15623901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guardian-related hooks now fail open silently when validation is unavailable or returns unusable output, without showing warning messages.
  * Updated hook behavior for missing, invalid, or erroring validator responses to keep user workflows uninterrupted.

* **Tests**
  * Expanded hook test coverage with a dedicated fake Guardian CLI.
  * Updated expectations to verify silent fail-open behavior and more specific routing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->