### PR TITLE
perf(state-store): debounce db writes and add try/catch (PERF-01, REL…

### DIFF
--- a/scripts/bootstrap-state-db.js
+++ b/scripts/bootstrap-state-db.js
@@ -23,14 +23,15 @@ if (require.main === module) {
         process.stderr.write('[bootstrap-state-db] WARNING: state store could not be initialized.\n');
         process.stderr.write('  The EGC state store was not created. Hook-level memory persistence is disabled.\n');
         process.stderr.write('  Run: egc init  to retry initialization.\n');
-        process.exit(0);
+        process.exitCode = 0;
+        return;
       }
       process.stderr.write(`[bootstrap-state-db] OK ${result.dbPath} (${result.migrations.length} migrations)\n`);
-      process.exit(0);
+      process.exitCode = 0;
     })
     .catch(err => {
       process.stderr.write(`[bootstrap-state-db] FAILED: ${err.message}\n`);
-      process.exit(1);
+      process.exitCode = 1;
     });
 }
 

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -153,13 +153,9 @@ class SqlJsDatabase {
 
   _flushPersist() {
     if (this._path === ':memory:' || !this._db) return;
-    try {
-      const data = this._db.export();
-      fs.mkdirSync(path.dirname(this._path), { recursive: true });
-      fs.writeFileSync(this._path, Buffer.from(data));
-    } catch (error) {
-      throw error;
-    }
+    const data = this._db.export();
+    fs.mkdirSync(path.dirname(this._path), { recursive: true });
+    fs.writeFileSync(this._path, Buffer.from(data));
   }
 
   async flush() {

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -70,6 +70,7 @@ class SqlJsDatabase {
     this._inTransaction = false;
     this._supportsWal = false;
     this._db = new sqlJs.Database(fileData || null);
+    this._persistTimeout = null;
   }
 
   pragma(str) {
@@ -120,7 +121,11 @@ class SqlJsDatabase {
   close() {
     if (!this._db) return;
     try {
-      this._persist();
+      if (this._persistTimeout) {
+        clearTimeout(this._persistTimeout);
+        this._persistTimeout = null;
+      }
+      this._flushPersist();
     } catch (_) {
       // Ignore persist errors on close to prevent masking original errors
     } finally {
@@ -131,9 +136,24 @@ class SqlJsDatabase {
 
   _persist() {
     if (this._path === ':memory:') return;
-    const data = this._db.export();
-    fs.mkdirSync(path.dirname(this._path), { recursive: true });
-    fs.writeFileSync(this._path, Buffer.from(data));
+    if (this._persistTimeout) {
+      clearTimeout(this._persistTimeout);
+    }
+    this._persistTimeout = setTimeout(() => {
+      this._persistTimeout = null;
+      this._flushPersist();
+    }, 50); // 50ms debounce
+  }
+
+  _flushPersist() {
+    if (this._path === ':memory:' || !this._db) return;
+    try {
+      const data = this._db.export();
+      fs.mkdirSync(path.dirname(this._path), { recursive: true });
+      fs.writeFileSync(this._path, Buffer.from(data));
+    } catch (error) {
+      console.error('[EGC] Failed to persist database:', error.message);
+    }
   }
 }
 

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -71,6 +71,7 @@ class SqlJsDatabase {
     this._supportsWal = false;
     this._db = new sqlJs.Database(fileData || null);
     this._persistTimeout = null;
+    this._initialPersistDone = false;
   }
 
   pragma(str) {
@@ -136,6 +137,11 @@ class SqlJsDatabase {
 
   _persist() {
     if (this._path === ':memory:') return;
+    if (!this._initialPersistDone) {
+      this._initialPersistDone = true;
+      this._flushPersist();
+      return;
+    }
     if (this._persistTimeout) {
       clearTimeout(this._persistTimeout);
     }
@@ -152,8 +158,16 @@ class SqlJsDatabase {
       fs.mkdirSync(path.dirname(this._path), { recursive: true });
       fs.writeFileSync(this._path, Buffer.from(data));
     } catch (error) {
-      console.error('[EGC] Failed to persist database:', error.message);
+      throw error;
     }
+  }
+
+  async flush() {
+    if (this._persistTimeout) {
+      clearTimeout(this._persistTimeout);
+      this._persistTimeout = null;
+    }
+    this._flushPersist();
   }
 }
 

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -49,7 +49,11 @@ async function createStateStore(options = {}) {
     appliedMigrations = applyMigrations(db);
     queryApi = createQueryApi(db);
   } catch (err) {
-    db.close();
+    try {
+      db.close();
+    } catch (_) {
+      // ignore close errors to preserve original initialization error
+    }
     throw err;
   }
 

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -62,6 +62,11 @@ async function createStateStore(options = {}) {
     close() {
       db.close();
     },
+    async flush() {
+      if (db.flush) {
+        await db.flush();
+      }
+    },
     getAppliedMigrations() {
       return getAppliedMigrations(db);
     },

--- a/tests/lib/state-store-concurrency.test.js
+++ b/tests/lib/state-store-concurrency.test.js
@@ -255,7 +255,7 @@ async function runTests() {
   });
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
-  process.exit(failed > 0 ? 1 : 0);
+  process.exitCode = failed > 0 ? 1 : 0;
 }
 
 runTests();

--- a/tests/stress/db-adapter.stress.js
+++ b/tests/stress/db-adapter.stress.js
@@ -282,8 +282,8 @@ async function runTests() {
       // Temporarily mock console.error to check if it's called
       const originalConsoleError = console.error;
       let errorLogged = false;
-      console.error = (msg, err) => {
-        if (msg.includes('Failed to persist database')) errorLogged = true;
+      console.error = (msg, _err) => {
+        if (msg && typeof msg === 'string' && msg.includes('Failed to persist database')) errorLogged = true;
       };
       
       db2.exec('INSERT INTO ro VALUES (1)');

--- a/tests/stress/db-adapter.stress.js
+++ b/tests/stress/db-adapter.stress.js
@@ -247,6 +247,55 @@ async function runTests() {
     }
   });
 
+  // ── 12. Debounce timer fires correctly without cancellation ─────────────────
+  await test('debounce timer fires without being cancelled by close()', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'debounce.db');
+    try {
+      const db = await openDatabase(dbPath);
+      db.exec('CREATE TABLE debounce (id INTEGER)');
+      // db.exec triggers _persist which starts a 50ms timer
+      await new Promise(resolve => setTimeout(resolve, 100)); // Wait for timer to fire
+      db.close();
+      assert.ok(fs.existsSync(dbPath), 'DB file must exist after debounce fires');
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // ── 13. Persist handles filesystem errors gracefully ────────────────────────
+  await test('_flushPersist catches fs errors and logs them instead of crashing', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'readonly.db');
+    try {
+      const db = await openDatabase(dbPath);
+      // Ensure file exists
+      db.exec('CREATE TABLE ro (id INTEGER)');
+      // db.close() will flush.
+      db.close();
+
+      // Make file read-only to trigger error on next write
+      fs.chmodSync(dbPath, 0o444);
+
+      const db2 = await openDatabase(dbPath);
+      
+      // Temporarily mock console.error to check if it's called
+      const originalConsoleError = console.error;
+      let errorLogged = false;
+      console.error = (msg, err) => {
+        if (msg.includes('Failed to persist database')) errorLogged = true;
+      };
+      
+      db2.exec('INSERT INTO ro VALUES (1)');
+      db2.close(); // This will trigger _flushPersist which will fail and catch
+      
+      console.error = originalConsoleError;
+      assert.ok(errorLogged, 'Expected console.error to be called for filesystem error');
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
   // ─── summary ────────────────────────────────────────────────────────────────
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   if (failures.length > 0) {


### PR DESCRIPTION
…-01)

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounces state-store DB writes by 50ms with a synchronous first persist; flushes pending writes on close and adds a `flush()` method to await debounced writes; switches scripts/tests to `process.exitCode` to avoid Windows exit crashes. Meets PERF-01 (reduce write churn) and REL-01 (preserve init errors, improve shutdown).

- **Refactors**
  - Debounced `_persist()` by 50ms; first call persists synchronously; `close()` clears timers and flushes once.
  - Added `_flushPersist()` and store `flush()`; no-ops for `:memory:` DBs and propagates FS errors (caught by `close()`).

- **Bug Fixes**
  - On initialization failure, wrap `db.close()` to preserve the original error.
  - Replace `process.exit()` with `process.exitCode` in `bootstrap-state-db` and tests to prevent Node.js crashes on Windows.

<sup>Written for commit db65904198b8365d22967fbe7cc59a96ba51b137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-disk state persistence by batching rapid updates to reduce frequent disk writes.
  * Ensured pending persistence work completes during shutdown and that explicit flushes run immediately.
  * More reliable error handling so initialization failures aren’t obscured by shutdown issues.
  * Updated the state DB bootstrap command to exit cleanly using standardized exit codes.

* **Tests**
  * Expanded concurrency and stress tests to verify debounce behavior and persistence failure handling (including log output).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->