### PR TITLE
fix(egc-memory): state recovery + concurrency test checklist

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -163,6 +163,14 @@ If you are proposing changes to `scripts/`, `src/llm/`, or the underlying orches
 - **Registry Synchronization:** Ensure that the catalog and CI validators can still parse the registry after your modifications.
 - **Orchestration Layer Modifications:** These are strictly reviewed. If you add a new orchestrator (e.g., a new DAG parser or parallel execution loop), it must include fallback safety mechanisms and graceful degradation if a task fails.
 
+### Concurrent-Access Regression Tests
+
+Any change that reads or writes a file shared across concurrent EGC processes -- the encryption key (`~/.egc/encryption.key`), state files under `~/.egc/state/`, install-state files, or any other lockfile-like resource under `~/.egc/` -- must include a concurrent-access regression test before it can be merged. CI (CodeQL, SonarCloud, the full OS/Node/package-manager matrix) is strong at many bug classes but cannot reason about interleaving between two independent process executions, so races in this category slip through undetected unless a test forces the interleaving explicitly.
+
+Commit 905b4f64 is the concrete example: `mcp/servers/egc-memory/src/encryption.ts`'s `loadOrCreateEncKey()` had a TOCTOU (time-of-check-to-time-of-use) race where two concurrent `egc-memory` processes starting before `~/.egc/encryption.key` existed could each generate a different key, silently leaving the loser unable to decrypt state written under the winner's key. It shipped in a published release without being caught, because no tool in the pipeline simulates two processes racing on the same file.
+
+Follow the pattern in `tests/egc-memory-encryption.test.js`, test `"TOCTOU race -- a concurrent winner's key is read back, never silently overwritten"`: it simulates the race by making the loser observe the file as not-yet-existing while a winner has already written to disk, then asserts the loser reads back the winner's data instead of overwriting it.
+
 ---
 
 ## Contributing Skills
@@ -497,6 +505,7 @@ How you ensured this maintains Runtime Integrity and Cross-Platform stability.
 - [ ] `npm audit --audit-level=high` shows no high or critical vulnerabilities
 - [ ] Markdownlint passes on all `.md` files you created or modified (agents, skills, commands, rules)
 - [ ] PR changes fewer than 150 code files
+- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated
 - [ ] Tested on Linux/macOS/Windows (if applicable to your change)
 - [ ] Preserves EGC identity and formatting
 - [ ] No sensitive data committed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@
 - [ ] Manual testing completed
 - [ ] Automated tests pass locally (`node tests/run-all.js`)
 - [ ] Edge cases considered and tested
+- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated
 
 ## Type of Change
 - [ ] `fix:` Bug fix

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -147,3 +147,17 @@ export function writeStateFile(filePath: string, plaintext: string, key: Buffer)
   try { fs.chmodSync(tmpPath, 0o600); } catch { /* chmod not supported on Windows */ }
   fs.renameSync(tmpPath, filePath);
 }
+
+/**
+ * Move a state file that can no longer be decrypted (corrupted, or
+ * encrypted with a key that no longer matches ~/.egc/encryption.key) out
+ * of the way so a caller can start writing fresh state in its place.
+ * Renames rather than deletes: the corrupted bytes are preserved at a
+ * sibling '.corrupted-backup-<timestamp>' path in case they turn out to
+ * be recoverable some other way. Returns the backup path.
+ */
+export function quarantineUndecryptableStateFile(filePath: string): string {
+  const backupPath = `${filePath}.corrupted-backup-${Date.now()}`;
+  fs.renameSync(filePath, backupPath);
+  return backupPath;
+}

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
 import { loadOrCreateKey, writeHmac, verifyHmac } from './integrity';
-import { loadOrCreateEncKey, readStateFile, writeStateFile } from './encryption';
+import { loadOrCreateEncKey, readStateFile, writeStateFile, quarantineUndecryptableStateFile } from './encryption';
 import { propagateStateToTools } from './propagate';
 import {
   createWorkingMemoryTable,
@@ -650,7 +650,8 @@ const UpdateStateSchema = z.object({
     why: z.string().max(500).optional()
   })).max(20).optional(),
   preferences: z.array(z.string().max(300)).max(20).optional(),
-  next: z.array(z.string().max(500)).max(10).optional()
+  next: z.array(z.string().max(500)).max(10).optional(),
+  force: z.boolean().optional()
 });
 
 const WorkingMemorySetSchema = z.object({
@@ -718,7 +719,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             decisions: { type: "array", items: { type: "object", properties: { what: { type: "string" }, why: { type: "string" } }, required: ["what"] }, description: "Decisions made this session." },
             avoid: { type: "array", items: { type: "object", properties: { what: { type: "string" }, why: { type: "string" } }, required: ["what"] }, description: "What failed and should not be repeated." },
             preferences: { type: "array", items: { type: "string" }, description: "Coding style, workflow, or communication preferences discovered." },
-            next: { type: "array", items: { type: "string" }, description: "What to pick up in the next session." }
+            next: { type: "array", items: { type: "string" }, description: "What to pick up in the next session." },
+            force: { type: "boolean", description: "Recover from a state file that cannot be decrypted (corrupted or encrypted with an orphaned key). When true and the existing file fails to decrypt, the corrupted file is renamed to a '.corrupted-backup-<timestamp>' sibling instead of being read, and this call's data becomes the fresh state — nothing is merged in from the unreadable file, and nothing is deleted. Only set this after confirming the failure is persistent, not a transient lock from another process writing at the same moment." }
           }
         }
       },
@@ -1081,8 +1083,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         try {
           existing = readStateDoc(resolved.filePath);
         } catch (err) {
-          log('ERROR', '[EGC encryption] Cannot read existing state — aborting update to prevent data loss', { file: resolved.filePath, error: String(err) });
-          throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing state file. The encryption key may have changed. Path: ${resolved.filePath}`);
+          if (args.force && fs.existsSync(resolved.filePath)) {
+            const backupPath = quarantineUndecryptableStateFile(resolved.filePath);
+            log('WARN', 'update_state: force=true, undecryptable state file backed up and replaced', { file: resolved.filePath, backup: backupPath, error: String(err) });
+            existing = {};
+          } else {
+            log('ERROR', '[EGC encryption] Cannot read existing state — aborting update to prevent data loss', { file: resolved.filePath, error: String(err) });
+            throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing state file. The encryption key may have changed. Path: ${resolved.filePath}. Retry with force: true to back up the unreadable file and start fresh — only do this after confirming the failure is persistent, not a transient lock from another process.`);
+          }
         }
         const filePath = resolveStateWrite(getStateDir(), projPath, branch);
 

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -40,7 +40,7 @@ if (!fs.existsSync(buildPath)) {
   process.exit(0);
 }
 
-const { loadOrCreateEncKey, encryptState, decryptState, isEncrypted, writeStateFile, readStateFile } = require(buildPath);
+const { loadOrCreateEncKey, encryptState, decryptState, isEncrypted, writeStateFile, readStateFile, quarantineUndecryptableStateFile } = require(buildPath);
 
 console.log('\n=== Testing egc-memory encryption ===\n');
 
@@ -139,6 +139,25 @@ if (test('loadOrCreateEncKey: TOCTOU race — a concurrent winner\'s key is read
     assert.ok(onDisk.equals(winnerKey), 'the winner\'s key on disk must remain untouched');
   } finally {
     fs.existsSync = origExistsSync;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+// ── quarantineUndecryptableStateFile ────────────────────────────────────────
+
+if (test('quarantineUndecryptableStateFile: renames the corrupted file to a backup path and leaves it readable', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  try {
+    const filePath = path.join(tmpDir, 'state.md');
+    fs.writeFileSync(filePath, 'garbage-not-decryptable', { mode: 0o600 });
+
+    const backupPath = quarantineUndecryptableStateFile(filePath);
+
+    assert.ok(!fs.existsSync(filePath), 'original path must no longer exist so a fresh write can take its place');
+    assert.ok(fs.existsSync(backupPath), 'backup must exist so the corrupted bytes are not lost');
+    assert.ok(backupPath.startsWith(`${filePath}.corrupted-backup-`), 'backup path must be a sibling of the original, clearly marked as corrupted');
+    assert.strictEqual(fs.readFileSync(backupPath, 'utf-8'), 'garbage-not-decryptable', 'backup must preserve the original bytes untouched');
+  } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 })) passed++; else failed++;


### PR DESCRIPTION
## Summary

- `update_state` gains an optional `force: true` parameter: when the existing state file cannot be decrypted (corrupted, or encrypted with an orphaned key, the failure mode from the TOCTOU race fixed in 905b4f64), it now quarantines the corrupted file (renamed to a `.corrupted-backup-<timestamp>` sibling, never deleted) and proceeds as a fresh write instead of aborting forever. The EGC Guardian shell block on `~/.egc/state/**` is unchanged; this only gives the already-trusted egc-memory process a sanctioned recovery path, not raw shell access.
- New exported `quarantineUndecryptableStateFile()` in `encryption.ts`, covered by a dedicated regression test.
- `.github/CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` now require a concurrent-access regression test for any change touching a file shared across concurrent EGC processes, citing the TOCTOU bug as the motivating example. This class of bug is invisible to CodeQL, SonarCloud, and the test matrix since none of them reason about interleaving between separate process executions.

## Test plan

- [x] `node tests/egc-memory-encryption.test.js`: 8/8 passing (new quarantine test included)
- [x] Full suite `node tests/run-all.js`: 2671/2671 passing
- [x] `tsc --noEmit` clean