### PR TITLE
feat(hooks): throttle the stop-hook memory save prompt per project

### DIFF
--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -4,9 +4,59 @@
 // Claude Code Stop hook. Injects a prompt asking the AI to call update_state
 // via the egc-memory MCP tool before the session ends. Never blocks the Stop
 // event: missing stdin or parse errors are silently ignored and exit 0.
+//
+// The save prompt is throttled: firing it on every assistant stop made the
+// AI persist memory after each reply, stalling real work. One reminder per
+// project per interval (default 30 minutes, EGC_STOP_SAVE_INTERVAL_MINUTES)
+// keeps memory fresh without interrupting every exchange.
 
 const fs = require('node:fs');
 const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+
+const DEFAULT_INTERVAL_MINUTES = 30;
+
+function saveIntervalMs() {
+  const parsed = Number.parseInt(process.env.EGC_STOP_SAVE_INTERVAL_MINUTES, 10);
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed * 60 * 1000;
+  return DEFAULT_INTERVAL_MINUTES * 60 * 1000;
+}
+
+function projectSlug(projectPath) {
+  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+function markerPath(input) {
+  const cwd = (typeof input.cwd === 'string' && input.cwd)
+    ? input.cwd
+    : (process.env.CLAUDE_PROJECT_DIR || process.env.PWD || process.cwd());
+  return path.join(os.homedir(), '.egc', 'state', `.save-prompt-${projectSlug(cwd)}`);
+}
+
+// One save prompt per project per interval. The marker mtime records the last
+// prompt; read or write failures fail open so a broken marker never silently
+// disables memory saves.
+function shouldPromptSave(input, nowMs) {
+  const interval = saveIntervalMs();
+  if (interval === 0) return true;
+
+  const marker = markerPath(input);
+  try {
+    if (nowMs - fs.statSync(marker).mtimeMs < interval) return false;
+  } catch {
+    // No marker yet: first stop for this project.
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(marker), { recursive: true });
+    fs.writeFileSync(marker, new Date(nowMs).toISOString(), 'utf8');
+  } catch {
+    // Marker is best-effort; still prompt.
+  }
+  return true;
+}
 
 function post(ev, done) {
   const body = JSON.stringify(ev);
@@ -41,7 +91,9 @@ function main() {
     + 'preferences, and next steps from this session. '
     + 'project_path is optional: omit it and it uses PWD automatically.';
 
-  const output = { ...input, promptForAssistant: prompt };
+  const output = shouldPromptSave(input, Date.now())
+    ? { ...input, promptForAssistant: prompt }
+    : { ...input };
 
   // Write the assistant prompt to stdout first (synchronous, always completes).
   // Then post the session_end event and exit only after the dashboard has

--- a/tests/hooks/claude-session-stop.test.js
+++ b/tests/hooks/claude-session-stop.test.js
@@ -1,0 +1,156 @@
+/**
+ * Subprocess tests for scripts/hooks/claude-session-stop.js save throttling.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'claude-session-stop.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function runHook(homeDir, stdinPayload, extraEnv = {}) {
+  const result = spawnSync('node', [SCRIPT], {
+    input: stdinPayload,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      CLAUDE_PROJECT_DIR: '',
+      PWD: '',
+      EGC_STOP_SAVE_INTERVAL_MINUTES: '',
+      ...extraEnv,
+    },
+    timeout: 10000,
+  });
+
+  return {
+    code: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+const STOP_INPUT = JSON.stringify({
+  cwd: '/workspace/demo',
+  session_id: 'session-1',
+  hook_event_name: 'Stop',
+});
+
+function markerFor(homeDir) {
+  return path.join(homeDir, '.egc', 'state', '.save-prompt-workspace--demo');
+}
+
+function runTests() {
+  console.log('\n=== Testing claude-session-stop.js hook ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('first stop prompts for update_state and writes the marker', () => {
+    const homeDir = createTempDir('claude-session-stop-home-');
+    try {
+      const result = runHook(homeDir, STOP_INPUT);
+
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('promptForAssistant'), 'prompt missing on first stop');
+      assert.ok(result.stdout.includes('update_state'), 'update_state instruction missing');
+      assert.ok(fs.existsSync(markerFor(homeDir)), 'marker file not written');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('a stop inside the interval does not prompt again', () => {
+    const homeDir = createTempDir('claude-session-stop-home-');
+    try {
+      runHook(homeDir, STOP_INPUT);
+      const second = runHook(homeDir, STOP_INPUT);
+
+      assert.strictEqual(second.code, 0);
+      assert.ok(!second.stdout.includes('promptForAssistant'), 'throttled stop must not prompt');
+      assert.ok(second.stdout.includes('session-1'), 'input must still pass through');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('an expired marker prompts again', () => {
+    const homeDir = createTempDir('claude-session-stop-home-');
+    try {
+      runHook(homeDir, STOP_INPUT);
+      const marker = markerFor(homeDir);
+      const past = new Date(Date.now() - 31 * 60 * 1000);
+      fs.utimesSync(marker, past, past);
+
+      const result = runHook(homeDir, STOP_INPUT);
+
+      assert.ok(result.stdout.includes('promptForAssistant'), 'expired marker must prompt again');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('interval of 0 prompts on every stop', () => {
+    const homeDir = createTempDir('claude-session-stop-home-');
+    try {
+      runHook(homeDir, STOP_INPUT, { EGC_STOP_SAVE_INTERVAL_MINUTES: '0' });
+      const second = runHook(homeDir, STOP_INPUT, { EGC_STOP_SAVE_INTERVAL_MINUTES: '0' });
+
+      assert.ok(second.stdout.includes('promptForAssistant'), 'interval 0 must always prompt');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('projects throttle independently', () => {
+    const homeDir = createTempDir('claude-session-stop-home-');
+    try {
+      runHook(homeDir, STOP_INPUT);
+      const other = runHook(homeDir, JSON.stringify({ cwd: '/workspace/other', session_id: 's2' }));
+
+      assert.ok(other.stdout.includes('promptForAssistant'), 'a different project must still prompt');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('exits silently on invalid stdin', () => {
+    const homeDir = createTempDir('claude-session-stop-home-');
+    try {
+      const result = runHook(homeDir, 'not json');
+
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Why

The Stop hook injects a prompt asking the assistant to call `update_state` after **every** reply. In practice this makes the AI persist memory after each exchange, stalling real work: every decision gets interrupted by a memory save. Users cannot (and should not) edit the managed hooks to escape this, so the fix belongs in the product.

## What

- The save prompt now fires at most **once per project per interval** (default 30 minutes).
- `EGC_STOP_SAVE_INTERVAL_MINUTES` tunes the interval; `0` restores the previous prompt-on-every-stop behavior.
- Throttle state is a marker file per project slug under `~/.egc/state/`; its mtime records the last prompt.
- Fail-open by design: if the marker cannot be read or written, the hook still prompts, so a broken marker never silently disables memory saves.
- The dashboard `session_end` event keeps firing on every stop, unchanged.

## Testing

New subprocess suite `tests/hooks/claude-session-stop.test.js` (6 cases): first-stop prompts and writes the marker, in-interval stop stays quiet, expired marker prompts again, interval 0 always prompts, projects throttle independently, invalid stdin exits silently.

No version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle the Stop hook memory-save prompt so it runs at most once per project per interval (30 minutes by default) to avoid interrupting every exchange. Configure via EGC_STOP_SAVE_INTERVAL_MINUTES; set to 0 to restore the previous prompt-on-every-stop behavior.

- **New Features**
  - Per-project marker under ~/.egc/state uses mtime to throttle; projects are independent.
  - Fail-open: if the marker can’t be read or written, the prompt still fires; dashboard session_end continues on every stop.
  - Added subprocess tests for first stop, in-interval suppression, expiry, zero-interval, per-project isolation, and invalid stdin.

<sup>Written for commit b2cd130ef3df001191c5b443156a11ab680a9f24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

