### PR TITLE
fix(core): prevent crash on JSON parse failure in queries (BUG-01)

### DIFF
--- a/scripts/lib/state-store/queries.js
+++ b/scripts/lib/state-store/queries.js
@@ -24,7 +24,12 @@ function parseJsonColumn(value, fallback) {
     return fallback;
   }
 
-  return JSON.parse(value);
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    console.warn(`[StateStore] Failed to parse JSON column: ${e.message}`);
+    return fallback;
+  }
 }
 
 function stringifyJson(value, label) {


### PR DESCRIPTION
Fixes BUG-01 by adding a try/catch to parseJsonColumn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when reading JSON columns in state-store queries by catching parse errors. On failure, we log a warning and return the fallback instead of throwing, addressing BUG-01.

<sup>Written for commit d06cc38fe2f1672b68e3e019c0c9f8d3eb345ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

