### PR TITLE
perf(core): optimize recent sessions and async trace log (PERF-02, PE…

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -721,7 +721,9 @@ function trace(event, data = {}) {
     event,
     ...data
   });
-  fs.appendFileSync(forensicLog, payload + '\n', 'utf8');
+  fs.appendFile(forensicLog, payload + '\n', 'utf8', (err) => {
+    if (err) console.error('trace write failed:', err);
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
…RF-04)

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up listing recent sessions and make trace logging non-blocking to reduce stalls under load. Aligns with Linear PERF-02 and PERF-04.

- **Performance**
  - Recent sessions: run count and list in a single DB transaction for a consistent snapshot and lower overhead.
  - Trace log: switch from `fs.appendFileSync` to `fs.appendFile` to avoid blocking the event loop; log write failures to console; payload format unchanged.

<sup>Written for commit 4f01f35e45a46674a329fed4019c4a8a6ec55980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

