### PR TITLE
feat(memory): semantic auto-intuition and session memory mining by code

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -62,6 +62,9 @@ That installs resolved hooks to `~/.gemini/hooks/hooks.json`. On Windows, the Ge
 | Hook | Event | What It Does |
 |------|-------|-------------|
 | **Prompt router** | `UserPromptSubmit` | Routes every prompt through the guardian catalog and injects recommended skills and agents into context. Keyword routing by default; set `EGC_ROUTING_LLM=1` for semantic LLM routing when a provider key is available. Never blocks |
+| **Auto-intuition** | `UserPromptSubmit` | Detects session intent semantically via a provider LLM, in any language, with no phrase lists. Requires a provider API key; without one it detects nothing and the lifecycle hooks carry the guarantees. On session-end intent it saves the state snapshot and mines the transcript before the AI responds; on resume it injects next steps; on remember it records the user's words verbatim; on history queries it injects project memory. Never blocks |
+| **Session memory miner** | `SessionEnd`, `PreCompact` | Extracts decisions, failures, preferences, and next steps from the session transcript via a provider LLM and merges them into the project state sections. Requires a provider API key; skips silently without one. `EGC_MEMORY_MINER=0` disables |
+| **Session auto-learn** | `SessionEnd` | Runs the guardian auto_learn miner automatically at session end so recurring tool failures become recommendations in the project's AI config files. Skips gracefully when no failures are found. `EGC_AUTO_LEARN=0` disables |
 | **Session start** | `SessionStart` | Loads previous project state and emits a stack briefing with relevant agents for the detected project type |
 | **Pre-compact** | `PreCompact` | Saves state before context compaction |
 | **Console.log audit** | `Stop` | Checks all modified files for `console.log` after each response |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -142,6 +142,18 @@
         ],
         "description": "Persist EGC memory state before context compaction so session decisions survive summarization",
         "id": "pre:compact:egc-memory-save"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js session:memory-miner scripts/hooks/session-memory-miner.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Block modifications to linter/formatter config files. Steers agent to fix code instead of weakening configs.",
+        "id": "pre:config-protection"
       }
     ],
     "SessionStart": [
@@ -418,6 +430,30 @@
         ],
         "description": "EGC cross-runtime session lifecycle bridge (SessionEnd)",
         "id": "sessionend:egc-session-bridge"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js session:memory-miner scripts/hooks/session-memory-miner.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Block modifications to linter/formatter config files. Steers agent to fix code instead of weakening configs.",
+        "id": "pre:config-protection"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js session:auto-learn scripts/hooks/session-auto-learn.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Block modifications to linter/formatter config files. Steers agent to fix code instead of weakening configs.",
+        "id": "pre:config-protection"
       }
     ],
     "UserPromptSubmit": [
@@ -427,6 +463,18 @@
           {
             "type": "command",
             "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js prompt:router scripts/hooks/prompt-router.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Block modifications to linter/formatter config files. Steers agent to fix code instead of weakening configs.",
+        "id": "pre:config-protection"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js prompt:intuition scripts/hooks/prompt-intuition.js standard,strict",
             "timeout": 5
           }
         ],

--- a/mcp/servers/egc-guardian/src/guardian-cli.ts
+++ b/mcp/servers/egc-guardian/src/guardian-cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
+import fs from 'node:fs';
 import { validateCommand, validateWrite } from './validator.js';
 import { llmRoute, keywordRoute } from './llm-router.js';
+import { detectIntent, digestTranscript, mineTranscript } from './intuition.js';
+import { autoLearn } from './learn-writer.js';
 
 // Thin CLI over the guardian engine so harness hooks can enforce the same
 // rules the MCP tools expose, without requiring the MCP server to be running.
@@ -9,49 +12,65 @@ import { llmRoute, keywordRoute } from './llm-router.js';
 
 const MAX_ROUTE_ITEMS = { agents: 3, skills: 5 };
 
+function commandBatch(payload: string): unknown {
+  let commands: string[] = [];
+  try {
+    const parsed = JSON.parse(payload);
+    if (Array.isArray(parsed)) commands = parsed.filter((c): c is string => typeof c === 'string');
+  } catch { /* malformed batch payload: validate nothing, return empty */ }
+  return commands.map(c => validateCommand(c));
+}
+
+async function route(payload: string): Promise<unknown> {
+  const useLlm = process.argv.includes('--llm');
+  let routed: { agents: string[]; skills: string[]; provider: string } | null = null;
+  if (useLlm) routed = await llmRoute(payload);
+  if (!routed) {
+    const kw = keywordRoute(payload);
+    routed = { agents: kw.agents, skills: kw.skills, provider: 'keyword' };
+  }
+  return {
+    agents: routed.agents.slice(0, MAX_ROUTE_ITEMS.agents),
+    skills: routed.skills.slice(0, MAX_ROUTE_ITEMS.skills),
+    provider: routed.provider,
+  };
+}
+
+async function mine(payload: string): Promise<unknown> {
+  let jsonl = '';
+  try {
+    jsonl = fs.readFileSync(payload, 'utf8'); // NOSONAR tssecurity:S8707
+  } catch {
+    return { skip: true, reason: 'transcript unreadable' };
+  }
+  const mined = await mineTranscript(digestTranscript(jsonl));
+  return mined ?? { skip: true, reason: 'nothing mined or no provider key' };
+}
+
+async function learn(payload: string): Promise<unknown> {
+  try {
+    return await autoLearn({ project_path: payload });
+  } catch (err) {
+    return { skip: true, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+const MODES: Record<string, (payload: string) => unknown | Promise<unknown>> = {
+  'command': payload => validateCommand(payload),
+  'command-batch': commandBatch,
+  'write': payload => validateWrite(payload),
+  'route': route,
+  'intent': payload => detectIntent(payload),
+  'mine': mine,
+  'learn': learn,
+};
+
 async function main() {
-  const mode = process.argv[2];
+  const mode = process.argv[2] ?? '';
   const payload = process.argv[3] ?? '';
-
-  if (mode === 'command') {
-    const result = validateCommand(payload);
-    process.stdout.write(JSON.stringify(result));
-    return;
-  }
-
-  if (mode === 'command-batch') {
-    let commands: string[] = [];
-    try {
-      const parsed = JSON.parse(payload);
-      if (Array.isArray(parsed)) commands = parsed.filter((c): c is string => typeof c === 'string');
-    } catch { /* malformed batch payload: validate nothing, return empty */ }
-    process.stdout.write(JSON.stringify(commands.map(c => validateCommand(c))));
-    return;
-  }
-
-  if (mode === 'write') {
-    const result = validateWrite(payload);
-    process.stdout.write(JSON.stringify(result));
-    return;
-  }
-
-  if (mode === 'route') {
-    const useLlm = process.argv.includes('--llm');
-    let routed: { agents: string[]; skills: string[]; provider: string } | null = null;
-    if (useLlm) routed = await llmRoute(payload);
-    if (!routed) {
-      const kw = keywordRoute(payload);
-      routed = { agents: kw.agents, skills: kw.skills, provider: 'keyword' };
-    }
-    process.stdout.write(JSON.stringify({
-      agents: routed.agents.slice(0, MAX_ROUTE_ITEMS.agents),
-      skills: routed.skills.slice(0, MAX_ROUTE_ITEMS.skills),
-      provider: routed.provider,
-    }));
-    return;
-  }
-
-  process.stdout.write(JSON.stringify({ error: `unknown mode: ${String(mode)}` }));
+  const handler = MODES[mode];
+  const result = handler ? await handler(payload) : { error: `unknown mode: ${mode}` };
+  process.stdout.write(JSON.stringify(result));
 }
 
 main().catch(err => {

--- a/mcp/servers/egc-guardian/src/intuition.ts
+++ b/mcp/servers/egc-guardian/src/intuition.ts
@@ -1,0 +1,133 @@
+import { completeJson } from './llm-router.js';
+
+// Intent detection for the auto-intuition hook. Understanding is semantic
+// only: a provider LLM classifies the message in whatever language the
+// user writes. There is deliberately no phrase list; EGC is global and
+// intent cannot be pre-programmed as vocabulary. Without a provider key
+// this returns none and the lifecycle hooks carry the state guarantees.
+// The length gate exists because session-level intent lives in short
+// conversational messages; long task prompts skip classification cost.
+
+export type Intent = 'session_end' | 'session_resume' | 'remember' | 'history_query' | 'none';
+
+const MAX_LLM_PROMPT_CHARS = 200;
+
+const CLASSIFIER_SYSTEM =
+  'Classify the user message into exactly one intent. Respond ONLY with JSON: {"intent":"..."}. ' +
+  'Intents: "session_end" (user is stopping work, saying goodbye, going to sleep), ' +
+  '"session_resume" (user is greeting or asking to pick up previous work), ' +
+  '"remember" (user asks to persist a decision or fact), ' +
+  '"history_query" (user asks what failed or was decided before), ' +
+  '"none" (anything else, including all task requests). Any language.';
+
+const VALID_INTENTS = new Set<Intent>(['session_end', 'session_resume', 'remember', 'history_query', 'none']);
+
+function hasProviderKey(): boolean {
+  return Boolean(
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY ||
+    process.env.OPENAI_API_KEY || process.env.OPENROUTER_API_KEY,
+  );
+}
+
+export async function detectIntent(prompt: string): Promise<{ intent: Intent; source: 'llm' | 'none' }> {
+  const llmDisabled = /^(0|false|no)$/i.test(String(process.env.EGC_INTUITION_LLM || ''));
+  if (llmDisabled || prompt.length > MAX_LLM_PROMPT_CHARS || !hasProviderKey()) {
+    return { intent: 'none', source: 'none' };
+  }
+
+  const completion = await completeJson(CLASSIFIER_SYSTEM, `Message: "${prompt}"`, 64, 3000);
+  if (!completion) return { intent: 'none', source: 'none' };
+
+  const parsed = completion.json as { intent?: unknown };
+  const intent = typeof parsed.intent === 'string' && VALID_INTENTS.has(parsed.intent as Intent)
+    ? parsed.intent as Intent
+    : 'none';
+  return { intent, source: 'llm' };
+}
+
+const MINER_SYSTEM =
+  'You extract project memory from an AI coding session transcript. Respond ONLY with JSON: ' +
+  '{"decisions":[{"what":"...","why":"..."}],"avoid":[{"what":"...","why":"..."}],"preferences":["..."],"next":["..."]}. ' +
+  'decisions: choices made this session. avoid: things that failed or were rejected. ' +
+  'preferences: workflow or style preferences the user expressed. next: concrete items to pick up next session. ' +
+  'Be terse. Max 5 items per list. Empty arrays when nothing qualifies. Use the language the user wrote in.';
+
+const MAX_DIGEST_CHARS = 14_000;
+
+function textOfContent(content: unknown): string {
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((c: { type?: string }) => c?.type === 'text')
+    .map((c: { text?: string }) => c.text || '')
+    .join(' ')
+    .trim();
+}
+
+function turnOfLine(line: string): string | null {
+  try {
+    const entry = JSON.parse(line);
+    const role = entry?.message?.role;
+    if (role !== 'user' && role !== 'assistant') return null;
+    const text = textOfContent(entry?.message?.content);
+    return text ? `${role}: ${text.slice(0, 600)}` : null;
+  } catch {
+    return null;
+  }
+}
+
+export function digestTranscript(jsonl: string): string {
+  const turns = jsonl.split('\n')
+    .filter(line => line.trim())
+    .map(turnOfLine)
+    .filter((t): t is string => t !== null);
+  const digest = turns.join('\n');
+  return digest.length > MAX_DIGEST_CHARS ? digest.slice(-MAX_DIGEST_CHARS) : digest;
+}
+
+export interface MinedMemory {
+  decisions: Array<{ what: string; why?: string }>;
+  avoid: Array<{ what: string; why?: string }>;
+  preferences: string[];
+  next: string[];
+  provider: string;
+}
+
+function stringList(value: unknown, max = 5): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((x): x is string => typeof x === 'string' && x.trim().length > 0).slice(0, max);
+}
+
+function pairList(value: unknown, max = 5): Array<{ what: string; why?: string }> {
+  if (!Array.isArray(value)) return [];
+  const out: Array<{ what: string; why?: string }> = [];
+  for (const item of value) {
+    if (item && typeof item === 'object' && typeof (item as { what?: unknown }).what === 'string') {
+      const what = String((item as { what: string }).what).trim();
+      const whyRaw = (item as { why?: unknown }).why;
+      if (what) out.push({ what, ...(typeof whyRaw === 'string' && whyRaw.trim() ? { why: whyRaw.trim() } : {}) });
+    }
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+export async function mineTranscript(digest: string): Promise<MinedMemory | null> {
+  if (!digest.trim() || !hasProviderKey()) return null;
+
+  const completion = await completeJson(MINER_SYSTEM, digest, 700, 12_000);
+  if (!completion) return null;
+
+  const parsed = completion.json as Record<string, unknown>;
+  const mined: MinedMemory = {
+    decisions: pairList(parsed.decisions),
+    avoid: pairList(parsed.avoid),
+    preferences: stringList(parsed.preferences),
+    next: stringList(parsed.next),
+    provider: completion.provider,
+  };
+
+  const total = mined.decisions.length + mined.avoid.length + mined.preferences.length + mined.next.length;
+  return total > 0 ? mined : null;
+}

--- a/mcp/servers/egc-guardian/src/llm-router.ts
+++ b/mcp/servers/egc-guardian/src/llm-router.ts
@@ -54,43 +54,27 @@ function buildUserMessage(prompt: string, catalogBlock: string): string {
   return `Task: "${prompt}"\n\nCatalog:\n${catalogBlock}`;
 }
 
-interface LlmRouteResult {
-  agents: string[];
-  skills: string[];
-  provider: string;
-}
-
-function parseJsonResponse(raw: string): { agents: string[]; skills: string[] } | null {
+function extractJsonBlock(raw: string): unknown {
   try {
     const match = raw.match(/\{[\s\S]*\}/);
     if (!match) return null;
-    const parsed = JSON.parse(match[0]) as { agents?: unknown; skills?: unknown };
-    const agents = Array.isArray(parsed.agents) ? (parsed.agents as unknown[]).filter((x): x is string => typeof x === 'string') : [];
-    const skills = Array.isArray(parsed.skills) ? (parsed.skills as unknown[]).filter((x): x is string => typeof x === 'string') : [];
-    return { agents, skills };
+    return JSON.parse(match[0]);
   } catch {
     return null;
   }
 }
 
-function validNames(names: string[], kind: 'agent' | 'skill' | 'rule'): string[] {
-  const valid = new Set(CATALOG.filter(e => e.kind === kind).map(e => e.name));
-  const ruleValid = new Set(CATALOG.filter(e => e.kind === 'rule').map(e => e.name));
-  return names.filter(n => valid.has(n) || (kind === 'skill' && ruleValid.has(n)));
-}
-
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), ROUTE_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(url, { ...init, signal: controller.signal });
-    return res;
+    return await fetch(url, { ...init, signal: controller.signal });
   } finally {
     clearTimeout(timer);
   }
 }
 
-async function callAnthropic(key: string, userMsg: string): Promise<LlmRouteResult | null> {
+async function anthropicText(key: string, system: string, user: string, maxTokens: number, timeoutMs: number): Promise<string | null> {
   try {
     const res = await fetchWithTimeout('https://api.anthropic.com/v1/messages', {
       method: 'POST',
@@ -101,56 +85,36 @@ async function callAnthropic(key: string, userMsg: string): Promise<LlmRouteResu
       },
       body: JSON.stringify({
         model: 'claude-haiku-4-5-20251001',
-        max_tokens: 256,
-        system: SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: userMsg }],
+        max_tokens: maxTokens,
+        system,
+        messages: [{ role: 'user', content: user }],
       }),
-    });
+    }, timeoutMs);
     if (!res.ok) return null;
     const data = await res.json() as { content?: Array<{ text?: string }> };
-    const text = data.content?.[0]?.text ?? '';
-    const parsed = parseJsonResponse(text);
-    if (!parsed) return null;
-    return {
-      agents: validNames(parsed.agents, 'agent').slice(0, MAX_AGENTS_OUT),
-      skills: validNames(parsed.skills, 'skill').slice(0, MAX_SKILLS_OUT),
-      provider: 'anthropic',
-    };
+    return data.content?.[0]?.text ?? null;
   } catch { return null; }
 }
 
-async function callGemini(key: string, userMsg: string): Promise<LlmRouteResult | null> {
+async function geminiText(key: string, system: string, user: string, maxTokens: number, timeoutMs: number): Promise<string | null> {
   try {
     const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=${key}`;
     const res = await fetchWithTimeout(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        system_instruction: { parts: [{ text: SYSTEM_PROMPT }] },
-        contents: [{ parts: [{ text: userMsg }] }],
-        generationConfig: { maxOutputTokens: 256, responseMimeType: 'application/json' },
+        system_instruction: { parts: [{ text: system }] },
+        contents: [{ parts: [{ text: user }] }],
+        generationConfig: { maxOutputTokens: maxTokens, responseMimeType: 'application/json' },
       }),
-    });
+    }, timeoutMs);
     if (!res.ok) return null;
     const data = await res.json() as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> };
-    const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-    const parsed = parseJsonResponse(text);
-    if (!parsed) return null;
-    return {
-      agents: validNames(parsed.agents, 'agent').slice(0, MAX_AGENTS_OUT),
-      skills: validNames(parsed.skills, 'skill').slice(0, MAX_SKILLS_OUT),
-      provider: 'gemini',
-    };
+    return data.candidates?.[0]?.content?.parts?.[0]?.text ?? null;
   } catch { return null; }
 }
 
-async function callOpenAICompat(
-  key: string,
-  baseUrl: string,
-  model: string,
-  providerName: string,
-  userMsg: string,
-): Promise<LlmRouteResult | null> {
+async function openAICompatText(key: string, baseUrl: string, model: string, system: string, user: string, maxTokens: number, timeoutMs: number): Promise<string | null> {
   try {
     const res = await fetchWithTimeout(`${baseUrl}/chat/completions`, {
       method: 'POST',
@@ -160,25 +124,80 @@ async function callOpenAICompat(
       },
       body: JSON.stringify({
         model,
-        max_tokens: 256,
+        max_tokens: maxTokens,
         response_format: { type: 'json_object' },
         messages: [
-          { role: 'system', content: SYSTEM_PROMPT },
-          { role: 'user', content: userMsg },
+          { role: 'system', content: system },
+          { role: 'user', content: user },
         ],
       }),
-    });
+    }, timeoutMs);
     if (!res.ok) return null;
     const data = await res.json() as { choices?: Array<{ message?: { content?: string } }> };
-    const text = data.choices?.[0]?.message?.content ?? '';
-    const parsed = parseJsonResponse(text);
-    if (!parsed) return null;
-    return {
-      agents: validNames(parsed.agents, 'agent').slice(0, MAX_AGENTS_OUT),
-      skills: validNames(parsed.skills, 'skill').slice(0, MAX_SKILLS_OUT),
-      provider: providerName,
-    };
+    return data.choices?.[0]?.message?.content ?? null;
   } catch { return null; }
+}
+
+export interface CompletionResult {
+  json: unknown;
+  provider: string;
+}
+
+type ProviderCall = (system: string, user: string, maxTokens: number, timeoutMs: number) => Promise<string | null>;
+
+function providerChain(): Array<{ name: string; call: ProviderCall }> {
+  const chain: Array<{ name: string; call: ProviderCall }> = [];
+
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (anthropicKey) {
+    chain.push({ name: 'anthropic', call: (s, u, m, t) => anthropicText(anthropicKey, s, u, m, t) });
+  }
+
+  const geminiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+  if (geminiKey) {
+    chain.push({ name: 'gemini', call: (s, u, m, t) => geminiText(geminiKey, s, u, m, t) });
+  }
+
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (openaiKey) {
+    chain.push({ name: 'openai', call: (s, u, m, t) => openAICompatText(openaiKey, 'https://api.openai.com/v1', 'gpt-4o-mini', s, u, m, t) });
+  }
+
+  const openrouterKey = process.env.OPENROUTER_API_KEY;
+  if (openrouterKey) {
+    const model = process.env.OPENROUTER_MODEL || 'openai/gpt-4o-mini';
+    chain.push({ name: 'openrouter', call: (s, u, m, t) => openAICompatText(openrouterKey, 'https://openrouter.ai/api/v1', model, s, u, m, t) });
+  }
+
+  return chain;
+}
+
+export async function completeJson(
+  system: string,
+  user: string,
+  maxTokens = 256,
+  timeoutMs = ROUTE_TIMEOUT_MS,
+): Promise<CompletionResult | null> {
+  for (const provider of providerChain()) {
+    const text = await provider.call(system, user, maxTokens, timeoutMs);
+    const json = text ? extractJsonBlock(text) : null;
+    if (json) return { json, provider: provider.name };
+  }
+  return null;
+}
+
+function validNames(names: unknown, kind: 'agent' | 'skill'): string[] {
+  if (!Array.isArray(names)) return [];
+  const strings = names.filter((x): x is string => typeof x === 'string');
+  const valid = new Set(CATALOG.filter(e => e.kind === kind).map(e => e.name));
+  const ruleValid = new Set(CATALOG.filter(e => e.kind === 'rule').map(e => e.name));
+  return strings.filter(n => valid.has(n) || (kind === 'skill' && ruleValid.has(n)));
+}
+
+interface LlmRouteResult {
+  agents: string[];
+  skills: string[];
+  provider: string;
 }
 
 export async function llmRoute(prompt: string): Promise<LlmRouteResult | null> {
@@ -189,38 +208,15 @@ export async function llmRoute(prompt: string): Promise<LlmRouteResult | null> {
   if (candidates.length === 0) return null;
 
   const userMsg = buildUserMessage(prompt, buildCatalogBlock(candidates));
+  const completion = await completeJson(SYSTEM_PROMPT, userMsg, 256, ROUTE_TIMEOUT_MS);
+  if (!completion) return null;
 
-  const anthropicKey = process.env.ANTHROPIC_API_KEY;
-  const geminiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
-  const openaiKey = process.env.OPENAI_API_KEY;
-  const openrouterKey = process.env.OPENROUTER_API_KEY;
-
-  if (anthropicKey) {
-    const result = await callAnthropic(anthropicKey, userMsg);
-    if (result) return result;
-  }
-
-  if (geminiKey) {
-    const result = await callGemini(geminiKey, userMsg);
-    if (result) return result;
-  }
-
-  if (openaiKey) {
-    const result = await callOpenAICompat(
-      openaiKey, 'https://api.openai.com/v1', 'gpt-4o-mini', 'openai', userMsg
-    );
-    if (result) return result;
-  }
-
-  if (openrouterKey) {
-    const model = process.env.OPENROUTER_MODEL || 'openai/gpt-4o-mini';
-    const result = await callOpenAICompat(
-      openrouterKey, 'https://openrouter.ai/api/v1', model, 'openrouter', userMsg
-    );
-    if (result) return result;
-  }
-
-  return null;
+  const parsed = completion.json as { agents?: unknown; skills?: unknown };
+  return {
+    agents: validNames(parsed.agents, 'agent').slice(0, MAX_AGENTS_OUT),
+    skills: validNames(parsed.skills, 'skill').slice(0, MAX_SKILLS_OUT),
+    provider: completion.provider,
+  };
 }
 
 export function keywordRoute(prompt: string): {

--- a/scripts/hooks/egc-memory-save.js
+++ b/scripts/hooks/egc-memory-save.js
@@ -1,66 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
-const { getStateDir, detectBranch, resolveStateRead, resolveStateWrite } = require('../lib/branch-state');
-
-const MARKER_RE = /^- \[session-snapshot [^\]]+\]\n?/gm;
-
-function updateTimestamp(content, ts) {
-  if (/^updated: /m.test(content)) {
-    return content.replace(/^updated: .*/m, `updated: ${ts}`);
-  }
-  return content.replace(/^(project: [^\n]*\n(?:branch: [^\n]*\n)?)/m, `$1updated: ${ts}\n`);
-}
-
-function injectSessionMarker(content, ts) {
-  const marker = `- [session-snapshot ${ts}]`;
-  const withoutStale = content.replace(MARKER_RE, '');
-  if (/^## Next Session$/m.test(withoutStale)) {
-    return withoutStale.replace(/^(## Next Session\n)/m, `$1${marker}\n`);
-  }
-  return withoutStale + `\n## Next Session\n${marker}\n`;
-}
-
-function buildSkeleton(projectPath, branch, ts) {
-  return [
-    '# Project State',
-    `project: ${projectPath}`,
-    ...(branch ? [`branch: ${branch}`] : []),
-    `updated: ${ts}`,
-    '',
-    '## Context',
-    '',
-    '## Active Decisions',
-    '',
-    '## Do Not Repeat',
-    '',
-    '## Preferences',
-    '',
-    '## Next Session',
-    '',
-  ].join('\n');
-}
-
-function writeSnapshotToDisk() {
-  const projectPath = process.env.PWD || process.cwd();
-  const branch = detectBranch(projectPath);
-  const stateDir = getStateDir(process.env.HOME);
-  const resolved = resolveStateRead(stateDir, projectPath, branch);
-  const filePath = resolveStateWrite(stateDir, projectPath, branch);
-  const ts = new Date().toISOString();
-
-  let content = (resolved.source !== 'none' && fs.existsSync(resolved.filePath))
-    ? fs.readFileSync(resolved.filePath, 'utf-8')
-    : buildSkeleton(projectPath, branch, ts);
-
-  content = updateTimestamp(content, ts);
-  content = injectSessionMarker(content, ts);
-
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, content, 'utf-8');
-  try { fs.chmodSync(filePath, 0o600); } catch { /* chmod not supported on Windows */ }
-}
+const { writeSnapshotToDisk } = require('../lib/state-snapshot');
 
 function main() {
   let raw = '';

--- a/scripts/hooks/prompt-intuition.js
+++ b/scripts/hooks/prompt-intuition.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Guardian Auto-Intuition Hook (UserPromptSubmit)
+ *
+ * Detects session-level intent in every user prompt and acts on it by
+ * code before the AI responds:
+ *   session_end    -> saves the state snapshot, mines the transcript for
+ *                     decisions when a provider key exists, and tells the
+ *                     AI the state is already saved
+ *   session_resume -> injects next steps and active decisions from the
+ *                     project state so the AI greets with them
+ *   remember       -> records the user's words verbatim into Active
+ *                     Decisions before the AI even sees the prompt
+ *   history_query  -> injects Do Not Repeat and Active Decisions so the
+ *                     AI answers from project memory
+ *
+ * Intent detection is semantic only: a provider LLM classifies short
+ * messages in any language, with no phrase lists. Without a provider
+ * key nothing is detected and the lifecycle hooks carry the state
+ * guarantees (EGC_INTUITION_LLM=0 disables the classifier).
+ *
+ * Never blocks: on any failure the hook stays silent and exits 0.
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { parseInput, runStandalone } = require('../lib/hook-io');
+const {
+  loadState, saveState, appendToSection, extractSection,
+  writeSnapshotToDisk, applyMinedMemory,
+} = require('../lib/state-snapshot');
+
+const INTENT_TIMEOUT_MS = 6000;
+const MINE_TIMEOUT_MS = 15000;
+const MAX_REMEMBER_CHARS = 400;
+const MAX_INJECT_CHARS = 1600;
+
+function cliJson(cli, args, timeout) {
+  const result = spawnSync(process.execPath, [cli, ...args], { encoding: 'utf8', timeout }); // NOSONAR jssecurity:S8705
+  if (result.error || result.status !== 0 || !result.stdout) return null;
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function clip(text, max) {
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+function handleSessionEnd(cli, projectPath, transcriptPath) {
+  const savedTo = writeSnapshotToDisk(projectPath);
+
+  let minedNote = '';
+  if (transcriptPath) {
+    const mined = cliJson(cli, ['mine', transcriptPath], MINE_TIMEOUT_MS);
+    if (mined && !mined.skip) {
+      const result = applyMinedMemory(projectPath, mined);
+      if (result.added > 0) minedNote = ` ${result.added} decisions and lessons from this session were extracted and merged.`;
+    }
+  }
+
+  return [
+    '=== EGC Session ===',
+    `Project state already saved to ${savedTo}.${minedNote}`,
+    'The user is ending the session: acknowledge briefly, confirm the state is saved, and do not start new work.',
+  ].join('\n');
+}
+
+function handleSessionResume(projectPath) {
+  const state = loadState(projectPath);
+  const next = extractSection(state.content, '## Next Session');
+  const decisions = extractSection(state.content, '## Active Decisions');
+  if (!next && !decisions) return '';
+
+  const parts = ['=== EGC Resume ==='];
+  if (next) parts.push('Next steps:', clip(next, MAX_INJECT_CHARS));
+  if (decisions) parts.push('Active decisions:', clip(decisions, MAX_INJECT_CHARS));
+  parts.push('Greet the user and present these next steps from project memory.');
+  return parts.join('\n');
+}
+
+function handleRemember(projectPath, prompt) {
+  const state = loadState(projectPath);
+  const entry = `- ${state.ts.slice(0, 10)}: ${clip(prompt.trim().replace(/\s+/g, ' '), MAX_REMEMBER_CHARS)}`;
+  const result = appendToSection(state.content, '## Active Decisions', [entry]);
+  if (result.added > 0) saveState(state.filePath, result.content);
+
+  return [
+    '=== EGC Memory ===',
+    'The decision above was already recorded verbatim into the project state by EGC.',
+    'Confirm to the user it is saved, and refine the wording via update_state if useful.',
+  ].join('\n');
+}
+
+function handleHistoryQuery(projectPath) {
+  const state = loadState(projectPath);
+  const avoid = extractSection(state.content, '## Do Not Repeat');
+  const decisions = extractSection(state.content, '## Active Decisions');
+  if (!avoid && !decisions) return '';
+
+  const parts = ['=== EGC History ==='];
+  if (avoid) parts.push('Do not repeat:', clip(avoid, MAX_INJECT_CHARS));
+  if (decisions) parts.push('Active decisions:', clip(decisions, MAX_INJECT_CHARS));
+  parts.push('Answer the user from this project memory.');
+  return parts.join('\n');
+}
+
+function run(inputOrRaw) {
+  const input = parseInput(inputOrRaw);
+  const prompt = input?.prompt || input?.user_prompt || '';
+  if (typeof prompt !== 'string' || prompt.trim().length < 2) return { exitCode: 0, stdout: '' };
+
+  const cli = resolveGuardianCli();
+  if (!cli) return { exitCode: 0, stdout: '' };
+
+  const detection = cliJson(cli, ['intent', prompt], INTENT_TIMEOUT_MS);
+  const intent = detection?.intent;
+  if (!intent || intent === 'none') return { exitCode: 0, stdout: '' };
+
+  const projectPath = input?.cwd || process.env.PWD || process.cwd();
+  const transcriptPath = typeof input?.transcript_path === 'string' ? input.transcript_path : '';
+
+  try {
+    let stdout = '';
+    if (intent === 'session_end') stdout = handleSessionEnd(cli, projectPath, transcriptPath);
+    else if (intent === 'session_resume') stdout = handleSessionResume(projectPath);
+    else if (intent === 'remember') stdout = handleRemember(projectPath, prompt);
+    else if (intent === 'history_query') stdout = handleHistoryQuery(projectPath);
+    return { exitCode: 0, stdout };
+  } catch {
+    return { exitCode: 0, stdout: '' };
+  }
+}
+
+module.exports = { run };
+
+if (require.main === module) {
+  runStandalone(run);
+}

--- a/scripts/hooks/prompt-router.js
+++ b/scripts/hooks/prompt-router.js
@@ -39,7 +39,7 @@ function routeViaCli(cli, prompt) {
   const args = [cli, 'route', prompt];
   if (useLlm) args.push('--llm');
 
-  const result = spawnSync(process.execPath, args, {
+  const result = spawnSync(process.execPath, args, { // NOSONAR jssecurity:S8705
     encoding: 'utf8',
     timeout: useLlm ? LLM_TIMEOUT_MS : KEYWORD_TIMEOUT_MS,
   });

--- a/scripts/hooks/session-auto-learn.js
+++ b/scripts/hooks/session-auto-learn.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Guardian Session Auto-Learn (SessionEnd)
+ *
+ * Runs the guardian auto_learn miner automatically when the session
+ * ends: recurring tool failures from session history become actionable
+ * recommendations written to the project's AI config files, without
+ * waiting for the AI to call the auto_learn MCP tool.
+ *
+ * auto_learn skips gracefully when no failures are found. Set
+ * EGC_AUTO_LEARN=0 to disable.
+ *
+ * Never blocks: on any failure the hook passes through and exits 0.
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { runStandalone } = require('../lib/hook-io');
+
+const LEARN_TIMEOUT_MS = 10000;
+
+function run(_inputOrRaw) {
+  if (/^(0|false|no)$/i.test(String(process.env.EGC_AUTO_LEARN || ''))) return { exitCode: 0 };
+
+  const cli = resolveGuardianCli();
+  if (!cli) return { exitCode: 0 };
+
+  const projectPath = process.env.PWD || process.cwd();
+  spawnSync(process.execPath, [cli, 'learn', projectPath], { // NOSONAR jssecurity:S8705
+    encoding: 'utf8',
+    timeout: LEARN_TIMEOUT_MS,
+  });
+
+  return { exitCode: 0 };
+}
+
+module.exports = { run };
+
+if (require.main === module) {
+  runStandalone(run);
+}

--- a/scripts/hooks/session-memory-miner.js
+++ b/scripts/hooks/session-memory-miner.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Guardian Session Memory Miner (SessionEnd, PreCompact)
+ *
+ * Extracts decisions, failures, preferences, and next steps from the
+ * session transcript via the guardian CLI and merges them into the
+ * project state file sections, so the semantic layer of memory no
+ * longer depends on the AI calling update_state voluntarily.
+ *
+ * Requires a provider API key; without one the CLI reports skip and
+ * nothing changes (the mechanical snapshot from egc-memory-save still
+ * runs). Set EGC_MEMORY_MINER=0 to disable.
+ *
+ * Never blocks: on any failure the hook passes through and exits 0.
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { applyMinedMemory } = require('../lib/state-snapshot');
+const { parseInput, runStandalone } = require('../lib/hook-io');
+
+const MINE_TIMEOUT_MS = 15000;
+
+function run(inputOrRaw) {
+  if (/^(0|false|no)$/i.test(String(process.env.EGC_MEMORY_MINER || ''))) return { exitCode: 0 };
+
+  const input = parseInput(inputOrRaw);
+  const transcriptPath = input?.transcript_path;
+  if (!transcriptPath || typeof transcriptPath !== 'string') return { exitCode: 0 };
+
+  const cli = resolveGuardianCli();
+  if (!cli) return { exitCode: 0 };
+
+  const result = spawnSync(process.execPath, [cli, 'mine', transcriptPath], { // NOSONAR jssecurity:S8705
+    encoding: 'utf8',
+    timeout: MINE_TIMEOUT_MS,
+  });
+  if (result.error || result.status !== 0 || !result.stdout) return { exitCode: 0 };
+
+  let mined;
+  try {
+    mined = JSON.parse(result.stdout);
+  } catch {
+    return { exitCode: 0 };
+  }
+  if (!mined || mined.skip) return { exitCode: 0 };
+
+  try {
+    const projectPath = input?.cwd || process.env.PWD || process.cwd();
+    applyMinedMemory(projectPath, mined);
+  } catch { /* state write failure must never block session lifecycle */ }
+
+  return { exitCode: 0 };
+}
+
+module.exports = { run };
+
+if (require.main === module) {
+  runStandalone(run);
+}

--- a/scripts/lib/hook-io.js
+++ b/scripts/lib/hook-io.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// Shared stdin/JSON plumbing for guardian hooks. Every hook receives the
+// harness payload as JSON on stdin, exposes run(inputOrRaw) for in-process
+// execution via run-with-flags, and needs identical standalone behavior.
+
+const MAX_STDIN = 1024 * 1024;
+
+function parseInput(inputOrRaw) {
+  if (typeof inputOrRaw === 'string') {
+    try {
+      return inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {};
+    } catch {
+      return {};
+    }
+  }
+  return inputOrRaw && typeof inputOrRaw === 'object' ? inputOrRaw : {};
+}
+
+function runStandalone(run, { echoInput = true, blockExitCode = 2 } = {}) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    const result = run(raw) || {};
+    if (result.stderr) process.stderr.write(result.stderr + '\n');
+    if (result.exitCode === blockExitCode) process.exit(blockExitCode);
+    if (typeof result.stdout === 'string') {
+      if (result.stdout) process.stdout.write(result.stdout + '\n');
+    } else if (echoInput) {
+      process.stdout.write(raw);
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { MAX_STDIN, parseInput, runStandalone };

--- a/scripts/lib/state-snapshot.js
+++ b/scripts/lib/state-snapshot.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { getStateDir, detectBranch, resolveStateRead, resolveStateWrite } = require('./branch-state');
+
+const MARKER_RE = /^- \[session-snapshot [^\]]+\]\n?/gm;
+
+const SECTIONS = ['## Context', '## Active Decisions', '## Do Not Repeat', '## Preferences', '## Next Session'];
+
+function updateTimestamp(content, ts) {
+  if (/^updated: /m.test(content)) {
+    return content.replace(/^updated: .*/m, `updated: ${ts}`);
+  }
+  return content.replace(/^(project: [^\n]*\n(?:branch: [^\n]*\n)?)/m, `$1updated: ${ts}\n`);
+}
+
+function injectSessionMarker(content, ts) {
+  const marker = `- [session-snapshot ${ts}]`;
+  const withoutStale = content.replace(MARKER_RE, '');
+  if (/^## Next Session$/m.test(withoutStale)) {
+    return withoutStale.replace(/^(## Next Session\n)/m, `$1${marker}\n`);
+  }
+  return withoutStale + `\n## Next Session\n${marker}\n`;
+}
+
+function buildSkeleton(projectPath, branch, ts) {
+  return [
+    '# Project State',
+    `project: ${projectPath}`,
+    ...(branch ? [`branch: ${branch}`] : []),
+    `updated: ${ts}`,
+    '',
+    ...SECTIONS.flatMap(s => [s, '']),
+  ].join('\n');
+}
+
+function loadState(projectPath) {
+  const branch = detectBranch(projectPath);
+  const stateDir = getStateDir(process.env.HOME);
+  const resolved = resolveStateRead(stateDir, projectPath, branch);
+  const filePath = resolveStateWrite(stateDir, projectPath, branch);
+  const ts = new Date().toISOString();
+
+  const content = (resolved.source !== 'none' && fs.existsSync(resolved.filePath))
+    ? fs.readFileSync(resolved.filePath, 'utf-8')
+    : buildSkeleton(projectPath, branch, ts);
+
+  return { content, filePath, ts };
+}
+
+function saveState(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+  try { fs.chmodSync(filePath, 0o600); } catch { /* chmod not supported on Windows */ }
+}
+
+function writeSnapshotToDisk(projectPath = process.env.PWD || process.cwd()) {
+  const state = loadState(projectPath);
+  let content = updateTimestamp(state.content, state.ts);
+  content = injectSessionMarker(content, state.ts);
+  saveState(state.filePath, content);
+  return state.filePath;
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractSection(content, heading) {
+  const re = new RegExp(`^${escapeRegExp(heading)}\\n([\\s\\S]*?)(?=^## |\\Z)`, 'm');
+  const match = content.match(re);
+  return match ? match[1].trim() : '';
+}
+
+function appendToSection(content, heading, lines) {
+  const existing = new Set(content.split('\n').map(l => l.trim()));
+  const fresh = lines.map(l => l.trim()).filter(l => l && !existing.has(l));
+  if (fresh.length === 0) return { content, added: 0 };
+
+  const block = fresh.join('\n') + '\n';
+  const escaped = escapeRegExp(heading);
+  if (new RegExp(`^${escaped}$`, 'm').test(content)) {
+    const updated = content.replace(
+      new RegExp(`^(${escaped}\\n)`, 'm'),
+      `$1${block}`,
+    );
+    return { content: updated, added: fresh.length };
+  }
+  return { content: `${content}\n${heading}\n${block}`, added: fresh.length };
+}
+
+const MINED_SECTION_MAP = [
+  ['decisions', '## Active Decisions'],
+  ['avoid', '## Do Not Repeat'],
+  ['preferences', '## Preferences'],
+  ['next', '## Next Session'],
+];
+
+function minedToLines(items) {
+  const lines = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    if (typeof item === 'string' && item.trim()) {
+      lines.push(`- ${item.trim()}`);
+    } else if (item && typeof item === 'object' && typeof item.what === 'string' && item.what.trim()) {
+      lines.push(item.why ? `- ${item.what.trim()} -- ${String(item.why).trim()}` : `- ${item.what.trim()}`);
+    }
+  }
+  return lines;
+}
+
+function applyMinedMemory(projectPath, mined) {
+  const state = loadState(projectPath);
+  let content = updateTimestamp(state.content, state.ts);
+  let added = 0;
+
+  for (const [key, heading] of MINED_SECTION_MAP) {
+    const lines = minedToLines(mined?.[key]);
+    if (lines.length === 0) continue;
+    const result = appendToSection(content, heading, lines);
+    content = result.content;
+    added += result.added;
+  }
+
+  if (added > 0) saveState(state.filePath, content);
+  return { filePath: state.filePath, added };
+}
+
+module.exports = {
+  SECTIONS,
+  applyMinedMemory,
+  buildSkeleton,
+  loadState,
+  saveState,
+  writeSnapshotToDisk,
+  extractSection,
+  appendToSection,
+  updateTimestamp,
+  injectSessionMarker,
+};

--- a/tests/fixtures/fake-guardian-cli.js
+++ b/tests/fixtures/fake-guardian-cli.js
@@ -43,6 +43,23 @@ if (mode === 'command') {
   }
 } else if (mode === 'route') {
   process.stdout.write(JSON.stringify({ agents: ['code-reviewer'], skills: ['security-review'], provider: 'keyword' }));
+} else if (mode === 'intent') {
+  const intent = process.env.FAKE_GUARDIAN_INTENT || 'none';
+  process.stdout.write(JSON.stringify({ intent, source: intent === 'none' ? 'none' : 'llm' }));
+} else if (mode === 'mine') {
+  if (process.env.FAKE_GUARDIAN_MINE === 'skip') {
+    process.stdout.write(JSON.stringify({ skip: true, reason: 'no provider key' }));
+  } else {
+    process.stdout.write(JSON.stringify({
+      decisions: [{ what: 'Use fixture-driven tests', why: 'CI has no guardian build' }],
+      avoid: [{ what: 'Piping CI watchers to tail', why: 'masks exit codes' }],
+      preferences: ['Conventional commits'],
+      next: ['Ship the memory miner'],
+      provider: 'fixture',
+    }));
+  }
+} else if (mode === 'learn') {
+  process.stdout.write(JSON.stringify({ patterns_found: 0, skipped: true, reason: 'fixture' }));
 } else {
   process.stdout.write(JSON.stringify({ error: `unknown mode: ${mode}` }));
 }

--- a/tests/hooks/prompt-intuition.test.js
+++ b/tests/hooks/prompt-intuition.test.js
@@ -1,0 +1,163 @@
+/**
+ * Tests for scripts/hooks/prompt-intuition.js via run-with-flags.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function makeHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-intuition-'));
+}
+
+function stateFileIn(homeDir) {
+  const stateDir = path.join(homeDir, '.egc', 'state');
+  if (!fs.existsSync(stateDir)) return null;
+  const stack = [stateDir];
+  while (stack.length) {
+    const dir = stack.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name.endsWith('.md')) return full;
+    }
+  }
+  return null;
+}
+
+function runHook(input, env = {}) {
+  const rawInput = JSON.stringify(input);
+  const result = spawnSync('node', [runner, 'prompt:intuition', 'scripts/hooks/prompt-intuition.js', 'standard,strict'], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      EGC_GUARDIAN_CLI: fakeCli,
+      ...env
+    },
+    timeout: 20000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing prompt-intuition ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('stays silent when intent is none', () => {
+    const result = runHook({ prompt: 'implement the oauth login feature' }, { FAKE_GUARDIAN_INTENT: 'none' });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, '', `Expected silence, got: ${result.stdout}`);
+  })) passed++; else failed++;
+
+  if (test('session_end saves the state snapshot before the AI responds', () => {
+    const home = makeHome();
+    try {
+      const result = runHook(
+        { prompt: 'ok im heading out', cwd: home },
+        { FAKE_GUARDIAN_INTENT: 'session_end', FAKE_GUARDIAN_MINE: 'skip', HOME: home, PWD: home }
+      );
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('=== EGC Session ==='), `Expected session block, got: ${result.stdout}`);
+      assert.ok(result.stdout.includes('already saved'), `Expected saved confirmation, got: ${result.stdout}`);
+      const stateFile = stateFileIn(home);
+      assert.ok(stateFile, 'Expected a state file to be written');
+      assert.ok(fs.readFileSync(stateFile, 'utf8').includes('## Next Session'), 'Expected snapshot skeleton');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('session_end merges mined memory into the state file', () => {
+    const home = makeHome();
+    const transcript = path.join(home, 'transcript.jsonl');
+    fs.writeFileSync(transcript, '{"message":{"role":"user","content":"x"}}\n');
+    try {
+      const result = runHook(
+        { prompt: 'good night', cwd: home, transcript_path: transcript },
+        { FAKE_GUARDIAN_INTENT: 'session_end', HOME: home, PWD: home }
+      );
+      assert.strictEqual(result.code, 0);
+      const stateFile = stateFileIn(home);
+      assert.ok(stateFile, 'Expected a state file');
+      const content = fs.readFileSync(stateFile, 'utf8');
+      assert.ok(content.includes('Use fixture-driven tests'), `Expected mined decision, got: ${content}`);
+      assert.ok(content.includes('Ship the memory miner'), `Expected mined next step, got: ${content}`);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('remember records the user words verbatim into Active Decisions', () => {
+    const home = makeHome();
+    try {
+      const result = runHook(
+        { prompt: 'keep the API split into two endpoints, latency matters here', cwd: home },
+        { FAKE_GUARDIAN_INTENT: 'remember', HOME: home, PWD: home }
+      );
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('=== EGC Memory ==='), `Expected memory block, got: ${result.stdout}`);
+      const stateFile = stateFileIn(home);
+      assert.ok(stateFile, 'Expected a state file');
+      const content = fs.readFileSync(stateFile, 'utf8');
+      assert.ok(content.includes('keep the API split into two endpoints'), `Expected verbatim decision, got: ${content}`);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('session_resume injects next steps from existing state', () => {
+    const home = makeHome();
+    try {
+      runHook(
+        { prompt: 'remember: finish the miner PR first thing', cwd: home },
+        { FAKE_GUARDIAN_INTENT: 'remember', HOME: home, PWD: home }
+      );
+      const result = runHook(
+        { prompt: 'hey, picking this back up', cwd: home },
+        { FAKE_GUARDIAN_INTENT: 'session_resume', HOME: home, PWD: home }
+      );
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('=== EGC Resume ==='), `Expected resume block, got: ${result.stdout}`);
+      assert.ok(result.stdout.includes('finish the miner PR'), `Expected stored decision in resume, got: ${result.stdout}`);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('never leaks the raw input JSON into context', () => {
+    const result = runHook({ prompt: 'short greeting here' }, { FAKE_GUARDIAN_INTENT: 'none' });
+    assert.ok(!result.stdout.includes('"prompt"'), `Raw input leaked: ${result.stdout}`);
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/session-auto-learn.test.js
+++ b/tests/hooks/session-auto-learn.test.js
@@ -1,0 +1,81 @@
+/**
+ * Tests for scripts/hooks/session-auto-learn.js via run-with-flags.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runHook(env = {}) {
+  const rawInput = JSON.stringify({ cwd: '/tmp' });
+  const result = spawnSync('node', [runner, 'session:auto-learn', 'scripts/hooks/session-auto-learn.js', 'standard,strict'], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      EGC_GUARDIAN_CLI: fakeCli,
+      ...env
+    },
+    timeout: 20000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing session-auto-learn ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('runs the learn mode and passes through', () => {
+    const rawInput = JSON.stringify({ cwd: '/tmp' });
+    const result = runHook();
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough');
+  })) passed++; else failed++;
+
+  if (test('respects EGC_AUTO_LEARN=0', () => {
+    const result = runHook({ EGC_AUTO_LEARN: '0' });
+    assert.strictEqual(result.code, 0);
+  })) passed++; else failed++;
+
+  if (test('fails open when the guardian CLI is broken', () => {
+    const brokenCli = path.join(os.tmpdir(), `egc-broken-cli-${Date.now()}.js`);
+    fs.writeFileSync(brokenCli, 'process.exit(1);\n');
+    try {
+      const result = runHook({ EGC_GUARDIAN_CLI: brokenCli });
+      assert.strictEqual(result.code, 0, 'Expected fail-open on broken CLI');
+    } finally {
+      try { fs.rmSync(brokenCli, { force: true }); } catch { /* best-effort cleanup */ }
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/session-memory-miner.test.js
+++ b/tests/hooks/session-memory-miner.test.js
@@ -1,0 +1,149 @@
+/**
+ * Tests for scripts/hooks/session-memory-miner.js via run-with-flags.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function stateFileIn(homeDir) {
+  const stateDir = path.join(homeDir, '.egc', 'state');
+  if (!fs.existsSync(stateDir)) return null;
+  const stack = [stateDir];
+  while (stack.length) {
+    const dir = stack.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name.endsWith('.md')) return full;
+    }
+  }
+  return null;
+}
+
+function runHook(input, env = {}) {
+  const rawInput = JSON.stringify(input);
+  const result = spawnSync('node', [runner, 'session:memory-miner', 'scripts/hooks/session-memory-miner.js', 'standard,strict'], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      EGC_GUARDIAN_CLI: fakeCli,
+      ...env
+    },
+    timeout: 20000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing session-memory-miner ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('merges mined memory into all state sections', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-miner-'));
+    const transcript = path.join(home, 't.jsonl');
+    fs.writeFileSync(transcript, '{"message":{"role":"user","content":"x"}}\n');
+    try {
+      const result = runHook(
+        { transcript_path: transcript, cwd: home },
+        { HOME: home, PWD: home }
+      );
+      assert.strictEqual(result.code, 0);
+      const stateFile = stateFileIn(home);
+      assert.ok(stateFile, 'Expected a state file');
+      const content = fs.readFileSync(stateFile, 'utf8');
+      assert.ok(content.includes('Use fixture-driven tests -- CI has no guardian build'), 'Expected decision with why');
+      assert.ok(content.includes('Piping CI watchers to tail'), 'Expected avoid entry');
+      assert.ok(content.includes('Conventional commits'), 'Expected preference');
+      assert.ok(content.includes('Ship the memory miner'), 'Expected next step');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('is idempotent: rerunning adds no duplicate lines', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-miner-'));
+    const transcript = path.join(home, 't.jsonl');
+    fs.writeFileSync(transcript, '{"message":{"role":"user","content":"x"}}\n');
+    try {
+      runHook({ transcript_path: transcript, cwd: home }, { HOME: home, PWD: home });
+      runHook({ transcript_path: transcript, cwd: home }, { HOME: home, PWD: home });
+      const content = fs.readFileSync(stateFileIn(home), 'utf8');
+      const occurrences = content.split('Ship the memory miner').length - 1;
+      assert.strictEqual(occurrences, 1, `Expected single entry, found ${occurrences}`);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('does nothing when the miner reports skip', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-miner-'));
+    const transcript = path.join(home, 't.jsonl');
+    fs.writeFileSync(transcript, '{"message":{"role":"user","content":"x"}}\n');
+    try {
+      const result = runHook(
+        { transcript_path: transcript, cwd: home },
+        { HOME: home, PWD: home, FAKE_GUARDIAN_MINE: 'skip' }
+      );
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(stateFileIn(home), null, 'Expected no state file when miner skips');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('respects EGC_MEMORY_MINER=0', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-miner-'));
+    const transcript = path.join(home, 't.jsonl');
+    fs.writeFileSync(transcript, '{"message":{"role":"user","content":"x"}}\n');
+    try {
+      const result = runHook(
+        { transcript_path: transcript, cwd: home },
+        { HOME: home, PWD: home, EGC_MEMORY_MINER: '0' }
+      );
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(stateFileIn(home), null, 'Expected no state file when disabled');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('passes through input without a transcript path', () => {
+    const rawInput = JSON.stringify({ cwd: '/tmp' });
+    const result = runHook({ cwd: '/tmp' });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough');
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## What Changed

Completes the enforcement work from #566/#568: the memory layer no longer depends on the AI voluntarily calling the right tools, and intuition has no pre-programmed vocabulary.

- **`prompt-intuition`** (UserPromptSubmit): classifies short prompts semantically via whichever provider key is available, in any language, with deliberately no phrase lists. On session-end intent it saves the state snapshot and mines the transcript before the AI responds; on resume it injects next steps and active decisions; on remember it records the user's words verbatim into the state; on history queries it injects project memory. Without a provider key it honestly detects nothing and the lifecycle hooks carry the guarantees.
- **`session-memory-miner`** (SessionEnd, PreCompact): digests the transcript, extracts decisions/failures/preferences/next steps via the provider LLM, and merges them into the project state sections with line-level dedupe. `EGC_MEMORY_MINER=0` disables.
- **`session-auto-learn`** (SessionEnd): runs the existing auto_learn miner automatically. `EGC_AUTO_LEARN=0` disables.
- **`guardian-cli`** gains `intent`, `mine`, and `learn` modes over the same engine the MCP tools use; `llm-router` exposes a generic `completeJson` provider cascade shared by routing, classification, and mining.
- Snapshot logic extracted from `egc-memory-save` into `scripts/lib/state-snapshot.js`, shared by all memory hooks (existing 12 memory-save tests stay green).
- Fixes the SonarCloud quality gate on main: S8705 suppressed on the argv-array spawnSync sites, matching the existing run-with-flags pattern (no shell involved).

## Why This Change

The product principle: every promise is either true by code or stated exactly as it is. Session memory enrichment and intuition were the last instruction-dependent pieces.

## Testing Done

- [x] Automated tests pass locally (`node tests/run-all.js`) - 2501/2501, including 14 new hook tests
- [x] Hermetic: all new tests run against the fixture CLI, no guardian build required
- [x] Edge cases: no provider key, miner skip, idempotent re-mining, disabled via env, broken CLI fail-open, raw input never leaked into context

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation (hooks/README.md lifecycle inventory)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds semantic auto-intuition and automatic session memory mining so intent and memory updates happen by code, not voluntary tool calls. Snapshots and project memory are reliably saved and reused across sessions.

- **New Features**
  - `prompt-intuition` (UserPromptSubmit): classifies short prompts semantically (any language, no phrase lists) and acts on intent: session_end saves and mines before the model responds, resume injects next steps/decisions, remember records verbatim, history_query injects memory; no-op without a provider key; `EGC_INTUITION_LLM=0` disables.
  - `session-memory-miner` (SessionEnd, PreCompact): digests the JSONL transcript and merges decisions/avoid/preferences/next into the state with line-level dedupe; skips without a provider key; `EGC_MEMORY_MINER=0` disables.
  - `session-auto-learn` (SessionEnd): runs the `auto_learn` miner automatically so recurring failures become recommendations; `EGC_AUTO_LEARN=0` disables.
  - `guardian-cli`: adds `intent`, `mine`, and `learn` modes; `llm-router` exposes a generic `completeJson` cascade reused by routing, intent, and mining.

- **Refactors**
  - Snapshot logic moved from `egc-memory-save` to `scripts/lib/state-snapshot.js` and shared across hooks; common stdin/json plumbing in `scripts/lib/hook-io.js`.
  - SonarCloud: S8705 suppressed on `spawnSync` calls that use argv arrays (no shell), matching the existing run-with-flags pattern.

<sup>Written for commit 2a3b107d3347ff096faaf19fcf28d31cf8949f0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

