### PR TITLE
docs: describe branch-scoped encrypted state storage and save cadence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ update_state({
 
 ## Where state is stored
 
-`~/.egc/state/<project-slug>.md`: one file per project, plain Markdown, human-readable.
+`~/.egc/state/<project-slug>/<branch>.md`: one file per project branch (flat `<project-slug>.md` files from older versions are still read). Files are encrypted at rest with AES-256-GCM (key at `~/.egc/encryption.key`); the memory server and session hooks decrypt them transparently.
 
 ## MCP servers required
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,7 +45,7 @@ update_state({
 
 ## Where state is stored
 
-`~/.egc/state/<project-slug>.md`: one file per project, plain Markdown, human-readable.
+`~/.egc/state/<project-slug>/<branch>.md`: one file per project branch (flat `<project-slug>.md` files from older versions are still read). Files are encrypted at rest with AES-256-GCM (key at `~/.egc/encryption.key`); the memory server and session hooks decrypt them transparently.
 
 ## MCP servers required
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ No commands to memorize. Your AI reads this table so you never have to. Say anyt
 | `compress_observations` | Compresses raw hook observations into typed summaries to reduce token usage |
 | `get_project_state` | Returns server health metadata and storage engine status |
 
-State files live at `~/.egc/state/<project-slug>.md`. One file per project, plain Markdown, human-readable.
+State files live at `~/.egc/state/<project-slug>/<branch>.md`, one per project branch (flat `<project-slug>.md` files from older versions are still read). They are encrypted at rest with AES-256-GCM and decrypted transparently by the memory server and session hooks; the key lives at `~/.egc/encryption.key`.
 
 ### Context and safety - 5 tools for when things get heavy
 
@@ -137,7 +137,7 @@ These tools run automatically in the background. Every shell command and every f
 
 Validation does not depend on the AI choosing to cooperate. EGC installs harness hooks that run on every tool call: each shell command and file write is validated before it executes, and destructive commands, credential paths, and force-pushes are blocked even inside compound commands. Every prompt is also routed against the component catalog so the right skills and agents are injected into context. If the validator is ever missing, hooks fail open so you are never locked out of your own tool.
 
-With a provider API key (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`), EGC also understands session intent semantically, in any language, with no predefined phrases: say you are done for the night and your state is saved before the AI even answers; greet it the next morning and your next steps are already in context. At session end a memory miner distills the session's decisions and lessons into your project state. Without a key these LLM features honestly do nothing, and the lifecycle hooks still guarantee your state is saved.
+With a provider API key (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`), EGC also understands session intent semantically, in any language, with no predefined phrases: say you are done for the night and your state is saved before the AI even answers; greet it the next morning and your next steps are already in context. At session end a memory miner distills the session's decisions and lessons into your project state. Without a key these LLM features honestly do nothing, and the lifecycle hooks still guarantee your state is saved. The end-of-reply save reminder is throttled to once per project every 30 minutes (`EGC_STOP_SAVE_INTERVAL_MINUTES` tunes it; `0` prompts on every stop), so memory stays fresh without interrupting the work.
 
 ### Always in sync - across every tool you use
 


### PR DESCRIPTION
The README, CLAUDE.md and GEMINI.md still described state files as flat `~/.egc/state/<project-slug>.md`, plain Markdown and human-readable. Since the memory hardening work, state is branch-scoped (`<project-slug>/<branch>.md`, with legacy flat files still read) and encrypted at rest with AES-256-GCM, decrypted transparently by the memory server and the session hooks.

Also documents the stop-hook save reminder cadence introduced in #677: at most one prompt per project every 30 minutes, tunable via `EGC_STOP_SAVE_INTERVAL_MINUTES` (`0` restores prompt-on-every-stop).

Docs only. No version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to reflect branch-scoped, AES-256-GCM–encrypted state files and the throttled save reminder.
Notes the new path `~/.egc/state/<project-slug>/<branch>.md` (legacy flat files still read), key at `~/.egc/encryption.key`, and stop-hook prompts once per project every 30 minutes, tunable via `EGC_STOP_SAVE_INTERVAL_MINUTES` (`0` prompts on every stop).

<sup>Written for commit e23e6c648b81583d9bd2e3c0ef4ca9f96ec791cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

