### PR TITLE
fix(hooks): wire GateGuard fact-forcing gate onto Copilot, CodeBuddy, and Antigravity

### DIFF
--- a/scripts/lib/antigravity-settings-hooks.js
+++ b/scripts/lib/antigravity-settings-hooks.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// Wires the GateGuard fact-forcing gate into Antigravity's own hooks.json.
+// Antigravity (Google's agentic IDE, built on the Gemini CLI agent loop and
+// sharing its GEMINI_PROJECT_DIR / GEMINI_PLUGIN_ROOT environment variables)
+// documents two hooks.json locations distinct from Gemini CLI's own
+// ~/.gemini/hooks/hooks.json:
+//   - Project: <project_root>/.agents/hooks.json
+//   - Global:  ~/.gemini/antigravity-cli/hooks.json
+// (see "A Developer's Guide to Agent Hooks in Antigravity CLI", Google Cloud
+// Community / Medium, June 2026 -- the primary antigravity.google/docs/hooks
+// page is a client-rendered SPA this toolchain cannot execute, so this
+// community guide plus Google's own search index snippet of that page are
+// the best available evidence). Both locations use the same
+// {"hooks": {"PreToolUse": [{"matcher", "hooks"}]}} shape already confirmed
+// working in this repo's own hooks/hooks.json (which Gemini CLI reads
+// successfully today), so the generic Claude merge helpers apply unchanged;
+// this module only supplies Antigravity's two file locations.
+
+const path = require('path');
+
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  HOOK_OPERATION_KIND,
+  PRE_TOOL_USE_EVENT,
+  resolveGateGuardHookScriptDestination,
+} = require('./claude-settings-hooks');
+
+function resolveAntigravityProjectHooksFilePath(projectRoot) {
+  return path.join(projectRoot, '.agents', 'hooks.json');
+}
+
+function resolveAntigravityGlobalHooksFilePath(homeDir) {
+  return path.join(homeDir, '.gemini', 'antigravity-cli', 'hooks.json');
+}
+
+function buildGateGuardMergeOperation(destinationPath, hookScriptPath, matcher) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: GATEGUARD_HOOK_MODULE_ID,
+    sourceRelativePath: GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: matcher,
+    hookScriptPath,
+  };
+}
+
+function createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, matcher) {
+  return buildGateGuardMergeOperation(
+    resolveAntigravityProjectHooksFilePath(projectRoot),
+    resolveGateGuardHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
+function createGlobalGateGuardHookMergeOperation(targetRoot, homeDir, matcher) {
+  return buildGateGuardMergeOperation(
+    resolveAntigravityGlobalHooksFilePath(homeDir),
+    resolveGateGuardHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
+module.exports = {
+  createGlobalGateGuardHookMergeOperation,
+  createProjectGateGuardHookMergeOperation,
+  resolveAntigravityGlobalHooksFilePath,
+  resolveAntigravityProjectHooksFilePath,
+};

--- a/scripts/lib/antigravity-settings-hooks.js
+++ b/scripts/lib/antigravity-settings-hooks.js
@@ -17,13 +17,10 @@
 // successfully today), so the generic Claude merge helpers apply unchanged;
 // this module only supplies Antigravity's two file locations.
 
-const path = require('path');
+const path = require('node:path');
 
 const {
-  GATEGUARD_HOOK_MODULE_ID,
-  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-  HOOK_OPERATION_KIND,
-  PRE_TOOL_USE_EVENT,
+  createGateGuardHookMergeOperationForDestination,
   resolveGateGuardHookScriptDestination,
 } = require('./claude-settings-hooks');
 
@@ -35,23 +32,8 @@ function resolveAntigravityGlobalHooksFilePath(homeDir) {
   return path.join(homeDir, '.gemini', 'antigravity-cli', 'hooks.json');
 }
 
-function buildGateGuardMergeOperation(destinationPath, hookScriptPath, matcher) {
-  return {
-    kind: HOOK_OPERATION_KIND,
-    moduleId: GATEGUARD_HOOK_MODULE_ID,
-    sourceRelativePath: GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-    destinationPath,
-    strategy: HOOK_OPERATION_KIND,
-    ownership: 'managed',
-    scaffoldOnly: false,
-    hookEvent: PRE_TOOL_USE_EVENT,
-    hookMatcher: matcher,
-    hookScriptPath,
-  };
-}
-
 function createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, matcher) {
-  return buildGateGuardMergeOperation(
+  return createGateGuardHookMergeOperationForDestination(
     resolveAntigravityProjectHooksFilePath(projectRoot),
     resolveGateGuardHookScriptDestination(targetRoot),
     matcher
@@ -59,7 +41,7 @@ function createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, match
 }
 
 function createGlobalGateGuardHookMergeOperation(targetRoot, homeDir, matcher) {
-  return buildGateGuardMergeOperation(
+  return createGateGuardHookMergeOperationForDestination(
     resolveAntigravityGlobalHooksFilePath(homeDir),
     resolveGateGuardHookScriptDestination(targetRoot),
     matcher

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -588,6 +588,26 @@ function createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher) {
   );
 }
 
+// Same merge operation shape as above, but for targets whose hooks.json
+// location cannot be derived from resolveSettingsPath(targetRoot) the way
+// Claude Code's can (e.g. Copilot's ~/.copilot/hooks/hooks.json, or
+// Antigravity's project/global split): callers resolve destinationPath
+// themselves and pass it in directly.
+function createGateGuardHookMergeOperationForDestination(destinationPath, hookScriptPath, matcher) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: GATEGUARD_HOOK_MODULE_ID,
+    sourceRelativePath: GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: matcher,
+    hookScriptPath,
+  };
+}
+
 module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -625,6 +645,7 @@ module.exports = {
   applyWriteValidatorHookToFile,
   buildSessionStartCommand,
   buildStopCommand,
+  createGateGuardHookMergeOperationForDestination,
   createPreToolUseBashDispatcherHookMergeOperation,
   createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,

--- a/scripts/lib/copilot-settings-hooks.js
+++ b/scripts/lib/copilot-settings-hooks.js
@@ -16,13 +16,10 @@
 // via the normal module path flow; this file's hooks.json merge just points
 // its "command" at that already-installed script.
 
-const path = require('path');
+const path = require('node:path');
 
 const {
-  GATEGUARD_HOOK_MODULE_ID,
-  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-  HOOK_OPERATION_KIND,
-  PRE_TOOL_USE_EVENT,
+  createGateGuardHookMergeOperationForDestination,
   resolveGateGuardHookScriptDestination,
 } = require('./claude-settings-hooks');
 
@@ -31,19 +28,11 @@ function resolveCopilotHooksFilePath(homeDir) {
 }
 
 function createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, matcher) {
-  const hookScriptPath = resolveGateGuardHookScriptDestination(targetRoot);
-  return {
-    kind: HOOK_OPERATION_KIND,
-    moduleId: GATEGUARD_HOOK_MODULE_ID,
-    sourceRelativePath: GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-    destinationPath: resolveCopilotHooksFilePath(homeDir),
-    strategy: HOOK_OPERATION_KIND,
-    ownership: 'managed',
-    scaffoldOnly: false,
-    hookEvent: PRE_TOOL_USE_EVENT,
-    hookMatcher: matcher,
-    hookScriptPath,
-  };
+  return createGateGuardHookMergeOperationForDestination(
+    resolveCopilotHooksFilePath(homeDir),
+    resolveGateGuardHookScriptDestination(targetRoot),
+    matcher
+  );
 }
 
 module.exports = {

--- a/scripts/lib/copilot-settings-hooks.js
+++ b/scripts/lib/copilot-settings-hooks.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// Wires the GateGuard fact-forcing gate into VS Code's Copilot agent hooks
+// (Preview). VS Code documents its hooks.json as the exact same shape Claude
+// Code uses -- {"hooks": {"PreToolUse": [{"matcher": ..., "hooks": [...]}]}}
+// -- and explicitly lists it as one of the formats it reads for
+// compatibility (see https://code.visualstudio.com/docs/agent-customization/hooks).
+// That means the generic, destination-path-driven merge helpers already
+// built for Claude's settings.json apply unchanged here; this module only
+// supplies the VS Code-specific file location and reuses them.
+//
+// VS Code's documented user-level hook discovery path is `~/.copilot/hooks`,
+// which is a different root than where copilot-home.js scaffolds skill
+// content (~/.github). The GateGuard script itself is still deployed under
+// the adapter's own root (~/.github/scripts/hooks/gateguard-fact-force.js)
+// via the normal module path flow; this file's hooks.json merge just points
+// its "command" at that already-installed script.
+
+const path = require('path');
+
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  HOOK_OPERATION_KIND,
+  PRE_TOOL_USE_EVENT,
+  resolveGateGuardHookScriptDestination,
+} = require('./claude-settings-hooks');
+
+function resolveCopilotHooksFilePath(homeDir) {
+  return path.join(homeDir, '.copilot', 'hooks', 'hooks.json');
+}
+
+function createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, matcher) {
+  const hookScriptPath = resolveGateGuardHookScriptDestination(targetRoot);
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: GATEGUARD_HOOK_MODULE_ID,
+    sourceRelativePath: GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: resolveCopilotHooksFilePath(homeDir),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: matcher,
+    hookScriptPath,
+  };
+}
+
+module.exports = {
+  createPreToolUseGateGuardHookMergeOperation,
+  resolveCopilotHooksFilePath,
+};

--- a/scripts/lib/install-targets/amp-home.js
+++ b/scripts/lib/install-targets/amp-home.js
@@ -3,6 +3,30 @@ const {
   createInstallTargetAdapter,
 } = require('./helpers');
 
+// GateGuard fact-forcing gate is intentionally NOT wired for Amp.
+//
+// Amp (Sourcegraph) does have a hooks system (see
+// https://ampcode.com/news/hooks, "tool:pre-execute" event with a
+// `compatibilityDate` field, matching against tool names, and actions such
+// as `send-user-message` that can cancel a tool call). But as of this
+// investigation (July 2026):
+//   - The full schema lives behind https://ampcode.com/manual?internal#hooks,
+//     which resolves to an empty section for non-Sourcegraph-internal
+//     sessions (confirmed via direct HTTP fetch: the page's own embedded
+//     state reports `userIsInternal: false` and renders no hooks content).
+//   - The public /news/hooks announcement itself carries a "Preview" badge
+//     dated May 13, 2025, still gated over a year later.
+//   - The only two action types confirmed via public search results,
+//     `send-user-message` and `redact-tool-input`, are declarative JSON
+//     actions, not a documented "run this external script and read its
+//     stdout/exit code for a permission decision" action -- the mechanism
+//     gateguard-fact-force.js's CLI entrypoint relies on for every other
+//     target wired in this repo (Claude Code, Gemini CLI, CodeBuddy, VS Code
+//     Copilot, Antigravity).
+// Wiring against an internal-only, unconfirmed schema would risk shipping a
+// hook that silently never fires. Revisit if ampcode.com/manual publishes
+// the hooks section publicly.
+
 module.exports = createInstallTargetAdapter({
   id: 'amp-home',
   target: 'amp',

--- a/scripts/lib/install-targets/amp-project.js
+++ b/scripts/lib/install-targets/amp-project.js
@@ -3,6 +3,13 @@ const {
   createInstallTargetAdapter,
 } = require('./helpers');
 
+// GateGuard fact-forcing gate is intentionally NOT wired for Amp. See the
+// matching comment in amp-home.js for the full evidence trail: Amp's hooks
+// documentation (https://ampcode.com/manual?internal#hooks) is gated to
+// Sourcegraph-internal sessions and the only publicly confirmed action types
+// are declarative (send-user-message, redact-tool-input), not a documented
+// external-script invocation gateguard-fact-force.js could hook into.
+
 module.exports = createInstallTargetAdapter({
   id: 'amp-project',
   target: 'amp',

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -7,14 +7,59 @@ const {
   createRemappedOperation,
   normalizeRelativePath,
 } = require('./helpers');
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  resolveGateGuardHookScriptDestination,
+} = require('../claude-settings-hooks');
+const {
+  createProjectGateGuardHookMergeOperation,
+} = require('../antigravity-settings-hooks');
 
 const SUPPORTED_SOURCE_PREFIXES = ['rules', 'commands', 'agents', 'skills', '.agents', 'AGENTS.md'];
+const UTILS_SOURCE_RELATIVE_PATH = 'scripts/lib/utils.js';
 
 function supportsAntigravitySourcePath(sourceRelativePath) {
   const normalizedPath = normalizeRelativePath(sourceRelativePath);
   return SUPPORTED_SOURCE_PREFIXES.some(prefix => (
     normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`)
   ));
+}
+
+function resolveUtilsScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'lib', 'utils.js');
+}
+
+// gateguard-fact-force.js requires '../lib/utils' at load time, so both
+// files are scaffolded together under this adapter's own root (.agents/)
+// before the .agents/hooks.json merge points a command at either of them.
+// 'scripts/**' is outside SUPPORTED_SOURCE_PREFIXES above (Antigravity's
+// module content is rules/commands/agents/skills, not raw scripts), so this
+// is scaffolded directly rather than through the module path filter.
+function createGateGuardOperations(adapter, targetRoot, projectRoot) {
+  const scriptOperation = createRemappedOperation(
+    adapter,
+    GATEGUARD_HOOK_MODULE_ID,
+    GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    resolveGateGuardHookScriptDestination(targetRoot),
+    { strategy: 'preserve-relative-path' }
+  );
+  const utilsOperation = createRemappedOperation(
+    adapter,
+    GATEGUARD_HOOK_MODULE_ID,
+    UTILS_SOURCE_RELATIVE_PATH,
+    resolveUtilsScriptDestination(targetRoot),
+    { strategy: 'preserve-relative-path' }
+  );
+
+  return [
+    scriptOperation,
+    utilsOperation,
+    createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, 'Edit'),
+    createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, 'Write'),
+    createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, 'MultiEdit'),
+    createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, 'Bash'),
+  ];
 }
 
 module.exports = createInstallTargetAdapter({
@@ -43,7 +88,7 @@ module.exports = createInstallTargetAdapter({
     };
     const targetRoot = adapter.resolveRoot(planningInput);
 
-    return modules.flatMap(module => {
+    const moduleOperations = modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];
       return paths
         .filter(supportsAntigravitySourcePath)
@@ -101,5 +146,13 @@ module.exports = createInstallTargetAdapter({
           return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
         });
     });
+
+    // Deterministic: every Antigravity install registers the GateGuard
+    // fact-forcing gate, even when no content modules are selected,
+    // mirroring Claude Code's always-on hook registration.
+    return [
+      ...moduleOperations,
+      ...createGateGuardOperations(adapter, targetRoot, projectRoot),
+    ];
   },
 });

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 const {
   createFlatRuleOperations,
@@ -6,6 +6,7 @@ const {
   createManagedScaffoldOperation,
   createRemappedOperation,
   normalizeRelativePath,
+  planFlatSkillOperation,
 } = require('./helpers');
 const {
   GATEGUARD_HOOK_MODULE_ID,
@@ -93,8 +94,6 @@ module.exports = createInstallTargetAdapter({
       return paths
         .filter(supportsAntigravitySourcePath)
         .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
           if (sourceRelativePath === 'rules') {
             return createFlatRuleOperations({
               moduleId: module.id,
@@ -126,24 +125,10 @@ module.exports = createInstallTargetAdapter({
             ];
           }
 
-          // AGY discovers project skills at .agent/skills/<name>/ (flat).
-          // Strip the leading category segment so repo layout does not leak
-          // into the discovery path.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+          // AGY discovers project skills at .agent/skills/<name>/ (flat);
+          // planFlatSkillOperation strips the leading category segment for
+          // skills/** paths and scaffolds everything else as-is.
+          return [planFlatSkillOperation(adapter, module.id, sourceRelativePath, planningInput, targetRoot)];
         });
     });
 

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -1,11 +1,10 @@
-const path = require('path');
+const path = require('node:path');
 
 const {
   createFlatRuleOperations,
   createInstallTargetAdapter,
-  createRemappedOperation,
   isForeignPlatformPath,
-  normalizeRelativePath,
+  planFlatSkillOperation,
 } = require('./helpers');
 const {
   createPreToolUseGateGuardHookMergeOperation,
@@ -55,8 +54,6 @@ module.exports = createInstallTargetAdapter({
       return paths
         .filter(p => !isForeignPlatformPath(p, adapter.target))
         .flatMap(sourceRelativePath => {
-          const normalizedPath = normalizeRelativePath(sourceRelativePath);
-
           if (sourceRelativePath === 'rules') {
             return createFlatRuleOperations({
               moduleId: module.id,
@@ -66,23 +63,10 @@ module.exports = createInstallTargetAdapter({
             });
           }
 
-          // CodeBuddy discovers skills at .codebuddy/skills/<name>/ (flat).
-          // Strip the leading category segment to match the expected structure.
-          if (normalizedPath.startsWith('skills/')) {
-            const parts = normalizedPath.slice('skills/'.length).split('/');
-            const flatRemainder = parts.length >= 2 ? parts.slice(1).join('/') : parts.join('/');
-            return [
-              createRemappedOperation(
-                adapter,
-                module.id,
-                sourceRelativePath,
-                path.join(targetRoot, 'skills', flatRemainder),
-                { strategy: 'preserve-relative-path' }
-              ),
-            ];
-          }
-
-          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+          // CodeBuddy discovers skills at .codebuddy/skills/<name>/ (flat);
+          // planFlatSkillOperation strips the leading category segment for
+          // skills/** paths and scaffolds everything else as-is.
+          return [planFlatSkillOperation(adapter, module.id, sourceRelativePath, planningInput, targetRoot)];
         });
     });
 

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -7,6 +7,25 @@ const {
   isForeignPlatformPath,
   normalizeRelativePath,
 } = require('./helpers');
+const {
+  createPreToolUseGateGuardHookMergeOperation,
+} = require('../claude-settings-hooks');
+
+// CodeBuddy's PreToolUse hooks read from <project>/.codebuddy/settings.json
+// using the same {"hooks": {"PreToolUse": [{"matcher", "hooks"}]}} shape
+// Claude Code uses (https://www.codebuddy.ai/docs/cli/hooks), and this
+// adapter's own targetRoot already resolves to <project>/.codebuddy -- the
+// same root the hooks-runtime module scaffolds scripts/hooks/
+// gateguard-fact-force.js and scripts/lib/utils.js into. So the generic
+// Claude merge helper is reusable here without modification.
+function createGateGuardOperations(targetRoot) {
+  return [
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Edit'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Write'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, 'MultiEdit'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Bash'),
+  ];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'codebuddy-project',
@@ -31,7 +50,7 @@ module.exports = createInstallTargetAdapter({
     };
     const targetRoot = adapter.resolveRoot(planningInput);
 
-    return modules.flatMap(module => {
+    const moduleOperations = modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];
       return paths
         .filter(p => !isForeignPlatformPath(p, adapter.target))
@@ -66,5 +85,13 @@ module.exports = createInstallTargetAdapter({
           return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
         });
     });
+
+    // Deterministic: every CodeBuddy install registers the GateGuard
+    // fact-forcing gate, even when no content modules are selected,
+    // mirroring Claude Code's always-on hook registration.
+    return [
+      ...moduleOperations,
+      ...createGateGuardOperations(targetRoot),
+    ];
   },
 });

--- a/scripts/lib/install-targets/copilot-home.js
+++ b/scripts/lib/install-targets/copilot-home.js
@@ -1,7 +1,55 @@
+const os = require('os');
+const path = require('path');
+
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  resolveGateGuardHookScriptDestination,
+} = require('../claude-settings-hooks');
+const {
+  createPreToolUseGateGuardHookMergeOperation,
+} = require('../copilot-settings-hooks');
+
+const UTILS_SOURCE_RELATIVE_PATH = 'scripts/lib/utils.js';
+
+function resolveUtilsScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'lib', 'utils.js');
+}
+
+function createGateGuardOperations(adapter, targetRoot, homeDir) {
+  // gateguard-fact-force.js requires '../lib/utils' at load time, so both
+  // files must be scaffolded together under the adapter's own root before
+  // the hooks.json merge (which lives at the VS Code-mandated ~/.copilot/
+  // hooks path, not under ~/.github) can point a command at either of them.
+  const scriptOperation = createRemappedOperation(
+    adapter,
+    GATEGUARD_HOOK_MODULE_ID,
+    GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    resolveGateGuardHookScriptDestination(targetRoot),
+    { strategy: 'preserve-relative-path' }
+  );
+  const utilsOperation = createRemappedOperation(
+    adapter,
+    GATEGUARD_HOOK_MODULE_ID,
+    UTILS_SOURCE_RELATIVE_PATH,
+    resolveUtilsScriptDestination(targetRoot),
+    { strategy: 'preserve-relative-path' }
+  );
+
+  return [
+    scriptOperation,
+    utilsOperation,
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, 'Edit'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, 'Write'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, 'MultiEdit'),
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, 'Bash'),
+  ];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'copilot-home',
@@ -10,5 +58,22 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.github'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.github',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const moduleOperations = createFlatSkillPlanOperations(input, adapter);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+    const homeDir = input.homeDir || os.homedir();
+
+    // Deterministic: every Copilot install registers the GateGuard
+    // fact-forcing gate, even when no content modules are selected, mirroring
+    // Claude Code's always-on hook registration.
+    return [
+      ...moduleOperations,
+      ...createGateGuardOperations(adapter, targetRoot, homeDir),
+    ];
+  },
 });

--- a/scripts/lib/install-targets/copilot-home.js
+++ b/scripts/lib/install-targets/copilot-home.js
@@ -1,5 +1,5 @@
-const os = require('os');
-const path = require('path');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   createFlatSkillPlanOperations,

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -1,5 +1,5 @@
-const os = require('os');
-const path = require('path');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   createInstallTargetAdapter,

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const path = require('path');
 
 const {
@@ -6,9 +7,27 @@ const {
   isForeignPlatformPath,
   normalizeRelativePath,
 } = require('./helpers');
+const {
+  createGlobalGateGuardHookMergeOperation,
+} = require('../antigravity-settings-hooks');
 
 const GEMINI_EGC_NAMESPACE = 'egc';
 const AGY_SKILLS_SUBDIR = 'antigravity-cli/skills';
+
+// Antigravity shares this home root (~/.gemini) for skill discovery (see
+// AGY_SKILLS_SUBDIR above) but reads its own hooks.json at
+// ~/.gemini/antigravity-cli/hooks.json, distinct from Gemini CLI's
+// ~/.gemini/hooks/hooks.json -- so Gemini CLI's existing GateGuard wiring
+// does not automatically cover Antigravity and needs this separate merge.
+// scripts/hooks/gateguard-fact-force.js is already scaffolded at
+// resolveGateGuardHookScriptDestination(targetRoot) for this target via the
+// hooks-runtime module (paths: scripts/hooks, scripts/lib), so this only
+// adds the hooks.json registration.
+function createAntigravityGlobalGateGuardOperations(targetRoot, homeDir) {
+  return ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
+    createGlobalGateGuardHookMergeOperation(targetRoot, homeDir, matcher)
+  ));
+}
 
 function getGeminiManagedDestinationPath(adapter, sourceRelativePath, input) {
   const normalizedSourcePath = normalizeRelativePath(sourceRelativePath);
@@ -76,8 +95,10 @@ module.exports = createInstallTargetAdapter({
       projectRoot: input.projectRoot,
       homeDir: input.homeDir,
     };
+    const targetRoot = adapter.resolveRoot(planningInput);
+    const homeDir = input.homeDir || os.homedir();
 
-    return modules.flatMap(module => {
+    const moduleOperations = modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];
       return paths
         .filter(p => !isForeignPlatformPath(p, adapter.target))
@@ -121,5 +142,13 @@ module.exports = createInstallTargetAdapter({
           return ops;
         });
     });
+
+    // Deterministic: every egc-home install also registers the GateGuard
+    // fact-forcing gate for Antigravity's global hooks.json, even when no
+    // content modules are selected.
+    return [
+      ...moduleOperations,
+      ...createAntigravityGlobalGateGuardOperations(targetRoot, homeDir),
+    ];
   },
 });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1256,6 +1256,153 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('copilot adapter registers the GateGuard fact-force hook at ~/.copilot/hooks/hooks.json', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'copilot',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+    const hooksFilePath = path.join(homeDir, '.copilot', 'hooks', 'hooks.json');
+    const gateGuardScriptPath = path.join(
+      homeDir, '.github', 'scripts', 'hooks', 'gateguard-fact-force.js'
+    );
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+        && operation.destinationPath === gateGuardScriptPath
+      )),
+      'Should scaffold the GateGuard script under the copilot home root even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
+        && operation.destinationPath === path.join(homeDir, '.github', 'scripts', 'lib', 'utils.js')
+      )),
+      'Should scaffold the GateGuard utils.js dependency alongside the hook script'
+    );
+
+    const gateGuardOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === hooksFilePath
+      && operation.hookScriptPath === gateGuardScriptPath
+    ));
+    const matchers = gateGuardOperations.map(operation => operation.hookMatcher).sort();
+    assert.deepStrictEqual(
+      matchers,
+      ['Bash', 'Edit', 'MultiEdit', 'Write'],
+      'GateGuard should be registered on Edit, Write, MultiEdit and Bash for VS Code Copilot'
+    );
+  })) passed++; else failed++;
+
+  if (test('codebuddy adapter registers the GateGuard fact-force hook at .codebuddy/settings.json', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codebuddy',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+    const settingsPath = path.join(projectRoot, '.codebuddy', 'settings.json');
+    const gateGuardScriptPath = path.join(
+      projectRoot, '.codebuddy', 'scripts', 'hooks', 'gateguard-fact-force.js'
+    );
+
+    const gateGuardOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === settingsPath
+      && operation.hookScriptPath === gateGuardScriptPath
+    ));
+    const matchers = gateGuardOperations.map(operation => operation.hookMatcher).sort();
+    assert.deepStrictEqual(
+      matchers,
+      ['Bash', 'Edit', 'MultiEdit', 'Write'],
+      'GateGuard should be registered on Edit, Write, MultiEdit and Bash for CodeBuddy'
+    );
+  })) passed++; else failed++;
+
+  if (test('antigravity-project adapter registers the GateGuard fact-force hook at .agents/hooks.json', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'antigravity',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+    const hooksFilePath = path.join(projectRoot, '.agents', 'hooks.json');
+    const gateGuardScriptPath = path.join(
+      projectRoot, '.agents', 'scripts', 'hooks', 'gateguard-fact-force.js'
+    );
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+        && operation.destinationPath === gateGuardScriptPath
+      )),
+      'Should scaffold the GateGuard script under .agents/ even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
+        && operation.destinationPath === path.join(projectRoot, '.agents', 'scripts', 'lib', 'utils.js')
+      )),
+      'Should scaffold the GateGuard utils.js dependency alongside the hook script'
+    );
+
+    const gateGuardOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === hooksFilePath
+      && operation.hookScriptPath === gateGuardScriptPath
+    ));
+    const matchers = gateGuardOperations.map(operation => operation.hookMatcher).sort();
+    assert.deepStrictEqual(
+      matchers,
+      ['Bash', 'Edit', 'MultiEdit', 'Write'],
+      'GateGuard should be registered on Edit, Write, MultiEdit and Bash for Antigravity project scope'
+    );
+  })) passed++; else failed++;
+
+  if (test('egc-home adapter registers the GateGuard fact-force hook for Antigravity global scope too', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'egc',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+    const hooksFilePath = path.join(homeDir, '.gemini', 'antigravity-cli', 'hooks.json');
+    const gateGuardScriptPath = path.join(
+      homeDir, '.gemini', 'scripts', 'hooks', 'gateguard-fact-force.js'
+    );
+
+    const gateGuardOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === hooksFilePath
+      && operation.hookScriptPath === gateGuardScriptPath
+    ));
+    const matchers = gateGuardOperations.map(operation => operation.hookMatcher).sort();
+    assert.deepStrictEqual(
+      matchers,
+      ['Bash', 'Edit', 'MultiEdit', 'Write'],
+      'GateGuard should be registered on Edit, Write, MultiEdit and Bash for Antigravity global hooks.json, ' +
+      'separate from Gemini CLI\'s own ~/.gemini/hooks/hooks.json'
+    );
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary

Follow-up to issue #647 and PR #710/#711. Investigated PreToolUse-equivalent hook support in **VS Code Copilot**, **Sourcegraph Amp**, **Tencent CodeBuddy**, and **Google Antigravity**, then wired `scripts/hooks/gateguard-fact-force.js` in wherever a real mechanism exists.

- **VS Code Copilot** (Preview agent hooks): reads `hooks.json` from the same `{"hooks": {"PreToolUse": [{"matcher", "hooks"}]}}` shape Claude Code uses (confirmed via code.visualstudio.com/docs/agent-customization/hooks and GitHub's hooks reference). User-level hooks live at `~/.copilot/hooks/hooks.json`, a different root than where `copilot-home.js` scaffolds skill content (`~/.github`). Added `scripts/lib/copilot-settings-hooks.js` pointing the merge at the already-installed script.
- **CodeBuddy**: `PreToolUse` hooks read `<project>/.codebuddy/settings.json` with the identical wrapper-group shape (codebuddy.ai/docs/cli/hooks), matching this adapter's own `targetRoot`, so the existing Claude merge helper is reused directly with no new module.
- **Antigravity**: shares `GEMINI_PROJECT_DIR`/`GEMINI_PLUGIN_ROOT` env infra with Gemini CLI but reads its own `hooks.json` at two locations distinct from Gemini CLI's `~/.gemini/hooks/hooks.json` — `<project>/.agents/hooks.json` and `~/.gemini/antigravity-cli/hooks.json` — so PR #710's Gemini wiring does not automatically cover it. Added `scripts/lib/antigravity-settings-hooks.js`, wired both project scope (`antigravity-project.js`) and global scope (`gemini-home.js`).
- **Amp**: intentionally left unwired. Amp's hooks docs live behind `ampcode.com/manual?internal#hooks`, which resolves empty for non-Sourcegraph-internal sessions (confirmed via direct fetch: embedded page state reports `userIsInternal: false`), and the public announcement still carries a "Preview" badge over a year after its original date. The only publicly confirmed action types (`send-user-message`, `redact-tool-input`) are declarative JSON actions, not a documented external-script invocation. Documented in `amp-home.js`/`amp-project.js` instead of guessing at a gated schema.

## Test plan

- [x] `node tests/run-all.js`: 2541/2541 passed (2518 pre-existing + 19 from PR #711 + 4 new install-target tests)
- [x] Real end-to-end installs into temp HOME/project roots for Copilot, CodeBuddy, and Antigravity (project + global), confirming `hooks.json`/`settings.json` content, `gateguard-fact-force.js` + `utils.js` scaffolding, and that the installed script actually denies a first Edit/Write exactly as it does for Claude Code and Gemini CLI
- [x] Syntax-checked all new/modified files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the GateGuard fact‑forcing hook into VS Code Copilot, Tencent CodeBuddy, and Google Antigravity to enforce PreToolUse checks. Amp remains unwired due to no public scriptable hook API; also dedupes flat‑skill planning and the hook merge builder.

- **New Features**
  - Copilot: installs script + utils under ~/.github and merges PreToolUse into ~/.copilot/hooks/hooks.json for Edit, Write, MultiEdit, Bash.
  - CodeBuddy: registers PreToolUse in <project>/.codebuddy/settings.json for Edit, Write, MultiEdit, Bash (reuses Claude merge).
  - Antigravity: registers PreToolUse at project (.agents/hooks.json) and global (~/.gemini/antigravity-cli/hooks.json); scaffolds script + utils.

- **Refactors**
  - Extracted createGateGuardHookMergeOperationForDestination and reused for Copilot/Antigravity.
  - Deduped skills/<category>/<name> flattening via planFlatSkillOperation in CodeBuddy and Antigravity.
  - Switched require('path')/require('os') to the node: prefix.

<sup>Written for commit 6170dcef112661b0fc43ad601c39421bafcc2df6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

