### PR TITLE
fix(core): use spawnSync for attrib and make migrations atomic (BUG-0…

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -5,17 +5,14 @@ import { CallToolRequestSchema, ListToolsRequestSchema, McpError, ErrorCode } fr
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { llmRoute, keywordRoute } from './llm-router.js';
 
 function hideEgcRootOnWindows(): void {
   if (process.platform !== 'win32') return;
   const egcRoot = path.join(os.homedir(), '.egc');
-  try {
-    execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
-  } catch (_) {
-    // non-critical: folder works even if attribute fails
-  }
+  const attribPath = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'attrib.exe');
+  spawnSync(attribPath, ['+h', egcRoot], { stdio: 'ignore', shell: false });
 }
 import { z } from 'zod';
 import { validateCommand, validateWrite, isProtectedPath } from './validator.js';

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -7,7 +7,7 @@ import { open, Database } from 'sqlite';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
@@ -72,11 +72,8 @@ function resolveStateStoreDbPath(): string {
 function hideEgcRootOnWindows(): void {
   if (process.platform !== 'win32') return;
   const egcRoot = path.join(os.homedir(), '.egc');
-  try {
-    execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
-  } catch (_) {
-    // non-critical: folder works even if attribute fails
-  }
+  const attribPath = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'attrib.exe');
+  spawnSync(attribPath, ['+h', egcRoot], { stdio: 'ignore', shell: false });
 }
 
 function ensurePrivateDir(dirPath: string): void {
@@ -242,10 +239,12 @@ async function runMigrations(db: Database, dbDir: string) {
   try {
     log('INFO', 'Running SQLite migrations');
     await db.exec(`
+      BEGIN;
       CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY);
       INSERT OR IGNORE INTO schema_migrations (version) VALUES (1);
       CREATE TABLE IF NOT EXISTS operational_state (id TEXT PRIMARY KEY, value TEXT);
       CREATE TABLE IF NOT EXISTS decisions (id INTEGER PRIMARY KEY AUTOINCREMENT, context TEXT, decision TEXT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP);
+      COMMIT;
     `);
 
     // Migration 2: FTS5 index over decisions for BM25 keyword search.

--- a/scripts/lib/state-store/migrations.js
+++ b/scripts/lib/state-store/migrations.js
@@ -263,7 +263,6 @@ function applyMigrations(db) {
       if (appliedVersions.has(migration.version)) {
         continue;
       }
-
       db.exec(migration.sql);
       insertMigration.run({
         version: migration.version,


### PR DESCRIPTION
…5, BUG-06, REL-02)

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Windows folder hiding to a safer call and makes the initial SQLite schema creation atomic to improve reliability on startup. Addresses BUG-05/BUG-06 (Windows hidden folder reliability) and REL-02 (stable boot).

- **Bug Fixes**
  - Use `spawnSync` with an explicit `System32\\attrib.exe` path and `shell: false` in `mcp/servers/egc-guardian` and `mcp/servers/egc-memory` to avoid PATH/shell quoting issues when hiding `.egc` on Windows.
  - Wrap initial schema creation in a single transaction (`BEGIN`/`COMMIT`) in `egc-memory` migrations to prevent partial schemas on first run.

<sup>Written for commit 9d1ce788535ca5bbc2989620059986ce1fcdc6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

