### PR TITLE
fix(hooks): wire GateGuard fact-forcing gate onto Cursor Write/Shell

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -15,6 +15,13 @@
         "description": "Persist session state and evaluate patterns"
       }
     ],
+    "preToolUse": [
+      {
+        "command": "node .cursor/hooks/before-tool-use.js",
+        "event": "preToolUse",
+        "description": "GateGuard Fact-Forcing Gate: require investigation before Write/Shell tool calls"
+      }
+    ],
     "beforeFileEdit": [
       {
         "command": "EGC_HOOK_EVENT=pre_tool node .cursor/hooks/dashboard-emit.js",

--- a/.cursor/hooks/adapter.js
+++ b/.cursor/hooks/adapter.js
@@ -78,4 +78,89 @@ function hookEnabled(hookId, allowedProfiles = ['standard', 'strict']) {
   return allowedProfiles.includes(profile);
 }
 
-module.exports = { readStdin, getPluginRoot, transformToClaude, runExistingHook, hookEnabled };
+// --- GateGuard fact-forcing gate translation ---
+//
+// gateguard-fact-force.js already speaks a Claude-Code-shaped dialect on its
+// two existing call paths (bash-hook-dispatcher.js, and Gemini's
+// run-with-flags.js): tool_name/tool_input in, and a deny signalled by an
+// exit-0 stdout JSON blob (hookSpecificOutput.permissionDecision). Cursor's
+// preToolUse hook uses the same tool_name/tool_input shape on input, but a
+// different shape on output: a top-level `permission` field
+// (allow/deny/ask) plus user_message/agent_message. These two functions are
+// the translation layer between the two contracts. The hook IDs below match
+// the literals gateguard-fact-force.js already embeds in its own
+// recovery-hint text (the EGC_DISABLED_HOOKS targets), so disabling the gate
+// via that env var works the same way across Claude Code, Gemini, and Cursor.
+const GATEGUARD_EDIT_WRITE_HOOK_ID = 'pre:edit-write:gateguard-fact-force';
+const GATEGUARD_BASH_HOOK_ID = 'pre:bash:gateguard-fact-force';
+
+/**
+ * Cursor's agent reports shell execution as tool_name "Shell", not "Bash".
+ * gateguard-fact-force.js only recognizes "Bash" (case-insensitively), so
+ * that one name needs remapping; every other tool_name passes through as-is
+ * (Cursor's file-write tool is already named "Write", which matches).
+ */
+function normalizeCursorToolName(rawToolName) {
+  const value = String(rawToolName || '');
+  return value.toLowerCase() === 'shell' ? 'Bash' : value;
+}
+
+/**
+ * Builds the Claude-shaped payload gateguard-fact-force.js's run() expects
+ * out of a raw Cursor preToolUse stdin payload.
+ */
+function buildGateGuardInput(cursorInput) {
+  const toolInput = (cursorInput && cursorInput.tool_input) || {};
+  const filePath = toolInput.file_path || toolInput.path || toolInput.filePath || '';
+  const payload = {
+    tool_name: normalizeCursorToolName(cursorInput && cursorInput.tool_name),
+    tool_input: {
+      command: toolInput.command || '',
+      file_path: filePath,
+    },
+    session_id: (cursorInput && cursorInput.conversation_id) || (cursorInput && cursorInput.session_id) || '',
+    transcript_path: (cursorInput && cursorInput.transcript_path) || '',
+  };
+  if (Array.isArray(toolInput.edits)) {
+    payload.tool_input.edits = toolInput.edits;
+  }
+  return payload;
+}
+
+/**
+ * Translates gateguard-fact-force.js's run() return value into Cursor's
+ * preToolUse output contract. run() returns one of:
+ *   - the original payload object (allow, pass-through)
+ *   - { stdout: '<json>', exitCode: 0 } where the JSON carries a deny decision
+ *   - { stderr: '<warning>', exitCode: 0 } when gate state could not persist
+ *     (fails open so a broken state dir never becomes a permanent block)
+ */
+function translateGateGuardResult(result) {
+  if (result && typeof result === 'object' && typeof result.stdout === 'string') {
+    try {
+      const parsed = JSON.parse(result.stdout);
+      const decision = parsed && parsed.hookSpecificOutput && parsed.hookSpecificOutput.permissionDecision;
+      if (decision === 'deny') {
+        const reason = parsed.hookSpecificOutput.permissionDecisionReason || '';
+        return { permission: 'deny', user_message: reason, agent_message: reason };
+      }
+    } catch (_) {
+      // Malformed JSON from the gate: fail open rather than block on our own bug.
+    }
+  }
+
+  return { permission: 'allow' };
+}
+
+module.exports = {
+  readStdin,
+  getPluginRoot,
+  transformToClaude,
+  runExistingHook,
+  hookEnabled,
+  GATEGUARD_EDIT_WRITE_HOOK_ID,
+  GATEGUARD_BASH_HOOK_ID,
+  normalizeCursorToolName,
+  buildGateGuardInput,
+  translateGateGuardResult,
+};

--- a/.cursor/hooks/before-tool-use.js
+++ b/.cursor/hooks/before-tool-use.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * preToolUse hook: routes Cursor's Write/Shell tool calls through the
+ * shared GateGuard fact-forcing gate (scripts/hooks/gateguard-fact-force.js),
+ * the same investigation gate Claude Code and Gemini CLI already enforce.
+ *
+ * Cursor's preToolUse input already matches gateguard-fact-force.js's
+ * expected shape (tool_name/tool_input over stdin), so this file's only job
+ * is calling the shared gate in-process (mirroring how bash-hook-dispatcher.js
+ * and Gemini's run-with-flags.js already require() and call run() directly,
+ * rather than re-implementing the gate logic here) and translating its
+ * Claude-shaped deny response into Cursor's `permission` output contract.
+ * See adapter.js for the translation helpers and why they're needed.
+ */
+const path = require('path');
+const {
+  readStdin,
+  hookEnabled,
+  GATEGUARD_EDIT_WRITE_HOOK_ID,
+  GATEGUARD_BASH_HOOK_ID,
+  buildGateGuardInput,
+  translateGateGuardResult,
+} = require('./adapter');
+
+const ALLOW = { permission: 'allow' };
+
+function allowAndExit() {
+  process.stdout.write(JSON.stringify(ALLOW));
+  process.exit(0);
+}
+
+readStdin()
+  .then(raw => {
+    let cursorInput;
+    try {
+      cursorInput = JSON.parse(raw || '{}');
+    } catch (_) {
+      return allowAndExit();
+    }
+
+    const gateInput = buildGateGuardInput(cursorInput);
+    const isBash = gateInput.tool_name === 'Bash';
+    const isEditWrite = gateInput.tool_name === 'Edit' || gateInput.tool_name === 'Write' || gateInput.tool_name === 'MultiEdit';
+
+    if (!isBash && !isEditWrite) {
+      return allowAndExit();
+    }
+
+    const hookId = isBash ? GATEGUARD_BASH_HOOK_ID : GATEGUARD_EDIT_WRITE_HOOK_ID;
+    if (!hookEnabled(hookId, ['standard', 'strict'])) {
+      return allowAndExit();
+    }
+
+    let result;
+    try {
+      const gateGuard = require(path.join(__dirname, '..', '..', 'scripts', 'hooks', 'gateguard-fact-force.js'));
+      result = gateGuard.run(gateInput);
+    } catch (_) {
+      return allowAndExit();
+    }
+
+    process.stdout.write(JSON.stringify(translateGateGuardResult(result)));
+    process.exit(0);
+  })
+  .catch(() => allowAndExit());

--- a/tests/hooks/cursor-gateguard.test.js
+++ b/tests/hooks/cursor-gateguard.test.js
@@ -1,0 +1,266 @@
+/**
+ * Tests for the Cursor preToolUse GateGuard translation layer:
+ *   - .cursor/hooks/adapter.js (normalizeCursorToolName, buildGateGuardInput,
+ *     translateGateGuardResult)
+ *   - .cursor/hooks/before-tool-use.js (the preToolUse entrypoint that wires
+ *     those helpers to scripts/hooks/gateguard-fact-force.js)
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapter = require('../../.cursor/hooks/adapter');
+const hookScript = path.join(__dirname, '..', '..', '.cursor', 'hooks', 'before-tool-use.js');
+
+const tmpRoot = process.env.TMPDIR || process.env.TEMP || process.env.TMP || '/tmp';
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function makeStateDir() {
+  return fs.mkdtempSync(path.join(tmpRoot, 'cursor-gateguard-test-'));
+}
+
+function runHook(input, env = {}) {
+  const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
+  const result = spawnSync('node', [hookScript], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function parseOutput(stdout) {
+  try {
+    return JSON.parse(stdout);
+  } catch (_) {
+    return null;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing Cursor GateGuard translation ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  // --- Unit tests: adapter.js translation helpers ---
+
+  if (test('normalizeCursorToolName maps Shell to Bash', () => {
+    assert.strictEqual(adapter.normalizeCursorToolName('Shell'), 'Bash');
+    assert.strictEqual(adapter.normalizeCursorToolName('shell'), 'Bash');
+  })) passed++; else failed++;
+
+  if (test('normalizeCursorToolName leaves other tool names unchanged', () => {
+    assert.strictEqual(adapter.normalizeCursorToolName('Write'), 'Write');
+    assert.strictEqual(adapter.normalizeCursorToolName('Read'), 'Read');
+    assert.strictEqual(adapter.normalizeCursorToolName(''), '');
+    assert.strictEqual(adapter.normalizeCursorToolName(undefined), '');
+  })) passed++; else failed++;
+
+  if (test('buildGateGuardInput maps tool_name, file_path, command, session and transcript', () => {
+    const cursorInput = {
+      tool_name: 'Shell',
+      tool_input: { command: 'npm test', working_directory: '/project' },
+      conversation_id: 'conv-123',
+      transcript_path: '/tmp/transcript.jsonl',
+    };
+    const built = adapter.buildGateGuardInput(cursorInput);
+    assert.strictEqual(built.tool_name, 'Bash', 'Shell should normalize to Bash');
+    assert.strictEqual(built.tool_input.command, 'npm test');
+    assert.strictEqual(built.session_id, 'conv-123');
+    assert.strictEqual(built.transcript_path, '/tmp/transcript.jsonl');
+  })) passed++; else failed++;
+
+  if (test('buildGateGuardInput falls back across path/filePath for file_path', () => {
+    const viaPath = adapter.buildGateGuardInput({ tool_name: 'Write', tool_input: { path: '/src/a.js' } });
+    assert.strictEqual(viaPath.tool_input.file_path, '/src/a.js');
+
+    const viaFilePath = adapter.buildGateGuardInput({ tool_name: 'Write', tool_input: { filePath: '/src/b.js' } });
+    assert.strictEqual(viaFilePath.tool_input.file_path, '/src/b.js');
+
+    const viaSnakeCase = adapter.buildGateGuardInput({ tool_name: 'Write', tool_input: { file_path: '/src/c.js' } });
+    assert.strictEqual(viaSnakeCase.tool_input.file_path, '/src/c.js');
+  })) passed++; else failed++;
+
+  if (test('buildGateGuardInput handles missing tool_input without throwing', () => {
+    const built = adapter.buildGateGuardInput({ tool_name: 'Write' });
+    assert.strictEqual(built.tool_input.file_path, '');
+    assert.strictEqual(built.tool_input.command, '');
+  })) passed++; else failed++;
+
+  if (test('translateGateGuardResult passes through an allow (pass-through) result', () => {
+    const passthroughInput = { tool_name: 'Read', tool_input: {} };
+    assert.deepStrictEqual(adapter.translateGateGuardResult(passthroughInput), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('translateGateGuardResult converts a Claude-shaped deny into Cursor permission:deny', () => {
+    const denyResult = {
+      stdout: JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: '[Fact-Forcing Gate]\n\nsome reason',
+        },
+      }),
+      exitCode: 0,
+    };
+    const translated = adapter.translateGateGuardResult(denyResult);
+    assert.strictEqual(translated.permission, 'deny');
+    assert.strictEqual(translated.user_message, '[Fact-Forcing Gate]\n\nsome reason');
+    assert.strictEqual(translated.agent_message, '[Fact-Forcing Gate]\n\nsome reason');
+  })) passed++; else failed++;
+
+  if (test('translateGateGuardResult fails open on malformed deny-shaped stdout', () => {
+    const malformed = { stdout: '{ not valid json', exitCode: 0 };
+    assert.deepStrictEqual(adapter.translateGateGuardResult(malformed), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('translateGateGuardResult fails open on a state-persistence warning (stderr-only result)', () => {
+    const stateError = { stderr: '[Fact-Forcing Gate] GateGuard state could not be persisted', exitCode: 0 };
+    assert.deepStrictEqual(adapter.translateGateGuardResult(stateError), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  // --- Integration tests: full before-tool-use.js process ---
+
+  let stateDir = makeStateDir();
+  if (test('direct invocation denies the first Write and produces Cursor deny JSON', () => {
+    const input = {
+      tool_name: 'Write',
+      tool_input: { file_path: '/src/cursor-write-a.js' },
+      conversation_id: 'session-a',
+    };
+    const result = runHook(input, { GATEGUARD_STATE_DIR: stateDir, EGC_SESSION_ID: 'session-a' });
+    assert.strictEqual(result.code, 0, 'exit code should be 0 (Cursor reads permission from JSON, not exit code)');
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.permission, 'deny');
+    assert.ok(output.user_message.includes('Fact-Forcing Gate'));
+    assert.ok(output.user_message.includes('/src/cursor-write-a.js'));
+    assert.ok(output.agent_message.includes('Fact-Forcing Gate'));
+  })) passed++; else failed++;
+
+  if (test('direct invocation allows the retried Write on the same file', () => {
+    const input = {
+      tool_name: 'Write',
+      tool_input: { file_path: '/src/cursor-write-a.js' },
+      conversation_id: 'session-a',
+    };
+    const result = runHook(input, { GATEGUARD_STATE_DIR: stateDir, EGC_SESSION_ID: 'session-a' });
+    assert.strictEqual(result.code, 0);
+    const output = parseOutput(result.stdout);
+    assert.deepStrictEqual(output, { permission: 'allow' });
+  })) passed++; else failed++;
+
+  stateDir = makeStateDir();
+  if (test('direct invocation maps Shell tool_name to the Bash gate and denies the first routine command', () => {
+    const input = {
+      tool_name: 'Shell',
+      tool_input: { command: 'npm test', working_directory: '/project' },
+      conversation_id: 'session-b',
+    };
+    const result = runHook(input, { GATEGUARD_STATE_DIR: stateDir, EGC_SESSION_ID: 'session-b' });
+    assert.strictEqual(result.code, 0);
+    const output = parseOutput(result.stdout);
+    assert.strictEqual(output.permission, 'deny');
+    assert.ok(output.user_message.includes('current user request'));
+  })) passed++; else failed++;
+
+  if (test('direct invocation allows a retried Shell command in the same session', () => {
+    const input = {
+      tool_name: 'Shell',
+      tool_input: { command: 'npm test', working_directory: '/project' },
+      conversation_id: 'session-b',
+    };
+    const result = runHook(input, { GATEGUARD_STATE_DIR: stateDir, EGC_SESSION_ID: 'session-b' });
+    assert.deepStrictEqual(parseOutput(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  stateDir = makeStateDir();
+  if (test('direct invocation denies a destructive Shell command with the destructive gate message', () => {
+    const input = {
+      tool_name: 'Shell',
+      tool_input: { command: 'rm -rf /tmp/cursor-demo' },
+      conversation_id: 'session-c',
+    };
+    const result = runHook(input, { GATEGUARD_STATE_DIR: stateDir, EGC_SESSION_ID: 'session-c' });
+    const output = parseOutput(result.stdout);
+    assert.strictEqual(output.permission, 'deny');
+    assert.ok(output.user_message.includes('Destructive command detected'));
+    assert.ok(output.user_message.includes('rollback'));
+  })) passed++; else failed++;
+
+  stateDir = makeStateDir();
+  if (test('direct invocation passes through tool names GateGuard does not gate (e.g. Read)', () => {
+    const input = { tool_name: 'Read', tool_input: { file_path: '/src/cursor-write-a.js' }, conversation_id: 'session-d' };
+    const result = runHook(input, { GATEGUARD_STATE_DIR: stateDir, EGC_SESSION_ID: 'session-d' });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(parseOutput(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  stateDir = makeStateDir();
+  if (test('direct invocation allows malformed stdin JSON instead of crashing', () => {
+    const result = runHook('{ not valid json', { GATEGUARD_STATE_DIR: stateDir, EGC_SESSION_ID: 'session-e' });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(parseOutput(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  stateDir = makeStateDir();
+  if (test('direct invocation respects EGC_DISABLED_HOOKS for the edit/write gate id', () => {
+    const input = { tool_name: 'Write', tool_input: { file_path: '/src/cursor-disabled.js' }, conversation_id: 'session-f' };
+    const result = runHook(input, {
+      GATEGUARD_STATE_DIR: stateDir,
+      EGC_SESSION_ID: 'session-f',
+      EGC_DISABLED_HOOKS: 'pre:edit-write:gateguard-fact-force',
+    });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(parseOutput(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  stateDir = makeStateDir();
+  if (test('direct invocation respects EGC_HOOK_PROFILE=minimal (gate not in minimal profile)', () => {
+    const input = { tool_name: 'Write', tool_input: { file_path: '/src/cursor-minimal.js' }, conversation_id: 'session-g' };
+    const result = runHook(input, {
+      GATEGUARD_STATE_DIR: stateDir,
+      EGC_SESSION_ID: 'session-g',
+      EGC_HOOK_PROFILE: 'minimal',
+    });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(parseOutput(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  stateDir = makeStateDir();
+  if (test('direct invocation respects EGC_GATEGUARD=off end to end', () => {
+    const input = { tool_name: 'Write', tool_input: { file_path: '/src/cursor-off.js' }, conversation_id: 'session-h' };
+    const result = runHook(input, {
+      GATEGUARD_STATE_DIR: stateDir,
+      EGC_SESSION_ID: 'session-h',
+      EGC_GATEGUARD: 'off',
+    });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(parseOutput(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

Follow-up to issue #647 and PR #710. PR #710 wired the GateGuard fact-forcing gate (`scripts/hooks/gateguard-fact-force.js`) onto Claude Code's Edit/Write/MultiEdit, and confirmed Gemini CLI already had full coverage via `~/.gemini/hooks/hooks.json`. This closes the remaining gap for Cursor.

Investigation for #647 found that Cursor already had a real hook adapter (`.cursor/hooks.json` + `.cursor/hooks/adapter.js`) delegating to the same `scripts/hooks/*.js` scripts Claude Code and Gemini use, but the fact-forcing gate specifically was never wired in: `gateguard-fact-force.js`'s exit-0 + stdout-JSON deny format did not match any event Cursor's adapter forwarded through (`beforeShellExecution` only forwards a blocking exit code 2, and no event existed at all for pre-edit blocking).

Checked against Cursor's own hooks documentation: the correct blocking mechanism for tool calls (including file writes) is the `preToolUse` hook. It receives the same `tool_name`/`tool_input` shape `gateguard-fact-force.js` already expects, but signals its decision through a different contract: a top-level `permission` field (`allow`/`deny`/`ask`) plus `user_message`/`agent_message`, instead of Claude Code's `hookSpecificOutput.permissionDecision` wrapper. One field also differs on the input side: Cursor reports shell execution as `tool_name: "Shell"`, not `"Bash"`.

- `.cursor/hooks/adapter.js`: adds `normalizeCursorToolName`, `buildGateGuardInput`, and `translateGateGuardResult`, the translation layer between the two contracts.
- `.cursor/hooks/before-tool-use.js`: new `preToolUse` entrypoint that requires `gateguard-fact-force.js` and calls `run()` in-process, the same pattern `bash-hook-dispatcher.js` and Gemini's `run-with-flags.js` already use, rather than re-implementing the gate.
- `.cursor/hooks.json`: registers the new `preToolUse` hook.
- No install-target manifest changes were needed: `hooks-runtime` already installs `scripts/hooks` alongside `.cursor` for the `cursor` target (`manifests/install-modules.json`), so `gateguard-fact-force.js` is already present at the path this hook requires it from once installed.

## Test plan

- [x] `tests/hooks/cursor-gateguard.test.js` (new): unit coverage for the three translation helpers, plus integration coverage of the full `before-tool-use.js` process — first-Write deny with correct Cursor JSON shape, retry-allow, `Shell` mapped onto the Bash gate, destructive-Bash gate message, malformed stdin, and the `EGC_DISABLED_HOOKS` / `EGC_HOOK_PROFILE=minimal` / `EGC_GATEGUARD=off` recovery paths.
- [x] Manual smoke test of `.cursor/hooks/before-tool-use.js` piping real Cursor-shaped `preToolUse` payloads for `Write` and `Shell` tool calls, confirming deny-then-allow-on-retry end to end.
- [x] `node tests/run-all.js`: 2537/2537 passed (2518 pre-existing + 19 new), run with `env -u EGC_DISABLED_HOOKS -u EGC_HOOK_PROFILE` for a clean environment.

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the GateGuard fact-forcing gate for Cursor `Write` and `Shell` tool calls via a new `preToolUse` hook. This closes the remaining enforcement gap and aligns Cursor with Claude Code and Gemini.

- **Bug Fixes**
  - Registered `preToolUse` in `.cursor/hooks.json` and routed calls to `scripts/hooks/gateguard-fact-force.js` in-process.
  - Added translation in `.cursor/hooks/adapter.js`: normalize `Shell`→`Bash`, build GateGuard input, and map deny to `{ permission: 'deny', user_message, agent_message }`.
  - Honored `EGC_DISABLED_HOOKS`, `EGC_HOOK_PROFILE`, and `EGC_GATEGUARD` flags; non-gated tools pass through cleanly.
  - Added `tests/hooks/cursor-gateguard.test.js` for helper unit tests and end-to-end deny-then-allow, destructive command messaging, and malformed input recovery.
  - No manifest changes needed; `scripts/hooks` is already installed for the `cursor` target.

<sup>Written for commit 392e6542ffc3ea82d3652d5a5fdec8f729246bc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

