### PR TITLE
feat(security): HMAC integrity check on state files (closes #580)

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
+import { loadOrCreateKey, writeHmac, verifyHmac } from './integrity';
 import { propagateStateToTools } from './propagate';
 import {
   createWorkingMemoryTable,
@@ -375,6 +376,7 @@ async function getDb(): Promise<Database> {
 }
 
 const server = new Server({ name: "egc-memory-orchestrator", version: "3.0.0" }, { capabilities: { tools: {} } });
+const _integrityKey: Buffer = loadOrCreateKey();
 
 function getStateDir(): string {
   const dir = path.join(os.homedir(), '.egc', 'state');
@@ -976,7 +978,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         const content = fs.readFileSync(resolved.filePath, 'utf-8');
-        log('INFO', 'Project state retrieved', { project: projPath, branch: branch || 'none', source: resolved.source });
+        const verify = verifyHmac(resolved.filePath, content, _integrityKey);
+        if (!verify.ok) {
+          log('WARN', '[EGC integrity] State file integrity check failed', { file: resolved.filePath, reason: (verify as { ok: false; reason: string }).reason });
+          log('INFO', 'Project state retrieved', { project: projPath, branch: branch || 'none', source: resolved.source, integrity: (verify as { ok: false; reason: string }).reason });
+        } else {
+          log('INFO', 'Project state retrieved', { project: projPath, branch: branch || 'none', source: resolved.source, integrity: 'ok' });
+        }
         return { content: [{ type: "text", text: content }] };
       }
 
@@ -1010,7 +1018,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         fs.mkdirSync(path.dirname(filePath), { recursive: true });
         writeStateDoc(filePath, projPath, args, existing, branch);
-
+        const writtenContent = fs.readFileSync(filePath, 'utf-8');
+        writeHmac(filePath, writtenContent, _integrityKey);
         const propagated = propagateStateToTools({
           projectPath: projPath,
           context: args.context,

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -34,7 +34,13 @@ export function loadOrCreateKey(): Buffer {
   if (fs.existsSync(KEY_PATH)) {
     try {
       const hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
-      if (hex.length === 64) return Buffer.from(hex, 'hex');
+      const key = Buffer.from(hex, 'hex');
+      if (key.length === 32) {
+        // Harden permissions even on existing key in case it was copied with wrong perms
+        try { fs.chmodSync(KEY_PATH, 0o600); } catch { /* best-effort */ }
+        try { fs.chmodSync(KEY_DIR, 0o700); } catch { /* best-effort */ }
+        return key;
+      }
     } catch {
       // fall through to regenerate
     }
@@ -45,7 +51,8 @@ export function loadOrCreateKey(): Buffer {
   try {
     fs.writeFileSync(KEY_PATH, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
     fs.chmodSync(KEY_PATH, 0o600);
-  } catch {
+  } catch (e) {
+    console.error('[EGC integrity] Failed to persist HMAC key:', String(e));
     // best-effort: if we cannot persist the key we still return it for
     // this process lifetime (integrity checks will fail on next boot).
   }
@@ -103,13 +110,12 @@ export function verifyHmac(
     return { ok: false, reason: 'read_error' };
   }
 
+  if (storedHmac.length !== 64 || !/^[0-9a-f]{64}$/.test(storedHmac)) {
+    return { ok: false, reason: 'hmac_mismatch' };
+  }
   const expected = computeHmac(content, key);
-  // Use timingSafeEqual to prevent timing attacks.
-  const storedBuf = Buffer.from(storedHmac.padEnd(64, '0'), 'hex');
+  const storedBuf = Buffer.from(storedHmac, 'hex');
   const expectedBuf = Buffer.from(expected, 'hex');
-  const match =
-    storedBuf.length === expectedBuf.length &&
-    crypto.timingSafeEqual(storedBuf, expectedBuf);
-
+  const match = crypto.timingSafeEqual(storedBuf, expectedBuf);
   return match ? { ok: true } : { ok: false, reason: 'hmac_mismatch' };
 }

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -1,0 +1,115 @@
+/**
+ * HMAC integrity checks for egc-memory state files.
+ *
+ * On every write: compute HMAC-SHA256 of the file content and store it in
+ * a sidecar file (<statefile>.hmac) owned only by the current user.
+ *
+ * On every read: verify the sidecar HMAC against the file content and emit
+ * a warning when they do not match (tamper detection). Reads still succeed
+ * so a corrupted HMAC never hard-blocks the agent.
+ *
+ * The HMAC key lives at ~/.egc/integrity.key (mode 0o600). It is generated
+ * once with 32 bytes of crypto-random data and reused on subsequent calls.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const KEY_DIR = path.join(os.homedir(), '.egc');
+const KEY_PATH = path.join(KEY_DIR, 'integrity.key');
+const HMAC_ALGORITHM = 'sha256';
+
+/**
+ * Load or create the HMAC key at ~/.egc/integrity.key.
+ * The key is 32 random bytes encoded as hex (64 hex chars on disk).
+ */
+export function loadOrCreateKey(): Buffer {
+  try {
+    fs.mkdirSync(KEY_DIR, { recursive: true, mode: 0o700 });
+  } catch {
+    // directory may already exist
+  }
+
+  if (fs.existsSync(KEY_PATH)) {
+    try {
+      const hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
+      if (hex.length === 64) return Buffer.from(hex, 'hex');
+    } catch {
+      // fall through to regenerate
+    }
+  }
+
+  // Generate a fresh key and persist it.
+  const key = crypto.randomBytes(32);
+  try {
+    fs.writeFileSync(KEY_PATH, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    fs.chmodSync(KEY_PATH, 0o600);
+  } catch {
+    // best-effort: if we cannot persist the key we still return it for
+    // this process lifetime (integrity checks will fail on next boot).
+  }
+  return key;
+}
+
+/**
+ * Compute HMAC-SHA256 of `content` using the provided key.
+ */
+export function computeHmac(content: string, key: Buffer): string {
+  return crypto.createHmac(HMAC_ALGORITHM, key).update(content, 'utf-8').digest('hex');
+}
+
+/**
+ * Write a sidecar HMAC file next to `stateFilePath`.
+ * The sidecar is stored at `<stateFilePath>.hmac` (mode 0o600).
+ */
+export function writeHmac(stateFilePath: string, content: string, key: Buffer): void {
+  const hmacPath = `${stateFilePath}.hmac`;
+  const hmac = computeHmac(content, key);
+  try {
+    fs.writeFileSync(hmacPath, hmac, { encoding: 'utf-8', mode: 0o600 });
+    fs.chmodSync(hmacPath, 0o600);
+  } catch {
+    // best-effort: integrity sidecar failure must never block state writes
+  }
+}
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: 'missing_sidecar' | 'hmac_mismatch' | 'read_error' };
+
+/**
+ * Verify the sidecar HMAC for `stateFilePath` against `content`.
+ *
+ * Returns `{ ok: true }` when the file is intact.
+ * Returns `{ ok: false, reason }` when tamper detection fires or the
+ * sidecar is absent — callers should warn but MUST NOT hard-block reads.
+ */
+export function verifyHmac(
+  stateFilePath: string,
+  content: string,
+  key: Buffer,
+): VerifyResult {
+  const hmacPath = `${stateFilePath}.hmac`;
+
+  if (!fs.existsSync(hmacPath)) {
+    return { ok: false, reason: 'missing_sidecar' };
+  }
+
+  let storedHmac: string;
+  try {
+    storedHmac = fs.readFileSync(hmacPath, 'utf-8').trim();
+  } catch {
+    return { ok: false, reason: 'read_error' };
+  }
+
+  const expected = computeHmac(content, key);
+  // Use timingSafeEqual to prevent timing attacks.
+  const storedBuf = Buffer.from(storedHmac.padEnd(64, '0'), 'hex');
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const match =
+    storedBuf.length === expectedBuf.length &&
+    crypto.timingSafeEqual(storedBuf, expectedBuf);
+
+  return match ? { ok: true } : { ok: false, reason: 'hmac_mismatch' };
+}

--- a/tests/egc-memory-integrity.test.js
+++ b/tests/egc-memory-integrity.test.js
@@ -1,0 +1,191 @@
+'use strict';
+/**
+ * Tests for mcp/servers/egc-memory/src/integrity.ts (issue #580)
+ *
+ * Covers key generation, HMAC write/verify, tamper detection, and
+ * missing-sidecar detection. Tests run against the compiled build output.
+ *
+ * Run with: node tests/egc-memory-integrity.test.js
+ */
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+const buildPath = path.join(
+  __dirname, '..', 'mcp', 'servers', 'egc-memory', 'build', 'integrity.js'
+);
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-memory first.');
+  process.exit(0);
+}
+
+const { loadOrCreateKey, computeHmac, writeHmac, verifyHmac } = require(buildPath);
+
+console.log('\n=== Testing egc-memory integrity (issue #580) ===\n');
+
+// ── loadOrCreateKey ──────────────────────────────────────────────────────────
+
+if (test('loadOrCreateKey: returns a 32-byte Buffer', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    // Override HOME so key is written to tmpDir
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    const key = loadOrCreateKey();
+    process.env.HOME = origHome;
+    assert.ok(Buffer.isBuffer(key), 'should be a Buffer');
+    assert.strictEqual(key.length, 32, 'should be 32 bytes');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('loadOrCreateKey: key file is created with mode 0600', () => {
+  // KEY_PATH is resolved at module load time from os.homedir()
+  const keyPath = path.join(os.homedir(), '.egc', 'integrity.key');
+  loadOrCreateKey();
+  assert.ok(fs.existsSync(keyPath), 'key file should exist');
+  const mode = fs.statSync(keyPath).mode & 0o777;
+  assert.strictEqual(mode, 0o600, `expected mode 0600, got ${mode.toString(8)}`);
+})) passed++; else failed++;
+
+if (test('loadOrCreateKey: returns same key on second call', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    const key1 = loadOrCreateKey();
+    const key2 = loadOrCreateKey();
+    process.env.HOME = origHome;
+    assert.ok(key1.equals(key2), 'keys should be identical on second load');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+// ── computeHmac ──────────────────────────────────────────────────────────────
+
+if (test('computeHmac: returns 64-char lowercase hex string', () => {
+  const key = crypto.randomBytes(32);
+  const mac = computeHmac('hello world', key);
+  assert.strictEqual(typeof mac, 'string');
+  assert.strictEqual(mac.length, 64);
+  assert.ok(/^[0-9a-f]{64}$/.test(mac), 'should be lowercase hex');
+})) passed++; else failed++;
+
+if (test('computeHmac: same content + key produces same HMAC', () => {
+  const key = crypto.randomBytes(32);
+  const mac1 = computeHmac('test content', key);
+  const mac2 = computeHmac('test content', key);
+  assert.strictEqual(mac1, mac2);
+})) passed++; else failed++;
+
+if (test('computeHmac: different content produces different HMAC', () => {
+  const key = crypto.randomBytes(32);
+  const mac1 = computeHmac('content A', key);
+  const mac2 = computeHmac('content B', key);
+  assert.notStrictEqual(mac1, mac2);
+})) passed++; else failed++;
+
+// ── writeHmac + verifyHmac ───────────────────────────────────────────────────
+
+if (test('verifyHmac: returns { ok: true } for untampered file', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    const key = crypto.randomBytes(32);
+    const stateFile = path.join(tmpDir, 'state.md');
+    const content = '# Project State\n- decision: use HMAC\n';
+    fs.writeFileSync(stateFile, content, 'utf-8');
+    writeHmac(stateFile, content, key);
+    assert.ok(fs.existsSync(`${stateFile}.hmac`), 'sidecar should exist');
+    const result = verifyHmac(stateFile, content, key);
+    assert.deepStrictEqual(result, { ok: true });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('verifyHmac: returns { ok: false, reason: "hmac_mismatch" } for tampered content', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    const key = crypto.randomBytes(32);
+    const stateFile = path.join(tmpDir, 'state.md');
+    const original = '# Project State\n- decision: use HMAC\n';
+    fs.writeFileSync(stateFile, original, 'utf-8');
+    writeHmac(stateFile, original, key);
+    // Tamper with the file
+    const tampered = original + '- injected: malicious line\n';
+    const result = verifyHmac(stateFile, tampered, key);
+    assert.deepStrictEqual(result, { ok: false, reason: 'hmac_mismatch' });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('verifyHmac: returns { ok: false, reason: "missing_sidecar" } when no .hmac file', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    const key = crypto.randomBytes(32);
+    const stateFile = path.join(tmpDir, 'state.md');
+    const content = '# Project State\n';
+    fs.writeFileSync(stateFile, content, 'utf-8');
+    // No writeHmac call — sidecar absent
+    const result = verifyHmac(stateFile, content, key);
+    assert.deepStrictEqual(result, { ok: false, reason: 'missing_sidecar' });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('verifyHmac: returns hmac_mismatch for malformed sidecar content', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    const key = crypto.randomBytes(32);
+    const stateFile = path.join(tmpDir, 'state.md');
+    const content = '# Project State\n';
+    fs.writeFileSync(stateFile, content, 'utf-8');
+    // Write a malformed sidecar
+    fs.writeFileSync(`${stateFile}.hmac`, 'not-a-valid-hex-string', 'utf-8');
+    const result = verifyHmac(stateFile, content, key);
+    assert.deepStrictEqual(result, { ok: false, reason: 'hmac_mismatch' });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('writeHmac: sidecar file has mode 0600', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    const key = crypto.randomBytes(32);
+    const stateFile = path.join(tmpDir, 'state.md');
+    const content = '# Project State\n';
+    fs.writeFileSync(stateFile, content, 'utf-8');
+    writeHmac(stateFile, content, key);
+    const hmacPath = `${stateFile}.hmac`;
+    const mode = fs.statSync(hmacPath).mode & 0o777;
+    assert.strictEqual(mode, 0o600, `expected mode 0600, got ${mode.toString(8)}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## What
Adds HMAC-SHA256 integrity verification to all egc-memory state file reads and writes, detecting external tampering without hard-blocking reads.

## Changes

**`mcp/servers/egc-memory/src/integrity.ts`** (new)
- `loadOrCreateKey()` — generates/loads 32-byte key at `~/.egc/integrity.key` (mode 0o600)
- `computeHmac()` — HMAC-SHA256 of file content using Node.js built-in `crypto`
- `writeHmac()` — writes sidecar `<statefile>.hmac` (mode 0o600) after every state write
- `verifyHmac()` — reads sidecar and verifies using `crypto.timingSafeEqual`; returns typed discriminated union: `missing_sidecar` | `hmac_mismatch` | `read_error`

**`mcp/servers/egc-memory/src/index.ts`**
- Initializes `_integrityKey` once at startup via `loadOrCreateKey()`
- `get_state`: verifies HMAC after read, logs `WARN` on mismatch (never blocks reads)
- `update_state`: writes HMAC sidecar after every successful state write

## Verified
```
✓ Key loaded, length: 32 bytes
✓ HMAC sidecar written, exists: true
✓ Untampered verify: {"ok":true}
✓ Tampered verify: {"ok":false,"reason":"hmac_mismatch"}
✓ Missing sidecar: {"ok":false,"reason":"missing_sidecar"}
✅ Issue #580 solved

npm run build  → 0 TypeScript errors ✅
npm test       → 2349 passed, 119 pre-existing failures unchanged ✅
```

Closes #580

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HMAC-SHA256 integrity checks to `egc-memory` state files to detect tampering without blocking reads. Closes #580.

- New Features
  - Per-user 32-byte key at `~/.egc/integrity.key` (0600).
  - Sidecar HMAC written to `<statefile>.hmac` (0600) after each write.
  - On read, verifies HMAC and logs WARN on missing/mismatch; reads still proceed.
  - Uses Node `crypto` HMAC-SHA256 with timing-safe comparison.

- Bug Fixes
  - Wired verification on reads and sidecar writes in `index.ts`; includes integrity status in logs.
  - Hardened validation and permissions: enforce 0600/0700 and strict 64-char lowercase hex for sidecar.
  - Added 11 unit tests covering key generation, permissions, write/verify, tamper, and missing-sidecar cases.

<sup>Written for commit c2968c2f954ae227d57aafb9c659513ad5c64f72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integrity checks for memory state files using a companion verification file.
  * Automatically creates and manages a local security key for validating saved state.

* **Bug Fixes**
  * Improved detection of missing or altered state data during reads.
  * Reduced the chance of integrity-check failures interrupting normal access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->