### PR TITLE
fix(hooks): wire GateGuard fact-forcing gate onto Codex CLI, OpenCode, Continue.dev, and Windsurf

### DIFF
--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -16,12 +16,89 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import * as fs from "fs"
 import * as path from "path"
+import { createRequire } from "module"
+import { fileURLToPath } from "url"
 import {
   initStore,
   recordChange,
   clearChanges,
 } from "./lib/changed-files-store.js"
 import changedFilesTool from "../tools/changed-files.js"
+
+// GateGuard Fact-Forcing Gate bridge.
+//
+// OpenCode's tool.execute.before hook (docs: https://opencode.ai/docs/plugins/)
+// runs gateguard-fact-force.js's own run() function in-process and throws to
+// block, since OpenCode has no exit-code/stdout wire contract like Claude
+// Code or Codex - it is a real JS function call, not a subprocess.
+//
+// The compiled plugin can live in two different layouts relative to
+// scripts/hooks/gateguard-fact-force.js: this repo's own .opencode/plugins/
+// (dogfooding, two levels above the repo root) or an installed copy under
+// <opencode root>/plugins/ with gateguard-fact-force.js copied alongside at
+// <opencode root>/scripts/hooks/ (one level up). Try both.
+type GateGuardModule = { run: (rawInput: string) => unknown }
+
+let gateguardModule: GateGuardModule | null | undefined
+
+function resolveGateGuardModulePath(pluginDir: string, worktreePath: string): string | null {
+  const candidates = [
+    path.join(worktreePath, "scripts", "hooks", "gateguard-fact-force.js"),
+    path.join(pluginDir, "..", "scripts", "hooks", "gateguard-fact-force.js"),
+    path.join(pluginDir, "..", "..", "scripts", "hooks", "gateguard-fact-force.js"),
+  ]
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null
+}
+
+function loadGateGuard(pluginDir: string, worktreePath: string): GateGuardModule | null {
+  if (gateguardModule !== undefined) return gateguardModule
+  const modulePath = resolveGateGuardModulePath(pluginDir, worktreePath)
+  if (!modulePath) {
+    gateguardModule = null
+    return null
+  }
+  try {
+    const req = createRequire(import.meta.url)
+    gateguardModule = req(modulePath) as GateGuardModule
+  } catch {
+    gateguardModule = null
+  }
+  return gateguardModule
+}
+
+const OPENCODE_TOOL_TO_GATEGUARD: Record<string, string> = {
+  edit: "Edit",
+  write: "Write",
+  bash: "Bash",
+}
+
+function buildGateGuardInput(tool: string, args: Record<string, unknown> | undefined): string | null {
+  const mappedTool = OPENCODE_TOOL_TO_GATEGUARD[tool]
+  if (!mappedTool) return null
+
+  if (mappedTool === "Bash") {
+    return JSON.stringify({ tool_name: "Bash", tool_input: { command: String(args?.command ?? "") } })
+  }
+
+  const filePath = (args?.filePath ?? args?.file_path ?? args?.path) as string | undefined
+  if (typeof filePath !== "string" || !filePath.trim()) return null
+  return JSON.stringify({ tool_name: mappedTool, tool_input: { file_path: filePath } })
+}
+
+function extractGateGuardDenyReason(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null
+  const stdout = (result as { stdout?: unknown }).stdout
+  if (typeof stdout !== "string") return null
+  try {
+    const parsed = JSON.parse(stdout)
+    if (parsed?.hookSpecificOutput?.permissionDecision === "deny") {
+      return String(parsed.hookSpecificOutput.permissionDecisionReason || "Blocked by the GateGuard Fact-Forcing Gate.")
+    }
+  } catch {
+    return null
+  }
+  return null
+}
 
 type EGCHooksPluginFn = (input: PluginInput) => Promise<Record<string, unknown>>
 
@@ -34,6 +111,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
   type HookProfile = "minimal" | "standard" | "strict"
 
   const worktreePath = worktree || directory
+  const pluginDir = path.dirname(fileURLToPath(import.meta.url))
   initStore(worktreePath)
 
   const editedFiles = new Set<string>()
@@ -223,6 +301,21 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
         req.on("error", ()=>{})
         req.end(body)
       } catch(_) {}
+
+      // Fact-Forcing Gate: block the first Edit/Write/Bash per file (or per
+      // session for Bash) and demand investigation before allowing it.
+      if (hookEnabled("pre:gateguard:fact-force", ["minimal", "standard", "strict"])) {
+        const gateguard = loadGateGuard(pluginDir, worktreePath)
+        if (gateguard) {
+          const payload = buildGateGuardInput(input.tool, input.args)
+          if (payload) {
+            const denyReason = extractGateGuardDenyReason(gateguard.run(payload))
+            if (denyReason) {
+              throw new Error(denyReason)
+            }
+          }
+        }
+      }
 
       if (input.tool === "write") {
         const filePath = getFilePath(input.args)

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -10,6 +10,8 @@
  *
  * Gates:
  *   - Edit/Write: list importers, affected API, verify data schemas, quote instruction
+ *   - apply_patch (Codex CLI's freeform file-edit tool): same gate as Edit,
+ *     applied to every file path parsed out of the patch text
  *   - Bash (destructive): list targets, rollback plan, quote instruction
  *   - Bash (routine): quote current instruction (once per session)
  *
@@ -458,6 +460,63 @@ function handleMultiEdit(rawInput, toolName, toolInput) {
 }
 
 /**
+ * Extract file paths touched by a Codex `apply_patch` freeform patch.
+ *
+ * Codex's apply_patch tool is a single freeform-text argument (a patch in
+ * `*** Begin Patch` / `*** Update File: <path>` / `*** End Patch` format),
+ * not a JSON object with a file_path field like Claude's Edit/Write. Parse
+ * the patch header lines to recover the path(s) it touches so the same
+ * fact-forcing gate can apply per file.
+ *
+ * @param {string} patchText
+ * @returns {string[]}
+ */
+function extractApplyPatchFilePaths(patchText) {
+  const text = String(patchText || '');
+  const pattern = /^\*\*\* (?:Update|Add|Delete) File: (.+)$/gm;
+  const paths = [];
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    if (match[1]) {
+      paths.push(match[1].trim());
+    }
+  }
+  return paths;
+}
+
+/**
+ * Handle the Codex `apply_patch` tool gate (freeform patch text, may touch
+ * multiple files in one call, so this mirrors handleMultiEdit's loop).
+ *
+ * @param {string} rawInput
+ * @param {*} rawPatchInput
+ * @returns {*}
+ */
+function handleApplyPatch(rawInput, rawPatchInput) {
+  const patchText = typeof rawPatchInput === 'string' ? rawPatchInput : '';
+  const filePaths = extractApplyPatchFilePaths(patchText);
+  if (filePaths.length === 0) {
+    trace('governance:allowed:apply_patch_unparsed');
+    return rawInput;
+  }
+
+  for (const filePath of filePaths) {
+    if (isClaudeSettingsPath(filePath) || isChecked(filePath)) {
+      continue;
+    }
+    if (!markChecked(filePath)) {
+      trace('governance:allowed:state_error', { toolName: 'apply_patch', filePath });
+      return allowWithStateWarning();
+    }
+    trace('governance:denied:fact_force', { toolName: 'apply_patch', filePath });
+    return denyResult(editGateMsg(filePath));
+  }
+
+  trace('governance:allowed:apply_patch');
+  return rawInput;
+}
+
+/**
  * Handle the Bash tool gate.
  *
  * @param {string} rawInput
@@ -519,8 +578,11 @@ function run(rawInput) {
 
   const rawToolName = data.tool_name || '';
   const toolInput = data.tool_input || {};
-  // Normalize: case-insensitive matching via lookup map
-  const TOOL_MAP = { edit: 'Edit', write: 'Write', multiedit: 'MultiEdit', bash: 'Bash' };
+  // Normalize: case-insensitive matching via lookup map.
+  // apply_patch is Codex CLI's canonical tool name for file edits (its
+  // freeform patch tool); Edit/Write/MultiEdit are only matcher aliases on
+  // the Codex side, the payload's tool_name stays "apply_patch".
+  const TOOL_MAP = { edit: 'Edit', write: 'Write', multiedit: 'MultiEdit', bash: 'Bash', apply_patch: 'ApplyPatch' };
   const toolName = TOOL_MAP[rawToolName.toLowerCase()] || rawToolName;
 
   if (toolName === 'Edit' || toolName === 'Write') {
@@ -529,6 +591,10 @@ function run(rawInput) {
 
   if (toolName === 'MultiEdit') {
     return handleMultiEdit(rawInput, toolName, toolInput);
+  }
+
+  if (toolName === 'ApplyPatch') {
+    return handleApplyPatch(rawInput, data.tool_input);
   }
 
   if (toolName === 'Bash') {

--- a/scripts/hooks/windsurf-gateguard-adapter.js
+++ b/scripts/hooks/windsurf-gateguard-adapter.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-const fs = require('fs');
+const fs = require('node:fs');
 const { run } = require('./gateguard-fact-force');
 
 function buildGateGuardInput(windsurfEvent) {
@@ -64,11 +64,14 @@ function extractDenyReason(result) {
   let parsed;
   try {
     parsed = JSON.parse(result.stdout);
-  } catch (_) {
+  } catch {
+    // Malformed stdout from run() is treated as "no deny decision" -- the
+    // same fail-open policy gateguard-fact-force.js applies to its own
+    // parse failures, so a non-JSON stdout never blocks Windsurf's action.
     return null;
   }
-  const output = parsed && parsed.hookSpecificOutput;
-  if (output && output.permissionDecision === 'deny') {
+  const output = parsed?.hookSpecificOutput;
+  if (output?.permissionDecision === 'deny') {
     return String(output.permissionDecisionReason || 'Blocked by the GateGuard Fact-Forcing Gate.');
   }
   return null;
@@ -87,8 +90,9 @@ function main() {
     let windsurfEvent;
     try {
       windsurfEvent = JSON.parse(raw);
-    } catch (_) {
-      process.exit(0); // allow on parse error, same fail-open policy as gateguard-fact-force.js
+    } catch {
+      // Allow on parse error: same fail-open policy as gateguard-fact-force.js.
+      process.exit(0);
     }
 
     const gateguardInput = buildGateGuardInput(windsurfEvent);

--- a/scripts/hooks/windsurf-gateguard-adapter.js
+++ b/scripts/hooks/windsurf-gateguard-adapter.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Windsurf Cascade Hooks adapter for the GateGuard Fact-Forcing Gate.
+ *
+ * Windsurf's pre_write_code and pre_run_command hooks (docs:
+ * https://docs.windsurf.com/windsurf/cascade/hooks, redirects to
+ * https://docs.devin.ai/desktop/cascade/hooks) use a different wire contract
+ * than Claude Code/Codex/Continue:
+ *   - stdin JSON shape: {agent_action_name, tool_info: {...}}, not
+ *     {tool_name, tool_input}
+ *   - blocking signal: exit code 2 with the reason on stderr, not a
+ *     hookSpecificOutput.permissionDecision:"deny" JSON object on stdout
+ *
+ * This script translates both directions so gateguard-fact-force.js's own
+ * run() function (unchanged) can gate Windsurf's file edits and shell
+ * commands too.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const { run } = require('./gateguard-fact-force');
+
+function buildGateGuardInput(windsurfEvent) {
+  const actionName = windsurfEvent.agent_action_name || '';
+  const toolInfo = windsurfEvent.tool_info || {};
+
+  if (actionName === 'pre_write_code') {
+    const filePath = toolInfo.file_path || '';
+    if (!filePath) {
+      return null;
+    }
+    // Windsurf reports every code write through the same event whether the
+    // file already exists or is being created; gateguard-fact-force.js
+    // phrases the two cases differently, so recover that distinction here.
+    const toolName = fs.existsSync(filePath) ? 'Edit' : 'Write';
+    return {
+      session_id: windsurfEvent.trajectory_id || '',
+      tool_name: toolName,
+      tool_input: { file_path: filePath },
+    };
+  }
+
+  if (actionName === 'pre_run_command') {
+    const command = toolInfo.command_line || '';
+    return {
+      session_id: windsurfEvent.trajectory_id || '',
+      tool_name: 'Bash',
+      tool_input: { command },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * @param {*} result - whatever gateguard-fact-force.js's run() returned
+ * @returns {string|null} deny reason, or null if the action should proceed
+ */
+function extractDenyReason(result) {
+  if (!result || typeof result !== 'object' || typeof result.stdout !== 'string') {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (_) {
+    return null;
+  }
+  const output = parsed && parsed.hookSpecificOutput;
+  if (output && output.permissionDecision === 'deny') {
+    return String(output.permissionDecisionReason || 'Blocked by the GateGuard Fact-Forcing Gate.');
+  }
+  return null;
+}
+
+function main() {
+  const MAX_STDIN = 1024 * 1024;
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    let windsurfEvent;
+    try {
+      windsurfEvent = JSON.parse(raw);
+    } catch (_) {
+      process.exit(0); // allow on parse error, same fail-open policy as gateguard-fact-force.js
+    }
+
+    const gateguardInput = buildGateGuardInput(windsurfEvent);
+    if (!gateguardInput) {
+      process.exit(0);
+    }
+
+    const result = run(JSON.stringify(gateguardInput));
+    const denyReason = extractDenyReason(result);
+    if (denyReason) {
+      process.stderr.write(denyReason.endsWith('\n') ? denyReason : `${denyReason}\n`);
+      process.exit(2);
+    }
+
+    process.exit(0);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { buildGateGuardInput, extractDenyReason };

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -9,8 +9,8 @@
 // the EGC hook (left behind when the install location or invocation form
 // changed) and is migrated in place instead of duplicated.
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const SESSION_START_EVENT = 'SessionStart';
 const STOP_EVENT = 'Stop';
@@ -606,7 +606,6 @@ const GATEGUARD_LIB_SOURCE_RELATIVE_PATH = 'scripts/lib/utils.js';
  * @returns {object[]}
  */
 function createGateGuardScriptCopyOperations(createRemappedOperation, targetRoot) {
-  const path = require('path');
   return [
     createRemappedOperation(
       GATEGUARD_HOOK_MODULE_ID,

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -588,11 +588,47 @@ function createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher) {
   );
 }
 
+// gateguard-fact-force.js's only internal dependency (require('../lib/utils')
+// resolved relative to itself), so any target that wires the gate outside the
+// generic module-scaffold path needs both files copied together.
+const GATEGUARD_LIB_SOURCE_RELATIVE_PATH = 'scripts/lib/utils.js';
+
+/**
+ * Builds copy operations that place gateguard-fact-force.js (and its one
+ * dependency) under `<targetRoot>/scripts/hooks/` and `<targetRoot>/scripts/lib/`,
+ * unconditionally (independent of module selection). Used by install targets
+ * whose own root does not already receive the shared "hooks-runtime" module
+ * scaffold (Codex, Windsurf) or that want the gate guaranteed regardless of
+ * profile (Continue).
+ *
+ * @param {(moduleId: string, sourceRelativePath: string, destinationPath: string, options?: object) => object} createRemappedOperation
+ * @param {string} targetRoot
+ * @returns {object[]}
+ */
+function createGateGuardScriptCopyOperations(createRemappedOperation, targetRoot) {
+  const path = require('path');
+  return [
+    createRemappedOperation(
+      GATEGUARD_HOOK_MODULE_ID,
+      GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveGateGuardHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ),
+    createRemappedOperation(
+      GATEGUARD_HOOK_MODULE_ID,
+      GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
+      path.join(targetRoot, 'scripts', 'lib', 'utils.js'),
+      { strategy: 'preserve-relative-path' }
+    ),
+  ];
+}
+
 module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
   HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -626,6 +662,7 @@ module.exports = {
   buildSessionStartCommand,
   buildStopCommand,
   createPreToolUseBashDispatcherHookMergeOperation,
+  createGateGuardScriptCopyOperations,
   createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
   createSessionStartHookMergeOperation,

--- a/scripts/lib/continue-gateguard-hooks.js
+++ b/scripts/lib/continue-gateguard-hooks.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// Continue CLI's hooks system is deliberately Claude Code-compatible: it
+// reads ~/.continue/settings.json (and ~/.claude/settings.json) with the
+// exact same {hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}}
+// schema, and its tool_name values for edits/shell are the same "Edit",
+// "Write", "MultiEdit", "Bash" strings Claude Code uses (confirmed against
+// extensions/cli/src/hooks/types.ts and hookConfig.ts in continuedev/continue).
+// So the merge operation built for Claude Code applies unchanged here, once
+// the gate script itself is copied into Continue's own root. Shared between
+// continue-home.js and continue-project.js: .continue/settings.json (project)
+// is read at the same precedence tier as .claude/settings.json, and the home
+// variant only differs in rootSegments/installStatePathSegments.
+
+const {
+  createGateGuardScriptCopyOperations,
+  createPreToolUseGateGuardHookMergeOperation,
+} = require('./claude-settings-hooks');
+
+function createContinueGateGuardOperations(adapter, targetRoot, createRemappedOperation) {
+  const copyOperations = createGateGuardScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  const mergeOperations = ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher)
+  ));
+
+  return [...copyOperations, ...mergeOperations];
+}
+
+module.exports = { createContinueGateGuardOperations };

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -1,5 +1,5 @@
-const os = require('os');
-const path = require('path');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   createInstallTargetAdapter,

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -1,7 +1,76 @@
+const os = require('os');
+const path = require('path');
+
 const {
   createInstallTargetAdapter,
+  createRemappedOperation,
   planFlatSkillOperation,
 } = require('./helpers');
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  HOOK_OPERATION_KIND,
+  PRE_TOOL_USE_EVENT,
+  createGateGuardScriptCopyOperations,
+} = require('../claude-settings-hooks');
+
+// Codex CLI's skills root (~/.agents, this adapter's own resolveRoot()) and
+// its runtime config root (~/.codex, where hooks.json/config.toml live) are
+// two different directories - confirmed against scripts/codex/*.sh and
+// codex-hooks.test.js, which both key hook/config installation off
+// CODEX_HOME (default ~/.codex), independent of AGENTS_HOME (default
+// ~/.agents). A PreToolUse hook registered under ~/.agents would never be
+// discovered by Codex CLI, so the gate has to be wired into ~/.codex/hooks.json
+// directly. Docs: https://developers.openai.com/codex/hooks (redirects to
+// https://learn.chatgpt.com/docs/hooks) documents ~/.codex/hooks.json as a
+// discovery location and the exact same
+// {hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}} JSON schema,
+// including hookSpecificOutput.permissionDecision:"deny" for blocking, that
+// gateguard-fact-force.js's CLI entrypoint already emits for Claude Code.
+//
+// Deliberately does NOT read process.env.CODEX_HOME here (unlike the
+// standalone scripts/sync-egc-to-codex.sh flow): every other adapter in this
+// registry derives its root purely from `input.homeDir`, and honoring an
+// ambient env var would make this adapter's output depend on the caller's
+// shell environment instead of its explicit input, which breaks test
+// hermeticity and risks writing to a real ~/.codex during a hermetic test run.
+function resolveCodexHome(input) {
+  return path.join(input.homeDir || os.homedir(), '.codex');
+}
+
+function buildCodexPreToolUseMergeOperation(codexHome, hookScriptPath, matcher) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: GATEGUARD_HOOK_MODULE_ID,
+    sourceRelativePath: GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: path.join(codexHome, 'hooks.json'),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: matcher,
+    hookScriptPath,
+  };
+}
+
+function createCodexGateGuardOperations(adapter, codexHome) {
+  const hookScriptPath = path.join(codexHome, 'scripts', 'hooks', 'gateguard-fact-force.js');
+  const copyOperations = createGateGuardScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    codexHome
+  );
+
+  // "apply_patch" is Codex's canonical tool_name for file edits (Edit/Write
+  // are matcher aliases only, per codex-rs/core/src/tools/hook_names.rs);
+  // "Bash" is used verbatim for both the legacy shell tool and unified_exec.
+  const mergeOperations = ['apply_patch', 'Bash'].map(matcher => (
+    buildCodexPreToolUseMergeOperation(codexHome, hookScriptPath, matcher)
+  ));
+
+  return [...copyOperations, ...mergeOperations];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'codex-home',
@@ -21,9 +90,14 @@ module.exports = createInstallTargetAdapter({
     };
     const targetRoot = adapter.resolveRoot(planningInput);
 
-    return modules.flatMap(module => {
+    const moduleOperations = modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];
       return paths.map(sourceRelativePath => planFlatSkillOperation(adapter, module.id, sourceRelativePath, planningInput, targetRoot));
     });
+
+    return [
+      ...moduleOperations,
+      ...createCodexGateGuardOperations(adapter, resolveCodexHome(planningInput)),
+    ];
   },
 });

--- a/scripts/lib/install-targets/continue-home.js
+++ b/scripts/lib/install-targets/continue-home.js
@@ -4,32 +4,8 @@ const {
   createRemappedOperation,
 } = require('./helpers');
 const {
-  createGateGuardScriptCopyOperations,
-  createPreToolUseGateGuardHookMergeOperation,
-} = require('../claude-settings-hooks');
-
-// Continue CLI's hooks system is deliberately Claude Code-compatible: it
-// reads ~/.continue/settings.json (and ~/.claude/settings.json) with the
-// exact same {hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}}
-// schema, and its tool_name values for edits/shell are the same "Edit",
-// "Write", "MultiEdit", "Bash" strings Claude Code uses (confirmed against
-// extensions/cli/src/hooks/types.ts and hookConfig.ts in continuedev/continue).
-// So the merge operation built for Claude Code applies unchanged here, once
-// the gate script itself is copied into Continue's own root.
-function createContinueGateGuardOperations(adapter, targetRoot) {
-  const copyOperations = createGateGuardScriptCopyOperations(
-    (moduleId, sourceRelativePath, destinationPath, options) => (
-      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-    ),
-    targetRoot
-  );
-
-  const mergeOperations = ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
-    createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher)
-  ));
-
-  return [...copyOperations, ...mergeOperations];
-}
+  createContinueGateGuardOperations,
+} = require('../continue-gateguard-hooks');
 
 module.exports = createInstallTargetAdapter({
   id: 'continue-home',
@@ -48,7 +24,7 @@ module.exports = createInstallTargetAdapter({
 
     return [
       ...createFlatSkillPlanOperations(input, adapter),
-      ...createContinueGateGuardOperations(adapter, targetRoot),
+      ...createContinueGateGuardOperations(adapter, targetRoot, createRemappedOperation),
     ];
   },
 });

--- a/scripts/lib/install-targets/continue-home.js
+++ b/scripts/lib/install-targets/continue-home.js
@@ -1,7 +1,35 @@
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const {
+  createGateGuardScriptCopyOperations,
+  createPreToolUseGateGuardHookMergeOperation,
+} = require('../claude-settings-hooks');
+
+// Continue CLI's hooks system is deliberately Claude Code-compatible: it
+// reads ~/.continue/settings.json (and ~/.claude/settings.json) with the
+// exact same {hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}}
+// schema, and its tool_name values for edits/shell are the same "Edit",
+// "Write", "MultiEdit", "Bash" strings Claude Code uses (confirmed against
+// extensions/cli/src/hooks/types.ts and hookConfig.ts in continuedev/continue).
+// So the merge operation built for Claude Code applies unchanged here, once
+// the gate script itself is copied into Continue's own root.
+function createContinueGateGuardOperations(adapter, targetRoot) {
+  const copyOperations = createGateGuardScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  const mergeOperations = ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher)
+  ));
+
+  return [...copyOperations, ...mergeOperations];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'continue-home',
@@ -10,5 +38,17 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.continue'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.continue',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createContinueGateGuardOperations(adapter, targetRoot),
+    ];
+  },
 });

--- a/scripts/lib/install-targets/continue-project.js
+++ b/scripts/lib/install-targets/continue-project.js
@@ -4,28 +4,8 @@ const {
   createRemappedOperation,
 } = require('./helpers');
 const {
-  createGateGuardScriptCopyOperations,
-  createPreToolUseGateGuardHookMergeOperation,
-} = require('../claude-settings-hooks');
-
-// See continue-home.js for why the Claude Code merge operation is reusable
-// as-is: Continue CLI's PreToolUse hook schema and tool_name values are
-// intentionally Claude Code-compatible, and .continue/settings.json (project)
-// is read at the same precedence tier as .claude/settings.json.
-function createContinueGateGuardOperations(adapter, targetRoot) {
-  const copyOperations = createGateGuardScriptCopyOperations(
-    (moduleId, sourceRelativePath, destinationPath, options) => (
-      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-    ),
-    targetRoot
-  );
-
-  const mergeOperations = ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
-    createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher)
-  ));
-
-  return [...copyOperations, ...mergeOperations];
-}
+  createContinueGateGuardOperations,
+} = require('../continue-gateguard-hooks');
 
 module.exports = createInstallTargetAdapter({
   id: 'continue-project',
@@ -44,7 +24,7 @@ module.exports = createInstallTargetAdapter({
 
     return [
       ...createFlatSkillPlanOperations(input, adapter),
-      ...createContinueGateGuardOperations(adapter, targetRoot),
+      ...createContinueGateGuardOperations(adapter, targetRoot, createRemappedOperation),
     ];
   },
 });

--- a/scripts/lib/install-targets/continue-project.js
+++ b/scripts/lib/install-targets/continue-project.js
@@ -1,7 +1,31 @@
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const {
+  createGateGuardScriptCopyOperations,
+  createPreToolUseGateGuardHookMergeOperation,
+} = require('../claude-settings-hooks');
+
+// See continue-home.js for why the Claude Code merge operation is reusable
+// as-is: Continue CLI's PreToolUse hook schema and tool_name values are
+// intentionally Claude Code-compatible, and .continue/settings.json (project)
+// is read at the same precedence tier as .claude/settings.json.
+function createContinueGateGuardOperations(adapter, targetRoot) {
+  const copyOperations = createGateGuardScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  const mergeOperations = ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
+    createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher)
+  ));
+
+  return [...copyOperations, ...mergeOperations];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'continue-project',
@@ -10,5 +34,17 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.continue'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.continue',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createContinueGateGuardOperations(adapter, targetRoot),
+    ];
+  },
 });

--- a/scripts/lib/install-targets/windsurf-home.js
+++ b/scripts/lib/install-targets/windsurf-home.js
@@ -1,7 +1,61 @@
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  HOOK_OPERATION_KIND,
+  createGateGuardScriptCopyOperations,
+} = require('../claude-settings-hooks');
+const {
+  ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT,
+  resolveAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('../windsurf-gateguard-hooks');
+
+// Windsurf Cascade Hooks (docs: https://docs.windsurf.com/windsurf/cascade/hooks,
+// redirects to https://docs.devin.ai/desktop/cascade/hooks) reads
+// ~/.codeium/windsurf/hooks.json for Devin Desktop, which is exactly this
+// adapter's own root (rootSegments below). pre_write_code and
+// pre_run_command are real pre-action hooks that can block by exiting 2, but
+// they use a different stdin/exit-code contract than Claude Code's, so the
+// gate runs through scripts/hooks/windsurf-gateguard-adapter.js instead of
+// gateguard-fact-force.js's own CLI entrypoint directly.
+function createWindsurfGateGuardOperations(adapter, targetRoot) {
+  const scriptCopyOperations = createGateGuardScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  const adapterScriptDestination = resolveAdapterScriptDestination(targetRoot);
+  const adapterCopyOperation = createRemappedOperation(
+    adapter,
+    GATEGUARD_HOOK_MODULE_ID,
+    ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    adapterScriptDestination,
+    { strategy: 'preserve-relative-path' }
+  );
+
+  const hooksJsonPath = resolveHooksJsonPath(targetRoot);
+  const mergeOperations = [PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT].map(event => ({
+    kind: HOOK_OPERATION_KIND,
+    moduleId: GATEGUARD_HOOK_MODULE_ID,
+    sourceRelativePath: ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: hooksJsonPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: event,
+    hookScriptPath: adapterScriptDestination,
+  }));
+
+  return [...scriptCopyOperations, adapterCopyOperation, ...mergeOperations];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'windsurf-home',
@@ -10,5 +64,17 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.codeium', 'windsurf'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.codeium/windsurf',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createWindsurfGateGuardOperations(adapter, targetRoot),
+    ];
+  },
 });

--- a/scripts/lib/install-targets/windsurf-home.js
+++ b/scripts/lib/install-targets/windsurf-home.js
@@ -4,58 +4,8 @@ const {
   createRemappedOperation,
 } = require('./helpers');
 const {
-  GATEGUARD_HOOK_MODULE_ID,
-  HOOK_OPERATION_KIND,
-  createGateGuardScriptCopyOperations,
-} = require('../claude-settings-hooks');
-const {
-  ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
-  PRE_RUN_COMMAND_EVENT,
-  PRE_WRITE_CODE_EVENT,
-  resolveAdapterScriptDestination,
-  resolveHooksJsonPath,
-} = require('../windsurf-gateguard-hooks');
-
-// Windsurf Cascade Hooks (docs: https://docs.windsurf.com/windsurf/cascade/hooks,
-// redirects to https://docs.devin.ai/desktop/cascade/hooks) reads
-// ~/.codeium/windsurf/hooks.json for Devin Desktop, which is exactly this
-// adapter's own root (rootSegments below). pre_write_code and
-// pre_run_command are real pre-action hooks that can block by exiting 2, but
-// they use a different stdin/exit-code contract than Claude Code's, so the
-// gate runs through scripts/hooks/windsurf-gateguard-adapter.js instead of
-// gateguard-fact-force.js's own CLI entrypoint directly.
-function createWindsurfGateGuardOperations(adapter, targetRoot) {
-  const scriptCopyOperations = createGateGuardScriptCopyOperations(
-    (moduleId, sourceRelativePath, destinationPath, options) => (
-      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-    ),
-    targetRoot
-  );
-
-  const adapterScriptDestination = resolveAdapterScriptDestination(targetRoot);
-  const adapterCopyOperation = createRemappedOperation(
-    adapter,
-    GATEGUARD_HOOK_MODULE_ID,
-    ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
-    adapterScriptDestination,
-    { strategy: 'preserve-relative-path' }
-  );
-
-  const hooksJsonPath = resolveHooksJsonPath(targetRoot);
-  const mergeOperations = [PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT].map(event => ({
-    kind: HOOK_OPERATION_KIND,
-    moduleId: GATEGUARD_HOOK_MODULE_ID,
-    sourceRelativePath: ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
-    destinationPath: hooksJsonPath,
-    strategy: HOOK_OPERATION_KIND,
-    ownership: 'managed',
-    scaffoldOnly: false,
-    hookEvent: event,
-    hookScriptPath: adapterScriptDestination,
-  }));
-
-  return [...scriptCopyOperations, adapterCopyOperation, ...mergeOperations];
-}
+  createWindsurfGateGuardOperations,
+} = require('../windsurf-gateguard-operations');
 
 module.exports = createInstallTargetAdapter({
   id: 'windsurf-home',
@@ -74,7 +24,7 @@ module.exports = createInstallTargetAdapter({
 
     return [
       ...createFlatSkillPlanOperations(input, adapter),
-      ...createWindsurfGateGuardOperations(adapter, targetRoot),
+      ...createWindsurfGateGuardOperations(adapter, targetRoot, createRemappedOperation),
     ];
   },
 });

--- a/scripts/lib/install-targets/windsurf-project.js
+++ b/scripts/lib/install-targets/windsurf-project.js
@@ -4,53 +4,8 @@ const {
   createRemappedOperation,
 } = require('./helpers');
 const {
-  GATEGUARD_HOOK_MODULE_ID,
-  HOOK_OPERATION_KIND,
-  createGateGuardScriptCopyOperations,
-} = require('../claude-settings-hooks');
-const {
-  ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
-  PRE_RUN_COMMAND_EVENT,
-  PRE_WRITE_CODE_EVENT,
-  resolveAdapterScriptDestination,
-  resolveHooksJsonPath,
-} = require('../windsurf-gateguard-hooks');
-
-// See windsurf-home.js for the hook contract details. This adapter's own
-// root (.windsurf/) is Windsurf's documented workspace-level hooks.json
-// location, merged together with the user-level file at hook-execution time.
-function createWindsurfGateGuardOperations(adapter, targetRoot) {
-  const scriptCopyOperations = createGateGuardScriptCopyOperations(
-    (moduleId, sourceRelativePath, destinationPath, options) => (
-      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-    ),
-    targetRoot
-  );
-
-  const adapterScriptDestination = resolveAdapterScriptDestination(targetRoot);
-  const adapterCopyOperation = createRemappedOperation(
-    adapter,
-    GATEGUARD_HOOK_MODULE_ID,
-    ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
-    adapterScriptDestination,
-    { strategy: 'preserve-relative-path' }
-  );
-
-  const hooksJsonPath = resolveHooksJsonPath(targetRoot);
-  const mergeOperations = [PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT].map(event => ({
-    kind: HOOK_OPERATION_KIND,
-    moduleId: GATEGUARD_HOOK_MODULE_ID,
-    sourceRelativePath: ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
-    destinationPath: hooksJsonPath,
-    strategy: HOOK_OPERATION_KIND,
-    ownership: 'managed',
-    scaffoldOnly: false,
-    hookEvent: event,
-    hookScriptPath: adapterScriptDestination,
-  }));
-
-  return [...scriptCopyOperations, adapterCopyOperation, ...mergeOperations];
-}
+  createWindsurfGateGuardOperations,
+} = require('../windsurf-gateguard-operations');
 
 module.exports = createInstallTargetAdapter({
   id: 'windsurf-project',
@@ -69,7 +24,7 @@ module.exports = createInstallTargetAdapter({
 
     return [
       ...createFlatSkillPlanOperations(input, adapter),
-      ...createWindsurfGateGuardOperations(adapter, targetRoot),
+      ...createWindsurfGateGuardOperations(adapter, targetRoot, createRemappedOperation),
     ];
   },
 });

--- a/scripts/lib/install-targets/windsurf-project.js
+++ b/scripts/lib/install-targets/windsurf-project.js
@@ -1,7 +1,56 @@
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  HOOK_OPERATION_KIND,
+  createGateGuardScriptCopyOperations,
+} = require('../claude-settings-hooks');
+const {
+  ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT,
+  resolveAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('../windsurf-gateguard-hooks');
+
+// See windsurf-home.js for the hook contract details. This adapter's own
+// root (.windsurf/) is Windsurf's documented workspace-level hooks.json
+// location, merged together with the user-level file at hook-execution time.
+function createWindsurfGateGuardOperations(adapter, targetRoot) {
+  const scriptCopyOperations = createGateGuardScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  const adapterScriptDestination = resolveAdapterScriptDestination(targetRoot);
+  const adapterCopyOperation = createRemappedOperation(
+    adapter,
+    GATEGUARD_HOOK_MODULE_ID,
+    ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    adapterScriptDestination,
+    { strategy: 'preserve-relative-path' }
+  );
+
+  const hooksJsonPath = resolveHooksJsonPath(targetRoot);
+  const mergeOperations = [PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT].map(event => ({
+    kind: HOOK_OPERATION_KIND,
+    moduleId: GATEGUARD_HOOK_MODULE_ID,
+    sourceRelativePath: ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: hooksJsonPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: event,
+    hookScriptPath: adapterScriptDestination,
+  }));
+
+  return [...scriptCopyOperations, adapterCopyOperation, ...mergeOperations];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'windsurf-project',
@@ -10,5 +59,17 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.windsurf'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.windsurf',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createWindsurfGateGuardOperations(adapter, targetRoot),
+    ];
+  },
 });

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -16,6 +16,13 @@ const {
   applySessionStartHookToFile,
   applyStopHookToFile,
 } = require('../claude-settings-hooks');
+const {
+  PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT,
+  applyWindsurfGateGuardHookToFile,
+} = require('../windsurf-gateguard-hooks');
+
+const WINDSURF_HOOK_EVENTS = new Set([PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT]);
 
 function readJsonObject(filePath, label) {
   let parsed;
@@ -140,6 +147,8 @@ function applyInstallPlan(plan) {
         applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
       } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
         applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
+      } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
+        applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
       } else {
         applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
       }

--- a/scripts/lib/windsurf-gateguard-hooks.js
+++ b/scripts/lib/windsurf-gateguard-hooks.js
@@ -9,8 +9,8 @@
 // addHookEntry(). Docs: https://docs.windsurf.com/windsurf/cascade/hooks
 // (redirects to https://docs.devin.ai/desktop/cascade/hooks).
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const PRE_WRITE_CODE_EVENT = 'pre_write_code';
 const PRE_RUN_COMMAND_EVENT = 'pre_run_command';

--- a/scripts/lib/windsurf-gateguard-hooks.js
+++ b/scripts/lib/windsurf-gateguard-hooks.js
@@ -1,0 +1,117 @@
+'use strict';
+
+// Manages the GateGuard entry inside a Windsurf Cascade hooks.json file
+// (.windsurf/hooks.json project-level, or ~/.codeium/windsurf/hooks.json
+// user-level). Windsurf's hooks.json schema is a flat
+// {hooks: {<event>: [{command, ...}]}} map - no matcher/group wrapper and no
+// "type": "command" field like Claude Code's settings.json - so it needs its
+// own merge logic instead of reusing claude-settings-hooks.js's
+// addHookEntry(). Docs: https://docs.windsurf.com/windsurf/cascade/hooks
+// (redirects to https://docs.devin.ai/desktop/cascade/hooks).
+
+const fs = require('fs');
+const path = require('path');
+
+const PRE_WRITE_CODE_EVENT = 'pre_write_code';
+const PRE_RUN_COMMAND_EVENT = 'pre_run_command';
+const ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/windsurf-gateguard-adapter.js';
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildHookCommand(scriptPath) {
+  return `"${process.execPath}" "${scriptPath}"`; // NOSONAR jssecurity:S8705
+}
+
+function resolveAdapterScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'windsurf-gateguard-adapter.js');
+}
+
+function resolveHooksJsonPath(targetRoot) {
+  return path.join(targetRoot, 'hooks.json');
+}
+
+function readHooksFile(hooksJsonPath) {
+  if (!fs.existsSync(hooksJsonPath)) {
+    return {};
+  }
+  const raw = fs.readFileSync(hooksJsonPath, 'utf8');
+  if (!raw.trim()) {
+    return {};
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse Windsurf hooks config at ${hooksJsonPath}: ${error.message}`, { cause: error });
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Invalid Windsurf hooks config at ${hooksJsonPath}: expected a JSON object`);
+  }
+  return parsed;
+}
+
+function writeHooksFile(hooksJsonPath, config) {
+  fs.mkdirSync(path.dirname(hooksJsonPath), { recursive: true });
+  fs.writeFileSync(hooksJsonPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+function isEgcEntry(entry, command) {
+  return isPlainObject(entry) && entry.command === command;
+}
+
+function isStaleEgcEntry(entry, command) {
+  if (!isPlainObject(entry) || typeof entry.command !== 'string' || entry.command === command) {
+    return false;
+  }
+  return entry.command.includes(path.basename(ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH));
+}
+
+function addWindsurfHookEntry(config, event, command) {
+  const base = isPlainObject(config) ? config : {};
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+
+  if (existing.some(entry => isEgcEntry(entry, command))) {
+    return { config: base, changed: false };
+  }
+
+  // Migrate a stale entry in place (same adapter script, different install
+  // path) instead of appending a duplicate.
+  let migrated = false;
+  const nextEntries = existing.map(entry => {
+    if (!migrated && isStaleEgcEntry(entry, command)) {
+      migrated = true;
+      return { ...entry, command };
+    }
+    return entry;
+  });
+
+  if (!migrated) {
+    nextEntries.push({ command });
+  }
+
+  hooks[event] = nextEntries;
+  return { config: { ...base, hooks }, changed: true };
+}
+
+function applyWindsurfGateGuardHookToFile(hooksJsonPath, event, adapterScriptPath) {
+  const command = buildHookCommand(adapterScriptPath);
+  const current = readHooksFile(hooksJsonPath);
+  const { config, changed } = addWindsurfHookEntry(current, event, command);
+  if (changed) {
+    writeHooksFile(hooksJsonPath, config);
+  }
+  return { changed };
+}
+
+module.exports = {
+  ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT,
+  addWindsurfHookEntry,
+  applyWindsurfGateGuardHookToFile,
+  resolveAdapterScriptDestination,
+  resolveHooksJsonPath,
+};

--- a/scripts/lib/windsurf-gateguard-operations.js
+++ b/scripts/lib/windsurf-gateguard-operations.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Windsurf Cascade Hooks (docs: https://docs.windsurf.com/windsurf/cascade/hooks,
+// redirects to https://docs.devin.ai/desktop/cascade/hooks) reads
+// ~/.codeium/windsurf/hooks.json for Devin Desktop (home) and
+// <project>/.windsurf/hooks.json for the workspace level (project), merged
+// together with the user-level file at hook-execution time. pre_write_code
+// and pre_run_command are real pre-action hooks that can block by exiting 2,
+// but they use a different stdin/exit-code contract than Claude Code's, so
+// the gate runs through scripts/hooks/windsurf-gateguard-adapter.js instead
+// of gateguard-fact-force.js's own CLI entrypoint directly. Shared between
+// windsurf-home.js and windsurf-project.js: both roots use this identical
+// operation shape, differing only in rootSegments/installStatePathSegments.
+
+const {
+  GATEGUARD_HOOK_MODULE_ID,
+  HOOK_OPERATION_KIND,
+  createGateGuardScriptCopyOperations,
+} = require('./claude-settings-hooks');
+const {
+  ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT,
+  resolveAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('./windsurf-gateguard-hooks');
+
+function createWindsurfGateGuardOperations(adapter, targetRoot, createRemappedOperation) {
+  const scriptCopyOperations = createGateGuardScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  const adapterScriptDestination = resolveAdapterScriptDestination(targetRoot);
+  const adapterCopyOperation = createRemappedOperation(
+    adapter,
+    GATEGUARD_HOOK_MODULE_ID,
+    ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    adapterScriptDestination,
+    { strategy: 'preserve-relative-path' }
+  );
+
+  const hooksJsonPath = resolveHooksJsonPath(targetRoot);
+  const mergeOperations = [PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT].map(event => ({
+    kind: HOOK_OPERATION_KIND,
+    moduleId: GATEGUARD_HOOK_MODULE_ID,
+    sourceRelativePath: ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: hooksJsonPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: event,
+    hookScriptPath: adapterScriptDestination,
+  }));
+
+  return [...scriptCopyOperations, adapterCopyOperation, ...mergeOperations];
+}
+
+module.exports = { createWindsurfGateGuardOperations };

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1043,6 +1043,105 @@ function runTests() {
     assert.deepStrictEqual(JSON.parse(result.stdout), input);
   })) passed++; else failed++;
 
+  // --- Codex CLI apply_patch (freeform patch text, not a JSON object with
+  // file_path like Claude's Edit/Write) ---
+
+  clearState();
+  if (test('denies first apply_patch call and names the touched file', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/codex-patch-target.js',
+      '@@',
+      '-old',
+      '+new',
+      '*** End Patch',
+      ''
+    ].join('\n');
+    const input = { session_id: TEST_SESSION_ID, tool_name: 'apply_patch', tool_input: patch };
+    const result = runDirectHook(input);
+    assert.strictEqual(result.code, 0);
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('src/codex-patch-target.js'));
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows a second apply_patch call touching an already-checked file', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/codex-patch-target-2.js',
+      '@@',
+      '-old',
+      '+new',
+      '*** End Patch',
+      ''
+    ].join('\n');
+    const input = { session_id: TEST_SESSION_ID, tool_name: 'apply_patch', tool_input: patch };
+    runDirectHook(input);
+    const result = runDirectHook(input);
+    assert.strictEqual(result.code, 0);
+    const output = parseOutput(result.stdout);
+    assert.ok(!output.hookSpecificOutput, 'second call should pass raw input through, not a deny decision');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('denies each new file in a multi-file apply_patch call one at a time', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: src/codex-patch-new-a.js',
+      '+content a',
+      '*** Update File: src/codex-patch-new-b.js',
+      '@@',
+      '-old',
+      '+new',
+      '*** Delete File: src/codex-patch-new-c.js',
+      '*** End Patch',
+      ''
+    ].join('\n');
+    const input = { session_id: TEST_SESSION_ID, tool_name: 'apply_patch', tool_input: patch };
+    const first = parseOutput(runDirectHook(input).stdout);
+    assert.strictEqual(first.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(first.hookSpecificOutput.permissionDecisionReason.includes('src/codex-patch-new-a.js'));
+
+    const second = parseOutput(runDirectHook(input).stdout);
+    assert.strictEqual(second.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(second.hookSpecificOutput.permissionDecisionReason.includes('src/codex-patch-new-b.js'));
+
+    const third = parseOutput(runDirectHook(input).stdout);
+    assert.strictEqual(third.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(third.hookSpecificOutput.permissionDecisionReason.includes('src/codex-patch-new-c.js'));
+
+    const fourthResult = runDirectHook(input);
+    const fourth = parseOutput(fourthResult.stdout);
+    assert.ok(!fourth || !fourth.hookSpecificOutput, 'all three files checked, call should pass through');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows apply_patch input that cannot be parsed as a patch (fails open)', () => {
+    const input = { session_id: TEST_SESSION_ID, tool_name: 'apply_patch', tool_input: 'not a real patch, no file markers' };
+    const result = runDirectHook(input);
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), input);
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('apply_patch on Claude settings path is never gated', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: .gemini/settings.json',
+      '@@',
+      '-old',
+      '+new',
+      '*** End Patch',
+      ''
+    ].join('\n');
+    const input = { session_id: TEST_SESSION_ID, tool_name: 'apply_patch', tool_input: patch };
+    const result = runDirectHook(input);
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), input);
+  })) passed++; else failed++;
+
   // Cleanup only the temp directory created by this test file.
   try {
     if (fs.existsSync(stateDir)) {

--- a/tests/hooks/windsurf-gateguard-adapter.test.js
+++ b/tests/hooks/windsurf-gateguard-adapter.test.js
@@ -1,0 +1,196 @@
+/**
+ * Tests for scripts/hooks/windsurf-gateguard-adapter.js
+ *
+ * Windsurf Cascade Hooks use a different wire contract than Claude Code/
+ * Codex/Continue: stdin is {agent_action_name, tool_info}, not {tool_name,
+ * tool_input}, and blocking is signaled with exit code 2 + a stderr reason,
+ * not a hookSpecificOutput JSON object on stdout. This file exercises both
+ * the pure translation functions and the real CLI entrypoint end to end.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'windsurf-gateguard-adapter.js');
+const { buildGateGuardInput, extractDenyReason } = require(adapterScript);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'windsurf-gateguard-test-'));
+  try {
+    const result = spawnSync('node', [adapterScript], {
+      input: typeof input === 'string' ? input : JSON.stringify(input),
+      encoding: 'utf8',
+      env: { ...process.env, GATEGUARD_STATE_DIR: stateDir, ...env },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return {
+      code: Number.isInteger(result.status) ? result.status : 1,
+      stdout: result.stdout || '',
+      stderr: result.stderr || '',
+    };
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing windsurf-gateguard-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('maps pre_write_code on a new file to a gateguard Write input', () => {
+    const mapped = buildGateGuardInput({
+      agent_action_name: 'pre_write_code',
+      trajectory_id: 'traj-1',
+      tool_info: { file_path: path.join(os.tmpdir(), `windsurf-does-not-exist-${Date.now()}.js`) },
+    });
+    assert.strictEqual(mapped.tool_name, 'Write');
+    assert.strictEqual(mapped.session_id, 'traj-1');
+  })) passed++; else failed++;
+
+  if (test('maps pre_write_code on an existing file to a gateguard Edit input', () => {
+    const existingFile = path.join(os.tmpdir(), `windsurf-exists-${Date.now()}.js`);
+    fs.writeFileSync(existingFile, 'x');
+    try {
+      const mapped = buildGateGuardInput({
+        agent_action_name: 'pre_write_code',
+        trajectory_id: 'traj-1',
+        tool_info: { file_path: existingFile },
+      });
+      assert.strictEqual(mapped.tool_name, 'Edit');
+      assert.strictEqual(mapped.tool_input.file_path, existingFile);
+    } finally {
+      fs.rmSync(existingFile, { force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('maps pre_run_command to a gateguard Bash input', () => {
+    const mapped = buildGateGuardInput({
+      agent_action_name: 'pre_run_command',
+      trajectory_id: 'traj-1',
+      tool_info: { command_line: 'echo hi', cwd: '/tmp' },
+    });
+    assert.deepStrictEqual(mapped, {
+      session_id: 'traj-1',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi' },
+    });
+  })) passed++; else failed++;
+
+  if (test('returns null for unmapped Windsurf events (pre_read_code, pre_mcp_tool_use, ...)', () => {
+    assert.strictEqual(buildGateGuardInput({ agent_action_name: 'pre_read_code', tool_info: {} }), null);
+    assert.strictEqual(buildGateGuardInput({ agent_action_name: 'pre_mcp_tool_use', tool_info: {} }), null);
+  })) passed++; else failed++;
+
+  if (test('returns null for pre_write_code with no file_path', () => {
+    assert.strictEqual(
+      buildGateGuardInput({ agent_action_name: 'pre_write_code', tool_info: {} }),
+      null
+    );
+  })) passed++; else failed++;
+
+  if (test('extractDenyReason reads hookSpecificOutput.permissionDecisionReason on deny', () => {
+    const reason = extractDenyReason({
+      stdout: JSON.stringify({
+        hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: 'nope' },
+      }),
+      exitCode: 0,
+    });
+    assert.strictEqual(reason, 'nope');
+  })) passed++; else failed++;
+
+  if (test('extractDenyReason returns null on allow (string passthrough)', () => {
+    assert.strictEqual(extractDenyReason('{"tool_name":"Bash"}'), null);
+  })) passed++; else failed++;
+
+  if (test('extractDenyReason returns null when stdout is not JSON', () => {
+    assert.strictEqual(extractDenyReason({ stdout: 'not json', exitCode: 0 }), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: pre_write_code on a new file exits 2 with the fact-forcing reason on stderr', () => {
+    const targetFile = path.join(os.tmpdir(), `windsurf-cli-new-${Date.now()}.js`);
+    const result = runAdapterCli({
+      agent_action_name: 'pre_write_code',
+      trajectory_id: 'traj-cli-1',
+      tool_info: { file_path: targetFile },
+    });
+    assert.strictEqual(result.code, 2);
+    assert.ok(result.stderr.includes('Fact-Forcing Gate'));
+    assert.ok(result.stderr.includes(targetFile));
+    assert.strictEqual(result.stdout, '');
+  })) passed++; else failed++;
+
+  if (test('CLI: second pre_write_code call on the same file exits 0 with no output', () => {
+    const targetFile = path.join(os.tmpdir(), `windsurf-cli-retry-${Date.now()}.js`);
+    const event = {
+      agent_action_name: 'pre_write_code',
+      trajectory_id: 'traj-cli-2',
+      tool_info: { file_path: targetFile },
+    };
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'windsurf-gateguard-retry-'));
+    try {
+      spawnSync('node', [adapterScript], {
+        input: JSON.stringify(event),
+        encoding: 'utf8',
+        env: { ...process.env, GATEGUARD_STATE_DIR: stateDir },
+      });
+      const second = spawnSync('node', [adapterScript], {
+        input: JSON.stringify(event),
+        encoding: 'utf8',
+        env: { ...process.env, GATEGUARD_STATE_DIR: stateDir },
+      });
+      assert.strictEqual(second.status, 0);
+      assert.strictEqual(second.stderr, '');
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('CLI: pre_run_command exits 2 on first command in a session', () => {
+    const result = runAdapterCli({
+      agent_action_name: 'pre_run_command',
+      trajectory_id: `traj-cli-bash-${Date.now()}`,
+      tool_info: { command_line: 'ls', cwd: '/tmp' },
+    });
+    assert.strictEqual(result.code, 2);
+    assert.ok(result.stderr.includes('Fact-Forcing Gate'));
+  })) passed++; else failed++;
+
+  if (test('CLI: unmapped event (pre_read_code) exits 0 with no output', () => {
+    const result = runAdapterCli({
+      agent_action_name: 'pre_read_code',
+      trajectory_id: 'traj-cli-3',
+      tool_info: { file_path: '/tmp/some-file.js' },
+    });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, '');
+    assert.strictEqual(result.stderr, '');
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed stdin JSON fails open (exit 0)', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -675,6 +675,133 @@ function runTests() {
     assert.ok(stillHasWriteValidator, 'GateGuard should be additive, not a replacement for the protected-path write validator');
   })) passed++; else failed++;
 
+  if (test('codex adapter wires GateGuard into ~/.codex/hooks.json, not ~/.agents (Codex CLI does not read hooks from its skills root)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codex',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+
+    const codexHome = path.join(homeDir, '.codex');
+    const gateGuardScriptPath = path.join(codexHome, 'scripts', 'hooks', 'gateguard-fact-force.js');
+
+    const hooksJsonOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.hookScriptPath === gateGuardScriptPath
+    ));
+
+    assert.ok(hooksJsonOperations.length > 0, 'Should plan at least one PreToolUse merge into ~/.codex/hooks.json');
+    for (const operation of hooksJsonOperations) {
+      assert.strictEqual(operation.destinationPath, path.join(codexHome, 'hooks.json'));
+    }
+
+    const matchers = hooksJsonOperations.map(operation => operation.hookMatcher).sort();
+    assert.deepStrictEqual(
+      matchers,
+      ['Bash', 'apply_patch'],
+      'Codex sends tool_name "apply_patch" for file edits (Edit/Write are matcher aliases only) and "Bash" for shell commands'
+    );
+
+    const scriptCopyOperation = plan.operations.find(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+      && operation.destinationPath === gateGuardScriptPath
+    ));
+    assert.ok(scriptCopyOperation, 'Should copy gateguard-fact-force.js into ~/.codex/scripts/hooks/');
+
+    const libCopyOperation = plan.operations.find(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
+      && operation.destinationPath === path.join(codexHome, 'scripts', 'lib', 'utils.js')
+    ));
+    assert.ok(libCopyOperation, 'Should copy gateguard-fact-force.js\'s only dependency alongside it');
+  })) passed++; else failed++;
+
+  for (const [target, expectedRootSegments] of [['continue', ['.continue']], ['continue-project', ['.continue']]]) {
+    if (test(`${target} adapter wires GateGuard PreToolUse for Edit/Write/MultiEdit/Bash into settings.json`, () => {
+      const repoRoot = path.join(__dirname, '..', '..');
+      const isProject = target === 'continue-project';
+      const homeDir = '/Users/example';
+      const projectRoot = '/workspace/app';
+
+      const plan = planInstallTargetScaffold({
+        target,
+        repoRoot,
+        homeDir,
+        projectRoot,
+        modules: [],
+      });
+
+      const targetRoot = path.join(isProject ? projectRoot : homeDir, ...expectedRootSegments);
+      const gateGuardScriptPath = path.join(targetRoot, 'scripts', 'hooks', 'gateguard-fact-force.js');
+
+      const gateGuardOperations = plan.operations.filter(operation => (
+        operation.kind === 'merge-claude-settings-hooks'
+        && operation.hookEvent === 'PreToolUse'
+        && operation.hookScriptPath === gateGuardScriptPath
+      ));
+
+      const matchers = gateGuardOperations.map(operation => operation.hookMatcher).sort();
+      assert.deepStrictEqual(matchers, ['Bash', 'Edit', 'MultiEdit', 'Write']);
+      for (const operation of gateGuardOperations) {
+        assert.strictEqual(operation.destinationPath, path.join(targetRoot, 'settings.json'));
+      }
+
+      const scriptCopyOperation = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+        && operation.destinationPath === gateGuardScriptPath
+      ));
+      assert.ok(scriptCopyOperation, 'Should copy gateguard-fact-force.js into Continue\'s own root, unconditional of module selection');
+    })) passed++; else failed++;
+  }
+
+  for (const [target, rootFn] of [
+    ['windsurf', homeDir => path.join(homeDir, '.codeium', 'windsurf')],
+    ['windsurf-project', (_homeDir, projectRoot) => path.join(projectRoot, '.windsurf')],
+  ]) {
+    if (test(`${target} adapter wires GateGuard into hooks.json via the Windsurf-contract adapter script (pre_write_code + pre_run_command)`, () => {
+      const repoRoot = path.join(__dirname, '..', '..');
+      const homeDir = '/Users/example';
+      const projectRoot = '/workspace/app';
+
+      const plan = planInstallTargetScaffold({
+        target,
+        repoRoot,
+        homeDir,
+        projectRoot,
+        modules: [],
+      });
+
+      const targetRoot = rootFn(homeDir, projectRoot);
+      const adapterScriptPath = path.join(targetRoot, 'scripts', 'hooks', 'windsurf-gateguard-adapter.js');
+      const hooksJsonPath = path.join(targetRoot, 'hooks.json');
+
+      const hookOperations = plan.operations.filter(operation => (
+        operation.kind === 'merge-claude-settings-hooks'
+        && operation.hookScriptPath === adapterScriptPath
+        && operation.destinationPath === hooksJsonPath
+      ));
+      const events = hookOperations.map(operation => operation.hookEvent).sort();
+      assert.deepStrictEqual(events, ['pre_run_command', 'pre_write_code']);
+
+      const adapterCopyOperation = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/windsurf-gateguard-adapter.js'
+        && operation.destinationPath === adapterScriptPath
+      ));
+      assert.ok(adapterCopyOperation, 'Should copy the Windsurf-contract adapter script');
+
+      const gateGuardScriptPath = path.join(targetRoot, 'scripts', 'hooks', 'gateguard-fact-force.js');
+      const gateGuardCopyOperation = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+        && operation.destinationPath === gateGuardScriptPath
+      ));
+      assert.ok(gateGuardCopyOperation, 'Should also copy gateguard-fact-force.js itself (the adapter requires it in-process)');
+    })) passed++; else failed++;
+  }
+
   if (test('resolves codex adapter root to ~/.agents and install-state path', () => {
     const adapter = getInstallTargetAdapter('codex');
     const homeDir = '/Users/example';

--- a/tests/lib/windsurf-gateguard-hooks.test.js
+++ b/tests/lib/windsurf-gateguard-hooks.test.js
@@ -1,0 +1,134 @@
+/**
+ * Tests for scripts/lib/windsurf-gateguard-hooks.js
+ *
+ * Windsurf's hooks.json schema is a flat {hooks: {<event>: [{command}]}} map
+ * (no matcher/group wrapper, no "type": "command" field), unlike Claude
+ * Code's settings.json, so it needs its own merge logic. These tests exercise
+ * that merge logic directly (additive, idempotent, preserves unrelated keys
+ * and third-party hooks) plus the full apply.js dispatch wiring.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT,
+  addWindsurfHookEntry,
+  applyWindsurfGateGuardHookToFile,
+  resolveAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('../../scripts/lib/windsurf-gateguard-hooks');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing windsurf-gateguard-hooks ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('resolveHooksJsonPath and resolveAdapterScriptDestination compute paths under targetRoot', () => {
+    const targetRoot = '/home/user/.codeium/windsurf';
+    assert.strictEqual(resolveHooksJsonPath(targetRoot), path.join(targetRoot, 'hooks.json'));
+    assert.strictEqual(
+      resolveAdapterScriptDestination(targetRoot),
+      path.join(targetRoot, 'scripts', 'hooks', 'windsurf-gateguard-adapter.js')
+    );
+  })) passed++; else failed++;
+
+  if (test('addWindsurfHookEntry appends a new event array on an empty config', () => {
+    const { config, changed } = addWindsurfHookEntry({}, PRE_WRITE_CODE_EVENT, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config.hooks[PRE_WRITE_CODE_EVENT], [{ command: 'node adapter.js' }]);
+  })) passed++; else failed++;
+
+  if (test('addWindsurfHookEntry is idempotent (no duplicate on re-add)', () => {
+    const first = addWindsurfHookEntry({}, PRE_WRITE_CODE_EVENT, 'node adapter.js');
+    const second = addWindsurfHookEntry(first.config, PRE_WRITE_CODE_EVENT, 'node adapter.js');
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.config.hooks[PRE_WRITE_CODE_EVENT].length, 1);
+  })) passed++; else failed++;
+
+  if (test('addWindsurfHookEntry preserves third-party hooks in the same event array', () => {
+    const base = { hooks: { [PRE_WRITE_CODE_EVENT]: [{ command: 'bash /some/other-hook.sh' }] } };
+    const { config } = addWindsurfHookEntry(base, PRE_WRITE_CODE_EVENT, 'node adapter.js');
+    assert.strictEqual(config.hooks[PRE_WRITE_CODE_EVENT].length, 2);
+    assert.ok(config.hooks[PRE_WRITE_CODE_EVENT].some(entry => entry.command === 'bash /some/other-hook.sh'));
+    assert.ok(config.hooks[PRE_WRITE_CODE_EVENT].some(entry => entry.command === 'node adapter.js'));
+  })) passed++; else failed++;
+
+  if (test('addWindsurfHookEntry preserves unrelated events and top-level keys', () => {
+    const base = { $schema: 'https://example.com', hooks: { pre_read_code: [{ command: 'echo read' }] } };
+    const { config } = addWindsurfHookEntry(base, PRE_RUN_COMMAND_EVENT, 'node adapter.js');
+    assert.strictEqual(config.$schema, 'https://example.com');
+    assert.deepStrictEqual(config.hooks.pre_read_code, [{ command: 'echo read' }]);
+    assert.deepStrictEqual(config.hooks[PRE_RUN_COMMAND_EVENT], [{ command: 'node adapter.js' }]);
+  })) passed++; else failed++;
+
+  if (test('addWindsurfHookEntry migrates a stale entry (same script, different path) in place instead of duplicating', () => {
+    const base = {
+      hooks: {
+        [PRE_WRITE_CODE_EVENT]: [{ command: 'node /old/path/windsurf-gateguard-adapter.js' }],
+      },
+    };
+    const { config, changed } = addWindsurfHookEntry(base, PRE_WRITE_CODE_EVENT, 'node /new/path/windsurf-gateguard-adapter.js');
+    assert.strictEqual(changed, true);
+    assert.strictEqual(config.hooks[PRE_WRITE_CODE_EVENT].length, 1);
+    assert.strictEqual(config.hooks[PRE_WRITE_CODE_EVENT][0].command, 'node /new/path/windsurf-gateguard-adapter.js');
+  })) passed++; else failed++;
+
+  if (test('applyWindsurfGateGuardHookToFile writes both events to a fresh file and is idempotent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'windsurf-hooks-apply-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      const first = applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_WRITE_CODE_EVENT, '/abs/adapter.js');
+      assert.strictEqual(first.changed, true);
+      applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, '/abs/adapter.js');
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(Object.keys(onDisk.hooks).sort(), [PRE_RUN_COMMAND_EVENT, PRE_WRITE_CODE_EVENT].sort());
+
+      const second = applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_WRITE_CODE_EVENT, '/abs/adapter.js');
+      assert.strictEqual(second.changed, false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyWindsurfGateGuardHookToFile preserves a hand-written hooks.json on disk', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'windsurf-hooks-preserve-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, JSON.stringify({
+        hooks: { pre_run_command: [{ command: 'bash /user/custom.sh', show_output: true }] },
+      }, null, 2));
+
+      applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_WRITE_CODE_EVENT, '/abs/adapter.js');
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(onDisk.hooks.pre_run_command, [{ command: 'bash /user/custom.sh', show_output: true }]);
+      assert.strictEqual(onDisk.hooks[PRE_WRITE_CODE_EVENT].length, 1);
+      assert.ok(onDisk.hooks[PRE_WRITE_CODE_EVENT][0].command.includes('adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/opencode-plugin-hooks.test.js
+++ b/tests/opencode-plugin-hooks.test.js
@@ -137,6 +137,57 @@ async function main() {
         )
       }),
     ],
+    [
+      "tool.execute.before blocks the first edit on a file with the GateGuard fact-forcing gate",
+      async () => withTempProject([], async (projectDir) => {
+        fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
+        fs.mkdirSync(path.join(projectDir, "scripts", "lib"), { recursive: true })
+        fs.copyFileSync(
+          path.join(__dirname, "..", "scripts", "hooks", "gateguard-fact-force.js"),
+          path.join(projectDir, "scripts", "hooks", "gateguard-fact-force.js")
+        )
+        fs.copyFileSync(
+          path.join(__dirname, "..", "scripts", "lib", "utils.js"),
+          path.join(projectDir, "scripts", "lib", "utils.js")
+        )
+        const targetFile = path.join(projectDir, "gated-file.ts")
+        fs.writeFileSync(targetFile, "export const x = 1\n")
+
+        const client = createClient()
+        const $ = createFailingShell()
+        const hooks = await EGCHooksPlugin({ client, $, directory: projectDir })
+
+        await assert.rejects(
+          () => hooks["tool.execute.before"]({ tool: "edit", callID: "call-1", args: { filePath: targetFile } }),
+          /Fact-Forcing Gate/
+        )
+
+        // Second call on the same file should be allowed through (gate already passed).
+        await hooks["tool.execute.before"]({ tool: "edit", callID: "call-2", args: { filePath: targetFile } })
+      }),
+    ],
+    [
+      "tool.execute.before ignores unmapped tools and args-less calls without throwing",
+      async () => withTempProject([], async (projectDir) => {
+        fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
+        fs.mkdirSync(path.join(projectDir, "scripts", "lib"), { recursive: true })
+        fs.copyFileSync(
+          path.join(__dirname, "..", "scripts", "hooks", "gateguard-fact-force.js"),
+          path.join(projectDir, "scripts", "hooks", "gateguard-fact-force.js")
+        )
+        fs.copyFileSync(
+          path.join(__dirname, "..", "scripts", "lib", "utils.js"),
+          path.join(projectDir, "scripts", "lib", "utils.js")
+        )
+
+        const client = createClient()
+        const $ = createFailingShell()
+        const hooks = await EGCHooksPlugin({ client, $, directory: projectDir })
+
+        await hooks["tool.execute.before"]({ tool: "read", callID: "call-1", args: { filePath: "/tmp/whatever" } })
+        await hooks["tool.execute.before"]({ tool: "edit", callID: "call-2", args: undefined })
+      }),
+    ],
   ]
 
   let passed = 0


### PR DESCRIPTION
## Summary

Follow-up to #710. Issue #647's investigation (comment: https://github.com/Fmarzochi/EGC/issues/647#issuecomment-4949860385) mapped which supported tools have a real pre-tool-execution hook mechanism versus rules-file-only injection. This PR wires the Fact-Forcing Gate (`scripts/hooks/gateguard-fact-force.js`) into the four tools flagged as "real hook mechanism exists, not yet wired": Codex CLI, OpenCode, Continue.dev, and Windsurf.

- **Codex CLI**: registers the gate in `~/.codex/hooks.json` (verified against `codex-rs` source on `openai/codex`: `hook_names.rs`, `pre_tool_use.rs`, `output_parser.rs`). Codex's canonical `tool_name` for file edits is `apply_patch` (a freeform patch string; `Edit`/`Write` are matcher aliases only, the wire payload always says `apply_patch`), so `gateguard-fact-force.js` now parses `*** Update/Add/Delete File:` markers out of the patch text to recover the touched path(s), the same way it already loops over `MultiEdit` edits. `Bash`/`unified_exec` both serialize as tool_name `"Bash"` with `{command}`, so that path needed no changes.
- **Continue.dev**: its CLI hooks system is intentionally Claude Code-compatible (confirmed against `extensions/cli/src/hooks/types.ts` and `hookConfig.ts` on `continuedev/continue`): same `{hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}}` schema, same `~/.claude/settings.json`/`~/.continue/settings.json` precedence, same `Edit`/`Write`/`MultiEdit`/`Bash` tool names. The existing Claude merge operation applies unchanged once the gate script is copied into Continue's own root.
- **Windsurf**: Cascade Hooks (`pre_write_code`, `pre_run_command`) use a different wire contract than Claude/Codex/Continue: `{agent_action_name, tool_info}` on stdin, and blocking via exit code 2 + stderr instead of a stdout JSON decision. A new `scripts/hooks/windsurf-gateguard-adapter.js` translates both directions and is wired into `.windsurf/hooks.json` (project) and `~/.codeium/windsurf/hooks.json` (user).
- **OpenCode**: already ships its own hook plugin at `.opencode/plugins/egc-hooks.ts`. `tool.execute.before` now loads `gateguard-fact-force.js` in-process and throws to block, matching OpenCode's plugin contract (throw = deny).

All four install targets copy the gate script (and its one dependency, `scripts/lib/utils.js`) unconditionally, independent of module selection, matching the reasoning already used for Claude Code's own SessionStart hook: a security/quality gate should not depend on which optional modules a user picked.

## Test plan

- [x] `node tests/hooks/gateguard-fact-force.test.js`: added `apply_patch` coverage (deny/allow/retry, multi-file patch, unparseable patch fails open, `.gemini/settings.json` bypass)
- [x] `node tests/hooks/windsurf-gateguard-adapter.test.js` (new): event mapping, deny-reason extraction, full CLI round trip (exit 2 + stderr on deny, exit 0 silent on allow)
- [x] `node tests/lib/windsurf-gateguard-hooks.test.js` (new): additive/idempotent merge into `hooks.json`, preserves third-party hooks and unrelated keys, migrates stale entries in place
- [x] `node tests/lib/install-targets.test.js`: added wiring assertions for all four adapters (Codex root correctly resolves to `~/.codex`, not `~/.agents`; Continue matchers; Windsurf event/script wiring)
- [x] `node tests/opencode-plugin-hooks.test.js`: added a real deny/retry-allow case and an unmapped-tool no-throw case
- [x] Manually ran real `install-apply.js --target codex/continue/windsurf --profile full` against fresh temp `HOME` dirs and inspected the resulting `hooks.json`/`settings.json`/copied scripts on disk
- [x] `node tests/run-all.js`: 2523/2523 passed, 0 failed, clean environment (`EGC_DISABLED_HOOKS`/`EGC_HOOK_PROFILE` unset)

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GateGuard protection for Codex `apply_patch` operations, including multi-file patches.
  * Added GateGuard integration for Windsurf Cascade write and command events.
  * Extended installation support for Codex, Continue, and Windsurf environments.
  * Preserved existing hook entries while avoiding duplicates and updating stale integrations.

* **Bug Fixes**
  * Added fail-open handling for malformed or unpersistable hook inputs to prevent retry loops.

* **Tests**
  * Expanded coverage for Codex, Windsurf, Continue, and OpenCode integrations, including repeated and multi-file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->