### PR TITLE
fix(memory): stop stale state propagation and read encrypted state in hooks

### DIFF
--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -26,6 +26,7 @@ const propagateStateContent = propagateStateLib ? propagateStateLib.propagateSta
 const projectDetect = tryRequire('../lib/project-detect');
 const branchState = tryRequire('../lib/branch-state');
 const autoConsolidate = tryRequire('../lib/auto-consolidate');
+const stateCrypto = tryRequire('../lib/state-crypto');
 
 function readStdinJson() {
   try {
@@ -187,16 +188,33 @@ function resolveStateFile(projectPath) {
   return fs.existsSync(flatFile) ? flatFile : null;
 }
 
+// Encrypted state (EGC1 payloads written by the memory server) is decrypted
+// via state-crypto; without that lib the hook stays silent instead of
+// printing or propagating ciphertext. Consolidation only runs on plaintext:
+// the memory server owns maintenance of encrypted files.
+function readPlaintextState(stateFile) {
+  let raw = fs.readFileSync(stateFile);
+
+  const encrypted = stateCrypto
+    ? stateCrypto.isEncryptedBuffer(raw)
+    : raw.subarray(0, 5).toString('utf8') === 'EGC1:';
+  if (encrypted) {
+    return stateCrypto ? stateCrypto.decryptStateBuffer(raw) : null;
+  }
+
+  if (autoConsolidate) {
+    const result = consolidateBestEffort(stateFile);
+    if (result && result.consolidated) raw = fs.readFileSync(stateFile);
+  }
+  return raw.toString('utf8');
+}
+
 function loadAndPrintState(projectPath) {
   const stateFile = resolveStateFile(projectPath);
   if (!stateFile) return;
 
-  if (autoConsolidate) {
-    consolidateBestEffort(stateFile);
-  }
-
-  const content = fs.readFileSync(stateFile, 'utf8');
-  if (!content.trim()) return;
+  const content = readPlaintextState(stateFile);
+  if (content === null || !content.trim()) return;
 
   if (propagateStateContent) {
     try {

--- a/scripts/lib/auto-consolidate.js
+++ b/scripts/lib/auto-consolidate.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 
 const { consolidateState, backupStateFile, DEFAULT_THRESHOLD } = require('./state-consolidate');
+const { isEncryptedBuffer } = require('./state-crypto');
 
 const AUTO_CONSOLIDATE_ENV = 'EGC_AUTO_CONSOLIDATE';
 
@@ -23,7 +24,13 @@ function autoConsolidateStateFile(filePath, options = {}) {
 
   let content;
   try {
-    content = fs.readFileSync(filePath, 'utf8');
+    const raw = fs.readFileSync(filePath);
+    // Encrypted state belongs to the memory server; rewriting it here would
+    // destroy the ciphertext and its HMAC sidecar.
+    if (isEncryptedBuffer(raw)) {
+      return { consolidated: false, reason: 'encrypted' };
+    }
+    content = raw.toString('utf8');
   } catch {
     return { consolidated: false, reason: 'unreadable' };
   }

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -35,8 +35,10 @@ const {
 } = require('../claude-settings-hooks');
 
 const HOOK_LIB_SOURCES = [
-  'scripts/lib/propagate-state.js',
+  'scripts/lib/branch-state.js',
   'scripts/lib/project-detect.js',
+  'scripts/lib/propagate-state.js',
+  'scripts/lib/state-crypto.js',
 ];
 
 function createSessionStateHookOperations(adapter, targetRoot) {

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -42,7 +42,9 @@ Detect user intent in any language and call the matching EGC tool — no keyword
 - User asks AI to learn from session errors → \`auto_learn\``;
 
 function parseStateContent(content) {
-  const result = { context: '', decisions: [], next: [] };
+  const result = { context: '', decisions: [], next: [], updated: '' };
+  const updatedMatch = content.match(/^updated:\s*(\S+)\s*$/m);
+  if (updatedMatch) result.updated = updatedMatch[1];
   let section = '';
 
   for (const line of content.split('\n')) {
@@ -61,7 +63,9 @@ function parseStateContent(content) {
 }
 
 function buildSummaryBlock(parsed) {
-  const lines = ['## EGC Project Memory'];
+  const lines = [];
+  if (parsed.updated) lines.push(`<!-- egc:state-updated:${parsed.updated} -->`);
+  lines.push('## EGC Project Memory');
 
   if (parsed.context) {
     lines.push('', `**Context:** ${parsed.context}`);
@@ -96,7 +100,27 @@ function upsertEgcSection(existing, block) {
   return existing ? `${existing.trimEnd()}\n\n${section}\n` : `${section}\n`;
 }
 
-function writeCursorContext(projectPath, block) {
+const STATE_UPDATED_RE = /<!-- egc:state-updated:(\S+) -->/;
+
+function extractStateUpdated(content) {
+  const match = typeof content === 'string' ? content.match(STATE_UPDATED_RE) : null;
+  return match ? match[1] : '';
+}
+
+// A mirror stamped by an equally new or newer state must not be overwritten:
+// stale sources (older update stamp, or no stamp at all) would silently roll
+// project memory back, as a leftover flat state file once did to AGENTS.md.
+function isStaleWrite(existingContent, stateUpdated) {
+  const existingUpdated = extractStateUpdated(existingContent || '');
+  if (!existingUpdated) return false;
+  if (!stateUpdated) return true;
+  const existingMs = Date.parse(existingUpdated);
+  const stateMs = Date.parse(stateUpdated);
+  if (Number.isNaN(existingMs) || Number.isNaN(stateMs)) return false;
+  return stateMs <= existingMs;
+}
+
+function writeCursorContext(projectPath, block, stateUpdated) {
   const cursorDir = path.join(projectPath, '.cursor');
   try {
     if (!fs.existsSync(cursorDir) || !fs.statSync(cursorDir).isDirectory()) return null;
@@ -108,12 +132,14 @@ function writeCursorContext(projectPath, block) {
   fs.mkdirSync(rulesDir, { recursive: true });
 
   const filePath = path.join(rulesDir, 'egc-context.mdc');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   const content = `---\ndescription: EGC project memory (auto-updated)\nalwaysApply: true\n---\n\n${block}\n`;
   fs.writeFileSync(filePath, content, 'utf-8');
   return filePath;
 }
 
-function writeCopilotContext(projectPath, block) {
+function writeCopilotContext(projectPath, block, stateUpdated) {
   const filePath = path.join(projectPath, '.github', 'copilot-instructions.md');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -122,11 +148,12 @@ function writeCopilotContext(projectPath, block) {
   }
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeGeminiContext(projectPath, block) {
+function writeGeminiContext(projectPath, block, stateUpdated) {
   const filePath = path.join(projectPath, 'GEMINI.md');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -135,11 +162,12 @@ function writeGeminiContext(projectPath, block) {
   }
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeWindsurfContext(projectPath, block) {
+function writeWindsurfContext(projectPath, block, stateUpdated) {
   const windsurfDir = path.join(projectPath, '.windsurf');
   try {
     if (!fs.existsSync(windsurfDir) || !fs.statSync(windsurfDir).isDirectory()) return null;
@@ -152,11 +180,12 @@ function writeWindsurfContext(projectPath, block) {
 
   const filePath = path.join(rulesDir, 'egc-context.md');
   const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeTraeContext(projectPath, block) {
+function writeTraeContext(projectPath, block, stateUpdated) {
   const traeDir = path.join(projectPath, '.trae');
   try {
     if (!fs.existsSync(traeDir) || !fs.statSync(traeDir).isDirectory()) return null;
@@ -169,11 +198,12 @@ function writeTraeContext(projectPath, block) {
 
   const filePath = path.join(rulesDir, 'egc-context.md');
   const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeZedContext(projectPath, block) {
+function writeZedContext(projectPath, block, stateUpdated) {
   const filePath = path.join(projectPath, '.rules');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -182,11 +212,12 @@ function writeZedContext(projectPath, block) {
   }
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeClineContext(projectPath, block) {
+function writeClineContext(projectPath, block, stateUpdated) {
   const filePath = path.join(projectPath, '.clinerules');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -195,11 +226,12 @@ function writeClineContext(projectPath, block) {
   }
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeAiderContext(projectPath, block) {
+function writeAiderContext(projectPath, block, stateUpdated) {
   const filePath = path.join(projectPath, 'CONVENTIONS.md');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -208,11 +240,12 @@ function writeAiderContext(projectPath, block) {
   }
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeLegacyCursorRules(projectPath, block) {
+function writeLegacyCursorRules(projectPath, block, stateUpdated) {
   const filePath = path.join(projectPath, '.cursorrules');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -221,11 +254,12 @@ function writeLegacyCursorRules(projectPath, block) {
   }
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
-function writeAgentsContext(projectPath, block) {
+function writeAgentsContext(projectPath, block, stateUpdated) {
   const filePath = path.join(projectPath, 'AGENTS.md');
   try {
     if (!fs.existsSync(filePath)) return null;
@@ -234,6 +268,7 @@ function writeAgentsContext(projectPath, block) {
   }
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
@@ -246,7 +281,10 @@ function writeLlmsTxt(projectPath, parsed) {
     return null;
   }
 
-  const lines = ['# EGC Project Memory'];
+  const stateUpdated = parsed.updated;
+  const lines = [];
+  if (stateUpdated) lines.push(`<!-- egc:state-updated:${stateUpdated} -->`);
+  lines.push('# EGC Project Memory');
   if (parsed.context) lines.push('', parsed.context);
   if (parsed.next.length > 0) {
     lines.push('', '## Next session');
@@ -256,6 +294,7 @@ function writeLlmsTxt(projectPath, parsed) {
   const block = lines.join('\n');
 
   const existing = fs.readFileSync(filePath, 'utf-8');
+  if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
@@ -264,17 +303,19 @@ function propagateStateContent(projectPath, stateContent) {
   const parsed = parseStateContent(stateContent);
   const block = buildSummaryBlock(parsed);
 
+  const stateUpdated = parsed.updated;
+
   return {
-    cursor: writeCursorContext(projectPath, block),
-    copilot: writeCopilotContext(projectPath, block),
-    gemini: writeGeminiContext(projectPath, block),
-    windsurf: writeWindsurfContext(projectPath, block),
-    trae: writeTraeContext(projectPath, block),
-    zed: writeZedContext(projectPath, block),
-    cline: writeClineContext(projectPath, block),
-    aider: writeAiderContext(projectPath, block),
-    cursorrules: writeLegacyCursorRules(projectPath, block),
-    agents: writeAgentsContext(projectPath, block),
+    cursor: writeCursorContext(projectPath, block, stateUpdated),
+    copilot: writeCopilotContext(projectPath, block, stateUpdated),
+    gemini: writeGeminiContext(projectPath, block, stateUpdated),
+    windsurf: writeWindsurfContext(projectPath, block, stateUpdated),
+    trae: writeTraeContext(projectPath, block, stateUpdated),
+    zed: writeZedContext(projectPath, block, stateUpdated),
+    cline: writeClineContext(projectPath, block, stateUpdated),
+    aider: writeAiderContext(projectPath, block, stateUpdated),
+    cursorrules: writeLegacyCursorRules(projectPath, block, stateUpdated),
+    agents: writeAgentsContext(projectPath, block, stateUpdated),
     llms: writeLlmsTxt(projectPath, parsed),
   };
 }

--- a/scripts/lib/state-crypto.js
+++ b/scripts/lib/state-crypto.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// Read-side decryption for egc-memory state files. The memory server encrypts
+// every state write as: "EGC1:" magic + 12-byte IV + 16-byte GCM auth tag +
+// AES-256-GCM ciphertext, keyed by ~/.egc/encryption.key (32 bytes as hex).
+// Hooks and watchers only read state, so this module never creates or rotates
+// the key; the write side lives in mcp/servers/egc-memory/src/encryption.ts.
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const MAGIC = 'EGC1:';
+const MAGIC_BYTES = Buffer.byteLength(MAGIC, 'utf-8');
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const ALGORITHM = 'aes-256-gcm';
+
+function defaultKeyPath() {
+  return path.join(os.homedir(), '.egc', 'encryption.key');
+}
+
+function isEncryptedBuffer(data) {
+  return Buffer.isBuffer(data)
+    && data.length >= MAGIC_BYTES
+    && data.subarray(0, MAGIC_BYTES).toString('utf-8') === MAGIC;
+}
+
+function loadKey(keyPath) {
+  const hex = fs.readFileSync(keyPath || defaultKeyPath(), 'utf-8').trim();
+  const key = Buffer.from(hex, 'hex');
+  return key.length === 32 ? key : null;
+}
+
+// Returns plaintext, or null when the payload cannot be authenticated and
+// decrypted (missing or malformed key, truncated or tampered ciphertext).
+function decryptStateBuffer(data, keyPath) {
+  try {
+    const key = loadKey(keyPath);
+    if (!key) return null;
+    const iv = data.subarray(MAGIC_BYTES, MAGIC_BYTES + IV_BYTES);
+    const authTag = data.subarray(MAGIC_BYTES + IV_BYTES, MAGIC_BYTES + IV_BYTES + AUTH_TAG_BYTES);
+    const ciphertext = data.subarray(MAGIC_BYTES + IV_BYTES + AUTH_TAG_BYTES);
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    return decipher.update(ciphertext, undefined, 'utf-8') + decipher.final('utf-8');
+  } catch {
+    return null;
+  }
+}
+
+// Reads a state file as plaintext: legacy plaintext passes through, EGC1
+// payloads are decrypted, and unreadable content resolves to null so callers
+// can stay silent instead of surfacing ciphertext.
+function readStateFileDecrypted(filePath, keyPath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath);
+  } catch {
+    return null;
+  }
+  if (!isEncryptedBuffer(raw)) return raw.toString('utf-8');
+  return decryptStateBuffer(raw, keyPath);
+}
+
+module.exports = {
+  MAGIC,
+  isEncryptedBuffer,
+  decryptStateBuffer,
+  readStateFileDecrypted,
+};

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 
 const { propagateStateContent } = require('./propagate-state');
 const { projectSlug, sanitizeBranchName, detectBranch } = require('./branch-state');
+const { isEncryptedBuffer } = require('./state-crypto');
 
 const EGC_START = '<!-- egc:start -->';
 const EGC_END = '<!-- egc:end -->';
@@ -68,14 +69,17 @@ function extractEgcBlock(content) {
   return content.slice(start + EGC_START.length, end).trim();
 }
 
-function parseBlockToStateContent(block) {
-  const lines = ['# Project State', ''];
+function parseBlockToStateContent(block, updatedIso) {
+  const lines = ['# Project State'];
+  if (updatedIso) lines.push(`updated: ${updatedIso}`);
+  lines.push('');
   let context = '';
   const decisions = [];
   const next = [];
 
   let section = '';
   for (const line of block.split('\n')) {
+    if (line.trimStart().startsWith('<!--')) continue;
     const h2 = line.match(/^\*\*(.+?):\*\*\s*(.*)/);
     if (h2) {
       const key = h2[1].trim();
@@ -136,7 +140,11 @@ function mergeBlockIntoStateFile(stateFilePath, block) {
   const parsed = parseBlockToStateContent(block);
   if (!parsed.trim()) return false;
 
-  const existing = fs.readFileSync(stateFilePath, 'utf-8');
+  const rawState = fs.readFileSync(stateFilePath);
+  // Encrypted state is owned by the memory server: appending plaintext here
+  // would corrupt the ciphertext and invalidate its HMAC sidecar.
+  if (isEncryptedBuffer(rawState)) return false;
+  const existing = rawState.toString('utf-8');
 
   // Only update Context and Next Session sections if they differ
   const contextMatch = parsed.match(/## Context\n([^\n]+)/);
@@ -256,7 +264,10 @@ class StateWatcher {
     const block = extractEgcBlock(content);
     if (!block) return;
 
-    const stateContent = parseBlockToStateContent(block);
+    // A manual edit to a mirror is the freshest source there is: stamping the
+    // synthetic state with "now" lets the freshness guard in propagate-state
+    // treat the fanned-out mirrors as newer than any stale state file.
+    const stateContent = parseBlockToStateContent(block, new Date().toISOString());
     if (!stateContent.includes('## Context') && !stateContent.includes('## Active Decisions')) return;
 
     // Propagate to all other tools

--- a/tests/hooks/claude-session-start.test.js
+++ b/tests/hooks/claude-session-start.test.js
@@ -3,6 +3,7 @@
  */
 
 const assert = require('assert');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -56,6 +57,15 @@ function writeStateFile(homeDir, slug, content) {
   const stateDir = path.join(homeDir, '.egc', 'state');
   fs.mkdirSync(stateDir, { recursive: true });
   fs.writeFileSync(path.join(stateDir, `${slug}.md`), content);
+}
+
+// Same payload layout the egc-memory server writes: EGC1 magic + IV + GCM tag
+// + ciphertext (see mcp/servers/egc-memory/src/encryption.ts).
+function encryptFixture(plaintext, key) {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+  return Buffer.concat([Buffer.from('EGC1:', 'utf-8'), iv, cipher.getAuthTag(), encrypted]);
 }
 
 function runTests() {
@@ -218,6 +228,45 @@ function runTests() {
     } finally {
       cleanup(homeDir);
       cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('stays silent for encrypted state when no key exists', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      const key = crypto.randomBytes(32);
+      writeStateFile(homeDir, 'workspace--secret', encryptFixture('# Project State\nclassified\n', key));
+
+      const result = runHook(homeDir, JSON.stringify({ cwd: '/workspace/secret' }));
+
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('prints decrypted state when the encryption key exists', () => {
+    const homeDir = createTempDir('claude-session-start-home-');
+    try {
+      const key = crypto.randomBytes(32);
+      const egcDir = path.join(homeDir, '.egc');
+      fs.mkdirSync(egcDir, { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'encryption.key'), key.toString('hex'), 'utf-8');
+      writeStateFile(
+        homeDir,
+        'workspace--secret',
+        encryptFixture('# Project State\n- decrypted memory line\n', key)
+      );
+
+      const result = runHook(homeDir, JSON.stringify({ cwd: '/workspace/secret' }));
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('EGC persistent memory'), 'state header missing');
+      assert.ok(result.stdout.includes('decrypted memory line'), 'plaintext missing');
+      assert.ok(!result.stdout.includes('EGC1:'), 'ciphertext must not leak');
+    } finally {
+      cleanup(homeDir);
     }
   })) passed++; else failed++;
 

--- a/tests/lib/auto-consolidate.test.js
+++ b/tests/lib/auto-consolidate.test.js
@@ -3,6 +3,7 @@
  */
 
 const assert = require('assert');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -188,6 +189,27 @@ function main() {
     } finally {
       cleanup(homeDir);
       cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('skips encrypted state files untouched', () => {
+    const homeDir = createTempDir('egc-autocons-home-');
+    try {
+      const stateDir = path.join(homeDir, '.egc', 'state');
+      fs.mkdirSync(stateDir, { recursive: true });
+      const filePath = path.join(stateDir, 'main.md');
+      const payload = Buffer.concat([Buffer.from('EGC1:', 'utf-8'), crypto.randomBytes(4096)]);
+      fs.writeFileSync(filePath, payload);
+
+      const result = withEnv({ EGC_AUTO_CONSOLIDATE: undefined }, () =>
+        autoConsolidateStateFile(filePath, { homeDir })
+      );
+
+      assert.strictEqual(result.consolidated, false);
+      assert.strictEqual(result.reason, 'encrypted');
+      assert.ok(fs.readFileSync(filePath).equals(payload), 'ciphertext must remain untouched');
+    } finally {
+      cleanup(homeDir);
     }
   })) passed++; else failed++;
 

--- a/tests/lib/state-crypto.test.js
+++ b/tests/lib/state-crypto.test.js
@@ -1,0 +1,154 @@
+/**
+ * Tests for scripts/lib/state-crypto.js read-side decryption.
+ */
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  MAGIC,
+  isEncryptedBuffer,
+  decryptStateBuffer,
+  readStateFileDecrypted,
+} = require('../../scripts/lib/state-crypto');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+// Mirrors the write side in mcp/servers/egc-memory/src/encryption.ts so the
+// fixtures match real server output without requiring a server build.
+function encryptFixture(plaintext, key) {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+  return Buffer.concat([Buffer.from(MAGIC, 'utf-8'), iv, cipher.getAuthTag(), encrypted]);
+}
+
+function writeKeyFile(dir, key) {
+  const keyPath = path.join(dir, 'encryption.key');
+  fs.writeFileSync(keyPath, key.toString('hex'), 'utf-8');
+  return keyPath;
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/state-crypto.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('isEncryptedBuffer detects the magic header', () => {
+    const key = crypto.randomBytes(32);
+    assert.strictEqual(isEncryptedBuffer(encryptFixture('state', key)), true);
+    assert.strictEqual(isEncryptedBuffer(Buffer.from('# Project State\n')), false);
+    assert.strictEqual(isEncryptedBuffer(Buffer.alloc(0)), false);
+  })) passed++; else failed++;
+
+  if (test('round-trips a state file encrypted with the server format', () => {
+    const dir = createTempDir('state-crypto-');
+    try {
+      const key = crypto.randomBytes(32);
+      const keyPath = writeKeyFile(dir, key);
+      const plaintext = '# Project State\nupdated: 2026-07-08T05:46:59.901Z\n\n## Context\nsecret memory\n';
+      const filePath = path.join(dir, 'main.md');
+      fs.writeFileSync(filePath, encryptFixture(plaintext, key));
+
+      assert.strictEqual(readStateFileDecrypted(filePath, keyPath), plaintext);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('legacy plaintext passes through unchanged', () => {
+    const dir = createTempDir('state-crypto-');
+    try {
+      const filePath = path.join(dir, 'flat.md');
+      fs.writeFileSync(filePath, '# Project State\nplain memory\n', 'utf-8');
+
+      assert.strictEqual(
+        readStateFileDecrypted(filePath, path.join(dir, 'missing.key')),
+        '# Project State\nplain memory\n'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('returns null when the key file is missing', () => {
+    const dir = createTempDir('state-crypto-');
+    try {
+      const key = crypto.randomBytes(32);
+      const filePath = path.join(dir, 'main.md');
+      fs.writeFileSync(filePath, encryptFixture('secret', key));
+
+      assert.strictEqual(readStateFileDecrypted(filePath, path.join(dir, 'missing.key')), null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('returns null when the key file is malformed', () => {
+    const dir = createTempDir('state-crypto-');
+    try {
+      const key = crypto.randomBytes(32);
+      const keyPath = path.join(dir, 'encryption.key');
+      fs.writeFileSync(keyPath, 'not-hex-and-too-short', 'utf-8');
+      const filePath = path.join(dir, 'main.md');
+      fs.writeFileSync(filePath, encryptFixture('secret', key));
+
+      assert.strictEqual(readStateFileDecrypted(filePath, keyPath), null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('returns null for tampered ciphertext', () => {
+    const dir = createTempDir('state-crypto-');
+    try {
+      const key = crypto.randomBytes(32);
+      const keyPath = writeKeyFile(dir, key);
+      const payload = encryptFixture('untampered state', key);
+      payload[payload.length - 1] ^= 0xff;
+
+      assert.strictEqual(decryptStateBuffer(payload, keyPath), null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('returns null for a missing state file', () => {
+    const dir = createTempDir('state-crypto-');
+    try {
+      assert.strictEqual(
+        readStateFileDecrypted(path.join(dir, 'nope.md'), path.join(dir, 'nope.key')),
+        null
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -338,8 +338,95 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  const freshness = runFreshnessGuardTests();
+  passed += freshness.passed;
+  failed += freshness.failed;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
+}
+
+function runFreshnessGuardTests() {
+  let passed = 0;
+  let failed = 0;
+
+  if (test('stamps mirrors with the state updated timestamp', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n');
+      propagateStateContent(dir, SAMPLE_STATE);
+      const content = fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8');
+      assert.ok(
+        content.includes('<!-- egc:state-updated:2026-06-20T00:00:00.000Z -->'),
+        'freshness stamp missing'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('older state does not overwrite a mirror stamped by a newer one', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n');
+      const newerState = SAMPLE_STATE
+        .replace('updated: 2026-06-20T00:00:00.000Z', 'updated: 2026-07-01T00:00:00.000Z')
+        .replace('EGC v1.1.1 stable on npm.', 'EGC v1.2.0 fresh context.');
+      propagateStateContent(dir, newerState);
+
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+
+      assert.ok(result.agents, 'mirror still reported as managed');
+      const content = fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8');
+      assert.ok(content.includes('EGC v1.2.0 fresh context.'), 'newer content preserved');
+      assert.ok(!content.includes('EGC v1.1.1 stable'), 'stale content must not roll the mirror back');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('unstamped state does not downgrade a stamped mirror', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n');
+      propagateStateContent(dir, SAMPLE_STATE);
+      const unstamped = SAMPLE_STATE
+        .replace('updated: 2026-06-20T00:00:00.000Z\n', '')
+        .replace('EGC v1.1.1 stable on npm.', 'anonymous rollback content');
+
+      propagateStateContent(dir, unstamped);
+
+      const content = fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8');
+      assert.ok(content.includes('EGC v1.1.1 stable'), 'stamped content preserved');
+      assert.ok(!content.includes('anonymous rollback content'), 'undated source must not win');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('newer state overwrites an older stamped mirror', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n');
+      propagateStateContent(dir, SAMPLE_STATE);
+      const newerState = SAMPLE_STATE
+        .replace('updated: 2026-06-20T00:00:00.000Z', 'updated: 2026-07-01T00:00:00.000Z')
+        .replace('EGC v1.1.1 stable on npm.', 'EGC v1.2.0 fresh context.');
+
+      propagateStateContent(dir, newerState);
+
+      const content = fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8');
+      assert.ok(content.includes('EGC v1.2.0 fresh context.'), 'newer content applied');
+      assert.ok(
+        content.includes('<!-- egc:state-updated:2026-07-01T00:00:00.000Z -->'),
+        'stamp advanced to the newer timestamp'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  return { passed, failed };
 }
 
 runTests();

--- a/tests/scripts/watch-state.test.js
+++ b/tests/scripts/watch-state.test.js
@@ -311,6 +311,35 @@ async function runTests() {
     });
   })) passed++; else failed++;
 
+  if (await test('parseBlockToStateContent stamps updated when provided', () => {
+    const state = parseBlockToStateContent(SAMPLE_BLOCK, '2026-07-08T12:00:00.000Z');
+    assert.ok(state.includes('updated: 2026-07-08T12:00:00.000Z'), 'updated line missing');
+    assert.ok(state.includes('## Context'), 'sections still parsed');
+  })) passed++; else failed++;
+
+  if (await test('parseBlockToStateContent ignores marker comments', () => {
+    const stamped = `<!-- egc:state-updated:2026-07-01T00:00:00.000Z -->\n${SAMPLE_BLOCK}`;
+    const state = parseBlockToStateContent(stamped);
+    assert.ok(!state.includes('egc:state-updated'), 'marker must not leak into state');
+    assert.ok(state.includes('EGC v1.1.1'), 'content still parsed');
+  })) passed++; else failed++;
+
+  if (await test('mergeBlockIntoStateFile refuses encrypted state files', () => {
+    const dir = mktemp();
+    try {
+      const stateFile = path.join(dir, 'main.md');
+      const payload = Buffer.concat([Buffer.from('EGC1:', 'utf-8'), Buffer.from('opaque-bytes')]);
+      fs.writeFileSync(stateFile, payload);
+
+      const changed = mergeBlockIntoStateFile(stateFile, SAMPLE_BLOCK);
+
+      assert.strictEqual(changed, false);
+      assert.ok(fs.readFileSync(stateFile).equals(payload), 'ciphertext must remain untouched');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Root cause

PR #671 made the Claude session-start hook depend on `scripts/lib/branch-state.js` (branch-layout state resolution) and `scripts/lib/auto-consolidate.js`, but the claude-home installer's `HOOK_LIB_SOURCES` allowlist was never updated. The hook registered in `settings.json` runs from `~/.claude/egc/hooks/` with libs in `~/.claude/egc/lib/`, where `branch-state.js` never arrived. The `tryRequire` fallback silently disabled branch-layout resolution, so every session start resolved the legacy flat state file (weeks old) and propagated it over the current mirrors (AGENTS.md, GEMINI.md, `.cursor`/`.trae` rules), rolling project memory back. `egc doctor` stayed green because it validates against the same incomplete allowlist.

A second latent bug sat behind the first: the memory server now encrypts every state write (`EGC1:` magic + AES-256-GCM, key at `~/.egc/encryption.key`), and the hook reads state files raw. Fixing only the allowlist would have made the hook print and propagate ciphertext.

## Changes

- **claude-home installer**: ship `branch-state.js` and the new `state-crypto.js` with the session-start hook libs
- **`scripts/lib/state-crypto.js` (new)**: read-side decryption of EGC1 payloads, mirroring `mcp/servers/egc-memory/src/encryption.ts`; never creates or rotates the key
- **session-start hook**: decrypts encrypted state; stays silent when it cannot be read instead of surfacing ciphertext; consolidation only runs on plaintext
- **propagate-state**: mirrors are stamped with `<!-- egc:state-updated:<ISO> -->`; writes from older or unstamped sources are refused, so a stale state file can never roll mirrors back again
- **auto-consolidate / watch-state**: refuse to rewrite encrypted state files, which would corrupt the ciphertext and invalidate its HMAC sidecar

## Testing

- New suite `tests/lib/state-crypto.test.js` (7 cases: round-trip against the server payload format, tampered ciphertext, missing/malformed key)
- Extended `claude-session-start`, `propagate-state`, `auto-consolidate`, `watch-state` suites (encrypted-state silence, decrypted print, freshness matrix, encrypted skip)
- Full suite: 2612 passed, 0 failed
- Smoke test: hook run against the real encrypted `main.md` + real key in an isolated HOME prints the decrypted state correctly

No version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops stale state rollbacks and adds read-side decryption for encrypted memory files. Hooks now read plaintext only and avoid overwriting newer mirrors.

- **Bug Fixes**
  - Installer now ships `branch-state.js` and `state-crypto.js`, restoring branch layout resolution and enabling decryption.
  - Session-start hook decrypts `EGC1:` state and stays silent without a key; consolidation runs only on plaintext.
  - Propagation stamps mirrors with `<!-- egc:state-updated:<ISO> -->` and blocks writes from older or unstamped sources to prevent rollbacks.
  - `auto-consolidate` and `watch-state` never rewrite encrypted files to avoid corrupting ciphertext.

<sup>Written for commit 213e0158b8ce85f1b1ff99db4055d3b2d542ef2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for encrypted session state, allowing the app to read protected memory files when a valid key is available.
  * State updates now carry a freshness timestamp to help keep mirrored content in sync.

* **Bug Fixes**
  * Prevents older state from overwriting newer content.
  * Skips modifying encrypted state files during automatic consolidation or watch-based updates.
  * Avoids showing unreadable or empty decrypted state on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->