### PR TITLE
fix(egc-memory): eliminate TOCTOU race in encryption key generation

### DIFF
--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -53,24 +53,35 @@ export function loadOrCreateEncKey(keyPath: string = ENC_KEY_PATH): Buffer {
     return readExistingKey();
   }
 
-  // Key file does not exist — generate a fresh one. Use an exclusive
-  // ('wx') write so a concurrent process racing to create the same key
+  try { fs.chmodSync(dir, 0o700); } catch { /* best-effort */ }
+
+  // Key file does not exist — generate a fresh one. A concurrent process
   // (e.g. a background agent's own egc-memory process starting up before
-  // ~/.egc/encryption.key exists) cannot silently overwrite a key another
-  // process has already generated. If we lose the race, EEXIST tells us
-  // to read back whichever key actually landed on disk instead of caching
-  // our own discarded one in memory for the lifetime of the process.
+  // ~/.egc/encryption.key exists) may be racing to create the same key.
+  // Writing directly to keyPath with an exclusive flag would leave a window
+  // where the file exists but is only partially written, so a racing reader
+  // could observe a truncated key. Instead, write the full key to a
+  // uniquely-named temp file first, then publish it with an exclusive
+  // fs.linkSync: the target only ever appears once fully written, and
+  // linkSync fails with EEXIST (without touching the target) if another
+  // process already published its key first — in which case we discard our
+  // own key and read back whichever one actually landed on disk.
   const key = crypto.randomBytes(32);
+  const tmpPath = `${keyPath}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
   try {
-    fs.chmodSync(dir, 0o700);
-    fs.writeFileSync(keyPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600, flag: 'wx' });
-    fs.chmodSync(keyPath, 0o600);
-    return key;
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
-      return readExistingKey();
+    fs.writeFileSync(tmpPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    try {
+      fs.linkSync(tmpPath, keyPath);
+      fs.chmodSync(keyPath, 0o600);
+      return key;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
+        return readExistingKey();
+      }
+      throw new Error(`[EGC encryption] Failed to persist encryption key to ${keyPath}: ${String(e)}. Remove the file or fix permissions and restart.`);
     }
-    throw new Error(`[EGC encryption] Failed to persist encryption key to ${keyPath}: ${String(e)}. Remove the file or fix permissions and restart.`);
+  } finally {
+    try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
   }
 }
 

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -37,9 +37,7 @@ export function loadOrCreateEncKey(keyPath: string = ENC_KEY_PATH): Buffer {
     // directory may already exist
   }
 
-  if (fs.existsSync(keyPath)) {
-    // Key file exists — load it. Do NOT silently regenerate on error;
-    // that would destroy access to all previously encrypted state files.
+  const readExistingKey = (): Buffer => {
     const hex = fs.readFileSync(keyPath, 'utf-8').trim();
     const key = Buffer.from(hex, 'hex');
     if (key.length !== 32) {
@@ -47,18 +45,33 @@ export function loadOrCreateEncKey(keyPath: string = ENC_KEY_PATH): Buffer {
     }
     try { fs.chmodSync(keyPath, 0o600); } catch { /* best-effort */ }
     return key;
+  };
+
+  if (fs.existsSync(keyPath)) {
+    // Key file exists — load it. Do NOT silently regenerate on error;
+    // that would destroy access to all previously encrypted state files.
+    return readExistingKey();
   }
 
-  // Key file does not exist — generate a fresh one.
+  // Key file does not exist — generate a fresh one. Use an exclusive
+  // ('wx') write so a concurrent process racing to create the same key
+  // (e.g. a background agent's own egc-memory process starting up before
+  // ~/.egc/encryption.key exists) cannot silently overwrite a key another
+  // process has already generated. If we lose the race, EEXIST tells us
+  // to read back whichever key actually landed on disk instead of caching
+  // our own discarded one in memory for the lifetime of the process.
   const key = crypto.randomBytes(32);
   try {
     fs.chmodSync(dir, 0o700);
-    fs.writeFileSync(keyPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    fs.writeFileSync(keyPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600, flag: 'wx' });
     fs.chmodSync(keyPath, 0o600);
+    return key;
   } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
+      return readExistingKey();
+    }
     throw new Error(`[EGC encryption] Failed to persist encryption key to ${keyPath}: ${String(e)}. Remove the file or fix permissions and restart.`);
   }
-  return key;
 }
 
 /**

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -427,7 +427,15 @@ function isProtectedPath(p: string): boolean {
 }
 
 function resolveProjectPath(provided?: string): string {
-  const raw = provided || process.env.EGC_PROJECT || process.env.PWD || os.homedir();
+  // process.cwd() reflects this process's actual working directory and is
+  // always accurate. process.env.PWD is a shell convention that is only
+  // updated by `cd` in an interactive shell — a process spawned
+  // programmatically with a different cwd (e.g. a background agent running
+  // in a git worktree) can inherit a stale PWD from its parent, silently
+  // resolving to the wrong project/branch and colliding with another
+  // process's state file. Prefer cwd(); keep PWD only as a last-resort
+  // fallback for environments where cwd() itself is unavailable.
+  const raw = provided || process.env.EGC_PROJECT || process.cwd() || process.env.PWD || os.homedir();
   if (provided && provided.split(/[/\\]/).some(s => s === '..')) {
     throw new Error(`project_path must not contain path traversal sequences: ${provided}`);
   }
@@ -703,7 +711,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: {
           type: "object",
           properties: {
-            project_path: { type: "string" },
+            project_path: { type: "string", description: "Absolute path to the project root (or worktree) to scope this state to. Always pass this explicitly when calling from an agent or worktree that is not the caller's own working directory — an omitted value falls back to this process's cwd, which can silently resolve to the wrong project/branch and collide with another process's state file." },
             context: { type: "string", description: "What this project is and its current phase." },
             decisions: { type: "array", items: { type: "object", properties: { what: { type: "string" }, why: { type: "string" } }, required: ["what"] }, description: "Decisions made this session." },
             avoid: { type: "array", items: { type: "object", properties: { what: { type: "string" }, why: { type: "string" } }, required: ["what"] }, description: "What failed and should not be repeated." },

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -435,7 +435,9 @@ function resolveProjectPath(provided?: string): string {
   // resolving to the wrong project/branch and colliding with another
   // process's state file. Prefer cwd(); keep PWD only as a last-resort
   // fallback for environments where cwd() itself is unavailable.
-  const raw = provided || process.env.EGC_PROJECT || process.cwd() || process.env.PWD || os.homedir();
+  let cwd: string | undefined;
+  try { cwd = process.cwd(); } catch { /* cwd unavailable, e.g. a deleted directory */ }
+  const raw = provided || process.env.EGC_PROJECT || cwd || process.env.PWD || os.homedir();
   if (provided && provided.split(/[/\\]/).some(s => s === '..')) {
     throw new Error(`project_path must not contain path traversal sequences: ${provided}`);
   }

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -1,0 +1,148 @@
+'use strict';
+/**
+ * Tests for mcp/servers/egc-memory/src/encryption.ts
+ *
+ * Covers encrypt/decrypt round-trip and the loadOrCreateEncKey TOCTOU
+ * race condition: two processes racing to create ~/.egc/encryption.key
+ * before it exists must not let the loser silently overwrite the
+ * winner's key with its own, which would leave the loser holding a key
+ * that can never decrypt state files written under the winner's key.
+ *
+ * Run with: node tests/egc-memory-encryption.test.js
+ */
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+const buildPath = path.join(
+  __dirname, '..', 'mcp', 'servers', 'egc-memory', 'build', 'encryption.js'
+);
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-memory first.');
+  process.exit(0);
+}
+
+const { loadOrCreateEncKey, encryptState, decryptState, isEncrypted, writeStateFile, readStateFile } = require(buildPath);
+
+console.log('\n=== Testing egc-memory encryption ===\n');
+
+// ── encrypt/decrypt round-trip ──────────────────────────────────────────────
+
+if (test('encryptState/decryptState: round-trips plaintext', () => {
+  const key = crypto.randomBytes(32);
+  const plaintext = 'hello state file';
+  const encrypted = encryptState(plaintext, key);
+  assert.ok(isEncrypted(encrypted), 'should carry the EGC1 magic header');
+  const decrypted = decryptState(encrypted, key);
+  assert.strictEqual(decrypted, plaintext);
+})) passed++; else failed++;
+
+if (test('decryptState: throws on wrong key (auth tag mismatch)', () => {
+  const keyA = crypto.randomBytes(32);
+  const keyB = crypto.randomBytes(32);
+  const encrypted = encryptState('secret', keyA);
+  assert.throws(() => decryptState(encrypted, keyB));
+})) passed++; else failed++;
+
+if (test('writeStateFile/readStateFile: round-trips through disk', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  try {
+    const key = crypto.randomBytes(32);
+    const filePath = path.join(tmpDir, 'state.md');
+    writeStateFile(filePath, '# Project State\ncontent here', key);
+    const content = readStateFile(filePath, key);
+    assert.strictEqual(content, '# Project State\ncontent here');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+// ── loadOrCreateEncKey ───────────────────────────────────────────────────────
+
+if (test('loadOrCreateEncKey: returns a 32-byte Buffer and creates the file with mode 0600', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  try {
+    const keyPath = path.join(tmpDir, 'encryption.key');
+    const key = loadOrCreateEncKey(keyPath);
+    assert.ok(Buffer.isBuffer(key));
+    assert.strictEqual(key.length, 32);
+    assert.ok(fs.existsSync(keyPath));
+    const mode = fs.statSync(keyPath).mode & 0o777;
+    assert.strictEqual(mode, 0o600, `expected mode 0600, got ${mode.toString(8)}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('loadOrCreateEncKey: returns the same key on a second call (loads, does not regenerate)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  try {
+    const keyPath = path.join(tmpDir, 'encryption.key');
+    const key1 = loadOrCreateEncKey(keyPath);
+    const key2 = loadOrCreateEncKey(keyPath);
+    assert.ok(key1.equals(key2));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('loadOrCreateEncKey: throws on a malformed key file instead of silently regenerating', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  try {
+    const keyPath = path.join(tmpDir, 'encryption.key');
+    fs.writeFileSync(keyPath, 'not-valid-hex-and-wrong-length', { mode: 0o600 });
+    assert.throws(() => loadOrCreateEncKey(keyPath), /malformed/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('loadOrCreateEncKey: TOCTOU race — a concurrent winner\'s key is read back, never silently overwritten', () => {
+  // Regression test for the bug behind "Failed to decrypt existing state
+  // file. The encryption key may have changed." Two egc-memory processes
+  // can both observe !existsSync(keyPath) before either writes (e.g. two
+  // agents/sessions starting close together with no ~/.egc/encryption.key
+  // yet). Simulate the loser's view: existsSync says false, but a winner
+  // has already written a real key to disk by the time our write executes.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  const keyPath = path.join(tmpDir, 'encryption.key');
+  const winnerKey = crypto.randomBytes(32);
+  fs.writeFileSync(keyPath, winnerKey.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+
+  const origExistsSync = fs.existsSync;
+  fs.existsSync = (p) => (p === keyPath ? false : origExistsSync(p));
+  try {
+    const result = loadOrCreateEncKey(keyPath);
+    assert.ok(
+      result.equals(winnerKey),
+      'loser must read back the key that actually won the race on disk, not keep its own discarded key in memory'
+    );
+    const onDisk = Buffer.from(fs.readFileSync(keyPath, 'utf-8').trim(), 'hex');
+    assert.ok(onDisk.equals(winnerKey), 'the winner\'s key on disk must remain untouched');
+  } finally {
+    fs.existsSync = origExistsSync;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exitCode = failed > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary
- Root-causes the "Failed to decrypt existing state file. The encryption key may have changed." error: `loadOrCreateEncKey()` had a TOCTOU race where two `egc-memory` processes starting before `~/.egc/encryption.key` exists (e.g. a background agent + the main session, or two worktrees) could each generate a different key, with the losing process caching its own orphaned key for its whole lifetime.
- Fixes the key generation to use an exclusive (`wx`) write, mirroring the existing migration-lock pattern in this same file, and falls back to reading the winner's key on `EEXIST`.
- Hardens `resolveProjectPath` to prefer `process.cwd()` over `process.env.PWD`, which is not reliably updated for programmatically-spawned processes with a different cwd (a worktree agent), reducing the odds of colliding with the main session's state file in the first place.
- Documents `project_path` in the `update_state` tool schema so agent orchestration code is prompted to pass it explicitly.

## Test plan
- [x] New `tests/egc-memory-encryption.test.js`: 7 tests, including a regression test for the exact race — verified it fails against the pre-fix code and passes after
- [x] Full local suite: 2670/2670 passing
- [x] CI green before merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TOCTOU race in `egc-memory` encryption key creation by atomically publishing a single key, preventing cross-process decryption failures. Also fixes cwd fallback logic and clarifies the `update_state` schema to avoid state file collisions.

- **Bug Fixes**
  - Atomically publish the key: write to a temp file and `fs.linkSync` it to the final path; on `EEXIST`, load the existing key to avoid partial writes and discarded in-memory keys; enforce `0600` perms and clean up the temp file.
  - Prefer `process.cwd()` (catch exceptions) over `process.env.PWD` in `resolveProjectPath`, using `PWD` only as a last resort to avoid resolving to the wrong worktree.
  - Document `project_path` in the `update_state` tool schema to prompt explicit passing from agents/worktrees.

<sup>Written for commit 4b5908345cc06a85f3406e61246d7f9395d68287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented encryption key files from being accidentally overwritten during concurrent startup by atomically publishing the key and safely handling race conditions.
  * Added stricter encryption key validation (including exact length) and clearer errors for malformed key files; ensured key files use secure `0600` permissions.
  * Improved project root resolution by preferring the current working directory when other signals are unreliable.
  * Updated the `update_state` tool schema to require `project_path` when the caller’s working directory may differ.

* **Tests**
  * Added end-to-end coverage for encryption/decryption, key persistence, permission checks, malformed-key handling, and a concurrent key-creation regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->