### PR TITLE
fix(guardian): add byte-load limits to reduce_context (SEC-05)

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -267,6 +267,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'protected path' });
                continue;
              }
+             
+             // SEC-05: Enforce byte-load limits
+             const stats = fs.statSync(realResolved);
+             const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+             const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50MB
+             
+             if (stats.size > MAX_FILE_SIZE) {
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `file exceeds 10MB limit (${stats.size} bytes)` });
+               continue;
+             }
+             if (totalBytesLoaded + stats.size > MAX_TOTAL_SIZE) {
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `aggregate size exceeds 50MB limit` });
+               continue;
+             }
+
              const content = await fs.promises.readFile(realResolved, 'utf-8');
              // Split context into chunks/paragraphs to allow granular pruning
              const chunks = content.split('\n\n').filter(c => c.trim().length > 0);


### PR DESCRIPTION
Fixes SEC-05 by adding a 10MB per-file max and 50MB aggregate limit to the reduce_context MCP tool.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements byte-load limits in the `reduce_context` MCP tool to address SEC-05 and prevent oversized context loads. Enforces 10MB per file and 50MB total per request, with audit denials when limits are hit.

- **Bug Fixes**
  - Enforce 10MB per-file and 50MB aggregate limits using `fs.statSync` before reading.
  - Log `CONTEXT_LOAD` denials with clear reasons and skip violating files.

<sup>Written for commit bbc33ed0b34302248c6b24b4d59227ebbb6c4884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

