### PR TITLE
fix(init): reapply manifest install when doctor reports resolution drift

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -156,6 +156,39 @@ function runStateDbBootstrap() {
   if (output) console.log('  ' + output.split('\n').join('\n  '));
 }
 
+/**
+ * Recorded-content repair restores files but never rewrites the recorded
+ * module resolution, so a resolution-drift finding survives `egc repair`
+ * forever. Reapply the manifest install for the affected targets instead.
+ */
+function reconcileResolutionDrift() {
+  let plans;
+  try {
+    const { buildDoctorReport } = require('./lib/install-lifecycle');
+    const { planDriftReinstalls } = require('./lib/init-remediation');
+    plans = planDriftReinstalls(buildDoctorReport({ repoRoot: ROOT_DIR }));
+  } catch (error) {
+    warn('drift reconciliation skipped', error.message);
+    return;
+  }
+
+  const applyScript = path.join(ROOT_DIR, 'scripts', 'install-apply.js');
+  for (const plan of plans) {
+    log(`\n  reapplying manifest install for ${plan.adapterId} (resolution drift)...`);
+    const result = spawnSync(
+      process.execPath,
+      [applyScript, ...plan.args, '--json'],
+      { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' }
+    );
+    if (result.status === 0) {
+      ok(plan.adapterId, 'reinstalled from current manifests');
+    } else {
+      const stderrText = (result.stderr || '').trim();
+      warn(plan.adapterId, stderrText.split('\n').pop() || 'install-apply failed');
+    }
+  }
+}
+
 function runDoctor() {
   const doctorScript = path.join(ROOT_DIR, 'scripts', 'doctor.js');
   log(`\n${c.dim}  running egc doctor for final validation...${c.reset}`);
@@ -164,10 +197,20 @@ function runDoctor() {
     return;
   }
   const doctorResult = spawnSync(process.execPath, [doctorScript], { stdio: 'inherit' });
-  if (doctorResult.status !== 0) {
-    const repairScript = path.join(ROOT_DIR, 'scripts', 'repair.js');
-    log(`\n  auto-repairing drift detected by doctor...`);
-    spawnSync(process.execPath, [repairScript], { stdio: 'inherit' });
+  if (doctorResult.status === 0) {
+    return;
+  }
+
+  reconcileResolutionDrift();
+
+  const repairScript = path.join(ROOT_DIR, 'scripts', 'repair.js');
+  log(`\n  auto-repairing drift detected by doctor...`);
+  spawnSync(process.execPath, [repairScript], { stdio: 'inherit' });
+
+  log(`\n${c.dim}  re-running egc doctor to confirm...${c.reset}`);
+  const verifyResult = spawnSync(process.execPath, [doctorScript], { stdio: 'inherit' });
+  if (verifyResult.status !== 0) {
+    warn('doctor still reports issues', 'run `egc doctor` for details');
   }
 }
 

--- a/scripts/lib/init-remediation.js
+++ b/scripts/lib/init-remediation.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const RESOLUTION_DRIFT_ISSUE_CODE = 'resolution-drift';
+
+/**
+ * Builds install-apply argv for every doctor result whose issues include
+ * resolution drift. Recorded-content repair restores files but never
+ * rewrites the recorded module resolution, so these targets need a fresh
+ * manifest apply built from the install request stored in install-state.
+ */
+function planDriftReinstalls(report) {
+  const results = Array.isArray(report?.results) ? report.results : [];
+  const plans = [];
+
+  for (const result of results) {
+    const request = result?.state?.request;
+    const target = result?.adapter?.target;
+    if (!request || !target || request.legacyMode) {
+      continue;
+    }
+
+    const issues = Array.isArray(result.issues) ? result.issues : [];
+    if (!issues.some(issue => issue.code === RESOLUTION_DRIFT_ISSUE_CODE)) {
+      continue;
+    }
+
+    const args = ['--target', target];
+    if (request.profile) {
+      args.push('--profile', request.profile);
+    } else if (Array.isArray(request.modules) && request.modules.length > 0) {
+      args.push('--modules', request.modules.join(','));
+    } else {
+      continue;
+    }
+
+    for (const componentId of request.includeComponents || []) {
+      args.push('--with', componentId);
+    }
+    for (const componentId of request.excludeComponents || []) {
+      args.push('--without', componentId);
+    }
+
+    plans.push({
+      adapterId: result.adapter.id,
+      target,
+      args,
+    });
+  }
+
+  return plans;
+}
+
+module.exports = {
+  planDriftReinstalls,
+};

--- a/tests/lib/init-remediation.test.js
+++ b/tests/lib/init-remediation.test.js
@@ -1,0 +1,107 @@
+/**
+ * Tests for scripts/lib/init-remediation.js
+ */
+
+const assert = require('assert');
+
+const { planDriftReinstalls } = require('../../scripts/lib/init-remediation');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function buildResult(overrides = {}) {
+  return {
+    adapter: { id: 'claude-home', target: 'claude', kind: 'home' },
+    state: {
+      request: {
+        profile: 'full',
+        modules: [],
+        includeComponents: [],
+        excludeComponents: [],
+        legacyMode: false,
+      },
+    },
+    issues: [{ severity: 'warning', code: 'resolution-drift', message: 'drift' }],
+    ...overrides,
+  };
+}
+
+function main() {
+  let passed = 0;
+  let failed = 0;
+
+  console.log('Testing init-remediation...\n');
+
+  if (test('plans a profile reinstall for a drifted non-legacy target', () => {
+    const plans = planDriftReinstalls({ results: [buildResult()] });
+    assert.strictEqual(plans.length, 1);
+    assert.strictEqual(plans[0].adapterId, 'claude-home');
+    assert.strictEqual(plans[0].target, 'claude');
+    assert.deepStrictEqual(plans[0].args, ['--target', 'claude', '--profile', 'full']);
+  })) passed++; else failed++;
+
+  if (test('plans a modules reinstall when no profile is recorded', () => {
+    const result = buildResult();
+    result.state.request.profile = null;
+    result.state.request.modules = ['hooks-runtime', 'database'];
+    const plans = planDriftReinstalls({ results: [result] });
+    assert.strictEqual(plans.length, 1);
+    assert.deepStrictEqual(
+      plans[0].args,
+      ['--target', 'claude', '--modules', 'hooks-runtime,database']
+    );
+  })) passed++; else failed++;
+
+  if (test('carries include and exclude components into the plan', () => {
+    const result = buildResult();
+    result.state.request.includeComponents = ['alpha'];
+    result.state.request.excludeComponents = ['beta'];
+    const plans = planDriftReinstalls({ results: [result] });
+    assert.deepStrictEqual(
+      plans[0].args,
+      ['--target', 'claude', '--profile', 'full', '--with', 'alpha', '--without', 'beta']
+    );
+  })) passed++; else failed++;
+
+  if (test('skips legacy states, healthy targets, and empty requests', () => {
+    const legacy = buildResult();
+    legacy.state.request.legacyMode = true;
+
+    const healthy = buildResult({ issues: [] });
+
+    const otherIssue = buildResult({
+      issues: [{ severity: 'warning', code: 'drifted-managed-files', message: 'files' }],
+    });
+
+    const emptyRequest = buildResult();
+    emptyRequest.state.request.profile = null;
+    emptyRequest.state.request.modules = [];
+
+    const missingState = buildResult({ state: null });
+
+    const plans = planDriftReinstalls({
+      results: [legacy, healthy, otherIssue, emptyRequest, missingState],
+    });
+    assert.strictEqual(plans.length, 0);
+  })) passed++; else failed++;
+
+  if (test('returns no plans for empty or malformed reports', () => {
+    assert.deepStrictEqual(planDriftReinstalls(null), []);
+    assert.deepStrictEqual(planDriftReinstalls({}), []);
+    assert.deepStrictEqual(planDriftReinstalls({ results: 'invalid' }), []);
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Problem

`egc init` runs doctor for final validation and, on failure, runs the repair pass. Recorded-content repair restores files but never rewrites the recorded module resolution, so a `resolution-drift` warning survives every repair pass. init then prints "Installation complete." without re-checking, and the next `egc doctor` shows the same warning again.

Reproduced on a claude-home install recorded before hooks-runtime targeted claude (#596 changed the resolution):

- Doctor: `claude-home WARNING resolution-drift`
- Auto-repair: `Repaired paths: 0`, install-state rewritten with the stale resolution
- Doctor again: same warning, forever

## Fix

- New `scripts/lib/init-remediation.js`: `planDriftReinstalls(report)` builds install-apply argv (`--target`, `--profile`/`--modules`, `--with`/`--without`) from the install request recorded in install-state, for every non-legacy doctor result carrying a `resolution-drift` issue.
- `scripts/init.js`: when final validation fails, reapply the manifest install for drifted targets before the repair pass, then re-run doctor and warn honestly if issues remain instead of claiming success.

Recorded-content repair semantics are unchanged; `egc repair` still restores from recorded state.

## Tests

- `tests/lib/init-remediation.test.js`: 5 new unit tests for the planner (profile args, module args, component passthrough, skip rules, malformed reports).
- Full suite: 2547 passed, 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a persistent `resolution-drift` warning after `egc init` by reapplying the manifest install for drifted targets, then running repair and re-checking with `egc doctor`. Prevents a false “Installation complete” when drift remains.

- **Bug Fixes**
  - Added `scripts/lib/init-remediation.js`: `planDriftReinstalls(report)` builds `install-apply` args from install-state for non-legacy targets with `resolution-drift`.
  - Updated `scripts/init.js` to reapply manifest installs on drift, run `egc repair`, then re-run doctor; warns if issues persist or if drift reconciliation is skipped.
  - Added unit tests for the planner in `tests/lib/init-remediation.test.js` (profiles/modules, component passthrough, skip rules, malformed reports).

<sup>Written for commit ba7e03dd442fb073cb6036d50ee3ca529eb8046a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `egc init` now automatically checks for resolution drift and tries to reconcile affected installs before continuing.
  * If drift reconciliation can’t be planned, it safely skips that step and proceeds with the usual repair flow.

* **Bug Fixes**
  * Improved post-init verification by re-checking diagnostics and warning if issues still remain after repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->