### PR TITLE
fix(docs): add doctor check and comments for divergent state databases (BUG-08)

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -358,6 +358,11 @@ async function runMigrations(db: Database, dbDir: string) {
   }
 }
 
+// Note (BUG-08): The MCP memory server uses `~/.egc/memory/state.db` whereas
+// the standard harness state-store logic (resolveStateStoreDbPath) uses
+// `~/.egc/egc/state.db`. This is a known architectural divergence where
+// CLI/harness telemetry and MCP memory state are stored in separate SQLite DBs.
+// A doctor check in scripts/doctor.js warns when these databases diverge.
 async function getDb(): Promise<Database> {
   if (dbInstance) return dbInstance;
   const dbDir = path.join(os.homedir(), '.egc', 'memory');

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -84,9 +84,19 @@ function printHuman(report) {
 }
 
 function checkStateDb() {
-  const dbPath = path.join(getEGCDir(), 'egc', 'state.db');
-  if (fs.existsSync(dbPath)) return null;
-  return { missing: true, dbPath };
+  const rootDir = getEGCDir();
+  const dbPath = path.join(rootDir, 'egc', 'state.db');
+  const memoryDbPath = path.join(rootDir, 'memory', 'state.db');
+  
+  const hasHarnessDb = fs.existsSync(dbPath);
+  const hasMemoryDb = fs.existsSync(memoryDbPath);
+  
+  if (hasHarnessDb && hasMemoryDb) {
+    return { divergent: true, dbPath, memoryDbPath };
+  } else if (!hasHarnessDb && !hasMemoryDb) {
+    return { missing: true, dbPath };
+  }
+  return null;
 }
 
 function main() {
@@ -112,8 +122,15 @@ function main() {
       printHuman(report);
       if (stateDb) {
         console.log('\nState store:');
-        console.log('  WARNING: state.db not found at ' + stateDb.dbPath);
-        console.log('  Run: egc init  to create the state store');
+        if (stateDb.divergent) {
+          console.log('  WARNING: Divergent database architecture detected!');
+          console.log(`  Harness DB: ${stateDb.dbPath}`);
+          console.log(`  Memory DB:  ${stateDb.memoryDbPath}`);
+          console.log('  (This is a known architectural limitation where the MCP memory server and harnesses log to separate databases)');
+        } else if (stateDb.missing) {
+          console.log('  WARNING: state.db not found at ' + stateDb.dbPath);
+          console.log('  Run: egc init  to create the state store');
+        }
       }
     }
 


### PR DESCRIPTION
Fixes BUG-08 by adding documentation and a doctor warning about the divergent database architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `doctor` check that warns when the harness and MCP memory databases diverge, and document the known dual-DB architecture. Addresses BUG-08 by making this behavior visible to users.

- **Bug Fixes**
  - `scripts/doctor.js`: Detects `~/.egc/egc/state.db` and `~/.egc/memory/state.db`; warns if both exist (divergent) or both are missing; keeps the init hint for missing.
  - `mcp/servers/egc-memory/src/index.ts`: Adds comments explaining that the MCP memory server uses `~/.egc/memory/state.db` while harnesses use `~/.egc/egc/state.db`, and references the new doctor check.

<sup>Written for commit b008f11a867468ac63b5f2293501342ffdf46ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

