### PR TITLE
sec(guardian): granular per-file credential denylist instead of whole-directory blocks

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -8,7 +8,16 @@ export const DANGEROUS = ['rm', 'mv'];
 
 export const SHELL_META_REGEX = /[&|;<>$`\n\r]/;
 
-// Protected file patterns (checked on full path string)
+// Protected file patterns (checked on full path string).
+//
+// AI coding tool home directories (~/.claude, ~/.cursor, ~/.gemini, ~/.config/*)
+// mix real credential files with functional data the tool's own assistant
+// legitimately writes (skills, agents, native memory, user-requested config
+// edits). Blocking the whole directory breaks that functional data for no
+// security gain, since the actual secret is always one specific file, not
+// the directory. Deny the credential file by pattern instead. Sources: each
+// tool's official docs, verified 2026-07-11 (see docs/architecture or the
+// PR that introduced this comment for the full per-tool research).
 export const PROTECTED_FILE_PATTERNS: RegExp[] = [
   /\.env$/,
   /\.env\./,
@@ -17,6 +26,29 @@ export const PROTECTED_FILE_PATTERNS: RegExp[] = [
   /\.p12$/,
   /\.npmrc$/,
   /\.pypirc$/,
+  // Claude Code: OAuth session lives in .credentials.json inside ~/.claude,
+  // and in ~/.claude.json at the home root (sibling of ~/.claude, not inside
+  // it). settings.json, skills, agents, and projects/*/memory/ are functional.
+  /\.claude[\\/]\.credentials\.json$/,
+  /(^|[\\/])\.claude\.json$/,
+  // Gemini CLI + Antigravity (share ~/.gemini). settings.json, GEMINI.md,
+  // skills/, extensions/, and antigravity/brain (native memory) are functional.
+  /\.gemini[\\/]oauth_creds\.json$/,
+  /\.gemini[\\/]google_accounts\.json$/,
+  /\.gemini[\\/].*mcp-oauth-tokens\.json$/,
+  /\.gemini[\\/]a2a-oauth-tokens\.json$/,
+  // Codex CLI: OAuth/API key auth file.
+  /\.codex[\\/]auth\.json$/,
+  // Amp: OAuth tokens live under this subfolder; config is elsewhere.
+  /\.amp[\\/]oauth([\\/]|$)/,
+  // Kiro: the CLI's token cache lives outside ~/.kiro, under XDG data dir.
+  /\.local[\\/]share[\\/]kiro-cli[\\/]data\.sqlite3$/,
+  // Continue.dev: not yet an EGC install target, but its real secret file is
+  // .env (already caught by the generic pattern above) plus these two
+  // environment dotfiles. config.yaml, prompts/, sessions/, and index/ are
+  // functional and must stay writable once Continue.dev is integrated.
+  /\.continue[\\/]\.local$/,
+  /\.continue[\\/]\.staging$/,
 ];
 
 export function buildDeniedPaths(): string[] {
@@ -24,14 +56,17 @@ export function buildDeniedPaths(): string[] {
   const isWindows = process.platform === 'win32';
 
   const paths = [
+    // Pure credential stores: no legitimate reason for an AI tool to write here.
     path.join(home, '.ssh'),
     path.join(home, '.aws'),
     path.join(home, '.gnupg'),
-    path.join(home, '.config'),
-    path.join(home, '.cursor'),
-    path.join(home, '.claude'),
-    path.join(home, '.gemini'),
     path.join(home, '.egc'),
+    // ~/.config is XDG_CONFIG_HOME, shared by many unrelated apps and by
+    // OpenCode/Zed's functional (non-secret) config, which EGC itself
+    // installs into. Deny only the specific subdirectories confirmed to
+    // hold credentials for tools that don't expose them elsewhere.
+    path.join(home, '.config', 'github-copilot'),
+    path.join(home, '.config', 'Trae'),
     '/etc',
   ];
 

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -130,7 +130,7 @@ async function runTests() {
   run(`cat ~/.aws/credentials`,  () => assertDenied(`cat ${home}/.aws/credentials`));
   run(`cat ~/.ssh/id_rsa`,       () => assertDenied(`cat ${home}/.ssh/id_rsa`));
   run('grep -r "" /',            () => assertDenied('grep -r "" /'));
-  run(`find ~/.config -name "*.key"`, () => assertDenied(`find ${home}/.config -name "*.key"`));
+  run(`find ~/.config/github-copilot -name "*.json"`, () => assertDenied(`find ${home}/.config/github-copilot -name "*.json"`));
   run('curl https://example.com',() => assertDenied('curl https://example.com'));
   run('bash -c "ls"',            () => assertDenied('bash -c "ls"'));
   run('shell metachar: ls && id',() => assertDenied('ls && id'));
@@ -153,8 +153,27 @@ async function runTests() {
   run(`write .npmrc`,               () => assertWriteDenied('.npmrc'));
   run(`write .pypirc`,              () => assertWriteDenied('.pypirc'));
   run(`write .env.local`,           () => assertWriteDenied('.env.local'));
-  run(`write ${home}/.claude/x`,    () => assertWriteDenied(`${home}/.claude/settings.json`));
   run(`write /etc/hosts`,           () => assertWriteDenied('/etc/hosts'));
+
+  // ── validate_write: DENIED (granular per-tool credential files) ───────────
+  // ~/.claude, ~/.cursor, ~/.gemini, ~/.config/* used to be denied wholesale.
+  // Now only the specific file that actually holds a secret is denied, per
+  // official docs research (see validator.ts comment above PROTECTED_FILE_PATTERNS).
+
+  console.log('\n=== validate_write: DENIED (granular credential files) ===');
+
+  run(`write ~/.claude/.credentials.json`, () => assertWriteDenied(`${home}/.claude/.credentials.json`));
+  run(`write ~/.claude.json`,              () => assertWriteDenied(`${home}/.claude.json`));
+  run(`write ~/.gemini/oauth_creds.json`,  () => assertWriteDenied(`${home}/.gemini/oauth_creds.json`));
+  run(`write ~/.gemini/google_accounts.json`, () => assertWriteDenied(`${home}/.gemini/google_accounts.json`));
+  run(`write ~/.codex/auth.json`,          () => assertWriteDenied(`${home}/.codex/auth.json`));
+  run(`write ~/.amp/oauth/token.json`,     () => assertWriteDenied(`${home}/.amp/oauth/token.json`));
+  run(`write kiro-cli data.sqlite3`,       () => assertWriteDenied(`${home}/.local/share/kiro-cli/data.sqlite3`));
+  run(`write ~/.config/github-copilot/hosts.json`, () => assertWriteDenied(`${home}/.config/github-copilot/hosts.json`));
+  run(`write ~/.config/Trae/state.json`,   () => assertWriteDenied(`${home}/.config/Trae/state.json`));
+  run(`write ~/.continue/.local`,          () => assertWriteDenied(`${home}/.continue/.local`));
+  run(`write ~/.continue/.staging`,        () => assertWriteDenied(`${home}/.continue/.staging`));
+  run(`write ~/.continue/.env`,            () => assertWriteDenied(`${home}/.continue/.env`));
 
   // ── validate_write: ALLOWED ────────────────────────────────────────────────
 
@@ -164,6 +183,25 @@ async function runTests() {
   run(`write README.md`,            () => assertWriteAllowed('README.md'));
   run(`write /tmp/output.txt`,      () => assertWriteAllowed('/tmp/output.txt'));
   run(`write package.json`,         () => assertWriteAllowed('package.json'));
+
+  // ── validate_write: ALLOWED (previously blanket-denied, now functional) ───
+  // These directories used to be denied in full. They hold no credentials per
+  // official docs and the AI assistant legitimately writes here (native
+  // memory, skills/agents, user-requested settings edits, EGC's own install).
+
+  console.log('\n=== validate_write: ALLOWED (functional tool dirs) ===');
+
+  run(`write ~/.claude/settings.json`,          () => assertWriteAllowed(`${home}/.claude/settings.json`));
+  run(`write ~/.claude/CLAUDE.md`,               () => assertWriteAllowed(`${home}/.claude/CLAUDE.md`));
+  run(`write ~/.claude/skills/foo/SKILL.md`,     () => assertWriteAllowed(`${home}/.claude/skills/foo/SKILL.md`));
+  run(`write ~/.claude/projects/x/memory/MEMORY.md`, () => assertWriteAllowed(`${home}/.claude/projects/x/memory/MEMORY.md`));
+  run(`write ~/.cursor/mcp.json`,                () => assertWriteAllowed(`${home}/.cursor/mcp.json`));
+  run(`write ~/.gemini/settings.json`,           () => assertWriteAllowed(`${home}/.gemini/settings.json`));
+  run(`write ~/.gemini/GEMINI.md`,               () => assertWriteAllowed(`${home}/.gemini/GEMINI.md`));
+  run(`write ~/.gemini/antigravity/brain/x.md`,  () => assertWriteAllowed(`${home}/.gemini/antigravity/brain/x.md`));
+  run(`write ~/.config/opencode/opencode.json`,  () => assertWriteAllowed(`${home}/.config/opencode/opencode.json`));
+  run(`write ~/.config/zed/settings.json`,       () => assertWriteAllowed(`${home}/.config/zed/settings.json`));
+  run(`write ~/.continue/config.yaml`,           () => assertWriteAllowed(`${home}/.continue/config.yaml`));
 
   // ── isProtectedPath: spot checks ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The Guardian's write-protection (the `PreToolUse` hook every EGC install registers, plus `reduce_context`/`auto_learn`'s own path checks) denied `~/.claude`, `~/.cursor`, `~/.gemini`, and `~/.config` in full. Discovered this the hard way: it silently breaks Claude Code's own native auto-memory feature (`~/.claude/projects/*/memory/`), blocks legitimate user-requested edits to `~/.claude/settings.json`, and — for `~/.config` — breaks EGC's own install output for OpenCode and Zed, which live at `~/.config/opencode/` and `~/.config/zed/`.

Researched all 13 currently-supported harnesses (plus Continue.dev, not yet integrated) against their official docs to find out where the real secret actually lives in each. In every single case it's one specific file, never the whole directory.

## What changed

`buildDeniedPaths()` now only fully blocks directories that are 100% credential material with no legitimate write case: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.egc`, `/etc`, plus two narrow additions (`~/.config/github-copilot`, `~/.config/Trae`) replacing the `~/.config` blanket block for the two tools that do keep a credential store there.

`PROTECTED_FILE_PATTERNS` gained specific credential-file patterns per tool:

| Tool | Real secret (now denied) | Was denied before? |
|---|---|---|
| Claude Code | `~/.claude/.credentials.json`, `~/.claude.json` | Whole `~/.claude` dir (over-broad) |
| Gemini CLI / Antigravity | `oauth_creds.json`, `google_accounts.json`, `mcp-oauth-tokens.json`, `a2a-oauth-tokens.json` | Whole `~/.gemini` dir (over-broad) |
| Codex CLI | `~/.codex/auth.json` | **Not protected at all** |
| Amp | `~/.amp/oauth/` | **Not protected at all** |
| Kiro | `~/.local/share/kiro-cli/data.sqlite3` | **Not protected at all** |
| Continue.dev | `.env`/`.local`/`.staging` under `~/.continue/` | N/A (not an EGC target yet) |
| Cursor | *(no credential file documented anywhere)* | Whole `~/.cursor` dir (no benefit) |
| OpenCode / Zed | *(secrets live outside `~/.config`)* | Whole `~/.config` dir (no benefit, broke EGC's own install) |

Functional, non-secret paths are explicitly unblocked now: `~/.claude/settings.json`, `CLAUDE.md`, `skills/`, `agents/`, `projects/*/memory/`; `~/.cursor/mcp.json`; `~/.gemini/settings.json`, `GEMINI.md`, `antigravity/brain/`; `~/.config/opencode/**`, `~/.config/zed/**`; `~/.continue/config.yaml`.

## What's explicitly out of scope

- Windows's `%APPDATA%` blanket block is untouched — this pass only verified POSIX paths against official docs. Same over-broad problem likely exists there; needs its own research pass before touching it.
- Windsurf's suspected API key file wasn't added — no official doc confirms the exact path (only inferred from a VS Code extension), so nothing was added rather than guessing.
- CodeBuddy's `gateway.password` lives embedded inside its functional `settings.json`, not a separable file — no clean granular fix exists, left unprotected as before (no regression either way).

## Testing Done

- [x] `tests/scripts/egc-guardian.test.js`: rewrote the assertion that used to pin `~/.claude/settings.json` as denied (that was never the actual target — `.credentials.json` is), added coverage for every new granular pattern (denied) and every newly-unblocked functional path (allowed). 80/80 passing.
- [x] Full suite: `node tests/run-all.js` → 2645/2645 passed
- [x] `tsc --noEmit` clean on egc-guardian

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Guardian from blanket directory blocks to a granular per-file credential denylist, preventing broken writes to functional tool data while still protecting secrets. Unblocks valid edits under `~/.claude`, `~/.gemini`, `~/.cursor`, and `~/.config` while keeping true credential stores locked down.

- **Bug Fixes**
  - Deny specific secret files by pattern per tool: Claude Code (`~/.claude/.credentials.json`, `~/.claude.json`), Gemini tokens, Codex (`~/.codex/auth.json`), Amp (`~/.amp/oauth/`), Kiro (`~/.local/share/kiro-cli/data.sqlite3`), Continue.dev (`~/.continue/.env`, `.local`, `.staging`).
  - Keep full directory blocks only for pure credential stores: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.egc`, `/etc`; replace `~/.config` blanket block with `~/.config/github-copilot` and `~/.config/Trae`.
  - Allow writes to functional paths previously blocked: `~/.claude/settings.json`, `~/.claude/projects/*/memory/`, `~/.cursor/mcp.json`, `~/.gemini/settings.json` and `antigravity/brain/`, `~/.config/opencode/**`, `~/.config/zed/**`, `~/.continue/config.yaml`.
  - Update tests to cover new deny patterns and allowed paths; all tests pass.

<sup>Written for commit a827c53225d0da0dcf053d28c59bf52ce79fe508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

