### PR TITLE
fix(hooks): wire GateGuard fact-forcing gate onto Claude Code Edit/Write/MultiEdit

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -539,3 +539,46 @@ function run(rawInput) {
 }
 
 module.exports = { run };
+
+// --- Direct CLI entrypoint ---
+//
+// Claude Code invokes PreToolUse hook scripts directly (`node <script>.js`
+// with the tool-call JSON on stdin), unlike Gemini's run-with-flags.js or
+// bash-hook-dispatcher.js, which both require() and call run() in-process.
+// This block only executes when the file is run as a standalone process, so
+// it does not change behavior for either of those existing callers.
+if (require.main === module) {
+  const MAX_STDIN = 1024 * 1024;
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    const output = run(raw);
+
+    if (typeof output === 'string' || Buffer.isBuffer(output)) {
+      process.stdout.write(String(output));
+      process.exit(0);
+    }
+
+    if (output && typeof output === 'object') {
+      if (typeof output.stderr === 'string' && output.stderr) {
+        process.stderr.write(output.stderr.endsWith('\n') ? output.stderr : `${output.stderr}\n`);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(output, 'stdout')) {
+        process.stdout.write(String(output.stdout ?? ''));
+      } else if (!Number.isInteger(output.exitCode) || output.exitCode === 0) {
+        process.stdout.write(raw);
+      }
+
+      process.exit(Number.isInteger(output.exitCode) ? output.exitCode : 0);
+    }
+
+    process.stdout.write(raw);
+    process.exit(0);
+  });
+}

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -29,6 +29,8 @@ const WRITE_VALIDATOR_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/pre-writ
 const WRITE_VALIDATOR_HOOK_MODULE_ID = 'claude-write-validator-hook';
 const ROUTER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/prompt-router.js';
 const ROUTER_HOOK_MODULE_ID = 'claude-prompt-router-hook';
+const GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/gateguard-fact-force.js';
+const GATEGUARD_HOOK_MODULE_ID = 'claude-gateguard-fact-force-hook';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -543,9 +545,54 @@ function createPreToolUseWriteValidatorHookMergeOperation(targetRoot, matcher) {
   );
 }
 
+// GateGuard fact-forcing gate: registered as its own PreToolUse entry
+// (alongside, not instead of, the write validator above) so Edit/Write/
+// MultiEdit get the same investigation gate that Bash already gets via
+// bash-hook-dispatcher.js. See scripts/hooks/gateguard-fact-force.js.
+function resolveGateGuardHookScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'gateguard-fact-force.js');
+}
+
+function hasGateGuardHook(settings, hookScriptPath, matcher) {
+  return hasHookEntry(settings, PRE_TOOL_USE_EVENT, hookScriptPath, matcher);
+}
+
+function addGateGuardHook(settings, hookScriptPath, matcher) {
+  return addHookEntry(settings, PRE_TOOL_USE_EVENT, hookScriptPath, { matcher });
+}
+
+function removeGateGuardHook(settings, hookScriptPath) {
+  return removeHookEntry(settings, PRE_TOOL_USE_EVENT, hookScriptPath);
+}
+
+function applyGateGuardHookToFile(settingsPath, hookScriptPath, matcher) {
+  return applyHookEntryToFile(settingsPath, PRE_TOOL_USE_EVENT, hookScriptPath, { matcher });
+}
+
+function removeGateGuardHookFromFile(settingsPath, hookScriptPath) {
+  return removeHookEntryFromFile(settingsPath, PRE_TOOL_USE_EVENT, hookScriptPath);
+}
+
+function inspectGateGuardHookFile(settingsPath, hookScriptPath, matcher) {
+  return inspectHookEntryFile(settingsPath, PRE_TOOL_USE_EVENT, hookScriptPath, matcher);
+}
+
+function createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher) {
+  const hookScriptPath = resolveGateGuardHookScriptDestination(targetRoot);
+  return buildPreToolUseMergeOperation(
+    targetRoot,
+    GATEGUARD_HOOK_MODULE_ID,
+    GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    hookScriptPath,
+    matcher
+  );
+}
+
 module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -562,12 +609,14 @@ module.exports = {
   ROUTER_HOOK_MODULE_ID,
   ROUTER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   addBashDispatcherHook,
+  addGateGuardHook,
   addIntuitionHook,
   addRouterHook,
   addSessionStartHook,
   addStopHook,
   addWriteValidatorHook,
   applyBashDispatcherHookToFile,
+  applyGateGuardHookToFile,
   applyHookEntryToFile,
   applyIntuitionHookToFile,
   applyRouterHookToFile,
@@ -577,18 +626,21 @@ module.exports = {
   buildSessionStartCommand,
   buildStopCommand,
   createPreToolUseBashDispatcherHookMergeOperation,
+  createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,
   createUserPromptSubmitHookMergeOperation,
   createUserPromptSubmitRouterHookMergeOperation,
   hasBashDispatcherHook,
+  hasGateGuardHook,
   hasIntuitionHook,
   hasRouterHook,
   hasSessionStartHook,
   hasStopHook,
   hasWriteValidatorHook,
   inspectBashDispatcherHookFile,
+  inspectGateGuardHookFile,
   inspectHookEntryFile,
   inspectIntuitionHookFile,
   inspectRouterHookFile,
@@ -598,6 +650,8 @@ module.exports = {
   readSettingsFile,
   removeBashDispatcherHook,
   removeBashDispatcherHookFromFile,
+  removeGateGuardHook,
+  removeGateGuardHookFromFile,
   removeHookEntryFromFile,
   removeIntuitionHook,
   removeIntuitionHookFromFile,
@@ -610,6 +664,7 @@ module.exports = {
   removeWriteValidatorHook,
   removeWriteValidatorHookFromFile,
   resolveBashDispatcherHookScriptDestination,
+  resolveGateGuardHookScriptDestination,
   resolveHookScriptDestination,
   resolveIntuitionHookScriptDestination,
   resolveRouterHookScriptDestination,

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -31,6 +31,7 @@ const {
   createUserPromptSubmitRouterHookMergeOperation,
   createPreToolUseBashDispatcherHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
+  createPreToolUseGateGuardHookMergeOperation,
   resolveHookScriptDestination,
   resolveStopHookScriptDestination,
 } = require('../claude-settings-hooks');
@@ -78,6 +79,13 @@ function createSessionStateHookOperations(adapter, targetRoot) {
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'MultiEdit'),
+    // GateGuard fact-forcing gate: Bash already gets this via
+    // bash-hook-dispatcher.js above. Edit/Write/MultiEdit only had the
+    // protected-path validator until now, so register GateGuard on them
+    // too (in addition to, not instead of, the write validator).
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Edit'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Write'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, 'MultiEdit'),
   ];
 }
 

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -113,6 +113,31 @@ function runBashHook(input, env = {}) {
   };
 }
 
+function runDirectHook(input, env = {}) {
+  // Claude Code invokes PreToolUse hook scripts directly (`node <script>.js`
+  // with the tool-call JSON on stdin), unlike run-with-flags.js above. This
+  // exercises that same invocation shape against the require.main entrypoint.
+  const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
+  const result = spawnSync('node', [hookScript], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GATEGUARD_STATE_DIR: stateDir,
+      EGC_SESSION_ID: TEST_SESSION_ID,
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
 function parseOutput(stdout) {
   try {
     return JSON.parse(stdout);
@@ -977,6 +1002,45 @@ function runTests() {
 
     assert.ok(!fs.existsSync(staleTmp), 'stale temp state file should be pruned');
     assert.ok(fs.existsSync(freshState), 'fresh state file should remain');
+  })) passed++; else failed++;
+
+  // --- Direct CLI entrypoint (Claude Code invokes the script directly,
+  // not via run-with-flags.js) ---
+
+  clearState();
+  if (test('direct invocation denies first Edit per file with fact-forcing message', () => {
+    const input = {
+      tool_name: 'Edit',
+      tool_input: { file_path: '/src/direct-invoke.js', old_string: 'foo', new_string: 'bar' }
+    };
+    const result = runDirectHook(input);
+    assert.strictEqual(result.code, 0, 'exit code should be 0');
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Fact-Forcing Gate'));
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('direct invocation allows the second Edit on the same file after being checked', () => {
+    const input = {
+      tool_name: 'Edit',
+      tool_input: { file_path: '/src/direct-invoke-2.js', old_string: 'foo', new_string: 'bar' }
+    };
+    runDirectHook(input);
+    const result = runDirectHook(input);
+    assert.strictEqual(result.code, 0, 'exit code should be 0');
+    const output = parseOutput(result.stdout);
+    assert.ok(!output.hookSpecificOutput, 'second call should pass raw input through, not a deny decision');
+    assert.deepStrictEqual(output, input, 'raw input should be echoed unchanged');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('direct invocation passes through non-gated tools unchanged', () => {
+    const input = { tool_name: 'Read', tool_input: { file_path: '/src/direct-invoke.js' } };
+    const result = runDirectHook(input);
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), input);
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.

--- a/tests/lib/claude-settings-hooks.test.js
+++ b/tests/lib/claude-settings-hooks.test.js
@@ -10,6 +10,8 @@ const path = require('path');
 const {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -24,11 +26,13 @@ const {
   WRITE_VALIDATOR_HOOK_MODULE_ID,
   WRITE_VALIDATOR_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   addBashDispatcherHook,
+  addGateGuardHook,
   addIntuitionHook,
   addSessionStartHook,
   addStopHook,
   addWriteValidatorHook,
   applyBashDispatcherHookToFile,
+  applyGateGuardHookToFile,
   applyIntuitionHookToFile,
   applyRouterHookToFile,
   applySessionStartHookToFile,
@@ -37,22 +41,26 @@ const {
   buildSessionStartCommand,
   buildStopCommand,
   createPreToolUseBashDispatcherHookMergeOperation,
+  createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,
   createUserPromptSubmitHookMergeOperation,
   hasBashDispatcherHook,
+  hasGateGuardHook,
   hasIntuitionHook,
   hasRouterHook,
   hasSessionStartHook,
   hasStopHook,
   hasWriteValidatorHook,
   inspectBashDispatcherHookFile,
+  inspectGateGuardHookFile,
   inspectIntuitionHookFile,
   inspectSessionStartHookFile,
   inspectStopHookFile,
   inspectWriteValidatorHookFile,
   removeBashDispatcherHook,
+  removeGateGuardHook,
   removeIntuitionHook,
   removeSessionStartHook,
   removeSessionStartHookFromFile,
@@ -60,6 +68,7 @@ const {
   removeStopHookFromFile,
   removeWriteValidatorHook,
   resolveBashDispatcherHookScriptDestination,
+  resolveGateGuardHookScriptDestination,
   resolveHookScriptDestination,
   resolveIntuitionHookScriptDestination,
   resolveSettingsPath,
@@ -72,6 +81,7 @@ const STOP_HOOK_SCRIPT_PATH = '/home/user/.claude/egc/hooks/claude-session-stop.
 const INTUITION_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/prompt-intuition.js';
 const BASH_DISPATCHER_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/bash-hook-dispatcher.js';
 const WRITE_VALIDATOR_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/pre-write-guardian-validate.js';
+const GATEGUARD_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/gateguard-fact-force.js';
 
 function test(name, fn) {
   try {
@@ -701,6 +711,86 @@ function runTests() {
     assert.strictEqual(operation.hookEvent, PRE_TOOL_USE_EVENT);
     assert.strictEqual(operation.hookMatcher, 'Edit');
     assert.strictEqual(operation.hookScriptPath, resolveWriteValidatorHookScriptDestination(targetRoot));
+  })) passed++; else failed++;
+
+  console.log('\n--- PreToolUse GateGuard fact-force hook (Edit / Write / MultiEdit) ---\n');
+
+  if (test('addGateGuardHook adds PreToolUse hook with Edit matcher', () => {
+    const result = addGateGuardHook({}, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit');
+    assert.strictEqual(result.changed, true);
+    assert.ok(hasGateGuardHook(result.settings, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit'));
+    const group = result.settings.hooks[PRE_TOOL_USE_EVENT][0];
+    assert.strictEqual(group.matcher, 'Edit');
+  })) passed++; else failed++;
+
+  if (test('same script can be registered for Edit, Write, and MultiEdit as separate groups', () => {
+    let s = {};
+    s = addGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit').settings;
+    s = addGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Write').settings;
+    s = addGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'MultiEdit').settings;
+
+    assert.strictEqual(s.hooks[PRE_TOOL_USE_EVENT].length, 3);
+    assert.ok(hasGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit'));
+    assert.ok(hasGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Write'));
+    assert.ok(hasGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'MultiEdit'));
+  })) passed++; else failed++;
+
+  if (test('addGateGuardHook is idempotent per matcher', () => {
+    let s = addGateGuardHook({}, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit').settings;
+    const result = addGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit');
+    assert.strictEqual(result.changed, false);
+    assert.strictEqual(result.settings.hooks[PRE_TOOL_USE_EVENT].length, 1);
+  })) passed++; else failed++;
+
+  if (test('GateGuard hook coexists with write validator and Bash dispatcher under PreToolUse', () => {
+    let s = addBashDispatcherHook({}, BASH_DISPATCHER_HOOK_SCRIPT_PATH).settings;
+    s = addWriteValidatorHook(s, WRITE_VALIDATOR_HOOK_SCRIPT_PATH, 'Edit').settings;
+    s = addGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit').settings;
+
+    assert.strictEqual(s.hooks[PRE_TOOL_USE_EVENT].length, 3);
+    assert.ok(hasBashDispatcherHook(s, BASH_DISPATCHER_HOOK_SCRIPT_PATH));
+    assert.ok(hasWriteValidatorHook(s, WRITE_VALIDATOR_HOOK_SCRIPT_PATH, 'Edit'));
+    assert.ok(hasGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit'));
+  })) passed++; else failed++;
+
+  if (test('removeGateGuardHook strips all GateGuard groups for that script without touching the write validator', () => {
+    let s = addWriteValidatorHook({}, WRITE_VALIDATOR_HOOK_SCRIPT_PATH, 'Edit').settings;
+    s = addGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit').settings;
+    s = addGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH, 'Write').settings;
+    const result = removeGateGuardHook(s, GATEGUARD_HOOK_SCRIPT_PATH);
+    assert.strictEqual(result.changed, true);
+    assert.ok(!hasGateGuardHook(result.settings, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit'));
+    assert.ok(!hasGateGuardHook(result.settings, GATEGUARD_HOOK_SCRIPT_PATH, 'Write'));
+    assert.ok(hasWriteValidatorHook(result.settings, WRITE_VALIDATOR_HOOK_SCRIPT_PATH, 'Edit'));
+  })) passed++; else failed++;
+
+  if (test('applyGateGuardHookToFile and inspectGateGuardHookFile work end-to-end', () => {
+    const homeDir = createTempDir('claude-gateguard-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      assert.strictEqual(inspectGateGuardHookFile(settingsPath, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit'), 'drifted');
+      applyGateGuardHookToFile(settingsPath, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit');
+      assert.strictEqual(inspectGateGuardHookFile(settingsPath, GATEGUARD_HOOK_SCRIPT_PATH, 'Edit'), 'ok');
+      applyGateGuardHookToFile(settingsPath, GATEGUARD_HOOK_SCRIPT_PATH, 'Write');
+      applyGateGuardHookToFile(settingsPath, GATEGUARD_HOOK_SCRIPT_PATH, 'MultiEdit');
+      const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      assert.strictEqual(data.hooks[PRE_TOOL_USE_EVENT].length, 3);
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('createPreToolUseGateGuardHookMergeOperation builds a managed operation per matcher', () => {
+    const targetRoot = path.join('/home/user', '.claude');
+    const operation = createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Edit');
+
+    assert.strictEqual(operation.kind, HOOK_OPERATION_KIND);
+    assert.strictEqual(operation.moduleId, GATEGUARD_HOOK_MODULE_ID);
+    assert.strictEqual(operation.sourceRelativePath, GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH);
+    assert.strictEqual(operation.destinationPath, resolveSettingsPath(targetRoot));
+    assert.strictEqual(operation.hookEvent, PRE_TOOL_USE_EVENT);
+    assert.strictEqual(operation.hookMatcher, 'Edit');
+    assert.strictEqual(operation.hookScriptPath, resolveGateGuardHookScriptDestination(targetRoot));
   })) passed++; else failed++;
 
   console.log('\n--- Stale entry migration (hook script relocation) ---\n');

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -636,6 +636,45 @@ function runTests() {
     assert.ok(mergeOperation.hookCommand.includes(hookScriptPath));
   })) passed++; else failed++;
 
+  if (test('claude adapter registers the GateGuard fact-force hook on Edit/Write/MultiEdit, not just Bash', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'claude',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+    const gateGuardScriptPath = path.join(
+      homeDir, '.claude', 'scripts', 'hooks', 'gateguard-fact-force.js'
+    );
+
+    const gateGuardOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.hookScriptPath === gateGuardScriptPath
+    ));
+
+    const matchers = gateGuardOperations.map(operation => operation.hookMatcher).sort();
+    assert.deepStrictEqual(
+      matchers,
+      ['Edit', 'MultiEdit', 'Write'],
+      'GateGuard should be registered on Edit, Write, and MultiEdit (Bash already gets it via the dispatcher)'
+    );
+
+    const writeValidatorScriptPath = path.join(
+      homeDir, '.claude', 'scripts', 'hooks', 'pre-write-guardian-validate.js'
+    );
+    const stillHasWriteValidator = plan.operations.some(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.hookScriptPath === writeValidatorScriptPath
+      && operation.hookMatcher === 'Edit'
+    ));
+    assert.ok(stillHasWriteValidator, 'GateGuard should be additive, not a replacement for the protected-path write validator');
+  })) passed++; else failed++;
+
   if (test('resolves codex adapter root to ~/.agents and install-state path', () => {
     const adapter = getInstallTargetAdapter('codex');
     const homeDir = '/Users/example';

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -404,7 +404,7 @@ function runTests() {
       assert.strictEqual(settings.model, 'opus');
 
       const preToolUseGroups = settings.hooks.PreToolUse;
-      assert.strictEqual(preToolUseGroups.length, 5, 'Reinstall must not duplicate PreToolUse hooks');
+      assert.strictEqual(preToolUseGroups.length, 8, 'Reinstall must not duplicate PreToolUse hooks');
       assert.strictEqual(preToolUseGroups[0].hooks[0].command, 'echo guard');
       assert.ok(
         preToolUseGroups[1].hooks[0].command.includes('bash-hook-dispatcher.js'),
@@ -417,6 +417,13 @@ function runTests() {
       assert.strictEqual(preToolUseGroups[2].matcher, 'Edit');
       assert.strictEqual(preToolUseGroups[3].matcher, 'Write');
       assert.strictEqual(preToolUseGroups[4].matcher, 'MultiEdit');
+      assert.ok(
+        preToolUseGroups[5].hooks[0].command.includes('gateguard-fact-force.js'),
+        'EGC GateGuard fact-forcing gate should be registered for Edit'
+      );
+      assert.strictEqual(preToolUseGroups[5].matcher, 'Edit');
+      assert.strictEqual(preToolUseGroups[6].matcher, 'Write');
+      assert.strictEqual(preToolUseGroups[7].matcher, 'MultiEdit');
 
       const sessionStartGroups = settings.hooks.SessionStart;
       assert.strictEqual(sessionStartGroups.length, 2, 'Reinstall must not duplicate the EGC hook');


### PR DESCRIPTION
## Summary

Follow-up to issue #647. Investigation for that issue found that Claude Code's Edit/Write/MultiEdit PreToolUse hook only ran the protected-path validator (`pre-write-guardian-validate.js`), never `gateguard-fact-force.js` (the fact-forcing investigation gate). Bash already had it, via `bash-hook-dispatcher.js`. Gemini CLI already had full Edit/Write/MultiEdit/Bash coverage via `hooks/hooks.json`. This closes the gap for Claude Code's `egc init` home install.

- `scripts/lib/claude-settings-hooks.js`: adds a `GateGuard` hook-entry API (constants, add/has/remove/apply/inspect helpers, `createPreToolUseGateGuardHookMergeOperation`), mirroring the existing `WriteValidator`/`BashDispatcher` pattern in the same file.
- `scripts/lib/install-targets/claude-home.js`: registers the new GateGuard merge operation on `Edit`, `Write`, and `MultiEdit`, additive to (not replacing) the existing write validator entry.
- `scripts/hooks/gateguard-fact-force.js`: adds a `require.main === module` stdin/stdout entrypoint so Claude Code can invoke it directly (`node <script>.js`), the same way it already invokes `pre-write-guardian-validate.js`. This only activates on direct invocation — the existing `require()`-based callers (`bash-hook-dispatcher.js`, and `run-with-flags.js` used by Gemini's `hooks/hooks.json`) are unaffected, since they call `run()` in-process and never hit this branch.
- The underlying script was already copied to `~/.claude/scripts/hooks/gateguard-fact-force.js` by the existing `hooks-runtime` module (`manifests/install-modules.json`), so no new file-copy operation was needed — only the settings.json wiring.

## Test plan

- [x] `node tests/lib/claude-settings-hooks.test.js` — 57/57 passed (new GateGuard block: add/remove/apply/inspect/idempotency/coexistence with write validator and bash dispatcher)
- [x] `node tests/lib/install-targets.test.js` — 57/57 passed (new test asserts GateGuard registers on Edit/Write/MultiEdit and the write validator is still present, i.e. additive not replacement)
- [x] `node tests/hooks/gateguard-fact-force.test.js` — new direct-invocation tests pass (deny-first-Edit, allow-second-Edit-after-check, pass-through-for-non-gated-tools)
- [x] `node tests/scripts/install-apply.test.js` — updated the reinstall-idempotency test's expected `PreToolUse` group count (5 → 8) and added assertions for the 3 new GateGuard groups
- [x] Full suite: `node tests/run-all.js` — 2518/2518 passed with a clean environment (`env -u EGC_DISABLED_HOOKS -u EGC_HOOK_PROFILE`). Without unsetting those two vars, 25 pre-existing tests fail identically on `main` before this change too — confirmed via `git stash` comparison, unrelated to this diff.

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the GateGuard fact-forcing gate into Claude Code’s PreToolUse for Edit/Write/MultiEdit and added a direct CLI entrypoint for the hook to match Bash/Gemini coverage. Keeps the existing write validator and adds GateGuard as an additional check.

- **Bug Fixes**
  - Register `scripts/hooks/gateguard-fact-force.js` on `Edit`, `Write`, and `MultiEdit` in Claude home settings, additive to `pre-write-guardian-validate.js`.
  - Add a `require.main` stdin/stdout entrypoint to `gateguard-fact-force.js` so Claude Code can invoke it directly; `bash-hook-dispatcher.js` and `run-with-flags.js` remain unchanged.
  - Expose GateGuard hook merge helpers in `claude-settings-hooks.js`, wire them in `install-targets/claude-home.js`, add targeted tests, and update reinstall expectations (PreToolUse groups from 5 to 8).

<sup>Written for commit 6478873ec22a27dcd78c4fcee3f2470d5d39b39b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GateGuard fact-forcing protections for Claude Code’s `Edit`, `Write`, and `MultiEdit` actions.
  * Added standalone execution support for the GateGuard hook, including appropriate output and exit-code handling.
  * GateGuard hook installation, inspection, removal, and reinstallation now integrate with existing settings while preserving other hooks.

* **Bug Fixes**
  * Ensured repeated installations remain idempotent and preserve existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->