### PR TITLE
feat(skills): add autonomous-lesson-learning orchestration skill

### DIFF
--- a/.agents/skills/ai-autonomous-lesson-learning
+++ b/.agents/skills/ai-autonomous-lesson-learning
@@ -1,0 +1,1 @@
+../../skills/ai/autonomous-lesson-learning

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # EGC: Agent Catalog
 
-Extended Global Context (EGC) is a production-grade, multi-agent system providing 63 specialized agents, 229+ skills, 76 commands to any compatible AI coding environment.
+Extended Global Context (EGC) is a production-grade, multi-agent system providing 63 specialized agents, 230+ skills, 77 commands to any compatible AI coding environment.
 
 ## Quick Start
 
@@ -14,8 +14,8 @@ node scripts/install-apply.js --target egc
 
 ```
 agents/    : 63 specialized subagents
-skills/    : 229+ workflow skills and domain knowledge
-commands/  : 76 slash commands
+skills/    : 230+ workflow skills and domain knowledge
+commands/  : 77 slash commands
 ```
 
 ## Agents

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See every tool call, token, and cost your agents generate -- live in your browse
 
 ## Prompt library
 
-**479 components** included as a bonus. Install to get access to 63 agents, 229 skills, and 76 commands, plus 111 rules, all written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.
+**481 components** included as a bonus. Install to get access to 63 agents, 230 skills, and 77 commands, plus 111 rules, all written from real engineering sessions. Skip them entirely and EGC still gives you persistent memory.
 
 ---
 

--- a/agent.yaml
+++ b/agent.yaml
@@ -19,6 +19,7 @@ skills:
   - api-design
   - architecture-decision-records
   - article-writing
+  - autonomous-lesson-learning
   - autonomous-loops
   - backend-patterns
   - benchmark
@@ -145,6 +146,7 @@ skills:
 commands:
   - aside
   - auto-update
+  - autonomous-lesson-learning
   - build-fix
   - checkpoint
   - code-review

--- a/commands/autonomous-lesson-learning.md
+++ b/commands/autonomous-lesson-learning.md
@@ -1,0 +1,41 @@
+---
+description: Start an autonomous loop that recalls stored lessons before each iteration and saves or reinforces lessons on failures and wins.
+---
+
+# Autonomous Lesson Learning Command
+
+Start a learning autonomous loop: `continuous-agent-loop` mechanics plus the `egc-memory` lesson tools (`lesson_recall`, `lesson_save`, `lesson_reinforce`).
+
+## Usage
+
+`/autonomous-lesson-learning <task> [--pattern sequential|continuous-pr] [--max-iterations N]`
+
+- `task`: what the loop should accomplish, with a verifiable done condition
+- `--pattern`: loop architecture from `continuous-agent-loop` (default `sequential`)
+- `--max-iterations`: hard stop (default 10)
+
+## Flow
+
+1. Read the `autonomous-lesson-learning` skill (`skills/ai/autonomous-lesson-learning/SKILL.md`) and confirm `egc-memory` is registered.
+2. Confirm the task has an explicit stop condition; refuse to start without one.
+3. Per iteration:
+   - `lesson_recall({ query: "<current step topic>" })` before acting; apply what comes back.
+   - `lesson_reinforce({ id })` for each recalled lesson that proved relevant or whose mistake recurred.
+   - Execute one iteration of the chosen loop pattern.
+   - On failure with no matching lesson: `lesson_save({ content, context })`.
+   - On a new approach that worked well: `lesson_save` with prescriptive wording.
+4. Stop on: done condition met, `--max-iterations` reached, or the same lesson reinforced three iterations in a row without progress (escalate to the user).
+5. Report iterations run, lessons recalled, saved, and reinforced.
+
+## Required Safety Checks
+
+- Explicit stop condition before the first iteration.
+- Quality gates between iterations per `continuous-agent-loop`.
+- Never save a lesson without calling `lesson_recall` first; reinforce instead of duplicating.
+
+## Arguments
+
+$ARGUMENTS:
+- `<task>` required
+- `--pattern sequential|continuous-pr` optional
+- `--max-iterations N` optional

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -528,6 +528,7 @@
         "skills/general/egc-devfleet",
         "skills/general/content-hash-cache-pattern",
         "skills/devops/continuous-agent-loop",
+        "skills/ai/autonomous-lesson-learning",
         "skills/ai/cost-aware-llm-pipeline",
         "skills/general/data-scraper-agent",
         "skills/general/enterprise-agent-ops",

--- a/mcp/servers/egc-guardian/src/catalog-index.ts
+++ b/mcp/servers/egc-guardian/src/catalog-index.ts
@@ -37,6 +37,11 @@ export const CATALOG: ReadonlyArray<{ kind: 'agent' | 'skill' | 'rule'; name: st
   },
   {
     "kind": "skill",
+    "name": "autonomous-lesson-learning",
+    "description": "Autonomous loop that learns while it runs: recalls stored lessons before each iteration, saves new lessons on failures and wins, and reinforces known lessons instead of repeating mistakes. Orchestrates continuous-agent-loop patterns with the egc-memory lesson tools."
+  },
+  {
+    "kind": "skill",
     "name": "autonomous-loops",
     "description": "Patterns and architectures for autonomous Gemini Code loops: from simple sequential pipelines to RFC-driven multi-agent DAG systems."
   },

--- a/scripts/lib/skill-index.json
+++ b/scripts/lib/skill-index.json
@@ -37,6 +37,11 @@
     },
     {
       "kind": "skill",
+      "name": "autonomous-lesson-learning",
+      "description": "Autonomous loop that learns while it runs: recalls stored lessons before each iteration, saves new lessons on failures and wins, and reinforces known lessons instead of repeating mistakes. Orchestrates continuous-agent-loop patterns with the egc-memory lesson tools."
+    },
+    {
+      "kind": "skill",
       "name": "autonomous-loops",
       "description": "Patterns and architectures for autonomous Gemini Code loops: from simple sequential pipelines to RFC-driven multi-agent DAG systems."
     },

--- a/skills/ai/autonomous-lesson-learning/SKILL.md
+++ b/skills/ai/autonomous-lesson-learning/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: autonomous-lesson-learning
+description: "Autonomous loop that learns while it runs: recalls stored lessons before each iteration, saves new lessons on failures and wins, and reinforces known lessons instead of repeating mistakes. Orchestrates continuous-agent-loop patterns with the egc-memory lesson tools."
+origin: EGC
+---
+
+# Autonomous Lesson Learning
+
+Run an autonomous work loop that gets smarter every iteration. This skill is pure orchestration: it combines the loop patterns from `continuous-agent-loop` / `autonomous-loops` with the `lesson_recall`, `lesson_save`, and `lesson_reinforce` tools from the `egc-memory` MCP server. It does not reimplement loops and it does not add a new lesson store.
+
+Works in any harness that has the `egc-memory` MCP server registered (all EGC Tier 1/2/3 targets). Nothing here is platform-specific: the loop is plain instruction-following and the memory calls are standard MCP tool calls.
+
+## When to Activate
+
+- Running a long multi-iteration task autonomously (fix all lint errors, raise coverage, burn down an issue list) where repeating a known mistake is expensive
+- Resuming a class of work that has failed before and the failure modes are worth remembering across sessions
+- Any `continuous-agent-loop` pattern (Sequential Pipeline, Continuous PR Loop) where you also want cross-session learning
+
+Use a plain loop (`/loop-start`, `continuous-agent-loop`) instead when the task is one-off, trivial, or exploratory throwaway work where lessons would be noise.
+
+## The Cycle
+
+```text
++--------------------------------------------------------+
+|  AUTONOMOUS LESSON LEARNING ITERATION                  |
+|                                                        |
+|  1. RECALL   lesson_recall({ query }) for the current  |
+|              step BEFORE acting                        |
+|  2. APPLY    adjust the plan using recalled lessons;   |
+|              lesson_reinforce({ id }) each lesson that |
+|              proved relevant                           |
+|  3. ACT      execute one loop iteration (implement,    |
+|              test, fix) per continuous-agent-loop      |
+|  4. RECORD                                             |
+|     - failure -> known lesson matches?                 |
+|         yes -> lesson_reinforce({ id })                |
+|         no  -> lesson_save({ content, context })       |
+|     - new pattern that worked well?                    |
+|         -> lesson_save with prescriptive wording       |
+|  5. CHECK    stop condition met? done : goto 1         |
++--------------------------------------------------------+
+```
+
+### 1. Recall before acting
+
+At the start of every iteration, query stored lessons for the area you are about to touch:
+
+```
+lesson_recall({ query: "flaky playwright timeout", limit: 5 })
+```
+
+`lesson_recall` searches content, context, and tags, and returns lessons ranked by confidence (default floor 0.2). Read the results and adjust the plan before executing. Skipping this step defeats the purpose of the skill.
+
+### 2. Reinforce what proved relevant
+
+When a recalled lesson applies to the current iteration, or a mistake it describes recurs, reinforce it by the `id` field returned from `lesson_recall`:
+
+```
+lesson_reinforce({ id: "<lesson id from lesson_recall>" })
+```
+
+Reinforcement raises confidence by 0.15 (capped at 1.0) and un-archives decayed lessons. Never save a duplicate lesson for a pattern that already exists: recall first, reinforce on match, save only on miss.
+
+### 3. Save on failure
+
+When an action fails during the loop (a command errors, a test breaks, a fix has to be redone), record what went wrong and why, with a `context` that says where it applies:
+
+```
+lesson_save({
+  content: "npm test hangs when the dashboard watcher is left running; kill the watcher before the suite.",
+  context: "test runs in the EGC dashboard package",
+  tags: "testing,watcher"
+})
+```
+
+Both `content` and `context` are required. Keep lessons atomic: one failure mode, one lesson. `initial_confidence` defaults to 0.7 and only needs overriding for tentative observations.
+
+### 4. Save wins too
+
+When a new approach works well, save it in positive, prescriptive form so the next loop starts from it:
+
+```
+lesson_save({
+  content: "Always regenerate the skill index (scripts/build-skill-index.js) before running the docs tests when a skill was added.",
+  context: "adding or renaming skills in the EGC repo",
+  tags: "workflow,skills"
+})
+```
+
+### 5. Stop conditions
+
+Inherit the safety rules from `continuous-agent-loop`: every loop needs an explicit stop condition (max iterations, completion signal, green test suite) and quality gates between iterations. If the same lesson gets reinforced on three consecutive iterations without progress, stop the loop and escalate: that is the "repeated retries with same root cause" failure mode.
+
+## Worked Example
+
+Task: "fix every failing test in the suite, autonomously".
+
+1. `lesson_recall({ query: "failing tests <project name>" })` -> a lesson says the fixture DB must be reset between runs (confidence 0.85).
+2. Reset the fixture DB first, then run the suite. The lesson applied: `lesson_reinforce({ id })`.
+3. Iteration 2: a fix is reverted because it broke an unrelated snapshot. No matching lesson from recall -> `lesson_save({ content: "Snapshot tests in pkg X break when locale helpers change; run pkg X snapshots after touching i18n.", context: "test fixing in project Y" })`.
+4. Iteration 5: discovered that running the linter before the type checker cuts iteration time in half -> save it as a prescriptive win.
+5. Suite green -> stop condition met -> loop ends.
+
+## Division of Labor
+
+| System | Mechanism | Speed | Use for |
+|--------|-----------|-------|---------|
+| autonomous-lesson-learning | explicit MCP calls inside an active loop | immediate, per-iteration | mistakes and wins observed while working |
+| continuous-learning-v2 | passive hook observation, background instinct clustering | slow, cross-session | broad behavioral patterns you did not notice yourself |
+| continuous-agent-loop | loop architecture, gates, recovery | n/a | the loop mechanics themselves |
+
+autonomous-lesson-learning and `continuous-learning-v2` coexist: this skill is the fast, deliberate path (the AI knows it just failed and writes it down); v2 is the slow, passive path (hooks notice patterns the AI missed). Neither replaces the other, and both read from independent stores.
+
+## Requirements
+
+- `egc-memory` MCP server registered (`egc doctor` to verify)
+- A loop pattern from `continuous-agent-loop` with an explicit stop condition

--- a/tests/docs/autonomous-lesson-learning-docs.test.js
+++ b/tests/docs/autonomous-lesson-learning-docs.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const assert = require('assert');
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+console.log('\n=== Testing autonomous-lesson-learning skill surface ===\n');
+
+const skillPath = path.join(repoRoot, 'skills/ai/autonomous-lesson-learning/SKILL.md');
+const commandPath = path.join(repoRoot, 'commands/autonomous-lesson-learning.md');
+const agentYamlPath = path.join(repoRoot, 'agent.yaml');
+
+const skill = fs.readFileSync(skillPath, 'utf8');
+const command = fs.readFileSync(commandPath, 'utf8');
+const agentYaml = fs.readFileSync(agentYamlPath, 'utf8');
+
+test('skill frontmatter declares name and description', () => {
+  const frontmatter = skill.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  assert.ok(frontmatter, 'SKILL.md is missing YAML frontmatter');
+  assert.ok(/^name: autonomous-lesson-learning$/m.test(frontmatter[1]), 'frontmatter name must be autonomous-lesson-learning');
+  assert.ok(/^description: /m.test(frontmatter[1]), 'frontmatter must include a description');
+});
+
+test('skill orchestrates all three egc-memory lesson tools', () => {
+  for (const tool of ['lesson_recall', 'lesson_save', 'lesson_reinforce']) {
+    assert.ok(skill.includes(tool), `SKILL.md must reference ${tool}`);
+  }
+});
+
+test('skill requires recall before save so duplicates are reinforced instead', () => {
+  assert.ok(
+    skill.includes('recall first, reinforce on match, save only on miss'),
+    'SKILL.md must state the recall-before-save rule'
+  );
+});
+
+test('skill defers loop mechanics to continuous-agent-loop instead of reimplementing them', () => {
+  assert.ok(skill.includes('continuous-agent-loop'), 'SKILL.md must reference continuous-agent-loop');
+  assert.ok(
+    skill.includes('continuous-learning-v2'),
+    'SKILL.md must position itself relative to continuous-learning-v2'
+  );
+});
+
+test('command file exists with description frontmatter and lesson flow', () => {
+  assert.ok(/^---\r?\ndescription: /.test(command), 'command must start with description frontmatter');
+  for (const tool of ['lesson_recall', 'lesson_save', 'lesson_reinforce']) {
+    assert.ok(command.includes(tool), `command must reference ${tool}`);
+  }
+});
+
+test('agent.yaml exports the autonomous-lesson-learning skill and command', () => {
+  const matches = agentYaml.match(/^ {2}- autonomous-lesson-learning$/gm) || [];
+  assert.strictEqual(matches.length, 2, 'autonomous-lesson-learning must be listed under both skills and commands');
+});
+
+if (failed > 0) {
+  console.log(`\nFailed: ${failed}`);
+  process.exit(1);
+}
+
+console.log(`\nPassed: ${passed}`);


### PR DESCRIPTION
## Summary

New orchestration skill `autonomous-lesson-learning` (`/autonomous-lesson-learning`): an autonomous work loop that learns while it runs. It combines two things that already exist in the catalog without reimplementing either:

- Loop mechanics from `continuous-agent-loop` / `autonomous-loops` (Sequential Pipeline and Continuous PR Loop patterns)
- The `egc-memory` lesson tools: `lesson_recall`, `lesson_save`, `lesson_reinforce`

## The cycle

1. **Recall**: `lesson_recall({ query })` before acting on each iteration, so known mistakes are not repeated.
2. **Reinforce**: `lesson_reinforce({ id })` when a recalled lesson proves relevant or a known mistake recurs, instead of saving a duplicate.
3. **Act**: one iteration of the chosen `continuous-agent-loop` pattern.
4. **Record**: `lesson_save({ content, context })` on failures with no matching lesson, and on new approaches that worked well (prescriptive wording).
5. **Stop**: explicit stop condition inherited from `continuous-agent-loop` safety rules, plus an escalation rule when the same lesson is reinforced three iterations in a row without progress.

## Design notes

- Pure orchestration: no new lesson storage, no loop reimplementation, no changes to `continuous-learning-v2` (the skill documents how the two coexist: this is the fast deliberate path, v2 is the slow passive hook-based path).
- Harness-agnostic: plain Markdown instructions plus standard MCP tool calls, so it works in every harness with the `egc-memory` server registered (all Tier 1/2/3 targets). Nothing platform-specific.

## Naming

Names considered during development: `lesson-loop` and `loop-lessons`. Final name confirmed by the project owner: `autonomous-lesson-learning`.

## Files

- `skills/ai/autonomous-lesson-learning/SKILL.md`: the skill
- `commands/autonomous-lesson-learning.md`: the slash command
- `tests/docs/autonomous-lesson-learning-docs.test.js`: surface conformance test
- Registration: `agent.yaml` (skills + commands), `manifests/install-modules.json` (agentic-patterns module), regenerated skill index (`scripts/lib/skill-index.json`, `mcp/servers/egc-guardian/src/catalog-index.ts`), `.agents/skills/ai-autonomous-lesson-learning` symlink
- Catalog counts: README.md (230 skills / 77 commands / 481 components), AGENTS.md (230+ / 77)

## Testing

- `env -u EGC_HOOK_PROFILE -u EGC_DISABLED_HOOKS node tests/run-all.js`: 2495/2495 passed
- `scripts/ci/validate-skills.js`, `validate-commands.js`, `validate-install-manifests.js`, `catalog.js`, `check-unicode-safety.js`: all green


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `autonomous-lesson-learning` orchestration skill and `/autonomous-lesson-learning` command. It runs an autonomous loop that recalls, reinforces, and saves lessons each iteration by combining `continuous-agent-loop` patterns with `egc-memory` tools to reduce repeated mistakes.

- **New Features**
  - `autonomous-lesson-learning`: recall via `lesson_recall` before each iteration, reinforce with `lesson_reinforce` when a lesson applies, and save new lessons with `lesson_save` on failures and wins.
  - Uses existing `continuous-agent-loop` patterns (no loop reimplementation or new storage).
  - Stops on inherited loop rules, `--max-iterations`, or when the same lesson is reinforced three times without progress (then escalates).
  - Adds `/autonomous-lesson-learning` command with `--pattern sequential|continuous-pr` and `--max-iterations` options.

- **Migration**
  - Requires the `egc-memory` MCP server to be registered.
  - Use: `/autonomous-lesson-learning <task> [--pattern sequential|continuous-pr] [--max-iterations N]`. The task must include a clear stop condition.

<sup>Written for commit 1a184e50b35ad2e38f4671d9e5ba4c1d6af1718f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `autonomous-lesson-learning` skill and command.
  * Introduced lesson recall, saving, and reinforcement guidance for iterative workflows.
  * Updated catalogs and installation metadata to include the new capability.

* **Documentation**
  * Updated catalog totals and component counts across project documentation.

* **Tests**
  * Added coverage to verify the new skill, command, documentation, and configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->