### PR TITLE
docs(readme): propagate hero/install rewrite to pt and es translations

### DIFF
--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -1,12 +1,12 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Idioma:** [English](../../README.md) | [العربية](../ar/README.md) | **Español** | [Português (Brasil)](../pt/README.md) | [हिन्दी](../hi/README.md) | [한국어](../ko/README.md) | [Русский](../ru/README.md) | [日本語](../ja/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [हिन्दी](../hi/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
 <img src="../../assets/hero.png" alt="EGC - Contexto Global Extendido" width="100%" />
 </div>
 
-[![npm version](https://img.shields.io/npm/v/@egchq/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egchq/egc) [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![Discord](https://img.shields.io/discord/1513941515452416130?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/AtazrtxJ) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](../../.github/CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=alert_status)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=security_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=reliability_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc) [![EGC MCP server](https://glama.ai/mcp/servers/Fmarzochi/EGC/badges/score.svg)](https://glama.ai/mcp/servers/Fmarzochi/EGC) [![Featured on Product Hunt](https://img.shields.io/badge/Product%20Hunt-featured-DA552F?logo=producthunt&logoColor=white)](https://www.producthunt.com/posts/egc)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=alert_status)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=security_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=reliability_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc) [![EGC MCP server](https://glama.ai/mcp/servers/Fmarzochi/EGC/badges/score.svg)](https://glama.ai/mcp/servers/Fmarzochi/EGC)
 
 <div align="center">
 
@@ -14,20 +14,22 @@
 
 **Tus agentes de IA nunca vuelven a empezar desde cero.**
 
+*Cero configuración. Cero comandos. Tú trabajas, EGC recuerda.*
+
 </div>
 
 ---
 
-EGC es un entorno de ejecución local que proporciona memoria persistente a todas las herramientas de programación con IA que utilizas. Al final de cada sesión, la IA guarda lo que aprendió sobre tu proyecto: las decisiones que tomaste, lo que falló, tus preferencias y los siguientes pasos. Al comienzo de la siguiente sesión, vuelve a cargar ese estado. Una sola instalación funciona para Claude Code, Cursor, Gemini CLI, Windsurf, VS Code con GitHub Copilot y más. Compatible con Claude, GPT-4o, Gemini y modelos de OpenRouter, incluidos DeepSeek, Qwen3 y Llama 4.
+EGC es un entorno de ejecución local que proporciona memoria persistente a todas las herramientas de programación con IA que utilizas. Al final de cada sesión, la IA guarda lo que aprendió sobre tu proyecto: las decisiones que tomaste, lo que falló, tus preferencias y los siguientes pasos. Al comienzo de la siguiente sesión, vuelve a cargar ese estado por sí sola, sin que tengas que pedirlo. Di "sigamos" o "¿dónde quedamos?" en cualquier idioma y tu IA ya sabe qué hacer. Una sola instalación funciona para Claude Code, Cursor, Gemini CLI, Windsurf, Zed, VS Code con GitHub Copilot y más. Compatible con Claude, GPT-4o, Gemini y modelos de OpenRouter, incluidos DeepSeek, Qwen3 y Llama 4.
 
 ---
 
-## Así es como EGC funciona en la práctica
+## Tu IA ya lo sabe
 
 Abres Claude Code en un proyecto que no has tocado en dos semanas. Sin escribir nada:
 
 ```text
-State loaded from egc-memory via ~/.egc/state/MyApp.md
+State loaded from egc-memory via ~/.egc/state/MyApp/main.md
 
 Context and preferences acknowledged.
 
@@ -40,10 +42,11 @@ Ready to pick up:
 Stack: typescript, node
 Skills: tdd-workflow, coding-standards
 Agents: code-reviewer
+Guardian: active, every command checked before it runs
 ===
 ```
 
-La IA ya sabe qué estabas construyendo, qué decisiones tomaste, qué falló y exactamente dónde te detuviste. Lo sabe porque EGC guardó ese estado al final de tu última sesión y lo cargó nuevamente cuando esta comenzó. No escribiste nada. Simplemente empezaste a trabajar.
+Esto no es una caché de tu última conversación. EGC recuerda las decisiones, los callejones sin salida y tus preferencias, y vigila durante toda la sesión, bloqueando los comandos que arruinarían tu código antes de que se ejecuten. No pediste nada de esto. Simplemente empezaste a trabajar.
 
 <div align="center">
   <img src="../../assets/egc-terminal.gif" alt="Demostración de EGC" width="700" />
@@ -52,6 +55,8 @@ La IA ya sabe qué estabas construyendo, qué decisiones tomaste, qué falló y 
 ---
 
 ## Instalación
+
+🪟 Windows &nbsp;&middot;&nbsp; 🍎 macOS &nbsp;&middot;&nbsp; 🐧 Linux, el mismo comando en todos:
 
 ```bash
 npm install -g @egchq/egc && egc install
@@ -63,57 +68,65 @@ O ejecútalo sin instalarlo globalmente:
 npx @egchq/egc install
 ```
 
-[Guía completa de instalación](../../docs/installation.md)
-
-### VS Code + GitHub Copilot
-
-Usa el target Copilot cuando quieras las skills de EGC disponibles en VS Code a través de GitHub Copilot Chat:
+**Un cerebro, muchas herramientas.** Con la extensión de GitHub Copilot Chat instalada, Copilot encuentra las skills por sí solo, y la misma memoria que ya tienes en Claude Code o Cursor aparece ahí también:
 
 ```bash
 npm install -g @egchq/egc
 egc install --target copilot
 ```
 
-Requiere la extensión GitHub Copilot Chat. EGC instala las skills en `~/.github/skills/`, donde Copilot las descubre automáticamente. El mismo estado de memoria se comparte con Claude Code, Cursor, Gemini CLI, Windsurf y otros targets de EGC.
+[Guía completa de instalación](../../docs/installation.md)
 
 ---
 
 ## Lo que EGC ofrece a tu IA
 
-EGC incluye dos servidores MCP que trabajan juntos durante cada sesión.
+EGC siempre ejecuta dos cosas juntas, en cada sesión: una memoria que guarda lo importante, y una capa de seguridad que bloquea comandos peligrosos antes de que se ejecuten. Todo viene listo, sin configurar nada.
 
-**`egc-memory`** - 14 herramientas para memoria persistente:
+### Memoria: lo que tu IA recuerda sola
 
-| Herramienta | Qué hace |
-|---|---|
-| `get_state` | Carga la memoria del proyecto al inicio de la sesión |
-| `update_state` | Guarda decisiones, preferencias y próximos pasos |
-| `store_decision` | Persiste una decisión individual en SQLite |
-| `query_history` | Devuelve decisiones pasadas por marca de tiempo |
-| `search_history` | Búsqueda de texto completo con clasificación BM25 |
-| `working_memory_set` | Almacena contexto temporal con TTL |
-| `working_memory_get` | Lee una clave temporal |
-| `working_memory_list` | Lista todas las entradas temporales activas del proyecto actual |
-| `lesson_save` | Registra conocimiento entre sesiones con degradación de confianza |
-| `lesson_recall` | Recupera lecciones activas por encima de un umbral de confianza |
-| `lesson_reinforce` | Aumenta la confianza en una lección cuando se repite el mismo patrón |
-| `detect_patterns` | Identifica comandos repetidos y errores recurrentes a partir de eventos hook |
-| `compress_observations` | Comprime observaciones sin procesar en resúmenes tipificados para reducir el uso de tokens |
-| `get_project_state` | Devuelve metadatos de estado del servidor y del motor de almacenamiento |
+Nunca vas a memorizar un solo comando. Dilo en cualquier idioma: "sigue desde ayer", "recuerda esta decisión", "qué falló la última vez", y tu IA sabe exactamente qué hacer. El trabajo es tuyo, el recuerdo es de EGC.
 
-Los archivos de estado se almacenan en `~/.egc/state/<project-slug>.md`. Un archivo por proyecto, en Markdown simple y legible para humanos.
-
-**`egc-guardian`** - 5 herramientas para contexto y seguridad:
+**`egc-memory`**
 
 | Herramienta | Qué hace |
 |---|---|
-| `validate_command` | Verifica comandos de shell contra las reglas de seguridad del proyecto antes de ejecutarlos |
-| `validate_write` | Valida rutas de escritura de archivos para prevenir escrituras inseguras |
-| `reduce_context` | Comprime los archivos del payload para ahorrar tu presupuesto de tokens |
-| `orchestrate_task` | Enruta prompts con contexto de agentes/skills y devuelve métricas de compresión |
-| `auto_learn` | Analiza fallos de sesión y escribe lecciones accionables en todos los archivos de configuración de herramientas de IA del proyecto |
+| `get_state` | Carga todo lo que tu IA ya sabía del proyecto en el momento en que abres la sesión |
+| `update_state` | Guarda lo que se decidió hoy para que mañana nadie pierda el hilo |
+| `store_decision` | Anota una decisión importante, para siempre |
+| `query_history` | Muestra decisiones pasadas en el orden en que ocurrieron |
+| `search_history` | Encuentra cualquier cosa que se haya decidido alguna vez, aunque no recuerdes la fecha |
+| `working_memory_set` / `_get` / `_list` | Notas rápidas que caducan solas cuando dejan de ser útiles |
+| `lesson_save` | Registra algo aprendido, que pierde fuerza con el tiempo si nadie lo confirma de nuevo |
+| `lesson_recall` | Recupera las lecciones que todavía valen la pena |
+| `lesson_reinforce` | Refuerza una lección cuando se confirma de nuevo |
+| `detect_patterns` | Nota cuando el mismo error o comando se repite demasiado |
+| `compress_observations` | Resume el historial en bruto para que no gastes tokens en vano |
+| `get_project_state` | Comprueba que la memoria funciona como debe |
 
-**`egc watch`** - daemon de sincronización bidireccional. Monitorea todos los archivos de configuración de herramientas gestionados por EGC en el proyecto. Cuando editas el contexto directamente en cualquier archivo de herramienta (Cursor, Gemini CLI, Copilot, etc.), el cambio se extrae del bloque EGC y se sincroniza con todas las demás herramientas y de vuelta a `~/.egc/state/` automáticamente.
+Cada branch de tu proyecto guarda su propia memoria, cifrada en tu equipo: nadie más tiene acceso, ni siquiera la nube. Privacidad de fábrica, sin configurar nada.
+
+### Contexto y seguridad: lo que vigila mientras trabajas
+
+**`egc-guardian`**
+
+Estas herramientas se ejecutan solas, en segundo plano. Cada comando de shell y cada escritura de archivo se comprueba antes de ejecutarse. Nunca las invocas directamente.
+
+| Herramienta | Qué hace |
+|---|---|
+| `validate_command` | Comprueba cada comando antes de ejecutarlo: bloquea los que podrían causar daño |
+| `validate_write` | Evita que la IA escriba en archivos sensibles por error |
+| `reduce_context` | Reduce archivos grandes para que no gastes tu presupuesto de tokens en vano |
+| `orchestrate_task` | Elige las herramientas correctas para cada solicitud, sin que tengas que saber cuáles existen |
+| `auto_learn` | Aprende de los errores de la sesión y lo deja anotado para que no se repita |
+
+### Aplicado por código, no por petición
+
+Seguridad que no depende de que la IA esté de buen humor: todo comando pasa por EGC antes de ejecutarse, siempre. [Detalles completos sobre la aplicación del harness, la detección de intención de sesión y el minero de memoria →](../../docs/installation.md#enforcement)
+
+### Una memoria. Todas tus herramientas.
+
+Ejecuta **`egc watch`** una vez y olvídate de que existe. Cambia contexto en Cursor y aparece solo en Gemini CLI, Copilot, Windsurf, Zed: en todo lo que usas. Sin pasos manuales, sin estado desactualizado en ningún lado.
 
 ```
 egc watch              # monitorear proyecto actual
@@ -121,21 +134,19 @@ egc watch /ruta/proj   # monitorear proyecto específico
 egc watch --quiet      # silenciar salida
 ```
 
-### Aplicado por código, no por petición
+### Dashboard: mira a tus agentes trabajar
 
-La validación no depende de que la IA elija cooperar. EGC instala hooks en el harness que se ejecutan en cada llamada de herramienta: cada comando de shell y cada escritura de archivo se valida antes de ejecutarse, y los comandos destructivos, las rutas de credenciales y los force-push se bloquean incluso dentro de comandos compuestos. Cada prompt también se enruta contra el catálogo de componentes, inyectando en el contexto las skills y agents correctos. Si el validador falta, los hooks fallan abiertos: nunca quedas bloqueado fuera de tu propia herramienta.
-
-Con una API key de proveedor (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY` u `OPENROUTER_API_KEY`), EGC también entiende la intención de la sesión semánticamente, en cualquier idioma, sin frases predefinidas: di que terminas por hoy y tu estado se guarda antes de que la IA responda; saluda a la mañana siguiente y tus próximos pasos ya están en contexto. Al final de la sesión, un minero de memoria destila las decisiones y lecciones de la sesión en el estado de tu proyecto. Sin key, estas funciones de LLM honestamente no hacen nada, y los hooks de ciclo de vida siguen garantizando el guardado del estado.
-
-### Dashboard - panel de control en tiempo real
-
-Ve cada llamada de herramienta, token y coste de tus agentes -- en vivo en el navegador. Arranca automáticamente tras `egc init`. [Guía completa](docs/installation.md#dashboard)
+Mira cada llamada de herramienta, token y coste que generan tus agentes, en vivo en el navegador. Arranca automáticamente tras `egc init`. [Guía completa](../../docs/installation.md#dashboard)
 
 ---
 
 ## Biblioteca de prompts
 
-**479 componentes** incluidos como bonus: 63 agentes, 229 habilidades, 76 comandos y 111 reglas escritos en sesiones de ingeniería reales. Ignóralos por completo y EGC seguirá dándote memoria persistente.
+Como bonus, EGC también te da acceso a 63 agents, 230 skills y 77 commands, más 111 rules: especialistas que revisan tu código solos, guías de buenas prácticas para cada lenguaje y situación, atajos que ejecutan toda una secuencia de tareas por ti, y reglas de estilo que mantienen tu código consistente. Todo escrito a partir de sesiones reales de ingeniería, no teoría. ¿No quieres usar nada de esto? No pasa nada: la memoria persistente de EGC funciona exactamente igual.
+
+---
+
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [हिन्दी](../hi/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md)
 
 ---
 
@@ -156,7 +167,7 @@ El apoyo de la comunidad mantiene este proyecto vivo e independiente.
 
 #### Partners de herramientas
 
-Herramientas de programacion con IA que se integran nativamente con EGC. Los partners reciben espacio para su logo en todos los READMEs y en EGCSite.
+Herramientas de programación con IA que se integran nativamente con EGC. Los partners reciben espacio para su logo en todos los READMEs y en EGCSite.
 
 <a href="https://www.pincushion.io/"><img src="https://www.pincushion.io/logo-icon.png" width="52" height="52" alt="Pincushion" title="Pincushion" /></a>
 
@@ -166,7 +177,7 @@ Herramientas de programacion con IA que se integran nativamente con EGC. Los par
 
 #### Colaboradores
 
-<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="52" height="52" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a> <a href="https://github.com/ayushikaul02"><img src="https://avatars.githubusercontent.com/u/212903502?v=4" width="48" height="48" alt="@ayushikaul02" title="@ayushikaul02 -- Spanish translation" /></a>
+<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="52" height="52" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a> <a href="https://github.com/ayushikaul02"><img src="https://avatars.githubusercontent.com/u/212903502?v=4" width="48" height="48" alt="@ayushikaul02" title="@ayushikaul02, Spanish translation" /></a>
 
 #### Patrocinadores mensuales · _se el primero_
 
@@ -174,7 +185,7 @@ Herramientas de programacion con IA que se integran nativamente con EGC. Los par
 
 <div align="center">
 
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](../../LICENSE) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3)
 
 <br>
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -1,12 +1,12 @@
 <!-- LANGUAGE-SELECTOR-START -->
-**Idioma:** [English](../../README.md) | [العربية](../ar/README.md) | [Español](../es/README.md) | **Português (Brasil)** | [हिन्दी](../hi/README.md) | [한국어](../ko/README.md) | [Русский](../ru/README.md) | [日本語](../ja/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
 <img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm version](https://img.shields.io/npm/v/@egchq/egc?color=cb3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@egchq/egc) [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org) [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org) [![Discord](https://img.shields.io/discord/1513941515452416130?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/AtazrtxJ) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](../../.github/CONTRIBUTING.md) [![Stars](https://img.shields.io/github/stars/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/stargazers) [![Forks](https://img.shields.io/github/forks/Fmarzochi/EGC?style=flat)](https://github.com/Fmarzochi/EGC/network/members) [![Issues](https://img.shields.io/github/issues/Fmarzochi/EGC)](https://github.com/Fmarzochi/EGC/issues) [![Maintained](https://img.shields.io/badge/Maintained-yes-brightgreen)](https://github.com/Fmarzochi/EGC/commits/main) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=alert_status)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=security_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=reliability_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc) [![EGC MCP server](https://glama.ai/mcp/servers/Fmarzochi/EGC/badges/score.svg)](https://glama.ai/mcp/servers/Fmarzochi/EGC) [![Featured on Product Hunt](https://img.shields.io/badge/Product%20Hunt-featured-DA552F?logo=producthunt&logoColor=white)](https://www.producthunt.com/posts/egc)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=alert_status)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=security_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Fmarzochi_EGC&metric=reliability_rating)](https://sonarcloud.io/project/overview?id=Fmarzochi_EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc) [![EGC MCP server](https://glama.ai/mcp/servers/Fmarzochi/EGC/badges/score.svg)](https://glama.ai/mcp/servers/Fmarzochi/EGC)
 
 <div align="center">
 
@@ -14,20 +14,22 @@
 
 **Seus agentes de IA nunca mais começarão do zero.**
 
+*Configuração zero. Comandos zero. Você trabalha, o EGC lembra.*
+
 </div>
 
 ---
 
-EGC é um runtime local que oferece memória persistente para cada ferramenta de IA que você usa. Ao final de cada sessão, a IA salva o que aprendeu sobre o seu projeto: as decisões tomadas, o que falhou, suas preferências e os próximos passos. No início da próxima sessão, ela carrega esse estado de volta. Uma única instalação cobre Claude Code, Cursor, Gemini CLI, Windsurf, VS Code com GitHub Copilot e muito mais. Compatível com Claude, GPT-4o, Gemini e modelos OpenRouter, incluindo DeepSeek, Qwen3 e Llama 4.
+EGC é um runtime local que oferece memória persistente para cada ferramenta de IA que você usa. Ao final de cada sessão, a IA salva o que aprendeu sobre o seu projeto: as decisões tomadas, o que falhou, suas preferências e os próximos passos. No início da próxima sessão, ela carrega esse estado de volta sozinha, sem você pedir nada. Diga "vamos continuar" ou "onde paramos?" em qualquer idioma e sua IA já sabe o que fazer. Uma única instalação cobre Claude Code, Cursor, Gemini CLI, Windsurf, Zed, VS Code com GitHub Copilot e muito mais. Compatível com Claude, GPT-4o, Gemini e modelos OpenRouter, incluindo DeepSeek, Qwen3 e Llama 4.
 
 ---
 
-## É assim que o EGC funciona na prática
+## Sua IA já sabe
 
-Você abre o Claude Code em um projeto que não tocou há duas semanas. Sem digitar nada:
+Você abre o Claude Code em um projeto que não toca há duas semanas. Sem digitar nada:
 
 ```
-State loaded from egc-memory via ~/.egc/state/MyApp.md
+State loaded from egc-memory via ~/.egc/state/MyApp/main.md
 
 Context and preferences acknowledged.
 
@@ -40,10 +42,11 @@ Ready to pick up:
 Stack: typescript, node
 Skills: tdd-workflow, coding-standards
 Agents: code-reviewer
+Guardian: active, every command checked before it runs
 ===
 ```
 
-A IA já sabe o que você estava construindo, quais decisões tomou, o que falhou e exatamente onde parou. Ela sabe porque o EGC salvou esse estado ao final da sua última sessão e o carregou de volta quando esta começou. Você não digitou nada. Você simplesmente começou a trabalhar.
+Isso não é um cache da sua última conversa. O EGC lembra das decisões, dos becos sem saída e das suas preferências, e fica de guarda a sessão inteira, bloqueando os comandos que incendiariam seu código antes deles rodarem. Você não pediu nada disso. Só começou a trabalhar.
 
 <div align="center">
   <img src="../../assets/egc-terminal.gif" alt="EGC demo" width="700" />
@@ -52,6 +55,8 @@ A IA já sabe o que você estava construindo, quais decisões tomou, o que falho
 ---
 
 ## Instalação
+
+🪟 Windows &nbsp;&middot;&nbsp; 🍎 macOS &nbsp;&middot;&nbsp; 🐧 Linux, o mesmo comando em qualquer sistema:
 
 ```bash
 npm install -g @egchq/egc && egc install
@@ -63,57 +68,65 @@ Ou execute sem instalar globalmente:
 npx @egchq/egc install
 ```
 
-[Guia de instalação completo](../../docs/installation.md)
-
-### VS Code + GitHub Copilot
-
-Use o target Copilot quando quiser as skills do EGC disponíveis no VS Code via GitHub Copilot Chat:
+**Um cérebro, várias ferramentas.** Com a extensão do GitHub Copilot Chat instalada, o Copilot encontra as skills sozinho, e a mesma memória que você já tem no Claude Code ou no Cursor aparece lá também:
 
 ```bash
 npm install -g @egchq/egc
 egc install --target copilot
 ```
 
-Requer a extensão GitHub Copilot Chat. O EGC instala as skills em `~/.github/skills/`, onde o Copilot as descobre automaticamente. O mesmo estado de memória é compartilhado com Claude Code, Cursor, Gemini CLI, Windsurf e outros targets do EGC.
+[Guia de instalação completo](../../docs/installation.md)
 
 ---
 
 ## O que o EGC oferece à sua IA
 
-O EGC inclui dois servidores MCP que trabalham juntos durante cada sessão.
+O EGC sempre roda duas coisas juntas, em toda sessão: uma memória que guarda o que importa, e uma camada de segurança que barra comando perigoso antes dele rodar. Vem tudo pronto, sem configurar nada.
 
-**`egc-memory`** - 14 ferramentas para memória persistente:
+### Memória: o que sua IA lembra sozinha
 
-| Ferramenta | O que faz |
-|---|---|
-| `get_state` | Carrega a memória do projeto no início da sessão |
-| `update_state` | Salva decisões, preferências e próximos passos |
-| `store_decision` | Persiste uma única decisão no SQLite |
-| `query_history` | Retorna decisões anteriores por timestamp |
-| `search_history` | Busca em texto completo com ranking BM25 |
-| `working_memory_set` | Armazena contexto transitório com TTL |
-| `working_memory_get` | Lê uma chave transitória |
-| `working_memory_list` | Lista todas as entradas transitórias ativas do projeto atual |
-| `lesson_save` | Registra conhecimento entre sessões com decaimento de confiança |
-| `lesson_recall` | Recupera lições ativas acima de um limite de confiança |
-| `lesson_reinforce` | Aumenta a confiança em uma lição quando o mesmo padrão se repete |
-| `detect_patterns` | Identifica comandos repetidos e erros recorrentes a partir de eventos de hook |
-| `compress_observations` | Comprime observações brutas em resumos tipados para reduzir o uso de tokens |
-| `get_project_state` | Retorna metadados de saúde do servidor e status do mecanismo de armazenamento |
+Você nunca vai memorizar comando nenhum. Fala em qualquer língua: "continua de ontem", "lembra dessa decisão", "o que quebrou da última vez", e sua IA sabe exatamente o que fazer. O trabalho é seu, a lembrança é do EGC.
 
-Os arquivos de estado ficam em `~/.egc/state/<project-slug>.md`. Um arquivo por projeto, Markdown simples, legível por humanos.
-
-**`egc-guardian`** - 5 ferramentas para contexto e segurança:
+**`egc-memory`**
 
 | Ferramenta | O que faz |
 |---|---|
-| `validate_command` | Verifica comandos de shell contra as regras de segurança do projeto antes da execução |
-| `validate_write` | Valida caminhos de escrita para prevenir gravações inseguras |
-| `reduce_context` | Comprime payloads de arquivos para economizar seu orçamento de tokens |
-| `orchestrate_task` | Roteia prompts com contexto de agentes/skills e retorna métricas de compressão |
-| `auto_learn` | Analisa falhas de sessão e escreve lições acionáveis em todos os arquivos de configuração de ferramentas de IA do projeto |
+| `get_state` | Carrega tudo que sua IA já sabia sobre o projeto assim que a sessão abre |
+| `update_state` | Guarda o que foi decidido hoje pra amanhã ninguém perder o fio |
+| `store_decision` | Anota uma decisão importante pra sempre |
+| `query_history` | Mostra decisões antigas, em ordem de quando aconteceram |
+| `search_history` | Busca qualquer coisa que já foi decidida, mesmo sem lembrar a data |
+| `working_memory_set` / `_get` / `_list` | Anotações rápidas que expiram sozinhas quando não servem mais |
+| `lesson_save` | Grava um aprendizado, que perde força com o tempo se ninguém confirmar de novo |
+| `lesson_recall` | Traz de volta os aprendizados que ainda valem a pena |
+| `lesson_reinforce` | Reforça um aprendizado quando ele se confirma de novo |
+| `detect_patterns` | Percebe quando o mesmo erro ou comando se repete demais |
+| `compress_observations` | Resume o histórico bruto pra não gastar tokens à toa |
+| `get_project_state` | Confere se a memória está funcionando direito |
 
-**`egc watch`** - daemon de sincronização bidirecional. Monitora todos os arquivos de configuração de ferramentas gerenciados pelo EGC no projeto. Quando você edita o contexto diretamente em qualquer arquivo de ferramenta (Cursor, Gemini CLI, Copilot, etc.), a mudança é extraída do bloco EGC e sincronizada com todas as outras ferramentas e de volta para `~/.egc/state/` automaticamente.
+Cada branch do seu projeto guarda sua própria memória, criptografada no seu computador: ninguém mais tem acesso, nem a nuvem. Privacidade de fábrica, sem configurar nada.
+
+### Contexto e segurança: o que fica de guarda enquanto você trabalha
+
+**`egc-guardian`**
+
+Essas ferramentas rodam sozinhas, em segundo plano. Todo comando de shell e toda escrita de arquivo é conferida antes de executar. Você nunca as chama diretamente.
+
+| Ferramenta | O que faz |
+|---|---|
+| `validate_command` | Confere todo comando antes de rodar: bloqueia o que pode dar problema |
+| `validate_write` | Impede que a IA escreva em arquivos sensíveis por engano |
+| `reduce_context` | Enxuga arquivos grandes pra não gastar seu orçamento de tokens à toa |
+| `orchestrate_task` | Escolhe as ferramentas certas pra cada pedido, sem você precisar saber quais existem |
+| `auto_learn` | Aprende com os erros da sessão e já deixa anotado pra não repetir |
+
+### Imposto por código, não por pedido
+
+Segurança que não depende da IA estar de bom humor: todo comando passa pelo EGC antes de rodar, sempre. [Detalhes completos sobre a aplicação via harness, detecção de intenção e o minerador de memória →](../../docs/installation.md#enforcement)
+
+### Uma memória. Todas as suas ferramentas.
+
+Roda **`egc watch`** uma vez, esquece que existe. Muda contexto no Cursor, aparece sozinho no Gemini CLI, Copilot, Windsurf, Zed: em tudo que você usa. Sem passo manual, sem versão desatualizada em lugar nenhum.
 
 ```
 egc watch              # monitorar projeto atual
@@ -121,21 +134,19 @@ egc watch /caminho     # monitorar projeto específico
 egc watch --quiet      # suprimir saída
 ```
 
-### Aplicado por código, não por pedido
+### Dashboard: veja seus agentes trabalhando
 
-A validação não depende de a IA escolher cooperar. O EGC instala hooks no harness que rodam em toda chamada de ferramenta: cada comando de shell e cada escrita de arquivo é validada antes de executar, e comandos destrutivos, caminhos de credenciais e force-push são bloqueados mesmo dentro de comandos compostos. Todo prompt também é roteado contra o catálogo de componentes, injetando no contexto as skills e os agents certos. Se o validador estiver ausente, os hooks falham abertos: você nunca fica trancado fora da sua própria ferramenta.
-
-Com uma API key de provider (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY` ou `OPENROUTER_API_KEY`), o EGC também entende a intenção da sessão semanticamente, em qualquer idioma, sem frases pré-definidas: diga que vai encerrar por hoje e o estado é salvo antes mesmo de a IA responder; cumprimente na manhã seguinte e os próximos passos já estão no contexto. Ao fim da sessão, um minerador de memória destila as decisões e lições da sessão para o estado do projeto. Sem key, esses recursos de LLM honestamente não fazem nada, e os hooks de ciclo de vida continuam garantindo o salvamento do estado.
-
-### Dashboard - painel de controle em tempo real
-
-Veja cada chamada de ferramenta, token e custo gerado pelos seus agentes -- ao vivo no navegador. Inicia automaticamente após `egc init`. [Guia completo](docs/installation.md#dashboard)
+Veja cada comando, token e custo gerado pelos seus agentes, direto no navegador. Inicia automaticamente após `egc init`. [Guia completo](../../docs/installation.md#dashboard)
 
 ---
 
 ## Biblioteca de prompts
 
-**479 componentes** inclusos como brinde: 63 agentes, 229 skills, 76 comandos e 111 regras escritos em sessoes reais de engenharia. Ignore-os completamente e o EGC ainda oferece memoria persistente.
+De bônus, o EGC também dá acesso a 63 agents, 230 skills e 77 commands, mais 111 rules: especialistas que revisam seu código sozinhos, guias de boas práticas pra cada linguagem e situação, atalhos que executam uma sequência inteira de tarefas, e regras de estilo que mantêm o código consistente. Tudo escrito a partir de sessões reais de engenharia, não teoria. Não quer usar nada disso? Tudo bem: a memória persistente do EGC funciona do mesmo jeito.
+
+---
+
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md)
 
 ---
 
@@ -156,7 +167,7 @@ O apoio da comunidade mantém este projeto vivo e independente.
 
 #### Parceiros de ferramentas
 
-Ferramentas de programacao com IA que se integram nativamente com o EGC. Os parceiros recebem espaco para logo em todos os READMEs e no EGCSite.
+Ferramentas de programação com IA que se integram nativamente com o EGC. Os parceiros recebem espaço para logo em todos os READMEs e no EGCSite.
 
 <a href="https://www.pincushion.io/"><img src="https://www.pincushion.io/logo-icon.png" width="52" height="52" alt="Pincushion" title="Pincushion" /></a>
 
@@ -174,7 +185,7 @@ Ferramentas de programacao com IA que se integram nativamente com o EGC. Os parc
 
 <div align="center">
 
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](../../LICENSE) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3)
 
 <br>
 


### PR DESCRIPTION
## Summary
- Mirrors PR #704's structural and tone changes in `translations/pt/README.md` and `translations/es/README.md`: trimmed badge row (6 instead of 14), unified language selector repeated top/bottom, new tagline, plain-language tool tables for both MCP servers, OS-neutral install framing, and the enforcement deep dive pointed at `docs/installation.md#enforcement`.
- Fixes stale component counts in both files (were showing 479/229/76, now match the real 481/230/77/111 used in the English README).
- Spanish translator credit (@ayushikaul02) preserved.

## Test plan
- [x] Manual proofread for stray em-dash/double-hyphen in both files (only legitimate CLI flags and markdown syntax remain)
- [x] Verified relative links (`../../docs/installation.md`, `../../assets/...`) unchanged from the pre-existing convention

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the Spanish and Portuguese READMEs with the English README rewrite for a consistent structure and clearer installation experience.

- **Refactors**
  - Trimmed badge row and unified language selector at top and bottom.
  - Added new tagline; rewrote `egc-memory` and `egc-guardian` tool tables in plain language.
  - OS-neutral install; Copilot notes retained; enforcement deep-dive linked to `docs/installation.md#enforcement`.
  - Updated component counts to 481/230/77/111; preserved Spanish translator credit; kept relative links and assets unchanged.

<sup>Written for commit 8c45f677b20907af7075144848329a71df01844e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

