### PR TITLE
fix: add null guards in stress tests (SonarCloud C reliability)

### DIFF
--- a/tests/stress/db-adapter.stress.js
+++ b/tests/stress/db-adapter.stress.js
@@ -120,6 +120,7 @@ async function runTests() {
       });
       tx();
       const rows = db.prepare('SELECT COUNT(*) as c FROM stress').get();
+      assert.ok(rows, 'SELECT COUNT returned no rows');
       assert.strictEqual(rows.c, 5000);
     } finally {
       db.close();
@@ -141,6 +142,7 @@ async function runTests() {
       try { badTx(); } catch (_) { /* expected */ }
 
       const rows = db.prepare('SELECT COUNT(*) as c FROM stable').get();
+      assert.ok(rows, 'SELECT COUNT returned no rows');
       assert.strictEqual(rows.c, 1, 'Rolled-back insert should not persist');
     } finally {
       db.close();
@@ -171,6 +173,8 @@ async function runTests() {
       db.prepare('INSERT INTO p VALUES (?, ?)').run([2, 'positional']);
       const rows = db.prepare('SELECT * FROM p ORDER BY a').all();
       assert.strictEqual(rows.length, 2);
+      assert.ok(rows[0], 'expected row at index 0');
+      assert.ok(rows[1], 'expected row at index 1');
       assert.strictEqual(rows[0].b, 'named');
       assert.strictEqual(rows[1].b, 'positional');
     } finally {
@@ -197,6 +201,7 @@ async function runTests() {
       const db2 = await openDatabase(dbPath);
       const count = db2.prepare('SELECT COUNT(*) as c FROM r').get();
       db2.close();
+      assert.ok(count, 'SELECT COUNT returned no rows');
       assert.strictEqual(count.c, 100);
     } finally {
       cleanup(tmpDir);
@@ -231,6 +236,7 @@ async function runTests() {
       // If it threw, the DB must still be usable (not corrupted).
       if (!outerThrew) {
         const rows = db.prepare('SELECT COUNT(*) as c FROM nest').get();
+        assert.ok(rows, 'SELECT COUNT returned no rows');
         assert.ok(rows.c >= 1, 'At least one row should be present on success');
       } else {
         // DB still usable after nested-tx failure

--- a/tests/stress/state-store.stress.js
+++ b/tests/stress/state-store.stress.js
@@ -140,6 +140,7 @@ async function runTests() {
       const sessionId = uid();
       store.upsertSession(makeSession({ id: sessionId, snapshot: bigSnapshot }));
       const { sessions } = store.listRecentSessions({ limit: 1 });
+      assert.ok(sessions[0], 'expected session at index 0');
       assert.ok(sessions[0].snapshot.workers.length === 500);
     } finally {
       store.close();
@@ -153,6 +154,7 @@ async function runTests() {
       store.upsertSession(makeSession({ repoRoot: null, snapshot: {} }));
       const { sessions } = store.listRecentSessions({ limit: 1 });
       assert.ok(sessions.length === 1);
+      assert.ok(sessions[0], 'expected session at index 0');
       assert.strictEqual(sessions[0].repoRoot, null);
     } finally {
       store.close();
@@ -166,6 +168,7 @@ async function runTests() {
       const longId = 'a'.repeat(1000);
       store.upsertSession(makeSession({ id: longId }));
       const { sessions } = store.listRecentSessions({ limit: 1 });
+      assert.ok(sessions[0], 'expected session at index 0');
       assert.strictEqual(sessions[0].id, longId);
     } finally {
       store.close();


### PR DESCRIPTION
SonarCloud flagged C Reliability Rating on the new code merged in #634.
The analysis identified potential null dereferences in the stress tests:

- `db.prepare(...).get()` returns `undefined` when no row matches -- accessing `.c` directly is a null deref
- `sessions[0]` can be `undefined` if the list is empty -- accessing `.snapshot`, `.repoRoot`, or `.id` is a null deref
- `.all()` results at specific indexes need length guards

Adds `assert.ok(value, message)` guards before each dereference to satisfy the static analysis requirement.

Co-authored-by: fuentes71 <83965570+fuentes71@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add null guards to stress tests to prevent potential undefined dereferences flagged by SonarCloud. Improves reliability by asserting query results and session entries before field access.

- **Bug Fixes**
  - Guard `.get()` results and `.all()` row indexes before reading fields in `tests/stress/db-adapter.stress.js`.
  - Guard `sessions[0]` before accessing `.snapshot`, `.repoRoot`, and `.id` in `tests/stress/state-store.stress.js`.

<sup>Written for commit 793243b92b9efdf1813afbac54f3133496de7a17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

