### PR TITLE
fix(state-store): prevent crash on JSON parse failure in queries (BUG…

### DIFF
--- a/scripts/lib/state-store/queries.js
+++ b/scripts/lib/state-store/queries.js
@@ -24,7 +24,12 @@ function parseJsonColumn(value, fallback) {
     return fallback;
   }
 
-  return JSON.parse(value);
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn('[EGC] Failed to parse JSON column:', error.message);
+    return fallback;
+  }
 }
 
 function stringifyJson(value, label) {

--- a/tests/lib/state-store.test.js
+++ b/tests/lib/state-store.test.js
@@ -817,6 +817,26 @@ async function runTests() {
     }
   })) passed += 1; else failed += 1;
 
+  if (await test('handles invalid JSON in database gracefully via parseJsonColumn fallback', async () => {
+    const testDir = createTempDir('egc-state-invalid-json-');
+    const dbPath = path.join(testDir, 'state.db');
+    
+    try {
+      const store = await createStateStore({ dbPath });
+      
+      store._db.exec(`INSERT INTO sessions (id, adapter_id, harness, state, snapshot) VALUES ('bad-json-session', 'test', 'egc', 'idle', '{bad json}')`);
+      
+      const session = store.getSession('bad-json-session');
+      assert.strictEqual(session.id, 'bad-json-session');
+      assert.deepStrictEqual(session.snapshot, {});
+      assert.strictEqual(session.workerCount, 0);
+
+      store.close();
+    } finally {
+      cleanupTempDir(testDir);
+    }
+  })) passed += 1; else failed += 1;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
…-01)

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes in state-store queries when JSON columns have malformed data by catching parse errors and using a safe fallback. Adds a test to ensure invalid JSON doesn’t break sessions. Addresses BUG-01.

- **Bug Fixes**
  - Wrap `JSON.parse` in `parseJsonColumn` with try/catch in `scripts/lib/state-store/queries.js`; on failure, log `[EGC] Failed to parse JSON column:` and return the fallback.
  - Add `tests/lib/state-store.test.js` to verify bad JSON in `sessions.snapshot` falls back to `{}` and does not crash.

<sup>Written for commit 04d614a3368f67798b6339b8c48dd8e1381c97a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

