### PR TITLE
fix(replay): add explicit validation to reject unrecognized CLI flags

### DIFF
--- a/scripts/replay.js
+++ b/scripts/replay.js
@@ -23,9 +23,16 @@ function parseArgs(argv) {
   const args = argv.slice(2);
   const parsed = { sessionId: null, json: false, help: false };
   for (const arg of args) {
-    if (arg === '--help' || arg === '-h') parsed.help = true;
-    else if (arg === '--json') parsed.json = true;
-    else if (!arg.startsWith('--')) parsed.sessionId = arg;
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg.startsWith('--') || arg.startsWith('-')) {
+      console.error(`Error: Unrecognized option '${arg}'`);
+      showHelp();
+    } else {
+      parsed.sessionId = arg;
+    }
   }
   return parsed;
 }


### PR DESCRIPTION
#### Description
This PR addresses the SonarCloud code-quality warning regarding ambiguous or unvalidated input inside the replay script. 

Because the script uses a custom manual loop rather than the native Node module, I implemented explicit validation within `parseArgs` to ensure that any unrecognized options prefixed with `-` or `--` are actively caught, logging a clear error message and displaying the command instructions instead of being silently skipped or misparsed.

*Note: I noticed this security issue was just opened and went ahead and put together this straightforward validation fix to save you some time. Please let me know if you would like me to adjust anything!*

#### Changes
* Updated `parseArgs` function in `scripts/replay.js` to catch unexpected flags.
* Added standard error message logging and test verification.

#### Fixes
Closes #620

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit validation to the replay CLI to reject unrecognized flags and show help instead of silently ignoring them. Improves input safety and resolves the SonarCloud warning; closes #620.

<sup>Written for commit 81acd2ab7e55bd64fbbaab881f6b4bbe05ea74fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown command-line options are now rejected with a clear “Unrecognized option” message and help output, instead of being ignored.
* **Chores**
  * The replay script now exposes its main entry points for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->