### PR TITLE
feat(security): encrypt .md state files at rest with AES-256-GCM (closes #579)

### DIFF
--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -56,8 +56,7 @@ export function loadOrCreateEncKey(keyPath: string = ENC_KEY_PATH): Buffer {
     fs.writeFileSync(keyPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
     fs.chmodSync(keyPath, 0o600);
   } catch (e) {
-    console.error('[EGC encryption] Failed to persist encryption key:', String(e));
-    // best-effort: return key for this process lifetime
+    throw new Error(`[EGC encryption] Failed to persist encryption key to ${keyPath}: ${String(e)}. Remove the file or fix permissions and restart.`);
   }
   return key;
 }

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -25,29 +25,38 @@ const MAGIC = 'EGC1:';
 /**
  * Load or create the AES-256-GCM encryption key at ~/.egc/encryption.key.
  * The key is 32 random bytes stored as hex (64 hex chars on disk).
+ * Throws if the key file exists but cannot be read or is malformed —
+ * only generates a new key when the file genuinely does not exist.
  */
 export function loadOrCreateEncKey(keyPath: string = ENC_KEY_PATH): Buffer {
   const dir = path.dirname(keyPath);
   try {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try { fs.chmodSync(dir, 0o700); } catch { /* best-effort */ }
   } catch {
     // directory may already exist
   }
 
   if (fs.existsSync(keyPath)) {
-    try {
-      const hex = fs.readFileSync(keyPath, 'utf-8').trim();
-      if (hex.length === 64) return Buffer.from(hex, 'hex');
-    } catch {
-      // fall through to regenerate
+    // Key file exists — load it. Do NOT silently regenerate on error;
+    // that would destroy access to all previously encrypted state files.
+    const hex = fs.readFileSync(keyPath, 'utf-8').trim();
+    const key = Buffer.from(hex, 'hex');
+    if (key.length !== 32) {
+      throw new Error(`[EGC encryption] Key file at ${keyPath} is malformed (expected 32 bytes, got ${key.length}). Remove it to regenerate.`);
     }
+    try { fs.chmodSync(keyPath, 0o600); } catch { /* best-effort */ }
+    return key;
   }
 
+  // Key file does not exist — generate a fresh one.
   const key = crypto.randomBytes(32);
   try {
+    fs.chmodSync(dir, 0o700);
     fs.writeFileSync(keyPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
     fs.chmodSync(keyPath, 0o600);
-  } catch {
+  } catch (e) {
+    console.error('[EGC encryption] Failed to persist encryption key:', String(e));
     // best-effort: return key for this process lifetime
   }
   return key;
@@ -81,7 +90,7 @@ export function decryptState(data: Buffer, key: Buffer): string {
   const ciphertext = data.subarray(magicLen + IV_BYTES + AUTH_TAG_BYTES);
   const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(authTag);
-  return decipher.update(ciphertext) + decipher.final('utf-8');
+  return decipher.update(ciphertext, undefined, 'utf-8') + decipher.final('utf-8');
 }
 
 /**
@@ -105,10 +114,13 @@ export function readStateFile(filePath: string, key: Buffer): string {
 }
 
 /**
- * Write a state file, always encrypting.
+ * Write a state file atomically, always encrypting.
+ * Writes to a temp file then renames to prevent partial-write corruption.
  */
 export function writeStateFile(filePath: string, plaintext: string, key: Buffer): void {
   const encrypted = encryptState(plaintext, key);
-  fs.writeFileSync(filePath, encrypted);
-  try { fs.chmodSync(filePath, 0o600); } catch { /* chmod not supported on Windows */ }
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, encrypted);
+  try { fs.chmodSync(tmpPath, 0o600); } catch { /* chmod not supported on Windows */ }
+  fs.renameSync(tmpPath, filePath);
 }

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -1,0 +1,114 @@
+/**
+ * AES-256-GCM encryption for egc-memory .md state files.
+ *
+ * Files are encrypted with a random 12-byte IV prepended to the ciphertext.
+ * A magic header ("EGC1:") is used to distinguish encrypted from plaintext
+ * files so existing unencrypted state files continue to work (graceful
+ * migration: read decrypts if magic present, writes always encrypt).
+ *
+ * The encryption key lives at ~/.egc/encryption.key (mode 0o600). It is
+ * generated once with 32 bytes of crypto-random data and reused on
+ * subsequent calls. Separate from the HMAC integrity key.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const KEY_DIR = path.join(os.homedir(), '.egc');
+const ENC_KEY_PATH = path.join(KEY_DIR, 'encryption.key');
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const MAGIC = 'EGC1:';
+
+/**
+ * Load or create the AES-256-GCM encryption key at ~/.egc/encryption.key.
+ * The key is 32 random bytes stored as hex (64 hex chars on disk).
+ */
+export function loadOrCreateEncKey(keyPath: string = ENC_KEY_PATH): Buffer {
+  const dir = path.dirname(keyPath);
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch {
+    // directory may already exist
+  }
+
+  if (fs.existsSync(keyPath)) {
+    try {
+      const hex = fs.readFileSync(keyPath, 'utf-8').trim();
+      if (hex.length === 64) return Buffer.from(hex, 'hex');
+    } catch {
+      // fall through to regenerate
+    }
+  }
+
+  const key = crypto.randomBytes(32);
+  try {
+    fs.writeFileSync(keyPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    fs.chmodSync(keyPath, 0o600);
+  } catch {
+    // best-effort: return key for this process lifetime
+  }
+  return key;
+}
+
+/**
+ * Encrypt a plaintext string with AES-256-GCM.
+ * Returns a Buffer: MAGIC(5) + IV(12) + authTag(16) + ciphertext.
+ */
+export function encryptState(plaintext: string, key: Buffer): Buffer {
+  const iv = crypto.randomBytes(IV_BYTES);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([
+    Buffer.from(MAGIC, 'utf-8'),
+    iv,
+    authTag,
+    encrypted,
+  ]);
+}
+
+/**
+ * Decrypt a Buffer produced by encryptState().
+ * Throws if authentication fails (tampered ciphertext).
+ */
+export function decryptState(data: Buffer, key: Buffer): string {
+  const magicLen = Buffer.byteLength(MAGIC, 'utf-8');
+  const iv = data.subarray(magicLen, magicLen + IV_BYTES);
+  const authTag = data.subarray(magicLen + IV_BYTES, magicLen + IV_BYTES + AUTH_TAG_BYTES);
+  const ciphertext = data.subarray(magicLen + IV_BYTES + AUTH_TAG_BYTES);
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return decipher.update(ciphertext) + decipher.final('utf-8');
+}
+
+/**
+ * Returns true when the file content starts with the EGC1 magic header,
+ * indicating it was encrypted by encryptState().
+ */
+export function isEncrypted(data: Buffer): boolean {
+  return data.subarray(0, Buffer.byteLength(MAGIC, 'utf-8')).toString('utf-8') === MAGIC;
+}
+
+/**
+ * Read a state file, decrypting if necessary. Returns plaintext string.
+ * Falls back to raw UTF-8 for legacy unencrypted files.
+ */
+export function readStateFile(filePath: string, key: Buffer): string {
+  const raw = fs.readFileSync(filePath);
+  if (isEncrypted(raw)) {
+    return decryptState(raw, key);
+  }
+  return raw.toString('utf-8');
+}
+
+/**
+ * Write a state file, always encrypting.
+ */
+export function writeStateFile(filePath: string, plaintext: string, key: Buffer): void {
+  const encrypted = encryptState(plaintext, key);
+  fs.writeFileSync(filePath, encrypted);
+  try { fs.chmodSync(filePath, 0o600); } catch { /* chmod not supported on Windows */ }
+}

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
 import { loadOrCreateKey, writeHmac, verifyHmac } from './integrity';
+import { loadOrCreateEncKey, readStateFile, writeStateFile } from './encryption';
 import { propagateStateToTools } from './propagate';
 import {
   createWorkingMemoryTable,
@@ -377,6 +378,7 @@ async function getDb(): Promise<Database> {
 
 const server = new Server({ name: "egc-memory-orchestrator", version: "3.0.0" }, { capabilities: { tools: {} } });
 const _integrityKey: Buffer = loadOrCreateKey();
+const _encKey: Buffer = loadOrCreateEncKey();
 
 function getStateDir(): string {
   const dir = path.join(os.homedir(), '.egc', 'state');
@@ -395,7 +397,7 @@ function resolveProjectPath(provided?: string): string {
 
 function readStateDoc(filePath: string): Record<string, string[]|string> {
   if (!fs.existsSync(filePath)) return {};
-  const content = fs.readFileSync(filePath, 'utf-8');
+  const content = readStateFile(filePath, _encKey);
   const result: Record<string, string[]|string> = {};
   let currentSection = '';
   for (const line of content.split('\n')) {
@@ -461,8 +463,7 @@ function writeStateDoc(filePath: string, projectPath: string, data: {
     ``
   ];
 
-  fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
-  try { fs.chmodSync(filePath, 0o600); } catch { /* chmod not supported on Windows */ }
+  writeStateFile(filePath, lines.join('\n'), _encKey);
 }
 
 const LESSON_REINFORCE_DELTA = 0.15;
@@ -977,7 +978,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: `No state found for this project yet.\n${branchLine}Path: ${resolved.filePath}\n\nCall update_state at the end of this session to start building project memory.` }] };
         }
 
-        const content = fs.readFileSync(resolved.filePath, 'utf-8');
+        const content = readStateFile(resolved.filePath, _encKey);
         const verify = verifyHmac(resolved.filePath, content, _integrityKey);
         if (!verify.ok) {
           log('WARN', '[EGC integrity] State file integrity check failed', { file: resolved.filePath, reason: (verify as { ok: false; reason: string }).reason });
@@ -1018,7 +1019,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         fs.mkdirSync(path.dirname(filePath), { recursive: true });
         writeStateDoc(filePath, projPath, args, existing, branch);
-        const writtenContent = fs.readFileSync(filePath, 'utf-8');
+        const writtenContent = readStateFile(filePath, _encKey);
         writeHmac(filePath, writtenContent, _integrityKey);
         const propagated = propagateStateToTools({
           projectPath: projPath,

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -395,13 +395,20 @@ function resolveProjectPath(provided?: string): string {
   return path.resolve(raw);
 }
 
+const H2_RE = /^## (.+)/;
 function readStateDoc(filePath: string): Record<string, string[]|string> {
   if (!fs.existsSync(filePath)) return {};
-  const content = readStateFile(filePath, _encKey);
+  let content: string;
+  try {
+    content = readStateFile(filePath, _encKey);
+  } catch (err) {
+    log('ERROR', '[EGC encryption] Failed to decrypt state file', { file: filePath, error: String(err) });
+    return {};
+  }
   const result: Record<string, string[]|string> = {};
   let currentSection = '';
   for (const line of content.split('\n')) {
-    const h2 = line.match(/^## (.+)/);
+    const h2 = H2_RE.exec(line);
     if (h2) { currentSection = h2[1].trim(); result[currentSection] = result[currentSection] || []; continue; }
     if (currentSection && line.trim() && !line.startsWith('#')) {
       const arr = result[currentSection];
@@ -978,7 +985,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: `No state found for this project yet.\n${branchLine}Path: ${resolved.filePath}\n\nCall update_state at the end of this session to start building project memory.` }] };
         }
 
-        const content = readStateFile(resolved.filePath, _encKey);
+        let content: string;
+        try {
+          content = readStateFile(resolved.filePath, _encKey);
+        } catch (err) {
+          log('ERROR', '[EGC encryption] Failed to decrypt state file', { file: resolved.filePath, error: String(err) });
+          return { content: [{ type: "text", text: `State file exists but could not be decrypted. The encryption key may have changed.\nPath: ${resolved.filePath}` }] };
+        }
         const verify = verifyHmac(resolved.filePath, content, _integrityKey);
         if (!verify.ok) {
           log('WARN', '[EGC integrity] State file integrity check failed', { file: resolved.filePath, reason: (verify as { ok: false; reason: string }).reason });

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -398,13 +398,7 @@ function resolveProjectPath(provided?: string): string {
 const H2_RE = /^## (.+)/;
 function readStateDoc(filePath: string): Record<string, string[]|string> {
   if (!fs.existsSync(filePath)) return {};
-  let content: string;
-  try {
-    content = readStateFile(filePath, _encKey);
-  } catch (err) {
-    log('ERROR', '[EGC encryption] Failed to decrypt state file', { file: filePath, error: String(err) });
-    return {};
-  }
+  const content = readStateFile(filePath, _encKey);
   const result: Record<string, string[]|string> = {};
   let currentSection = '';
   for (const line of content.split('\n')) {
@@ -1027,7 +1021,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         // Merge from the same file get_state would read, so the first
         // branch-scoped write inherits the pre-existing flat state
         const resolved = resolveStateRead(getStateDir(), projPath, branch);
-        const existing = readStateDoc(resolved.filePath);
+        let existing: Record<string, string[]|string>;
+        try {
+          existing = readStateDoc(resolved.filePath);
+        } catch (err) {
+          log('ERROR', '[EGC encryption] Cannot read existing state — aborting update to prevent data loss', { file: resolved.filePath, error: String(err) });
+          throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing state file. The encryption key may have changed. Path: ${resolved.filePath}`);
+        }
         const filePath = resolveStateWrite(getStateDir(), projPath, branch);
 
         fs.mkdirSync(path.dirname(filePath), { recursive: true });


### PR DESCRIPTION
## What
Encrypts egc-memory `.md` state files at rest using AES-256-GCM (Node.js built-in `crypto` — no native dependencies).

## Changes

**`mcp/servers/egc-memory/src/encryption.ts`** (new)
- `loadOrCreateEncKey()` — generates/loads 32-byte AES key at `~/.egc/encryption.key` (mode 0o600)
- `encryptState()` — AES-256-GCM with random 12-byte IV; output: `EGC1:` magic + IV + authTag + ciphertext
- `decryptState()` — verifies GCM auth tag then decrypts
- `isEncrypted()` — detects `EGC1:` magic for backward-compatible migration
- `readStateFile()` — decrypts if magic present, falls back to plaintext for legacy files
- `writeStateFile()` — always encrypts, sets mode 0o600

**`mcp/servers/egc-memory/src/index.ts`**
- Initializes `_encKey` once at startup via `loadOrCreateEncKey()`
- `readStateDoc()`: uses `readStateFile()` instead of raw `readFileSync`
- `writeStateDoc()`: uses `writeStateFile()` instead of raw `writeFileSync`
- `get_state`: decrypts before returning content to the LLM
- `update_state`: reads back encrypted content for HMAC signing

## SQLite — why not implemented
SQLCipher requires native compilation and breaks cross-platform CI. Field-level encryption breaks the FTS index powering `search_decisions` / `search_lessons`. The `.md` state files contain the most sensitive content and are the priority target for this PR.

## Verified
```
✓ Key loaded (32 bytes)
✓ EGC1: magic header present on disk
✓ Raw bytes unreadable
✓ Decrypt roundtrip matches original
✓ Legacy plaintext files still readable
✅ All tests pass — zero new failures
```

Closes #579

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts `.md` state files at rest with AES-256-GCM to protect project memory, while remaining backward compatible with plaintext files. Adds strict key handling, atomic writes, and aborts updates on decrypt errors to prevent data loss. Closes #579.

- New Features
  - AES-256-GCM via Node.js `crypto`; on-disk: `EGC1:` + 12-byte IV + 16-byte tag + ciphertext.
  - 32-byte key at `~/.egc/encryption.key` (dir 700, file 600), reused across runs.
  - Auto-detect and decrypt on read; legacy plaintext still reads; all writes encrypt via `readStateFile`/`writeStateFile` with atomic rename.
  - HMAC signs decrypted content.

- Bug Fixes
  - Throw on malformed key and on key persist failure (no silent regeneration).
  - Catch decrypt failures in `get_state` with clear message; `update_state` aborts on decrypt errors to avoid overwriting data.
  - Explicit UTF-8 decoding and `RegExp.exec` for H2 parsing.

<sup>Written for commit 5ab770362fa4ce9a89e97f0a2b61e6ce5ee6bcd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State files are now encrypted at rest using stronger built-in encryption.
  * Existing unencrypted state files are still supported and can be read normally.
  * A secure key is automatically created and stored locally if one does not already exist.
  * File permissions are tightened where possible to help protect saved state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->