### PR TITLE
feat(install): add native Trae install target (Tier 1)

### DIFF
--- a/.trae/install.sh
+++ b/.trae/install.sh
@@ -104,8 +104,11 @@ do_install() {
     echo "Target:  $trae_full_path/"
     echo ""
 
-    # Subdirectories to create
-    SUBDIRS="commands agents skills rules"
+    # Subdirectories to create. Skills are NOT handled here: they ship
+    # through the unified Tier 1 pipeline (`egc install --target trae`),
+    # which stays in sync with the full skill library instead of this
+    # script copying its own snapshot.
+    SUBDIRS="commands agents rules"
 
     for dir in $SUBDIRS; do
         mkdir -p "$trae_full_path/$dir"
@@ -118,7 +121,6 @@ do_install() {
     # Counters for summary
     commands=0
     agents=0
-    skills=0
     rules=0
     other=0
 
@@ -140,29 +142,6 @@ do_install() {
             target_path="$trae_full_path/agents/$local_name"
             if copy_managed_file "$f" "$target_path" "$MANIFEST" "agents/$local_name"; then
                 agents=$((agents + 1))
-            fi
-        done
-    fi
-
-    if [ -d "$REPO_ROOT/skills" ]; then
-        for d in "$REPO_ROOT/skills"/*/; do
-            [ -d "$d" ] || continue
-            skill_name="$(basename "$d")"
-            target_skill_dir="$trae_full_path/skills/$skill_name"
-            skill_copied=0
-
-            while IFS= read -r source_file; do
-                relative_path="${source_file#$d}"
-                target_path="$target_skill_dir/$relative_path"
-
-                mkdir -p "$(dirname "$target_path")"
-                if copy_managed_file "$source_file" "$target_path" "$MANIFEST" "skills/$skill_name/$relative_path"; then
-                    skill_copied=1
-                fi
-            done < <(find "$d" -type f | sort)
-
-            if [ "$skill_copied" -eq 1 ]; then
-                skills=$((skills + 1))
             fi
         done
     fi
@@ -207,8 +186,11 @@ do_install() {
     echo "Components installed:"
     echo "  Commands:  $commands"
     echo "  Agents:    $agents"
-    echo "  Skills:    $skills"
     echo "  Rules:     $rules"
+    echo ""
+    echo "Note: skills are not installed by this script anymore. Run"
+    echo "  'egc install --target trae' to install skills from the full,"
+    echo "  always up-to-date EGC skill library."
     echo ""
     echo "Directory:   $(basename "$trae_full_path")"
     echo ""

--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -29,13 +29,13 @@ EGC supports 14 AI coding tools through 3 distinct integration mechanisms. This 
 | 11 | **Zed** | 1 | `zed` | `~/.config/zed/skills/<name>/` | Skills installed flat (category stripped); MCP via `context_servers` in `settings.json`; cognitive bootstrap into `~/.config/zed/AGENTS.md` |
 | 12 | **Continue.dev** | 1 | `continue` | `~/.continue/skills/<name>/SKILL.md` | Skills installed flat; MCP via YAML block files in `~/.continue/mcpServers/`; memory protocol prompt in `~/.continue/prompts/`; rules discovered natively at workspace `.continue/rules/` |
 | 13 | **Kiro** | 1 | `kiro` | `~/.kiro/skills/<name>/` (home) and `.kiro/skills/<name>/` (project) | Skills installed flat via the unified pipeline; the legacy `.kiro/install.sh` script still handles project-local agents, steering docs, hooks, scripts, and settings (a separate concern from skill distribution, not yet migrated) |
-| 14 | **Trae** | 2 | (none) | `~/.trae/` (or `~/.trae-cn/` with `TRAE_ENV=cn`) via `.trae/install.sh` | Memory protocol written to `~/.trae/MEMORY.md` |
+| 14 | **Trae** | 1 | `trae` | `.trae/skills/<name>/` (project only, no home target) | Skills installed flat via the unified pipeline; the legacy `.trae/install.sh` script still handles commands, agents, rules, and the `~/.trae/MEMORY.md` memory protocol (project-scoped only; `TRAE_ENV=cn` for `~/.trae-cn/`) |
 
 ## Why three tiers (history, not aspiration)
 
 Tier 1 (unified) is the canonical pipeline. It is the result of `install-plan.js` resolving install manifests against `SUPPORTED_INSTALL_TARGETS`, then `install-apply.js` materializing files. The pipeline emits provenance, supports dry-run, and is covered by 200+ tests under `tests/`.
 
-Tier 2 (custom-script) exists because Kiro and Trae landed in EGC before the unified pipeline was stable. Their installers do roughly the same work as the unified pipeline, but the shape of the assets they ship differs enough that retrofitting them is non-trivial. They are first-class but technically isolated. Kiro's skill distribution was migrated to Tier 1 (target id `kiro`); its agents/steering/hooks/settings assets still ship through the original `.kiro/install.sh` script.
+Tier 2 (custom-script) exists because Kiro and Trae landed in EGC before the unified pipeline was stable. Their installers do roughly the same work as the unified pipeline, but the shape of the assets they ship differs enough that retrofitting them is non-trivial. They are first-class but technically isolated. Both Kiro's and Trae's skill distribution have since been migrated to Tier 1 (target ids `kiro` and `trae`); their non-skill assets (Kiro: agents/steering/hooks/settings; Trae: commands/agents/rules/memory protocol) still ship through their original `.{tool}/install.sh` scripts.
 
 Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude Code was previously Tier 3, but now supports `~/.claude/skills/<name>/SKILL.md` as a skill discovery path, so it has been promoted to Tier 1 with target id `claude`. Windsurf, Amp, and VS Code Copilot were added as Tier 1 targets in v1.0.2 following the same skill-discovery pattern. Continue.dev followed the same pattern as the 14th harness (its MCP registration via `~/.continue/mcpServers/` YAML block files landed separately in #564).
 
@@ -75,5 +75,5 @@ Tier 1 is preferred when possible. Tier 2 is acceptable for tools with non-stand
 
 ## Known gaps (audit findings 2026-06-10)
 
-- Trae is still Tier 2 because it predates the unified pipeline. It could be migrated to Tier 1 with ~6-8h of work. Kiro's skill distribution made the same move (see row 13); its non-skill assets (agents, steering, hooks, settings) remain on the legacy `.kiro/install.sh` path
+- Both Kiro's and Trae's skill distribution moved to Tier 1 (see rows 13-14); each tool's non-skill assets remain on its legacy `.{tool}/install.sh` path
 - `harness-audit` scores the repo, not individual harnesses - per-harness rollup is the next maturation step

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -31,7 +31,8 @@
         "copilot",
         "zed",
         "continue",
-        "kiro"
+        "kiro",
+        "trae"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -60,7 +60,8 @@
                 "copilot",
                 "zed",
                 "continue",
-                "kiro"
+                "kiro",
+                "trae"
               ]
             }
           },

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -110,6 +110,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   opencode:     { name: 'OpenCode',           url: 'https://opencode.ai' },
   codebuddy:    { name: 'CodeBuddy',          url: 'https://copilot.tencent.com' },
   kiro:         { name: 'Kiro',               url: 'https://kiro.dev' },
+  trae:         { name: 'Trae',               url: 'https://www.trae.ai' },
   windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -16,6 +16,7 @@ const copilotHome = require('./copilot-home');
 const zedHome = require('./zed-home');
 const continueHome = require('./continue-home');
 const continueProject = require('./continue-project');
+const traeProject = require('./trae-project');
 
 const ADAPTERS = Object.freeze([
   egcHome,
@@ -36,6 +37,7 @@ const ADAPTERS = Object.freeze([
   zedHome,
   continueHome,
   continueProject,
+  traeProject,
 ]);
 
 function listInstallTargetAdapters() {

--- a/scripts/lib/install-targets/trae-project.js
+++ b/scripts/lib/install-targets/trae-project.js
@@ -1,0 +1,10 @@
+const { createInstallTargetAdapter } = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'trae-project',
+  target: 'trae',
+  kind: 'project',
+  rootSegments: ['.trae'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.trae',
+});

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1618,6 +1618,56 @@ function runTests() {
     assert.ok(targets.includes('kiro'), 'Should include kiro target');
   })) passed++; else failed++;
 
+  if (test('resolves trae adapter root and install-state path from project root', () => {
+    const adapter = getInstallTargetAdapter('trae');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'trae-project');
+    assert.strictEqual(adapter.target, 'trae');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.trae'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.trae', 'egc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('trae adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('trae');
+    const byId = getInstallTargetAdapter('trae-project');
+
+    assert.strictEqual(byTarget.id, 'trae-project');
+    assert.strictEqual(byId.id, 'trae-project');
+    assert.ok(byTarget.supports('trae'));
+    assert.ok(byTarget.supports('trae-project'));
+  })) passed++; else failed++;
+
+  if (test('trae adapter preserves category structure under .trae/skills/ (default scaffold, no flat stripping)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'trae',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'trae-project');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(projectRoot, '.trae', 'skills', 'workflow', 'tdd-workflow')
+      )),
+      'Should preserve skills/<category>/<name> structure under .trae/skills/, same default scaffold as gemini-project'
+    );
+  })) passed++; else failed++;
+
+  if (test('trae adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('trae'), 'Should include trae target');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/trae-install.test.js
+++ b/tests/scripts/trae-install.test.js
@@ -102,7 +102,7 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('records nested skill files and the full rules tree in the manifest', () => {
+  if (test('records the full rules tree in the manifest', () => {
     const homeDir = createTempDir('trae-home-');
     const projectRoot = createTempDir('trae-project-');
 
@@ -110,14 +110,28 @@ function runTests() {
       runInstall({ cwd: projectRoot, homeDir });
 
       const manifestLines = readManifestLines(projectRoot);
-      assert.ok(manifestLines.includes('skills/general_part2/skill-comply/pyproject.toml'));
       assert.ok(manifestLines.includes('rules/common/code-review.md'));
       assert.ok(manifestLines.includes('rules/python/coding-style.md'));
       assert.ok(manifestLines.includes('rules/zh/README.md'));
 
-      assert.ok(fs.existsSync(path.join(projectRoot, '.trae', 'skills', 'general_part2', 'skill-comply', 'pyproject.toml')));
       assert.ok(fs.existsSync(path.join(projectRoot, '.trae', 'rules', 'python', 'coding-style.md')));
       assert.ok(fs.existsSync(path.join(projectRoot, '.trae', 'rules', 'zh', 'README.md')));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not copy skills -- they ship through the unified Tier 1 pipeline instead', () => {
+    const homeDir = createTempDir('trae-home-');
+    const projectRoot = createTempDir('trae-project-');
+
+    try {
+      runInstall({ cwd: projectRoot, homeDir });
+
+      const manifestLines = readManifestLines(projectRoot);
+      assert.ok(!manifestLines.some((line) => line.startsWith('skills/')));
+      assert.ok(!fs.existsSync(path.join(projectRoot, '.trae', 'skills')));
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -29,7 +29,7 @@ const EXPECTED_HARNESSES = [
   'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary
- Adds `trae-project.js` mirroring `gemini-project.js` exactly (default scaffold, no category flattening) since Trae's legacy install script already preserved `skills/<category>/<name>` structure.
- `.trae/install.sh` keeps handling commands, agents, rules, and the `~/.trae/MEMORY.md` memory protocol; its skill-copy loop was removed to avoid two mechanisms writing into the same project's `.trae/skills/`.
- Top-level `install.sh`'s global auto-install block is intentionally left unchanged for Trae: it only targets `~/.trae` (home), and Trae has no home skill discovery path.
- Docs (`docs/spec/integration-tiers.md`) and schemas updated to reflect Trae as Tier 1 for skills.

Closes #734

## Test plan
- [x] `node tests/lib/install-targets.test.js` (76/76 passing, 4 new Trae cases)
- [x] `node tests/scripts/trae-install.test.js` (5/5 passing, updated for skill-copy removal)
- [x] `node tests/spec/integration-tiers.test.js` (4/4 passing)
- [x] `node tests/run-all.js` full suite: 2699/2723 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Tier 1 install target for Trae (`trae`) to install skills into project `.trae/skills/<category>/<name>`. Skill installs now go through the unified pipeline and no longer duplicate work with the legacy script.

- **New Features**
  - Added `trae` project adapter (`trae-project`) mirroring the default scaffold and preserving category structure.
  - `.trae/install.sh` stops copying skills; it still installs commands, agents, rules, and writes `~/.trae/MEMORY.md`.
  - Updated docs and schemas to include `trae` as a supported Tier 1 target.
  - Global auto-install remains unchanged for Trae (no home skill path).

- **Migration**
  - Use `egc install --target trae` in a project to install skills.
  - If you relied on `.trae/install.sh` for skills, switch to the command above; the script no longer creates `.trae/skills/`.

<sup>Written for commit 329ab697f8ed8a6267fc1d106f434e49da8fe8c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

