### PR TITLE
fix(security): deliver untrusted payload via stdin to guardian-cli

### DIFF
--- a/mcp/servers/egc-guardian/src/guardian-cli.ts
+++ b/mcp/servers/egc-guardian/src/guardian-cli.ts
@@ -65,9 +65,21 @@ const MODES: Record<string, (payload: string) => unknown | Promise<unknown>> = {
   'learn': learn,
 };
 
+// Payload arrives on stdin, never as a command-line argument. Untrusted
+// content (user prompts, commands, paths) must not flow into argv, where a
+// leading dash could be parsed as a flag by this or any wrapped process.
+// Only the fixed mode and literal flags travel in argv.
+function readStdin(): string {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
 async function main() {
   const mode = process.argv[2] ?? '';
-  const payload = process.argv[3] ?? '';
+  const payload = readStdin();
   const handler = MODES[mode];
   const result = handler ? await handler(payload) : { error: `unknown mode: ${mode}` };
   process.stdout.write(JSON.stringify(result));

--- a/scripts/hooks/pre-bash-guardian-validate.js
+++ b/scripts/hooks/pre-bash-guardian-validate.js
@@ -21,8 +21,7 @@
 
 'use strict';
 
-const { spawnSync } = require('child_process');
-const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { resolveGuardianCli, callGuardian } = require('../lib/guardian-bin');
 
 const MAX_STDIN = 1024 * 1024;
 const VALIDATE_TIMEOUT_MS = 4000;
@@ -76,22 +75,7 @@ function run(inputOrRaw) {
     return { exitCode: 0 };
   }
 
-  const result = spawnSync(
-    process.execPath,
-    [cli, 'command-batch', JSON.stringify(segments)],
-    { encoding: 'utf8', timeout: VALIDATE_TIMEOUT_MS },
-  );
-
-  if (result.error || result.status !== 0 || !result.stdout) {
-    return { exitCode: 0 };
-  }
-
-  let verdicts;
-  try {
-    verdicts = JSON.parse(result.stdout);
-  } catch {
-    return { exitCode: 0 };
-  }
+  const verdicts = callGuardian(cli, ['command-batch'], JSON.stringify(segments), VALIDATE_TIMEOUT_MS);
   if (!Array.isArray(verdicts)) return { exitCode: 0 };
 
   for (let i = 0; i < verdicts.length; i++) {

--- a/scripts/hooks/pre-write-guardian-validate.js
+++ b/scripts/hooks/pre-write-guardian-validate.js
@@ -16,8 +16,7 @@
 
 'use strict';
 
-const { spawnSync } = require('child_process');
-const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { resolveGuardianCli, callGuardian } = require('../lib/guardian-bin');
 
 const MAX_STDIN = 1024 * 1024;
 const VALIDATE_TIMEOUT_MS = 4000;
@@ -43,21 +42,8 @@ function run(inputOrRaw) {
     return { exitCode: 0 };
   }
 
-  const result = spawnSync(process.execPath, [cli, 'write', filePath], {
-    encoding: 'utf8',
-    timeout: VALIDATE_TIMEOUT_MS,
-  });
-
-  if (result.error || result.status !== 0 || !result.stdout) {
-    return { exitCode: 0 };
-  }
-
-  let verdict;
-  try {
-    verdict = JSON.parse(result.stdout);
-  } catch {
-    return { exitCode: 0 };
-  }
+  const verdict = callGuardian(cli, ['write'], filePath, VALIDATE_TIMEOUT_MS);
+  if (!verdict) return { exitCode: 0 };
 
   if (verdict.allowed === false) {
     return {

--- a/scripts/hooks/prompt-intuition.js
+++ b/scripts/hooks/prompt-intuition.js
@@ -24,8 +24,7 @@
 
 'use strict';
 
-const { spawnSync } = require('node:child_process');
-const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { resolveGuardianCli, callGuardian } = require('../lib/guardian-bin');
 const { parseInput, runStandalone } = require('../lib/hook-io');
 const {
   loadState, saveState, appendToSection, extractSection,
@@ -37,16 +36,6 @@ const MINE_TIMEOUT_MS = 15000;
 const MAX_REMEMBER_CHARS = 400;
 const MAX_INJECT_CHARS = 1600;
 
-function cliJson(cli, args, timeout) {
-  const result = spawnSync(process.execPath, [cli, ...args], { encoding: 'utf8', timeout }); // NOSONAR jssecurity:S8705
-  if (result.error || result.status !== 0 || !result.stdout) return null;
-  try {
-    return JSON.parse(result.stdout);
-  } catch {
-    return null;
-  }
-}
-
 function clip(text, max) {
   return text.length > max ? `${text.slice(0, max)}...` : text;
 }
@@ -56,7 +45,7 @@ function handleSessionEnd(cli, projectPath, transcriptPath) {
 
   let minedNote = '';
   if (transcriptPath) {
-    const mined = cliJson(cli, ['mine', transcriptPath], MINE_TIMEOUT_MS);
+    const mined = callGuardian(cli, ['mine'], transcriptPath, MINE_TIMEOUT_MS);
     if (mined && !mined.skip) {
       const result = applyMinedMemory(projectPath, mined);
       if (result.added > 0) minedNote = ` ${result.added} decisions and lessons from this session were extracted and merged.`;
@@ -117,7 +106,7 @@ function run(inputOrRaw) {
   const cli = resolveGuardianCli();
   if (!cli) return { exitCode: 0, stdout: '' };
 
-  const detection = cliJson(cli, ['intent', prompt], INTENT_TIMEOUT_MS);
+  const detection = callGuardian(cli, ['intent'], prompt, INTENT_TIMEOUT_MS);
   const intent = detection?.intent;
   if (!intent || intent === 'none') return { exitCode: 0, stdout: '' };
 

--- a/scripts/hooks/prompt-router.js
+++ b/scripts/hooks/prompt-router.js
@@ -15,10 +15,9 @@
 
 'use strict';
 
-const { spawnSync } = require('child_process');
-const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { resolveGuardianCli, callGuardian } = require('../lib/guardian-bin');
+const { runStandalone } = require('../lib/hook-io');
 
-const MAX_STDIN = 1024 * 1024;
 const KEYWORD_TIMEOUT_MS = 3000;
 const LLM_TIMEOUT_MS = 8000;
 const MIN_PROMPT_LENGTH = 12;
@@ -36,25 +35,13 @@ function parseInput(inputOrRaw) {
 
 function routeViaCli(cli, prompt) {
   const useLlm = /^(1|true|yes)$/i.test(String(process.env.EGC_ROUTING_LLM || ''));
-  const args = [cli, 'route', prompt];
-  if (useLlm) args.push('--llm');
-
-  const result = spawnSync(process.execPath, args, { // NOSONAR jssecurity:S8705
-    encoding: 'utf8',
-    timeout: useLlm ? LLM_TIMEOUT_MS : KEYWORD_TIMEOUT_MS,
-  });
-
-  if (result.error || result.status !== 0 || !result.stdout) return null;
-
-  try {
-    const routing = JSON.parse(result.stdout);
-    return {
-      agents: Array.isArray(routing.agents) ? routing.agents : [],
-      skills: Array.isArray(routing.skills) ? routing.skills : [],
-    };
-  } catch {
-    return null;
-  }
+  const args = useLlm ? ['route', '--llm'] : ['route'];
+  const routing = callGuardian(cli, args, prompt, useLlm ? LLM_TIMEOUT_MS : KEYWORD_TIMEOUT_MS);
+  if (!routing) return null;
+  return {
+    agents: Array.isArray(routing.agents) ? routing.agents : [],
+    skills: Array.isArray(routing.skills) ? routing.skills : [],
+  };
 }
 
 function run(inputOrRaw) {
@@ -83,16 +70,5 @@ function run(inputOrRaw) {
 module.exports = { run };
 
 if (require.main === module) {
-  let raw = '';
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', chunk => {
-    if (raw.length < MAX_STDIN) {
-      raw += chunk.substring(0, MAX_STDIN - raw.length);
-    }
-  });
-  process.stdin.on('end', () => {
-    const result = run(raw);
-    if (result.stdout) process.stdout.write(result.stdout + '\n');
-    process.exit(0);
-  });
+  runStandalone(run);
 }

--- a/scripts/hooks/session-auto-learn.js
+++ b/scripts/hooks/session-auto-learn.js
@@ -15,8 +15,7 @@
 
 'use strict';
 
-const { spawnSync } = require('node:child_process');
-const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { resolveGuardianCli, callGuardian } = require('../lib/guardian-bin');
 const { runStandalone } = require('../lib/hook-io');
 
 const LEARN_TIMEOUT_MS = 10000;
@@ -28,10 +27,7 @@ function run(_inputOrRaw) {
   if (!cli) return { exitCode: 0 };
 
   const projectPath = process.env.PWD || process.cwd();
-  spawnSync(process.execPath, [cli, 'learn', projectPath], { // NOSONAR jssecurity:S8705
-    encoding: 'utf8',
-    timeout: LEARN_TIMEOUT_MS,
-  });
+  callGuardian(cli, ['learn'], projectPath, LEARN_TIMEOUT_MS);
 
   return { exitCode: 0 };
 }

--- a/scripts/hooks/session-memory-miner.js
+++ b/scripts/hooks/session-memory-miner.js
@@ -16,8 +16,7 @@
 
 'use strict';
 
-const { spawnSync } = require('node:child_process');
-const { resolveGuardianCli } = require('../lib/guardian-bin');
+const { resolveGuardianCli, callGuardian } = require('../lib/guardian-bin');
 const { applyMinedMemory } = require('../lib/state-snapshot');
 const { parseInput, runStandalone } = require('../lib/hook-io');
 
@@ -33,18 +32,7 @@ function run(inputOrRaw) {
   const cli = resolveGuardianCli();
   if (!cli) return { exitCode: 0 };
 
-  const result = spawnSync(process.execPath, [cli, 'mine', transcriptPath], { // NOSONAR jssecurity:S8705
-    encoding: 'utf8',
-    timeout: MINE_TIMEOUT_MS,
-  });
-  if (result.error || result.status !== 0 || !result.stdout) return { exitCode: 0 };
-
-  let mined;
-  try {
-    mined = JSON.parse(result.stdout);
-  } catch {
-    return { exitCode: 0 };
-  }
+  const mined = callGuardian(cli, ['mine'], transcriptPath, MINE_TIMEOUT_MS);
   if (!mined || mined.skip) return { exitCode: 0 };
 
   try {

--- a/scripts/lib/guardian-bin.js
+++ b/scripts/lib/guardian-bin.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
 
 // Locates the compiled guardian CLI so hooks can enforce validation without
 // the MCP server running. Resolution order: explicit env override, the
@@ -51,4 +52,23 @@ function resolveGuardianCli() {
   return fromEnv() || fromPackageLayout() || fromMcpConfigs();
 }
 
-module.exports = { resolveGuardianCli };
+// Invokes the guardian CLI with the payload on stdin, never in argv.
+// Untrusted content (prompts, commands, paths) must not travel as command
+// arguments where a leading dash could be parsed as a flag. argv carries
+// only the fixed mode and literal flags. Returns parsed JSON, or null on
+// any failure so callers fail open.
+function callGuardian(cli, args, input, timeoutMs) {
+  const result = spawnSync(process.execPath, [cli, ...args], {
+    input: input == null ? '' : String(input),
+    encoding: 'utf8',
+    timeout: timeoutMs,
+  });
+  if (result.error || result.status !== 0 || !result.stdout) return null;
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { resolveGuardianCli, callGuardian };

--- a/tests/fixtures/fake-guardian-cli.js
+++ b/tests/fixtures/fake-guardian-cli.js
@@ -2,13 +2,15 @@
 /**
  * Deterministic stand-in for the compiled guardian CLI, used by hook tests
  * so they do not depend on the egc-guardian build existing in the test
- * environment. Mirrors the CLI protocol (mode + payload argv, JSON verdict
- * on stdout, exit 0); the verdict rules cover only what the hook tests
- * assert. Validator correctness itself is covered by the guardian tests.
+ * environment. Mirrors the CLI protocol (mode in argv, payload via stdin,
+ * JSON verdict on stdout, exit 0); the verdict rules cover only what the
+ * hook tests assert. Validator correctness itself is covered by the
+ * guardian tests.
  */
 
 'use strict';
 
+const fs = require('node:fs');
 const PROTECTED_RE = /\.ssh|\.aws|id_rsa|\.pem$|\.key$/;
 
 function verdictForCommand(segment) {
@@ -26,7 +28,8 @@ function verdictForCommand(segment) {
 }
 
 const mode = process.argv[2];
-const payload = process.argv[3] || '';
+let payload;
+try { payload = fs.readFileSync(0, 'utf8'); } catch { payload = ''; }
 
 if (mode === 'command') {
   process.stdout.write(JSON.stringify(verdictForCommand(payload)));


### PR DESCRIPTION
## Summary

- Fixes security alert #265 (High -- jssecurity:S8705): user prompts, commands and file paths were passed as command-line arguments to `spawnSync`, where a leading dash could be parsed as a flag
- All untrusted content now travels via stdin; only fixed mode strings and literal flags remain in argv
- Removes all `// NOSONAR jssecurity:S8705` suppressions since the real fix eliminates the vulnerability

## Files changed

- `guardian-cli.ts`: reads payload with `fs.readFileSync(0)` instead of `process.argv[3]`
- `scripts/lib/guardian-bin.js`: adds `callGuardian()` that passes input via `spawnSync.input` (stdin)
- All hook callers migrated to `callGuardian()`: `prompt-router`, `prompt-intuition`, `pre-bash-guardian-validate`, `pre-write-guardian-validate`, `session-memory-miner`, `session-auto-learn`
- `tests/fixtures/fake-guardian-cli.js`: mirrors the new stdin-based protocol

## Test plan

- [ ] All 2501 tests pass locally
- [ ] SonarCloud quality gate passes
- [ ] Security alert #265 resolved in code scanning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all untrusted input to the guardian CLI over stdin to prevent argument injection (jssecurity:S8705), resolving security alert #265. Only the fixed mode and literal flags remain in argv.

- **Bug Fixes**
  - `guardian-cli` now reads payload from stdin, not argv.
  - Added `callGuardian()` in `scripts/lib/guardian-bin.js` to invoke the CLI with stdin and parse JSON.
  - Migrated all hooks to `callGuardian()` (prompt-router, prompt-intuition, pre-bash-guardian-validate, pre-write-guardian-validate, session-memory-miner, session-auto-learn).
  - Updated the test fixture to the stdin protocol and removed `// NOSONAR jssecurity:S8705` suppressions.

- **Migration**
  - If you call the CLI directly, send the payload via stdin; keep only the mode and literal flags in argv.

<sup>Written for commit 0ff1a94739a6fdad711e947a311864bfcb818bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Guardian-related checks and prompts by making request handling more consistent.
  * Reduced cases where validation or routing could silently fail, while preserving existing fail-open behavior where appropriate.

* **New Features**
  * Guardian-driven prompt routing and session guidance now work more smoothly across the app.
  * Session memory learning and mining are now handled through a shared execution path for better consistency.

* **Tests**
  * Updated test support to match the new request format used by Guardian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->