### PR TITLE
fix(hooks): load branch-layout state on session start and auto-consolidate oversized files

### DIFF
--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -24,6 +24,20 @@ try {
   // Optional module - minimal installations without project-detect skip the briefing.
 }
 
+let branchState = null;
+try {
+  branchState = require('../lib/branch-state');
+} catch (_) {
+  // Optional module - without it only the flat state layout is loaded.
+}
+
+let autoConsolidate = null;
+try {
+  autoConsolidate = require('../lib/auto-consolidate');
+} catch (_) {
+  // Optional module - oversized state files are then loaded as-is.
+}
+
 function readStdinJson() {
   try {
     const raw = fs.readFileSync(0, 'utf8');
@@ -44,9 +58,12 @@ function resolveProjectPath(input) {
   return process.env.CLAUDE_PROJECT_DIR || process.env.PWD || process.cwd();
 }
 
+// Fallback slug for minimal installs without branch-state. Uses the same
+// double-hyphen join as branch-state.projectSlug; the previous single-hyphen
+// form never matched the files the memory server actually writes.
 function projectSlug(projectPath) {
   const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
-  return parts.slice(-2).join('-').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 
 function parseFrontmatterValue(val) {
@@ -159,9 +176,29 @@ function emitStackBriefing(projectPath) {
   process.stdout.write(buildBriefingLines(stack, stackSpecific, generic, missing).join('\n'));
 }
 
+function resolveStateFile(projectPath) {
+  if (branchState) {
+    const stateDir = branchState.getStateDir();
+    const branch = branchState.detectBranch(projectPath);
+    const resolved = branchState.resolveStateRead(stateDir, projectPath, branch);
+    return resolved.source === 'none' ? null : resolved.filePath;
+  }
+
+  const flatFile = path.join(os.homedir(), '.egc', 'state', `${projectSlug(projectPath)}.md`);
+  return fs.existsSync(flatFile) ? flatFile : null;
+}
+
 function loadAndPrintState(projectPath) {
-  const stateFile = path.join(os.homedir(), '.egc', 'state', `${projectSlug(projectPath)}.md`);
-  if (!fs.existsSync(stateFile)) return;
+  const stateFile = resolveStateFile(projectPath);
+  if (!stateFile) return;
+
+  if (autoConsolidate) {
+    try {
+      autoConsolidate.autoConsolidateStateFile(stateFile);
+    } catch (_) {
+      // Consolidation is best-effort; never block session startup.
+    }
+  }
 
   const content = fs.readFileSync(stateFile, 'utf8');
   if (!content.trim()) return;

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -10,33 +10,22 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-let propagateStateContent = null;
-try {
-  propagateStateContent = require('../lib/propagate-state').propagateStateContent;
-} catch (_) {
-  // Lib not installed yet; run `egc repair` to restore it.
+// Optional libs: minimal installations may lack them, so a failed require
+// resolves to null and the dependent feature is skipped instead of failing
+// session startup. Run `egc repair` to restore missing libs.
+function tryRequire(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
 }
 
-let projectDetect = null;
-try {
-  projectDetect = require('../lib/project-detect');
-} catch (_) {
-  // Optional module - minimal installations without project-detect skip the briefing.
-}
-
-let branchState = null;
-try {
-  branchState = require('../lib/branch-state');
-} catch (_) {
-  // Optional module - without it only the flat state layout is loaded.
-}
-
-let autoConsolidate = null;
-try {
-  autoConsolidate = require('../lib/auto-consolidate');
-} catch (_) {
-  // Optional module - oversized state files are then loaded as-is.
-}
+const propagateStateLib = tryRequire('../lib/propagate-state');
+const propagateStateContent = propagateStateLib ? propagateStateLib.propagateStateContent : null;
+const projectDetect = tryRequire('../lib/project-detect');
+const branchState = tryRequire('../lib/branch-state');
+const autoConsolidate = tryRequire('../lib/auto-consolidate');
 
 function readStdinJson() {
   try {
@@ -176,6 +165,16 @@ function emitStackBriefing(projectPath) {
   process.stdout.write(buildBriefingLines(stack, stackSpecific, generic, missing).join('\n'));
 }
 
+// Consolidation must never block session startup: on any failure the
+// state file is simply loaded as-is.
+function consolidateBestEffort(stateFile) {
+  try {
+    return autoConsolidate.autoConsolidateStateFile(stateFile);
+  } catch {
+    return null;
+  }
+}
+
 function resolveStateFile(projectPath) {
   if (branchState) {
     const stateDir = branchState.getStateDir();
@@ -193,11 +192,7 @@ function loadAndPrintState(projectPath) {
   if (!stateFile) return;
 
   if (autoConsolidate) {
-    try {
-      autoConsolidate.autoConsolidateStateFile(stateFile);
-    } catch (_) {
-      // Consolidation is best-effort; never block session startup.
-    }
+    consolidateBestEffort(stateFile);
   }
 
   const content = fs.readFileSync(stateFile, 'utf8');

--- a/scripts/lib/auto-consolidate.js
+++ b/scripts/lib/auto-consolidate.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+
+const { consolidateState, backupStateFile, DEFAULT_THRESHOLD } = require('./state-consolidate');
+
+const AUTO_CONSOLIDATE_ENV = 'EGC_AUTO_CONSOLIDATE';
+
+/**
+ * Compacts a project state file in place when it grows past the layered
+ * summary threshold. Backs the original up to the state archive first, so
+ * the automatic path is as safe as running `egc consolidate` by hand.
+ * Disabled with EGC_AUTO_CONSOLIDATE=0.
+ */
+function autoConsolidateStateFile(filePath, options = {}) {
+  if (String(process.env[AUTO_CONSOLIDATE_ENV] || '1') === '0') {
+    return { consolidated: false, reason: 'disabled' };
+  }
+  if (!fs.existsSync(filePath)) {
+    return { consolidated: false, reason: 'missing' };
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { consolidated: false, reason: 'unreadable' };
+  }
+
+  const result = consolidateState(content, {
+    threshold: options.threshold || DEFAULT_THRESHOLD,
+    now: options.now,
+  });
+  if (!result.needed || result.linesAfter >= result.linesBefore) {
+    return { consolidated: false, reason: 'below-threshold' };
+  }
+
+  const homeDir = options.homeDir || os.homedir();
+  let backupPath = null;
+  try {
+    backupPath = backupStateFile(homeDir, filePath, options.now);
+    fs.writeFileSync(filePath, result.output, 'utf8');
+  } catch {
+    return { consolidated: false, reason: 'write-failed', backupPath };
+  }
+
+  return {
+    consolidated: true,
+    linesBefore: result.linesBefore,
+    linesAfter: result.linesAfter,
+    backupPath,
+  };
+}
+
+module.exports = {
+  AUTO_CONSOLIDATE_ENV,
+  autoConsolidateStateFile,
+};

--- a/tests/hooks/claude-session-start.test.js
+++ b/tests/hooks/claude-session-start.test.js
@@ -67,7 +67,7 @@ function runTests() {
   if (test('prints the state file for the cwd received on stdin', () => {
     const homeDir = createTempDir('claude-session-start-home-');
     try {
-      writeStateFile(homeDir, 'workspace-demo', '# Project State\n- resume feature X\n');
+      writeStateFile(homeDir, 'workspace--demo', '# Project State\n- resume feature X\n');
 
       const result = runHook(
         homeDir,
@@ -85,7 +85,7 @@ function runTests() {
   if (test('uses the same slug sanitization as the egc-memory server', () => {
     const homeDir = createTempDir('claude-session-start-home-');
     try {
-      writeStateFile(homeDir, 'My_Projects-app_v2_0', 'sanitized slug state\n');
+      writeStateFile(homeDir, 'My_Projects--app_v2_0', 'sanitized slug state\n');
 
       const result = runHook(
         homeDir,
@@ -128,7 +128,7 @@ function runTests() {
   if (test('tolerates invalid stdin and falls back to environment paths', () => {
     const homeDir = createTempDir('claude-session-start-home-');
     try {
-      writeStateFile(homeDir, 'env-project', 'state from env fallback\n');
+      writeStateFile(homeDir, 'env--project', 'state from env fallback\n');
 
       const result = runHook(homeDir, 'not json at all', {
         CLAUDE_PROJECT_DIR: '/env/project',
@@ -171,7 +171,7 @@ function runTests() {
         JSON.stringify({ name: 'test', version: '1.0.0' })
       );
 
-      const slug = path.basename(os.tmpdir()) + '-' + path.basename(projectDir);
+      const slug = path.basename(os.tmpdir()) + '--' + path.basename(projectDir);
       const sanitized = slug.replace(/[^a-zA-Z0-9-_]/g, '_');
       writeStateFile(homeDir, sanitized, '# My Project State\n- resume task A\n');
 

--- a/tests/lib/auto-consolidate.test.js
+++ b/tests/lib/auto-consolidate.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for scripts/lib/auto-consolidate.js and the SessionStart state load.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { autoConsolidateStateFile } = require('../../scripts/lib/auto-consolidate');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function bigStateDocument(projectPath) {
+  const decisions = [];
+  for (let index = 0; index < 30; index += 1) {
+    decisions.push(`- old decision ${index} recorded 2026-01-0${(index % 9) + 1}: rationale ${index}`);
+  }
+  return [
+    '# Project State',
+    `project: ${projectPath}`,
+    'branch: main',
+    'updated: 2026-07-07T00:00:00.000Z',
+    '',
+    '## Context',
+    'Big project context line.',
+    '',
+    '## Active Decisions',
+    ...decisions,
+    '',
+    '## Next Session',
+    '- keep this actionable item verbatim',
+    '',
+  ].join('\n');
+}
+
+function withEnv(env, fn) {
+  const previous = {};
+  for (const [key, value] of Object.entries(env)) {
+    previous[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function main() {
+  let passed = 0;
+  let failed = 0;
+
+  console.log('Testing auto-consolidate and session-start state load...\n');
+
+  if (test('consolidates an oversized state file with backup', () => {
+    const homeDir = createTempDir('egc-autocons-home-');
+    try {
+      const stateDir = path.join(homeDir, '.egc', 'state');
+      fs.mkdirSync(stateDir, { recursive: true });
+      const filePath = path.join(stateDir, 'Projetos--demo.md');
+      fs.writeFileSync(filePath, bigStateDocument('/home/user/Projetos/demo'));
+      const linesBefore = fs.readFileSync(filePath, 'utf8').split('\n').length;
+
+      const result = withEnv({ EGC_AUTO_CONSOLIDATE: undefined }, () =>
+        autoConsolidateStateFile(filePath, { homeDir, now: new Date('2026-07-07T12:00:00Z') })
+      );
+
+      assert.strictEqual(result.consolidated, true);
+      assert.ok(result.linesAfter < linesBefore);
+      assert.ok(fs.existsSync(result.backupPath));
+      const rewritten = fs.readFileSync(filePath, 'utf8');
+      assert.ok(rewritten.includes('keep this actionable item verbatim'));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('leaves small files alone and respects the disable flag', () => {
+    const homeDir = createTempDir('egc-autocons-home-');
+    try {
+      const stateDir = path.join(homeDir, '.egc', 'state');
+      fs.mkdirSync(stateDir, { recursive: true });
+      const small = path.join(stateDir, 'small.md');
+      fs.writeFileSync(small, '# Project State\n\n## Context\nshort\n');
+
+      const below = autoConsolidateStateFile(small, { homeDir });
+      assert.strictEqual(below.consolidated, false);
+      assert.strictEqual(below.reason, 'below-threshold');
+
+      const big = path.join(stateDir, 'big.md');
+      fs.writeFileSync(big, bigStateDocument('/home/user/big'));
+      const disabled = withEnv({ EGC_AUTO_CONSOLIDATE: '0' }, () =>
+        autoConsolidateStateFile(big, { homeDir })
+      );
+      assert.strictEqual(disabled.consolidated, false);
+      assert.strictEqual(disabled.reason, 'disabled');
+
+      const missing = autoConsolidateStateFile(path.join(stateDir, 'nope.md'), { homeDir });
+      assert.strictEqual(missing.reason, 'missing');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('session-start hook loads branch-layout state and consolidates it', () => {
+    const homeDir = createTempDir('egc-autocons-home-');
+    const projectDir = createTempDir('egc-autocons-project-');
+    try {
+      const init = spawnSync('git', ['init', '-b', 'main', '--quiet'], { cwd: projectDir, encoding: 'utf8' });
+      assert.strictEqual(init.status, 0, init.stderr);
+      const projectSlugValue = projectDir.replace(/\\/g, '/').split('/').filter(Boolean).slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_');
+      const projectStateDir = path.join(homeDir, '.egc', 'state', projectSlugValue);
+      fs.mkdirSync(projectStateDir, { recursive: true });
+      const stateFile = path.join(projectStateDir, 'main.md');
+      fs.writeFileSync(stateFile, bigStateDocument(projectDir));
+      const linesBefore = fs.readFileSync(stateFile, 'utf8').split('\n').length;
+
+      const hookPath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'claude-session-start.js');
+      const result = spawnSync(process.execPath, [hookPath], {
+        input: JSON.stringify({ cwd: projectDir }),
+        encoding: 'utf8',
+        env: { ...process.env, HOME: homeDir },
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('EGC persistent memory'), 'state not injected: ' + result.stdout.slice(0, 200));
+      assert.ok(result.stdout.includes('keep this actionable item verbatim'));
+
+      const linesAfter = fs.readFileSync(stateFile, 'utf8').split('\n').length;
+      assert.ok(linesAfter < linesBefore, `expected consolidation (${linesAfter} vs ${linesBefore})`);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('session-start hook falls back to the flat double-hyphen layout', () => {
+    const homeDir = createTempDir('egc-autocons-home-');
+    const projectDir = createTempDir('egc-autocons-project-');
+    try {
+      const projectSlugValue = projectDir.replace(/\\/g, '/').split('/').filter(Boolean).slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_');
+      const stateDir = path.join(homeDir, '.egc', 'state');
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(stateDir, `${projectSlugValue}.md`),
+        '# Project State\n\n## Context\nflat layout memory line\n'
+      );
+
+      const hookPath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'claude-session-start.js');
+      const result = spawnSync(process.execPath, [hookPath], {
+        input: JSON.stringify({ cwd: projectDir }),
+        encoding: 'utf8',
+        env: { ...process.env, HOME: homeDir },
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('flat layout memory line'), 'flat state not injected: ' + result.stdout.slice(0, 200));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();

--- a/tests/lib/auto-consolidate.test.js
+++ b/tests/lib/auto-consolidate.test.js
@@ -149,7 +149,7 @@ function main() {
       const result = spawnSync(process.execPath, [hookPath], {
         input: JSON.stringify({ cwd: projectDir }),
         encoding: 'utf8',
-        env: { ...process.env, HOME: homeDir },
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
       });
 
       assert.strictEqual(result.status, 0, result.stderr);
@@ -180,7 +180,7 @@ function main() {
       const result = spawnSync(process.execPath, [hookPath], {
         input: JSON.stringify({ cwd: projectDir }),
         encoding: 'utf8',
-        env: { ...process.env, HOME: homeDir },
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
       });
 
       assert.strictEqual(result.status, 0, result.stderr);


### PR DESCRIPTION
## Problem

The Claude Code SessionStart hook never actually injected persistent memory:

- It built the project slug with a single-hyphen join (`Projetos-EGC`) while the egc-memory server and branch-state library write `Projetos--EGC`, so the file lookup always missed.
- It only knew the flat `<slug>.md` layout and ignored the branch-per-file directories the server has been writing.
- The hook's own test suite asserted the same wrong slug, so CI kept passing while every real session started without memory.

Additionally, nothing ever compacted state files automatically: `egc consolidate` existed but only as a manual command, so per-branch state files grow without bound.

## Fix

- `scripts/hooks/claude-session-start.js` now resolves the state file through `branch-state.resolveStateRead` (branch file, then `main.md`, then flat), detecting the branch from `.git/HEAD`. The no-library fallback slug was corrected to the real double-hyphen form.
- New `scripts/lib/auto-consolidate.js`: `autoConsolidateStateFile` compacts a state file in place through the existing `consolidateState` layering when it exceeds the threshold, backing it up to the state archive first. `EGC_AUTO_CONSOLIDATE=0` disables.
- The SessionStart hook runs auto-consolidation on the resolved state file before injecting it, so oversized memories are compacted exactly where they are consumed.

## Tests

- `tests/lib/auto-consolidate.test.js`: 4 cases: oversized file consolidated with backup, below-threshold and disabled-flag no-ops, end-to-end hook run loading branch-layout state (git repo fixture) and consolidating it, and flat-layout fallback.
- `tests/hooks/claude-session-start.test.js`: fixtures corrected to the real server slug format (they previously encoded the bug).
- Full suite: 2592 passed, 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SessionStart hook to load branch-aware persistent memory, handle missing libs safely, and auto-consolidate oversized state files. This restores memory on session start and prevents unbounded file growth.

- **Bug Fixes**
  - Resolve state via `branch-state.resolveStateRead` using the current Git branch; fall back to the flat file.
  - Correct fallback slug to use double hyphens (e.g., `Projetos--EGC`) and update tests to match; set `USERPROFILE` in test env for reliable home resolution.
  - Use safe optional requires to skip missing libs without failing session startup.

- **New Features**
  - Add `autoConsolidateStateFile` to compact large state files with a backup.
  - Run auto-consolidation during SessionStart (best-effort) before injecting memory; disable with `EGC_AUTO_CONSOLIDATE=0`.

<sup>Written for commit 3a9b457cdce55f415a0292afdb7ed8bd6a46cfaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

