### PR TITLE
fix(install): migrate stale hook entries instead of duplicating on settings merge

### DIFF
--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -4,6 +4,10 @@
 // All merges are additive and idempotent: third-party hooks and unrelated
 // settings keys are always preserved, and the EGC entry is identified by the
 // installed hook script path so uninstall removes only what EGC added.
+// Within the same event and matcher, an entry whose command runs a script
+// with the same basename but a different path is treated as a stale copy of
+// the EGC hook (left behind when the install location or invocation form
+// changed) and is migrated in place instead of duplicated.
 
 const fs = require('fs');
 const path = require('path');
@@ -77,19 +81,91 @@ function hasHookEntry(settings, event, hookScriptPath, matcherFilter) {
     && groups.some(group => matcherGroupHasEgcEntry(group, hookScriptPath, matcherFilter));
 }
 
+function extractScriptBasename(command) {
+  const scriptPaths = String(command).match(/[^\s"']+\.js\b/g);
+  if (!scriptPaths || scriptPaths.length === 0) {
+    return null;
+  }
+  return path.basename(scriptPaths[scriptPaths.length - 1]);
+}
+
+function isStaleEgcHookEntry(entry, hookScriptPath) {
+  if (!isPlainObject(entry) || typeof entry.command !== 'string') {
+    return false;
+  }
+  if (entry.command.includes(hookScriptPath)) {
+    return false;
+  }
+  return extractScriptBasename(entry.command) === path.basename(hookScriptPath);
+}
+
+function migrateStaleGroupEntries(group, hookScriptPath, alreadyPresent) {
+  let present = alreadyPresent;
+  let groupChanged = false;
+  const entries = [];
+
+  for (const entry of group.hooks) {
+    if (!isStaleEgcHookEntry(entry, hookScriptPath)) {
+      entries.push(entry);
+      continue;
+    }
+    groupChanged = true;
+    if (!present) {
+      // Migrate in place so entry-level keys like statusMessage survive.
+      entries.push({ ...entry, command: buildHookCommand(hookScriptPath) });
+      present = true;
+    }
+  }
+
+  return { entries, groupChanged, present };
+}
+
 function addHookEntry(settings, event, hookScriptPath, options = {}) {
   const base = isPlainObject(settings) ? settings : {};
   const matcher = typeof options.matcher === 'string' && options.matcher ? options.matcher : undefined;
-  if (hasHookEntry(base, event, hookScriptPath, matcher)) {
+  const existingGroups = isPlainObject(base.hooks) && Array.isArray(base.hooks[event])
+    ? base.hooks[event]
+    : [];
+
+  let present = hasHookEntry(base, event, hookScriptPath, matcher);
+  let changed = false;
+  const groups = [];
+
+  for (const group of existingGroups) {
+    const sameMatcher = matcher === undefined
+      ? group?.matcher === undefined
+      : group?.matcher === matcher;
+    if (!isPlainObject(group) || !Array.isArray(group.hooks) || !sameMatcher) {
+      groups.push(group);
+      continue;
+    }
+
+    const migration = migrateStaleGroupEntries(group, hookScriptPath, present);
+    present = migration.present;
+    if (!migration.groupChanged) {
+      groups.push(group);
+    } else {
+      changed = true;
+      if (migration.entries.length > 0) {
+        groups.push({ ...group, hooks: migration.entries });
+      }
+    }
+  }
+
+  if (!present) {
+    const group = { hooks: [{ type: 'command', command: buildHookCommand(hookScriptPath) }] };
+    if (matcher) {
+      group.matcher = matcher;
+    }
+    groups.push(group);
+    changed = true;
+  }
+
+  if (!changed) {
     return { settings: base, changed: false };
   }
+
   const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
-  const groups = Array.isArray(hooks[event]) ? hooks[event].slice() : [];
-  const group = { hooks: [{ type: 'command', command: buildHookCommand(hookScriptPath) }] };
-  if (matcher) {
-    group.matcher = matcher;
-  }
-  groups.push(group);
   hooks[event] = groups;
   return { settings: { ...base, hooks }, changed: true };
 }

--- a/tests/lib/claude-settings-hooks.test.js
+++ b/tests/lib/claude-settings-hooks.test.js
@@ -30,6 +30,7 @@ const {
   addWriteValidatorHook,
   applyBashDispatcherHookToFile,
   applyIntuitionHookToFile,
+  applyRouterHookToFile,
   applySessionStartHookToFile,
   applyStopHookToFile,
   applyWriteValidatorHookToFile,
@@ -42,6 +43,7 @@ const {
   createUserPromptSubmitHookMergeOperation,
   hasBashDispatcherHook,
   hasIntuitionHook,
+  hasRouterHook,
   hasSessionStartHook,
   hasStopHook,
   hasWriteValidatorHook,
@@ -699,6 +701,152 @@ function runTests() {
     assert.strictEqual(operation.hookEvent, PRE_TOOL_USE_EVENT);
     assert.strictEqual(operation.hookMatcher, 'Edit');
     assert.strictEqual(operation.hookScriptPath, resolveWriteValidatorHookScriptDestination(targetRoot));
+  })) passed++; else failed++;
+
+  console.log('\n--- Stale entry migration (hook script relocation) ---\n');
+
+  const OLD_INTUITION_HOOK_SCRIPT_PATH = '/home/user/.claude/egc/hooks/prompt-intuition.js';
+  const REPO_ROUTER_HOOK_SCRIPT_PATH = '/home/user/Projects/EGC/scripts/hooks/prompt-router.js';
+  const ROUTER_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/prompt-router.js';
+
+  if (test('migrates a stale entry from an old install location in place', () => {
+    const base = {
+      hooks: {
+        [USER_PROMPT_SUBMIT_EVENT]: [
+          {
+            hooks: [{
+              type: 'command',
+              command: `node "${OLD_INTUITION_HOOK_SCRIPT_PATH}"`,
+              statusMessage: 'Detecting intent...',
+            }],
+          },
+        ],
+      },
+    };
+    const result = addIntuitionHook(base, INTUITION_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(result.changed, true);
+    const groups = result.settings.hooks[USER_PROMPT_SUBMIT_EVENT];
+    assert.strictEqual(groups.length, 1);
+    assert.strictEqual(groups[0].hooks.length, 1);
+    assert.ok(groups[0].hooks[0].command.includes(INTUITION_HOOK_SCRIPT_PATH));
+    assert.strictEqual(groups[0].hooks[0].statusMessage, 'Detecting intent...');
+    assert.ok(hasIntuitionHook(result.settings, INTUITION_HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('drops stale duplicates when the current entry already exists', () => {
+    const base = {
+      hooks: {
+        [USER_PROMPT_SUBMIT_EVENT]: [
+          { hooks: [{ type: 'command', command: `node "${OLD_INTUITION_HOOK_SCRIPT_PATH}"` }] },
+          { hooks: [{ type: 'command', command: 'node "/somewhere/else/prompt-intuition.js"' }] },
+          { hooks: [{ type: 'command', command: buildSessionStartCommand(INTUITION_HOOK_SCRIPT_PATH) }] },
+        ],
+      },
+    };
+    const result = addIntuitionHook(base, INTUITION_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(result.changed, true);
+    const groups = result.settings.hooks[USER_PROMPT_SUBMIT_EVENT];
+    assert.strictEqual(groups.length, 1);
+    assert.ok(groups[0].hooks[0].command.includes(INTUITION_HOOK_SCRIPT_PATH));
+
+    const repeat = addIntuitionHook(result.settings, INTUITION_HOOK_SCRIPT_PATH);
+    assert.strictEqual(repeat.changed, false);
+  })) passed++; else failed++;
+
+  if (test('leaves hooks with different script basenames or plain commands untouched', () => {
+    const base = {
+      hooks: {
+        [USER_PROMPT_SUBMIT_EVENT]: [
+          { hooks: [{ type: 'command', command: 'node "/opt/tools/my-prompt-logger.js"' }] },
+          { hooks: [{ type: 'command', command: 'echo plain-command' }] },
+        ],
+      },
+    };
+    const result = addIntuitionHook(base, INTUITION_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(result.settings.hooks[USER_PROMPT_SUBMIT_EVENT].length, 3);
+    assert.strictEqual(
+      result.settings.hooks[USER_PROMPT_SUBMIT_EVENT][0].hooks[0].command,
+      'node "/opt/tools/my-prompt-logger.js"'
+    );
+    assert.strictEqual(
+      result.settings.hooks[USER_PROMPT_SUBMIT_EVENT][1].hooks[0].command,
+      'echo plain-command'
+    );
+  })) passed++; else failed++;
+
+  if (test('does not migrate entries under a different matcher', () => {
+    const base = {
+      hooks: {
+        [PRE_TOOL_USE_EVENT]: [
+          {
+            matcher: 'Edit',
+            hooks: [{ type: 'command', command: 'node "/old/place/pre-write-guardian-validate.js"' }],
+          },
+        ],
+      },
+    };
+    const added = addWriteValidatorHook(base, WRITE_VALIDATOR_HOOK_SCRIPT_PATH, 'Write');
+
+    assert.strictEqual(added.settings.hooks[PRE_TOOL_USE_EVENT].length, 2);
+    assert.ok(added.settings.hooks[PRE_TOOL_USE_EVENT][0].hooks[0].command.includes('/old/place/'));
+
+    const migrated = addWriteValidatorHook(added.settings, WRITE_VALIDATOR_HOOK_SCRIPT_PATH, 'Edit');
+    assert.strictEqual(migrated.changed, true);
+    assert.strictEqual(migrated.settings.hooks[PRE_TOOL_USE_EVENT].length, 2);
+    assert.ok(hasWriteValidatorHook(migrated.settings, WRITE_VALIDATOR_HOOK_SCRIPT_PATH, 'Edit'));
+  })) passed++; else failed++;
+
+  if (test('apply migrates the real-world duplicated UserPromptSubmit layout', () => {
+    const homeDir = createTempDir('claude-hook-migration-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: {
+          [USER_PROMPT_SUBMIT_EVENT]: [
+            {
+              hooks: [{
+                type: 'command',
+                command: `node "${OLD_INTUITION_HOOK_SCRIPT_PATH}"`,
+                statusMessage: 'Detecting intent...',
+              }],
+            },
+            {
+              hooks: [{
+                type: 'command',
+                command: `node "${REPO_ROUTER_HOOK_SCRIPT_PATH}"`,
+                statusMessage: 'Routing prompt...',
+              }],
+            },
+            { hooks: [{ type: 'command', command: buildSessionStartCommand(INTUITION_HOOK_SCRIPT_PATH) }] },
+            { hooks: [{ type: 'command', command: buildSessionStartCommand(ROUTER_HOOK_SCRIPT_PATH) }] },
+          ],
+        },
+      }, null, 2));
+
+      const intuitionResult = applyIntuitionHookToFile(settingsPath, INTUITION_HOOK_SCRIPT_PATH);
+      const routerResult = applyRouterHookToFile(settingsPath, ROUTER_HOOK_SCRIPT_PATH);
+      const settings = readJson(settingsPath);
+      const groups = settings.hooks[USER_PROMPT_SUBMIT_EVENT];
+
+      assert.strictEqual(intuitionResult.changed, true);
+      assert.strictEqual(routerResult.changed, true);
+      assert.strictEqual(groups.length, 2);
+      assert.ok(hasIntuitionHook(settings, INTUITION_HOOK_SCRIPT_PATH));
+      assert.ok(hasRouterHook(settings, ROUTER_HOOK_SCRIPT_PATH));
+      const commands = groups.map(group => group.hooks[0].command).join('\n');
+      assert.ok(!commands.includes(OLD_INTUITION_HOOK_SCRIPT_PATH));
+      assert.ok(!commands.includes(REPO_ROUTER_HOOK_SCRIPT_PATH));
+
+      const repeatIntuition = applyIntuitionHookToFile(settingsPath, INTUITION_HOOK_SCRIPT_PATH);
+      const repeatRouter = applyRouterHookToFile(settingsPath, ROUTER_HOOK_SCRIPT_PATH);
+      assert.strictEqual(repeatIntuition.changed, false);
+      assert.strictEqual(repeatRouter.changed, false);
+    } finally {
+      cleanup(homeDir);
+    }
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Problem

Hook merges into Claude Code `settings.json` identify the EGC entry by the full installed script path (`command.includes(hookScriptPath)`). When a hook script relocates between releases (the intuition hook moved from `<root>/egc/hooks/` to `<root>/scripts/hooks/`) or the invocation form changes (`node "script"` vs absolute node path), the existing user entry no longer matches, so the merge appends a fresh entry and leaves the old one behind.

Real-world result observed after a reinstall:

- `UserPromptSubmit` ended up with 4 entries: one dead path (`~/.claude/egc/hooks/prompt-intuition.js`, which no longer exists, failing every prompt with `node:internal/modules/cjs/loader:1503`), the prompt router registered twice (repo path + managed path, running twice per prompt), and the new managed entries.
- The write validator under `PreToolUse` was also doubled per matcher.
- Because the current entry exists, subsequent merges report no change and the stale entries are never cleaned up.

## Fix

Within the same event and matcher, an entry whose command runs a script with the same basename but a different path is treated as a stale copy of the EGC hook:

- If the current entry is not present yet, the stale entry is migrated in place (command updated to the managed invocation), preserving entry-level keys such as `statusMessage`.
- Additional stale duplicates are dropped, and groups left empty are removed.
- Entries with different basenames, plain non-script commands, or a different matcher are never touched, keeping the existing third-party guarantees.

`extractScriptBasename` and `migrateStaleGroupEntries` are small helpers; `addHookEntry` keeps its signature and return contract.

## Tests

- 5 new cases in `tests/lib/claude-settings-hooks.test.js`: in-place migration preserving `statusMessage`, stale duplicate cleanup with idempotent re-run, third-party basenames untouched, matcher isolation, and an end-to-end reproduction of the real-world duplicated `UserPromptSubmit` layout.
- All 45 pre-existing module tests unchanged and passing (50/50 total).
- Full suite: 2579 passed, 0 failed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate stale Claude Code hook entries during settings merge to avoid duplicates when script paths or invocation forms change. Prevents dead paths and double execution, making merges idempotent.

- **Bug Fixes**
  - Detects stale EGC entries by matching the script basename within the same event and matcher, then migrates them in place to the managed command while preserving fields like `statusMessage`.
  - Removes extra stale duplicates and prunes empty groups; no change reported on repeat merges if the current entry exists.
  - Leaves third-party hooks, plain commands, different basenames, and different matchers untouched.
  - Added 5 tests covering migration and isolation; all tests pass; `addHookEntry` signature unchanged.

<sup>Written for commit c72dd34070574571858603a23a703f6fc4e24501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

