### PR TITLE
feat(hooks): add verification gate with egc verify receipts for commit and push

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -42,6 +42,7 @@ That installs resolved hooks to `~/.gemini/hooks/hooks.json`. On Windows, the Ge
 | **Tmux reminder** | `Bash` | Suggests tmux for long-running commands (npm test, cargo build, docker) | 0 (warns) |
 | **Git push reminder** | `Bash` | Reminds to review changes before `git push` | 0 (warns) |
 | **Pre-commit quality check** | `Bash` | Runs quality checks before `git commit`: lints staged files, validates commit message format when provided via `-m/--message`, detects console.log/debugger/secrets | 2 (blocks critical) / 0 (warns) |
+| **Verification gate** | `Bash` | Before `git commit`/`git push`, checks the `egc verify` receipt for the current tree: warns when it is missing, stale, or failed (default) and blocks with `EGC_VERIFY_GATE=block`, reinjecting the failing verification output | 0 (warns) / 2 (blocks) |
 | **Doc file warning** | `Write` | Warns about non-standard `.md`/`.txt` files (allows README, GEMINI, CONTRIBUTING, CHANGELOG, LICENSE, SKILL, docs/, skills/); cross-platform path handling | 0 (warns) |
 | **Strategic compact** | `Edit\|Write` | Suggests manual `/compact` at logical intervals (every ~50 tool calls) | 0 (warns) |
 
@@ -107,6 +108,9 @@ export EGC_DISABLED_HOOKS="pre:bash:tmux-reminder,post:edit:typecheck"
 
 # Disable only GateGuard during setup or recovery
 export EGC_GATEGUARD=off
+
+# Verification gate mode for git commit/push: off | warn | block (default: warn)
+export EGC_VERIFY_GATE=block
 
 # Cap SessionStart additional context (default: 8000 chars)
 export EGC_SESSION_START_MAX_CHARS=4000

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -69,6 +69,10 @@ const COMMANDS = {
     script: 'overview.js',
     description: 'Aggregated read-only view of every per-project memory state',
   },
+  verify: {
+    script: 'verify.js',
+    description: 'Run the project verification command and record a receipt for the commit gate',
+  },
   sessions: {
     script: 'sessions-cli.js',
     description: 'List or inspect EGC sessions from the SQLite state store',
@@ -132,6 +136,7 @@ const PRIMARY_COMMANDS = [
   'auto-update',
   'status',
   'overview',
+  'verify',
   'sessions',
   'replay',
   'session-inspect',
@@ -185,6 +190,8 @@ Examples:
   egc status --json
   egc overview
   egc overview --json
+  egc verify
+  egc verify -- npm run test:unit
   egc sessions
   egc sessions session-active --json
   egc session-inspect egc:latest

--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -10,6 +10,7 @@ const { run: runAutoTmuxDev } = require('./auto-tmux-dev');
 const { run: runTmuxReminder } = require('./pre-bash-tmux-reminder');
 const { run: runGitPushReminder } = require('./pre-bash-git-push-reminder');
 const { run: runCommitQuality } = require('./pre-bash-commit-quality');
+const { run: runVerificationGate } = require('./pre-bash-verification-gate');
 const { run: runGateGuard } = require('./gateguard-fact-force');
 const { run: runBudgetCheck } = require('./pre-budget-check');
 const { run: runCommandLog } = require('./post-bash-command-log');
@@ -47,6 +48,11 @@ const PRE_BASH_HOOKS = [
     id: 'pre:bash:commit-quality',
     profiles: 'strict',
     run: rawInput => runCommitQuality(rawInput),
+  },
+  {
+    id: 'pre:bash:verification-gate',
+    profiles: 'standard,strict',
+    run: rawInput => runVerificationGate(rawInput),
   },
   {
     id: 'pre:bash:gateguard-fact-force',

--- a/scripts/hooks/pre-bash-verification-gate.js
+++ b/scripts/hooks/pre-bash-verification-gate.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse Hook: Verification Gate
+ *
+ * Before git commit and git push commands, consults the egc verify
+ * receipt for the current project. A missing, stale, or failed receipt
+ * produces a warning by default and blocks the command when
+ * EGC_VERIFY_GATE=block, feeding the failing verification output back
+ * into the agent context so the failure can be fixed before landing.
+ *
+ * Modes (EGC_VERIFY_GATE): off | warn (default) | block
+ *
+ * Exit codes:
+ *   0 - Allow (pass, warn mode, or gate not applicable)
+ *   2 - Block (block mode with a missing, stale, or failed receipt)
+ */
+
+'use strict';
+
+const { evaluateReceipt } = require('../lib/verify-receipt');
+
+const MAX_STDIN = 1024 * 1024;
+const GATE_MODE_ENV = 'EGC_VERIFY_GATE';
+const TRIGGER_REGEX = /\bgit\b[^|;&\n]*\s(commit|push)\b/;
+
+function gateMode() {
+  const raw = String(process.env[GATE_MODE_ENV] || 'warn').trim().toLowerCase();
+  return raw === 'off' || raw === 'block' ? raw : 'warn';
+}
+
+function buildMessage(evaluation, mode, action) {
+  const prefix = mode === 'block' ? '[Hook] BLOCKED by verification gate' : '[Hook] Verification gate';
+  const lines = [];
+
+  if (evaluation.status === 'missing') {
+    lines.push(`${prefix}: no verification receipt for this project before "git ${action}".`);
+    lines.push('Run `egc verify` (defaults to npm test) or `egc verify -- <command>` first.');
+  } else if (evaluation.status === 'stale') {
+    lines.push(`${prefix}: the working tree changed after the last \`egc verify\` run.`);
+    lines.push('Re-run `egc verify` to bind a fresh receipt before "git ' + action + '".');
+  } else {
+    const receipt = evaluation.receipt || {};
+    lines.push(`${prefix}: the last \`egc verify\` run FAILED (exit ${receipt.exitCode}, command: ${receipt.command}).`);
+    lines.push('Fix the failures and re-run `egc verify`. Last output:');
+    if (receipt.logTail) {
+      lines.push(String(receipt.logTail).trim());
+    }
+  }
+
+  lines.push(`Set ${GATE_MODE_ENV}=off to disable this gate or ${GATE_MODE_ENV}=block to enforce it.`);
+  return lines.join('\n');
+}
+
+function evaluate(rawInput) {
+  const mode = gateMode();
+  if (mode === 'off') {
+    return { output: rawInput, exitCode: 0 };
+  }
+
+  let command;
+  try {
+    const input = JSON.parse(rawInput);
+    command = input?.tool_input?.command || '';
+  } catch {
+    return { output: rawInput, exitCode: 0 };
+  }
+
+  const trigger = command.match(TRIGGER_REGEX);
+  if (!trigger) {
+    return { output: rawInput, exitCode: 0 };
+  }
+
+  let evaluation;
+  try {
+    evaluation = evaluateReceipt(process.cwd());
+  } catch {
+    return { output: rawInput, exitCode: 0 };
+  }
+
+  if (evaluation.status === 'ok' || evaluation.status === 'unbound') {
+    return { output: rawInput, exitCode: 0 };
+  }
+
+  return {
+    output: rawInput,
+    stderr: buildMessage(evaluation, mode, trigger[1]),
+    exitCode: mode === 'block' ? 2 : 0,
+  };
+}
+
+function run(rawInput) {
+  const result = evaluate(rawInput);
+  return {
+    stdout: result.output,
+    stderr: result.stderr || '',
+    exitCode: result.exitCode,
+  };
+}
+
+if (require.main === module) {
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (data.length < MAX_STDIN) {
+      data += chunk.substring(0, MAX_STDIN - data.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    const result = evaluate(data);
+    if (result.stderr) {
+      process.stderr.write(`${result.stderr}\n`);
+    }
+    process.stdout.write(result.output);
+    process.exit(result.exitCode);
+  });
+}
+
+module.exports = { run, evaluate };

--- a/scripts/hooks/pre-bash-verification-gate.js
+++ b/scripts/hooks/pre-bash-verification-gate.js
@@ -30,25 +30,31 @@ function gateMode() {
 
 function buildMessage(evaluation, mode, action) {
   const prefix = mode === 'block' ? '[Hook] BLOCKED by verification gate' : '[Hook] Verification gate';
-  const lines = [];
+  let lines;
 
   if (evaluation.status === 'missing') {
-    lines.push(`${prefix}: no verification receipt for this project before "git ${action}".`);
-    lines.push('Run `egc verify` (defaults to npm test) or `egc verify -- <command>` first.');
+    lines = [
+      `${prefix}: no verification receipt for this project before "git ${action}".`,
+      'Run `egc verify` (defaults to npm test) or `egc verify -- <command>` first.',
+    ];
   } else if (evaluation.status === 'stale') {
-    lines.push(`${prefix}: the working tree changed after the last \`egc verify\` run.`);
-    lines.push('Re-run `egc verify` to bind a fresh receipt before "git ' + action + '".');
+    lines = [
+      `${prefix}: the working tree changed after the last \`egc verify\` run.`,
+      `Re-run \`egc verify\` to bind a fresh receipt before "git ${action}".`,
+    ];
   } else {
     const receipt = evaluation.receipt || {};
-    lines.push(`${prefix}: the last \`egc verify\` run FAILED (exit ${receipt.exitCode}, command: ${receipt.command}).`);
-    lines.push('Fix the failures and re-run `egc verify`. Last output:');
-    if (receipt.logTail) {
-      lines.push(String(receipt.logTail).trim());
-    }
+    lines = [
+      `${prefix}: the last \`egc verify\` run FAILED (exit ${receipt.exitCode}, command: ${receipt.command}).`,
+      'Fix the failures and re-run `egc verify`. Last output:',
+      ...(receipt.logTail ? [String(receipt.logTail).trim()] : []),
+    ];
   }
 
-  lines.push(`Set ${GATE_MODE_ENV}=off to disable this gate or ${GATE_MODE_ENV}=block to enforce it.`);
-  return lines.join('\n');
+  return [
+    ...lines,
+    `Set ${GATE_MODE_ENV}=off to disable this gate or ${GATE_MODE_ENV}=block to enforce it.`,
+  ].join('\n');
 }
 
 function evaluate(rawInput) {

--- a/scripts/lib/verify-receipt.js
+++ b/scripts/lib/verify-receipt.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { projectSlug } = require('./branch-state');
+
+const RECEIPT_SCHEMA_VERSION = 'egc.verify.v1';
+const VERIFY_DIR_ENV = 'EGC_VERIFY_DIR';
+
+function resolveVerifyDir(options = {}) {
+  if (options.baseDir) {
+    return options.baseDir;
+  }
+  if (process.env[VERIFY_DIR_ENV]) {
+    return process.env[VERIFY_DIR_ENV];
+  }
+  return path.join(os.homedir(), '.egc', 'verify');
+}
+
+function receiptPath(projectPath, options = {}) {
+  return path.join(resolveVerifyDir(options), `${projectSlug(projectPath)}.json`);
+}
+
+function runGit(cwd, args) {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+  return result.stdout;
+}
+
+/**
+ * Binds a verification result to the exact working-tree content: HEAD
+ * commit plus the porcelain status and the diff against HEAD. Any change
+ * to tracked content after a verify run produces a different fingerprint.
+ * Returns null outside a git repository or before the first commit.
+ */
+function computeTreeFingerprint(projectPath) {
+  const head = runGit(projectPath, ['rev-parse', 'HEAD']);
+  if (head === null) {
+    return null;
+  }
+  const status = runGit(projectPath, ['status', '--porcelain']) || '';
+  const diff = runGit(projectPath, ['diff', 'HEAD']) || '';
+
+  return crypto.createHash('sha256')
+    .update(head)
+    .update('\0')
+    .update(status)
+    .update('\0')
+    .update(diff)
+    .digest('hex');
+}
+
+function writeReceipt(projectPath, data, options = {}) {
+  const filePath = receiptPath(projectPath, options);
+  const receipt = {
+    schemaVersion: RECEIPT_SCHEMA_VERSION,
+    projectPath,
+    fingerprint: computeTreeFingerprint(projectPath),
+    ...data,
+    finishedAt: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  return receipt;
+}
+
+function readReceipt(projectPath, options = {}) {
+  const filePath = receiptPath(projectPath, options);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Evaluates the stored receipt against the current tree.
+ * Statuses: "unbound" (not a git repo or no HEAD, gate cannot bind),
+ * "missing" (no receipt yet), "stale" (tree changed since the run),
+ * "failed" (last run did not pass), "ok".
+ */
+function evaluateReceipt(projectPath, options = {}) {
+  const fingerprint = computeTreeFingerprint(projectPath);
+  if (fingerprint === null) {
+    return { status: 'unbound', receipt: null };
+  }
+
+  const receipt = readReceipt(projectPath, options);
+  if (!receipt) {
+    return { status: 'missing', receipt: null };
+  }
+  if (receipt.fingerprint !== fingerprint) {
+    return { status: 'stale', receipt };
+  }
+  if (receipt.exitCode !== 0) {
+    return { status: 'failed', receipt };
+  }
+  return { status: 'ok', receipt };
+}
+
+module.exports = {
+  RECEIPT_SCHEMA_VERSION,
+  VERIFY_DIR_ENV,
+  computeTreeFingerprint,
+  evaluateReceipt,
+  readReceipt,
+  receiptPath,
+  writeReceipt,
+};

--- a/scripts/lib/verify-receipt.js
+++ b/scripts/lib/verify-receipt.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const crypto = require('crypto');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const { projectSlug } = require('./branch-state');
 
@@ -26,7 +26,8 @@ function receiptPath(projectPath, options = {}) {
 }
 
 function runGit(cwd, args) {
-  const result = spawnSync('git', args, {
+  const result = spawnSync('git', args, { // NOSONAR typescript:S4036 -- resolving git through PATH is the standard contract in developer environments, matching every other git invocation in this repo
+
     cwd,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { writeReceipt, receiptPath } = require('./lib/verify-receipt');
+
+const LOG_TAIL_LIMIT = 4000;
+
+function showHelp(exitCode = 0) {
+  console.log(`
+Usage: egc verify [--json] [-- <command> [args...]]
+
+Runs the project's verification command and records a receipt bound to
+the current working tree. The verification gate hook consults this
+receipt before git commit and git push.
+
+Command resolution:
+  1. Everything after "--" is executed as-is.
+  2. Otherwise, if package.json defines a "test" script, "npm test" runs.
+
+Options:
+  --json      Emit the written receipt as JSON
+  --help, -h  Show this help
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const parsed = { json: false, help: false, command: null };
+  const separatorIndex = args.indexOf('--');
+
+  const ownArgs = separatorIndex === -1 ? args : args.slice(0, separatorIndex);
+  if (separatorIndex !== -1) {
+    const commandArgs = args.slice(separatorIndex + 1);
+    if (commandArgs.length === 0) {
+      throw new Error('No command provided after "--"');
+    }
+    parsed.command = commandArgs;
+  }
+
+  for (const arg of ownArgs) {
+    if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function resolveDefaultCommand(projectPath) {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  if (fs.existsSync(packageJsonPath)) {
+    try {
+      const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+      if (manifest && manifest.scripts && typeof manifest.scripts.test === 'string') {
+        return ['npm', 'test'];
+      }
+    } catch {
+      // Fall through to the guidance error below.
+    }
+  }
+  return null;
+}
+
+function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+  if (options.help) {
+    showHelp(0);
+  }
+
+  const projectPath = process.cwd();
+  const command = options.command || resolveDefaultCommand(projectPath);
+  if (!command) {
+    console.error('Error: no verification command found.');
+    console.error('Pass one explicitly: egc verify -- <command> [args...]');
+    process.exit(1);
+  }
+
+  const startedAt = Date.now();
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: projectPath,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe'],
+    maxBuffer: 64 * 1024 * 1024,
+    shell: process.platform === 'win32',
+  });
+
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
+  if (stderr) {
+    process.stderr.write(stderr);
+  }
+
+  const exitCode = result.error ? 1 : (result.status ?? 1);
+  const combined = `${stdout}${stderr}${result.error ? `\n${result.error.message}` : ''}`;
+  const receipt = writeReceipt(projectPath, {
+    command: command.join(' '),
+    exitCode,
+    durationMs: Date.now() - startedAt,
+    logTail: exitCode === 0 ? undefined : combined.slice(-LOG_TAIL_LIMIT),
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(receipt, null, 2));
+  } else {
+    const label = exitCode === 0 ? 'PASS' : `FAIL (exit ${exitCode})`;
+    console.error(`\n[egc verify] ${label}: receipt written to ${receiptPath(projectPath)}`);
+  }
+
+  process.exit(exitCode);
+}
+
+main();

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const { writeReceipt, receiptPath } = require('./lib/verify-receipt');
 
@@ -59,7 +59,7 @@ function resolveDefaultCommand(projectPath) {
   if (fs.existsSync(packageJsonPath)) {
     try {
       const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-      if (manifest && manifest.scripts && typeof manifest.scripts.test === 'string') {
+      if (typeof manifest?.scripts?.test === 'string') {
         return ['npm', 'test'];
       }
     } catch {
@@ -108,7 +108,8 @@ function main() {
   }
 
   const exitCode = result.error ? 1 : (result.status ?? 1);
-  const combined = `${stdout}${stderr}${result.error ? `\n${result.error.message}` : ''}`;
+  const errorSuffix = result.error ? `\n${result.error.message}` : '';
+  const combined = stdout + stderr + errorSuffix;
   const receipt = writeReceipt(projectPath, {
     command: command.join(' '),
     exitCode,

--- a/tests/lib/verify-receipt.test.js
+++ b/tests/lib/verify-receipt.test.js
@@ -1,0 +1,249 @@
+/**
+ * Tests for scripts/lib/verify-receipt.js and the verification gate hook.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const {
+  computeTreeFingerprint,
+  evaluateReceipt,
+  readReceipt,
+  writeReceipt,
+} = require('../../scripts/lib/verify-receipt');
+const { run: runGate } = require('../../scripts/hooks/pre-bash-verification-gate');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function git(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.strictEqual(result.status, 0, `git ${args.join(' ')} failed: ${result.stderr}`);
+  return result.stdout;
+}
+
+function createGitProject() {
+  const projectPath = createTempDir('egc-verify-repo-');
+  git(projectPath, ['init', '--quiet']);
+  git(projectPath, ['config', 'user.email', 'test@example.com']);
+  git(projectPath, ['config', 'user.name', 'Test']);
+  fs.writeFileSync(path.join(projectPath, 'index.js'), 'module.exports = 1;\n');
+  git(projectPath, ['add', '.']);
+  git(projectPath, ['commit', '--quiet', '-m', 'init']);
+  return projectPath;
+}
+
+function gateInput(command) {
+  return JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+}
+
+function withCwdAndEnv(cwd, env, fn) {
+  const previousCwd = process.cwd();
+  const previousValues = {};
+  for (const [key, value] of Object.entries(env)) {
+    previousValues[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  process.chdir(cwd);
+  try {
+    return fn();
+  } finally {
+    process.chdir(previousCwd);
+    for (const [key, value] of Object.entries(previousValues)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function main() {
+  let passed = 0;
+  let failed = 0;
+
+  console.log('Testing verify-receipt and verification gate...\n');
+
+  if (test('fingerprint changes when tracked content changes', () => {
+    const projectPath = createGitProject();
+    try {
+      const before = computeTreeFingerprint(projectPath);
+      assert.ok(before);
+      fs.writeFileSync(path.join(projectPath, 'index.js'), 'module.exports = 2;\n');
+      const after = computeTreeFingerprint(projectPath);
+      assert.ok(after);
+      assert.notStrictEqual(after, before);
+    } finally {
+      cleanup(projectPath);
+    }
+  })) passed++; else failed++;
+
+  if (test('fingerprint is null outside a git repository', () => {
+    const plainDir = createTempDir('egc-verify-plain-');
+    try {
+      assert.strictEqual(computeTreeFingerprint(plainDir), null);
+    } finally {
+      cleanup(plainDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('write and read receipt roundtrip with custom base dir', () => {
+    const projectPath = createGitProject();
+    const baseDir = createTempDir('egc-verify-store-');
+    try {
+      const written = writeReceipt(projectPath, { command: 'npm test', exitCode: 0 }, { baseDir });
+      assert.strictEqual(written.exitCode, 0);
+      assert.ok(written.fingerprint);
+      const read = readReceipt(projectPath, { baseDir });
+      assert.strictEqual(read.command, 'npm test');
+      assert.strictEqual(read.fingerprint, written.fingerprint);
+    } finally {
+      cleanup(projectPath);
+      cleanup(baseDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('evaluateReceipt reports missing, ok, stale, and failed', () => {
+    const projectPath = createGitProject();
+    const baseDir = createTempDir('egc-verify-store-');
+    try {
+      assert.strictEqual(evaluateReceipt(projectPath, { baseDir }).status, 'missing');
+
+      writeReceipt(projectPath, { command: 'npm test', exitCode: 0 }, { baseDir });
+      assert.strictEqual(evaluateReceipt(projectPath, { baseDir }).status, 'ok');
+
+      fs.writeFileSync(path.join(projectPath, 'index.js'), 'module.exports = 3;\n');
+      assert.strictEqual(evaluateReceipt(projectPath, { baseDir }).status, 'stale');
+
+      writeReceipt(projectPath, { command: 'npm test', exitCode: 1, logTail: 'boom' }, { baseDir });
+      const evaluation = evaluateReceipt(projectPath, { baseDir });
+      assert.strictEqual(evaluation.status, 'failed');
+      assert.strictEqual(evaluation.receipt.logTail, 'boom');
+    } finally {
+      cleanup(projectPath);
+      cleanup(baseDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('evaluateReceipt is unbound outside git', () => {
+    const plainDir = createTempDir('egc-verify-plain-');
+    try {
+      assert.strictEqual(evaluateReceipt(plainDir).status, 'unbound');
+    } finally {
+      cleanup(plainDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('gate passes through non-git-commit commands and off mode', () => {
+    const projectPath = createGitProject();
+    try {
+      withCwdAndEnv(projectPath, { EGC_VERIFY_GATE: undefined, EGC_VERIFY_DIR: createTempDir('egc-verify-store-') }, () => {
+        const listing = runGate(gateInput('ls -la'));
+        assert.strictEqual(listing.exitCode, 0);
+        assert.strictEqual(listing.stderr, '');
+      });
+      withCwdAndEnv(projectPath, { EGC_VERIFY_GATE: 'off' }, () => {
+        const commit = runGate(gateInput('git commit -m "x"'));
+        assert.strictEqual(commit.exitCode, 0);
+        assert.strictEqual(commit.stderr, '');
+      });
+    } finally {
+      cleanup(projectPath);
+    }
+  })) passed++; else failed++;
+
+  if (test('gate warns on missing receipt by default and blocks in block mode', () => {
+    const projectPath = createGitProject();
+    const baseDir = createTempDir('egc-verify-store-');
+    try {
+      withCwdAndEnv(projectPath, { EGC_VERIFY_GATE: undefined, EGC_VERIFY_DIR: baseDir }, () => {
+        const warn = runGate(gateInput('git commit -m "feat: x"'));
+        assert.strictEqual(warn.exitCode, 0);
+        assert.ok(warn.stderr.includes('no verification receipt'));
+      });
+      withCwdAndEnv(projectPath, { EGC_VERIFY_GATE: 'block', EGC_VERIFY_DIR: baseDir }, () => {
+        const block = runGate(gateInput('git push origin main'));
+        assert.strictEqual(block.exitCode, 2);
+        assert.ok(block.stderr.includes('BLOCKED'));
+      });
+    } finally {
+      cleanup(projectPath);
+      cleanup(baseDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('gate passes with a fresh ok receipt and reinjects failing log output', () => {
+    const projectPath = createGitProject();
+    const baseDir = createTempDir('egc-verify-store-');
+    try {
+      writeReceipt(projectPath, { command: 'npm test', exitCode: 0 }, { baseDir });
+      withCwdAndEnv(projectPath, { EGC_VERIFY_GATE: 'block', EGC_VERIFY_DIR: baseDir }, () => {
+        const pass = runGate(gateInput('git commit -m "feat: x"'));
+        assert.strictEqual(pass.exitCode, 0);
+        assert.strictEqual(pass.stderr, '');
+      });
+
+      writeReceipt(projectPath, { command: 'npm test', exitCode: 1, logTail: '3 tests failed: auth.spec' }, { baseDir });
+      withCwdAndEnv(projectPath, { EGC_VERIFY_GATE: 'block', EGC_VERIFY_DIR: baseDir }, () => {
+        const blocked = runGate(gateInput('git commit -m "feat: x"'));
+        assert.strictEqual(blocked.exitCode, 2);
+        assert.ok(blocked.stderr.includes('FAILED'));
+        assert.ok(blocked.stderr.includes('3 tests failed: auth.spec'));
+      });
+    } finally {
+      cleanup(projectPath);
+      cleanup(baseDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('verify CLI writes a receipt for an explicit command', () => {
+    const projectPath = createGitProject();
+    const baseDir = createTempDir('egc-verify-store-');
+    try {
+      const cliPath = path.join(__dirname, '..', '..', 'scripts', 'verify.js');
+      const result = spawnSync(process.execPath, [cliPath, '--', process.execPath, '-e', 'process.exit(0)'], {
+        cwd: projectPath,
+        encoding: 'utf8',
+        env: { ...process.env, EGC_VERIFY_DIR: baseDir },
+      });
+      assert.strictEqual(result.status, 0, result.stderr);
+      const receipt = readReceipt(projectPath, { baseDir });
+      assert.ok(receipt);
+      assert.strictEqual(receipt.exitCode, 0);
+      assert.strictEqual(evaluateReceipt(projectPath, { baseDir }).status, 'ok');
+    } finally {
+      cleanup(projectPath);
+      cleanup(baseDir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## What

Closes the verification feedback loop with enforcement instead of execution: the agent (or the developer) runs the project's test command through `egc verify`, which records a receipt bound to the exact working tree; a new PreToolUse hook consults that receipt before `git commit` and `git push` and feeds failures back into the agent context.

## How

- `egc verify [--json] [-- <command>]` (`scripts/verify.js`): runs the verification command (explicit after `--`, or `npm test` when `package.json` has a test script), prints its output, and writes a receipt to `~/.egc/verify/<project-slug>.json` with the command, exit code, duration, and the log tail on failure. Exits with the command's exit code.
- `scripts/lib/verify-receipt.js`: receipt read/write plus `computeTreeFingerprint` (sha256 of HEAD, `git status --porcelain`, and `git diff HEAD`), so any change to tracked content invalidates the receipt. `evaluateReceipt` returns `unbound` (not a git repo), `missing`, `stale`, `failed`, or `ok`.
- `scripts/hooks/pre-bash-verification-gate.js` (`pre:bash:verification-gate`, profiles standard/strict): triggers on `git commit`/`git push`. Modes via `EGC_VERIFY_GATE`: `warn` (default, stderr guidance, never blocks), `block` (exit 2 for missing/stale/failed receipts, reinjecting the failing verification log tail so the agent can fix before landing), `off`.
- Registered in the Bash dispatcher, wired as `egc verify` in the CLI, documented in `hooks/README.md` (table row plus runtime control).

Default is warn so existing installs see guidance without any workflow breakage; teams opt into enforcement with one environment variable.

## Tests

- `tests/lib/verify-receipt.test.js`: 9 cases covering fingerprint sensitivity, non-git fallback, receipt roundtrip, all evaluate statuses, gate trigger matrix (off/warn/block, pass-through commands), failing-log reinjection, and a CLI end-to-end run.
- Full suite: 2588 passed, 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verification gate that checks `egc verify` receipts before `git commit` and `git push`. It warns or blocks until the working tree has a passing run; includes small SonarCloud cleanups in the new verification code.

- **New Features**
  - Added `egc verify` to run a verification command and write a receipt to `~/.egc/verify/<project-slug>.json` (explicit via `--`, or defaults to `npm test`).
  - Receipts are bound to the exact tree via a SHA256 of `HEAD`, `git status --porcelain`, and `git diff HEAD`.
  - New `pre:bash:verification-gate` runs on `git commit`/`git push`; warns by default, blocks with `EGC_VERIFY_GATE=block`, and shows the failing log tail. Wired into the CLI/dispatcher and documented.

- **Migration**
  - Run `egc verify` (or `egc verify -- <command>`) before committing or pushing to record a receipt.
  - Use `EGC_VERIFY_GATE=warn` (default), `block`, or `off` to control enforcement.

<sup>Written for commit 20d030a28d847acb1d03db1925e44f97aa6e2fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a verification command that records a receipt for the current working tree after a check runs.
  * Added a commit/push gate that can warn or block when the latest receipt is missing, stale, or failed.
  * Added support for controlling the gate behavior with a simple runtime setting.

* **Documentation**
  * Updated the hook documentation with setup and usage guidance for the new verification gate and control setting.

* **Bug Fixes**
  * Improved feedback by surfacing failed verification details when a command is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->