### PR TITLE
feat: add Continue.dev as the 14th supported harness (Tier 1 target)

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 13 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 14 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 13 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 13 harnesses
+## The 14 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -27,8 +27,9 @@ EGC supports 13 AI coding tools through 3 distinct integration mechanisms. This 
 | 9 | **Amp** | 1 | `amp` | `~/.amp/skills/<name>/SKILL.md` | Skills installed flat |
 | 10 | **VS Code Copilot** | 1 | `copilot` | `~/.github/skills/<name>/SKILL.md` | Skills installed flat |
 | 11 | **Zed** | 1 | `zed` | `~/.config/zed/skills/<name>/` | Skills installed flat (category stripped); MCP via `context_servers` in `settings.json`; cognitive bootstrap into `~/.config/zed/AGENTS.md` |
-| 12 | **Kiro** | 2 | (none) | `~/.kiro/` via `.kiro/install.sh` | Session hooks installed to `~/.kiro/hooks/` |
-| 13 | **Trae** | 2 | (none) | `~/.trae/` (or `~/.trae-cn/` with `TRAE_ENV=cn`) via `.trae/install.sh` | Memory protocol written to `~/.trae/MEMORY.md` |
+| 12 | **Continue.dev** | 1 | `continue` | `~/.continue/skills/<name>/SKILL.md` | Skills installed flat; MCP via YAML block files in `~/.continue/mcpServers/`; memory protocol prompt in `~/.continue/prompts/`; rules discovered natively at workspace `.continue/rules/` |
+| 13 | **Kiro** | 2 | (none) | `~/.kiro/` via `.kiro/install.sh` | Session hooks installed to `~/.kiro/hooks/` |
+| 14 | **Trae** | 2 | (none) | `~/.trae/` (or `~/.trae-cn/` with `TRAE_ENV=cn`) via `.trae/install.sh` | Memory protocol written to `~/.trae/MEMORY.md` |
 
 ## Why three tiers (history, not aspiration)
 
@@ -36,11 +37,11 @@ Tier 1 (unified) is the canonical pipeline. It is the result of `install-plan.js
 
 Tier 2 (custom-script) exists because Kiro and Trae landed in EGC before the unified pipeline was stable. Their installers do roughly the same work as the unified pipeline, but the shape of the assets they ship differs enough that retrofitting them is non-trivial. They are first-class but technically isolated.
 
-Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude Code was previously Tier 3, but now supports `~/.claude/skills/<name>/SKILL.md` as a skill discovery path, so it has been promoted to Tier 1 with target id `claude`. Windsurf, Amp, and VS Code Copilot were added as Tier 1 targets in v1.0.2 following the same skill-discovery pattern.
+Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude Code was previously Tier 3, but now supports `~/.claude/skills/<name>/SKILL.md` as a skill discovery path, so it has been promoted to Tier 1 with target id `claude`. Windsurf, Amp, and VS Code Copilot were added as Tier 1 targets in v1.0.2 following the same skill-discovery pattern. Continue.dev followed the same pattern as the 14th harness (its MCP registration via `~/.continue/mcpServers/` YAML block files landed separately in #564).
 
 ## What "supported" guarantees
 
-For all 9 harnesses, EGC guarantees:
+For all 14 harnesses, EGC guarantees:
 
 - The install path is documented above
 - MCP server registration (if the tool supports MCP)
@@ -62,7 +63,7 @@ For Tier 1 only:
 
 `node scripts/harness-audit.js` produces a report scored against the 7 categories defined in `CATEGORIES`. The score reflects repo-level health, not per-harness health. A future enhancement is per-harness rollup (see `docs/spec/README.md` Next Steps).
 
-## Adding a 10th harness
+## Adding a 15th harness
 
 Choose tier based on what the target tool actually consumes:
 

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -165,7 +165,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "rules-core",
@@ -198,7 +199,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -241,7 +243,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -280,7 +283,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "workflow-quality"
@@ -309,7 +313,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -345,7 +350,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -388,7 +394,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -416,7 +423,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "business-content"
@@ -447,7 +455,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -506,7 +515,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -551,7 +561,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -579,7 +590,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -613,7 +625,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -641,7 +654,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"
@@ -748,7 +762,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ],
       "dependencies": [
         "platform-configs"

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -29,7 +29,8 @@
         "windsurf",
         "amp",
         "copilot",
-        "zed"
+        "zed",
+        "continue"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -58,7 +58,8 @@
                 "windsurf",
                 "amp",
                 "copilot",
-                "zed"
+                "zed",
+                "continue"
               ]
             }
           },

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -247,6 +247,25 @@ try {
   }
 })();
 
+// ── Continue.dev (~/.continue/prompts/egc-memory.prompt) ─────────────────────
+(function bootstrapContinue() {
+  try {
+    const continueDir = path.join(HOME, '.continue');
+    if (!fs.existsSync(continueDir)) return;
+    const promptsDir = path.join(continueDir, 'prompts');
+    const target = path.join(promptsDir, 'egc-memory.prompt');
+    if (fs.existsSync(target)) {
+      console.log('  [cognitive] Continue.dev: already configured');
+      return;
+    }
+    if (!fs.existsSync(promptsDir)) fs.mkdirSync(promptsDir, { recursive: true });
+    fs.writeFileSync(target, 'name: EGC Session Memory\ndescription: Restore and persist EGC cross-session memory\n---\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr. Judge by full context not literal words.\n\n## EGC Guardian Protocol\n\nThese calls are automatic and non-negotiable. Never wait for the user to ask.\n\n- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`\n- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`\n- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`\n- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`\n\nSkipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.\n');
+    console.log('  [cognitive] Continue.dev: memory protocol installed (~/.continue/prompts/egc-memory.prompt)');
+  } catch (e) {
+    console.log(`  [cognitive] Continue.dev: unexpected error: ${e.message}`);
+  }
+})();
+
 // ── Kiro (~/.kiro/hooks/) ─────────────────────────────────────────────────────
 (function bootstrapKiro() {
   try {

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/amp-home.js
+++ b/scripts/lib/install-targets/amp-home.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,42 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.amp'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.amp',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // Amp discovers skills at ~/.amp/skills/<name>/ (flat).
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/install-targets/amp-project.js
+++ b/scripts/lib/install-targets/amp-project.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,47 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.amp'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.amp',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const {
-      repoRoot,
-      projectRoot,
-      homeDir,
-    } = input;
-    const planningInput = {
-      repoRoot,
-      projectRoot,
-      homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // Amp discovers skills at .amp/skills/<name>/ (flat).
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -5,6 +5,7 @@ const {
   createRemappedOperation,
   isForeignPlatformPath,
   normalizeRelativePath,
+  planFlatSkillOperation,
 } = require('./helpers');
 
 const CLAUDE_EXCLUDED_SOURCE_PREFIXES = [
@@ -102,27 +103,7 @@ module.exports = createInstallTargetAdapter({
       const paths = Array.isArray(module.paths) ? module.paths : [];
       return paths
         .filter(p => !isForeignPlatformPath(p, adapter.target) && !isClaudeExcludedPath(p))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // Claude Code discovers skills at ~/.claude/skills/<name>/ (flat).
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
+        .map(sourceRelativePath => planFlatSkillOperation(adapter, module.id, sourceRelativePath, planningInput, targetRoot));
     });
 
     // Deterministic memory loading: every Claude Code install registers the

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -1,9 +1,6 @@
-const path = require('path');
-
 const {
   createInstallTargetAdapter,
-  createRemappedOperation,
-  normalizeRelativePath,
+  planFlatSkillOperation,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -26,27 +23,7 @@ module.exports = createInstallTargetAdapter({
 
     return modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths.flatMap(sourceRelativePath => {
-        const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-        // Codex discovers skills at $HOME/.agents/skills/<name>/ (flat).
-        // Strip the leading category segment to match the expected structure.
-        if (normalizedPath.startsWith('skills/')) {
-          const parts = normalizedPath.slice('skills/'.length).split('/');
-          const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-          return [
-            createRemappedOperation(
-              adapter,
-              module.id,
-              sourceRelativePath,
-              path.join(targetRoot, 'skills', flatRemainder),
-              { strategy: 'preserve-relative-path' }
-            ),
-          ];
-        }
-
-        return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-      });
+      return paths.map(sourceRelativePath => planFlatSkillOperation(adapter, module.id, sourceRelativePath, planningInput, targetRoot));
     });
   },
 });

--- a/scripts/lib/install-targets/continue-home.js
+++ b/scripts/lib/install-targets/continue-home.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,43 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.continue'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.continue',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // Skills install flat at ~/.continue/skills/<name>/, matching the
-          // layout used by the other Tier 1 targets.
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/install-targets/continue-home.js
+++ b/scripts/lib/install-targets/continue-home.js
@@ -1,0 +1,56 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'continue-home',
+  target: 'continue',
+  kind: 'home',
+  rootSegments: ['.continue'],
+  installStatePathSegments: ['egc', 'install-state.json'],
+  nativeRootRelativePath: '.continue',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+          // Skills install flat at ~/.continue/skills/<name>/, matching the
+          // layout used by the other Tier 1 targets.
+          // Strip the leading category segment to match the expected structure.
+          if (normalizedPath.startsWith('skills/')) {
+            const parts = normalizedPath.slice('skills/'.length).split('/');
+            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+            return [
+              createRemappedOperation(
+                adapter,
+                module.id,
+                sourceRelativePath,
+                path.join(targetRoot, 'skills', flatRemainder),
+                { strategy: 'preserve-relative-path' }
+              ),
+            ];
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/continue-project.js
+++ b/scripts/lib/install-targets/continue-project.js
@@ -1,0 +1,61 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'continue-project',
+  target: 'continue',
+  kind: 'project',
+  rootSegments: ['.continue'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.continue',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    } = input;
+    const planningInput = {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+          // Skills install flat at .continue/skills/<name>/, matching the
+          // layout used by the other Tier 1 targets.
+          // Strip the leading category segment to match the expected structure.
+          if (normalizedPath.startsWith('skills/')) {
+            const parts = normalizedPath.slice('skills/'.length).split('/');
+            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+            return [
+              createRemappedOperation(
+                adapter,
+                module.id,
+                sourceRelativePath,
+                path.join(targetRoot, 'skills', flatRemainder),
+                { strategy: 'preserve-relative-path' }
+              ),
+            ];
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/continue-project.js
+++ b/scripts/lib/install-targets/continue-project.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,48 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.continue'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.continue',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const {
-      repoRoot,
-      projectRoot,
-      homeDir,
-    } = input;
-    const planningInput = {
-      repoRoot,
-      projectRoot,
-      homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // Skills install flat at .continue/skills/<name>/, matching the
-          // layout used by the other Tier 1 targets.
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/install-targets/copilot-home.js
+++ b/scripts/lib/install-targets/copilot-home.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,42 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.github'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.github',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // VS Code Copilot discovers skills at ~/.github/skills/<name>/ (flat).
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -113,6 +113,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },
   zed:          { name: 'Zed',               url: 'https://zed.dev' },
+  continue:     { name: 'Continue.dev',      url: 'https://continue.dev' },
 });
 
 function defaultValidateAdapterInput(config, input = {}) {

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -282,6 +282,62 @@ function createFlatRuleOperations(options) {
   return createFlatFileOperations(options);
 }
 
+/**
+ * Builds the install operation for a single module source path on a target
+ * whose native skill layout is flat (<root>/skills/<name>/, no category
+ * subfolder). Skill sources are remapped from skills/<category>/<name> to
+ * skills/<name>; every other path scaffolds through the adapter's default
+ * strategy. This is the one piece every flat-skill adapter shares -
+ * including Claude Code's, which layers its own extra path filter and
+ * hook-operation append around it - so it lives here instead of being
+ * copied into each adapter file.
+ */
+function planFlatSkillOperation(adapter, moduleId, sourceRelativePath, planningInput, targetRoot) {
+  const normalizedPath = normalizeRelativePath(sourceRelativePath);
+
+  if (normalizedPath.startsWith('skills/')) {
+    const parts = normalizedPath.slice('skills/'.length).split('/');
+    const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
+    return createRemappedOperation(
+      adapter,
+      moduleId,
+      sourceRelativePath,
+      path.join(targetRoot, 'skills', flatRemainder),
+      { strategy: 'preserve-relative-path' }
+    );
+  }
+
+  return adapter.createScaffoldOperation(moduleId, sourceRelativePath, planningInput);
+}
+
+/**
+ * Shared planOperations body for Tier 1 targets that discover skills flat
+ * and have no adapter-specific path filtering or extra operations beyond
+ * planFlatSkillOperation (Windsurf, Amp, Copilot, Zed, Continue.dev).
+ *
+ * Signature matches config.planOperations(input, adapter) so it can be
+ * assigned directly (e.g. `planOperations: createFlatSkillPlanOperations`)
+ * without a wrapper closure in each adapter file.
+ */
+function createFlatSkillPlanOperations(input = {}, adapter) {
+  const modules = Array.isArray(input.modules)
+    ? input.modules
+    : (input.module ? [input.module] : []);
+  const planningInput = {
+    repoRoot: input.repoRoot,
+    projectRoot: input.projectRoot,
+    homeDir: input.homeDir,
+  };
+  const targetRoot = adapter.resolveRoot(planningInput);
+
+  return modules.flatMap(module => {
+    const paths = Array.isArray(module.paths) ? module.paths : [];
+    return paths
+      .filter(p => !isForeignPlatformPath(p, adapter.target))
+      .map(sourceRelativePath => planFlatSkillOperation(adapter, module.id, sourceRelativePath, planningInput, targetRoot));
+  });
+}
+
 function createInstallTargetAdapter(config) {
   const adapter = {
     id: config.id,
@@ -384,6 +440,7 @@ module.exports = {
   buildValidationIssue,
   createFlatFileOperations,
   createFlatRuleOperations,
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
   createManagedOperation,
   createManagedScaffoldOperation: (moduleId, sourceRelativePath, destinationPath, strategy) => (
@@ -398,4 +455,5 @@ module.exports = {
   createRemappedOperation,
   isForeignPlatformPath,
   normalizeRelativePath,
+  planFlatSkillOperation,
 };

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -12,6 +12,8 @@ const ampHome = require('./amp-home');
 const ampProject = require('./amp-project');
 const copilotHome = require('./copilot-home');
 const zedHome = require('./zed-home');
+const continueHome = require('./continue-home');
+const continueProject = require('./continue-project');
 
 const ADAPTERS = Object.freeze([
   egcHome,
@@ -28,6 +30,8 @@ const ADAPTERS = Object.freeze([
   ampProject,
   copilotHome,
   zedHome,
+  continueHome,
+  continueProject,
 ]);
 
 function listInstallTargetAdapters() {

--- a/scripts/lib/install-targets/windsurf-home.js
+++ b/scripts/lib/install-targets/windsurf-home.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,42 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.codeium', 'windsurf'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.codeium/windsurf',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // Windsurf discovers skills at ~/.codeium/windsurf/skills/<name>/ (flat).
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/install-targets/windsurf-project.js
+++ b/scripts/lib/install-targets/windsurf-project.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,47 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.windsurf'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.windsurf',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const {
-      repoRoot,
-      projectRoot,
-      homeDir,
-    } = input;
-    const planningInput = {
-      repoRoot,
-      projectRoot,
-      homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          // Windsurf discovers skills at .windsurf/skills/<name>/ (flat).
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/install-targets/zed-home.js
+++ b/scripts/lib/install-targets/zed-home.js
@@ -1,10 +1,6 @@
-const path = require('path');
-
 const {
+  createFlatSkillPlanOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
-  isForeignPlatformPath,
-  normalizeRelativePath,
 } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
@@ -14,40 +10,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.config', 'zed'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.zed',
-  planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
-
-    return modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
-        });
-    });
-  },
+  planOperations: createFlatSkillPlanOperations,
 });

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -98,6 +98,7 @@ function getEGCDir() {
     path.join(home, '.cursor'),
     path.join(home, '.agents'),
     path.join(home, '.amp'),
+    path.join(home, '.continue'),
     path.join(home, '.github'),
     path.join(home, '.kiro'),
     path.join(home, '.trae'),

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1040,6 +1040,107 @@ function runTests() {
     assert.ok(targets.includes('continue'), 'Should include continue target');
   })) passed++; else failed++;
 
+  if (test('continue-project adapter strips category from skill paths and installs flat under .continue/skills/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'continue-project',
+      repoRoot,
+      projectRoot,
+      homeDir: '/Users/example',
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'continue-project');
+    assert.strictEqual(plan.targetRoot, path.join(projectRoot, '.continue'));
+    assert.strictEqual(plan.installStatePath, path.join(projectRoot, '.continue', 'egc-install-state.json'));
+    assert.ok(
+      plan.operations.some(op =>
+        normalizedRelativePath(op.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && op.destinationPath === path.join(projectRoot, '.continue', 'skills', 'tdd-workflow')
+      ),
+      'Should strip category and install skill flat under .continue/skills/'
+    );
+  })) passed++; else failed++;
+
+  if (test('continue-project adapter handles already-flat skill paths without double-stripping', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'continue-project',
+      repoRoot,
+      projectRoot,
+      homeDir: '/Users/example',
+      modules: [{ id: 'workflow', paths: ['skills/tdd-workflow'] }],
+    });
+
+    assert.ok(
+      plan.operations.some(op =>
+        normalizedRelativePath(op.sourceRelativePath) === 'skills/tdd-workflow'
+        && op.destinationPath === path.join(projectRoot, '.continue', 'skills', 'tdd-workflow')
+      ),
+      'Should handle already-flat skill path without stripping anything'
+    );
+  })) passed++; else failed++;
+
+  if (test('continue-project adapter passes non-skill paths through the default scaffold operation', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'continue-project',
+      repoRoot,
+      projectRoot,
+      homeDir: '/Users/example',
+      modules: [{ id: 'workflow', paths: ['AGENTS.md'] }],
+    });
+
+    assert.ok(
+      plan.operations.some(op =>
+        normalizedRelativePath(op.sourceRelativePath) === 'AGENTS.md'
+        && op.destinationPath === path.join(projectRoot, '.continue', 'AGENTS.md')
+        && op.strategy === 'preserve-relative-path'
+      ),
+      'Should pass non-skill paths through to the default scaffold operation'
+    );
+  })) passed++; else failed++;
+
+  if (test('continue-project adapter filters out foreign-platform source paths', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'continue-project',
+      repoRoot,
+      projectRoot,
+      homeDir: '/Users/example',
+      modules: [{ id: 'workflow', paths: ['.cursor', 'skills/tdd-workflow'] }],
+    });
+
+    assert.ok(
+      !plan.operations.some(op => normalizedRelativePath(op.sourceRelativePath) === '.cursor'),
+      'Should filter out paths owned by a different platform (.cursor belongs to the cursor target)'
+    );
+    assert.ok(
+      plan.operations.some(op => normalizedRelativePath(op.sourceRelativePath) === 'skills/tdd-workflow'),
+      'Should still install the module\'s own skill path'
+    );
+  })) passed++; else failed++;
+
+  if (test('continue-project adapter exposes validate and planOperations with no blocking errors', () => {
+    const continueProjectAdapter = getInstallTargetAdapter('continue-project');
+
+    assert.strictEqual(typeof continueProjectAdapter.planOperations, 'function');
+    assert.strictEqual(typeof continueProjectAdapter.validate, 'function');
+    assert.ok(
+      !continueProjectAdapter.validate({ projectRoot: '/workspace/app', homeDir: '/Users/example' })
+        .some(i => i.severity === 'error'),
+      'continue-project adapter should have no blocking validation errors'
+    );
+  })) passed++; else failed++;
+
   if (test('every schema target enum value has a matching adapter (regression guard)', () => {
     const schemaPath = path.join(__dirname, '..', '..', 'schemas', 'egc-install-config.schema.json');
     const schema = JSON.parse(require('fs').readFileSync(schemaPath, 'utf8'));

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -954,6 +954,92 @@ function runTests() {
     assert.ok(targets.includes('zed'), 'Should include zed target');
   })) passed++; else failed++;
 
+  if (test('resolves continue home adapter root to ~/.continue and install-state path', () => {
+    const adapter = getInstallTargetAdapter('continue');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'continue-home');
+    assert.strictEqual(adapter.target, 'continue');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.continue'));
+    assert.strictEqual(statePath, path.join(homeDir, '.continue', 'egc', 'install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('continue adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('continue');
+    const byId = getInstallTargetAdapter('continue-home');
+    const projectById = getInstallTargetAdapter('continue-project');
+
+    assert.strictEqual(byTarget.id, 'continue-home');
+    assert.strictEqual(byId.id, 'continue-home');
+    assert.strictEqual(projectById.id, 'continue-project');
+    assert.ok(byTarget.supports('continue'));
+    assert.ok(byTarget.supports('continue-home'));
+  })) passed++; else failed++;
+
+  if (test('continue adapter strips category from skill paths and installs flat under ~/.continue/skills/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'continue',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'continue-home');
+    assert.strictEqual(plan.targetRoot, path.join(homeDir, '.continue'));
+    assert.strictEqual(plan.installStatePath, path.join(homeDir, '.continue', 'egc', 'install-state.json'));
+    assert.ok(
+      plan.operations.some(op =>
+        normalizedRelativePath(op.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && op.destinationPath === path.join(homeDir, '.continue', 'skills', 'tdd-workflow')
+      ),
+      'Should strip category and install skill flat under ~/.continue/skills/'
+    );
+  })) passed++; else failed++;
+
+  if (test('continue adapter handles already-flat skill paths without double-stripping', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'continue',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'workflow', paths: ['skills/tdd-workflow'] }],
+    });
+
+    assert.ok(
+      plan.operations.some(op =>
+        normalizedRelativePath(op.sourceRelativePath) === 'skills/tdd-workflow'
+        && op.destinationPath === path.join(homeDir, '.continue', 'skills', 'tdd-workflow')
+      ),
+      'Should handle already-flat skill path without stripping anything'
+    );
+  })) passed++; else failed++;
+
+  if (test('continue-project adapter resolves root to <project>/.continue', () => {
+    const adapter = getInstallTargetAdapter('continue-project');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.target, 'continue');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.continue'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.continue', 'egc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('continue adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('continue'), 'Should include continue target');
+  })) passed++; else failed++;
+
   if (test('every schema target enum value has a matching adapter (regression guard)', () => {
     const schemaPath = path.join(__dirname, '..', '..', 'schemas', 'egc-install-config.schema.json');
     const schema = JSON.parse(require('fs').readFileSync(schemaPath, 'utf8'));

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -26,9 +26,10 @@ const EXPECTED_HARNESSES = [
   'Windsurf',
   'Amp',
   'VS Code Copilot',
+  'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {

--- a/translations/pt/docs/spec/integration-tiers.md
+++ b/translations/pt/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > O mapa honesto de como cada ferramenta de IA suportada se integra com o EGC.
 
-O EGC suporta 13 ferramentas de IA por meio de 3 mecanismos de integracao distintos. Este documento e a fonte de verdade sobre o que esta e nao esta integrado, e em qual profundidade.
+O EGC suporta 14 ferramentas de IA por meio de 3 mecanismos de integracao distintos. Este documento e a fonte de verdade sobre o que esta e nao esta integrado, e em qual profundidade.
 
 ## Definicoes de Nivel
 
@@ -12,7 +12,7 @@ O EGC suporta 13 ferramentas de IA por meio de 3 mecanismos de integracao distin
 | **2** | Script customizado | Ativos especificos da ferramenta via instalador dedicado | `.{ferramenta}/install.sh` chamado por `install.sh` |
 | **3** | Somente protocolo | Registro do servidor MCP + injecao de protocolo de memoria | `scripts/bootstrap-cognitive.js` + registro MCP em `install.sh` |
 
-## Os 13 Harnesses
+## Os 14 Harnesses
 
 | # | Ferramenta | Nivel | Target id | Caminho de instalacao | Notas |
 |---|------------|-------|-----------|----------------------|-------|
@@ -27,8 +27,9 @@ O EGC suporta 13 ferramentas de IA por meio de 3 mecanismos de integracao distin
 | 9 | **Amp** | 1 | `amp` | `~/.amp/skills/<nome>/SKILL.md` | Skills instaladas de forma plana |
 | 10 | **VS Code Copilot** | 1 | `copilot` | `~/.github/skills/<nome>/SKILL.md` | Skills instaladas de forma plana |
 | 11 | **Zed** | 1 | `zed` | `~/.config/zed/skills/<nome>/` | Skills instaladas de forma plana (categoria removida); MCP via `context_servers` em `settings.json`; bootstrap cognitivo em `~/.config/zed/AGENTS.md` |
-| 12 | **Kiro** | 2 | (nenhum) | `~/.kiro/` via `.kiro/install.sh` | Hooks de sessao instalados em `~/.kiro/hooks/` |
-| 13 | **Trae** | 2 | (nenhum) | `~/.trae/` (ou `~/.trae-cn/` com `TRAE_ENV=cn`) via `.trae/install.sh` | Protocolo de memoria gravado em `~/.trae/MEMORY.md` |
+| 12 | **Continue.dev** | 1 | `continue` | `~/.continue/skills/<nome>/SKILL.md` | Skills instaladas de forma plana; MCP via arquivos de bloco YAML em `~/.continue/mcpServers/`; prompt do protocolo de memoria em `~/.continue/prompts/`; regras descobertas nativamente em `.continue/rules/` do workspace |
+| 13 | **Kiro** | 2 | (nenhum) | `~/.kiro/` via `.kiro/install.sh` | Hooks de sessao instalados em `~/.kiro/hooks/` |
+| 14 | **Trae** | 2 | (nenhum) | `~/.trae/` (ou `~/.trae-cn/` com `TRAE_ENV=cn`) via `.trae/install.sh` | Protocolo de memoria gravado em `~/.trae/MEMORY.md` |
 
 ## Por que tres niveis (historia, nao aspiracao)
 
@@ -36,11 +37,11 @@ O Nivel 1 (unificado) e o pipeline canonico. E o resultado de `install-plan.js` 
 
 O Nivel 2 (script customizado) existe porque Kiro e Trae chegaram ao EGC antes de o pipeline unificado estar estavel. Seus instaladores fazem aproximadamente o mesmo trabalho que o pipeline unificado, mas a forma dos ativos que publicam difere o suficiente para que a retrocompatibilizacao seja nao trivial. Sao de primeira classe, mas tecnicamente isolados.
 
-O Nivel 3 (somente protocolo) e o ponto de entrada para qualquer ferramenta que suporte MCP. O Claude Code era anteriormente Nivel 3, mas agora suporta `~/.claude/skills/<nome>/SKILL.md` como caminho de descoberta de skills, portanto foi promovido ao Nivel 1 com target id `claude`. Windsurf, Amp e VS Code Copilot foram adicionados como targets Nivel 1 na v1.0.2 seguindo o mesmo padrao de descoberta de skills.
+O Nivel 3 (somente protocolo) e o ponto de entrada para qualquer ferramenta que suporte MCP. O Claude Code era anteriormente Nivel 3, mas agora suporta `~/.claude/skills/<nome>/SKILL.md` como caminho de descoberta de skills, portanto foi promovido ao Nivel 1 com target id `claude`. Windsurf, Amp e VS Code Copilot foram adicionados como targets Nivel 1 na v1.0.2 seguindo o mesmo padrao de descoberta de skills. O Continue.dev seguiu o mesmo padrao como o 14o harness (o registro MCP via arquivos de bloco YAML em `~/.continue/mcpServers/` chegou separadamente na #564).
 
 ## O que "suportado" garante
 
-Para todos os 9 harnesses, o EGC garante:
+Para todos os 14 harnesses, o EGC garante:
 
 - O caminho de instalacao esta documentado acima
 - Registro do servidor MCP (se a ferramenta suportar MCP)
@@ -62,7 +63,7 @@ Somente para Nivel 1:
 
 `node scripts/harness-audit.js` produz um relatorio pontuado contra as 7 categorias definidas em `CATEGORIES`. A pontuacao reflete a saude no nivel do repositorio, nao a saude por harness. Uma melhoria futura e o rollup por harness (veja `docs/spec/README.md` Proximos Passos).
 
-## Adicionando um 14o harness
+## Adicionando um 15o harness
 
 Escolha o nivel com base no que a ferramenta target realmente consome:
 


### PR DESCRIPTION
## What

Adds **Continue.dev** as the 14th supported harness, wired in as a Tier 1 target (`continue`) through the unified install pipeline, following the exact pattern used by the most recent Tier 1 additions (Windsurf, Amp, VS Code Copilot, Zed).

### Changes

- **Adapters**: new `scripts/lib/install-targets/continue-home.js` and `continue-project.js`, rooted at `~/.continue/` and `<project>/.continue/`, with the same flat skill remap (`skills/<category>/<name>` -> `skills/<name>`) as Windsurf/Amp/Copilot/Zed
- **Registry + target list**: `continue` added to `SUPPORTED_INSTALL_TARGETS`, the adapter registry, both JSON schema target enums, and all 15 skill-module manifests that already target `copilot`/`zed`
- **Cognitive bootstrap**: Continue.dev has no native auto-memory, so `scripts/bootstrap-cognitive.js` now writes the EGC memory/guardian protocol as a Continue prompt file at `~/.continue/prompts/egc-memory.prompt` (created only when `~/.continue` exists, idempotent, same pattern as the OpenCode/CodeBuddy blocks)
- **Harness detection**: `~/.continue` added to the harness home-dir list in `scripts/lib/utils.js`
- **Docs**: `docs/spec/integration-tiers.md` (and the pt translation) updated to 14 harnesses, with a new Tier 1 row for Continue.dev; stale counts in the guarantees/playbook sections corrected
- **Tests**: `tests/spec/integration-tiers.test.js` now expects 14 harnesses / 13 Tier 1 targets; `tests/lib/install-targets.test.js` gains 6 tests covering root/state-path resolution, flat skill stripping, already-flat paths, project adapter, and adapter-list inclusion. The existing schema/adapter bidirectional regression guards pick up the new target automatically.

### What is deliberately NOT in this PR

- **MCP registration**: already shipped in #564 via `scripts/lib/mcp-register.js` (`registerContinueYaml` writes standalone YAML block files to `~/.continue/mcpServers/`). Untouched here, same for `docs/installation.md` which already documents it.
- **Guardian secret protection** for `.continue/.env|.local|.staging`: handled in parallel work on `main`; `validator.ts` untouched.
- **No version bump**: the tier-history note references the pattern and #564 instead of naming a release.

## Research sources (official)

- Rules discovery: [docs.continue.dev/customize/deep-dives/rules](https://docs.continue.dev/customize/deep-dives/rules) confirms workspace `.continue/rules/` (Markdown preferred, YAML supported). No global `~/.continue/rules/` is documented, and `core/util/paths.ts` in continuedev/continue defines no rules dir under the global folder.
- Global prompts dir: `getGlobalPromptsPath()` in [core/util/paths.ts](https://github.com/continuedev/continue/blob/main/core/util/paths.ts) confirms `~/.continue/prompts/` - used for the bootstrap prompt file.
- MCP: [docs.continue.dev/customize/deep-dives/mcp](https://docs.continue.dev/customize/deep-dives/mcp) confirms `mcpServers` blocks and standalone block files (already implemented in #564).

## Not confirmed officially (known limitations)

1. **Native SKILL.md discovery**: Continue.dev does not document a native `skills/<name>/SKILL.md` discovery path (open upstream request: continuedev/continue#9216). Skills are installed flat under `~/.continue/skills/` for layout parity with the other Tier 1 targets; Continue agents can read them, but automatic discovery is not guaranteed by Continue itself. The integration-tiers row words this as "skills installed flat" without claiming native discovery.
2. **Pre-existing, unrelated**: manifest-mode installs where skill modules depend on `platform-configs` (e.g. `--target windsurf --profile full`) select zero modules because `platform-configs` does not list the flat-skill targets. The `continue` target reproduces the existing Windsurf/Amp behavior exactly; fixing that dependency gap is out of scope here.

## Testing

Full suite: `env -u EGC_HOOK_PROFILE -u EGC_DISABLED_HOOKS node tests/run-all.js` -> **2629 passed, 0 failed** (after `npm run build:mcp`). Bootstrap block manually verified against a temp HOME.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Continue.dev as a new Tier 1 install target (`continue`) with home and project adapters and a cognitive bootstrap prompt, bringing the total to 14 harnesses. Also centralizes flat‑skill planning in shared helpers and applies it across flat‑skill adapters.

- **New Features**
  - `continue-home` and `continue-project` adapters at `.continue/`, installing skills flat under `.continue/skills/<name>`.
  - `continue` added to `SUPPORTED_INSTALL_TARGETS`, both schema enums, and manifests aligned with `copilot`/`zed`.
  - Cognitive bootstrap writes `~/.continue/prompts/egc-memory.prompt` when `~/.continue` exists; harness detection now includes `~/.continue`.
  - Docs (en + pt) updated to 14 harnesses; tests cover adapter resolution and enum/registry guards.

- **Refactors**
  - Extracted `planFlatSkillOperation` and `createFlatSkillPlanOperations` to `scripts/lib/install-targets/helpers.js`; applied to `windsurf`, `amp`, `copilot`, `zed`, `claude`, `codex`, and `continue`.
  - Expanded tests for `continue-project` planOperations (category strip, already-flat, non-skill pass-through, foreign-path filtering); 100% coverage for that adapter.

<sup>Written for commit 94181077a0b9517bdf8e787ff17eeed54dda2e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

