### PR TITLE
feat(ci): gate CodeRabbit review behind contributor history + basic checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,13 @@ reviews:
   high_level_summary: true
   review_status: true
   auto_review:
-    enabled: true
+    # Disabled: review is triggered conditionally by
+    # .github/workflows/first-time-contributor-gate.yml instead of firing
+    # on every PR open. Established contributors get an immediate
+    # @coderabbitai review comment; first-time contributors only get one
+    # after basic tests + DCO pass, so review quota isn't spent on PRs
+    # with no real chance of merging.
+    enabled: false
     drafts: false
 
   path_filters:

--- a/.github/workflows/dco-comment.yml
+++ b/.github/workflows/dco-comment.yml
@@ -1,0 +1,89 @@
+name: DCO Comment
+
+on:
+  workflow_run:
+    workflows: ["DCO"]
+    types: [completed]
+
+# Runs from the base branch's workflow definition -- workflow_run never
+# checks out or executes PR code, so write is safe here.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post DCO guidance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download result artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          pattern: dco-result-*
+          path: /tmp/dco-result
+
+      - name: Post guidance comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const resultDir = fs.readdirSync('/tmp/dco-result')[0];
+            const result = JSON.parse(
+              fs.readFileSync(path.join('/tmp/dco-result', resultDir, 'result.json'), 'utf8')
+            );
+            if (result.missing !== '1') return;
+
+            // The PR number in the artifact is untrusted: it is produced by
+            // the unprivileged pull_request job, whose own workflow YAML is
+            // read from the fork and can be rewritten by the PR author to
+            // claim any number. Validate it against the trusted
+            // workflow_run payload before using it for anything privileged.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: result.pr,
+            });
+            if (
+              pr.head.ref !== context.payload.workflow_run.head_branch ||
+              pr.head.repo.full_name !== context.payload.workflow_run.head_repository.full_name
+            ) {
+              core.setFailed(`Artifact PR #${result.pr} does not match the workflow_run that produced it -- refusing to comment.`);
+              return;
+            }
+            const issue_number = pr.number;
+
+            const marker = '<!-- dco-guidance -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+            if (comments.some(c => c.body.includes(marker))) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: `${marker}
+            **DCO sign-off missing**
+
+            One or more commits in this PR are missing a \`Signed-off-by\` line (Developer Certificate of Origin).
+
+            **How to fix:**
+            \`\`\`bash
+            # Single commit
+            git commit --amend -s
+            git push --force-with-lease
+
+            # Multiple commits -- replace N with the number of commits in your PR
+            git rebase --signoff HEAD~N
+            git push --force-with-lease
+            \`\`\`
+
+            > Note: This check is **informational only** -- a maintainer can still merge your PR without sign-off.`
+            });

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,9 +4,16 @@ on:
   pull_request:
     branches: [main]
 
+# pull_request (not pull_request_target): fork PR code runs the checkout
+# here, so the token stays unprivileged. GitHub silently caps write
+# scopes to read-only for fork-originated pull_request runs regardless
+# of this block -- confirmed in production: the old inline "Post
+# guidance comment" step here 403'd on every fork PR (e.g. #718) and
+# never actually posted. Commenting now happens in dco-comment.yml via
+# workflow_run, which runs with the base branch's own privileges.
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   dco:
@@ -41,37 +48,24 @@ jobs:
           fi
           echo "All commits have DCO sign-off. OK"
 
-      - name: Post guidance comment
-        if: always() && steps.dco.outputs.missing == '1'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Write result artifact
+        if: always()
+        env:
+          MISSING: ${{ steps.dco.outputs.missing || '0' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p /tmp/dco-result
+          cat > /tmp/dco-result/result.json <<EOF
+          {
+            "pr": ${PR_NUMBER},
+            "missing": "${MISSING}"
+          }
+          EOF
+
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa9 # v4.6.2
         with:
-          script: |
-            const marker = '<!-- dco-guidance -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            if (comments.some(c => c.body.includes(marker))) return;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `${marker}
-            **DCO sign-off missing**
-
-            One or more commits in this PR are missing a \`Signed-off-by\` line (Developer Certificate of Origin).
-
-            **How to fix:**
-            \`\`\`bash
-            # Single commit
-            git commit --amend -s
-            git push --force-with-lease
-
-            # Multiple commits -- replace N with the number of commits in your PR
-            git rebase --signoff HEAD~N
-            git push --force-with-lease
-            \`\`\`
-
-            > Note: This check is **informational only** -- a maintainer can still merge your PR without sign-off.`
-            });
+          name: dco-result-${{ github.event.pull_request.number }}
+          path: /tmp/dco-result/result.json
+          retention-days: 1

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload result artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa9 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dco-result-${{ github.event.pull_request.number }}
           path: /tmp/dco-result/result.json

--- a/.github/workflows/first-time-contributor-gate-comment.yml
+++ b/.github/workflows/first-time-contributor-gate-comment.yml
@@ -1,0 +1,155 @@
+name: First-Time Contributor Gate Comment
+
+on:
+  workflow_run:
+    workflows: ["First-Time Contributor Gate"]
+    types: [completed]
+
+# Runs from the base branch's workflow definition, not the fork's --
+# workflow_run never checks out or executes PR code, so it is safe to
+# grant write here. This is the only place in the gate that comments.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post gate result
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 5
+    steps:
+      - name: Download result artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          pattern: gate-result-*
+          path: /tmp/gate-result
+
+      - name: Post review trigger or guidance
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const resultDir = fs.readdirSync('/tmp/gate-result')[0];
+            const result = JSON.parse(
+              fs.readFileSync(path.join('/tmp/gate-result', resultDir, 'result.json'), 'utf8')
+            );
+
+            // The PR number in the artifact is untrusted: it is produced by
+            // the unprivileged pull_request job, whose own workflow YAML is
+            // read from the fork and can be rewritten by the PR author to
+            // claim any number. Validate it against the trusted
+            // workflow_run payload (head branch + head repo full name,
+            // always populated correctly by GitHub regardless of fork)
+            // before using it for anything privileged.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: result.pr,
+            });
+            if (
+              pr.head.ref !== context.payload.workflow_run.head_branch ||
+              pr.head.repo.full_name !== context.payload.workflow_run.head_repository.full_name
+            ) {
+              core.setFailed(`Artifact PR #${result.pr} does not match the workflow_run that produced it -- refusing to comment.`);
+              return;
+            }
+            const issue_number = pr.number;
+
+            const { data: search } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${pr.user.login} is:merged`,
+            });
+            const established = search.total_count > 0;
+
+            // testOutcome/dcoMissing ARE read from the artifact and can be
+            // spoofed by the same fork -- but the only effect of spoofing
+            // them is triggering @coderabbitai review on the attacker's own
+            // PR, identical to today's baseline behavior before this gate
+            // existed. Accepted tradeoff, not a privilege escalation.
+            const testFailed = result.testOutcome !== 'success';
+            const dcoMissing = result.dcoMissing === '1';
+
+            if (established || (!testFailed && !dcoMissing)) {
+              // Dedup by head SHA: a new push (new SHA) should re-trigger
+              // review, but a workflow re-run for the same commit must not
+              // spam a second "@coderabbitai review" comment.
+              const triggerMarker = `<!-- coderabbitai-triggered:${pr.head.sha} -->`;
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+              });
+              if (comments.some(c => c.body.includes(triggerMarker))) return;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: `${triggerMarker}\n@coderabbitai review`,
+              });
+              return;
+            }
+
+            const marker = '<!-- first-time-contributor-gate -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            const sections = [];
+            if (testFailed) {
+              sections.push([
+                '**Tests are failing.**',
+                'Run them locally before pushing again:',
+                '```bash',
+                'npm ci',
+                'npm test',
+                '```',
+                'Fix any failures shown in the "Run fast test check" step log on this PR.',
+              ].join('\n'));
+            }
+            if (dcoMissing) {
+              sections.push([
+                '**DCO sign-off missing.**',
+                '```bash',
+                'git commit --amend -s',
+                'git push --force-with-lease',
+                '```',
+                '(multiple commits: `git rebase --signoff HEAD~N && git push --force-with-lease`)',
+              ].join('\n'));
+            }
+
+            const body = [
+              marker,
+              '**Welcome! A couple of things to fix before this gets a full review.**',
+              '',
+              'EGC is a large project (hooks, Guardian, DCO, conventions) -- this is normal for a first PR, not a rejection.',
+              '',
+              sections.join('\n\n'),
+              '',
+              'Make sure your branch is on your own fork (not a branch on this repo directly) -- see [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the full guide.',
+              '',
+              'Push your fixes and this check re-runs automatically. Once it passes, CodeRabbit reviews the PR in full.',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/first-time-contributor-gate.yml
+++ b/.github/workflows/first-time-contributor-gate.yml
@@ -1,0 +1,107 @@
+name: First-Time Contributor Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: contributor-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# pull_request (not pull_request_target): PR code from forks runs here,
+# so the GITHUB_TOKEN must stay unprivileged. GitHub silently downgrades
+# write scopes to read-only for fork PRs regardless of what this block
+# declares, which is exactly why commenting happens in a separate
+# workflow_run job (first-time-contributor-gate-comment.yml) instead of
+# here. Never add pull-requests: write to this file.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Contributor gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Check contributor history
+        id: history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          MERGED=$(gh pr list --repo "${{ github.repository }}" --author "$AUTHOR" --state merged --json number --jq 'length')
+          echo "Prior merged PRs by $AUTHOR: $MERGED"
+          if [ "$MERGED" -gt 0 ]; then
+            echo "established=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "established=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: steps.history.outputs.established == 'false'
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        if: steps.history.outputs.established == 'false'
+        run: npm ci
+
+      # Known limitation: a PR can neuter this check by rewriting the
+      # "test" script in its own package.json. Accepted tradeoff -- worst
+      # case matches today's behavior (CodeRabbit runs on a bad PR), it
+      # does not regress security. The DCO check below cannot be gamed
+      # the same way since it inspects commit trailers, not PR-controlled
+      # scripts.
+      - name: Run fast test check
+        if: steps.history.outputs.established == 'false'
+        id: test
+        continue-on-error: true
+        run: npm test
+
+      - name: Check DCO sign-off
+        if: steps.history.outputs.established == 'false'
+        id: dco
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          missing=0
+          while IFS= read -r sha; do
+            body=$(git log -1 --format="%B" "$sha")
+            if ! echo "$body" | grep -qE "^Signed-off-by: .+ <.+>$"; then
+              missing=1
+            fi
+          done < <(git log --format="%H" "${BASE_SHA}..${HEAD_SHA}")
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+      - name: Write result artifact
+        env:
+          ESTABLISHED: ${{ steps.history.outputs.established }}
+          TEST_OUTCOME: ${{ steps.test.outcome || 'skipped' }}
+          DCO_MISSING: ${{ steps.dco.outputs.missing || '0' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p /tmp/gate-result
+          cat > /tmp/gate-result/result.json <<EOF
+          {
+            "pr": ${PR_NUMBER},
+            "established": "${ESTABLISHED}",
+            "testOutcome": "${TEST_OUTCOME}",
+            "dcoMissing": "${DCO_MISSING}"
+          }
+          EOF
+          cat /tmp/gate-result/result.json
+
+      - name: Upload result artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa9 # v4.6.2
+        with:
+          name: gate-result-${{ github.event.pull_request.number }}
+          path: /tmp/gate-result/result.json
+          retention-days: 1

--- a/.github/workflows/first-time-contributor-gate.yml
+++ b/.github/workflows/first-time-contributor-gate.yml
@@ -100,7 +100,7 @@ jobs:
           cat /tmp/gate-result/result.json
 
       - name: Upload result artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa9 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gate-result-${{ github.event.pull_request.number }}
           path: /tmp/gate-result/result.json


### PR DESCRIPTION
## Summary
- `.coderabbit.yaml`: disable `auto_review` (was firing on every PR open, burning review quota on PRs with no chance of merging).
- New `first-time-contributor-gate.yml` + `first-time-contributor-gate-comment.yml`: established contributors (prior merged PR) trigger `@coderabbitai review` immediately; first-timers only trigger it after a fast test pass + DCO check. Otherwise they get an automated guidance comment (fork/test/DCO instructions) instead.
- Fixes a real pre-existing bug in `dco.yml`: its guidance comment step always 403'd on fork PRs (GITHUB_TOKEN forced read-only for `pull_request` events from forks regardless of the declared `permissions:` block) -- confirmed against the actual failed run logs on PR #718. Split into `dco.yml` (checks, uploads artifact) + `dco-comment.yml` (`workflow_run`, posts the comment with write access).

## Security notes
- Every check-running job stays on `pull_request` (not `pull_request_target`), so fork PR code never runs with elevated privileges.
- The artifact's self-reported PR number is never trusted directly by the privileged `workflow_run` job -- it's validated against `head_branch`/`head_repository` from the trusted `workflow_run` payload before use, since a fork can rewrite its own copy of the `pull_request`-triggered workflow file.
- The `@coderabbitai review` trigger comment is deduped by head SHA so re-runs don't spam the PR thread, while genuinely new pushes still get reviewed.
- Reviewed over four rounds with a second model (Antigravity/Gemini) acting as independent security auditor; each round's findings were verified against real repo evidence before being accepted or pushed back on.

## Test plan
- [x] YAML syntax validated for all 4 changed/new workflow files
- [x] DCO 403 bug reproduced against real `dco.yml` run logs on PR #718 before fixing
- [x] Four rounds of independent security review (artifact trust, PR-number spoofing, comment spam, git log range semantics)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates CodeRabbit reviews behind contributor history and basic checks to reduce quota waste and noise. Also fixes DCO guidance comments for fork PRs and corrects the `actions/upload-artifact` pin to prevent setup failures.

- **New Features**
  - Disabled `auto_review` in `.coderabbit.yaml`; review now triggered by a new `First-Time Contributor Gate`.
  - Established contributors get an immediate `@coderabbitai review`; first-timers must pass fast tests and DCO, otherwise get an automated guidance comment.
  - Gate runs on `pull_request` with read-only token, uploads an artifact, and a separate `workflow_run` posts comments; trigger comments are deduped by head SHA.

- **Bug Fixes**
  - Split DCO into `dco.yml` (checks + artifact) and `dco-comment.yml` (`workflow_run` posts comment) to resolve 403s on fork PRs.
  - Validate artifact-reported PR numbers against `workflow_run` data before commenting to prevent spoofing.
  - Pinned `actions/upload-artifact` to verified SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1) to fix “unable to resolve action” setup failures in both gate and DCO workflows.

<sup>Written for commit e0bda4120c89911482ac5e9cd8de8db876b32a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added automated checks for first-time contributors, including test results and DCO sign-off status.
  * Added clear pull request guidance when required checks or sign-offs are missing.
  * Improved safeguards around automated pull request comments and review triggers.
  * Reduced unnecessary automatic review runs while preserving reviews when applicable.
  * Improved security by limiting permissions used during pull request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->