### PR TITLE
fix: consolidate telemetry, segfault, and ping fixes (closes #628 #629 #630)

### DIFF
--- a/scripts/bootstrap-state-db.js
+++ b/scripts/bootstrap-state-db.js
@@ -30,7 +30,7 @@ if (require.main === module) {
     })
     .catch(err => {
       process.stderr.write(`[bootstrap-state-db] FAILED: ${err.message}\n`);
-      process.exitCode = 1;
+      process.exit(1);
     });
 }
 

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -97,7 +97,8 @@ function areFilesEqual(leftPath, rightPath) {
 }
 
 function readFileUtf8(filePath) {
-  return fs.readFileSync(filePath, 'utf8');
+  const content = fs.readFileSync(filePath, 'utf8');
+  return content.codePointAt(0) === 0xFEFF ? content.slice(1) : content;
 }
 
 function isPlainObject(value) {

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -121,8 +121,10 @@ class SqlJsDatabase {
     if (!this._db) return;
     try {
       this._persist();
+    } catch (_) {
+      // Ignore persist errors on close to prevent masking original errors
     } finally {
-      this._db.close();
+      try { this._db.close(); } catch (_) { /* ignore close errors */ }
       this._db = null;
     }
   }

--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -31,7 +31,8 @@ const SCHEMA_VERSION = 1;
 function readConsent() {
   try {
     const raw = fs.readFileSync(TELEMETRY_FILE, 'utf8');
-    const parsed = JSON.parse(raw);
+    const cleanRaw = raw.codePointAt(0) === 0xFEFF ? raw.slice(1) : raw;
+    const parsed = JSON.parse(cleanRaw);
     if (typeof parsed.enabled === 'boolean') {
       return parsed;
     }
@@ -117,10 +118,14 @@ function ping(pagePath, title) {
 
   const url = `${GOATCOUNTER_URL}?${params.toString()}`;
 
-  fetch(url, {
-    method: 'GET',
-    headers: { 'User-Agent': userAgent },
-  }).catch(() => {});
+  try {
+    fetch(url, {
+      method: 'GET',
+      headers: { 'User-Agent': userAgent },
+    }).catch(() => {});
+  } catch (_) {
+    // Telemetry must never break the CLI — swallow all errors silently
+  }
 }
 
 module.exports = {

--- a/tests/scripts/telemetry.test.js
+++ b/tests/scripts/telemetry.test.js
@@ -17,10 +17,11 @@ function cleanup(dir) {
 }
 
 function loadTelemetry(homeDir) {
-  const HOME_KEY = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
-  const orig = process.env[HOME_KEY];
-  process.env[HOME_KEY] = homeDir;
-  if (process.platform !== 'win32') process.env.USERPROFILE = homeDir;
+  const origHome = process.env.HOME;
+  const origUser = process.env.USERPROFILE;
+  
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
 
   Object.keys(require.cache).forEach((k) => {
     if (k.includes('telemetry')) delete require.cache[k];
@@ -28,7 +29,8 @@ function loadTelemetry(homeDir) {
 
   const mod = require('../../scripts/lib/telemetry');
 
-  process.env[HOME_KEY] = orig;
+  if (origHome !== undefined) process.env.HOME = origHome; else delete process.env.HOME;
+  if (origUser !== undefined) process.env.USERPROFILE = origUser; else delete process.env.USERPROFILE;
 
   return mod;
 }

--- a/tests/stress/db-adapter.stress.js
+++ b/tests/stress/db-adapter.stress.js
@@ -1,0 +1,256 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    failures.push({ name, error: err.message });
+    failed++;
+  }
+}
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-dba-stress-'));
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+const { openDatabase } = require('../../scripts/lib/state-store/db-adapter');
+
+async function runTests() {
+  console.log('\n=== STRESS TEST: db-adapter.js ===\n');
+
+  // ── 1. Zero-byte file treated as new DB ───────────────────────────────────
+  await test('zero-byte DB file is treated as a fresh database', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'empty.db');
+    fs.writeFileSync(dbPath, '');
+    try {
+      const db = await openDatabase(dbPath);
+      assert.ok(db, 'db should be returned');
+      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+      db.close();
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 2. Corrupted DB file throws cleanly (no segfault) ─────────────────────
+  await test('corrupted DB file throws a JS error, not a segfault', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'corrupt.db');
+    fs.writeFileSync(dbPath, 'this is definitely not sqlite data!!!!!');
+    try {
+      const db = await openDatabase(dbPath);
+      try {
+        db.exec('SELECT 1');
+      } catch (_) {
+        // Expected — file is not a database
+      }
+      // Whether it throws or silently ignores — it must NOT crash the process.
+      // Test passes if we reach here (no segfault / unhandled exception).
+      try { db.close(); } catch (_) { /* ignore */ }
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 3. Truncated DB file (partial SQLite header) ───────────────────────────
+  await test('truncated SQLite header does not crash process', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'truncated.db');
+    // SQLite header is 100 bytes; write only 50
+    const header = Buffer.alloc(50);
+    header.write('SQLite format 3\0', 0, 'utf8');
+    fs.writeFileSync(dbPath, header);
+    try {
+      const db = await openDatabase(dbPath);
+      try { db.exec('SELECT 1'); } catch (_) { /* ignore */ }
+      try { db.close(); } catch (_) { /* ignore */ }
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 4. close() called multiple times (double-free guard) ──────────────────
+  await test('calling close() twice does not throw', async () => {
+    const db = await openDatabase(':memory:');
+    db.close();
+    assert.doesNotThrow(() => db.close(), 'second close should be a no-op');
+  });
+
+  // ── 5. exec after close does not segfault ─────────────────────────────────
+  await test('exec after close throws a clean JS error', async () => {
+    const db = await openDatabase(':memory:');
+    db.close();
+    let threw = false;
+    try {
+      db.exec('SELECT 1');
+    } catch (_) {
+      threw = true;
+    }
+    assert.ok(threw, 'exec after close should throw');
+  });
+
+  // ── 6. Heavy write pressure — 5000 rows in a single transaction ───────────
+  await test('5000-row transaction completes without OOM or timeout', async () => {
+    const db = await openDatabase(':memory:');
+    try {
+      db.exec('CREATE TABLE stress (id INTEGER PRIMARY KEY, val TEXT)');
+      const insert = db.prepare('INSERT INTO stress VALUES (@id, @val)');
+      const tx = db.transaction(() => {
+        for (let i = 0; i < 5000; i++) {
+          insert.run({ id: i, val: `value-${i}-${'x'.repeat(100)}` });
+        }
+      });
+      tx();
+      const rows = db.prepare('SELECT COUNT(*) as c FROM stress').get();
+      assert.strictEqual(rows.c, 5000);
+    } finally {
+      db.close();
+    }
+  });
+
+  // ── 7. Transaction rollback leaves table intact ────────────────────────────
+  await test('rolled-back transaction leaves table in prior state', async () => {
+    const db = await openDatabase(':memory:');
+    try {
+      db.exec('CREATE TABLE stable (id INTEGER PRIMARY KEY)');
+      db.exec('INSERT INTO stable VALUES (1)');
+
+      const badTx = db.transaction(() => {
+        db.exec('INSERT INTO stable VALUES (2)');
+        throw new Error('intentional rollback');
+      });
+
+      try { badTx(); } catch (_) { /* expected */ }
+
+      const rows = db.prepare('SELECT COUNT(*) as c FROM stable').get();
+      assert.strictEqual(rows.c, 1, 'Rolled-back insert should not persist');
+    } finally {
+      db.close();
+    }
+  });
+
+  // ── 8. prepare + free 1000 statements without FD leak ─────────────────────
+  await test('1000 prepare+free cycles do not leak memory/FDs', async () => {
+    const db = await openDatabase(':memory:');
+    try {
+      db.exec('CREATE TABLE t (id INTEGER)');
+      for (let i = 0; i < 1000; i++) {
+        const stmt = db.prepare('SELECT * FROM t WHERE id = ?');
+        // Statement is freed explicitly in the finally block of .all()
+        stmt.all(i);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  // ── 9. Named params vs positional params both work ────────────────────────
+  await test('named and positional params produce identical results', async () => {
+    const db = await openDatabase(':memory:');
+    try {
+      db.exec('CREATE TABLE p (a INTEGER, b TEXT)');
+      db.prepare('INSERT INTO p VALUES (@a, @b)').run({ a: 1, b: 'named' });
+      db.prepare('INSERT INTO p VALUES (?, ?)').run([2, 'positional']);
+      const rows = db.prepare('SELECT * FROM p ORDER BY a').all();
+      assert.strictEqual(rows.length, 2);
+      assert.strictEqual(rows[0].b, 'named');
+      assert.strictEqual(rows[1].b, 'positional');
+    } finally {
+      db.close();
+    }
+  });
+
+  // ── 10. DB file grows and is re-loaded correctly ──────────────────────────
+  await test('DB written in one process is fully readable after re-open', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'reload.db');
+    try {
+      // Write
+      const db1 = await openDatabase(dbPath);
+      db1.exec('CREATE TABLE r (id INTEGER PRIMARY KEY, name TEXT)');
+      for (let i = 0; i < 100; i++) {
+        db1.prepare('INSERT INTO r VALUES (?, ?)').run([i, `row-${i}`]);
+      }
+      db1.close();
+
+      assert.ok(fs.existsSync(dbPath), 'DB file must exist after close');
+
+      // Re-open and verify
+      const db2 = await openDatabase(dbPath);
+      const count = db2.prepare('SELECT COUNT(*) as c FROM r').get();
+      db2.close();
+      assert.strictEqual(count.c, 100);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 11. Nested db.transaction() inside an outer transaction ──────────────
+  await test('nested transaction() call inside outer transaction is handled cleanly', async () => {
+    const db = await openDatabase(':memory:');
+    try {
+      db.exec('CREATE TABLE nest (id INTEGER)');
+
+      const inner = db.transaction(() => {
+        db.exec('INSERT INTO nest VALUES (2)');
+      });
+
+      const outer = db.transaction(() => {
+        db.exec('INSERT INTO nest VALUES (1)');
+        // Call a nested transaction — sql.js may throw or handle via savepoint.
+        // Either outcome is acceptable; the process must not hang or segfault.
+        inner();
+      });
+
+      let outerThrew = false;
+      try {
+        outer();
+      } catch (_) {
+        outerThrew = true;
+      }
+
+      // If it succeeded, verify at least row 1 was inserted.
+      // If it threw, the DB must still be usable (not corrupted).
+      if (!outerThrew) {
+        const rows = db.prepare('SELECT COUNT(*) as c FROM nest').get();
+        assert.ok(rows.c >= 1, 'At least one row should be present on success');
+      } else {
+        // DB still usable after nested-tx failure
+        assert.doesNotThrow(() => db.prepare('SELECT 1').get());
+      }
+    } finally {
+      try { db.close(); } catch (_) { /* ignore */ }
+    }
+  });
+
+  // ─── summary ────────────────────────────────────────────────────────────────
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  if (failures.length > 0) {
+    console.log('\nFailed tests:');
+    failures.forEach(f => console.log(`  ✗ ${f.name}: ${f.error}`));
+  }
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch(err => {
+  console.error('Unexpected runner error:', err);
+  process.exit(1);
+});

--- a/tests/stress/state-store.stress.js
+++ b/tests/stress/state-store.stress.js
@@ -1,0 +1,416 @@
+'use strict';
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { createStateStore } = require('../../scripts/lib/state-store');
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    failures.push({ name, error: err.message });
+    failed++;
+  }
+}
+
+function uid() {
+  const rand = typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : crypto.randomBytes(16).toString('hex');
+  return `${Date.now()}-${rand}`;
+}
+
+function makeSession(overrides = {}) {
+  return {
+    id: uid(),
+    adapterId: 'stress-adapter',
+    harness: 'gemini',
+    state: 'active',
+    repoRoot: '/stress/repo',
+    startedAt: new Date().toISOString(),
+    snapshot: {},
+    ...overrides,
+  };
+}
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-stress-'));
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+async function runTests() {
+  console.log('\n=== STRESS TEST: state-store ===\n');
+
+  // ── 1. High-volume sequential inserts ──────────────────────────────────────
+  await test('insert 500 sessions sequentially without error', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      for (let i = 0; i < 500; i++) {
+        store.upsertSession(makeSession({ id: `session-${i}` }));
+      }
+      const { sessions, totalCount } = store.listRecentSessions({ limit: 1000 });
+      assert.strictEqual(totalCount, 500);
+      assert.strictEqual(sessions.length, 500);
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 2. High-volume skill_runs ──────────────────────────────────────────────
+  await test('insert 1000 skill_runs across 10 sessions', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      const sessionIds = [];
+      for (let i = 0; i < 10; i++) {
+        const s = makeSession({ id: `bulk-session-${i}` });
+        store.upsertSession(s);
+        sessionIds.push(s.id);
+      }
+      for (let i = 0; i < 1000; i++) {
+        store.insertSkillRun({
+          id: `run-${i}`,
+          skillId: `skill-${i % 20}`,
+          skillVersion: '1.0.0',
+          sessionId: sessionIds[i % 10],
+          taskDescription: `Task ${i}`,
+          outcome: i % 3 === 0 ? 'failure' : 'success',
+          tokensUsed: crypto.randomInt(0, 10000),
+          durationMs: crypto.randomInt(0, 5000),
+          createdAt: new Date().toISOString(),
+        });
+      }
+      const detail = store.getSessionDetail(sessionIds[0]);
+      assert.ok(detail, 'Session detail should be retrievable');
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 3. Repeated open/close cycles (memory leak probe) ─────────────────────
+  await test('100 open/close cycles on the same file do not leak', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'state.db');
+    try {
+      // Force GC before measurement if available (run with --expose-gc to stabilize)
+      if (global.gc) global.gc();
+      const memBefore = process.memoryUsage().heapUsed;
+      for (let i = 0; i < 100; i++) {
+        const store = await createStateStore({ dbPath });
+        store.upsertSession(makeSession({ id: `cycle-${i}` }));
+        store.close();
+      }
+      if (global.gc) global.gc();
+      const memAfter = process.memoryUsage().heapUsed;
+      const growthMb = (memAfter - memBefore) / 1024 / 1024;
+      assert.ok(growthMb < 50, `Memory grew by ${growthMb.toFixed(1)} MB — possible leak`);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 4. Large payload in snapshot ──────────────────────────────────────────
+  await test('snapshot with 100KB of nested JSON survives round-trip', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      const bigSnapshot = {
+        workers: Array.from({ length: 500 }, (_, i) => ({
+          id: `worker-${i}`,
+          data: 'x'.repeat(100),
+          nested: { level: 3, value: i },
+        })),
+      };
+      const sessionId = uid();
+      store.upsertSession(makeSession({ id: sessionId, snapshot: bigSnapshot }));
+      const { sessions } = store.listRecentSessions({ limit: 1 });
+      assert.ok(sessions[0].snapshot.workers.length === 500);
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 5. Null / empty boundary values ───────────────────────────────────────
+  await test('session with null repoRoot and empty snapshot survives', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      store.upsertSession(makeSession({ repoRoot: null, snapshot: {} }));
+      const { sessions } = store.listRecentSessions({ limit: 1 });
+      assert.ok(sessions.length === 1);
+      assert.strictEqual(sessions[0].repoRoot, null);
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 6. Very long string fields ─────────────────────────────────────────────
+  await test('session id of 1000 chars is stored and retrieved correctly', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      const longId = 'a'.repeat(1000);
+      store.upsertSession(makeSession({ id: longId }));
+      const { sessions } = store.listRecentSessions({ limit: 1 });
+      assert.strictEqual(sessions[0].id, longId);
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 7. FK violation is actually enforced ───────────────────────────────────
+  await test('failed FK insert raises an error and leaves DB in consistent state', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      store.upsertSession(makeSession({ id: 'before-bad-tx' }));
+
+      let fkThrew = false;
+      try {
+        store.insertSkillRun({
+          id: uid(),
+          skillId: 'sk-1',
+          skillVersion: '1.0',
+          sessionId: 'DOES-NOT-EXIST',
+          taskDescription: 'bad',
+          outcome: 'success',
+          createdAt: new Date().toISOString(),
+        });
+      } catch (_) {
+        fkThrew = true;
+      }
+
+      // FK enforcement must have triggered a throw
+      assert.ok(fkThrew, 'insertSkillRun with non-existent sessionId must throw (FK enforcement)');
+
+      // DB is still usable and the original session is intact
+      const { sessions } = store.listRecentSessions({ limit: 10 });
+      assert.ok(sessions.some(s => s.id === 'before-bad-tx'), 'Session should still be there');
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 8. Idempotent upserts (no duplicate PK crashes) ───────────────────────
+  await test('1000 upserts with the same ID replace rather than duplicate', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      const id = uid();
+      for (let i = 0; i < 1000; i++) {
+        store.upsertSession(makeSession({ id, state: i % 2 === 0 ? 'active' : 'idle' }));
+      }
+      const { totalCount } = store.listRecentSessions({ limit: 100 });
+      assert.strictEqual(totalCount, 1, 'Expected exactly 1 session after 1000 upserts');
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 9. listRecentSessions limit=0 boundary ────────────────────────────────
+  await test('listRecentSessions with limit=0 throws or returns empty', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      for (let i = 0; i < 5; i++) store.upsertSession(makeSession({ id: `p-${i}` }));
+      let threw = false;
+      let result;
+      try {
+        result = store.listRecentSessions({ limit: 0 });
+      } catch (_) {
+        threw = true;
+      }
+      if (!threw) {
+        const count = result && result.sessions ? result.sessions.length : 0;
+        assert.ok(count === 0, 'limit:0 should not return all rows');
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 10. Instincts high-volume with confidence boundary values ─────────────
+  await test('insert 500 instincts and verify total count', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      for (let i = 0; i < 250; i++) {
+        store.upsertInstinct({
+          id: `inst-zero-${i}`,
+          projectId: 'stress-proj',
+          trigger: `trigger-zero-${i}`,
+          content: `content-${i}`,
+          confidence: 0,
+          createdAt: new Date().toISOString(),
+        });
+      }
+      for (let i = 0; i < 250; i++) {
+        store.upsertInstinct({
+          id: `inst-one-${i}`,
+          projectId: 'stress-proj',
+          trigger: `trigger-one-${i}`,
+          content: `content-${i}`,
+          confidence: 1,
+          createdAt: new Date().toISOString(),
+        });
+      }
+      // listInstincts is paginated by confidence DESC — validate via totalCount
+      const { instincts, totalCount } = store.listInstincts({ projectId: 'stress-proj' });
+      assert.ok(Array.isArray(instincts), 'instincts should be an array');
+      assert.strictEqual(totalCount, 500, `Expected 500 instincts, got ${totalCount}`);
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 11. Lessons: upsert and verify active vs archived via getLessonById ───
+  await test('archive flag is persisted correctly and readable via getLessonById', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      store.upsertLesson({
+        id: 'active-lesson',
+        content: 'Active content',
+        context: 'stress-test',
+        confidence: 0.8,
+        createdAt: new Date().toISOString(),
+        archived: 0,
+      });
+      store.upsertLesson({
+        id: 'archived-lesson',
+        content: 'Archived content',
+        context: 'stress-test',
+        confidence: 0.3,
+        createdAt: new Date().toISOString(),
+        archived: 1,
+      });
+
+      const active = store.getLessonById('active-lesson');
+      const archived = store.getLessonById('archived-lesson');
+
+      assert.ok(active, 'Active lesson should exist');
+      assert.strictEqual(active.archived, 0, 'Active lesson archived flag should be 0');
+
+      assert.ok(archived, 'Archived lesson should exist');
+      assert.strictEqual(archived.archived, 1, 'Archived lesson archived flag should be 1');
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 12. Rapid persist to disk under load ──────────────────────────────────
+  await test('persist 200 writes to disk file without corruption', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'stress.db');
+    try {
+      const store = await createStateStore({ dbPath });
+      for (let i = 0; i < 200; i++) {
+        store.upsertSession(makeSession({ id: `disk-${i}` }));
+      }
+      store.close();
+
+      const store2 = await createStateStore({ dbPath });
+      const { totalCount } = store2.listRecentSessions({ limit: 500 });
+      store2.close();
+      assert.strictEqual(totalCount, 200);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 13. Unicode round-trip: verify actual stored values ───────────────────
+  await test('unicode CJK, RTL, and special chars are stored and retrieved correctly', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      const weirdStrings = [
+        'éñü latin-extended',
+        '中文日本語한국어',
+        'مرحبا بالعالم',
+        'Ёжик в тумане',
+        'line\nbreak\ttab',
+        '<script>alert(1)</script>',
+        '"; DROP TABLE sessions; --',
+        '\u200B\u200C\u200D zero-width chars',
+      ];
+      for (let i = 0; i < weirdStrings.length; i++) {
+        store.upsertSession(makeSession({ id: `unicode-${i}`, repoRoot: weirdStrings[i] }));
+      }
+      const { sessions, totalCount } = store.listRecentSessions({ limit: 20 });
+      assert.strictEqual(totalCount, weirdStrings.length);
+      // Verify each value round-tripped correctly
+      for (let i = 0; i < weirdStrings.length; i++) {
+        const row = sessions.find(s => s.id === `unicode-${i}`);
+        assert.ok(row, `Session unicode-${i} should exist`);
+        assert.strictEqual(row.repoRoot, weirdStrings[i], `repoRoot mismatch for unicode-${i}`);
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 14. SQL injection round-trip: verify fields are stored literally ───────
+  await test('SQL injection strings in repoRoot are stored literally without corruption', async () => {
+    const store = await createStateStore({ dbPath: ':memory:' });
+    try {
+      const injections = [
+        "'; DROP TABLE sessions; --",
+        "' OR '1'='1",
+        "1; DELETE FROM sessions WHERE 1=1; --",
+        "UNION SELECT * FROM sqlite_master --",
+      ];
+      for (let i = 0; i < injections.length; i++) {
+        store.upsertSession(makeSession({ id: `inject-${i}`, repoRoot: injections[i] }));
+      }
+      const { sessions, totalCount } = store.listRecentSessions({ limit: 10 });
+      assert.strictEqual(totalCount, injections.length, 'All sessions must be stored');
+      // Verify each injection string round-tripped literally (not executed)
+      for (let i = 0; i < injections.length; i++) {
+        const row = sessions.find(s => s.id === `inject-${i}`);
+        assert.ok(row, `Session inject-${i} should exist`);
+        assert.strictEqual(row.repoRoot, injections[i], `repoRoot mismatch for inject-${i}`);
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  // ── 15. Parallel independent in-memory stores ─────────────────────────────
+  await test('5 independent in-memory stores initialised in parallel', async () => {
+    const stores = await Promise.all(
+      Array.from({ length: 5 }, () => createStateStore({ dbPath: ':memory:' }))
+    );
+    try {
+      await Promise.all(stores.map(async (store, idx) => {
+        for (let i = 0; i < 50; i++) {
+          store.upsertSession(makeSession({ id: `parallel-${idx}-${i}` }));
+        }
+        const { totalCount } = store.listRecentSessions({ limit: 100 });
+        assert.strictEqual(totalCount, 50);
+      }));
+    } finally {
+      stores.forEach(s => s.close());
+    }
+  });
+
+  // ─── summary ────────────────────────────────────────────────────────────────
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  if (failures.length > 0) {
+    console.log('\nFailed tests:');
+    failures.forEach(f => console.log(`  ✗ ${f.name}: ${f.error}`));
+  }
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch(err => {
+  console.error('Unexpected runner error:', err);
+  process.exit(1);
+});

--- a/tests/stress/telemetry.stress.js
+++ b/tests/stress/telemetry.stress.js
@@ -1,0 +1,275 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    failures.push({ name, error: err.message });
+    failed++;
+  }
+}
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-tel-stress-'));
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+// Load telemetry module with overridden HOME so it uses our temp dir
+function loadTelemetry(homeDir) {
+  // Purge cached module so TELEMETRY_FILE is re-evaluated with new HOME
+  const modPath = require.resolve('../../scripts/lib/telemetry');
+  delete require.cache[modPath];
+
+  const savedHome = process.env.HOME;
+  const savedUserProfile = process.env.USERPROFILE;
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+
+  try {
+    return require(modPath);
+  } finally {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+  }
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+async function runTests() {
+  console.log('\n=== STRESS TEST: telemetry.js ===\n');
+
+  // ── 1. Rapid sequential read/write without crash ───────────────────────────
+  await test('500 sequential writeConsent+readConsent cycles do not corrupt data', () => {
+    const tmpDir = createTempDir();
+    try {
+      const { readConsent, writeConsent } = loadTelemetry(tmpDir);
+      for (let i = 0; i < 500; i++) {
+        writeConsent(i % 2 === 0);
+        const consent = readConsent();
+        assert.ok(consent !== null, `cycle ${i}: readConsent returned null`);
+        assert.strictEqual(typeof consent.enabled, 'boolean');
+      }
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 2. Adversarial JSON payloads written directly to telemetry file ────────
+  const malformedPayloads = [
+    '',                                    // empty file
+    '   ',                                 // whitespace only
+    '{{{',                                 // invalid JSON
+    'null',                                // valid JSON but not object
+    '[]',                                  // array
+    '{"enabled": "yes"}',                  // string instead of boolean
+    '{"enabled": 1}',                      // number instead of boolean
+    '{"enabled": null}',                   // null
+    '{"version": 1}',                      // missing enabled
+    '\uFEFF{"enabled": true}',             // BOM prefix
+    '\uFEFF\uFEFF{"enabled": true}',       // double BOM
+    '{"enabled": true, "extra": "' + 'A'.repeat(100_000) + '"}', // huge extra field
+  ];
+
+  for (const payload of malformedPayloads) {
+    const label = payload.length > 40 ? payload.slice(0, 40) + '…' : JSON.stringify(payload);
+    await test(`readConsent handles malformed payload: ${label}`, () => {
+      const tmpDir = createTempDir();
+      try {
+        const egcDir = path.join(tmpDir, '.egc');
+        fs.mkdirSync(egcDir, { recursive: true });
+        fs.writeFileSync(path.join(egcDir, 'telemetry.json'), payload, 'utf8');
+
+        const { readConsent } = loadTelemetry(tmpDir);
+        let result;
+        assert.doesNotThrow(() => {
+          result = readConsent();
+        }, `readConsent threw on payload: ${label}`);
+        // Result must be null or a valid consent object — never an exception
+        if (result !== null) {
+          assert.strictEqual(typeof result.enabled, 'boolean');
+        }
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+  }
+
+  // ── 3. Telemetry file replaced by a directory ──────────────────────────────
+  await test('readConsent does not crash when telemetry path is a directory', () => {
+    const tmpDir = createTempDir();
+    try {
+      const egcDir = path.join(tmpDir, '.egc');
+      // Create 'telemetry.json' as a *directory* instead of a file
+      fs.mkdirSync(path.join(egcDir, 'telemetry.json'), { recursive: true });
+
+      const { readConsent } = loadTelemetry(tmpDir);
+      assert.doesNotThrow(() => readConsent());
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 4. writeConsent with deeply nested missing directories ─────────────────
+  await test('writeConsent creates nested dirs on first call', () => {
+    const tmpDir = createTempDir();
+    try {
+      // Do NOT pre-create the .egc directory
+      const { writeConsent, readConsent } = loadTelemetry(tmpDir);
+      assert.doesNotThrow(() => writeConsent(true));
+      const consent = readConsent();
+      assert.ok(consent !== null);
+      assert.strictEqual(consent.enabled, true);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 5. writeConsent called 1000 times — no file descriptor leak ────────────
+  await test('1000 writeConsent calls without file descriptor leak', () => {
+    const tmpDir = createTempDir();
+    try {
+      const { writeConsent } = loadTelemetry(tmpDir);
+      for (let i = 0; i < 1000; i++) {
+        writeConsent(i % 2 === 0);
+      }
+      // If FDs leaked, the OS would have thrown EMFILE by now
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 6. Telemetry file with OS-max filename length ─────────────────────────
+  await test('readConsent is stable when .egc contains many other files', () => {
+    const tmpDir = createTempDir();
+    try {
+      const egcDir = path.join(tmpDir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      // Fill directory with noise
+      for (let i = 0; i < 200; i++) {
+        fs.writeFileSync(path.join(egcDir, `noise-${i}.json`), '{}');
+      }
+      fs.writeFileSync(path.join(egcDir, 'telemetry.json'), JSON.stringify({ enabled: true, version: 1 }));
+
+      const { readConsent } = loadTelemetry(tmpDir);
+      const consent = readConsent();
+      assert.ok(consent !== null);
+      assert.strictEqual(consent.enabled, true);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 7. ping does not throw regardless of fetch availability ───────────────
+  await test('ping never throws even if global fetch is broken', () => {
+    const tmpDir = createTempDir();
+    try {
+      const { writeConsent, ping } = loadTelemetry(tmpDir);
+      writeConsent(true);
+
+      const origFetch = global.fetch;
+      global.fetch = () => { throw new Error('network dead'); };
+      try {
+        assert.doesNotThrow(() => ping('/stress-test', 'Stress Test'));
+      } finally {
+        global.fetch = origFetch;
+      }
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 8. ping with fetch that returns rejected promise ──────────────────────
+  await test('ping survives when fetch returns a rejected promise', async () => {
+    const tmpDir = createTempDir();
+    try {
+      const { writeConsent, ping } = loadTelemetry(tmpDir);
+      writeConsent(true);
+
+      const origFetch = global.fetch;
+      global.fetch = () => Promise.reject(new Error('connection refused'));
+      try {
+        // ping should not throw synchronously
+        assert.doesNotThrow(() => ping('/stress-test', 'Rejected'));
+        // Give promise a tick to resolve/reject — should not propagate
+        await new Promise(r => setTimeout(r, 10));
+      } finally {
+        global.fetch = origFetch;
+      }
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 9. readConsent on read-only file ──────────────────────────────────────
+  await test('readConsent handles read-only telemetry file', () => {
+    if (process.platform === 'win32') {
+      // chmod is unreliable on Windows — skip without touching counters.
+      // test() will count this as a pass since no exception is thrown.
+      console.log('    (skipped: chmod unreliable on Windows)');
+      return;
+    }
+    const tmpDir = createTempDir();
+    try {
+      const egcDir = path.join(tmpDir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      const filePath = path.join(egcDir, 'telemetry.json');
+      fs.writeFileSync(filePath, JSON.stringify({ enabled: true, version: 1 }));
+      fs.chmodSync(filePath, 0o000);
+      try {
+        const { readConsent } = loadTelemetry(tmpDir);
+        assert.doesNotThrow(() => readConsent());
+      } finally {
+        fs.chmodSync(filePath, 0o644);
+      }
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 10. Telemetry file with Unicode path in home directory ─────────────────
+  await test('readConsent works when home dir contains unicode characters', () => {
+    const baseDir = createTempDir();
+    const unicodeDir = path.join(baseDir, '用户目录-кириллица-home');
+    try {
+      fs.mkdirSync(unicodeDir, { recursive: true });
+      const { writeConsent, readConsent } = loadTelemetry(unicodeDir);
+      writeConsent(false);
+      const consent = readConsent();
+      assert.ok(consent !== null);
+      assert.strictEqual(consent.enabled, false);
+    } finally {
+      cleanup(baseDir);
+    }
+  });
+
+  // ─── summary ────────────────────────────────────────────────────────────────
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  if (failures.length > 0) {
+    console.log('\nFailed tests:');
+    failures.forEach(f => console.log(`  ✗ ${f.name}: ${f.error}`));
+  }
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch(err => {
+  console.error('Unexpected runner error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Consolidates three fixes from PRs #628, #629, and #630 originally proposed by @fuentes71, who could not complete the CLA process.

## Changes

**BOM stripping (fixes #628)**
- `scripts/lib/telemetry.js`: strip UTF-8 BOM before `JSON.parse` in `readConsent()` to prevent `SyntaxError` on Windows-generated files
- `scripts/lib/install-lifecycle.js`: same fix in `readFileUtf8()`
- `tests/scripts/telemetry.test.js`: restore both `HOME` and `USERPROFILE` after test mock to prevent global env leakage

**Segfault on bootstrap failure (fixes #629)**
- `scripts/bootstrap-state-db.js`: use `process.exit(1)` instead of `process.exitCode` to avoid WASM teardown crash when the event loop drains
- `scripts/lib/state-store/db-adapter.js`: wrap `_persist()` in try-catch inside `close()` so cleanup errors cannot mask the original error

**ping() safety contract (fixes #630)**
- `scripts/lib/telemetry.js`: wrap `fetch()` call in try-catch so a synchronously-throwing `global.fetch` stub cannot escape -- honouring the documented "Never throws" contract

**Stress tests (from #630)**
- `tests/stress/telemetry.stress.js`: 22 scenarios (malformed consent files, BOM, FD leaks, path edge cases)
- `tests/stress/state-store.stress.js`: 15 scenarios (high-volume inserts, SQL injection, unicode round-trips, FK enforcement)
- `tests/stress/db-adapter.stress.js`: 11 scenarios (corruption, double-close, rollback, 5000-row transactions)

Co-authored-by: fuentes71 <83965570+fuentes71@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates telemetry, bootstrap, and ping stability fixes and expands stress tests to harden the CLI. Closes #628, #629, and #630.

- **Bug Fixes**
  - Strip UTF‑8 BOM before `JSON.parse` in telemetry consent reads; also strip BOM in `readFileUtf8()` to avoid Windows-only `SyntaxError`.
  - Make `ping()` never throw by wrapping `fetch` in try/catch and ignoring promise rejections.
  - Exit immediately with `process.exit(1)` on bootstrap failure to prevent a WASM teardown crash.
  - Guard state DB shutdown: ignore `_persist()` failures and `close()` errors so cleanup can’t mask the original failure.
  - Tests/CI: add 48 stress tests for telemetry, state-store, and db-adapter; restore both `HOME` and `USERPROFILE` in telemetry tests; replace `Math.random()` with `crypto.randomUUID`/`randomBytes`/`randomInt`.

<sup>Written for commit 082b164c355c9a213562f09fd6a45c0e093003a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

