### PR TITLE
fix(mcp): prevent pathtraversal in resolveProjectPath (BUG-04)

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -388,10 +388,18 @@ function getStateDir(): string {
 }
 
 function resolveProjectPath(provided?: string): string {
-  const raw = provided || process.env.EGC_PROJECT || process.env.PWD || os.homedir();
-  if (provided && provided.split(/[/\\]/).some(s => s === '..')) {
-    throw new Error(`project_path must not contain path traversal sequences: ${provided}`);
+  if (provided) {
+    if (provided.indexOf('\0') !== -1) {
+      throw new Error(`project_path must not contain null bytes`);
+    }
+    let decoded = provided;
+    try { decoded = decodeURIComponent(provided); } catch (e) {}
+    const isBadSegment = (s: string) => s === '..' || /^[A-Za-z]:\.\.$/.test(s);
+    if (decoded.split(/[/\\]/).some(isBadSegment) || provided.split(/[/\\]/).some(isBadSegment)) {
+      throw new Error(`project_path must not contain path traversal sequences: ${provided}`);
+    }
   }
+  const raw = provided || process.env.EGC_PROJECT || process.env.PWD || os.homedir();
   return path.resolve(raw);
 }
 


### PR DESCRIPTION
## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents path traversal in `resolveProjectPath` by rejecting traversal segments like `..` and `C:..` (including URL-encoded) and null bytes to ensure safe path resolution. Addresses BUG-04.

- **Bug Fixes**
  - Reject `..` and Windows-style `C:..` segments in both raw and URL-decoded input.
  - Reject inputs containing null bytes.

<sup>Written for commit 6aa38615f2f7fe4bf091fb66cf0ec15b98934c28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

