### PR TITLE
sec+perf: consolidate real fixes from fuentes71's 7 open PRs

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -263,25 +263,36 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                continue;
              }
              
-             // SEC-05: Enforce byte-load limits
-             const stats = fs.statSync(realResolved);
+             // SEC-05/SEC-06: enforce byte-load limits against the same file handle
+             // used to read (stat-then-read on a path is a TOCTOU race if the file
+             // is swapped between the two calls).
              const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
              const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50MB
-             
-             if (stats.size > MAX_FILE_SIZE) {
-               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `file exceeds 10MB limit (${stats.size} bytes)` });
-               continue;
-             }
-             if (totalBytesLoaded + stats.size > MAX_TOTAL_SIZE) {
-               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `aggregate size exceeds 50MB limit` });
-               continue;
-             }
 
-             const content = await fs.promises.readFile(realResolved, 'utf-8');
-             // Split context into chunks/paragraphs to allow granular pruning
-             const chunks = content.split('\n\n').filter(c => c.trim().length > 0);
-             rawPayloads.push(...chunks);
-             totalBytesLoaded += Buffer.byteLength(content, 'utf8');
+             const fileHandle = await fs.promises.open(realResolved, 'r');
+             try {
+               const stats = await fileHandle.stat();
+               if (!stats.isFile()) {
+                 auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'not a regular file' });
+                 continue;
+               }
+               if (stats.size > MAX_FILE_SIZE) {
+                 auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `file exceeds 10MB limit (${stats.size} bytes)` });
+                 continue;
+               }
+               if (totalBytesLoaded + stats.size > MAX_TOTAL_SIZE) {
+                 auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `aggregate size exceeds 50MB limit` });
+                 continue;
+               }
+
+               const content = await fileHandle.readFile('utf-8');
+               // Split context into chunks/paragraphs to allow granular pruning
+               const chunks = content.split('\n\n').filter(c => c.trim().length > 0);
+               rawPayloads.push(...chunks);
+               totalBytesLoaded += Buffer.byteLength(content, 'utf8');
+             } finally {
+               await fileHandle.close();
+             }
            } catch(e: unknown) {
              const reason = e instanceof Error ? e.message : String(e);
              auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason });
@@ -385,6 +396,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         if (!projectPath) {
           throw new McpError(ErrorCode.InvalidParams, 'project_path is required');
+        }
+
+        let realProjectPath: string;
+        try {
+          realProjectPath = fs.realpathSync(path.resolve(projectPath));
+        } catch {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path resolution failed');
+        }
+        if (isProtectedPath(realProjectPath)) {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path must not be a protected path');
         }
 
         const result = await autoLearn({ project_path: projectPath, target_file: targetFile, limit });

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -31,6 +31,7 @@ export function buildDeniedPaths(): string[] {
     path.join(home, '.cursor'),
     path.join(home, '.claude'),
     path.join(home, '.gemini'),
+    path.join(home, '.egc'),
     '/etc',
   ];
 

--- a/scripts/bootstrap-state-db.js
+++ b/scripts/bootstrap-state-db.js
@@ -23,14 +23,15 @@ if (require.main === module) {
         process.stderr.write('[bootstrap-state-db] WARNING: state store could not be initialized.\n');
         process.stderr.write('  The EGC state store was not created. Hook-level memory persistence is disabled.\n');
         process.stderr.write('  Run: egc init  to retry initialization.\n');
-        process.exit(0);
+        process.exitCode = 0;
+        return;
       }
       process.stderr.write(`[bootstrap-state-db] OK ${result.dbPath} (${result.migrations.length} migrations)\n`);
-      process.exit(0);
+      process.exitCode = 0;
     })
     .catch(err => {
       process.stderr.write(`[bootstrap-state-db] FAILED: ${err.message}\n`);
-      process.exit(1);
+      process.exitCode = 1;
     });
 }
 

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -70,6 +70,8 @@ class SqlJsDatabase {
     this._inTransaction = false;
     this._supportsWal = false;
     this._db = new sqlJs.Database(fileData || null);
+    this._persistTimeout = null;
+    this._initialPersistDone = false;
   }
 
   pragma(str) {
@@ -119,8 +121,12 @@ class SqlJsDatabase {
 
   close() {
     if (!this._db) return;
+    if (this._persistTimeout) {
+      clearTimeout(this._persistTimeout);
+      this._persistTimeout = null;
+    }
     try {
-      this._persist();
+      this._flushPersist();
     } catch (_) {
       // Ignore persist errors on close to prevent masking original errors
     } finally {
@@ -129,8 +135,42 @@ class SqlJsDatabase {
     }
   }
 
+  // PERF-01: coalesce bursts of writes into a single disk write instead of
+  // re-serializing and rewriting the whole DB on every exec()/transaction().
+  // The very first persist still happens synchronously so the DB file exists
+  // on disk immediately after the first write, before any close()/flush().
   _persist() {
     if (this._path === ':memory:') return;
+    if (!this._initialPersistDone) {
+      this._initialPersistDone = true;
+      this._flushPersist();
+      return;
+    }
+    if (this._persistTimeout) {
+      clearTimeout(this._persistTimeout);
+    }
+    this._persistTimeout = setTimeout(() => {
+      this._persistTimeout = null;
+      try {
+        this._flushPersist();
+      } catch (_) {
+        // _flushPersist already logs the failure. Swallowing it here keeps a
+        // failed debounced write from becoming an unhandled exception inside
+        // a bare setTimeout callback, which would crash the process.
+      }
+    }, 50);
+  }
+
+  async flush() {
+    if (this._persistTimeout) {
+      clearTimeout(this._persistTimeout);
+      this._persistTimeout = null;
+    }
+    this._flushPersist();
+  }
+
+  _flushPersist() {
+    if (this._path === ':memory:' || !this._db) return;
     try {
       const data = this._db.export();
       fs.mkdirSync(path.dirname(this._path), { recursive: true });

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -58,6 +58,12 @@ async function createStateStore(options = {}) {
     close() {
       db.close();
     },
+    // Force any debounced write to disk now instead of waiting for the next
+    // write burst or close(). Unlike close(), this surfaces persist failures
+    // to the caller instead of swallowing them.
+    async flush() {
+      if (db.flush) await db.flush();
+    },
     getAppliedMigrations() {
       return getAppliedMigrations(db);
     },

--- a/scripts/lib/state-store/queries.js
+++ b/scripts/lib/state-store/queries.js
@@ -1187,4 +1187,5 @@ module.exports = {
   DECAY_GRACE_DAYS,
   ARCHIVE_THRESHOLD,
   createQueryApi,
+  normalizeLimit,
 };

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
-const { execSync, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 // Platform detection
 const isWindows = process.platform === 'win32';
@@ -501,12 +501,12 @@ function commandExists(cmd) {
 /**
  * Run a command and return output
  *
- * SECURITY NOTE: This function executes shell commands. Only use with
- * trusted, hardcoded commands. Never pass user-controlled input directly.
- * For user input, use spawnSync with argument arrays instead.
+ * SECURITY NOTE: This function executes commands via spawnSync with
+ * shell:false (no shell is spawned). Only use with trusted, hardcoded
+ * commands. Never pass user-controlled input directly.
  *
  * @param {string} cmd - Command to execute (should be trusted/hardcoded)
- * @param {object} options - execSync options
+ * @param {object} options - spawnSync options
  */
 function runCommand(cmd, options = {}) {
   // Allowlist: only permit known-safe command prefixes
@@ -523,15 +523,41 @@ function runCommand(cmd, options = {}) {
     return { success: false, output: 'runCommand blocked: shell metacharacters not allowed' };
   }
 
+  // SEC-02: tokenize into an argv array and use spawnSync with shell:false
+  // instead of execSync, which always spawns a shell even for hardcoded input.
+  const tokenRegex = /"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+)/g;
+  const args = [];
+  let match;
+  while ((match = tokenRegex.exec(cmd)) !== null) {
+    if (match[1] !== undefined) {
+      args.push(match[1].replace(/\\(["\\])/g, '$1'));
+    } else if (match[2] !== undefined) {
+      args.push(match[2].replace(/\\(['\\])/g, '$1'));
+    } else {
+      args.push(match[3]);
+    }
+  }
+  const [program, ...progArgs] = args;
+
+  // npx on Windows is a .cmd shim and needs a shell to resolve/execute.
+  const needsShell = isWindows && program === 'npx';
+
   try {
-    const result = execSync(cmd, {
+    const result = spawnSync(program, progArgs, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: needsShell,
       ...options
     });
-    return { success: true, output: result.trim() };
+    if (result.error) {
+      return { success: false, output: result.error.message };
+    }
+    if (result.status !== 0) {
+      return { success: false, output: result.stderr || result.stdout || `Command failed with exit code ${result.status}` };
+    }
+    return { success: true, output: (result.stdout || '').trim() };
   } catch (err) {
-    return { success: false, output: err.stderr || err.message };
+    return { success: false, output: err.message };
   }
 }
 

--- a/tests/lib/state-store-concurrency.test.js
+++ b/tests/lib/state-store-concurrency.test.js
@@ -255,7 +255,7 @@ async function runTests() {
   });
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
-  process.exit(failed > 0 ? 1 : 0);
+  process.exitCode = failed > 0 ? 1 : 0;
 }
 
 runTests();

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -100,6 +100,9 @@ for (const testFile of testFiles) {
 
   if (result.status !== 0) {
     console.log(`✗ ${displayPath} exited with status ${result.status}`);
+    if (!combined.trim()) {
+      console.log(`  [!] Script crashed with no output. Counted as 1 unknown failure.`);
+    }
     totalFailed += failedMatch ? 0 : 1;
   }
 }

--- a/tests/stress/db-adapter.stress.js
+++ b/tests/stress/db-adapter.stress.js
@@ -247,6 +247,28 @@ async function runTests() {
     }
   });
 
+  // ── 12. Debounced persist eventually flushes without an explicit close/flush ──
+  await test('debounced write reaches disk on its own after the debounce window', async () => {
+    const tmpDir = createTempDir();
+    const dbPath = path.join(tmpDir, 'debounce.db');
+    try {
+      const db = await openDatabase(dbPath);
+      db.exec('CREATE TABLE debounce (id INTEGER)'); // first write: flushed synchronously
+      db.exec('INSERT INTO debounce VALUES (1)'); // second write: debounced ~50ms
+      await new Promise(resolve => setTimeout(resolve, 150)); // wait past the debounce window
+      const reopened = await openDatabase(dbPath);
+      try {
+        const row = reopened.prepare('SELECT COUNT(*) as c FROM debounce').get();
+        assert.strictEqual(row.c, 1, 'debounced insert must be visible after the window elapses');
+      } finally {
+        reopened.close();
+      }
+      db.close();
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
   // ─── summary ────────────────────────────────────────────────────────────────
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   if (failures.length > 0) {

--- a/tests/stress/normalize-limit.test.js
+++ b/tests/stress/normalize-limit.test.js
@@ -1,0 +1,49 @@
+/**
+ * Tests for normalizeLimit boundary inputs.
+ * normalizeLimit throws on invalid values by design (contract pinned by
+ * tests/lib/state-store.test.js) — callers rely on the throw to surface bad
+ * MCP tool arguments instead of silently substituting a default.
+ */
+const assert = require('node:assert');
+const { normalizeLimit } = require('../../scripts/lib/state-store/queries.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.error(`    Error: ${err.message}`);
+    failed++;
+  }
+}
+
+test('normalizeLimit handles valid positive integers', () => {
+  assert.strictEqual(normalizeLimit(5, 10), 5);
+  assert.strictEqual(normalizeLimit(100, 10), 100);
+});
+
+test('normalizeLimit handles string representations of positive integers', () => {
+  assert.strictEqual(normalizeLimit('15', 10), 15);
+});
+
+test('normalizeLimit returns the fallback for undefined/null', () => {
+  assert.strictEqual(normalizeLimit(undefined, 10), 10);
+  assert.strictEqual(normalizeLimit(null, 10), 10);
+});
+
+test('normalizeLimit throws on zero, negative, non-finite, or non-numeric input', () => {
+  assert.throws(() => normalizeLimit(0, 10), /Invalid limit: 0/);
+  assert.throws(() => normalizeLimit(-1, 10), /Invalid limit: -1/);
+  assert.throws(() => normalizeLimit(NaN, 10), /Invalid limit: NaN/);
+  assert.throws(() => normalizeLimit(Infinity, 10), /Invalid limit: Infinity/);
+  assert.throws(() => normalizeLimit('abc', 10), /Invalid limit: abc/);
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exitCode = failed > 0 ? 1 : 0;

--- a/tests/stress/readonly-filesystem.stress.test.js
+++ b/tests/stress/readonly-filesystem.stress.test.js
@@ -1,0 +1,84 @@
+/**
+ * STR-05: Read-only filesystem simulation.
+ * Revoke write permission on the DB file after creation. Writes are
+ * debounced (PERF-01), so upsertSession() itself no longer throws
+ * synchronously — the failure is logged when the write is actually
+ * flushed to disk. Assert store.flush() surfaces that failure.
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.error(`    Error: ${err.stack}`);
+    failed++;
+  }
+}
+
+(async () => {
+  await test('store.flush() throws Error when the DB file is read-only', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-test-'));
+    const dbPath = path.join(tempDir, 'state.db');
+
+    const { createStateStore } = require('../../scripts/lib/state-store/index.js');
+
+    const store = await createStateStore({ dbPath });
+
+    const validSession = {
+      id: 'session-1',
+      adapterId: 'stress-test',
+      harness: 'cli',
+      state: 'active',
+      repoRoot: null,
+      startedAt: null,
+      endedAt: null,
+      snapshot: { foo: 'bar' }
+    };
+
+    try {
+      // Initial upsert (and the migrations before it) already flushed the
+      // file to disk synchronously, so it exists at this point.
+      store.upsertSession(validSession);
+      assert.ok(fs.existsSync(dbPath), 'DB file must exist before the read-only simulation');
+
+      // Make the file read-only to simulate a read-only filesystem
+      fs.chmodSync(dbPath, 0o444);
+
+      const originalConsoleError = console.error;
+      let errorLogged = false;
+      console.error = (msg, ..._rest) => {
+        if (typeof msg === 'string' && msg.includes('Failed to persist state')) errorLogged = true;
+      };
+      try {
+        store.upsertSession({ ...validSession, snapshot: { foo: 'baz' } });
+        await assert.rejects(
+          () => store.flush(),
+          /EPERM|EACCES|EROFS/,
+          'Expected a filesystem permission error'
+        );
+        assert.ok(errorLogged, 'Expected console.error to be called for the filesystem error');
+      } finally {
+        console.error = originalConsoleError;
+      }
+    } finally {
+      // Restore permissions so we can close/clean up
+      try { fs.chmodSync(dbPath, 0o666); } catch (_e) { /* ignore */ }
+      try { store.close(); } catch (_e) { /* ignore */ }
+      try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch (_e) { /* ignore */ }
+    }
+  });
+
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+  process.exitCode = failed > 0 ? 1 : 0;
+})();


### PR DESCRIPTION
## Summary

Consolidates the still-valid fixes scattered across 7 open PRs from @fuentes71 (#648, #651, #654, #656, #657, #659, #660) into one branch, re-implemented against current `main` and with the regressions in the original implementations fixed. Those 7 PRs are being closed in favor of this one — see the credit note below.

## What's included and why

- **SEC-02** — `runCommand()` in `scripts/lib/utils.js` still used `execSync(cmd)`, which spawns a shell even for hardcoded/allowlisted commands. Rewritten to tokenize into argv and run via `spawnSync(prog, args, {shell:false})`, keeping the existing allowlist/metacharacter checks. Windows still needs `shell:true` for `npx` (it resolves to a `.cmd` shim).
- **SEC-04** — `~/.egc` (state files, encryption key) was missing from the guardian's denied-paths list, and `auto_learn`'s `project_path` argument had no protected-path check at all — unlike `orchestrate_task`/`reduce_context`, which already validate their paths. Fixed both.
- **SEC-05/06** — `reduce_context` used to `fs.statSync()` a path and then `fs.promises.readFile()` the same path as two separate syscalls (TOCTOU race). Now reads through a single file handle (open → stat → read → close).
- **PERF-01** — `SqlJsDatabase._persist()` rewrote the entire DB file to disk on every single `exec()`/transaction commit. Now debounced 50ms, with the first write still flushed synchronously so the file exists immediately after creation.
- **REL-06** — a couple of CLI scripts called `process.exit()` right after a `stderr.write()`, which can truncate output that hasn't flushed yet (especially piped output on CI runners). Switched to `process.exitCode`.
- **Tests** — boundary coverage for `normalizeLimit` (now exported), a stress test for the debounce window, and a stress test that a failed persist under a read-only filesystem surfaces through the new `flush()` method.

## What was deliberately left out (already in `main` or superseded)

- `auto_learn`/`resolveProjectPath` protected-path checks in `egc-memory` — already merged via #661.
- `getDb()` singleton race fix in `egc-memory` — already merged (`fix(mcp): prevent TOCTOU in getDb singleton`).
- `reduce_context` byte-limit checks — functionally already in `main`.
- `runCommand(program, args[])` signature change (from one of the PRs) — would have required rewriting ~20 existing tests in `tests/lib/utils.test.js` for no behavior gain over the string-based fix already applied here.
- `normalizeLimit` throw→fallback behavior change — reverted to keep the existing pinned contract (`tests/lib/state-store.test.js`); only the export is new.

## Regressions fixed relative to the original PRs

- The original debounce implementation dropped the `console.error` + rethrow on persist failure entirely, and the debounced write ran inside a bare `setTimeout` with no try/catch — a failed write there would have become an unhandled exception and crashed the process. Restored the logging and wrapped the debounced flush so a failed write is logged, not fatal.
- One of the `runCommand` rewrites was missing the Windows `npx` shell exception, which is why its Windows CI jobs were red.
- One PR re-added `agents`/`skills` destructuring in `orchestrate_task` against a Zod schema that no longer has those fields (removed in an already-merged PR) — dead code, dropped.

## Credit

All of this was originally reported/attempted by @fuentes71 across #648, #651, #654, #656, #657, #659, #660. Closing those in favor of this consolidated, rebased, and corrected PR.

## Testing Done

- [x] Full local suite: `node tests/run-all.js` → 2623/2623 passed
- [x] `tsc --noEmit` clean on both `egc-guardian` and `egc-memory`
- [x] `npm run build:mcp` clean
- [x] ESLint clean on all changed JS files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates security and performance fixes: hardens path validation and command execution, removes TOCTOU in file reads, and debounces state-store persists to cut I/O. Makes `egc-guardian` safer and the state store faster and more resilient.

- **Security**
  - `runCommand()` now tokenizes and uses `spawnSync` with `shell:false`; `npx` on Windows keeps a shell.
  - Add `~/.egc` to denied paths and validate `auto_learn` `project_path` via realpath + protected-path check.
  - Fix TOCTOU in `reduce_context` by stat+read via one handle; enforce file and aggregate size limits.

- **Performance & Reliability**
  - Debounce DB persists by 50ms; first write flushes sync; new `flush()` forces persist; failed debounced writes log without crashing.
  - Replace `process.exit()` with `process.exitCode` in CLI/tests to avoid truncated output; improve test runner reporting for silent crashes.
  - Add tests for `normalizeLimit` boundaries, debounced persist reaching disk, and read-only filesystem errors surfaced via `flush()`.

<sup>Written for commit 6aafab399db79aeb4f6a6163d823397973b1f999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved protected-path handling, including the application’s configuration directory.
  - Strengthened file access checks and audit logging for blocked files and size-limit violations.
  - Improved project path validation and rejection of invalid or protected locations.
  - Enhanced command execution safety across supported platforms.

- **Reliability**
  - Added debounced state persistence to reduce unnecessary disk writes.
  - Added a flush option to ensure pending changes are written immediately.
  - Improved handling of persistence failures and process shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->