### PR TITLE
feat(security): restrict ~/.egc directory permissions to 0700

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -76,13 +76,20 @@ function hideEgcRootOnWindows(): void {
   }
 }
 
+function ensurePrivateDir(dirPath: string): void {
+  if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true });
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(dirPath, 0o700); } catch { /* best-effort */ }
+  }
+}
+
 class PersistentLogger {
   private logPath: string;
   private maxSizeBytes = 5 * 1024 * 1024; // 5MB
 
   constructor(serviceName: string) {
     const logDir = path.join(os.homedir(), '.egc', 'logs');
-    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+    ensurePrivateDir(logDir);
     hideEgcRootOnWindows();
     this.logPath = path.join(logDir, `${serviceName}.log`);
   }
@@ -344,7 +351,7 @@ async function runMigrations(db: Database, dbDir: string) {
 async function getDb(): Promise<Database> {
   if (dbInstance) return dbInstance;
   const dbDir = path.join(os.homedir(), '.egc', 'memory');
-  if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
+  ensurePrivateDir(dbDir);
   hideEgcRootOnWindows();
   
   const dbPath = path.join(dbDir, 'state.db');
@@ -363,7 +370,7 @@ const server = new Server({ name: "egc-memory-orchestrator", version: "3.0.0" },
 
 function getStateDir(): string {
   const dir = path.join(os.homedir(), '.egc', 'state');
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  ensurePrivateDir(dir);
   hideEgcRootOnWindows();
   return dir;
 }

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -77,7 +77,7 @@ function hideEgcRootOnWindows(): void {
 }
 
 function ensurePrivateDir(dirPath: string): void {
-  if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true });
+  if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
   if (process.platform !== 'win32') {
     try { fs.chmodSync(dirPath, 0o700); } catch { /* best-effort */ }
   }

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { ensurePrivateDir } = require('./utils');
 
 const DEFAULT_THRESHOLD = 40;
 const WORKING_WINDOW_DAYS = 7;
@@ -281,7 +282,7 @@ function consolidateState(content, options = {}) {
 
 function backupStateFile(homeDir, filePath, now = new Date()) {
   const dir = archiveDir(homeDir);
-  fs.mkdirSync(dir, { recursive: true });
+  ensurePrivateDir(dir);
   const stamp = now.toISOString().replace(/[:.]/g, '-');
   const base = path.basename(filePath, '.md');
   const backupPath = path.join(dir, `${base}.${stamp}.md`);

--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const readline = require('readline');
+const { ensurePrivateDir } = require('./utils');
 
 const TELEMETRY_FILE = path.join(
   process.env.HOME || process.env.USERPROFILE || os.homedir(),
@@ -45,9 +46,7 @@ function readConsent() {
  */
 function writeConsent(enabled) {
   const dir = path.dirname(TELEMETRY_FILE);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  ensurePrivateDir(dir);
   fs.writeFileSync(
     TELEMETRY_FILE,
     JSON.stringify({ enabled, version: SCHEMA_VERSION }, null, 2) + '\n',

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -176,14 +176,21 @@ function ensureDir(dirPath) {
 
 /**
  * Ensure a private directory exists with restricted permissions (owner only).
- * On POSIX systems this sets mode 0700; on Windows permissions are unchanged.
- * Safe to call on an already-existing directory -- permissions are always
- * enforced, not just at creation time.
+ * On POSIX systems this sets mode 0700 at creation time and re-enforces it on
+ * already-existing directories. On Windows permissions are unchanged.
  * @param {string} dirPath - Directory path to create
  * @returns {string} The directory path
  */
 function ensurePrivateDir(dirPath) {
-  ensureDir(dirPath);
+  try {
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+    }
+  } catch (err) {
+    if (err.code !== 'EEXIST') {
+      throw new Error(`Failed to create directory '${dirPath}': ${err.message}`, { cause: err });
+    }
+  }
   if (!isWindows) {
     try {
       fs.chmodSync(dirPath, 0o700);

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -175,6 +175,26 @@ function ensureDir(dirPath) {
 }
 
 /**
+ * Ensure a private directory exists with restricted permissions (owner only).
+ * On POSIX systems this sets mode 0700; on Windows permissions are unchanged.
+ * Safe to call on an already-existing directory -- permissions are always
+ * enforced, not just at creation time.
+ * @param {string} dirPath - Directory path to create
+ * @returns {string} The directory path
+ */
+function ensurePrivateDir(dirPath) {
+  ensureDir(dirPath);
+  if (!isWindows) {
+    try {
+      fs.chmodSync(dirPath, 0o700);
+    } catch {
+      // best-effort -- do not crash if chmod is not supported (e.g. tmpfs)
+    }
+  }
+  return dirPath;
+}
+
+/**
  * Get current date in YYYY-MM-DD format
  */
 function getDateString() {
@@ -716,6 +736,7 @@ module.exports = {
   getLearnedSkillsDir,
   getTempDir,
   ensureDir,
+  ensurePrivateDir,
 
   // Date/Time
   getDateString,


### PR DESCRIPTION
## Summary

Closes #576

All `~/.egc/*` subdirectories were being created with the default umask (typically 755 or 022), which allowed other users on the same machine to list their contents. This PR restricts them to mode **0700** (owner-only) on POSIX systems.

### Changes

- `scripts/lib/utils.js`: adds `ensurePrivateDir(dirPath)` -- wraps `ensureDir` and applies `chmod 700` on POSIX after creation. Exported alongside `ensureDir`.
- `scripts/lib/telemetry.js`: uses `ensurePrivateDir` instead of inline `mkdirSync` when creating `~/.egc/`.
- `scripts/lib/state-consolidate.js`: uses `ensurePrivateDir` for `~/.egc/state/archive/`.
- `mcp/servers/egc-memory/src/index.ts`: adds `ensurePrivateDir` helper; applies it to `~/.egc/logs`, `~/.egc/memory`, and `~/.egc/state` directories.

### Behaviour

- **POSIX (Linux/macOS)**: directories are created with `mkdirSync` then immediately `chmodSync(0o700)`. The chmod is applied even when the directory already exists, so existing installations are secured on next run.
- **Windows**: no change (`attrib +h` is still applied via `hideEgcRootOnWindows`).
- **chmod failure**: caught silently -- the process continues. This handles tmpfs/overlay mounts that don't support permission bits.

### Testing

Verified locally:

```js
const { ensurePrivateDir } = require('./scripts/lib/utils.js');
ensurePrivateDir('/tmp/test-egc-perms');
// fs.statSync('/tmp/test-egc-perms').mode & 0o777 === 0o700 ✓
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures `~/.egc` directories on POSIX by enforcing 0700 permissions so only the owner can read/list them. Permissions are set at creation time and re-applied for existing dirs; applied across telemetry, state backups, and the `egc-memory` server; Windows is unchanged.

- **New Features**
  - Added `ensurePrivateDir(dir)` in `scripts/lib/utils.js`; uses `mkdirSync(..., { mode: 0o700 })` and re-enforces with `chmodSync(0o700)` on POSIX.
  - Replaced direct `mkdir` with `ensurePrivateDir` for `~/.egc/logs`, `~/.egc/memory`, `~/.egc/state`, and `~/.egc/state/archive`.
  - Best-effort: ignore `chmod` errors on filesystems without POSIX perms; Windows continues using `hideEgcRootOnWindows`.

<sup>Written for commit bc3fa5ff44605bdcc0f99c9564fe4f26455a0931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved protection for newly created local app directories and files.
  * Added stronger default permissions for private data storage on supported systems.

* **Bug Fixes**
  * Updated directory creation behavior to consistently prepare storage locations before writing logs, state, backups, and consent data.
  * Reduced the chance of permission-related access issues when these files are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->