### PR TITLE
sec(hooks): prevent shell injection by using spawnSync (SEC-02)

### DIFF
--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -136,7 +136,7 @@ function runMain() {
 }
 
 function getSessionMetadata() {
-  const branchResult = runCommand('git rev-parse --abbrev-ref HEAD');
+  const branchResult = runCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
 
   return {
     project: getProjectName() || 'unknown',

--- a/scripts/lib/utils.d.ts
+++ b/scripts/lib/utils.d.ts
@@ -3,7 +3,7 @@
  * Works on Windows, macOS, and Linux.
  */
 
-import type { ExecSyncOptions } from 'child_process';
+import type { SpawnSyncOptions } from 'child_process';
 
 // Platform detection
 export const isWindows: boolean;
@@ -181,10 +181,11 @@ export interface CommandResult {
 
 /**
  * Run a shell command and return the output.
- * SECURITY: Only use with trusted, hardcoded commands.
+ * SECURITY: Only use with trusted, hardcoded programs.
  * Never pass user-controlled input directly.
+ * For user input, use spawnSync with argument arrays instead.
  */
-export function runCommand(cmd: string, options?: ExecSyncOptions): CommandResult;
+export function runCommand(program: string, args?: string[], options?: SpawnSyncOptions): CommandResult;
 
 /** Check if the current directory is inside a git repository */
 export function isGitRepo(): boolean;

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -226,7 +226,7 @@ function getTimeString() {
  * Get the git repository name
  */
 function getGitRepoName() {
-  const result = runCommand('git rev-parse --show-toplevel');
+  const result = runCommand('git', ['rev-parse', '--show-toplevel']);
   if (!result.success) return null;
   return path.basename(result.output);
 }
@@ -504,33 +504,38 @@ function commandExists(cmd) {
  * trusted, hardcoded commands. Never pass user-controlled input directly.
  * For user input, use spawnSync with argument arrays instead.
  *
- * @param {string} cmd - Command to execute (should be trusted/hardcoded)
- * @param {object} options - execSync options
+ * @param {string} program - The trusted program to execute (e.g. 'git', 'node')
+ * @param {string[]} args - Array of string arguments
+ * @param {object} options - spawnSync options
  */
-function runCommand(cmd, options = {}) {
+function runCommand(program, args = [], options = {}) {
   // Allowlist: only permit known-safe command prefixes
-  const allowedPrefixes = ['git ', 'node ', 'npx ', 'which ', 'where '];
-  if (!allowedPrefixes.some(prefix => cmd.startsWith(prefix))) {
-    return { success: false, output: 'runCommand blocked: unrecognized command prefix' };
+  const allowedPrograms = ['git', 'node', 'npx', 'which', 'where'];
+  if (!allowedPrograms.includes(program)) {
+    return { success: false, output: 'runCommand blocked: unrecognized program' };
   }
 
-  // Reject shell metacharacters. $() and backticks are evaluated inside
-  // double quotes, so block $ and ` anywhere in cmd. Other operators
-  // (;|&) are literal inside quotes, so only check unquoted portions.
-  const unquoted = cmd.replace(/"[^"]*"/g, '').replace(/'[^']*'/g, '');
-  if (/[;|&\n\r<>()]/.test(unquoted) || /[`$]/.test(cmd)) {
-    return { success: false, output: 'runCommand blocked: shell metacharacters not allowed' };
-  }
+  const isWindows = process.platform === 'win32';
 
   try {
-    const result = execSync(cmd, {
+    const result = spawnSync(program, args, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: isWindows && program === 'npx',
       ...options
     });
-    return { success: true, output: result.trim() };
+    
+    if (result.error) {
+      return { success: false, output: result.error.message };
+    }
+    
+    if (result.status !== 0) {
+      return { success: false, output: result.stderr || `Command failed with status ${result.status}` };
+    }
+
+    return { success: true, output: (result.stdout || '').trim() };
   } catch (err) {
-    return { success: false, output: err.stderr || err.message };
+    return { success: false, output: err.message };
   }
 }
 
@@ -538,7 +543,7 @@ function runCommand(cmd, options = {}) {
  * Check if current directory is a git repository
  */
 function isGitRepo() {
-  return runCommand('git rev-parse --git-dir').success;
+  return runCommand('git', ['rev-parse', '--git-dir']).success;
 }
 
 /**
@@ -550,7 +555,7 @@ function isGitRepo() {
 function getGitModifiedFiles(patterns = []) {
   if (!isGitRepo()) return [];
 
-  const result = runCommand('git diff --name-only HEAD');
+  const result = runCommand('git', ['diff', '--name-only', 'HEAD']);
   if (!result.success) return [];
 
   let files = result.output.split('\n').filter(Boolean);


### PR DESCRIPTION
## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents shell injection in hooks by replacing string-based command execution with `spawnSync` and argument arrays. Addresses SEC-02 by blocking shell interpretation and enforcing an allowlist.

- **Bug Fixes**
  - Switched `runCommand` to `spawnSync(program, args)` (no shell by default; shell enabled only for `npx` on Windows). Updated typings to `SpawnSyncOptions` and new signature.
  - Added allowlist for programs: `git`, `node`, `npx`, `which`, `where`.
  - Improved error handling: surface stderr and non-zero status failures.
  - Migrated git calls in `scripts/hooks/session-end.js` and `scripts/lib/utils.js` to the new API.

- **Migration**
  - Update any remaining `runCommand('some string')` calls to `runCommand('program', ['arg1', 'arg2'])`.

<sup>Written for commit c07bd36f68604881397aface98e1bd17f401f630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

