### PR TITLE
fix(core): path traversal, stdin leak, and db persist

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -427,10 +427,8 @@ function resolveProjectPath(provided?: string): string {
     throw new Error(`project_path must not contain path traversal sequences: ${provided}`);
   }
   let resolved = path.resolve(raw);
-  try {
+  if (fs.existsSync(resolved)) {
     resolved = fs.realpathSync(resolved);
-  } catch (_e) {
-    // path does not exist yet -- fallback to path.resolve() result
   }
   if (isProtectedPath(resolved)) {
     throw new Error(`project_path is protected and cannot be used: ${resolved}`);

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -404,12 +404,38 @@ function getStateDir(): string {
   return dir;
 }
 
+function isProtectedPath(p: string): boolean {
+  const home = os.homedir();
+  const denied = [
+    path.join(home, '.ssh'),
+    path.join(home, '.aws'),
+    path.join(home, '.config'),
+    path.join(home, '.cursor'),
+    path.join(home, '.claude'),
+    path.join(home, '.gemini')
+  ];
+  const normalizedP = path.resolve(p);
+  for (const d of denied) {
+    if (normalizedP === d || normalizedP.startsWith(d + path.sep)) return true;
+  }
+  return false;
+}
+
 function resolveProjectPath(provided?: string): string {
   const raw = provided || process.env.EGC_PROJECT || process.env.PWD || os.homedir();
   if (provided && provided.split(/[/\\]/).some(s => s === '..')) {
     throw new Error(`project_path must not contain path traversal sequences: ${provided}`);
   }
-  return path.resolve(raw);
+  let resolved = path.resolve(raw);
+  try {
+    resolved = fs.realpathSync(resolved);
+  } catch (_e) {
+    // path does not exist yet -- fallback to path.resolve() result
+  }
+  if (isProtectedPath(resolved)) {
+    throw new Error(`project_path is protected and cannot be used: ${resolved}`);
+  }
+  return resolved;
 }
 
 const H2_RE = /^## (.+)/;

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -1335,11 +1335,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (error instanceof z.ZodError) {
       throw new McpError(ErrorCode.InvalidParams, `Invalid arguments: ${error.message}`);
     }
+    log('ERROR', 'Tool execution failed', { tool: request.params.name, error: String(error) });
     if (error instanceof Error && error.message.includes('SQLITE_FULL')) {
-      log('ERROR', 'Tool execution failed', { tool: request.params.name, error: String(error) });
       throw new McpError(ErrorCode.InternalError, `Database disk image is full: ${error.message}`);
     }
-    log('ERROR', 'Tool execution failed', { tool: request.params.name, error: String(error) });
     throw error;
   }
 });


### PR DESCRIPTION
Addresses BUG-04, REL-01, REL-04 from IaaS v2 audit. Adds isProtectedPath to egc-memory, destroys stdin on utils timeout, wraps db-adapter _persist in try/catch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened project path resolution, fixed a stdin timeout leak, improved DB persist error reporting, and cleaned up logging to remove SonarCloud code smells. Addresses BUG-04, REL-01, and REL-04 from the IaaS v2 audit.

- **Bug Fixes**
  - In `egc-memory` project path: guard `realpathSync` with `fs.existsSync` (no empty catch), resolve symlinks when present, block `..`, and deny protected home dirs (`.ssh`, `.aws`, `.config`, `.cursor`, `.claude`, `.gemini`). (BUG-04)
  - Destroy `stdin` on read timeout; deduplicate tool handler error logging to fix a SonarCloud code smell. (REL-01)
  - Wrap DB adapter `_persist` in try/catch to log a clear error and rethrow. (REL-04)

<sup>Written for commit 4ab15071766c9471837aa380ef0edaaeb363473d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

