### PR TITLE
fix(install): sync install completion to the status-store install_state table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,22 @@ All notable changes to EGC are documented here.
 
 ### Security
 
-- **`egc-memory`: TOCTOU race in encryption key generation eliminated**: `loadOrCreateEncKey` used to leave a window where a concurrent process (e.g. a background agent's own `egc-memory` server starting before `~/.egc/encryption.key` existed) could read a key file that was created but not yet fully written, or -- in the original exclusive-write approach -- silently generate and cache its own discarded key for the rest of the process lifetime. Key publication is now atomic (write-to-temp + `fs.linkSync`), so a racing reader either sees no file or a fully-written one, never a partial write. (#696)
+- **`egc-memory`: TOCTOU race in encryption key generation eliminated**: `loadOrCreateEncKey` used to leave a window where a concurrent process (e.g. a background agent's own `egc-memory` server starting before `~/.egc/encryption.key` existed) could read a key file that was created but not yet fully written. In the original exclusive-write approach, it could also silently generate and cache its own discarded key for the rest of the process lifetime. Key publication is now atomic (write-to-temp plus `fs.linkSync`), so a racing reader either sees no file or a fully-written one, never a partial write. (#696)
 - **`resolveProjectPath`: cwd/PWD fallback fixed**: `process.cwd() || process.env.PWD` never reached the `PWD` fallback, because `process.cwd()` throws rather than returning a falsy value when the working directory is unavailable. Now wrapped in try/catch so the documented fallback actually triggers. (#696)
 
 ### New Features
 
-- **`update_state`: recovery path for undecryptable state files**: a state file that fails to decrypt (corrupted, or encrypted under an orphaned key from a race) used to permanently block every future `get_state`/`update_state` call for that project, with no sanctioned way to recover -- not through the tool itself, and not through the EGC Guardian, which blocks raw shell access to `~/.egc/state/**` by design. `update_state` now accepts an optional `force: true`: when the existing file cannot be decrypted, it is quarantined (renamed to a `.corrupted-backup-<timestamp>` sibling, never deleted) and the call proceeds as a fresh write instead of aborting forever. (#697)
+- **`update_state`: recovery path for undecryptable state files**: a state file that fails to decrypt (corrupted, or encrypted under an orphaned key from a race) used to permanently block every future `get_state`/`update_state` call for that project, with no sanctioned way to recover: not through the tool itself, and not through the EGC Guardian, which blocks raw shell access to `~/.egc/state/**` by design. `update_state` now accepts an optional `force: true`: when the existing file cannot be decrypted, it is quarantined (renamed to a `.corrupted-backup-<timestamp>` sibling, never deleted) and the call proceeds as a fresh write instead of aborting forever. (#697)
 
 ### Contributing
 
-- **Concurrent-access regression tests required**: `CONTRIBUTING.md` and the PR template now require a concurrent-access regression test for any change touching a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), citing the TOCTOU bug above as the motivating example -- this bug class is invisible to CodeQL, SonarCloud, and the full test matrix, since none of them reason about interleaving between separate process executions. (#697)
+- **Concurrent-access regression tests required**: `CONTRIBUTING.md` and the PR template now require a concurrent-access regression test for any change touching a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), citing the TOCTOU bug above as the motivating example. This bug class is invisible to CodeQL, SonarCloud, and the full test matrix, since none of them reason about interleaving between separate process executions. (#697)
+
+## [1.1.10] - 2026-07-11
+
+### Bug Fixes
+
+- **`egc status`: install health now reflects reality**: `egc status` always reported "Install health: missing" regardless of actual install state, because `upsertInstallState()`, the function that populates the SQLite table `status` reads, was never called anywhere in the install pipeline. `doctor`, `repair`, `auto-update`, and `list-installed` were unaffected, since they read the JSON install-state files directly. Both real completion points (a fresh install and repair/auto-update) now sync into the status store right after writing the JSON file, fire-and-forget so a status-store write failure can never block or fail a real install. Verified end-to-end in a sandboxed environment: status went from "missing" to "healthy" immediately after a real install. (#699)
 
 ## [1.1.8] - 2026-07-11
 

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const { resolveInstallPlan, loadInstallManifests } = require('./install-manifests');
 const { readInstallState, writeInstallState } = require('./install-state');
+const { syncInstallStateToStore } = require('./install-state-store-sync');
 const {
   createManifestInstallPlan,
 } = require('./install-executor');
@@ -1029,6 +1030,10 @@ function repairInstalledStates(options = {}) {
       } else {
         writeInstallState(desiredPlan.installStatePath, desiredPlan.statePreview);
       }
+
+      syncInstallStateToStore(desiredPlan.statePreview, {
+        onError: error => console.error(`Warning: Failed to sync install state to status store: ${error.message}`),
+      });
 
       return {
         adapter: record.adapter,

--- a/scripts/lib/install-state-store-sync.js
+++ b/scripts/lib/install-state-store-sync.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * Best-effort sync of a completed install into the SQLite state-store's
+ * install_state table, which `egc status` reads to report install health.
+ * The JSON install-state file (written separately by the caller via
+ * writeInstallState) remains the actual source of truth for
+ * doctor/repair/auto-update -- this call must never block or fail a real
+ * install, so every error is swallowed after an optional onError callback.
+ */
+function syncInstallStateToStore(state, options = {}) {
+  return (async () => {
+    const { createStateStore } = require('./state-store');
+    let store = null;
+    try {
+      store = await createStateStore({ homeDir: options.homeDir, dbPath: options.dbPath });
+      store.upsertInstallState({
+        targetId: state.target.id,
+        targetRoot: state.target.root,
+        profile: state.request.profile,
+        modules: state.resolution.selectedModules,
+        operations: state.operations,
+        installedAt: state.installedAt,
+        sourceVersion: state.source.repoVersion,
+      });
+      await store.flush();
+    } finally {
+      if (store) {
+        store.close();
+      }
+    }
+  })().catch(error => {
+    if (options.onError) {
+      options.onError(error);
+    }
+  });
+}
+
+module.exports = { syncInstallStateToStore };

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { writeInstallState } = require('../install-state');
+const { syncInstallStateToStore } = require('../install-state-store-sync');
 const { filterMcpConfig, parseDisabledMcpServers } = require('../mcp-config');
 const {
   HOOK_OPERATION_KIND,
@@ -185,6 +186,10 @@ function applyInstallPlan(plan) {
   }
 
   writeInstallState(plan.installStatePath, plan.statePreview);
+
+  syncInstallStateToStore(plan.statePreview, {
+    onError: error => console.error(`Warning: Failed to sync install state to status store: ${error.message}`),
+  });
 
   return {
     ...plan,

--- a/tests/lib/install-state-store-sync.test.js
+++ b/tests/lib/install-state-store-sync.test.js
@@ -1,0 +1,140 @@
+/**
+ * Tests for scripts/lib/install-state-store-sync.js
+ *
+ * Regression coverage for the bug where `egc status` always reported
+ * "Install health: missing" -- upsertInstallState() existed in the
+ * state-store but nothing in the install pipeline ever called it.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { syncInstallStateToStore } = require('../../scripts/lib/install-state-store-sync');
+const { createStateStore } = require('../../scripts/lib/state-store');
+const { createInstallState } = require('../../scripts/lib/install-state');
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupTempDir(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function buildSampleState(overrides = {}) {
+  return createInstallState({
+    adapter: { id: 'claude-home' },
+    targetRoot: '/home/tester/.claude',
+    installStatePath: '/home/tester/.claude/egc/install-state.json',
+    request: {
+      profile: 'full',
+      modules: ['rules-core'],
+      legacyLanguages: [],
+      legacyMode: false,
+    },
+    resolution: {
+      selectedModules: ['rules-core'],
+      skippedModules: [],
+    },
+    source: {
+      repoVersion: '1.1.9',
+      manifestVersion: 1,
+    },
+    operations: [],
+    ...overrides,
+  });
+}
+
+async function runTests() {
+  console.log('\n=== Testing install-state-store-sync.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('syncInstallStateToStore makes the install visible to getStatus()/installHealth', async () => {
+    const tmpDir = createTempDir('install-state-store-sync-');
+    const dbPath = path.join(tmpDir, 'state.db');
+    try {
+      const state = buildSampleState();
+      await syncInstallStateToStore(state, { dbPath });
+
+      const store = await createStateStore({ dbPath });
+      try {
+        const status = store.getStatus({});
+        assert.strictEqual(status.installHealth.status, 'healthy');
+        assert.strictEqual(status.installHealth.totalCount, 1);
+        assert.strictEqual(status.installHealth.installations[0].targetId, 'claude-home');
+      } finally {
+        store.close();
+      }
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('syncInstallStateToStore upserts, does not duplicate, on repeated calls for the same target', async () => {
+    const tmpDir = createTempDir('install-state-store-sync-');
+    const dbPath = path.join(tmpDir, 'state.db');
+    try {
+      const state = buildSampleState();
+      await syncInstallStateToStore(state, { dbPath });
+      await syncInstallStateToStore(state, { dbPath });
+
+      const store = await createStateStore({ dbPath });
+      try {
+        const status = store.getStatus({});
+        assert.strictEqual(status.installHealth.totalCount, 1, 'a second sync for the same target must update, not duplicate, the row');
+      } finally {
+        store.close();
+      }
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('syncInstallStateToStore never throws, even when the store cannot be created', async () => {
+    const unwritableDbPath = path.join('/nonexistent-root-that-cannot-be-created', 'nested', 'state.db');
+    const state = buildSampleState();
+
+    let onErrorCalled = false;
+    await syncInstallStateToStore(state, {
+      dbPath: unwritableDbPath,
+      onError: () => { onErrorCalled = true; },
+    });
+
+    assert.ok(onErrorCalled, 'onError must be invoked so callers can log, but the returned promise must still resolve cleanly');
+  })) passed++; else failed++;
+
+  if (await test('syncInstallStateToStore resolves without throwing when no onError callback is given', async () => {
+    const unwritableDbPath = path.join('/nonexistent-root-that-cannot-be-created', 'nested', 'state.db');
+    const state = buildSampleState();
+
+    await syncInstallStateToStore(state, { dbPath: unwritableDbPath });
+  })) passed++; else failed++;
+
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+  return failed === 0;
+}
+
+if (require.main === module) {
+  runTests().then(ok => {
+    process.exitCode = ok ? 0 : 1;
+  });
+}
+
+module.exports = { runTests };

--- a/tests/lib/install-state-store-sync.test.js
+++ b/tests/lib/install-state-store-sync.test.js
@@ -106,24 +106,45 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  // A path that cannot be created on any OS: mkdir(recursive) must fail when
+  // a path segment it needs to create a directory at is already a plain
+  // file. Unlike relying on a permission error (EACCES), this failure mode
+  // is a filesystem invariant, not an OS-specific permission model, so it
+  // reproduces identically on Linux, macOS, and Windows CI runners.
+  function makeUnwritableDbPath(tmpDir) {
+    const blockerFile = path.join(tmpDir, 'blocker-file');
+    fs.writeFileSync(blockerFile, 'not a directory');
+    return path.join(blockerFile, 'nested', 'state.db');
+  }
+
   if (await test('syncInstallStateToStore never throws, even when the store cannot be created', async () => {
-    const unwritableDbPath = path.join('/nonexistent-root-that-cannot-be-created', 'nested', 'state.db');
-    const state = buildSampleState();
+    const tmpDir = createTempDir('install-state-store-sync-');
+    try {
+      const unwritableDbPath = makeUnwritableDbPath(tmpDir);
+      const state = buildSampleState();
 
-    let onErrorCalled = false;
-    await syncInstallStateToStore(state, {
-      dbPath: unwritableDbPath,
-      onError: () => { onErrorCalled = true; },
-    });
+      let onErrorCalled = false;
+      await syncInstallStateToStore(state, {
+        dbPath: unwritableDbPath,
+        onError: () => { onErrorCalled = true; },
+      });
 
-    assert.ok(onErrorCalled, 'onError must be invoked so callers can log, but the returned promise must still resolve cleanly');
+      assert.ok(onErrorCalled, 'onError must be invoked so callers can log, but the returned promise must still resolve cleanly');
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
   })) passed++; else failed++;
 
   if (await test('syncInstallStateToStore resolves without throwing when no onError callback is given', async () => {
-    const unwritableDbPath = path.join('/nonexistent-root-that-cannot-be-created', 'nested', 'state.db');
-    const state = buildSampleState();
+    const tmpDir = createTempDir('install-state-store-sync-');
+    try {
+      const unwritableDbPath = makeUnwritableDbPath(tmpDir);
+      const state = buildSampleState();
 
-    await syncInstallStateToStore(state, { dbPath: unwritableDbPath });
+      await syncInstallStateToStore(state, { dbPath: unwritableDbPath });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
   })) passed++; else failed++;
 
   console.log(`\nPassed: ${passed}`);


### PR DESCRIPTION
## Summary

egc status always reported "Install health: missing" regardless of actual install state. Root cause: `getStatus()` reads the SQLite `install_state` table, populated by `upsertInstallState()`, but nothing in the install pipeline ever called that function. `doctor`, `repair`, `auto-update`, and `list-installed` were unaffected since they read the JSON install-state files directly, a separate source of truth that was never broken.

- New `syncInstallStateToStore()` helper (`scripts/lib/install-state-store-sync.js`), called right after the existing `writeInstallState()` on both real completion points: a fresh install (`applyInstallPlan`) and repair/auto-update (`repairInstalledStates`).
- Fire-and-forget by design: swallows its own errors so a status-store write failure never blocks or fails a real install. `applyInstallPlan`'s synchronous return contract, and every existing test asserting on it, is unchanged.
- Verified end-to-end in a sandboxed HOME with a real `egc install`: status went from "missing" to "healthy, 1 target" immediately, and stayed at 1 target, not duplicated, after a follow-up `auto-update`.

## Test plan

- [x] New regression test `tests/lib/install-state-store-sync.test.js`, 4/4 passing
- [x] Full suite `node tests/run-all.js`, 2675/2675 passing
- [x] Real end-to-end reproduction in a sandboxed HOME (install, then auto-update, checking `egc status` and `egc doctor` before and after)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `egc status` always showing “Install health: missing” by syncing completed installs to the SQLite status store. Status now reflects real installs without changing the install flow.

- **Bug Fixes**
  - Added `syncInstallStateToStore` and call it after `writeInstallState` in `applyInstallPlan` and `repairInstalledStates`, so `getStatus()` sees completed installs and does not duplicate entries.
  - Non-blocking sync: errors are swallowed (optional `onError`), and the JSON install-state remains the source of truth.
  - Stabilized the failure-path test to be cross-platform by using an `ENOTDIR` path instead of OS-specific permissions (fixes Windows CI failures).

<sup>Written for commit a054ea30ab1333a3bbbad5177ad0a50ffec6ed48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `egc status` accuracy so installation health reflects the actual installation state.
  * Install state updates now remain reliable after installation and repair operations.
  * Installation continues successfully even if status synchronization encounters an error.

* **Tests**
  * Added regression coverage for accurate health reporting, repeated updates, and synchronization error handling.

* **Documentation**
  * Updated the changelog with the latest fixes and recovery improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->