### PR TITLE
fix(state-store): add error handling to _persist (REL-01)

### DIFF
--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -131,9 +131,14 @@ class SqlJsDatabase {
 
   _persist() {
     if (this._path === ':memory:') return;
-    const data = this._db.export();
-    fs.mkdirSync(path.dirname(this._path), { recursive: true });
-    fs.writeFileSync(this._path, Buffer.from(data));
+    try {
+      const data = this._db.export();
+      fs.mkdirSync(path.dirname(this._path), { recursive: true });
+      fs.writeFileSync(this._path, Buffer.from(data));
+    } catch (e) {
+      console.error(`[StateStoreDbAdapter] Failed to persist state to ${this._path}: ${e.message}`);
+      throw e;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes REL-01 by wrapping fs operations in _persist with a try/catch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add error handling to `SqlJsDatabase._persist` to log clear errors when exporting, creating the directory, or writing the DB file fails. On failure, it logs `[StateStoreDbAdapter] Failed to persist state to <path>: <message>` and rethrows to surface the issue (REL-01).

<sup>Written for commit 216bceaafa45eed2b68dfb43e3c8d84776a0f2d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

