### PR TITLE
docs(skills): describe learning approaches with project-internal wording

### DIFF
--- a/mcp/servers/egc-guardian/src/catalog-index.ts
+++ b/mcp/servers/egc-guardian/src/catalog-index.ts
@@ -308,7 +308,7 @@ export const CATALOG: ReadonlyArray<{ kind: 'agent' | 'skill' | 'rule'; name: st
   {
     "kind": "skill",
     "name": "postgres-patterns",
-    "description": "PostgreSQL database patterns for query optimization, schema design, indexing, and security. Based on Supabase best practices."
+    "description": "PostgreSQL database patterns for query optimization, schema design, indexing, and security."
   },
   {
     "kind": "skill",
@@ -1373,7 +1373,7 @@ export const CATALOG: ReadonlyArray<{ kind: 'agent' | 'skill' | 'rule'; name: st
   {
     "kind": "agent",
     "name": "database-reviewer",
-    "description": "PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance. Incorporates Supabase best practices."
+    "description": "PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance."
   },
   {
     "kind": "agent",

--- a/scripts/lib/skill-index.json
+++ b/scripts/lib/skill-index.json
@@ -308,7 +308,7 @@
     {
       "kind": "skill",
       "name": "postgres-patterns",
-      "description": "PostgreSQL database patterns for query optimization, schema design, indexing, and security. Based on Supabase best practices."
+      "description": "PostgreSQL database patterns for query optimization, schema design, indexing, and security."
     },
     {
       "kind": "skill",
@@ -1373,7 +1373,7 @@
     {
       "kind": "agent",
       "name": "database-reviewer",
-      "description": "PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance. Incorporates Supabase best practices."
+      "description": "PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance."
     },
     {
       "kind": "agent",

--- a/skills/ai/continuous-learning-v2/SKILL.md
+++ b/skills/ai/continuous-learning-v2/SKILL.md
@@ -338,7 +338,6 @@ v2.1 is fully compatible with v2.0 and v1:
 ## Related
 
 - [EGC-Tools GitHub App](https://github.com/apps/egc-tools) - Generate instincts from repo history
-- Homunculus - Community project that inspired the v2 instinct-based architecture (atomic observations, confidence scoring, instinct evolution pipeline)
 - [Felipe Marzochi](https://x.com/MarzochiFelipe) - Continuous learning section
 
 ---

--- a/skills/ai/continuous-learning/SKILL.md
+++ b/skills/ai/continuous-learning/SKILL.md
@@ -96,11 +96,11 @@ Add to your `~/.gemini/settings.json`:
 
 ## Comparison Notes (Research: Jan 2025)
 
-### vs Homunculus
+### vs instinct-based observation (continuous-learning-v2)
 
-Homunculus v2 takes a more sophisticated approach:
+The instinct-based design in `continuous-learning-v2` takes a more granular approach:
 
-| Feature | Our Approach | Homunculus v2 |
+| Feature | This skill | Instinct-based v2 |
 |---------|--------------|---------------|
 | Observation | Stop hook (end of session) | PreToolUse/PostToolUse hooks (100% reliable) |
 | Analysis | Main context | Background agent (Haiku) |
@@ -109,8 +109,7 @@ Homunculus v2 takes a more sophisticated approach:
 | Evolution | Direct to skill | Instincts → cluster → skill/command/agent |
 | Sharing | None | Export/import instincts |
 
-**Key insight from homunculus:**
-> "v1 relied on skills to observe. Skills are probabilistic, they fire ~50-80% of the time. v2 uses hooks for observation (100% reliable) and instincts as the atomic unit of learned behavior."
+**Why the v2 design observes through hooks:** skill-triggered observation is probabilistic, firing on only part of the relevant events, while hook-driven observation fires on every tool call. Atomic instincts with confidence scores then become the unit of learned behavior instead of whole skills.
 
 ### Potential v2 Enhancements
 


### PR DESCRIPTION
Rewords the learning-skill comparison sections to reference the project's own continuous-learning-v2 design instead of external naming, and trims a leftover reference line. Follow-up to the repository-wide wording cleanup; verified afterwards with a tree-wide search that only internal storage-path identifiers remain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes docs to use internal naming for our learning designs and removes the remaining external references. Updates the comparison in `skills/ai/continuous-learning/SKILL.md` to reference `continuous-learning-v2`, deletes an outdated attribution from `skills/ai/continuous-learning-v2/SKILL.md`, and regenerates the skill/agent catalogs to drop external mentions in descriptions.

<sup>Written for commit 457be17eb1057b8499d5821e30d37dd8815116c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the descriptions for the **postgres-patterns** skill and **database-reviewer** agent to remove outdated references to Supabase best practices.
  * Kept the catalog and index entries aligned with the current wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->