### PR TITLE
fix(build): redirect build-skill-index stdout to stderr

### DIFF
--- a/scripts/build-skill-index.js
+++ b/scripts/build-skill-index.js
@@ -70,4 +70,4 @@ export const CATALOG: ReadonlyArray<{ kind: 'agent' | 'skill' | 'rule'; name: st
 `;
 
 fs.writeFileSync(outFile, out, 'utf8');
-console.log(`build-skill-index: ${entries.length} entries written to catalog-index.ts`);
+process.stderr.write(`build-skill-index: ${entries.length} entries written to catalog-index.ts\n`);


### PR DESCRIPTION
## Summary

- `scripts/build-skill-index.js` was using `console.log()` to print a progress message, which writes to stdout
- The release workflow at `.github/workflows/release.yml` line 77 runs `npm pack --json | node -p "JSON.parse(...)[0].filename"`
- The `prepack` lifecycle calls `build-skill-index.js`, so its stdout output gets prepended to the JSON, causing `SyntaxError: Unexpected token 'b'`

## Fix

Changed line 73 of `scripts/build-skill-index.js` from `console.log(...)` to `process.stderr.write(...)` so the progress message goes to stderr and the npm pack JSON is clean.

## Test plan

- [ ] Run `npm pack --json` locally and verify the output is valid JSON
- [ ] Re-trigger v1.1.7 release workflow after this merges

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirected progress output in `scripts/build-skill-index.js` from stdout to stderr. This keeps `npm pack --json` JSON valid and fixes the release workflow step that parses the output.

<sup>Written for commit d1c70ea79f011d92a65cd24269a08f8ec50737ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted a build-time completion message to use standard error instead of standard output.
  * The message still reports how many entries were generated and the output target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->