### PR TITLE
sec(guardian): add path validation and limits (SEC-04, SEC-05, SEC-06…

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -343,8 +343,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "orchestrate_task": {
         const prompt = request.params.arguments?.prompt as string;
-        const agents: string[] = (request.params.arguments?.agents ?? []) as string[];
-        const skills: string[] = (request.params.arguments?.skills ?? []) as string[];
         const files: string[] = (request.params.arguments?.filepaths ?? []) as string[];
 
         // Read any provided file payloads

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -13,8 +13,8 @@ function hideEgcRootOnWindows(): void {
   const egcRoot = path.join(os.homedir(), '.egc');
   try {
     execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
-  } catch (_) {
-    // non-critical: folder works even if attribute fails
+  } catch (error) {
+    console.error('non-critical: folder works even if attribute fails', error);
   }
 }
 import { z } from 'zod';

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -106,7 +106,9 @@ class PersistentLogger {
         // file might not exist
       }
       await fs.promises.appendFile(this.logPath, payload + '\n', 'utf-8');
-    } catch(e) {}
+    } catch (e) {
+      console.error('[EGC guardian] Log write failed (disk full?):', String(e));
+    }
   }
 }
 

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -267,6 +267,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'protected path' });
                continue;
              }
+             const stats = fs.statSync(realResolved);
+             if (!stats.isFile()) {
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'not a regular file' });
+               continue;
+             }
+             if (stats.size > 10 * 1024 * 1024) { // 10MB per file max
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'exceeds per-file 10MB limit' });
+               continue;
+             }
+             if (totalBytesLoaded + stats.size > 50 * 1024 * 1024) { // 50MB aggregate max
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'exceeds aggregate 50MB limit' });
+               continue;
+             }
              const content = await fs.promises.readFile(realResolved, 'utf-8');
              // Split context into chunks/paragraphs to allow granular pruning
              const chunks = content.split('\n\n').filter(c => c.trim().length > 0);
@@ -374,6 +387,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         if (!projectPath) {
           throw new McpError(ErrorCode.InvalidParams, 'project_path is required');
+        }
+        let realProjectPath: string;
+        try {
+          realProjectPath = fs.realpathSync(path.resolve(projectPath));
+        } catch {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path resolution failed');
+        }
+        if (isProtectedPath(realProjectPath)) {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path must not be a protected path');
         }
 
         const result = await autoLearn({ project_path: projectPath, target_file: targetFile, limit });

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -31,6 +31,7 @@ export function buildDeniedPaths(): string[] {
     path.join(home, '.cursor'),
     path.join(home, '.claude'),
     path.join(home, '.gemini'),
+    path.join(home, '.egc'), // MCP internal data dir — protected from user/LLM access
     '/etc',
   ];
 

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -74,8 +74,8 @@ function hideEgcRootOnWindows(): void {
   const egcRoot = path.join(os.homedir(), '.egc');
   try {
     execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
-  } catch (_) {
-    // non-critical: folder works even if attribute fails
+  } catch (error) {
+    console.error('non-critical: folder works even if attribute fails', error);
   }
 }
 

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -101,7 +101,7 @@ for (const testFile of testFiles) {
   if (result.status !== 0) {
     console.log(`✗ ${displayPath} exited with status ${result.status}`);
     if (!combined.trim()) {
-      console.log(`  ⚠ Script crashed with no output. Counted as 1 unknown failure.`);
+      console.log(`  [!] Script crashed with no output. Counted as 1 unknown failure.`);
     }
     totalFailed += failedMatch ? 0 : 1;
   }

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -100,6 +100,9 @@ for (const testFile of testFiles) {
 
   if (result.status !== 0) {
     console.log(`✗ ${displayPath} exited with status ${result.status}`);
+    if (!combined.trim()) {
+      console.log(`  ⚠ Script crashed with no output. Counted as 1 unknown failure.`);
+    }
     totalFailed += failedMatch ? 0 : 1;
   }
 }


### PR DESCRIPTION
…, REL-06)

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict path validation, non-regular file rejection, and 10MB/50MB size caps in `egc-guardian` to block sensitive or oversized loads. Hardens auto-learn input validation and updates test runner output for CI.

- **New Features**
  - Reject non-regular files; enforce 10MB per-file and 50MB aggregate caps (SEC-05, SEC-06).
  - Resolve and validate auto-learn `project_path`; block protected paths incl. `~/.egc` (SEC-04).

- **Bug Fixes**
  - Handle log write failures in `PersistentLogger`; remove unused variables in `orchestrate_task` to satisfy SonarQube.
  - In `tests/run-all.js`, count crash-without-output as one unknown failure and remove unicode emoji to satisfy CI checks (REL-06).
  - Log errors when hiding `~/.egc` on Windows instead of swallowing exceptions in `egc-guardian` and `egc-memory`.

<sup>Written for commit b7292b05787116c2d0e1a5364c0282fa6d1426c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Protected sensitive project locations, including the application’s configuration directory, from unauthorized access.
  * Added safeguards to skip non-file entries and prevent individual files over 10 MB or total context loads over 50 MB.
  * Improved validation and error reporting for invalid or protected project paths.

* **Bug Fixes**
  * Test runs now clearly report when a script crashes without producing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->