### PR TITLE
fix(i18n): remove duplicate language selector entries in ko, hi, ru READMEs

### DIFF
--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**भाषा:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **हिन्दी** | [한국어](../ko/README.md) | [Русский](../ru/README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [日本語](../ja/README.md)
+**भाषा:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [Português (Brasil)](../pt/README.md) | **हिन्दी** | [한국어](../ko/README.md) | [Русский](../ru/README.md) | [日本語](../ja/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**언어:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [हिन्दी](../hi/README.md) | [Português (Brasil)](../pt/README.md) | **한국어** | [Русский](../ru/README.md) | [日本語](../ja/README.md) | [Русский](../ru/README.md) | [日本語](../ja/README.md)
+**언어:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [हिन्दी](../hi/README.md) | [Português (Brasil)](../pt/README.md) | **한국어** | [Русский](../ru/README.md) | [日本語](../ja/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">

--- a/translations/ru/README.md
+++ b/translations/ru/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Язык:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [हिन्दी](../hi/README.md) | [한국어](../ko/README.md) | [Português (Brasil)](../pt/README.md) | **Русский** | [日本語](../ja/README.md) | [日本語](../ja/README.md)
+**Язык:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | [हिन्दी](../hi/README.md) | [한국어](../ko/README.md) | [Português (Brasil)](../pt/README.md) | **Русский** | [日本語](../ja/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">


### PR DESCRIPTION
## Summary

PR #615 (sync bot) appended `[Русский]` and `[日本語]` without checking for existing entries, creating duplicates in three translation files:

- `translations/ko/README.md`: `[Русский]` and `[日本語]` duplicated
- `translations/hi/README.md`: `[Русский]` and `[日本語]` duplicated
- `translations/ru/README.md`: `[日本語]` duplicated

The centered language selector was unaffected. This is a minimal one-line fix per file.

## Test plan

- [ ] `translations/ko/README.md` line 2 has exactly one `[日本語]` entry
- [ ] `translations/hi/README.md` line 2 has exactly one `[日本語]` entry
- [ ] `translations/ru/README.md` line 2 has exactly one `[日本語]` entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated language selector links in the Korean, Hindi, and Russian READMEs so each language appears once. Removed extra [Русский] and [日本語] in `translations/ko/README.md` and `translations/hi/README.md`, and the extra [日本語] in `translations/ru/README.md`.

<sup>Written for commit 68c3b03a3bf851222304656c4fb9634f72be9d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

