### PR TITLE
fix(utils): replace execSync with spawnSync in runCommand (SEC-02)

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -358,22 +358,36 @@ async function runMigrations(db: Database, dbDir: string) {
   }
 }
 
+let dbInitPromise: Promise<Database> | null = null;
+
 async function getDb(): Promise<Database> {
   if (dbInstance) return dbInstance;
-  const dbDir = path.join(os.homedir(), '.egc', 'memory');
-  ensurePrivateDir(dbDir);
-  hideEgcRootOnWindows();
-  
-  const dbPath = path.join(dbDir, 'state.db');
-  dbInstance = await open({ filename: dbPath, driver: sqlite3.Database });
-  
-  await dbInstance.exec('PRAGMA journal_mode = WAL;');
-  await dbInstance.exec('PRAGMA synchronous = NORMAL;');
-  await dbInstance.exec('PRAGMA foreign_keys = ON;');
-  await dbInstance.exec('PRAGMA busy_timeout = 5000;'); // Native fallback
-  
-  await runMigrations(dbInstance, dbDir);
-  return dbInstance;
+  if (dbInitPromise) return dbInitPromise;
+
+  dbInitPromise = (async () => {
+    try {
+      const dbDir = path.join(os.homedir(), '.egc', 'memory');
+      ensurePrivateDir(dbDir);
+      hideEgcRootOnWindows();
+      
+      const dbPath = path.join(dbDir, 'state.db');
+      dbInstance = await open({ filename: dbPath, driver: sqlite3.Database });
+      
+      await dbInstance.exec('PRAGMA journal_mode = WAL;');
+      await dbInstance.exec('PRAGMA synchronous = NORMAL;');
+      await dbInstance.exec('PRAGMA foreign_keys = ON;');
+      await dbInstance.exec('PRAGMA busy_timeout = 5000;'); // Native fallback
+      
+      await runMigrations(dbInstance, dbDir);
+      return dbInstance;
+    } catch (error) {
+      dbInitPromise = null;
+      dbInstance = null;
+      throw error;
+    }
+  })();
+
+  return dbInitPromise;
 }
 
 const server = new Server({ name: "egc-memory-orchestrator", version: "3.0.0" }, { capabilities: { tools: {} } });

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -381,8 +381,11 @@ async function getDb(): Promise<Database> {
       await runMigrations(dbInstance, dbDir);
       return dbInstance;
     } catch (error) {
+      if (dbInstance) {
+        try { await dbInstance.close(); } catch { /* best-effort cleanup */ }
+        dbInstance = null;
+      }
       dbInitPromise = null;
-      dbInstance = null;
       throw error;
     }
   })();

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -522,15 +522,39 @@ function runCommand(cmd, options = {}) {
     return { success: false, output: 'runCommand blocked: shell metacharacters not allowed' };
   }
 
+  const argsRegex = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^']*)'|([^\s]+)/g;
+  const args = [];
+  let match;
+  while ((match = argsRegex.exec(cmd)) !== null) {
+    if (match[1] !== undefined) {
+      args.push(match[1].replace(/\\(.)/g, '$1'));
+    } else if (match[2] !== undefined) {
+      args.push(match[2]);
+    } else if (match[3] !== undefined) {
+      args.push(match[3]);
+    }
+  }
+  const [prog, ...progArgs] = args;
+
+  const isWindows = process.platform === 'win32';
+  const spawnOptions = { ...options };
+  // Ensure shell is explicitly false unless we're running npx on Windows, where the shim requires it
+  spawnOptions.shell = isWindows && prog === 'npx';
+  spawnOptions.encoding = spawnOptions.encoding || 'utf8';
+  spawnOptions.stdio = spawnOptions.stdio || ['pipe', 'pipe', 'pipe'];
+
   try {
-    const result = execSync(cmd, {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      ...options
-    });
-    return { success: true, output: result.trim() };
+    const { spawnSync } = require('child_process');
+    const result = spawnSync(prog, progArgs, spawnOptions);
+    if (result.error) {
+      return { success: false, output: result.error.message };
+    }
+    if (result.status !== 0) {
+      return { success: false, output: result.stderr || result.stdout || `Command failed with exit code ${result.status}` };
+    }
+    return { success: true, output: (result.stdout || '').trim() };
   } catch (err) {
-    return { success: false, output: err.stderr || err.message };
+    return { success: false, output: err.message };
   }
 }
 


### PR DESCRIPTION
Addresses SEC-02 from IaaS Audit v2. Replaces execSync with spawnSync to eliminate shell injection risk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace `execSync` with `spawnSync` in `runCommand` to remove shell injection risk (SEC-02). Harden `egc-memory` DB startup by making `getDb` a single-flight async singleton to prevent TOCTOU races (BUG-02).

- **Bug Fixes**
  - `scripts/lib/utils.js`: Use `spawnSync` without a shell; parse quoted args; default `encoding`/`stdio`; special-case Windows `npx`; improve error and non-zero exit handling.
  - `mcp/servers/egc-memory/src/index.ts`: Add `dbInitPromise` to serialize init; on failure close DB and reset state; prevents concurrent-start races.

<sup>Written for commit 2137bae2e543084712728cdfc2309a0fddbe67b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

