### PR TITLE
fix(llm): harden native DeepSeek provider — temperature normalization, exception retagging, provider resolution (#725)

### DIFF
--- a/src/llm/core/model_resolver.py
+++ b/src/llm/core/model_resolver.py
@@ -445,12 +445,13 @@ class ModelResolver:
 
     # Per-provider default model ID (single place provider defaults live).
     _PROVIDER_DEFAULTS: Dict[str, str] = {
-        "gemini": "gemini-2.5-pro",
-        "claude": "claude-sonnet-4-7",
-        "openai": "gpt-4o",
-        "ollama": "llama3.2",
-        "openrouter": "openrouter/auto",
-        "mistral": "mistral-large-latest",
+    "gemini": "gemini-2.5-pro",
+    "claude": "claude-sonnet-4-7",
+    "openai": "gpt-4o",
+    "ollama": "llama3.2",
+    "openrouter": "openrouter/auto",
+    "mistral": "mistral-large-latest",
+    "deepseek": "deepseek-chat",
     }
 
     _DEFAULT_PROVIDER = "gemini"
@@ -466,7 +467,7 @@ class ModelResolver:
             or "gemma" in v
             or "claude-" in v
             or "mistral-" in v
-            or v.startswith(("gpt-", "o1", "o3", "o4", "ministral-", "codestral-"))
+            or v.startswith(("gpt-", "o1", "o3", "o4", "ministral-", "codestral-", "deepseek-"))
             or "/models/" in v          # Vertex AI fully-qualified path
             or ("/" in v and not v.startswith("/"))  # OpenRouter "vendor/model" style
         )
@@ -488,6 +489,8 @@ class ModelResolver:
             return "mistral"
         if "gemini" in v or "gemma" in v:
             return "gemini"
+        if v.startswith("deepseek-"):
+            return "deepseek"
         return cls._DEFAULT_PROVIDER
 
     # ------------------------------------------------------------------ #

--- a/src/llm/providers/deepseek.py
+++ b/src/llm/providers/deepseek.py
@@ -17,13 +17,17 @@ try:
 except ImportError:  # pragma: no cover - SDK optional
     OpenAI = None  # type: ignore[assignment]
 
-from llm.core.interface import AuthenticationError, LLMProvider
+from llm.core.interface import AuthenticationError, LLMError, LLMProvider
 from llm.core.model_resolver import ModelResolver
 from llm.core.types import ModelInfo, ProviderType
 from llm.providers.openai import OpenAIProvider
 
 DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
 _DEFAULT_MODEL = "deepseek-chat"
+
+# deepseek-reasoner (R1) only accepts temperature at or near 1.0.
+# Passing any other value causes the API to reject the request.
+_REASONER_TEMPERATURE = 1.0
 
 
 class DeepSeekProvider(OpenAIProvider):
@@ -60,31 +64,38 @@ class DeepSeekProvider(OpenAIProvider):
 
     def generate(self, llm_input: "LLMInput") -> "LLMOutput":  # type: ignore[override]
         from llm.core.types import LLMInput, LLMOutput
-        # deepseek-reasoner does not support tool calls — strip them to avoid
-        # sending an unsupported request to the API.
         model = llm_input.model or self.get_default_model()
-        if model == "deepseek-reasoner" and llm_input.tools:
-            llm_input = LLMInput(
-                messages=llm_input.messages,
-                session_id=llm_input.session_id,
-                model=llm_input.model,
-                temperature=llm_input.temperature,
-                max_tokens=llm_input.max_tokens,
-                tools=None,
-                stream=llm_input.stream,
-                metadata=llm_input.metadata,
-            )
+        if model == "deepseek-reasoner":
+            # deepseek-reasoner does not support tool calls or custom
+            # temperature values — normalize both to avoid API rejections.
+            if llm_input.tools or llm_input.temperature != _REASONER_TEMPERATURE:
+                llm_input = LLMInput(
+                    messages=llm_input.messages,
+                    session_id=llm_input.session_id,
+                    model=llm_input.model,
+                    temperature=_REASONER_TEMPERATURE,  # fix #1: force to 1.0
+                    max_tokens=llm_input.max_tokens,
+                    tools=None,
+                    stream=llm_input.stream,
+                    metadata=llm_input.metadata,
+                )
         try:
             return super().generate(llm_input)
+        except LLMError as exc:
+            # Re-tag LLMErrors so telemetry sees ProviderType.DEEPSEEK.
+            raise LLMError(
+                str(exc),
+                provider=ProviderType.DEEPSEEK,
+            ) from exc
         except Exception as exc:
-            # Re-tag any LLMError so telemetry sees ProviderType.DEEPSEEK.
-            from llm.core.interface import LLMError
-            if isinstance(exc, LLMError):
-                raise LLMError(
-                    str(exc),
-                    provider=ProviderType.DEEPSEEK,
-                ) from exc
-            raise
+            # fix #2: native OpenAI SDK exceptions (RateLimitError,
+            # APIConnectionError, AuthenticationError, etc.) propagate here
+            # unwrapped when OpenAIProvider.generate() hits the bare `raise`.
+            # Wrap them so telemetry always attributes to DEEPSEEK, never OPENAI.
+            raise LLMError(
+                str(exc),
+                provider=ProviderType.DEEPSEEK,
+            ) from exc
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()
@@ -94,9 +105,10 @@ class DeepSeekProvider(OpenAIProvider):
 
     def get_default_model(self) -> str:
         resolved = ModelResolver.resolve(None, provider="deepseek")
-        # ModelResolver returns the registry default (may be Gemini) when
-        # "deepseek" has no registered default; guard against cross-provider bleed.
-        if resolved and resolved.startswith("deepseek"):
+        # fix #3: use _provider_for() instead of a fragile string prefix check.
+        # Guards against ModelResolver returning a cross-provider default
+        # (e.g. gemini-2.5-pro) when no deepseek env override is set.
+        if resolved and ModelResolver._provider_for(resolved) == "deepseek":
             return resolved
         return _DEFAULT_MODEL
 

--- a/tests/test_deepseek_provider.py
+++ b/tests/test_deepseek_provider.py
@@ -159,3 +159,114 @@ def test_get_default_model_returns_deepseek_chat_when_resolver_bleeds(monkeypatc
         mock_openai.return_value = MagicMock()
         p = DeepSeekProvider()
     assert p.get_default_model() == "deepseek-chat"
+
+# ── Tests added for issue #725 ────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_reasoner_forces_temperature_to_one(provider: DeepSeekProvider) -> None:
+    """fix #1: deepseek-reasoner must always receive temperature=1.0."""
+    from llm.core.types import LLMInput, Message, Role
+    response = MagicMock()
+    choice = MagicMock()
+    choice.message.content = "answer"
+    choice.message.tool_calls = None
+    choice.finish_reason = "stop"
+    response.choices = [choice]
+    response.model = "deepseek-reasoner"
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = 5
+    usage.total_tokens = 15
+    response.usage = usage
+    provider.client.chat.completions.create.return_value = response
+
+    llm_input = LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="deepseek-reasoner",
+        temperature=0.0,  # non-default — would be rejected by the API
+    )
+    provider.generate(llm_input)
+    _, kwargs = provider.client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 1.0
+
+
+@pytest.mark.unit
+def test_reasoner_leaves_temperature_unchanged_when_already_one(provider: DeepSeekProvider) -> None:
+    """fix #1: no unnecessary LLMInput rebuild when temperature is already 1.0."""
+    from llm.core.types import LLMInput, Message, Role
+    response = MagicMock()
+    choice = MagicMock()
+    choice.message.content = "answer"
+    choice.message.tool_calls = None
+    choice.finish_reason = "stop"
+    response.choices = [choice]
+    response.model = "deepseek-reasoner"
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = 5
+    usage.total_tokens = 15
+    response.usage = usage
+    provider.client.chat.completions.create.return_value = response
+
+    llm_input = LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="deepseek-reasoner",
+        temperature=1.0,
+    )
+    provider.generate(llm_input)
+    _, kwargs = provider.client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 1.0
+
+
+@pytest.mark.unit
+def test_native_sdk_exception_is_retagged_as_deepseek(provider: DeepSeekProvider) -> None:
+    """fix #2: raw SDK exceptions that bypass OpenAIProvider wrapping must still
+    surface as LLMError with provider=DEEPSEEK, not as bare SDK errors."""
+    provider.client.chat.completions.create.side_effect = RuntimeError("connection reset")
+    with pytest.raises(LLMError) as exc:
+        provider.generate(_simple_input())
+    assert exc.value.provider == ProviderType.DEEPSEEK
+
+
+@pytest.mark.unit
+def test_provider_for_deepseek_model_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """fix #3: ModelResolver._provider_for must return 'deepseek' for both
+    current and hypothetical future DeepSeek native model names."""
+    from llm.core.model_resolver import ModelResolver
+    assert ModelResolver._provider_for("deepseek-chat") == "deepseek"
+    assert ModelResolver._provider_for("deepseek-reasoner") == "deepseek"
+    # Hypothetical future name that doesn't start with "deepseek" won't be
+    # caught by this heuristic, but current names must be correct.
+    assert ModelResolver._provider_for("gemini-2.5-pro") != "deepseek"
+
+
+@pytest.mark.unit
+def test_model_resolver_default_for_deepseek_provider() -> None:
+    """fix #3: ModelResolver.resolve(None, provider='deepseek') must return a
+    deepseek model, not bleed into gemini or another provider's default."""
+    from llm.core.model_resolver import ModelResolver
+    resolved = ModelResolver.resolve(None, provider="deepseek")
+    assert ModelResolver._provider_for(resolved) == "deepseek"
+
+# ── Tests added to address cubic-dev-ai P2 review comments ───────────────────
+
+@pytest.mark.unit
+def test_resolve_deepseek_reasoner_is_not_replaced_by_default() -> None:
+    """P2 fix: deepseek-reasoner passed as a hint must resolve to itself,
+    not silently collapse to deepseek-chat via _PROVIDER_DEFAULTS."""
+    from llm.core.model_resolver import ModelResolver
+    resolved = ModelResolver.resolve("deepseek-reasoner", provider="deepseek")
+    assert resolved == "deepseek-reasoner"
+
+
+@pytest.mark.unit
+def test_bare_deepseek_alias_does_not_claim_deepseek_provider() -> None:
+    """P2 fix: the bare token 'deepseek' is an alias, not a model ID.
+    _provider_for must not return 'deepseek' for it, so LLM_MODEL=deepseek
+    does not bypass the alias resolution path."""
+    from llm.core.model_resolver import ModelResolver
+    # bare alias token — must NOT be classified as a native deepseek model
+    assert ModelResolver._provider_for("deepseek") != "deepseek"
+    # real model IDs — must be classified correctly
+    assert ModelResolver._provider_for("deepseek-chat") == "deepseek"
+    assert ModelResolver._provider_for("deepseek-reasoner") == "deepseek"


### PR DESCRIPTION
## Summary

Follow-up hardening for the native DeepSeek provider introduced in #724,
addressing all three items raised in the post-merge audit (#725), plus
three additional edge cases surfaced during code review. No behaviour
changes for the happy path — all fixes target paths that don't trigger
with default settings today but would cause silent failures or
misattributed telemetry in production.

Closes #725

---

## What was wrong and what we changed

### Fix 1 — `temperature` not adjusted for `deepseek-reasoner`

**Problem:** `deepseek-reasoner` (R1) only accepts `temperature` at or
near `1.0`. The DeepSeek API rejects requests with any other value.
`generate()` already stripped `tools` for this model but passed
`llm_input.temperature` through unchanged, so any caller using a
non-default temperature (e.g. `0.7`, `0.0`) would get a hard API
rejection.

**Fix:** Added a module-level constant `_REASONER_TEMPERATURE = 1.0` and
merged temperature normalization into the existing `LLMInput`
reconstruction block that already stripped tools. The rebuild now only
happens when needed (`tools` present OR `temperature != 1.0`), keeping
the no-op path allocation-free.

```python
# before — tools stripped, temperature passed through unchanged
if model == "deepseek-reasoner" and llm_input.tools:
    llm_input = LLMInput(..., temperature=llm_input.temperature, tools=None, ...)

# after — both normalized together
if model == "deepseek-reasoner":
    if llm_input.tools or llm_input.temperature != _REASONER_TEMPERATURE:
        llm_input = LLMInput(..., temperature=_REASONER_TEMPERATURE, tools=None, ...)
```

---

### Fix 2 — `LLMError` retag misses native SDK exceptions

**Problem:** `OpenAIProvider.generate()` catches recognisable errors
(401, 429, context length) and wraps them in `LLMError` subclasses, but
re-raises everything else bare via `raise`. Those bare SDK exceptions
(`APIConnectionError`, unrecognised `APIStatusError`, etc.) propagated
into `DeepSeekProvider.generate()`'s `except Exception` block, which
only retagged when `isinstance(exc, LLMError)` — so unrecognised SDK
exceptions bypassed the retag entirely, leaving telemetry attributed to
`ProviderType.OPENAI` or with no provider set.

**Fix:** Split the single `except Exception` into two clauses. `except
LLMError` handles already-wrapped errors. A new `except Exception` below
it catches every remaining exception — raw SDK or otherwise — and wraps
it in `LLMError(provider=ProviderType.DEEPSEEK)` before re-raising,
guaranteeing telemetry always sees the correct provider.

```python
# before
except Exception as exc:
    if isinstance(exc, LLMError):
        raise LLMError(str(exc), provider=ProviderType.DEEPSEEK) from exc
    raise  # ← bare SDK exceptions escape untagged here

# after
except LLMError as exc:
    raise LLMError(str(exc), provider=ProviderType.DEEPSEEK) from exc
except Exception as exc:
    raise LLMError(str(exc), provider=ProviderType.DEEPSEEK) from exc
```

---

### Fix 3 — Fragile `startswith("deepseek")` in `get_default_model()` + supporting `ModelResolver` gaps

**Problem (original):** `get_default_model()` used
`resolved.startswith("deepseek")` to guard against cross-provider bleed.
There were also two gaps in `ModelResolver`:

1. `_PROVIDER_DEFAULTS` had no `"deepseek"` entry, so
   `ModelResolver.resolve(None, provider="deepseek")` fell through to
   `gemini-2.5-pro`.
2. `_provider_for()` had no `"deepseek"` heuristic, so
   `_provider_for("deepseek-chat")` returned `"gemini"`.

**Additional edge cases found during review:**

3. `deepseek-chat` and `deepseek-reasoner` were not in `_looks_like_real_id`,
   so `ModelResolver.resolve("deepseek-reasoner", provider="deepseek")`
   silently collapsed to `deepseek-chat` via `_PROVIDER_DEFAULTS` instead
   of passing through as an explicit model ID.
4. The `_provider_for` heuristic was initially written as
   `v.startswith("deepseek")` (no hyphen), which misclassified the bare
   alias token `"deepseek"` (which maps to `gemini-2.5-pro` in `_ALIASES`)
   as a native DeepSeek model ID — meaning `LLM_MODEL=deepseek` would
   bypass alias resolution.

**Fix (all four parts):**

- `model_resolver.py`: added `"deepseek": "deepseek-chat"` to
  `_PROVIDER_DEFAULTS` so the resolver returns the correct native default.
- `model_resolver.py`: added `"deepseek-"` to `_looks_like_real_id` so
  explicit native model IDs like `deepseek-reasoner` pass through
  `resolve()` unchanged instead of collapsing to the provider default.
- `model_resolver.py`: added `if v.startswith("deepseek-"):` heuristic
  (with hyphen) to `_provider_for()` — real model IDs match, the bare
  alias token does not.
- `deepseek.py`: replaced `resolved.startswith("deepseek")` with
  `ModelResolver._provider_for(resolved) == "deepseek"`, sharing the
  same resolution logic as the rest of the system.

---

## Tests

7 new unit tests added to `tests/test_deepseek_provider.py`:

| Test | Covers |
|---|---|
| `test_reasoner_forces_temperature_to_one` | Fix 1 — non-default temp normalized to 1.0 |
| `test_reasoner_leaves_temperature_unchanged_when_already_one` | Fix 1 — no unnecessary rebuild when already correct |
| `test_native_sdk_exception_is_retagged_as_deepseek` | Fix 2 — bare SDK exceptions surface as `LLMError(provider=DEEPSEEK)` |
| `test_provider_for_deepseek_model_names` | Fix 3 — `_provider_for` returns `"deepseek"` for current model names |
| `test_model_resolver_default_for_deepseek_provider` | Fix 3 — resolver never bleeds into another provider's default |
| `test_resolve_deepseek_reasoner_is_not_replaced_by_default` | Review P2 — explicit `deepseek-reasoner` hint is not collapsed to `deepseek-chat` |
| `test_bare_deepseek_alias_does_not_claim_deepseek_provider` | Review P2 — bare alias token `deepseek` is not misclassified as a model ID |

All 21 tests pass (14 pre-existing + 7 new).

---

## Files changed

- `src/llm/providers/deepseek.py` — fixes 1, 2, 3
- `src/llm/core/model_resolver.py` — supporting fixes for 3 (`_PROVIDER_DEFAULTS`, `_looks_like_real_id`, `_provider_for`)
- `tests/test_deepseek_provider.py` — 7 new unit tests