### PR TITLE
feat(dashboard): export session data to CSV and JSON (#592)

### DIFF
--- a/dashboard/public/export.js
+++ b/dashboard/public/export.js
@@ -1,0 +1,33 @@
+'use strict';
+
+function escapeCSVCell(val) {
+  if (val === null || val === undefined) return '';
+  const str = String(val);
+  const needsQuotes = str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r');
+  return needsQuotes ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+function sessionsToCSV(sessions) {
+  const keys = ['timestamp', 'timestamp_iso', 'ide', 'model', 'input_tokens', 'output_tokens', 'total_tokens', 'cost', 'duration_s'];
+  const header = keys.join(',');
+  const rows = sessions.map(s =>
+    keys.map(k => {
+      if (k === 'timestamp_iso') return escapeCSVCell(s.timestamp ? new Date(s.timestamp).toISOString() : '');
+      if (k === 'duration_s') return escapeCSVCell(s.duration_s !== undefined ? s.duration_s : '');
+      return escapeCSVCell(s[k]);
+    }).join(',')
+  );
+  return [header, ...rows].join('\r\n');
+}
+
+function sessionsToJSON(sessions) {
+  return JSON.stringify(sessions, null, 2);
+}
+
+function exportFilename(format, date = new Date()) {
+  return `egc-sessions-${date.toISOString().split('T')[0]}.${format}`;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { escapeCSVCell, sessionsToCSV, sessionsToJSON, exportFilename };
+}

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -350,6 +350,8 @@ body.minimized footer{display:none!important;}
 .cost-sess-time{font-size:9px;color:var(--muted);font-variant-numeric:tabular-nums;min-width:52px;text-align:right;}
 .cost-empty{padding:14px 0;text-align:center;color:var(--muted);font-size:11px;}
 .cost-section-lbl{font-size:9px;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--muted);margin-top:4px;}
+.export-row{display:flex;align-items:center;justify-content:space-between;gap:8px;}
+.export-btns{display:flex;gap:6px;flex-shrink:0;}
 /* Time range selector */
 .cost-range-wrap{display:flex;gap:4px;margin-bottom:8px;}
 .cost-range-btn{font-size:9px;font-weight:700;letter-spacing:1px;text-transform:uppercase;
@@ -548,7 +550,13 @@ body.minimized footer{display:none!important;}
   <div class="cost-bars" id="costBars">
     <div class="cost-empty">No session data yet.</div>
   </div>
-  <div class="cost-section-lbl">recent sessions</div>
+  <div class="cost-section-lbl export-row">
+    <span>recent sessions</span>
+    <span class="export-btns">
+      <button class="btn-sm" id="exportCsvBtn" onclick="exportSessionsAs('csv')">Export CSV</button>
+      <button class="btn-sm" id="exportJsonBtn" onclick="exportSessionsAs('json')">Export JSON</button>
+    </span>
+  </div>
   <div class="cost-sessions" id="costSessions">
     <div class="cost-empty">Waiting for sessions…</div>
   </div>
@@ -1379,6 +1387,45 @@ if('serviceWorker' in navigator){
     },200);
   });
 })();
+</script>
+<script src="/export.js"></script>
+<script>
+async function exportSessionsAs(format) {
+  const btnId = format === 'csv' ? 'exportCsvBtn' : 'exportJsonBtn';
+  const btn = document.getElementById(btnId);
+  const original = btn.textContent;
+
+  try {
+    const res = await fetch('/session-history');
+    if (!res.ok) throw new Error(`Server returned ${res.status}`);
+    const sessions = await res.json();
+
+    if (!sessions.length) {
+      btn.textContent = 'No data';
+      setTimeout(() => { btn.textContent = original; }, 1500);
+      return;
+    }
+
+    const content = format === 'csv' ? sessionsToCSV(sessions) : sessionsToJSON(sessions);
+    const mime = format === 'csv' ? 'text/csv' : 'application/json';
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = exportFilename(format);
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    btn.textContent = 'Exported!';
+    setTimeout(() => { btn.textContent = original; }, 1500);
+  } catch (err) {
+    console.error('Export failed:', err);
+    btn.textContent = 'Error';
+    setTimeout(() => { btn.textContent = original; }, 1500);
+  }
+}
 </script>
 </body>
 </html>

--- a/tests/dashboard-export.test.js
+++ b/tests/dashboard-export.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { escapeCSVCell, sessionsToCSV, sessionsToJSON, exportFilename } = require('../dashboard/public/export.js');
+
+test('escapeCSVCell returns empty string for null and undefined', () => {
+  assert.equal(escapeCSVCell(null), '');
+  assert.equal(escapeCSVCell(undefined), '');
+});
+
+test('escapeCSVCell wraps value with comma in double quotes', () => {
+  assert.equal(escapeCSVCell('claude-3,5-sonnet'), '"claude-3,5-sonnet"');
+});
+
+test('escapeCSVCell doubles internal double quotes', () => {
+  assert.equal(escapeCSVCell('say "hi"'), '"say ""hi"""');
+});
+
+test('escapeCSVCell returns plain string when no special characters', () => {
+  assert.equal(escapeCSVCell('claude'), 'claude');
+  assert.equal(escapeCSVCell(42), '42');
+});
+
+test('sessionsToCSV generates correct header and row', () => {
+  const sessions = [{
+    timestamp: 1751500000000,
+    ide: 'claude',
+    model: 'claude-sonnet-4-6',
+    input_tokens: 1000,
+    output_tokens: 200,
+    total_tokens: 1200,
+    cost: 0.0042,
+    duration_s: 30
+  }];
+  const csv = sessionsToCSV(sessions);
+  const [header, row] = csv.split('\r\n');
+  assert.equal(header, 'timestamp,timestamp_iso,ide,model,input_tokens,output_tokens,total_tokens,cost,duration_s');
+  assert.ok(row.includes('claude'));
+  assert.ok(row.includes('1200'));
+  assert.ok(row.includes('0.0042'));
+});
+
+test('sessionsToCSV produces empty row fields when session values are missing', () => {
+  const csv = sessionsToCSV([{}]);
+  const row = csv.split('\r\n')[1];
+  assert.equal(row, ',,,,,,,,');
+});
+
+test('sessionsToJSON produces valid parseable JSON', () => {
+  const sessions = [{ ide: 'cursor', cost: 0.01 }];
+  const result = sessionsToJSON(sessions);
+  assert.deepEqual(JSON.parse(result), sessions);
+});
+
+test('exportFilename formats date-stamped name correctly', () => {
+  const date = new Date('2026-07-02T10:00:00Z');
+  assert.equal(exportFilename('csv', date), 'egc-sessions-2026-07-02.csv');
+  assert.equal(exportFilename('json', date), 'egc-sessions-2026-07-02.json');
+});


### PR DESCRIPTION
Closes #592

## What Changed

Adds one-click export of session history from the Cost Comparison panel.

- `dashboard/public/export.js`: RFC 4180-compliant CSV serializer, JSON formatter, and date-stamped filename generator
- `dashboard/public/index.html`: **Export CSV** and **Export JSON** buttons wired to the live `/session-history` endpoint; button label gives feedback on success, empty state, and error
- `tests/dashboard-export.test.js`: 8 unit tests covering escaping edge cases, CSV/JSON output, missing fields, and filename formatting

## Why This Change

Session data was only accessible by hitting `/session-history` directly. This adds a one-click export path from the dashboard UI.

## Testing Done

- [x] `node --test tests/dashboard-export.test.js` — 8/8 pass
- [x] Export buttons fetch real data from `/session-history` and trigger a browser download
- [x] Empty state and fetch error are surfaced on the button label

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or credentials in code
- [x] No sanitizeFilename regex complexity (removed — not needed for this feature)
- [x] Input comes from own server endpoint, not user-supplied strings

Co-authored-by: Kunal jaiswal <140198382+Kunall7890@users.noreply.github.com>