### PR TITLE
feat(install): add native Kiro install target (Tier 1)

### DIFF
--- a/.kiro/install.sh
+++ b/.kiro/install.sh
@@ -40,8 +40,11 @@ echo "Source:  $SOURCE_KIRO"
 echo "Target:  $TARGET/.kiro/"
 echo ""
 
-# Subdirectories to create and populate
-SUBDIRS="agents skills steering hooks scripts settings"
+# Subdirectories to create and populate. Skills are NOT handled here: they
+# ship through the unified Tier 1 pipeline (`egc install --target kiro`),
+# which stays in sync with the full skill library instead of this script's
+# old hand-curated snapshot.
+SUBDIRS="agents steering hooks scripts settings"
 
 # Create all required .kiro/ subdirectories
 for dir in $SUBDIRS; do
@@ -49,7 +52,7 @@ for dir in $SUBDIRS; do
 done
 
 # Counters for summary
-agents=0; skills=0; steering=0; hooks=0; scripts=0; settings=0
+agents=0; steering=0; hooks=0; scripts=0; settings=0
 
 # Copy agents (JSON for CLI, Markdown for IDE)
 if [ -d "$SOURCE_KIRO/agents" ]; then
@@ -59,19 +62,6 @@ if [ -d "$SOURCE_KIRO/agents" ]; then
     if [ ! -f "$TARGET/.kiro/agents/$local_name" ]; then
       cp "$f" "$TARGET/.kiro/agents/" 2>/dev/null || true
       agents=$((agents + 1))
-    fi
-  done
-fi
-
-# Copy skills (directories with SKILL.md)
-if [ -d "$SOURCE_KIRO/skills" ]; then
-  for d in "$SOURCE_KIRO/skills"/*/; do
-    [ -d "$d" ] || continue
-    skill_name="$(basename "$d")"
-    if [ ! -d "$TARGET/.kiro/skills/$skill_name" ]; then
-      mkdir -p "$TARGET/.kiro/skills/$skill_name"
-      cp "$d"* "$TARGET/.kiro/skills/$skill_name/" 2>/dev/null || true
-      skills=$((skills + 1))
     fi
   done
 fi
@@ -125,16 +115,19 @@ echo "Installation complete!"
 echo ""
 echo "Components installed:"
 echo "  Agents:    $agents"
-echo "  Skills:    $skills"
 echo "  Steering:  $steering"
 echo "  Hooks:     $hooks"
 echo "  Scripts:   $scripts"
 echo "  Settings:  $settings"
 echo ""
+echo "Note: skills are not installed by this script anymore. Run"
+echo "  'egc install --target kiro' to install skills from the full,"
+echo "  always up-to-date EGC skill library."
+echo ""
 echo "Next steps:"
 echo "  1. Open your project in Kiro"
 echo "  2. Agents: Automatic in IDE, /agent swap in CLI"
-echo "  3. Skills: Available via / menu in chat"
+echo "  3. Skills: run 'egc install --target kiro', then available via / menu in chat"
 echo "  4. Steering files with 'auto' inclusion load automatically"
 echo "  5. Toggle hooks in the Agent Hooks panel"
 echo "  6. Copy desired MCP servers from .kiro/settings/mcp.json.example to .kiro/settings/mcp.json"

--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -28,14 +28,14 @@ EGC supports 14 AI coding tools through 3 distinct integration mechanisms. This 
 | 10 | **VS Code Copilot** | 1 | `copilot` | `~/.github/skills/<name>/SKILL.md` | Skills installed flat |
 | 11 | **Zed** | 1 | `zed` | `~/.config/zed/skills/<name>/` | Skills installed flat (category stripped); MCP via `context_servers` in `settings.json`; cognitive bootstrap into `~/.config/zed/AGENTS.md` |
 | 12 | **Continue.dev** | 1 | `continue` | `~/.continue/skills/<name>/SKILL.md` | Skills installed flat; MCP via YAML block files in `~/.continue/mcpServers/`; memory protocol prompt in `~/.continue/prompts/`; rules discovered natively at workspace `.continue/rules/` |
-| 13 | **Kiro** | 2 | (none) | `~/.kiro/` via `.kiro/install.sh` | Session hooks installed to `~/.kiro/hooks/` |
+| 13 | **Kiro** | 1 | `kiro` | `~/.kiro/skills/<name>/` (home) and `.kiro/skills/<name>/` (project) | Skills installed flat via the unified pipeline; the legacy `.kiro/install.sh` script still handles project-local agents, steering docs, hooks, scripts, and settings (a separate concern from skill distribution, not yet migrated) |
 | 14 | **Trae** | 2 | (none) | `~/.trae/` (or `~/.trae-cn/` with `TRAE_ENV=cn`) via `.trae/install.sh` | Memory protocol written to `~/.trae/MEMORY.md` |
 
 ## Why three tiers (history, not aspiration)
 
 Tier 1 (unified) is the canonical pipeline. It is the result of `install-plan.js` resolving install manifests against `SUPPORTED_INSTALL_TARGETS`, then `install-apply.js` materializing files. The pipeline emits provenance, supports dry-run, and is covered by 200+ tests under `tests/`.
 
-Tier 2 (custom-script) exists because Kiro and Trae landed in EGC before the unified pipeline was stable. Their installers do roughly the same work as the unified pipeline, but the shape of the assets they ship differs enough that retrofitting them is non-trivial. They are first-class but technically isolated.
+Tier 2 (custom-script) exists because Kiro and Trae landed in EGC before the unified pipeline was stable. Their installers do roughly the same work as the unified pipeline, but the shape of the assets they ship differs enough that retrofitting them is non-trivial. They are first-class but technically isolated. Kiro's skill distribution was migrated to Tier 1 (target id `kiro`); its agents/steering/hooks/settings assets still ship through the original `.kiro/install.sh` script.
 
 Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude Code was previously Tier 3, but now supports `~/.claude/skills/<name>/SKILL.md` as a skill discovery path, so it has been promoted to Tier 1 with target id `claude`. Windsurf, Amp, and VS Code Copilot were added as Tier 1 targets in v1.0.2 following the same skill-discovery pattern. Continue.dev followed the same pattern as the 14th harness (its MCP registration via `~/.continue/mcpServers/` YAML block files landed separately in #564).
 
@@ -75,5 +75,5 @@ Tier 1 is preferred when possible. Tier 2 is acceptable for tools with non-stand
 
 ## Known gaps (audit findings 2026-06-10)
 
-- Kiro and Trae are Tier 2 because they predate the unified pipeline. They could be migrated to Tier 1 with ~6-8h of work each
+- Trae is still Tier 2 because it predates the unified pipeline. It could be migrated to Tier 1 with ~6-8h of work. Kiro's skill distribution made the same move (see row 13); its non-skill assets (agents, steering, hooks, settings) remain on the legacy `.kiro/install.sh` path
 - `harness-audit` scores the repo, not individual harnesses - per-harness rollup is the next maturation step

--- a/install.sh
+++ b/install.sh
@@ -149,6 +149,7 @@ if [ -t 0 ] && [ "$DRY_RUN" = false ]; then
     fi
     if [ -d "$HOME/.kiro" ] || command -v kiro >/dev/null 2>&1; then
       echo "  installing to Kiro..."
+      node "$ROOT_DIR/scripts/install-apply.js" --target kiro --profile full
       bash "$ROOT_DIR/.kiro/install.sh" ~
     fi
     if [ -d "$HOME/.trae" ] || [ -d "$HOME/.trae-cn" ] || command -v trae >/dev/null 2>&1; then

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -30,7 +30,8 @@
         "amp",
         "copilot",
         "zed",
-        "continue"
+        "continue",
+        "kiro"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -59,7 +59,8 @@
                 "amp",
                 "copilot",
                 "zed",
-                "continue"
+                "continue",
+                "kiro"
               ]
             }
           },

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -109,6 +109,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   codex:        { name: 'Codex CLI',          url: 'https://github.com/openai/codex' },
   opencode:     { name: 'OpenCode',           url: 'https://opencode.ai' },
   codebuddy:    { name: 'CodeBuddy',          url: 'https://copilot.tencent.com' },
+  kiro:         { name: 'Kiro',               url: 'https://kiro.dev' },
   windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },

--- a/scripts/lib/install-targets/kiro-home.js
+++ b/scripts/lib/install-targets/kiro-home.js
@@ -1,0 +1,14 @@
+const {
+  createFlatSkillPlanOperations,
+  createInstallTargetAdapter,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'kiro-home',
+  target: 'kiro',
+  kind: 'home',
+  rootSegments: ['.kiro'],
+  installStatePathSegments: ['egc', 'install-state.json'],
+  nativeRootRelativePath: '.kiro',
+  planOperations: createFlatSkillPlanOperations,
+});

--- a/scripts/lib/install-targets/kiro-project.js
+++ b/scripts/lib/install-targets/kiro-project.js
@@ -1,0 +1,14 @@
+const {
+  createFlatSkillPlanOperations,
+  createInstallTargetAdapter,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'kiro-project',
+  target: 'kiro',
+  kind: 'project',
+  rootSegments: ['.kiro'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.kiro',
+  planOperations: createFlatSkillPlanOperations,
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -5,6 +5,8 @@ const codebuddyProject = require('./codebuddy-project');
 const codexHome = require('./codex-home');
 const cursorProject = require('./cursor-project');
 const geminiProject = require('./gemini-project');
+const kiroHome = require('./kiro-home');
+const kiroProject = require('./kiro-project');
 const opencodeHome = require('./opencode-home');
 const windsurfHome = require('./windsurf-home');
 const windsurfProject = require('./windsurf-project');
@@ -24,6 +26,8 @@ const ADAPTERS = Object.freeze([
   geminiProject,
   opencodeHome,
   codebuddyProject,
+  kiroHome,
+  kiroProject,
   windsurfHome,
   windsurfProject,
   ampHome,

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1530,6 +1530,94 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('resolves kiro home adapter root to ~/.kiro and install-state path', () => {
+    const adapter = getInstallTargetAdapter('kiro');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'kiro-home');
+    assert.strictEqual(adapter.target, 'kiro');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.kiro'));
+    assert.strictEqual(statePath, path.join(homeDir, '.kiro', 'egc', 'install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('resolves kiro project adapter root to .kiro and install-state path', () => {
+    const adapter = getInstallTargetAdapter('kiro-project');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'kiro-project');
+    assert.strictEqual(adapter.target, 'kiro');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.kiro'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.kiro', 'egc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('kiro adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('kiro');
+    const byId = getInstallTargetAdapter('kiro-home');
+    const projectById = getInstallTargetAdapter('kiro-project');
+
+    assert.strictEqual(byTarget.id, 'kiro-home');
+    assert.strictEqual(byId.id, 'kiro-home');
+    assert.strictEqual(projectById.id, 'kiro-project');
+    assert.ok(byTarget.supports('kiro'));
+    assert.ok(byTarget.supports('kiro-home'));
+    assert.ok(projectById.supports('kiro'));
+    assert.ok(projectById.supports('kiro-project'));
+  })) passed++; else failed++;
+
+  if (test('kiro home adapter strips category from skill paths and installs flat under ~/.kiro/skills/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'kiro',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'kiro-home');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(homeDir, '.kiro', 'skills', 'tdd-workflow')
+      )),
+      'Should strip category and install skill flat under ~/.kiro/skills/'
+    );
+  })) passed++; else failed++;
+
+  if (test('kiro project adapter strips category from skill paths and installs flat under .kiro/skills/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'kiro-project',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'kiro-project');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(projectRoot, '.kiro', 'skills', 'tdd-workflow')
+      )),
+      'Should strip category and install skill flat under .kiro/skills/'
+    );
+  })) passed++; else failed++;
+
+  if (test('kiro adapters are included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('kiro'), 'Should include kiro target');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -29,7 +29,7 @@ const EXPECTED_HARNESSES = [
   'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary
- Migrates Kiro's skill distribution from a hand-curated 19-skill snapshot in `.kiro/install.sh` to the unified Tier 1 pipeline (`kiro-home.js` / `kiro-project.js`), so `egc install --target kiro` always installs the full, current skill library.
- `.kiro/install.sh` keeps handling agents, steering, hooks, scripts, and settings; its skill-copy loop was removed to avoid clobbering the new pipeline's output.
- Top-level `install.sh` now runs both paths for auto-detected Kiro installs.
- Docs (`docs/spec/integration-tiers.md`) and schemas updated to reflect Kiro as Tier 1 for skills.

Closes #733

## Test plan
- [x] `node tests/lib/install-targets.test.js` (72/72 passing, 6 new Kiro cases)
- [x] `node tests/spec/integration-tiers.test.js` (4/4 passing)
- [x] `node tests/run-all.js` full suite: 2694/2718 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue, verified via git stash before starting)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native `kiro` Tier 1 install target and moves Kiro skill installs to the unified pipeline. `egc install --target kiro` now installs the full, current skill library to `~/.kiro/skills/<name>/` and `.kiro/skills/<name>/`; `.kiro/install.sh` continues to handle agents, steering, hooks, scripts, and settings.

- New Features
  - Added adapters `kiro-home` and `kiro-project` to install skills flat under `~/.kiro/skills/<name>/` and `.kiro/skills/<name>/`.
  - Auto-detect in `install.sh` runs `--target kiro --profile full` before `.kiro/install.sh`.
  - Updated docs, schemas, registry, and tests to include `kiro` as a Tier 1 target for skills.

- Migration
  - For skills, run `egc install --target kiro` (or use the top-level `install.sh`).
  - Use `.kiro/install.sh` for agents, steering, hooks, scripts, and settings.

<sup>Written for commit aeecd22b407c245ede184b327f7501b130799a35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

