### PR TITLE
sec(guardian): enforce schema validation and fix silent catches (SEC-…

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -102,11 +102,13 @@ class PersistentLogger {
         if (stats.size > this.maxSizeBytes) {
            await fs.promises.rename(this.logPath, `${this.logPath}.${Date.now()}.bak`);
         }
-      } catch (e) {
+      } catch (_e) {
         // file might not exist
       }
       await fs.promises.appendFile(this.logPath, payload + '\n', 'utf-8');
-    } catch(e) {}
+    } catch(err) {
+      console.error('[EGC Guardian] PersistentLogger failed to write:', err);
+    }
   }
 }
 
@@ -140,8 +142,6 @@ const ReduceContextSchema = z.object({
 const OrchestrateTaskSchema = z.object({
   prompt: z.string(),
   filepaths: z.array(z.string()).optional().default([]),
-  agents: z.array(z.string()).optional().default([]),
-  skills: z.array(z.string()).optional().default([]),
   heuristic_sandbox_id: z.string().optional()
 });
 
@@ -169,9 +169,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: {
              prompt: { type: "string" },
-             filepaths: { type: "array", items: { type: "string" } },
-             agents: { type: "array", items: { type: "string" } },
-             skills: { type: "array", items: { type: "string" } }
+             filepaths: { type: "array", items: { type: "string" } }
           },
           required: ["prompt"]
         }
@@ -327,10 +325,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "orchestrate_task": {
-        const prompt = request.params.arguments?.prompt as string;
-        const agents: string[] = (request.params.arguments?.agents ?? []) as string[];
-        const skills: string[] = (request.params.arguments?.skills ?? []) as string[];
-        const files: string[] = (request.params.arguments?.filepaths ?? []) as string[];
+        const parsed = OrchestrateTaskSchema.parse(request.params.arguments);
+        const prompt = parsed.prompt;
+        const files: string[] = parsed.filepaths ?? [];
 
         // Read any provided file payloads
         const rawPayloads: string[] = [];
@@ -339,7 +336,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const abs = path.resolve(filePath);
             const realAbs = fs.realpathSync(abs);
             if (!isProtectedPath(realAbs)) rawPayloads.push(fs.readFileSync(realAbs, 'utf8'));
-          } catch {}
+          } catch (err) {
+            console.error(`[EGC guardian] Failed to read file ${filePath}:`, err);
+          }
         }
 
         const pipeline = runCompressionPipeline(rawPayloads);


### PR DESCRIPTION
…03, REL-03, L-01, L-02)

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces schema validation for `orchestrate_task` and replaces silent catches with error logging in the guardian server. Aligns with SEC-03, REL-03, L-01, and L-02.

- **Bug Fixes**
  - Validate and parse `orchestrate_task` with `OrchestrateTaskSchema`; accept `prompt` and optional `filepaths` (default `[]`), removing `agents` and `skills` from both handler and tool schema.
  - Log errors in `PersistentLogger` writes and when reading provided files; missing log file during rotation remains safely ignored.

<sup>Written for commit 3f6721f74efc84212133b3dc1ff7d9bd5a14f402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

