### PR TITLE
fix: prevent libuv assertion failure on state store init crash

### DIFF
--- a/scripts/bootstrap-state-db.js
+++ b/scripts/bootstrap-state-db.js
@@ -30,7 +30,7 @@ if (require.main === module) {
     })
     .catch(err => {
       process.stderr.write(`[bootstrap-state-db] FAILED: ${err.message}\n`);
-      process.exit(1);
+      process.exitCode = 1;
     });
 }
 

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -118,8 +118,13 @@ class SqlJsDatabase {
   }
 
   close() {
-    this._persist();
-    this._db.close();
+    if (!this._db) return;
+    try {
+      this._persist();
+    } finally {
+      this._db.close();
+      this._db = null;
+    }
   }
 
   _persist() {

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -43,9 +43,15 @@ async function createStateStore(options = {}) {
   const dbPath = resolveStateStorePath(options);
 
   const db = await openDatabase(dbPath);
-  db.pragma('foreign_keys = ON');
-  const appliedMigrations = applyMigrations(db);
-  const queryApi = createQueryApi(db);
+  let queryApi, appliedMigrations;
+  try {
+    db.pragma('foreign_keys = ON');
+    appliedMigrations = applyMigrations(db);
+    queryApi = createQueryApi(db);
+  } catch (err) {
+    db.close();
+    throw err;
+  }
 
   return {
     dbPath,


### PR DESCRIPTION
Fixes a native Node.js crash (Assertion failed in uv_async.c) on Windows when the EGC state store fails to initialize. Ensures the database is correctly closed, preventing WASM memory leaks before terminating the process.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a native Node.js crash on Windows (libuv assertion in uv_async.c) when the state store initialization fails. Ensures the SQLite WASM DB is always closed and the process exits cleanly to avoid memory leaks.

- **Bug Fixes**
  - Wrap state store setup in try/catch; on error, close the DB before rethrowing.
  - Make DB adapter close() safe and idempotent; persist in try/finally and null out the handle.
  - Use process.exitCode = 1 in `bootstrap-state-db` so the event loop can drain before exiting.

<sup>Written for commit 5e9bafa45b45b3c46c5545c208a6930acd0dd49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state database startup and shutdown handling to clean up more reliably when errors occur.
  * The app now exits more gracefully on bootstrap failures while preserving the error message output.
  * Database closing is now more defensive, reducing the chance of lingering resources after a failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->