### PR TITLE
fix(docs): correct Antigravity install path in integration-tiers.md

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -17,7 +17,7 @@ EGC supports 14 AI coding tools through 3 distinct integration mechanisms. This 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
 | 1 | **Claude Code** | 1 | `claude` | `~/.claude/skills/<name>/SKILL.md` | Skills installed flat; MCP + cognitive bootstrap via `~/.claude/CLAUDE.md` |
-| 2 | **Antigravity (AGY)** | 1 | `antigravity` | `~/.gemini/` (shared with Gemini CLI) | Reuses GEMINI.md from Gemini CLI |
+| 2 | **Antigravity (AGY)** | 1 | `antigravity` | `.agents/` (project-scoped, per repo) | Skills, agents, rules, and commands installed per-project; GateGuard hooks registered; no home-level target (Antigravity has no global rule discovery) |
 | 3 | **Gemini CLI** | 1 | `gemini` | `~/.gemini/` | Cognitive bootstrap into `GEMINI.md` |
 | 4 | **Cursor** | 1 | `cursor` | `~/.cursor/` | Rules injected into global cursor.rules |
 | 5 | **Codex CLI** | 1 | `codex` | `~/.agents/skills/<name>/SKILL.md` | Skills installed flat; `persistent_instructions` appended |


### PR DESCRIPTION
## Summary
- The Tier 1 table for **Antigravity (AGY)** claimed install path `~/.gemini/` (shared with Gemini CLI), reusing GEMINI.md from Gemini CLI.
- That was never true. The actual installer (`scripts/lib/install-targets/antigravity-project.js`) is `kind: 'project'`, `rootSegments: ['.agents']` -- it writes only into `.agents/` per repository. There is no home-level Antigravity adapter in `registry.js`.
- Confirmed independently by Antigravity's own bundled documentation (`agy-customizations/docs/rules.md`): rule discovery walks from cwd up to the repo root only, with no global rules mechanism in the product itself.
- Anyone installing with `--target antigravity` and checking this doc to find where their global rules landed would be misled into looking at `~/.gemini/GEMINI.md`, which is unrelated.

## Test plan
- [x] `node tests/spec/integration-tiers.test.js` passes (4/4)
- [x] Doc-only change, no code path affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Tier 1 table to show Antigravity (AGY) installs into `.agents/` per project instead of `~/.gemini/`. Clarifies that AGY does not reuse `GEMINI.md` and has no home-level target or global rule discovery.

<sup>Written for commit 260b5d9dd8b1365f6a4cac1e580c12345ae8f6de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Antigravity’s integration documentation to reflect project-scoped installation in the `.agents/` directory.
  * Clarified that skills, agents, rules, and commands are installed per repository, with GateGuard hook registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->