### PR TITLE
fix: replace try/catch with Promise chain in ping() (SonarCloud S4822)

### DIFF
--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -118,14 +118,12 @@ function ping(pagePath, title) {
 
   const url = `${GOATCOUNTER_URL}?${params.toString()}`;
 
-  try {
-    fetch(url, {
+  Promise.resolve()
+    .then(() => fetch(url, {
       method: 'GET',
       headers: { 'User-Agent': userAgent },
-    }).catch(() => {});
-  } catch (_) {
-    // Telemetry must never break the CLI — swallow all errors silently
-  }
+    }))
+    .catch(() => {});
 }
 
 module.exports = {

--- a/tests/scripts/telemetry.test.js
+++ b/tests/scripts/telemetry.test.js
@@ -255,7 +255,7 @@ async function runTests() {
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 
-  if (await test('ping fires fetch with correct URL when consent is enabled', () => {
+  if (await test('ping fires fetch with correct URL when consent is enabled', async () => {
     const dir = createTempDir();
     try {
       const egcDir = path.join(dir, '.egc');
@@ -269,6 +269,8 @@ async function runTests() {
 
       const { ping } = loadTelemetry(dir);
       ping('/cli/install', 'EGC Install');
+
+      await Promise.resolve(); // flush microtask queue so ping()'s .then() fires
 
       global.fetch = origFetch;
       assert.ok(capturedUrl !== null, 'fetch should have been called');


### PR DESCRIPTION
## Summary

SonarCloud flags the `try { fetch(...).catch(() => {}) } catch (_) {}` pattern in `ping()` as a C Reliability bug (S4822): the outer try/catch is redundant because promise rejection is already captured by `.catch()`.

**Fix:** replace the try/catch with `Promise.resolve().then(() => fetch(...)).catch(() => {})`.

This is semantically equivalent and stronger:
- Synchronous throws from `fetch()` (e.g. a stubbed global in tests) become rejections caught by `.catch()`
- Async rejections are also caught by `.catch()`
- `ping()` never throws synchronously -- contract preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the try/catch wrapper in telemetry ping() with a Promise chain to satisfy SonarCloud S4822 and ensure both sync and async fetch errors are swallowed so telemetry never breaks the CLI. Updated the telemetry test to await a microtask so the new .then() path runs before assertions.

<sup>Written for commit 8a15028a3783d790ffe608cbf269bdc10090db43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

