### PR TITLE
fix(mcp): prevent TOCTOU in getDb singleton (BUG-02)

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -362,22 +362,35 @@ async function runMigrations(db: Database, dbDir: string) {
 // `~/.egc/egc/state.db`. This is a known architectural divergence where
 // CLI/harness telemetry and MCP memory state are stored in separate SQLite DBs.
 // A doctor check in scripts/doctor.js warns when these databases diverge.
+let dbInitPromise: Promise<Database> | null = null;
 async function getDb(): Promise<Database> {
   if (dbInstance) return dbInstance;
-  const dbDir = path.join(os.homedir(), '.egc', 'memory');
-  ensurePrivateDir(dbDir);
-  hideEgcRootOnWindows();
-  
-  const dbPath = path.join(dbDir, 'state.db');
-  dbInstance = await open({ filename: dbPath, driver: sqlite3.Database });
-  
-  await dbInstance.exec('PRAGMA journal_mode = WAL;');
-  await dbInstance.exec('PRAGMA synchronous = NORMAL;');
-  await dbInstance.exec('PRAGMA foreign_keys = ON;');
-  await dbInstance.exec('PRAGMA busy_timeout = 5000;'); // Native fallback
-  
-  await runMigrations(dbInstance, dbDir);
-  return dbInstance;
+  if (dbInitPromise !== null) return dbInitPromise;
+
+  dbInitPromise = (async () => {
+    try {
+      const dbDir = path.join(os.homedir(), '.egc', 'memory');
+      ensurePrivateDir(dbDir);
+      hideEgcRootOnWindows();
+      
+      const dbPath = path.join(dbDir, 'state.db');
+      dbInstance = await open({ filename: dbPath, driver: sqlite3.Database });
+      
+      await dbInstance.exec('PRAGMA journal_mode = WAL;');
+      await dbInstance.exec('PRAGMA synchronous = NORMAL;');
+      await dbInstance.exec('PRAGMA foreign_keys = ON;');
+      await dbInstance.exec('PRAGMA busy_timeout = 5000;'); // Native fallback
+      
+      await runMigrations(dbInstance, dbDir);
+      return dbInstance;
+    } catch (error) {
+      dbInitPromise = null;
+      dbInstance = null;
+      throw error;
+    }
+  })();
+
+  return dbInitPromise;
 }
 
 const server = new Server({ name: "egc-memory-orchestrator", version: "3.0.0" }, { capabilities: { tools: {} } });


### PR DESCRIPTION
## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TOCTOU race in `getDb` by gating initialization behind a shared promise so concurrent calls share one setup. Adds safe retry by resetting the in-flight promise and `dbInstance` on errors; addresses BUG-02.

- **Bug Fixes**
  - Introduced `dbInitPromise` so all callers await one init; early-return if `dbInstance` exists.
  - Wrapped dir creation, `hideEgcRootOnWindows`, DB open, PRAGMAs, and migrations inside the promise so they run once; on error, clear both `dbInitPromise` and `dbInstance` for a clean retry.

<sup>Written for commit 7e9af2dc18af98b331281764dd291c38c6ea97d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when the memory service starts under concurrent load, preventing duplicate initialization attempts.
  * Reduced the chance of startup failures during database setup and migration.
  * Preserved existing platform-specific storage handling and recovery behavior if initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->