### PR TITLE
docs(changelog): add unreleased entry for guardian harness enforcement (#568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to EGC are documented here.
 
 ### New Features
 
+- **Guardian enforcement at the harness level**: every Bash command and every Write/Edit/MultiEdit target is validated by the egc-guardian validator through PreToolUse hooks before it executes. Destructive commands, protected paths, and forbidden git flags are blocked even inside compound commands or behind sudo/env wrappers; allowlist misses stay advisory so normal workflows keep working. A new UserPromptSubmit hook routes every prompt through the component catalog and injects recommended skills and agents into context (local keyword routing by default; set `EGC_ROUTING_LLM=1` for semantic LLM routing when a provider key is available). All guards fail open silently when the validator is unavailable, so a broken install never locks you out. (#568)
 - **`orchestrate_task` now performs real skill/agent/rule routing**: a build-time generator indexes the full component catalog (260 skills, 63 agents, 109 rules) and the guardian classifies each task prompt against it. With an `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`/`GOOGLE_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY` (model configurable via `OPENROUTER_MODEL`) in the environment, routing is semantic via the corresponding LLM; without any key it falls back to a local keyword scorer and keeps working, adding a `routing_hint` that explains how to enable semantic routing. LLM responses are validated against the catalog so models cannot invent component names, and every provider call has a 5s timeout. (#566)
 
 ### Bug Fixes


### PR DESCRIPTION
## What Changed

Adds the Unreleased changelog entry for the guardian harness enforcement merged in #568 (with the hermetic test fix from #569).

## Type of Change

- [x] `docs:` Documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Unreleased changelog entry documenting guardian harness enforcement. It covers pre-execution validation of Bash and write/edit operations via `egc-guardian`, blocking destructive commands and protected paths, advisory allowlist misses, prompt routing through the component catalog with optional LLM-based routing, and fail-open behavior.

<sup>Written for commit b12de484d1db465d3d9ff28a02b14bec12d1b45e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

