### PR TITLE
fix: guard against undefined in stress tests (SonarCloud C reliability)

### DIFF
--- a/tests/stress/state-store.stress.js
+++ b/tests/stress/state-store.stress.js
@@ -141,6 +141,7 @@ async function runTests() {
       store.upsertSession(makeSession({ id: sessionId, snapshot: bigSnapshot }));
       const { sessions } = store.listRecentSessions({ limit: 1 });
       assert.ok(sessions[0], 'expected session at index 0');
+      assert.ok(sessions[0].snapshot, 'expected snapshot on session');
       assert.ok(sessions[0].snapshot.workers.length === 500);
     } finally {
       store.close();

--- a/tests/stress/telemetry.stress.js
+++ b/tests/stress/telemetry.stress.js
@@ -103,7 +103,7 @@ async function runTests() {
           result = readConsent();
         }, `readConsent threw on payload: ${label}`);
         // Result must be null or a valid consent object — never an exception
-        if (result !== null) {
+        if (result != null) {
           assert.strictEqual(typeof result.enabled, 'boolean');
         }
       } finally {


### PR DESCRIPTION
## Summary
- `telemetry.stress.js`: changed `result !== null` to `result != null` to also guard against `undefined` before accessing `result.enabled`
- `state-store.stress.js`: added `assert.ok(sessions[0].snapshot)` guard before accessing `sessions[0].snapshot.workers`

Both were flagged by SonarCloud as C Reliability (potential null dereference) on the main branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard against null/undefined in stress tests to resolve SonarCloud C Reliability warnings for potential null dereferences.

In `tests/stress/telemetry.stress.js`, use `result != null` before reading `result.enabled`. In `tests/stress/state-store.stress.js`, add `assert.ok(sessions[0].snapshot)` before checking `snapshot.workers.length`.

<sup>Written for commit b63bb7d1372cf6139e14579965af40874b5f0286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened stress test coverage for session snapshot retrieval by verifying the snapshot field is present.
  * Updated malformed-payload telemetry stress checks to handle both `null` and `undefined` results consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->