### PR TITLE
chore(deps): bump codeql-action init and analyze to 4.37.0 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -100,6 +100,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Dependabot opened #681 and #682 as separate bumps for the `init` and `analyze` steps of the same CodeQL workflow. Each PR alone mixes 4.36.2 with 4.37.0, which is why all three Analyze jobs fail on both. This bumps the two pins together, using the same v4.37.0 SHA dependabot resolved. Supersedes #681 and #682 (will close both after merge).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `github/codeql-action/init` and `github/codeql-action/analyze` to v4.37.0 in the CodeQL workflow, pinning both to the same SHA. Keeps steps in sync and fixes Analyze job failures caused by mixed versions.

<sup>Written for commit aec36c7b56710785937d698e99b68a871f4250c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s code scanning workflow to use newer pinned versions of the security analysis actions.
  * No changes to build, deployment, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->