### PR TITLE
docs: add Copilot setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ---
 
-EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own - no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
+EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own - no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, VS Code with GitHub Copilot, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
 
 ---
 
@@ -78,6 +78,17 @@ npx @egchq/egc install
 ```
 
 [Full installation guide](docs/installation.md)
+
+### VS Code + GitHub Copilot
+
+Use the Copilot target when you want EGC skills available in VS Code through GitHub Copilot Chat:
+
+```bash
+npm install -g @egchq/egc
+egc install --target copilot
+```
+
+This requires the GitHub Copilot Chat extension. EGC installs skills to `~/.github/skills/`, where Copilot discovers them automatically, and the same memory state is shared with Claude Code, Cursor, Gemini CLI, Windsurf, and other EGC targets.
 
 ---
 
@@ -174,7 +185,7 @@ AI coding tools that integrate natively with EGC. Partners get logo placement ac
 
 <a href="https://www.pincushion.io/"><img src="https://www.pincushion.io/logo-icon.png" width="52" height="52" alt="Pincushion" title="Pincushion" /></a>
 
-#### Annual Sponsors · _Be the first annual sponsor._
+#### Annual Sponsors · *Be the first annual sponsor.*
 
 ---
 
@@ -182,7 +193,7 @@ AI coding tools that integrate natively with EGC. Partners get logo placement ac
 
 <a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="52" height="52" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
 
-#### Monthly sponsors · _be the first_
+#### Monthly sponsors · *be the first*
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,21 @@ That's it. The installer detects which AI tools you have installed and configure
 
 > **Note:** If you use a Node.js version manager (mise, nvm, asdf, fnm), install EGC under your **default** Node version -- the one active outside any project directory. Installing it under multiple Node versions causes version conflicts. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for details.
 
+### VS Code + GitHub Copilot
+
+If VS Code is your primary editor, install the [GitHub Copilot Chat extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) first. Inline autocomplete alone is not enough; Copilot needs the chat extension to discover and use EGC skills.
+
+Then install the Copilot target:
+
+```bash
+npm install -g @egchq/egc
+egc install --target copilot
+```
+
+The Copilot target installs EGC skills under `~/.github/skills/`, using one flat directory per skill. VS Code Copilot discovers that directory automatically.
+
+Memory is shared across EGC targets. Context saved while using Copilot is the same state used by Claude Code, Cursor, Gemini CLI, Windsurf, and the rest of the supported tools.
+
 ---
 
 ## Linux / macOS (from source)


### PR DESCRIPTION
Closes #577

Summary:
- Add VS Code with GitHub Copilot to the README's supported tool language.
- Add a README quick path for egc install --target copilot.
- Add a dedicated installation guide subsection covering Copilot Chat, ~/.github/skills/, and shared EGC memory across targets.
- Convert two existing README emphasis markers to the configured markdownlint style so the touched docs pass lint.

Validation:
- git diff --check
- npx --yes markdownlint-cli README.md docs/installation.md

Note:
- Full test suite not run because this is a docs-only change.
- Local EGC Guardian MCP tools requested by AGENTS.md were not available in this Codex thread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VS Code + GitHub Copilot setup path so users can enable EGC skills in Copilot and share memory across tools. Updates the README to list Copilot as supported and aligns emphasis style with markdownlint.

- **New Features**
  - README quick start for `egc install --target copilot`.
  - Installation guide subsection: requires Copilot Chat, installs skills to `~/.github/skills/`, notes shared memory across EGC targets.
  - Adds “VS Code with GitHub Copilot” to supported tools and updates emphasis markers to pass markdownlint.

<sup>Written for commit 8d1761bab8130eef81be2959136d42c2cc228f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

