### PR TITLE
docs(contributing): add one-time DCO hook -- remove per-commit -s friction

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Auto-add Signed-off-by if missing. Runs once per commit -- zero friction.
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
+  exit 0
+fi
+SOB="Signed-off-by: $NAME <$EMAIL>"
+if ! grep -qF "$SOB" "$1"; then
+  printf '\n%s\n' "$SOB" >> "$1"
+fi

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,46 +64,41 @@ For all contributions, the two hard requirements are `git commit -s` (DCO) and s
 gh repo fork Fmarzochi/EGC --clone
 cd EGC
 
-# 2. Create a feature branch
+# 2. One-time setup: activate the auto sign-off hook (do this once per clone)
+git config core.hooksPath .githooks
+
+# 3. Create a feature branch
 git checkout -b feat/my-contribution
 
-# 3. Add your contribution following the architectural standards below
+# 4. Add your contribution following the architectural standards below
 
-# 4. Verify locally (all of these must pass before you open a PR)
+# 5. Verify locally (all of these must pass before you open a PR)
 npm ci
 node tests/run-all.js              # full test suite (runs on Linux, macOS, Windows)
 npm audit --audit-level=high       # must show 0 high/critical vulnerabilities
 
-# 5. Submit PR (note: -s adds the required DCO sign-off to your commit)
-git add . && git commit -s -m "feat: add my-feature" && git push -u origin feat/my-contribution
+# 6. Submit PR — Signed-off-by is added automatically by the hook
+git add . && git commit -m "feat: add my-feature" && git push -u origin feat/my-contribution
 ```
 
 ---
 
 ## Developer Certificate of Origin (DCO)
 
-Every commit in your pull request **must** include a `Signed-off-by` line. This certifies that you wrote the code and have the right to contribute it under the project's MIT license. The `dco.yml` workflow checks every commit in every PR and blocks the merge if any commit is missing the signature.
+Every commit in your pull request must include a `Signed-off-by` line. This certifies that you wrote the code and have the right to contribute it under the project's MIT license.
 
-**For new commits, always use the `-s` flag:**
-
-```bash
-git commit -s -m "feat: add my-feature"
-```
-
-This automatically appends the required line to your commit message:
-
-```
-Signed-off-by: Your Full Name <your@email.com>
-```
-
-**To sign an existing unsigned commit:**
+**Zero-friction setup — run once per clone, never again:**
 
 ```bash
-git commit --amend -s
-git push --force-with-lease
+git config core.hooksPath .githooks
 ```
 
-**To sign all commits in a branch at once:**
+That is it. The `.githooks/prepare-commit-msg` hook adds `Signed-off-by: Your Name <your@email.com>` to every commit automatically. You never need to type `-s` again.
+
+> Want it globally across all your repos? Run instead:
+> `git config --global commit.signoff true`
+
+**If you already have unsigned commits on your branch:**
 
 ```bash
 git rebase --signoff main
@@ -500,7 +495,7 @@ How you ensured this maintains Runtime Integrity and Cross-Platform stability.
 
 ## Checklist
 - [ ] CLA signed (first contribution only - reply to the bot comment)
-- [ ] All commits are signed off with `git commit -s` (required by DCO check)
+- [ ] All commits carry `Signed-off-by` (run `git config core.hooksPath .githooks` once and it is automatic)
 - [ ] `node tests/run-all.js` passes locally with zero failures
 - [ ] `npm audit --audit-level=high` shows no high or critical vulnerabilities
 - [ ] Markdownlint passes on all `.md` files you created or modified (agents, skills, commands, rules)


### PR DESCRIPTION
## Summary

- Adds `.githooks/prepare-commit-msg` -- a shell hook that auto-appends `Signed-off-by` to every commit that is missing it
- Contributors run `git config core.hooksPath .githooks` **once after cloning** and never need to type `-s` again
- Documents the global alternative: `git config --global commit.signoff true`
- Updates Quick Start and DCO section in CONTRIBUTING.md to reflect zero-friction flow
- Removes the `git commit -s -m` pattern from Quick Start (replaced by the hook)

## Why

The previous flow required `-s` on every single commit. This was unnecessary friction: the DCO certifies each commit, but the signature can be added automatically. Contributors who forgot `-s` had to rebase to fix it, which created confusion (especially for new contributors like the one in PR #718).

## What changes for contributors

Before: `git commit -s -m "feat: ..."` (every commit)
After: `git config core.hooksPath .githooks` (once, then `git commit -m "feat: ..."` forever)

## Test plan

- [ ] Clone a fresh fork, run `git config core.hooksPath .githooks`, make a commit without `-s` -- verify `Signed-off-by` appears in the commit message
- [ ] CI DCO check passes on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-time DCO setup with a `prepare-commit-msg` hook that auto-adds Signed-off-by to every commit, removing the need for `-s`. Updated CONTRIBUTING to reflect the zero-friction flow and documented a global alternative.

- **Migration**
  - Run once per clone: git config core.hooksPath .githooks
  - Optional global: git config --global commit.signoff true

<sup>Written for commit 904b05a29afa08c07de26797e4088cfbed82870f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution instructions with a one-time Git hook setup.
  * Clarified that the hook automatically adds the `Signed-off-by` line to commits.
  * Revised the pull request checklist to reflect the updated sign-off workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->