### PR TITLE
fix: resolve process segfault on state db bootstrap failure

### DIFF
--- a/scripts/bootstrap-state-db.js
+++ b/scripts/bootstrap-state-db.js
@@ -30,7 +30,7 @@ if (require.main === module) {
     })
     .catch(err => {
       process.stderr.write(`[bootstrap-state-db] FAILED: ${err.message}\n`);
-      process.exitCode = 1;
+      process.exit(1);
     });
 }
 

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -121,8 +121,10 @@ class SqlJsDatabase {
     if (!this._db) return;
     try {
       this._persist();
+    } catch (_) {
+      // Ignore persist errors on close to prevent masking original errors
     } finally {
-      this._db.close();
+      try { this._db.close(); } catch (_) { /* ignore close errors */ }
       this._db = null;
     }
   }


### PR DESCRIPTION
Fixes a critical issue where a database initialization failure would crash the Node.js process with a Segfault (Access Violation).

- Updated scripts/bootstrap-state-db.js to use process.exit(1) instead of setting process.exitCode to prevent WASM teardown issues during event loop exhaustion.
- Wrapped _persist() in a try-catch block inside db-adapter.js close() method to prevent exceptions from overriding each other and crashing the V8 isolate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a Node.js segfault when state DB bootstrap fails by exiting immediately with code 1 and making DB shutdown ignore cleanup errors so the original error isn’t masked.

- **Bug Fixes**
  - In `scripts/bootstrap-state-db.js`, call `process.exit(1)` instead of setting `process.exitCode` to avoid WASM teardown crashes when the event loop is exhausted.
  - In `scripts/lib/state-store/db-adapter.js` `close()`, ignore `_persist()` errors and wrap `_db.close()` in try/catch so cleanup can’t hide the original error.

<sup>Written for commit 5c0f476d9b182ac4af7dadbf5d44f7730c98727d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

