### PR TITLE
feat(zed): native Zed IDE integration (#602)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ---
 
-EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own - no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
+EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own - no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, Zed, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
 
 ---
 
@@ -132,7 +132,7 @@ With a provider API key (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`
 
 ### Always in sync - across every tool you use
 
-**`egc watch`** - run it once and every tool you use stays in sync. Edit context in Cursor and it appears in Gemini CLI, Copilot, Windsurf, and everywhere else automatically. When your state updates, all your tool config files update with it. No manual steps, no stale state.
+**`egc watch`** - run it once and every tool you use stays in sync. Edit context in Cursor and it appears in Gemini CLI, Copilot, Windsurf, Zed, and everywhere else automatically. When your state updates, all your tool config files update with it. No manual steps, no stale state.
 
 ```
 egc watch              # watch current project

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -33,7 +33,8 @@
         "cursor",
         "antigravity",
         "codex",
-        "codebuddy"
+        "codebuddy",
+        "zed"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -163,7 +164,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "rules-core",
@@ -195,7 +197,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -237,7 +240,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -275,7 +279,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "workflow-quality"
@@ -303,7 +308,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -338,7 +344,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -380,7 +387,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -407,7 +415,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "business-content"
@@ -437,7 +446,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -495,7 +505,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -538,7 +549,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -565,7 +577,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -598,7 +611,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -625,7 +639,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"
@@ -731,7 +746,8 @@
         "codebuddy",
         "windsurf",
         "amp",
-        "copilot"
+        "copilot",
+        "zed"
       ],
       "dependencies": [
         "platform-configs"

--- a/mcp-configs/zed-context-servers.json
+++ b/mcp-configs/zed-context-servers.json
@@ -1,0 +1,20 @@
+{
+  "context_servers": {
+    "egc-guardian": {
+      "command": {
+        "path": "node",
+        "args": ["__GUARDIAN_BIN__"],
+        "env": {}
+      },
+      "settings": {}
+    },
+    "egc-memory": {
+      "command": {
+        "path": "node",
+        "args": ["__MEMORY_BIN__"],
+        "env": {}
+      },
+      "settings": {}
+    }
+  }
+}

--- a/memory/zed-bootstrap.template.md
+++ b/memory/zed-bootstrap.template.md
@@ -1,0 +1,14 @@
+# EGC Memory Protocol
+
+You have access to persistent project memory via two MCP tools:
+
+- `get_state` — retrieve stored context, decisions, and lessons for this project
+- `update_state` — save new decisions, patterns, or lessons learned
+
+## How to use
+
+At the start of every session, call `get_state` to load project context before making decisions.
+
+When you discover something worth remembering — a pattern that works, a decision that was made and why, a gotcha to avoid — call `update_state` to persist it.
+
+This memory persists across sessions and is shared with your teammates.

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -57,7 +57,8 @@
                 "codebuddy",
                 "windsurf",
                 "amp",
-                "copilot"
+                "copilot",
+                "zed"
               ]
             }
           },

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -89,6 +89,12 @@ function buildMcpRegistrationTargets(homeDir) {
       gate: () => fs.existsSync(path.join(homeDir, '.config', 'opencode', 'config.json')),
       format: 'json',
     },
+    {
+      name: 'Zed',
+      path: path.join(homeDir, '.config', 'zed', 'settings.json'),
+      gate: () => fs.existsSync(path.join(homeDir, '.config', 'zed')),
+      format: 'zed-context-servers',
+    },
   ];
 }
 
@@ -229,6 +235,47 @@ function registerContinueYaml(targetDir, bins) {
 }
 
 /**
+ * Merges egc-guardian / egc-memory into Zed's settings.json under the
+ * context_servers key. Reads mcp-configs/zed-context-servers.json as a
+ * template, substitutes __GUARDIAN_BIN__ and __MEMORY_BIN__ with the
+ * resolved paths, then merges the result into the existing settings file
+ * without overwriting unrelated keys. Returns true if changed.
+ */
+function registerZedContextServers(targetPath, bins) {
+  const { guardianBin, memoryBin } = bins;
+  const templatePath = path.join(__dirname, '..', '..', 'mcp-configs', 'zed-context-servers.json');
+  const template = fs.readFileSync(templatePath, 'utf8')
+    .replaceAll('__GUARDIAN_BIN__', guardianBin)
+    .replaceAll('__MEMORY_BIN__', memoryBin);
+  const incoming = JSON.parse(template);
+
+  let settings = {};
+  if (fs.existsSync(targetPath)) {
+    try {
+      settings = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
+      }
+      throw err;
+    }
+  }
+
+  if (!settings.context_servers) settings.context_servers = {};
+  let changed = false;
+  for (const [key, value] of Object.entries(incoming.context_servers)) {
+    if (!settings.context_servers[key]) {
+      settings.context_servers[key] = value;
+      changed = true;
+    }
+  }
+  if (!changed) return false;
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, JSON.stringify(settings, null, 2) + '\n');
+  return true;
+}
+
+/**
  * Walks every gated target for homeDir and registers egc-guardian /
  * egc-memory into whichever tools are actually installed. Callbacks let the
  * caller (scripts/init.js) drive its own console output without this module
@@ -252,6 +299,8 @@ function registerMcpServers(homeDir, bins, callbacks = {}) {
         registered = registerToml(target.path, bins);
       } else if (target.format === 'continue-yaml') {
         registered = registerContinueYaml(target.path, bins);
+      } else if (target.format === 'zed-context-servers') {
+        registered = registerZedContextServers(target.path, bins);
       }
       if (registered && onRegister) onRegister(target);
     } catch (err) {
@@ -267,5 +316,6 @@ module.exports = {
   registerJson,
   registerToml,
   registerContinueYaml,
+  registerZedContextServers,
   registerMcpServers,
 };


### PR DESCRIPTION
Closes #602

## What this does
Completes the Zed IDE integration. The install adapter, schema entry,
and 63 test assertions already existed — this PR wires up the content layer.

## Changes

**`manifests/install-modules.json`**
Added `zed` to 16 modules — all skill modules that already have
windsurf/amp/copilot support, plus agents-core for the AGENTS.md bootstrap.

Skipped per owner guidance:
- `rules-core` — Zed has no MDC rules system
- `hooks-runtime` — Zed has no PreToolUse/PostToolUse lifecycle hooks
- `commands-core` — Zed slash commands live in editor extension layer
- `platform-configs` — mirrors windsurf/amp/copilot exclusion

**`mcp-configs/zed-context-servers.json`**
MCP config using Zed's `context_servers` format per the integration
tier spec at `docs/spec/integration-tiers.md`.

**`memory/zed-bootstrap.template.md`**
Template for `~/.config/zed/AGENTS.md` cognitive bootstrap.

**`README.md`**
Added Zed to the supported tools list in two places.

## Tests
All 45 install-target tests and 31 install-manifest tests pass.
63 existing test assertions already cover the zed adapter.

## Still TODO (pending direction confirmation)
- Wire AGENTS.md bootstrap into the install pipeline so it materializes
  to `~/.config/zed/AGENTS.md` during `egc install --target zed`
- Hook emitter for Dashboard WebSocket (if in scope for this PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Zed IDE integration across 16 modules, auto-registers MCP `egc-guardian` and `egc-memory` in Zed `settings.json`, and ships an `AGENTS.md` bootstrap. Updates the install schema and README to include `zed`.

- **New Features**
  - manifests/install-modules.json: add `zed` to 16 skill modules; skip `rules-core`, `hooks-runtime`, `commands-core`, `platform-configs`.
  - schemas/install-modules.schema.json: allow `zed` as a valid install target.
  - mcp-configs/zed-context-servers.json: Zed `context_servers` template for `egc-guardian` and `egc-memory` via `node`.
  - scripts/lib/mcp-register.js: add Zed target and merge into `~/.config/zed/settings.json` without overwriting other keys.
  - memory/zed-bootstrap.template.md: template for `~/.config/zed/AGENTS.md`.

<sup>Written for commit 7589964d72c9bfe56bc466f3e6de66f09708ff6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for **Zed** in the list of AI coding tools covered by EGC.
  * Expanded install target support to include **Zed** across multiple modules, enabling it to be selected alongside existing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->