### PR TITLE
fix(docker): fix three latent build/runtime failures breaking Glama

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a
+FROM node:24-trixie-slim@sha256:366fdef91728b1b7fa18c84fba63b6e79ed77b7e10cc206878e9705da4d7b169
 
 WORKDIR /app
 
 COPY docker/package.json docker/package-lock.json /tmp/mcp-proxy-install/
 RUN cd /tmp/mcp-proxy-install && npm ci --silent && \
-    cp -r node_modules/mcp-proxy /usr/local/lib/node_modules/mcp-proxy && \
+    mkdir -p /usr/local/lib/node_modules && \
+    cp -r node_modules/. /usr/local/lib/node_modules/ && \
     ln -sf /usr/local/lib/node_modules/mcp-proxy/dist/bin/mcp-proxy.mjs /usr/local/bin/mcp-proxy
 
 COPY package*.json ./
+COPY scripts/preinstall.js scripts/preinstall.js
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
## Summary

Glama's automated build failed after the v1.1.9/v1.1.10 version bumps invalidated Docker's layer cache for the first time in a while, exposing three pre-existing bugs that had been hidden by cached layers (confirmed via git log: none of the affected lines changed recently).

1. `npm ci` at the root failed with `MODULE_NOT_FOUND`: package.json's `preinstall` script needs `scripts/preinstall.js`, but the Dockerfile only copies `package*.json` before running `npm ci`. Fixed by copying that one file ahead of `npm ci`.
2. The `mcp-proxy` install step only copied `node_modules/mcp-proxy` itself, not its own hoisted dependency (`pipenet`), so the container crashed at startup with `ERR_MODULE_NOT_FOUND`. Fixed by copying the whole `node_modules` tree from that install step.
3. `sqlite3`'s prebuilt native binary requires glibc 2.38, which the pinned `node:24-slim` (Debian 12 bookworm, glibc 2.36) does not provide, crashing at startup with `ERR_DLOPEN_FAILED`. No `node:24-slim` tag currently ships a newer glibc, so the pinned base image is now `node:24-trixie-slim` (Debian 13, glibc 2.41).

## Test plan

- [x] `docker build --no-cache .` succeeds end to end
- [x] Real MCP `initialize` handshake piped into `docker run` gets a live response: SQLite migrations run, `egc-memory-orchestrator` initializes, `mcp-proxy` serves on port 8080
- [x] Full suite `node tests/run-all.js`: 2675/2675 passing (unaffected, Dockerfile has no existing CI coverage, which is itself a gap worth a follow-up)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker build and runtime failures by restoring the root install flow, ensuring `mcp-proxy` dependencies are present, and updating the base image to satisfy `sqlite3`’s glibc requirement. Builds now pass with `--no-cache` and the container boots successfully.

- **Bug Fixes**
  - Copy `scripts/preinstall.js` before root `npm ci` to satisfy the `preinstall` script.
  - Copy the full `node_modules` from the `mcp-proxy` install stage so hoisted deps like `pipenet` are available at runtime.
  - Switch base image from `node:24-slim` (Debian 12) to `node:24-trixie-slim` (Debian 13, glibc 2.41) to support `sqlite3`’s prebuilt binary.

<sup>Written for commit c025dfe68e086f81ee8aa9e703c9fc0c472b3bca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

