### PR TITLE
refactor(commands): redesign prp workflow series with EGC-native process

### DIFF
--- a/commands/code-review.md
+++ b/commands/code-review.md
@@ -5,8 +5,6 @@ argument-hint: [pr-number | pr-url | blank for local review]
 
 # Code Review
 
-> PR review mode adapted from PRPs-agentic-eng by Wirasm. Part of the PRP workflow series.
-
 **Input**: $ARGUMENTS
 
 ---
@@ -75,215 +73,90 @@ Never approve code with security vulnerabilities.
 
 ## PR Review Mode
 
-Comprehensive GitHub PR review: fetches diff, reads full files, runs validation, posts review.
+Review a GitHub pull request through an evidence ledger: every finding carries proof (file, line, failure scenario), and the final decision is computed from the ledger, never from overall impression.
 
-### Phase 1: FETCH
+### Stage A: Resolve the PR
 
-Parse input to determine PR:
-
-| Input | Action |
+| `$ARGUMENTS` contains | Resolution |
 |---|---|
-| Number (e.g. `42`) | Use as PR number |
-| URL (`github.com/.../pull/42`) | Extract PR number |
-| Branch name | Find PR via `gh pr list --head <branch>` |
+| A number | That PR number |
+| A GitHub URL | The number extracted from the URL |
+| A branch name | `gh pr list --head <branch>` |
 
 ```bash
-gh pr view <NUMBER> --json number,title,body,author,baseRefName,headRefName,changedFiles,additions,deletions
+gh pr view <NUMBER> --json title,body,author,baseRefName,headRefName,isDraft,additions,deletions
+```
+
+Unresolvable input stops the command with the list of open PRs as a hint.
+
+### Stage B: Absorb the change
+
+1. Read the PR description for stated intent and linked issues; the review judges the diff against that intent.
+2. Read the project's contributing rules and agent instructions if present.
+3. Read `.gemini/PRPs/reports/` and `.gemini/PRPs/plans/` for artifacts related to this branch; a plan explains choices the diff alone cannot.
+4. Pull the diff and read every touched source file **at the head revision, in full**; diff hunks without surrounding context hide bugs:
+
+```bash
 gh pr diff <NUMBER>
+gh pr checkout <NUMBER>  # preferred when a local checkout is possible
 ```
 
-If PR not found, stop with error. Store PR metadata for later phases.
+### Stage C: Build the findings ledger
 
-### Phase 2: CONTEXT
+Hunt in two sweeps, recording each finding as a ledger row.
 
-Build review context:
+**Sweep 1, will it break**: logic errors, unhandled inputs, race conditions, security holes (injection, secret exposure, path traversal, missing authorization), data loss paths, performance cliffs on real data sizes.
 
-1. **Project rules**: Read `GEMINI.md`, `.gemini/docs/`, and any contributing guidelines
-2. **PRP artifacts**: Check `.gemini/PRPs/reports/` and `.gemini/PRPs/plans/` for implementation context related to this PR
-3. **PR intent**: Parse PR description for goals, linked issues, test plans
-4. **Changed files**: List all modified files and categorize by type (source, test, config, docs)
+**Sweep 2, will it rot**: convention drift from the surrounding code, missing tests for the new behavior, dead code, unclear naming, documentation the change makes stale.
 
-### Phase 3: REVIEW
+Ledger row format:
 
-Read each changed file **in full** (not just the diff hunks: you need surrounding context).
-
-For PR reviews, fetch the full file contents at the PR head revision:
-```bash
-gh pr diff <NUMBER> --name-only | while IFS= read -r file; do
-  gh api "repos/{owner}/{repo}/contents/$file?ref=<head-branch>" --jq '.content' | base64 -d
-done
+```text
+[severity] file:line
+  claim: what is wrong, one sentence
+  proof: input or state that triggers it, and the wrong result
+  fix: the smallest correct change
 ```
 
-Apply the review checklist across 7 categories:
+A finding without a concrete proof is an opinion; either construct the failing scenario or drop the row. Severity scale: `blocker` (exploitable or data-destroying), `major` (wrong behavior a user will hit), `minor` (quality debt), `note` (style, optional).
 
-| Category | What to Check |
+### Stage D: Independent verification
+
+Run the repository's own checks locally on the PR head when checked out (detect commands from the project's config files; run what exists: lint, typecheck, tests, build). Record each command and its result in the ledger footer. When a local run is impossible, record the CI status from `gh pr checks <NUMBER>` instead and mark it as second-hand evidence.
+
+### Stage E: Decide and deliver
+
+The decision is a function of the ledger:
+
+| Ledger state | Verdict |
 |---|---|
-| **Correctness** | Logic errors, off-by-ones, null handling, edge cases, race conditions |
-| **Type Safety** | Type mismatches, unsafe casts, `any` usage, missing generics |
-| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
-| **Security** | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS |
-| **Performance** | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads |
-| **Completeness** | Missing tests, missing error handling, incomplete migrations, missing docs |
-| **Maintainability** | Dead code, magic numbers, deep nesting, unclear naming, missing types |
+| Any `blocker` | Request changes, listing blockers first |
+| Any `major`, or any failed check | Request changes |
+| Only `minor`/`note`, checks pass | Approve, findings attached as comments |
+| Empty ledger, checks pass | Approve |
+| PR is a draft | Comment only, regardless of ledger |
 
-Assign severity to each finding:
-
-| Severity | Meaning | Action |
-|---|---|---|
-| **CRITICAL** | Security vulnerability or data loss risk | Must fix before merge |
-| **HIGH** | Bug or logic error likely to cause issues | Should fix before merge |
-| **MEDIUM** | Code quality issue or missing best practice | Fix recommended |
-| **LOW** | Style nit or minor suggestion | Optional |
-
-### Phase 4: VALIDATE
-
-Run available validation commands:
-
-Detect the project type from config files (`package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`, etc.), then run the appropriate commands:
-
-**Node.js / TypeScript** (has `package.json`):
-```bash
-npm run typecheck 2>/dev/null || npx tsc --noEmit 2>/dev/null  # Type check
-npm run lint                                                    # Lint
-npm test                                                        # Tests
-npm run build                                                   # Build
-```
-
-**Rust** (has `Cargo.toml`):
-```bash
-cargo clippy -- -D warnings  # Lint
-cargo test                   # Tests
-cargo build                  # Build
-```
-
-**Go** (has `go.mod`):
-```bash
-go vet ./...    # Lint
-go test ./...   # Tests
-go build ./...  # Build
-```
-
-**Python** (has `pyproject.toml` / `setup.py`):
-```bash
-pytest  # Tests
-```
-
-Run only the commands that apply to the detected project type. Record pass/fail for each.
-
-### Phase 5: DECIDE
-
-Form recommendation based on findings:
-
-| Condition | Decision |
-|---|---|
-| Zero CRITICAL/HIGH issues, validation passes | **APPROVE** |
-| Only MEDIUM/LOW issues, validation passes | **APPROVE** with comments |
-| Any HIGH issues or validation failures | **REQUEST CHANGES** |
-| Any CRITICAL issues | **BLOCK**: must fix before merge |
-
-Special cases:
-- Draft PR → Always use **COMMENT** (not approve/block)
-- Only docs/config changes → Lighter review, focus on correctness
-- Explicit `--approve` or `--request-changes` flag → Override decision (but still report all findings)
-
-### Phase 6: REPORT
-
-Create review artifact at `.gemini/PRPs/reviews/pr-<NUMBER>-review.md`:
-
-```markdown
-# PR Review: #<NUMBER>: <TITLE>
-
-**Reviewed**: <date>
-**Author**: <author>
-**Branch**: <head> → <base>
-**Decision**: APPROVE | REQUEST CHANGES | BLOCK
-
-## Summary
-<1-2 sentence overall assessment>
-
-## Findings
-
-### CRITICAL
-<findings or "None">
-
-### HIGH
-<findings or "None">
-
-### MEDIUM
-<findings or "None">
-
-### LOW
-<findings or "None">
-
-## Validation Results
-
-| Check | Result |
-|---|---|
-| Type check | Pass / Fail / Skipped |
-| Lint | Pass / Fail / Skipped |
-| Tests | Pass / Fail / Skipped |
-| Build | Pass / Fail / Skipped |
-
-## Files Reviewed
-<list of files with change type: Added/Modified/Deleted>
-```
-
-### Phase 7: PUBLISH
-
-Post the review to GitHub:
+Save the ledger to `.gemini/PRPs/reviews/pr-<NUMBER>-review.md`, then publish:
 
 ```bash
-# If APPROVE
-gh pr review <NUMBER> --approve --body "<summary of review>"
-
-# If REQUEST CHANGES
-gh pr review <NUMBER> --request-changes --body "<summary with required fixes>"
-
-# If COMMENT only (draft PR or informational)
-gh pr review <NUMBER> --comment --body "<summary>"
+gh pr review <NUMBER> --approve --body "<ledger summary>"
+gh pr review <NUMBER> --request-changes --body "<ledger summary, blockers first>"
+gh pr review <NUMBER> --comment --body "<ledger summary>"
 ```
 
-For inline comments on specific lines, use the GitHub review comments API:
-```bash
-gh api "repos/{owner}/{repo}/pulls/<NUMBER>/comments" \
-  -f body="<comment>" \
-  -f path="<file>" \
-  -F line=<line-number> \
-  -f side="RIGHT" \
-  -f commit_id="$(gh pr view <NUMBER> --json headRefOid --jq .headRefOid)"
-```
+For line-anchored comments, submit one review carrying all inline comments:
 
-Alternatively, post a single review with multiple inline comments at once:
 ```bash
 gh api "repos/{owner}/{repo}/pulls/<NUMBER>/reviews" \
   -f event="COMMENT" \
-  -f body="<overall summary>" \
-  --input comments.json  # [{"path": "file", "line": N, "body": "comment"}, ...]
+  -f body="<summary>" \
+  --input comments.json
 ```
 
-### Phase 8: OUTPUT
+Close by telling the user the verdict, the ledger counts per severity, the verification results, and the saved ledger path.
 
-Report to user:
+### Degraded situations
 
-```
-PR #<NUMBER>: <TITLE>
-Decision: <APPROVE|REQUEST_CHANGES|BLOCK>
-
-Issues: <critical_count> critical, <high_count> high, <medium_count> medium, <low_count> low
-Validation: <pass_count>/<total_count> checks passed
-
-Artifacts:
-  Review: .gemini/PRPs/reviews/pr-<NUMBER>-review.md
-  GitHub: <PR URL>
-
-Next steps:
-  - <contextual suggestions based on decision>
-```
-
----
-
-## Edge Cases
-
-- **No `gh` CLI**: Fall back to local-only review (read the diff, skip GitHub publish). Warn user.
-- **Diverged branches**: Suggest `git fetch origin && git rebase origin/<base>` before review.
-- **Large PRs (>50 files)**: Warn about review scope. Focus on source changes first, then tests, then config/docs.
+- **`gh` missing or unauthenticated**: produce the ledger from a local diff only, skip publishing, and say so.
+- **PR far behind its base**: note it in the review and recommend a rebase before merge.
+- **Very large PR**: review source files first and say explicitly which files were not reviewed; a silent partial review is worse than a declared one.

--- a/commands/prp-commit.md
+++ b/commands/prp-commit.md
@@ -5,108 +5,58 @@ argument-hint: "[target description] (blank = all changes)"
 
 # Smart Commit
 
-> Adapted from PRPs-agentic-eng by Wirasm. Part of the PRP workflow series.
-
 **Input**: $ARGUMENTS
 
----
+Turn "commit the parser fix" into the right `git add` set and a clean conventional commit, without the user naming a single path.
 
-## Phase 1: ASSESS
-
-```bash
-git status --short
-```
-
-If output is empty → stop: "Nothing to commit."
-
-Show the user a summary of what's changed (added, modified, deleted, untracked).
-
----
-
-## Phase 2: INTERPRET & STAGE
-
-Interpret `$ARGUMENTS` to determine what to stage:
-
-| Input | Interpretation | Git Command |
-|---|---|---|
-| *(blank / empty)* | Stage everything | `git add -A` |
-| `staged` | Use whatever is already staged | *(no git add)* |
-| `*.ts` or `*.py` etc. | Stage matching glob | `git add '*.ts'` |
-| `except tests` | Stage all, then unstage tests | `git add -A && git reset -- '**/*.test.*' '**/*.spec.*' '**/test_*' 2>/dev/null \|\| true` |
-| `only new files` | Stage untracked files only | `git ls-files --others --exclude-standard \| grep . && git ls-files --others --exclude-standard \| xargs git add` |
-| `the auth changes` | Interpret from status/diff: find auth-related files | `git add <matched files>` |
-| Specific filenames | Stage those files | `git add <files>` |
-
-For natural language inputs (like "the auth changes"), cross-reference the `git status` output and `git diff` to identify relevant files. Show the user which files you're staging and why.
+## Step 1: Inventory
 
 ```bash
-git add <determined files>
+git status --porcelain
+git diff --stat
 ```
 
-After staging, verify:
-```bash
-git diff --cached --stat
-```
+If there is nothing to commit, say so and stop.
 
-If nothing staged, stop: "No files matched your description."
+## Step 2: Resolve the target
 
----
-
-## Phase 3: COMMIT
-
-Craft a single-line commit message in imperative mood:
-
-```
-{type}: {description}
-```
-
-Types:
-- `feat`: New feature or capability
-- `fix`: Bug fix
-- `refactor`: Code restructuring without behavior change
-- `docs`: Documentation changes
-- `test`: Adding or updating tests
-- `chore`: Build, config, dependencies
-- `perf`: Performance improvement
-- `ci`: CI/CD changes
-
-Rules:
-- Imperative mood ("add feature" not "added feature")
-- Lowercase after the type prefix
-- No period at the end
-- Under 72 characters
-- Describe WHAT changed, not HOW
-
-```bash
-git commit -m "{type}: {description}"
-```
-
----
-
-## Phase 4: OUTPUT
-
-Report to user:
-
-```
-Committed: {hash_short}
-Message:   {type}: {description}
-Files:     {count} file(s) changed
-
-Next steps:
-  - git push           → push to remote
-  - /prp-pr            → create a pull request
-  - /code-review       → review before pushing
-```
-
----
-
-## Examples
-
-| You say | What happens |
+| `$ARGUMENTS` | Selection |
 |---|---|
-| `/prp-commit` | Stages all, auto-generates message |
-| `/prp-commit staged` | Commits only what's already staged |
-| `/prp-commit *.ts` | Stages all TypeScript files, commits |
-| `/prp-commit except tests` | Stages everything except test files |
-| `/prp-commit the database migration` | Finds DB migration files from status, stages them |
-| `/prp-commit only new files` | Stages untracked files only |
+| Blank | All modified and untracked files |
+| Plain-English description | Files whose path, directory, or diff content match the description |
+
+Matching is semantic, not string-based: "the parser fix" selects the files whose diff touches parsing logic, even if no path contains the word "parser". When the description matches nothing, show the changed files and ask; never guess into an empty commit.
+
+## Step 3: Split into atomic commits
+
+One commit = one concern. If the selected files mix concerns (a bug fix plus an unrelated rename), propose a split and create the commits in sequence. Never bundle unrelated changes to save a step.
+
+## Step 4: Guard
+
+Before staging, scan the selected diff for:
+
+- Secrets: keys, tokens, passwords, `.env` content. Finding one aborts the commit for that file with a warning.
+- Debug leftovers: `console.log`, commented-out blocks, stray TODO added by this change. Flag them; commit only if the user confirms.
+- Files that are clearly accidental: lockfile churn without dependency changes, editor artifacts.
+
+## Step 5: Commit
+
+Write a conventional commit message derived from the diff, not from the user's phrasing:
+
+```text
+{type}({scope}): {what changed, imperative, under 72 chars}
+
+{body only when the diff does not speak for itself: the why, not the what}
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `perf`.
+
+Sign-off: run `git commit -s` when the repository enforces DCO (a DCO check in CI or a CONTRIBUTING requirement); plain `git commit` otherwise.
+
+## Output
+
+```text
+{n} commit(s) created:
+  {short-hash} {message}
+Not committed: {files left out and why, or "nothing"}
+```

--- a/commands/prp-implement.md
+++ b/commands/prp-implement.md
@@ -3,383 +3,92 @@ description: Execute an implementation plan with rigorous validation loops
 argument-hint: <path/to/plan.md>
 ---
 
-> Adapted from PRPs-agentic-eng by Wirasm. Part of the PRP workflow series.
+# Plan Executor
 
-# PRP Implement
+**Input**: $ARGUMENTS (plan file path, required)
 
-Execute a plan file step-by-step with continuous validation. Every change is verified immediately: never accumulate broken state.
+Execute a plan file increment by increment under one non-negotiable rule: **green to green**. The repo is verified working before an increment starts and verified working when it ends. Broken state is never carried forward into the next increment.
 
-**Core Philosophy**: Validation loops catch mistakes early. Run checks after every change. Fix issues immediately.
+## Startup
 
-**Golden Rule**: If a validation fails, fix it before moving on. Never accumulate broken state.
+1. Read the plan file in full. If `$ARGUMENTS` is blank or the file does not exist, list available plans in `PRPs/plans/` and stop.
+2. Read every file in the plan's Context capsule.
+3. Find the first unchecked increment; this makes the command resumable after an interruption.
+4. Run the plan's validation commands once to establish the baseline. If the baseline is already red, stop and report: the plan assumed a green repo.
 
----
+## Increment loop
 
-## Phase 0: DETECT
+For each unchecked increment, in order:
 
-### Package Manager Detection
+1. **Apply**: make the changes described, following the Mirror file's shape and the capsule's conventions.
+2. **Validate**: run the increment's Validate command exactly as written.
+3. **Settle**:
+   - Green: mark the increment's checkbox in the plan file, then continue.
+   - Red: enter the failure protocol below.
 
-| File Exists | Package Manager | Runner |
-|---|---|---|
-| `bun.lockb` | bun | `bun run` |
-| `pnpm-lock.yaml` | pnpm | `pnpm run` |
-| `yarn.lock` | yarn | `yarn` |
-| `package-lock.json` | npm | `npm run` |
-| `pyproject.toml` or `requirements.txt` | uv / pip | `uv run` or `python -m` |
-| `Cargo.toml` | cargo | `cargo` |
-| `go.mod` | go | `go` |
+Never start increment N+1 while increment N is red.
 
-### Validation Scripts
+## Failure protocol
 
-Check `package.json` (or equivalent) for available scripts:
+On a red validation:
 
-```bash
-# For Node.js projects
-cat package.json | grep -A 20 '"scripts"'
+1. Read the full error output; fix the actual cause, not the symptom.
+2. Re-validate. If still red, try **one** structurally different approach (not the same edit again).
+3. Still red after the second attempt: stop. Revert the increment's changes so the repo returns to green, mark the increment as blocked in the plan file, and write a partial report (format below) describing what was tried and the exact error. Do not brute-force a third variation; a plan that fails twice has a wrong assumption that the user should see.
+
+## Completion
+
+When every increment is checked:
+
+1. Run the **full** validation suite from the Context capsule (lint, typecheck, tests, build).
+2. Check the plan's "Done means" list item by item.
+3. Write the report to:
+
+```text
+PRPs/reports/{plan-name}-report.md
 ```
 
-Note available commands for: type-check, lint, test, build.
+4. Move the finished plan to:
 
----
-
-## Phase 1: LOAD
-
-Read the plan file:
-
-```bash
-cat "$ARGUMENTS"
+```text
+PRPs/plans/completed/{plan-name}.plan.md
 ```
 
-Extract these sections from the plan:
-- **Summary**: What is being built
-- **Patterns to Mirror**: Code conventions to follow
-- **Files to Change**: What to create or modify
-- **Step-by-Step Tasks**: Implementation sequence
-- **Validation Commands**: How to verify correctness
-- **Acceptance Criteria**: Definition of done
+Create both directories if needed.
 
-If the file doesn't exist or isn't a valid plan:
-```
-Error: Plan file not found or invalid.
-Run /prp-plan <feature-description> to create a plan first.
-```
-
-**CHECKPOINT**: Plan loaded. All sections identified. Tasks extracted.
-
----
-
-## Phase 2: PREPARE
-
-### Git State
-
-```bash
-git branch --show-current
-git status --porcelain
-```
-
-### Branch Decision
-
-| Current State | Action |
-|---|---|
-| On feature branch | Use current branch |
-| On main, clean working tree | Create feature branch: `git checkout -b feat/{plan-name}` |
-| On main, dirty working tree | **STOP**: Ask user to stash or commit first |
-| In a git worktree for this feature | Use the worktree |
-
-### Sync Remote
-
-```bash
-git pull --rebase origin $(git branch --show-current) 2>/dev/null || true
-```
-
-**CHECKPOINT**: On correct branch. Working tree ready. Remote synced.
-
----
-
-## Phase 3: EXECUTE
-
-Process each task from the plan sequentially.
-
-### Per-Task Loop
-
-For each task in **Step-by-Step Tasks**:
-
-1. **Read MIRROR reference**: Open the pattern file referenced in the task's MIRROR field. Understand the convention before writing code.
-
-2. **Implement**: Write the code following the pattern exactly. Apply GOTCHA warnings. Use specified IMPORTS.
-
-3. **Validate immediately**: After EVERY file change:
-   ```bash
-   # Run type-check (adjust command per project)
-   [type-check command from Phase 0]
-   ```
-   If type-check fails → fix the error before moving to the next file.
-
-4. **Track progress**: Log: `[done] Task N: [task name]: complete`
-
-### Handling Deviations
-
-If implementation must deviate from the plan:
-- Note **WHAT** changed
-- Note **WHY** it changed
-- Continue with the corrected approach
-- These deviations will be captured in the report
-
-**CHECKPOINT**: All tasks executed. Deviations logged.
-
----
-
-## Phase 4: VALIDATE
-
-Run all validation levels from the plan. Fix issues at each level before proceeding.
-
-### Level 1: Static Analysis
-
-```bash
-# Type checking: zero errors required
-[project type-check command]
-
-# Linting: fix automatically where possible
-[project lint command]
-[project lint-fix command]
-```
-
-If lint errors remain after auto-fix, fix manually.
-
-### Level 2: Unit Tests
-
-Write tests for every new function (as specified in the plan's Testing Strategy).
-
-```bash
-[project test command for affected area]
-```
-
-- Every function needs at least one test
-- Cover edge cases listed in the plan
-- If a test fails → fix the implementation (not the test, unless the test is wrong)
-
-### Level 3: Build Check
-
-```bash
-[project build command]
-```
-
-Build must succeed with zero errors.
-
-### Level 4: Integration Testing (if applicable)
-
-```bash
-# Start server, run tests, stop server
-[project dev server command] &
-SERVER_PID=$!
-
-# Wait for server to be ready (adjust port as needed)
-SERVER_READY=0
-for i in $(seq 1 30); do
-  if curl -sf http://localhost:PORT/health >/dev/null 2>&1; then
-    SERVER_READY=1
-    break
-  fi
-  sleep 1
-done
-
-if [ "$SERVER_READY" -ne 1 ]; then
-  kill "$SERVER_PID" 2>/dev/null || true
-  echo "ERROR: Server failed to start within 30s" >&2
-  exit 1
-fi
-
-[integration test command]
-TEST_EXIT=$?
-
-kill "$SERVER_PID" 2>/dev/null || true
-wait "$SERVER_PID" 2>/dev/null || true
-
-exit "$TEST_EXIT"
-```
-
-### Level 5: Edge Case Testing
-
-Run through edge cases from the plan's Testing Strategy checklist.
-
-**CHECKPOINT**: All 5 validation levels pass. Zero errors.
-
----
-
-## Phase 5: REPORT
-
-### Create Implementation Report
-
-```bash
-mkdir -p .gemini/PRPs/reports
-```
-
-Write report to `.gemini/PRPs/reports/{plan-name}-report.md`:
+### Report format
 
 ```markdown
-# Implementation Report: [Feature Name]
+# Report: {plan name}
 
-## Summary
-[What was implemented]
+executed: {date}
+result: complete | blocked at increment {N}
 
-## Assessment vs Reality
+## What changed
 
-| Metric | Predicted (Plan) | Actual |
+{file list with one-line purpose each}
+
+## Validation evidence
+
+| Check | Command | Result |
 |---|---|---|
-| Complexity | [from plan] | [actual] |
-| Confidence | [from plan] | [actual] |
-| Files Changed | [from plan] | [actual count] |
+| Lint | {command} | pass/fail |
+| Typecheck | {command} | pass/fail |
+| Tests | {command} | pass/fail |
+| Build | {command} | pass/fail |
 
-## Tasks Completed
+## Deviations from plan
 
-| # | Task | Status | Notes |
-|---|---|---|---|
-| 1 | [task name] | [done] Complete | |
-| 2 | [task name] | [done] Complete | Deviated: [reason] |
+{Anything done differently than written, and why. "None" if faithful.}
 
-## Validation Results
+## Blocked (only when result is blocked)
 
-| Level | Status | Notes |
-|---|---|---|
-| Static Analysis | [done] Pass | |
-| Unit Tests | [done] Pass | N tests written |
-| Build | [done] Pass | |
-| Integration | [done] Pass | or N/A |
-| Edge Cases | [done] Pass | |
-
-## Files Changed
-
-| File | Action | Lines |
-|---|---|---|
-| `path/to/file` | CREATED | +N |
-| `path/to/file` | UPDATED | +N / -M |
-
-## Deviations from Plan
-[List any deviations with WHAT and WHY, or "None"]
-
-## Issues Encountered
-[List any problems and how they were resolved, or "None"]
-
-## Tests Written
-
-| Test File | Tests | Coverage |
-|---|---|---|
-| `path/to/test` | N tests | [area covered] |
-
-## Next Steps
-- [ ] Code review via `/code-review`
-- [ ] Create PR via `/prp-pr`
+{Increment, both attempted approaches, exact error output, suspected wrong assumption.}
 ```
 
-### Update PRD (if applicable)
+## Handoff
 
-If this implementation was for a PRD phase:
-1. Update the phase status from `in-progress` to `complete`
-2. Add report path as reference
-
-### Archive Plan
-
-```bash
-mkdir -p .gemini/PRPs/plans/completed
-mv "$ARGUMENTS" .gemini/PRPs/plans/completed/
+```text
+Report: PRPs/reports/{name}-report.md
+Next: /prp-commit  (then /prp-pr when ready)
 ```
-
-**CHECKPOINT**: Report created. PRD updated. Plan archived.
-
----
-
-## Phase 6: OUTPUT
-
-Report to user:
-
-```
-## Implementation Complete
-
-- **Plan**: [plan file path] → archived to completed/
-- **Branch**: [current branch name]
-- **Status**: [done] All tasks complete
-
-### Validation Summary
-
-| Check | Status |
-|---|---|
-| Type Check | [done] |
-| Lint | [done] |
-| Tests | [done] (N written) |
-| Build | [done] |
-| Integration | [done] or N/A |
-
-### Files Changed
-- [N] files created, [M] files updated
-
-### Deviations
-[Summary or "None: implemented exactly as planned"]
-
-### Artifacts
-- Report: `.gemini/PRPs/reports/{name}-report.md`
-- Archived Plan: `.gemini/PRPs/plans/completed/{name}.plan.md`
-
-### PRD Progress (if applicable)
-| Phase | Status |
-|---|---|
-| Phase 1 | [done] Complete |
-| Phase 2 | [next] |
-| ... | ... |
-
-> Next step: Run `/prp-pr` to create a pull request, or `/code-review` to review changes first.
-```
-
----
-
-## Handling Failures
-
-### Type Check Fails
-1. Read the error message carefully
-2. Fix the type error in the source file
-3. Re-run type-check
-4. Continue only when clean
-
-### Tests Fail
-1. Identify whether the bug is in the implementation or the test
-2. Fix the root cause (usually the implementation)
-3. Re-run tests
-4. Continue only when green
-
-### Lint Fails
-1. Run auto-fix first
-2. If errors remain, fix manually
-3. Re-run lint
-4. Continue only when clean
-
-### Build Fails
-1. Usually a type or import issue: check error message
-2. Fix the offending file
-3. Re-run build
-4. Continue only when successful
-
-### Integration Test Fails
-1. Check server started correctly
-2. Verify endpoint/route exists
-3. Check request format matches expected
-4. Fix and re-run
-
----
-
-## Success Criteria
-
-- **TASKS_COMPLETE**: All tasks from the plan executed
-- **TYPES_PASS**: Zero type errors
-- **LINT_PASS**: Zero lint errors
-- **TESTS_PASS**: All tests green, new tests written
-- **BUILD_PASS**: Build succeeds
-- **REPORT_CREATED**: Implementation report saved
-- **PLAN_ARCHIVED**: Plan moved to `completed/`
-
----
-
-## Next Steps
-
-- Run `/code-review` to review changes before committing
-- Run `/prp-commit` to commit with a descriptive message
-- Run `/prp-pr` to create a pull request
-- Run `/prp-plan <next-phase>` if the PRD has more phases

--- a/commands/prp-plan.md
+++ b/commands/prp-plan.md
@@ -3,500 +3,114 @@ description: Create comprehensive feature implementation plan with codebase anal
 argument-hint: <feature description | path/to/prd.md>
 ---
 
-> Adapted from PRPs-agentic-eng by Wirasm. Part of the PRP workflow series.
+# Implementation Plan Builder
 
-# PRP Plan
+**Input**: $ARGUMENTS
 
-Create a detailed, self-contained implementation plan that captures all codebase patterns, conventions, and context needed to implement a feature in a single pass.
+Produce a plan that survives a cold start: a fresh session with zero conversation history must be able to open the plan file and implement the feature without re-researching the codebase. Everything the implementer needs lives inside the plan.
 
-**Core Philosophy**: A great plan contains everything needed to implement without asking further questions. Every pattern, every convention, every gotcha: captured once, referenced throughout.
+## Input resolution
 
-**Golden Rule**: If you would need to search the codebase during implementation, capture that knowledge NOW in the plan.
-
----
-
-## Phase 0: DETECT
-
-Determine input type from `$ARGUMENTS`:
-
-| Input Pattern | Detection | Action |
+| `$ARGUMENTS` looks like | Treat as | First action |
 |---|---|---|
-| Path ending in `.prd.md` | File path to PRD | Parse PRD, find next pending phase |
-| Path to `.md` with "Implementation Phases" | PRD-like document | Parse phases, find next pending |
-| Path to any other file | Reference file | Read file for context, treat as free-form |
-| Free-form text | Feature description | Proceed directly to Phase 1 |
-| Empty / blank | No input | Ask user what feature to plan |
+| Path ending in `.md` | PRD or phase document | Read it; pick the first unchecked entry under "Implementation Phases" |
+| Free text | Feature description | Use the text as the goal statement |
+| Blank | Missing input | Ask for a feature description or a PRD path, then stop |
 
-### PRD Parsing (when input is a PRD)
+When the source is a PRD, the plan covers **one phase**, not the whole document. Name the plan after the phase.
 
-1. Read the PRD file with `cat "$PRD_PATH"`
-2. Parse the **Implementation Phases** section
-3. Find phases by status:
-   - Look for `pending` phases
-   - Check dependency chains (a phase may depend on prior phases being `complete`)
-   - Select the **next eligible pending phase**
-4. Extract from the selected phase:
-   - Phase name and description
-   - Acceptance criteria
-   - Dependencies on prior phases
-   - Any scope notes or constraints
-5. Use the phase description as the feature to plan
+## Step 1: Reconnaissance
 
-If no pending phases remain, report that all phases are complete.
+Before writing a single plan line, learn the codebase. Collect and record:
 
----
+- **Conventions**: naming, directory layout, error handling style, import style. Cite the config files that enforce them (linter, formatter, tsconfig or equivalent).
+- **Nearest neighbor**: the existing feature most similar to the new one. Note its file paths; the implementation will mirror its shape.
+- **Test harness**: how tests are written and executed here. Copy the exact command that runs them.
+- **Validation commands**: the real lint, typecheck, test, and build commands this repo uses, verified by running them once.
 
-## Phase 1: PARSE
+Anything you could not verify goes in the plan under Open risks, never silently guessed.
 
-Extract and clarify the feature requirements.
+## Step 2: Slice into increments
 
-### Feature Understanding
+Cut the work into increments where **each one leaves the repo green**: compiling, tests passing, feature partially working. Prefer vertical slices (a thin end-to-end path first) over horizontal layers. An increment that cannot be validated on its own is two increments glued together; cut again.
 
-From the input (PRD phase or free-form description), identify:
+## Step 3: Write the plan file
 
-- **What** is being built (concrete deliverable)
-- **Why** it matters (user value)
-- **Who** uses it (target user/system)
-- **Where** it fits (which part of the codebase)
+Save to:
 
-### User Story
-
-Format as:
-```
-As a [type of user],
-I want [capability],
-So that [benefit].
+```text
+PRPs/plans/{kebab-case-feature-name}.plan.md
 ```
 
-### Complexity Assessment
+Create the directory if needed.
 
-| Level | Indicators | Typical Scope |
-|---|---|---|
-| **Small** | Single file, isolated change, no new dependencies | 1-3 files, <100 lines |
-| **Medium** | Multiple files, follows existing patterns, minor new concepts | 3-10 files, 100-500 lines |
-| **Large** | Cross-cutting concerns, new patterns, external integrations | 10+ files, 500+ lines |
-| **XL** | Architectural changes, new subsystems, migration needed | 20+ files, consider splitting |
+### Plan format
 
-### Ambiguity Gate
+```markdown
+# Plan: {feature name}
 
-If any of these are unclear, **STOP and ask the user** before proceeding:
+source: {PRD path or "direct request"}
+created: {date}
+status: pending
 
-- The core deliverable is vague
-- Success criteria are undefined
-- There are multiple valid interpretations
-- Technical approach has major unknowns
+## Goal
 
-Do NOT guess. Ask. A plan built on assumptions fails during implementation.
+{Two sentences maximum: what exists when this plan is done, and how we know.}
 
----
+## Context capsule
 
-## Phase 2: EXPLORE
+Read these before touching anything:
 
-Gather deep codebase intelligence. Search the codebase directly for each category below.
+| File | Why it matters |
+|---|---|
+| {path} | {the pattern or contract it defines} |
 
-### Codebase Search (8 Categories)
+Conventions that apply here:
 
-For each category, search using grep, find, and file reading:
+- {convention}: enforced by {config file}
 
-1. **Similar Implementations**: Find existing features that resemble the planned one. Look for analogous patterns, endpoints, components, or modules.
+Validation commands (verified working):
 
-2. **Naming Conventions**: Identify how files, functions, variables, classes, and exports are named in the relevant area of the codebase.
+- Lint: `{command}`
+- Typecheck: `{command}`
+- Tests: `{command}`
+- Build: `{command}`
 
-3. **Error Handling**: Find how errors are caught, propagated, logged, and returned to users in similar code paths.
+## Increments
 
-4. **Logging Patterns**: Identify what gets logged, at what level, and in what format.
+### [ ] Increment 1: {name}
 
-5. **Type Definitions**: Find relevant types, interfaces, schemas, and how they're organized.
+- Goal: {what works after this increment}
+- Files: {paths to create or change}
+- Mirror: {existing file whose shape to follow}
+- Steps: {short numbered list}
+- Validate: `{exact command}` plus {any manual check}
 
-6. **Test Patterns**: Find how similar features are tested. Note test file locations, naming, setup/teardown patterns, and assertion styles.
+### [ ] Increment 2: {name}
 
-7. **Configuration**: Find relevant config files, environment variables, and feature flags.
+{same structure}
 
-8. **Dependencies**: Identify packages, imports, and internal modules used by similar features.
+## Open risks
 
-### Codebase Analysis (5 Traces)
+- {unverified assumption or fragile area, and what to do if it bites}
 
-Read relevant files to trace:
+## Done means
 
-1. **Entry Points**: How does a request/action enter the system and reach the area you're modifying?
-2. **Data Flow**: How does data move through the relevant code paths?
-3. **State Changes**: What state is modified and where?
-4. **Contracts**: What interfaces, APIs, or protocols must be honored?
-5. **Patterns**: What architectural patterns are used (repository, service, controller, etc.)?
-
-### Unified Discovery Table
-
-Compile findings into a single reference:
-
-| Category | File:Lines | Pattern | Key Snippet |
-|---|---|---|---|
-| Naming | `src/services/userService.ts:1-5` | camelCase services, PascalCase types | `export class UserService` |
-| Error | `src/middleware/errorHandler.ts:10-25` | Custom AppError class | `throw new AppError(...)` |
-| ... | ... | ... | ... |
-
----
-
-## Phase 3: RESEARCH
-
-If the feature involves external libraries, APIs, or unfamiliar technology:
-
-1. Search the web for official documentation
-2. Find usage examples and best practices
-3. Identify version-specific gotchas
-
-Format each finding as:
-
-```
-KEY_INSIGHT: [what you learned]
-APPLIES_TO: [which part of the plan this affects]
-GOTCHA: [any warnings or version-specific issues]
+- All increments checked
+- Full validation suite green
+- {feature-specific acceptance check}
 ```
 
-If the feature uses only well-understood internal patterns, skip this phase and note: "No external research needed: feature uses established internal patterns."
+## Quality bar before saving
 
----
+- Every increment has a runnable Validate command
+- Every Mirror points to a real file that exists today
+- The Context capsule alone is enough to start: no "see conversation" references
+- Increments are ordered so the repo never goes red between them
 
-## Phase 4: DESIGN
+## Handoff
 
-### UX Transformation (if applicable)
-
-Document the before/after user experience:
-
-**Before:**
+```text
+Plan saved: PRPs/plans/{name}.plan.md
+Next: /prp-implement PRPs/plans/{name}.plan.md
 ```
-┌─────────────────────────────┐
-│  [Current user experience]  │
-│  Show the current flow,     │
-│  what the user sees/does    │
-└─────────────────────────────┘
-```
-
-**After:**
-```
-┌─────────────────────────────┐
-│  [New user experience]      │
-│  Show the improved flow,    │
-│  what changes for the user  │
-└─────────────────────────────┘
-```
-
-### Interaction Changes
-
-| Touchpoint | Before | After | Notes |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-If the feature is purely backend/internal with no UX change, note: "Internal change: no user-facing UX transformation."
-
----
-
-## Phase 5: ARCHITECT
-
-### Strategic Design
-
-Define the implementation approach:
-
-- **Approach**: High-level strategy (e.g., "Add new service layer following existing repository pattern")
-- **Alternatives Considered**: What other approaches were evaluated and why they were rejected
-- **Scope**: Concrete boundaries of what WILL be built
-- **NOT Building**: Explicit list of what is OUT OF SCOPE (prevents scope creep during implementation)
-
----
-
-## Phase 6: GENERATE
-
-Write the full plan document using the template below. Save to `.gemini/PRPs/plans/{kebab-case-feature-name}.plan.md`.
-
-Create the directory if it doesn't exist:
-```bash
-mkdir -p .gemini/PRPs/plans
-```
-
-### Plan Template
-
-````markdown
-# Plan: [Feature Name]
-
-## Summary
-[2-3 sentence overview]
-
-## User Story
-As a [user], I want [capability], so that [benefit].
-
-## Problem → Solution
-[Current state] → [Desired state]
-
-## Metadata
-- **Complexity**: [Small | Medium | Large | XL]
-- **Source PRD**: [path or "N/A"]
-- **PRD Phase**: [phase name or "N/A"]
-- **Estimated Files**: [count]
-
----
-
-## UX Design
-
-### Before
-[ASCII diagram or "N/A: internal change"]
-
-### After
-[ASCII diagram or "N/A: internal change"]
-
-### Interaction Changes
-| Touchpoint | Before | After | Notes |
-|---|---|---|---|
-
----
-
-## Mandatory Reading
-
-Files that MUST be read before implementing:
-
-| Priority | File | Lines | Why |
-|---|---|---|---|
-| P0 (critical) | `path/to/file` | 1-50 | Core pattern to follow |
-| P1 (important) | `path/to/file` | 10-30 | Related types |
-| P2 (reference) | `path/to/file` | all | Similar implementation |
-
-## External Documentation
-
-| Topic | Source | Key Takeaway |
-|---|---|---|
-| ... | ... | ... |
-
----
-
-## Patterns to Mirror
-
-Code patterns discovered in the codebase. Follow these exactly.
-
-### NAMING_CONVENTION
-// SOURCE: [file:lines]
-[actual code snippet showing the naming pattern]
-
-### ERROR_HANDLING
-// SOURCE: [file:lines]
-[actual code snippet showing error handling]
-
-### LOGGING_PATTERN
-// SOURCE: [file:lines]
-[actual code snippet showing logging]
-
-### REPOSITORY_PATTERN
-// SOURCE: [file:lines]
-[actual code snippet showing data access]
-
-### SERVICE_PATTERN
-// SOURCE: [file:lines]
-[actual code snippet showing service layer]
-
-### TEST_STRUCTURE
-// SOURCE: [file:lines]
-[actual code snippet showing test setup]
-
----
-
-## Files to Change
-
-| File | Action | Justification |
-|---|---|---|
-| `path/to/file.ts` | CREATE | New service for feature |
-| `path/to/existing.ts` | UPDATE | Add new method |
-
-## NOT Building
-
-- [Explicit item 1 that is out of scope]
-- [Explicit item 2 that is out of scope]
-
----
-
-## Step-by-Step Tasks
-
-### Task 1: [Name]
-- **ACTION**: [What to do]
-- **IMPLEMENT**: [Specific code/logic to write]
-- **MIRROR**: [Pattern from Patterns to Mirror section to follow]
-- **IMPORTS**: [Required imports]
-- **GOTCHA**: [Known pitfall to avoid]
-- **VALIDATE**: [How to verify this task is correct]
-
-### Task 2: [Name]
-- **ACTION**: ...
-- **IMPLEMENT**: ...
-- **MIRROR**: ...
-- **IMPORTS**: ...
-- **GOTCHA**: ...
-- **VALIDATE**: ...
-
-[Continue for all tasks...]
-
----
-
-## Testing Strategy
-
-### Unit Tests
-
-| Test | Input | Expected Output | Edge Case? |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-### Edge Cases Checklist
-- [ ] Empty input
-- [ ] Maximum size input
-- [ ] Invalid types
-- [ ] Concurrent access
-- [ ] Network failure (if applicable)
-- [ ] Permission denied
-
----
-
-## Validation Commands
-
-### Static Analysis
-```bash
-# Run type checker
-[project-specific type check command]
-```
-EXPECT: Zero type errors
-
-### Unit Tests
-```bash
-# Run tests for affected area
-[project-specific test command]
-```
-EXPECT: All tests pass
-
-### Full Test Suite
-```bash
-# Run complete test suite
-[project-specific full test command]
-```
-EXPECT: No regressions
-
-### Database Validation (if applicable)
-```bash
-# Verify schema/migrations
-[project-specific db command]
-```
-EXPECT: Schema up to date
-
-### Browser Validation (if applicable)
-```bash
-# Start dev server and verify
-[project-specific dev server command]
-```
-EXPECT: Feature works as designed
-
-### Manual Validation
-- [ ] [Step-by-step manual verification checklist]
-
----
-
-## Acceptance Criteria
-- [ ] All tasks completed
-- [ ] All validation commands pass
-- [ ] Tests written and passing
-- [ ] No type errors
-- [ ] No lint errors
-- [ ] Matches UX design (if applicable)
-
-## Completion Checklist
-- [ ] Code follows discovered patterns
-- [ ] Error handling matches codebase style
-- [ ] Logging follows codebase conventions
-- [ ] Tests follow test patterns
-- [ ] No hardcoded values
-- [ ] Documentation updated (if needed)
-- [ ] No unnecessary scope additions
-- [ ] Self-contained: no questions needed during implementation
-
-## Risks
-| Risk | Likelihood | Impact | Mitigation |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-## Notes
-[Any additional context, decisions, or observations]
-```
-
----
-
-## Output
-
-### Save the Plan
-
-Write the generated plan to:
-```
-.gemini/PRPs/plans/{kebab-case-feature-name}.plan.md
-```
-
-### Update PRD (if input was a PRD)
-
-If this plan was generated from a PRD phase:
-1. Update the phase status from `pending` to `in-progress`
-2. Add the plan file path as a reference in the phase
-
-### Report to User
-
-```
-## Plan Created
-
-- **File**: .gemini/PRPs/plans/{kebab-case-feature-name}.plan.md
-- **Source PRD**: [path or "N/A"]
-- **Phase**: [phase name or "standalone"]
-- **Complexity**: [level]
-- **Scope**: [N files, M tasks]
-- **Key Patterns**: [top 3 discovered patterns]
-- **External Research**: [topics researched or "none needed"]
-- **Risks**: [top risk or "none identified"]
-- **Confidence Score**: [1-10]: likelihood of single-pass implementation
-
-> Next step: Run `/prp-implement .gemini/PRPs/plans/{name}.plan.md` to execute this plan.
-```
-
----
-
-## Verification
-
-Before finalizing, verify the plan against these checklists:
-
-### Context Completeness
-- [ ] All relevant files discovered and documented
-- [ ] Naming conventions captured with examples
-- [ ] Error handling patterns documented
-- [ ] Test patterns identified
-- [ ] Dependencies listed
-
-### Implementation Readiness
-- [ ] Every task has ACTION, IMPLEMENT, MIRROR, and VALIDATE
-- [ ] No task requires additional codebase searching
-- [ ] Import paths are specified
-- [ ] GOTCHAs documented where applicable
-
-### Pattern Faithfulness
-- [ ] Code snippets are actual codebase examples (not invented)
-- [ ] SOURCE references point to real files and line numbers
-- [ ] Patterns cover naming, errors, logging, data access, and tests
-- [ ] New code will be indistinguishable from existing code
-
-### Validation Coverage
-- [ ] Static analysis commands specified
-- [ ] Test commands specified
-- [ ] Build verification included
-
-### UX Clarity
-- [ ] Before/after states documented (or marked N/A)
-- [ ] Interaction changes listed
-- [ ] Edge cases for UX identified
-
-### No Prior Knowledge Test
-A developer unfamiliar with this codebase should be able to implement the feature using ONLY this plan, without searching the codebase or asking questions. If not, add the missing context.
-
----
-
-## Next Steps
-
-- Run `/prp-implement <plan-path>` to execute this plan
-- Run `/plan` for quick conversational planning without artifacts
-- Run `/prp-prd` to create a PRD first if scope is unclear
-````

--- a/commands/prp-pr.md
+++ b/commands/prp-pr.md
@@ -3,182 +3,86 @@ description: "Create a GitHub PR from current branch with unpushed commits: disc
 argument-hint: "[base-branch] (default: main)"
 ---
 
-# Create Pull Request
+# Pull Request Creator
 
-> Adapted from PRPs-agentic-eng by Wirasm. Part of the PRP workflow series.
+**Input**: `$ARGUMENTS`: optional base branch name and/or flags (e.g., `--draft`).
 
-**Input**: `$ARGUMENTS`: optional, may contain a base branch name and/or flags (e.g., `--draft`).
+Open a pull request whose description a reviewer can trust: assembled from the actual commits and diff, with verification evidence, never from memory of the conversation.
 
-**Parse `$ARGUMENTS`**:
-- Extract any recognized flags (`--draft`)
-- Treat remaining non-flag text as the base branch name
-- Default base branch to `main` if none specified
+## Step 1: Preflight
 
----
+All four must hold before anything is pushed:
 
-## Phase 1: VALIDATE
-
-Check preconditions:
-
-```bash
-git branch --show-current
-git status --short
-git log origin/<base>..HEAD --oneline
-```
-
-| Check | Condition | Action if Failed |
+| Check | Command | On failure |
 |---|---|---|
-| Not on base branch | Current branch ≠ base | Stop: "Switch to a feature branch first." |
-| Clean working directory | No uncommitted changes | Warn: "You have uncommitted changes. Commit or stash first. Use `/prp-commit` to commit." |
-| Has commits ahead | `git log origin/<base>..HEAD` not empty | Stop: "No commits ahead of `<base>`. Nothing to PR." |
-| No existing PR | `gh pr list --head <branch> --json number` is empty | Stop: "PR already exists: #<number>. Use `gh pr view <number> --web` to open it." |
+| Not on the base branch | `git branch --show-current` | Offer to create a feature branch from the current state |
+| Base branch exists | `git rev-parse --verify {base}` | Ask for the correct base |
+| There are commits to propose | `git log {base}..HEAD --oneline` | Stop: nothing to open a PR for |
+| `gh` is authenticated | `gh auth status` | Stop with the login instruction |
 
-If all checks pass, proceed.
+Base branch: first word of `$ARGUMENTS` if present, otherwise `main`.
 
----
+## Step 2: Understand the change
 
-## Phase 2: DISCOVER
-
-### PR Template
-
-Search for PR template in order:
-
-1. `.github/PULL_REQUEST_TEMPLATE/` directory: if exists, list files and let user choose (or use `default.md`)
-2. `.github/PULL_REQUEST_TEMPLATE.md`
-3. `.github/pull_request_template.md`
-4. `docs/pull_request_template.md`
-
-If found, read it and use its structure for the PR body.
-
-### Commit Analysis
+Build the PR narrative from evidence:
 
 ```bash
-git log origin/<base>..HEAD --format="%h %s" --reverse
+git log {base}..HEAD --format='%h %s%n%b'
+git diff {base}...HEAD --stat
 ```
 
-Analyze commits to determine:
-- **PR title**: Use conventional commit format with type prefix: `feat: ...`, `fix: ...`, etc.
-  - If multiple types, use the dominant one
-  - If single commit, use its message as-is
-- **Change summary**: Group commits by type/area
+Identify: the user-visible outcome, the commits that carry it, breaking changes, and anything a reviewer will ask about (large diffs, deleted files, dependency changes).
 
-### File Analysis
+## Step 3: Template discovery
 
-```bash
-git diff origin/<base>..HEAD --stat
-git diff origin/<base>..HEAD --name-only
+Look for a PR template, in order:
+
+```text
+.github/PULL_REQUEST_TEMPLATE.md
+.github/pull_request_template.md
+.github/PULL_REQUEST_TEMPLATE/*.md
+docs/pull_request_template.md
 ```
 
-Categorize changed files: source, tests, docs, config, migrations.
-
-### PRP Artifacts
-
-Check for related PRP artifacts:
-- `.gemini/PRPs/reports/`: Implementation reports
-- `.gemini/PRPs/plans/`: Plans that were executed
-- `.gemini/PRPs/prds/`: Related PRDs
-
-Reference these in the PR body if they exist.
-
----
-
-## Phase 3: PUSH
-
-```bash
-git push -u origin HEAD
-```
-
-If push fails due to divergence:
-```bash
-git fetch origin
-git rebase origin/<base>
-git push -u origin HEAD
-```
-
-If rebase conflicts occur, stop and inform the user.
-
----
-
-## Phase 4: CREATE
-
-### With Template
-
-If a PR template was found in Phase 2, fill in each section using the commit and file analysis. Preserve all template sections: leave sections as "N/A" if not applicable rather than removing them.
-
-### Without Template
-
-Use this default format:
+When one exists, fill its sections faithfully; empty template sections are deleted, not left as placeholder text. When none exists, use:
 
 ```markdown
-## Summary
+## What
 
-<1-2 sentence description of what this PR does and why>
+{the change, stated as its user-visible outcome}
 
-## Changes
+## Why
 
-<bulleted list of changes grouped by area>
+{the problem or request behind it}
 
-## Files Changed
+## Verification
 
-<table or list of changed files with change type: Added/Modified/Deleted>
+{commands run and their results; screenshots for UI changes}
 
-## Testing
+## Notes for review
 
-<description of how changes were tested, or "Needs testing">
-
-## Related Issues
-
-<linked issues with Closes/Fixes/Relates to #N, or "None">
+{breaking changes, migration steps, or "none"}
 ```
 
-### Create the PR
+## Step 4: Push and open
 
 ```bash
-gh pr create \
-  --title "<PR title>" \
-  --base <base-branch> \
-  --body "<PR body>"
-  # Add --draft if the --draft flag was parsed from $ARGUMENTS
+git push -u origin {current-branch}
+gh pr create --base {base} --title "{conventional-commit style title}" --body "{assembled body}"
 ```
 
----
+Add `--draft` when the flag was passed. The PR title follows the same conventional format as commit messages.
 
-## Phase 5: VERIFY
+## Step 5: Output
 
-```bash
-gh pr view --json number,url,title,state,baseRefName,headRefName,additions,deletions,changedFiles
-gh pr checks --json name,status,conclusion 2>/dev/null || true
+```text
+PR opened: {url}
+  {base} <- {branch}: {n} commits, +{additions}/-{deletions}
+CI: {link or "no checks configured"}
 ```
 
----
+## Edge cases
 
-## Phase 6: OUTPUT
-
-Report to user:
-
-```
-PR #<number>: <title>
-URL: <url>
-Branch: <head> → <base>
-Changes: +<additions> -<deletions> across <changedFiles> files
-
-CI Checks: <status summary or "pending" or "none configured">
-
-Artifacts referenced:
-  - <any PRP reports/plans linked in PR body>
-
-Next steps:
-  - gh pr view <number> --web   → open in browser
-  - /code-review <number>       → review the PR
-  - gh pr merge <number>        → merge when ready
-```
-
----
-
-## Edge Cases
-
-- **No `gh` CLI**: Stop with: "GitHub CLI (`gh`) is required. Install: <https://cli.github.com/>"
-- **Not authenticated**: Stop with: "Run `gh auth login` first."
-- **Force push needed**: If remote has diverged and rebase was done, use `git push --force-with-lease` (never `--force`).
-- **Multiple PR templates**: If `.github/PULL_REQUEST_TEMPLATE/` has multiple files, list them and ask user to choose.
-- **Large PR (>20 files)**: Warn about PR size. Suggest splitting if changes are logically separable.
+- **Diverged from base**: warn and suggest `git fetch origin && git rebase origin/{base}` before opening.
+- **Existing open PR for this branch**: do not create a duplicate; show the existing URL and offer to update its body instead.
+- **Fork workflow**: when `origin` is a fork, push to `origin` and target the upstream repo with `--repo`.

--- a/commands/prp-prd.md
+++ b/commands/prp-prd.md
@@ -3,445 +3,126 @@ description: "Interactive PRD generator - problem-first, hypothesis-driven produ
 argument-hint: "[feature/product idea] (blank = start with questions)"
 ---
 
-# Product Requirements Document Generator
-
-> Adapted from PRPs-agentic-eng by Wirasm. Part of the PRP workflow series.
+# PRD Builder
 
 **Input**: $ARGUMENTS
 
----
+Build a Product Requirements Document by interviewing the user until the problem is understood, then writing the spec. The document is the output of the conversation, never a form filled in one shot.
 
-## Your Role
+## Operating rule: the certainty board
 
-You are a sharp product manager who:
-- Starts with PROBLEMS, not solutions
-- Demands evidence before building
-- Thinks in hypotheses, not specs
-- Asks clarifying questions before assuming
-- Acknowledges uncertainty honestly
+Maintain a three-column board for the whole session:
 
-**Anti-pattern**: Don't fill sections with fluff. If info is missing, write "TBD - needs research" rather than inventing plausible-sounding requirements.
+| Column | Contents |
+|---|---|
+| **Known** | Facts the user stated or evidence you gathered |
+| **Assumed** | Working hypotheses you adopted to move forward |
+| **Unknown** | Questions that still block a trustworthy spec |
 
----
+Every answer moves items between columns. You may only write the PRD when **Unknown is empty** or the user explicitly says "write it with what we have". Anything still in Assumed at writing time goes into the PRD's assumptions section, visible and testable.
 
-## Process Overview
+## Session flow
 
+### 1. Seed
+
+If `$ARGUMENTS` contains an idea, restate it in one sentence and place it in Assumed (it is a hypothesis, not a fact). If blank, open with exactly one question: "What problem keeps happening, and to whom?"
+
+### 2. Question rounds
+
+Ask in rounds of **at most three questions**. Never send a questionnaire. Pick the three questions that would eliminate the most Unknowns, favoring this order:
+
+1. Who has the problem and how do they cope today
+2. What evidence shows the problem is real (frequency, cost, complaints)
+3. What outcome would make the user say "solved"
+4. What must NOT change (constraints, integrations, budget)
+5. What happens if nothing is built
+
+After each round, show the updated board in compact form so the user sees progress and can correct wrong Assumed entries.
+
+### 3. Evidence pass
+
+Before writing, verify what can be verified without the user:
+
+- Search the repo for related code, prior attempts, TODO markers
+- Check `PRPs/prds/` for an earlier PRD on the same area
+- Note every verification in Known with its source
+
+### 4. Write
+
+Generate the document from the board. Kebab-case the title for the filename and save to:
+
+```text
+PRPs/prds/{kebab-case-name}.prd.md
 ```
-QUESTION SET 1 → GROUNDING → QUESTION SET 2 → RESEARCH → QUESTION SET 3 → GENERATE
-```
 
-Each question set builds on previous answers. Grounding phases validate assumptions.
+Create the directory if it does not exist.
 
----
-
-## Phase 1: INITIATE - Core Problem
-
-**If no input provided**, ask:
-
-> **What do you want to build?**
-> Describe the product, feature, or capability in a few sentences.
-
-**If input provided**, confirm understanding by restating:
-
-> I understand you want to build: {restated understanding}
-> Is this correct, or should I adjust my understanding?
-
-**GATE**: Wait for user response before proceeding.
-
----
-
-## Phase 2: FOUNDATION - Problem Discovery
-
-Ask these questions (present all at once, user can answer together):
-
-> **Foundation Questions:**
->
-> 1. **Who** has this problem? Be specific - not just "users" but what type of person/role?
->
-> 2. **What** problem are they facing? Describe the observable pain, not the assumed need.
->
-> 3. **Why** can't they solve it today? What alternatives exist and why do they fail?
->
-> 4. **Why now?** What changed that makes this worth building?
->
-> 5. **How** will you know if you solved it? What would success look like?
-
-**GATE**: Wait for user responses before proceeding.
-
----
-
-## Phase 3: GROUNDING - Market & Context Research
-
-After foundation answers, conduct research:
-
-**Research market context:**
-
-1. Find similar products/features in the market
-2. Identify how competitors solve this problem
-3. Note common patterns and anti-patterns
-4. Check for recent trends or changes in this space
-
-Compile findings with direct links, key insights, and any gaps in available information.
-
-**If a codebase exists, explore it in parallel:**
-
-1. Find existing functionality relevant to the product/feature idea
-2. Identify patterns that could be leveraged
-3. Note technical constraints or opportunities
-
-Record file locations, code patterns, and conventions observed.
-
-**Summarize findings to user:**
-
-> **What I found:**
-> - {Market insight 1}
-> - {Competitor approach}
-> - {Relevant pattern from codebase, if applicable}
->
-> Does this change or refine your thinking?
-
-**GATE**: Brief pause for user input (can be "continue" or adjustments).
-
----
-
-## Phase 4: DEEP DIVE - Vision & Users
-
-Based on foundation + research, ask:
-
-> **Vision & Users:**
->
-> 1. **Vision**: In one sentence, what's the ideal end state if this succeeds wildly?
->
-> 2. **Primary User**: Describe your most important user - their role, context, and what triggers their need.
->
-> 3. **Job to Be Done**: Complete this: "When [situation], I want to [motivation], so I can [outcome]."
->
-> 4. **Non-Users**: Who is explicitly NOT the target? Who should we ignore?
->
-> 5. **Constraints**: What limitations exist? (time, budget, technical, regulatory)
-
-**GATE**: Wait for user responses before proceeding.
-
----
-
-## Phase 5: GROUNDING - Technical Feasibility
-
-**If a codebase exists, perform two parallel investigations:**
-
-Investigation 1: Explore feasibility:
-1. Identify existing infrastructure that can be leveraged
-2. Find similar patterns already implemented
-3. Map integration points and dependencies
-4. Locate relevant configuration and type definitions
-
-Record file locations, code patterns, and conventions observed.
-
-Investigation 2: Analyze constraints:
-1. Trace how existing related features are implemented end-to-end
-2. Map data flow through potential integration points
-3. Identify architectural patterns and boundaries
-4. Estimate complexity based on similar features
-
-Document what exists with precise file:line references. No suggestions.
-
-**If no codebase, research technical approaches:**
-
-1. Find technical approaches others have used
-2. Identify common implementation patterns
-3. Note known technical challenges and pitfalls
-
-Compile findings with citations and gap analysis.
-
-**Summarize to user:**
-
-> **Technical Context:**
-> - Feasibility: {HIGH/MEDIUM/LOW} because {reason}
-> - Can leverage: {existing patterns/infrastructure}
-> - Key technical risk: {main concern}
->
-> Any technical constraints I should know about?
-
-**GATE**: Brief pause for user input.
-
----
-
-## Phase 6: DECISIONS - Scope & Approach
-
-Ask final clarifying questions:
-
-> **Scope & Approach:**
->
-> 1. **MVP Definition**: What's the absolute minimum to test if this works?
->
-> 2. **Must Have vs Nice to Have**: What 2-3 things MUST be in v1? What can wait?
->
-> 3. **Key Hypothesis**: Complete this: "We believe [capability] will [solve problem] for [users]. We'll know we're right when [measurable outcome]."
->
-> 4. **Out of Scope**: What are you explicitly NOT building (even if users ask)?
->
-> 5. **Open Questions**: What uncertainties could change the approach?
-
-**GATE**: Wait for user responses before generating.
-
----
-
-## Phase 7: GENERATE - Write PRD
-
-**Output path**: `.gemini/PRPs/prds/{kebab-case-name}.prd.md`
-
-Create directory if needed: `mkdir -p .gemini/PRPs/prds`
-
-### PRD Template
+## PRD template
 
 ```markdown
-# {Product/Feature Name}
+# {Name}
 
-## Problem Statement
+status: draft
+written: {date}
 
-{2-3 sentences: Who has what problem, and what's the cost of not solving it?}
+## Problem
+
+{One paragraph. Who hurts, how often, what it costs. No solution language here.}
 
 ## Evidence
 
-- {User quote, data point, or observation that proves this problem exists}
-- {Another piece of evidence}
-- {If none: "Assumption - needs validation through [method]"}
+{Bulleted facts from the Known column, each with its source: user statement,
+repo finding, metric. If evidence is thin, say so explicitly.}
 
-## Proposed Solution
+## Users and jobs
 
-{One paragraph: What we're building and why this approach over alternatives}
+{Each user type and the job they are trying to get done. Real roles, not personas.}
 
-## Key Hypothesis
+## Outcome metrics
 
-We believe {capability} will {solve problem} for {users}.
-We'll know we're right when {measurable outcome}.
+{2-4 measurable statements that define success. Each one must be checkable
+after shipping: number, threshold, and how it will be measured.}
 
-## What We're NOT Building
+## Scope ledger
 
-- {Out of scope item 1} - {why}
-- {Out of scope item 2} - {why}
+Committed:
 
-## Success Metrics
+- {what this PRD promises}
 
-| Metric | Target | How Measured |
-|--------|--------|--------------|
-| {Primary metric} | {Specific number} | {Method} |
-| {Secondary metric} | {Specific number} | {Method} |
+Excluded:
 
-## Open Questions
+- {what was consciously left out, with the one-line reason}
 
-- [ ] {Unresolved question 1}
-- [ ] {Unresolved question 2}
+Deferred:
 
----
+- {what waits for a later phase}
 
-## Users & Context
+## Assumptions to validate
 
-**Primary User**
-- **Who**: {Specific description}
-- **Current behavior**: {What they do today}
-- **Trigger**: {What moment triggers the need}
-- **Success state**: {What "done" looks like}
-
-**Job to Be Done**
-When {situation}, I want to {motivation}, so I can {outcome}.
-
-**Non-Users**
-{Who this is NOT for and why}
-
----
-
-## Solution Detail
-
-### Core Capabilities (MoSCoW)
-
-| Priority | Capability | Rationale |
-|----------|------------|-----------|
-| Must | {Feature} | {Why essential} |
-| Must | {Feature} | {Why essential} |
-| Should | {Feature} | {Why important but not blocking} |
-| Could | {Feature} | {Nice to have} |
-| Won't | {Feature} | {Explicitly deferred and why} |
-
-### MVP Scope
-
-{What's the minimum to validate the hypothesis}
-
-### User Flow
-
-{Critical path - shortest journey to value}
-
----
-
-## Technical Approach
-
-**Feasibility**: {HIGH/MEDIUM/LOW}
-
-**Architecture Notes**
-- {Key technical decision and why}
-- {Dependency or integration point}
-
-**Technical Risks**
-
-| Risk | Likelihood | Mitigation |
-|------|------------|------------|
-| {Risk} | {H/M/L} | {How to handle} |
-
----
+{Everything still in the Assumed column at writing time. Each entry gets a
+validation idea: how we will find out if it is wrong, and what we do then.}
 
 ## Implementation Phases
 
-<!--
-  STATUS: pending | in-progress | complete
-  PARALLEL: phases that can run concurrently (e.g., "with 3" or "-")
-  DEPENDS: phases that must complete first (e.g., "1, 2" or "-")
-  PRP: link to generated plan file once created
--->
+- [ ] Phase 1: {smallest end-to-end slice that proves the approach}
+- [ ] Phase 2: {next increment}
+- [ ] Phase 3: {and so on}
 
-| # | Phase | Description | Status | Parallel | Depends | PRP Plan |
-|---|-------|-------------|--------|----------|---------|----------|
-| 1 | {Phase name} | {What this phase delivers} | pending | - | - | - |
-| 2 | {Phase name} | {What this phase delivers} | pending | - | 1 | - |
-| 3 | {Phase name} | {What this phase delivers} | pending | with 4 | 2 | - |
-| 4 | {Phase name} | {What this phase delivers} | pending | with 3 | 2 | - |
-| 5 | {Phase name} | {What this phase delivers} | pending | - | 3, 4 | - |
-
-### Phase Details
-
-**Phase 1: {Name}**
-- **Goal**: {What we're trying to achieve}
-- **Scope**: {Bounded deliverables}
-- **Success signal**: {How we know it's done}
-
-**Phase 2: {Name}**
-- **Goal**: {What we're trying to achieve}
-- **Scope**: {Bounded deliverables}
-- **Success signal**: {How we know it's done}
-
-{Continue for each phase...}
-
-### Parallelism Notes
-
-{Explain which phases can run in parallel and why}
-
----
-
-## Decisions Log
-
-| Decision | Choice | Alternatives | Rationale |
-|----------|--------|--------------|-----------|
-| {Decision} | {Choice} | {Options considered} | {Why this one} |
-
----
-
-## Research Summary
-
-**Market Context**
-{Key findings from market research}
-
-**Technical Context**
-{Key findings from technical exploration}
-
----
-
-*Generated: {timestamp}*
-*Status: DRAFT - needs validation*
+Each phase must be independently shippable and verifiable.
 ```
 
----
+## Quality bar before saving
 
-## Phase 8: OUTPUT - Summary
+- The Problem section contains zero solution words (no "add", "build", "implement")
+- Every metric in Outcome metrics has a measurement method
+- Scope ledger has at least one Excluded entry (a PRD that excludes nothing was not thought through)
+- Every phase in Implementation Phases can be verified on its own
 
-After generating, report:
+## Handoff
 
-```markdown
-## PRD Created
+After saving, tell the user:
 
-**File**: `.gemini/PRPs/prds/{name}.prd.md`
-
-### Summary
-
-**Problem**: {One line}
-**Solution**: {One line}
-**Key Metric**: {Primary success metric}
-
-### Validation Status
-
-| Section | Status |
-|---------|--------|
-| Problem Statement | {Validated/Assumption} |
-| User Research | {Done/Needed} |
-| Technical Feasibility | {Assessed/TBD} |
-| Success Metrics | {Defined/Needs refinement} |
-
-### Open Questions ({count})
-
-{List the open questions that need answers}
-
-### Recommended Next Step
-
-{One of: user research, technical spike, prototype, stakeholder review, etc.}
-
-### Implementation Phases
-
-| # | Phase | Status | Can Parallel |
-|---|-------|--------|--------------|
-{Table of phases from PRD}
-
-### To Start Implementation
-
-Run: `/prp-plan .gemini/PRPs/prds/{name}.prd.md`
-
-This will automatically select the next pending phase and create an implementation plan.
+```text
+PRD saved: PRPs/prds/{name}.prd.md
+Next: /prp-plan PRPs/prds/{name}.prd.md
 ```
-
----
-
-## Question Flow Summary
-
-```
-┌─────────────────────────────────────────────────────────┐
-│  INITIATE: "What do you want to build?"                 │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│  FOUNDATION: Who, What, Why, Why now, How to measure    │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│  GROUNDING: Market research, competitor analysis        │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│  DEEP DIVE: Vision, Primary user, JTBD, Constraints     │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│  GROUNDING: Technical feasibility, codebase exploration │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│  DECISIONS: MVP, Must-haves, Hypothesis, Out of scope   │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│  GENERATE: Write PRD to .gemini/PRPs/prds/              │
-└─────────────────────────────────────────────────────────┘
-```
-
----
-
-## Integration with EGC
-
-After PRD generation:
-- Use `/prp-plan` to create implementation plans from PRD phases
-- Use `/plan` for simpler planning without PRD structure
-- Use `/save-session` to preserve PRD context across sessions
-
-## Success Criteria
-
-- **PROBLEM_VALIDATED**: Problem is specific and evidenced (or marked as assumption)
-- **USER_DEFINED**: Primary user is concrete, not generic
-- **HYPOTHESIS_CLEAR**: Testable hypothesis with measurable outcome
-- **SCOPE_BOUNDED**: Clear must-haves and explicit out-of-scope
-- **QUESTIONS_ACKNOWLEDGED**: Uncertainties are listed, not hidden
-- **ACTIONABLE**: A skeptic could understand why this is worth building


### PR DESCRIPTION
## What

Rewrites the five prp-* commands and the PR review mode of code-review.md from scratch with process designs native to EGC:

- **prp-prd**: interview driven by a Known/Assumed/Unknown certainty board; PRD template with evidence, scope ledger, and testable assumptions
- **prp-plan**: plans built to survive a cold start; context capsule with verified validation commands and mirror files
- **prp-implement**: green-to-green execution; two-attempt failure protocol with revert and partial report
- **prp-commit**: semantic natural-language file targeting, atomic split, secret guard
- **prp-pr**: preflight table, template discovery, evidence-based PR body
- **code-review** (PR mode): findings ledger where every finding carries proof; verdict computed from the ledger

## Compatibility

Command names, frontmatter (description, argument-hint), and artifact paths (PRPs/prds/, PRPs/plans/, PRPs/reports/, PRPs/plans/completed/, .gemini/PRPs/reviews/) are unchanged. The PRD template keeps the "Implementation Phases" section that prp-plan parses. Nothing leaves the catalog.

## Why

The previous versions followed the structure of an external workflow project (reference line at the top of each file). This rewrite replaces them with original designs, after which the reference no longer applies and is removed. Follow-up to #672.

## Verification

- markdownlint-cli2 on all six files: 0 errors
- Frontmatter fields byte-identical to previous versions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the `prp-*` commands and PR review mode with EGC-native workflows to make specs, plans, execution, commits, PRs, and reviews evidence-driven and reliably green. Command names, frontmatter, and artifact paths stay the same, so existing integrations keep working.

- **Refactors**
  - `prp-prd`: Interview via a Known/Assumed/Unknown board; PRD template adds evidence, scope ledger, and testable assumptions.
  - `prp-plan`: Cold‑start plans with a context capsule, mirror files, verified validation commands, and green-on-each-increment slicing.
  - `prp-implement`: Green‑to‑green execution with a two‑attempt failure protocol that reverts and produces a partial report.
  - `prp-commit`: Semantic file targeting from plain English, atomic splits, secret/debug guards, and conventional commit messages (DCO sign‑off when required).
  - `prp-pr`: Preflight checks, template discovery, and an evidence‑based PR body; conventional titles; supports forks and drafts.
  - `code-review` (PR mode): Findings ledger with proof and computed verdicts; local/CI verification; clear degraded-mode behavior.

- **Migration**
  - No breaking changes. Command names, frontmatter fields, and artifact paths are unchanged (`PRPs/prds/`, `PRPs/plans/`, `PRPs/reports/`, `PRPs/plans/completed/`, `.gemini/PRPs/reviews/`). The PRD keeps the "Implementation Phases" section parsed by `prp-plan`.

<sup>Written for commit c2033cb4a8b633b55f773dde0daa634b1ea8843f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

