### PR TITLE
fix(core): hook dispatch, stdin timeouts, and MCP db crashes (BUG-07,…

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -1292,6 +1292,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (error instanceof z.ZodError) {
       throw new McpError(ErrorCode.InvalidParams, `Invalid arguments: ${error.message}`);
     }
+    if (error instanceof Error && error.message.includes('SQLITE_FULL')) {
+      log('ERROR', 'Tool execution failed', { tool: request.params.name, error: String(error) });
+      throw new McpError(ErrorCode.InternalError, `Database disk image is full: ${error.message}`);
+    }
     log('ERROR', 'Tool execution failed', { tool: request.params.name, error: String(error) });
     throw error;
   }

--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -151,6 +151,7 @@ function runHooks(rawInput, hooks) {
     } catch (error) {
       trace('hook:dispatch:error', { id: hook.id, error: error.message });
       stderr += `[Hook] ${hook.id} failed: ${error.message}\n`;
+      return { output: currentRaw, stderr, exitCode: 1 };
     }
   }
 

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -387,8 +387,9 @@ async function readStdinJson(options = {}) {
         settled = true;
         process.stdin.removeAllListeners('data');
         process.stdin.removeAllListeners('end');
-        process.stdin.removeAllListeners('error');
         if (process.stdin.unref) process.stdin.unref();
+        if (process.stdin.destroy) process.stdin.destroy();
+        process.stdin.removeAllListeners('error');
         // Resolve with whatever we have so far rather than hanging
         try {
           resolve(data.trim() ? JSON.parse(data) : {});


### PR DESCRIPTION
… REL-04, REL-05)

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hook dispatch failures, stdin timeout hangs, and MCP DB crash handling to improve reliability and clearer errors. Addresses BUG-07, REL-04, and REL-05.

- **Bug Fixes**
  - Hook dispatcher stops on the first hook error and returns exitCode 1; preserves current output and writes the error to stderr (BUG-07).
  - `readStdinJson` destroys stdin on timeout to prevent lingering processes and hangs (REL-04).
  - `mcp/servers/egc-memory` surfaces SQLITE_FULL as an InternalError with a clear “Database disk image is full” message instead of crashing (REL-05).

<sup>Written for commit 4992c8a1ad0cfd3993bf1f7b78db93c19959c704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

