### PR TITLE
chore(memory): sync EGC project memory to tool config files

### DIFF
--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -5,14 +5,13 @@ alwaysApply: true
 
 ## EGC Project Memory
 
-**Context:** EGC v1.1.7 released and published to npm. @egchq/egc@1.1.7 is live as latest.
+**Context:** Sessao encerrada 2026-07-13. Hero banner (PR #726) e provedor Mistral nativo (PR #718) mergeados, Multica corrigido de vez (workspace EGC), 2 issues-isca novas abertas (#728 Vertex AI, #729 Cohere).
 
 **Active decisions:**
-- v1.1.7 is the last authorized bump -- no further bumps without explicit Felipe authorization
-- build-skill-index.js fixed: console.log -> process.stderr.write (PR #639, merged)
-- EGCSite updated: 14 tools, v1.1.7 badge, terminal demo, Guardian desc, fuentes71
-- Discord #announcements #changelog #roadmap all updated to v1.1.7
+- Multica: card canonico EGC-90 (Parth) atualizado de 'IN REVIEW' pra 'Hall of Fame' (4 PRs, PR #718 mergeada), status done. Card pai EGC-86 atualizado: secao Active zerada, tabela Hall of Fame com 16 contributors.
+- Issues-isca #728 (Vertex AI) e #729 (Cohere) criadas no lugar do pedido original ambiguo 'Google Gemini provider' -- Gemini direto ja e provider nativo desde o inicio, entao a issue foi reinterpretada como Vertex AI (caminho enterprise/ADC do Google, mesmo SDK google-genai, auth diferente)
+- Issue #716 (Mistral) confirmada fechada automaticamente pela PR #718 -- removida da lista de 'aguardando resposta'
 
 **Next session:**
-- No pending release tasks -- v1.1.7 is complete
-- Monitor npm publish and GitHub Release page for any issues
+- Proxima sessao: conferir se #715 (Groq), #728 (Vertex AI) ou #729 (Cohere) receberam resposta de algum contribuidor
+- Backlog sem mudanca: EGC-109 (issue #725), EGC-110 (revisao do Vault, 523+ arquivos)


### PR DESCRIPTION
## Summary
- Syncs `.cursor/rules/egc-context.mdc` with the latest project memory (auto-generated by `egc-memory update_state` after this session's PR #726/#718 merges and Multica cleanup).

## Test plan
- [x] No functional code changes — memory context file only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs EGC project memory in `.cursor/rules/egc-context.mdc` to the latest session: #726/#718 merged, Multica moved to Hall of Fame, new issues #728 (Vertex AI) and #729 (Cohere), #716 (Mistral) closed, and next-session notes updated to watch #715/#728/#729.
No functional or build changes; config text only.

<sup>Written for commit 82d0f3f0a4b33f5f79b27544c24f134a55b2c7fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

