### PR TITLE
feat(cli): add egc overview aggregating per-project memory states

### DIFF
--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -65,6 +65,10 @@ const COMMANDS = {
     script: 'status.js',
     description: 'Query the EGC SQLite state store status summary',
   },
+  overview: {
+    script: 'overview.js',
+    description: 'Aggregated read-only view of every per-project memory state',
+  },
   sessions: {
     script: 'sessions-cli.js',
     description: 'List or inspect EGC sessions from the SQLite state store',
@@ -127,6 +131,7 @@ const PRIMARY_COMMANDS = [
   'repair',
   'auto-update',
   'status',
+  'overview',
   'sessions',
   'replay',
   'session-inspect',
@@ -178,6 +183,8 @@ Examples:
   egc repair --dry-run
   egc auto-update --dry-run
   egc status --json
+  egc overview
+  egc overview --json
   egc sessions
   egc sessions session-active --json
   egc session-inspect egc:latest

--- a/scripts/lib/state-overview.js
+++ b/scripts/lib/state-overview.js
@@ -1,0 +1,227 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { DEFAULT_BRANCH_FILE, getStateDir } = require('./branch-state');
+
+const HEADER_FIELD_REGEX = /^(project|branch|updated):\s*(.+)$/;
+const SECTION_HEADING_REGEX = /^##\s+(.+)$/;
+
+/**
+ * Parses one project-state Markdown file produced by the egc-memory
+ * server. Returns header fields plus section bodies keyed by heading.
+ */
+function parseStateFile(content) {
+  const lines = String(content).split(/\r?\n/);
+  const header = { project: null, branch: null, updated: null };
+  const sections = {};
+  let currentSection = null;
+
+  for (const line of lines) {
+    const headingMatch = line.match(SECTION_HEADING_REGEX);
+    if (headingMatch) {
+      currentSection = headingMatch[1].trim();
+      sections[currentSection] = [];
+      continue;
+    }
+
+    if (!currentSection) {
+      const fieldMatch = line.match(HEADER_FIELD_REGEX);
+      if (fieldMatch) {
+        header[fieldMatch[1]] = fieldMatch[2].trim();
+      }
+      continue;
+    }
+
+    sections[currentSection].push(line);
+  }
+
+  const sectionText = {};
+  for (const [name, body] of Object.entries(sections)) {
+    sectionText[name] = body.join('\n').trim();
+  }
+
+  return { header, sections: sectionText };
+}
+
+function extractBullets(sectionBody) {
+  if (!sectionBody) {
+    return [];
+  }
+
+  return sectionBody
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.startsWith('- '))
+    .map(line => line.slice(2).trim())
+    .filter(Boolean);
+}
+
+function firstParagraph(sectionBody) {
+  if (!sectionBody) {
+    return null;
+  }
+
+  const paragraph = sectionBody.split(/\n\s*\n/)[0].replace(/\s+/g, ' ').trim();
+  return paragraph || null;
+}
+
+function readStateEntry(filePath, slug, branchInfo) {
+  let stat;
+  let parsed;
+  try {
+    stat = fs.statSync(filePath);
+    parsed = parseStateFile(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    return {
+      slug,
+      filePath,
+      error: error.message,
+    };
+  }
+
+  return {
+    slug,
+    filePath,
+    project: parsed.header.project || slug,
+    branch: parsed.header.branch || branchInfo.branch || null,
+    updated: parsed.header.updated || stat.mtime.toISOString(),
+    modifiedAt: stat.mtime.toISOString(),
+    context: firstParagraph(parsed.sections.Context),
+    next: extractBullets(parsed.sections['Next Session']),
+    decisionCount: extractBullets(parsed.sections['Active Decisions']).length,
+    avoidCount: extractBullets(parsed.sections['Do Not Repeat']).length,
+    preferenceCount: extractBullets(parsed.sections.Preferences).length,
+    branchStateCount: branchInfo.branchStateCount,
+    layout: branchInfo.layout,
+    error: null,
+  };
+}
+
+function listMarkdownFiles(dirPath) {
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter(entry => entry.isFile() && entry.name.endsWith('.md'))
+    .map(entry => entry.name);
+}
+
+/**
+ * Picks the file that represents a branch-per-file project directory:
+ * main.md when present, otherwise the most recently modified branch file.
+ */
+function pickPrimaryBranchFile(dirPath, fileNames) {
+  if (fileNames.includes(DEFAULT_BRANCH_FILE)) {
+    return DEFAULT_BRANCH_FILE;
+  }
+
+  let newest = null;
+  let newestMtime = -1;
+  for (const name of fileNames) {
+    const mtime = fs.statSync(path.join(dirPath, name)).mtimeMs;
+    if (mtime > newestMtime) {
+      newestMtime = mtime;
+      newest = name;
+    }
+  }
+  return newest;
+}
+
+/**
+ * Collects every per-project state under the state root. Projects using
+ * the branch-per-file directory layout take precedence over a legacy
+ * flat file with the same slug, matching the read resolution order in
+ * branch-state.js.
+ */
+function collectProjectStates(options = {}) {
+  const stateDir = options.stateDir || getStateDir(options.homeDir);
+  if (!fs.existsSync(stateDir)) {
+    return { stateDir, entries: [] };
+  }
+
+  const dirents = fs.readdirSync(stateDir, { withFileTypes: true });
+  const directorySlugs = new Set(
+    dirents.filter(entry => entry.isDirectory()).map(entry => entry.name)
+  );
+  const entries = [];
+
+  for (const dirent of dirents) {
+    if (dirent.isDirectory()) {
+      const dirPath = path.join(stateDir, dirent.name);
+      const fileNames = listMarkdownFiles(dirPath);
+      if (fileNames.length === 0) {
+        continue;
+      }
+      const primary = pickPrimaryBranchFile(dirPath, fileNames);
+      entries.push(readStateEntry(path.join(dirPath, primary), dirent.name, {
+        branch: primary === DEFAULT_BRANCH_FILE ? 'main' : path.basename(primary, '.md'),
+        branchStateCount: fileNames.length,
+        layout: 'branch',
+      }));
+      continue;
+    }
+
+    if (!dirent.isFile() || !dirent.name.endsWith('.md')) {
+      continue;
+    }
+
+    const slug = path.basename(dirent.name, '.md');
+    if (directorySlugs.has(slug)) {
+      continue;
+    }
+
+    entries.push(readStateEntry(path.join(stateDir, dirent.name), slug, {
+      branch: null,
+      branchStateCount: 1,
+      layout: 'flat',
+    }));
+  }
+
+  entries.sort((a, b) => String(b.updated || '').localeCompare(String(a.updated || '')));
+
+  return { stateDir, entries };
+}
+
+function renderOverviewMarkdown(overview) {
+  const lines = [];
+  const readable = overview.entries.filter(entry => !entry.error);
+  const failed = overview.entries.filter(entry => entry.error);
+
+  lines.push('# EGC State Overview');
+  lines.push('');
+  lines.push(`State root: ${overview.stateDir}`);
+  lines.push(`Projects: ${readable.length}`);
+  lines.push('');
+
+  for (const entry of readable) {
+    lines.push(`## ${entry.project}`);
+    lines.push(`- Branch: ${entry.branch || 'n/a'} (${entry.branchStateCount} state file${entry.branchStateCount === 1 ? '' : 's'}, ${entry.layout} layout)`);
+    lines.push(`- Updated: ${entry.updated}`);
+    if (entry.context) {
+      lines.push(`- Context: ${entry.context}`);
+    }
+    lines.push(`- Memory: ${entry.decisionCount} decisions, ${entry.avoidCount} avoid rules, ${entry.preferenceCount} preferences`);
+    if (entry.next.length > 0) {
+      lines.push('- Next:');
+      for (const item of entry.next) {
+        lines.push(`  - ${item}`);
+      }
+    }
+    lines.push('');
+  }
+
+  if (failed.length > 0) {
+    lines.push('## Unreadable state files');
+    for (const entry of failed) {
+      lines.push(`- ${entry.filePath}: ${entry.error}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd() + '\n';
+}
+
+module.exports = {
+  collectProjectStates,
+  parseStateFile,
+  renderOverviewMarkdown,
+};

--- a/scripts/overview.js
+++ b/scripts/overview.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const {
+  collectProjectStates,
+  renderOverviewMarkdown,
+} = require('./lib/state-overview');
+
+function showHelp(exitCode = 0) {
+  console.log(`
+Usage: egc overview [--json] [--state-dir <path>]
+
+Aggregated read-only view of every per-project memory state under
+~/.egc/state. Projects write their own state; this command only reads.
+
+Options:
+  --state-dir <path>  Read states from an alternate root (default: ~/.egc/state)
+  --json              Emit the aggregated overview as JSON
+  --help, -h          Show this help
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const parsed = { json: false, stateDir: null, help: false };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--state-dir') {
+      parsed.stateDir = args[index + 1] || null;
+      index += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv);
+    if (options.help) {
+      showHelp(0);
+    }
+
+    const overview = collectProjectStates({ stateDir: options.stateDir });
+
+    if (options.json) {
+      console.log(JSON.stringify(overview, null, 2));
+    } else {
+      process.stdout.write(renderOverviewMarkdown(overview));
+    }
+
+    process.exitCode = overview.entries.some(entry => entry.error) ? 1 : 0;
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tests/lib/state-overview.test.js
+++ b/tests/lib/state-overview.test.js
@@ -1,0 +1,258 @@
+/**
+ * Tests for scripts/lib/state-overview.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  collectProjectStates,
+  parseStateFile,
+  renderOverviewMarkdown,
+} = require('../../scripts/lib/state-overview');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function stateDocument({ project, branch, updated, context, next }) {
+  return [
+    '# Project State',
+    `project: ${project}`,
+    `branch: ${branch}`,
+    `updated: ${updated}`,
+    '',
+    '## Context',
+    context,
+    '',
+    '## Active Decisions',
+    '- decided one: because',
+    '- decided two: because',
+    '',
+    '## Do Not Repeat',
+    '- avoid this: it failed',
+    '',
+    '## Preferences',
+    '- keep output in English',
+    '',
+    '## Next Session',
+    ...next.map(item => `- ${item}`),
+    '',
+  ].join('\n');
+}
+
+function main() {
+  let passed = 0;
+  let failed = 0;
+
+  console.log('Testing state-overview...\n');
+
+  if (test('parseStateFile extracts header fields and sections', () => {
+    const parsed = parseStateFile(stateDocument({
+      project: '/tmp/demo',
+      branch: 'main',
+      updated: '2026-07-07T00:00:00.000Z',
+      context: 'Demo project in phase one.',
+      next: ['ship the overview command'],
+    }));
+    assert.strictEqual(parsed.header.project, '/tmp/demo');
+    assert.strictEqual(parsed.header.branch, 'main');
+    assert.strictEqual(parsed.header.updated, '2026-07-07T00:00:00.000Z');
+    assert.strictEqual(parsed.sections.Context, 'Demo project in phase one.');
+    assert.ok(parsed.sections['Next Session'].includes('ship the overview command'));
+  })) passed++; else failed++;
+
+  if (test('collects branch-layout and flat-layout projects together', () => {
+    const stateDir = createTempDir('egc-overview-');
+    try {
+      fs.mkdirSync(path.join(stateDir, 'Projetos--alpha'));
+      fs.writeFileSync(
+        path.join(stateDir, 'Projetos--alpha', 'main.md'),
+        stateDocument({
+          project: '/home/user/Projetos/alpha',
+          branch: 'main',
+          updated: '2026-07-07T10:00:00.000Z',
+          context: 'Alpha context.',
+          next: ['alpha next step'],
+        })
+      );
+      fs.writeFileSync(
+        path.join(stateDir, 'Projetos--alpha', 'feat-x.md'),
+        stateDocument({
+          project: '/home/user/Projetos/alpha',
+          branch: 'feat-x',
+          updated: '2026-07-06T10:00:00.000Z',
+          context: 'Alpha feature branch context.',
+          next: [],
+        })
+      );
+      fs.writeFileSync(
+        path.join(stateDir, 'legacy-project.md'),
+        stateDocument({
+          project: '/home/user/legacy-project',
+          branch: 'main',
+          updated: '2026-07-05T10:00:00.000Z',
+          context: 'Legacy flat file context.',
+          next: ['migrate to branch layout'],
+        })
+      );
+      fs.writeFileSync(path.join(stateDir, 'notes.json'), '{}');
+
+      const overview = collectProjectStates({ stateDir });
+      assert.strictEqual(overview.entries.length, 2);
+
+      const alpha = overview.entries.find(entry => entry.slug === 'Projetos--alpha');
+      assert.ok(alpha);
+      assert.strictEqual(alpha.layout, 'branch');
+      assert.strictEqual(alpha.branch, 'main');
+      assert.strictEqual(alpha.branchStateCount, 2);
+      assert.strictEqual(alpha.context, 'Alpha context.');
+      assert.deepStrictEqual(alpha.next, ['alpha next step']);
+      assert.strictEqual(alpha.decisionCount, 2);
+      assert.strictEqual(alpha.avoidCount, 1);
+      assert.strictEqual(alpha.preferenceCount, 1);
+
+      const legacy = overview.entries.find(entry => entry.slug === 'legacy-project');
+      assert.ok(legacy);
+      assert.strictEqual(legacy.layout, 'flat');
+
+      assert.strictEqual(overview.entries[0].slug, 'Projetos--alpha');
+    } finally {
+      cleanup(stateDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('branch directory takes precedence over same-slug flat file', () => {
+    const stateDir = createTempDir('egc-overview-');
+    try {
+      fs.mkdirSync(path.join(stateDir, 'Projetos--beta'));
+      fs.writeFileSync(
+        path.join(stateDir, 'Projetos--beta', 'main.md'),
+        stateDocument({
+          project: '/home/user/Projetos/beta',
+          branch: 'main',
+          updated: '2026-07-07T10:00:00.000Z',
+          context: 'Beta branch layout.',
+          next: [],
+        })
+      );
+      fs.writeFileSync(
+        path.join(stateDir, 'Projetos--beta.md'),
+        stateDocument({
+          project: '/home/user/Projetos/beta',
+          branch: 'main',
+          updated: '2026-01-01T00:00:00.000Z',
+          context: 'Beta stale flat file.',
+          next: [],
+        })
+      );
+
+      const overview = collectProjectStates({ stateDir });
+      assert.strictEqual(overview.entries.length, 1);
+      assert.strictEqual(overview.entries[0].layout, 'branch');
+      assert.strictEqual(overview.entries[0].context, 'Beta branch layout.');
+    } finally {
+      cleanup(stateDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('falls back to newest branch file when main.md is absent', () => {
+    const stateDir = createTempDir('egc-overview-');
+    try {
+      const dirPath = path.join(stateDir, 'Projetos--gamma');
+      fs.mkdirSync(dirPath);
+      fs.writeFileSync(path.join(dirPath, 'feat-old.md'), stateDocument({
+        project: '/home/user/Projetos/gamma',
+        branch: 'feat-old',
+        updated: '2026-07-01T00:00:00.000Z',
+        context: 'Old branch.',
+        next: [],
+      }));
+      fs.writeFileSync(path.join(dirPath, 'feat-new.md'), stateDocument({
+        project: '/home/user/Projetos/gamma',
+        branch: 'feat-new',
+        updated: '2026-07-07T00:00:00.000Z',
+        context: 'New branch.',
+        next: [],
+      }));
+      const past = new Date(Date.now() - 60000);
+      fs.utimesSync(path.join(dirPath, 'feat-old.md'), past, past);
+
+      const overview = collectProjectStates({ stateDir });
+      assert.strictEqual(overview.entries.length, 1);
+      assert.strictEqual(overview.entries[0].branch, 'feat-new');
+    } finally {
+      cleanup(stateDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('handles missing state root and malformed files without throwing', () => {
+    const missing = collectProjectStates({
+      stateDir: path.join(os.tmpdir(), 'egc-overview-does-not-exist'),
+    });
+    assert.deepStrictEqual(missing.entries, []);
+
+    const stateDir = createTempDir('egc-overview-');
+    try {
+      fs.writeFileSync(path.join(stateDir, 'broken.md'), 'not a state file at all');
+      const overview = collectProjectStates({ stateDir });
+      assert.strictEqual(overview.entries.length, 1);
+      assert.strictEqual(overview.entries[0].error, null);
+      assert.strictEqual(overview.entries[0].context, null);
+      assert.deepStrictEqual(overview.entries[0].next, []);
+    } finally {
+      cleanup(stateDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('renderOverviewMarkdown produces the aggregated document', () => {
+    const stateDir = createTempDir('egc-overview-');
+    try {
+      fs.mkdirSync(path.join(stateDir, 'Projetos--delta'));
+      fs.writeFileSync(
+        path.join(stateDir, 'Projetos--delta', 'main.md'),
+        stateDocument({
+          project: '/home/user/Projetos/delta',
+          branch: 'main',
+          updated: '2026-07-07T10:00:00.000Z',
+          context: 'Delta context line.',
+          next: ['delta task'],
+        })
+      );
+
+      const overview = collectProjectStates({ stateDir });
+      const markdown = renderOverviewMarkdown(overview);
+      assert.ok(markdown.startsWith('# EGC State Overview'));
+      assert.ok(markdown.includes('Projects: 1'));
+      assert.ok(markdown.includes('## /home/user/Projetos/delta'));
+      assert.ok(markdown.includes('- Context: Delta context line.'));
+      assert.ok(markdown.includes('  - delta task'));
+      assert.ok(markdown.includes('2 decisions, 1 avoid rules, 1 preferences'));
+    } finally {
+      cleanup(stateDir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## What

New `egc overview` command: an aggregated, read-only view of every per-project memory state under `~/.egc/state`.

Design principle: per-project write, aggregated global read. Each project keeps writing its own state file through the egc-memory server; this command only reads and never mutates, so no session can clobber another project's memory.

## How

- `scripts/lib/state-overview.js`:
  - `collectProjectStates()` walks the state root, supporting both layouts: branch-per-file project directories (prefers `main.md`, falls back to the newest branch file) and legacy flat `<slug>.md` files. A branch directory takes precedence over a same-slug flat file, matching the read resolution in `branch-state.js`.
  - `parseStateFile()` extracts the header fields (`project`, `branch`, `updated`) and the sections written by egc-memory (`Context`, `Active Decisions`, `Do Not Repeat`, `Preferences`, `Next Session`).
  - `renderOverviewMarkdown()` renders the aggregated document: per project it shows branch, layout, last update, first Context paragraph, memory counts, and the full Next Session list.
- `scripts/overview.js`: CLI entry with `--json`, `--state-dir <path>`, `--help`. Exit code 1 when any state file is unreadable.
- `scripts/egc.js`: `overview` registered in `COMMANDS`, `PRIMARY_COMMANDS`, and help examples.

## Tests

- `tests/lib/state-overview.test.js`: 6 unit tests covering parsing, mixed layouts, same-slug precedence, newest-branch fallback, missing/malformed inputs, and Markdown rendering.
- Full suite: 2574 passed, 0 failed.
- Smoke run against a real `~/.egc/state` with 15 projects in both layouts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new CLI command `egc overview` that provides a read-only, aggregated view of all per-project memory states. This lets you inspect every project at once in Markdown or JSON.

- **New Features**
  - Aggregates states from `~/.egc/state`; supports branch-per-file directories and legacy flat files. Branch layout wins over same-slug flat files; prefers `main.md`, else the newest branch file.
  - CLI: `egc overview [--json] [--state-dir <path>]`; exits with code 1 if any state file is unreadable.
  - Output: per project shows branch, layout, last update, first Context paragraph, memory counts, and full Next Session list; JSON returns raw entries.
  - Implemented in `scripts/lib/state-overview.js`, CLI entry in `scripts/overview.js`, and command wired in `scripts/egc.js`.

<sup>Written for commit 4507e207f192b3645b4b36186f0a746259869cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

