### PR TITLE
fix(mcp): add missing schema validation and limits to guardian

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -248,6 +248,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const rawPayloads: string[] = [];
         
         let totalBytesLoaded = 0;
+        const AGGREGATE_LIMIT = 50 * 1024 * 1024;
+        const PER_FILE_LIMIT = 10 * 1024 * 1024;
         for (const filepath of filepaths) {
            try {
              const resolved = path.resolve(filepath);
@@ -262,26 +264,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'protected path' });
                continue;
              }
-             
-             // SEC-05: Enforce byte-load limits
-             const stats = fs.statSync(realResolved);
-             const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-             const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50MB
-             
-             if (stats.size > MAX_FILE_SIZE) {
-               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `file exceeds 10MB limit (${stats.size} bytes)` });
-               continue;
+           try {
+             let fileHandle;
+             try {
+               fileHandle = await fs.promises.open(realResolved, 'r');
+               const stat = await fileHandle.stat();
+               const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+               const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50MB
+               
+               if (stat.size > MAX_FILE_SIZE) {
+                 auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `file exceeds 10MB limit (${stat.size} bytes)` });
+                 continue;
+               }
+               if (totalBytesLoaded + stat.size > MAX_TOTAL_SIZE) {
+                 auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `aggregate size exceeds 50MB limit` });
+                 continue;
+               }
+               const content = await fileHandle.readFile('utf-8');
+               // Split context into chunks/paragraphs to allow granular pruning
+               const chunks = content.split('\n\n').filter(c => c.trim().length > 0);
+               rawPayloads.push(...chunks);
+               totalBytesLoaded += Buffer.byteLength(content, 'utf8');
+             } finally {
+               if (fileHandle) {
+                 await fileHandle.close();
+               }
              }
-             if (totalBytesLoaded + stats.size > MAX_TOTAL_SIZE) {
-               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `aggregate size exceeds 50MB limit` });
-               continue;
-             }
-
-             const content = await fs.promises.readFile(realResolved, 'utf-8');
-             // Split context into chunks/paragraphs to allow granular pruning
-             const chunks = content.split('\n\n').filter(c => c.trim().length > 0);
-             rawPayloads.push(...chunks);
-             totalBytesLoaded += Buffer.byteLength(content, 'utf8');
            } catch(e: unknown) {
              const reason = e instanceof Error ? e.message : String(e);
              auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason });
@@ -337,9 +345,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "orchestrate_task": {
-        const parsed = OrchestrateTaskSchema.parse(request.params.arguments);
-        const prompt = parsed.prompt;
-        const files: string[] = parsed.filepaths ?? [];
+        const parsedArgs = OrchestrateTaskSchema.parse(request.params.arguments);
+        const prompt = parsedArgs.prompt;
+        const agents = parsedArgs.agents;
+        const skills = parsedArgs.skills;
+        const files: string[] = parsedArgs.filepaths ?? [];
 
         // Read any provided file payloads
         const rawPayloads: string[] = [];
@@ -348,8 +358,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const abs = path.resolve(filePath);
             const realAbs = fs.realpathSync(abs);
             if (!isProtectedPath(realAbs)) rawPayloads.push(fs.readFileSync(realAbs, 'utf8'));
-          } catch (err) {
-            console.error(`[EGC guardian] Failed to read file ${filePath}:`, err);
+          } catch (e: unknown) {
+            const reason = e instanceof Error ? e.message : String(e);
+            console.warn(`[EGC guardian] Failed to read file ${filePath}: ${reason}`);
           }
         }
 
@@ -385,6 +396,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         if (!projectPath) {
           throw new McpError(ErrorCode.InvalidParams, 'project_path is required');
+        }
+
+        let realProjectAbs;
+        try {
+          realProjectAbs = fs.realpathSync(path.resolve(projectPath));
+        } catch {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path resolution failed');
+        }
+
+        if (isProtectedPath(realProjectAbs)) {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path is protected');
         }
 
         const result = await autoLearn({ project_path: projectPath, target_file: targetFile, limit });

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -523,15 +523,37 @@ function runCommand(cmd, options = {}) {
     return { success: false, output: 'runCommand blocked: shell metacharacters not allowed' };
   }
 
+  const argsRegex = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([^\s]+)/g;
+  const args = [];
+  let match;
+  while ((match = argsRegex.exec(cmd)) !== null) {
+    if (match[1] !== undefined) {
+      args.push(match[1].replace(/\\(.)/g, '$1'));
+    } else if (match[2] !== undefined) {
+      args.push(match[2].replace(/\\(.)/g, '$1'));
+    } else if (match[3] !== undefined) {
+      args.push(match[3]);
+    }
+  }
+  const [prog, ...progArgs] = args;
+
   try {
-    const result = execSync(cmd, {
+    const { spawnSync } = require('child_process');
+    const result = spawnSync(prog, progArgs, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: false,
       ...options
     });
-    return { success: true, output: result.trim() };
+    if (result.error) {
+      return { success: false, output: result.error.message };
+    }
+    if (result.status !== 0) {
+      return { success: false, output: result.stderr || result.stdout || `Command failed with exit code ${result.status}` };
+    }
+    return { success: true, output: (result.stdout || '').trim() };
   } catch (err) {
-    return { success: false, output: err.stderr || err.message };
+    return { success: false, output: err.message };
   }
 }
 

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -528,7 +528,7 @@ function runCommand(cmd, options = {}) {
   let match;
   while ((match = argsRegex.exec(cmd)) !== null) {
     if (match[1] !== undefined) {
-      args.push(match[1].replace(/\\(.)/g, '$1'));
+      args.push(match[1].replace(/\\(["\\])/g, '$1'));
     } else if (match[2] !== undefined) {
       args.push(match[2].replace(/\\(.)/g, '$1'));
     } else if (match[3] !== undefined) {


### PR DESCRIPTION
Addresses SEC-03, SEC-04, SEC-05 from IaaS Audit v2: adds Zod schema validation to orchestrate_task, limits to reduce_context, and path validation to auto_learn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Security hardening across `egc-guardian`, `egc-memory`, and utils to address IaaS Audit v2 findings. Adds strict input validation and file size limits, safer command execution, and a race-safe DB init (SEC-03/04/05, SEC-02, BUG-02).

- **Bug Fixes**
  - `egc-guardian`: Zod-validate `orchestrate_task` (incl. `agents`/`skills`); enforce 10MB per-file and 50MB total limits with pre-open/stat checks and audit logs; resolve and validate `project_path` to block protected paths; warn on file read failures.
  - Utils: Replace `execSync` with `spawnSync` (shell: false) with robust quoted-arg parsing; treat non-zero exits and spawn errors as failures.
  - `egc-memory`: Make `getDb()` a race-safe singleton via an init promise; reset state on failure to avoid TOCTOU.

<sup>Written for commit 1b6215728e53e9cbb3b7488173da4672bd8f871d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file inputs by enforcing size limits more reliably and returning clearer warnings when a file can’t be read.
  * Strengthened path validation so invalid or restricted locations are rejected earlier with clearer errors.
  * Made command execution more consistent, with clearer success output and better error messages when commands fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->