### PR TITLE
feat(install): add native Goose install target

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 14 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 15 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 14 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 14 harnesses
+## The 15 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -30,6 +30,7 @@ EGC supports 14 AI coding tools through 3 distinct integration mechanisms. This 
 | 12 | **Continue.dev** | 1 | `continue` | `~/.continue/skills/<name>/SKILL.md` | Skills installed flat; MCP via YAML block files in `~/.continue/mcpServers/`; memory protocol prompt in `~/.continue/prompts/`; rules discovered natively at workspace `.continue/rules/` |
 | 13 | **Kiro** | 1 | `kiro` | `~/.kiro/skills/<name>/` (home) and `.kiro/skills/<name>/` (project) | Skills installed flat via the unified pipeline; the legacy `.kiro/install.sh` script still handles project-local agents, steering docs, hooks, scripts, and settings (a separate concern from skill distribution, not yet migrated) |
 | 14 | **Trae** | 1 | `trae` | `.trae/skills/<name>/` (project only, no home target) | Skills installed flat via the unified pipeline; the legacy `.trae/install.sh` script still handles commands, agents, rules, and the `~/.trae/MEMORY.md` memory protocol (project-scoped only; `TRAE_ENV=cn` for `~/.trae-cn/`) |
+| 15 | **Goose** | 1 | `goose` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex) | Skills installed flat; no GateGuard hook wiring (Goose has no documented hook API); discoverability-only adapter over the same `~/.agents` root `codex-home.js` already writes to |
 
 ## Why three tiers (history, not aspiration)
 

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -32,7 +32,8 @@
         "zed",
         "continue",
         "kiro",
-        "trae"
+        "trae",
+        "goose"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -61,7 +61,8 @@
                 "zed",
                 "continue",
                 "kiro",
-                "trae"
+                "trae",
+                "goose"
               ]
             }
           },

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/goose-home.js
+++ b/scripts/lib/install-targets/goose-home.js
@@ -1,0 +1,19 @@
+const {
+  createFlatSkillPlanOperations,
+  createInstallTargetAdapter,
+} = require('./helpers');
+
+// Goose already reads skills from ~/.agents/skills/<name>/ -- the same
+// shared directory codex-home.js writes to. This adapter exists purely for
+// discoverability (`--target goose` instead of requiring `--target codex`),
+// so it deliberately skips codex-home's GateGuard hook wiring: Goose has no
+// documented hook API equivalent to ~/.codex/hooks.json.
+module.exports = createInstallTargetAdapter({
+  id: 'goose-home',
+  target: 'goose',
+  kind: 'home',
+  rootSegments: ['.agents'],
+  installStatePathSegments: ['egc', 'goose-install-state.json'],
+  nativeRootRelativePath: '.agents',
+  planOperations: createFlatSkillPlanOperations,
+});

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -111,6 +111,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   codebuddy:    { name: 'CodeBuddy',          url: 'https://copilot.tencent.com' },
   kiro:         { name: 'Kiro',               url: 'https://kiro.dev' },
   trae:         { name: 'Trae',               url: 'https://www.trae.ai' },
+  goose:        { name: 'Goose',              url: 'https://block.github.io/goose/' },
   windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -5,6 +5,7 @@ const codebuddyProject = require('./codebuddy-project');
 const codexHome = require('./codex-home');
 const cursorProject = require('./cursor-project');
 const geminiProject = require('./gemini-project');
+const gooseHome = require('./goose-home');
 const kiroHome = require('./kiro-home');
 const kiroProject = require('./kiro-project');
 const opencodeHome = require('./opencode-home');
@@ -24,6 +25,7 @@ const ADAPTERS = Object.freeze([
   cursorProject,
   antigravityProject,
   codexHome,
+  gooseHome,
   geminiProject,
   opencodeHome,
   codebuddyProject,

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1668,6 +1668,73 @@ function runTests() {
     assert.ok(targets.includes('trae'), 'Should include trae target');
   })) passed++; else failed++;
 
+  if (test('resolves goose adapter root to ~/.agents (shared with Codex) and its own install-state path', () => {
+    const adapter = getInstallTargetAdapter('goose');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'goose-home');
+    assert.strictEqual(adapter.target, 'goose');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.agents'));
+    assert.strictEqual(statePath, path.join(homeDir, '.agents', 'egc', 'goose-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('goose adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('goose');
+    const byId = getInstallTargetAdapter('goose-home');
+
+    assert.strictEqual(byTarget.id, 'goose-home');
+    assert.strictEqual(byId.id, 'goose-home');
+    assert.ok(byTarget.supports('goose'));
+    assert.ok(byTarget.supports('goose-home'));
+  })) passed++; else failed++;
+
+  if (test('goose adapter strips category from skill paths and installs flat under ~/.agents/skills/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'goose',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'goose-home');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(homeDir, '.agents', 'skills', 'tdd-workflow')
+      )),
+      'Should strip category and install skill flat under ~/.agents/skills/, same root Codex writes to'
+    );
+  })) passed++; else failed++;
+
+  if (test('goose adapter has no GateGuard hook wiring (unlike codex-home)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'goose',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.ok(
+      !plan.operations.some(operation => operation.kind === 'merge-claude-settings-hooks'),
+      'Goose adapter should not register any hook merge operations'
+    );
+  })) passed++; else failed++;
+
+  if (test('goose adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('goose'), 'Should include goose target');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -23,13 +23,14 @@ const EXPECTED_HARNESSES = [
   'CodeBuddy',
   'Kiro',
   'Trae',
+  'Goose',
   'Windsurf',
   'Amp',
   'VS Code Copilot',
   'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary
- Adds `goose-home.js` pointing at the same `~/.agents` shared root `codex-home.js` already writes to, so `egc install --target goose` resolves by name instead of requiring `--target codex`.
- No GateGuard hook wiring, unlike `codex-home.js` -- Goose has no documented hook API.
- Separate `installStatePathSegments` (`goose-install-state.json` vs `codex-install-state.json`) so the two targets' provenance metadata doesn't collide.
- Docs (`docs/spec/integration-tiers.md`) and schemas updated: EGC now supports 15 harnesses.

**Known residual limitation (non-blocking, flagged during review):** since both targets write to the same physical directory, uninstalling one via its own state file could in theory remove files the other target still relies on. A true fix needs reference counting across targets sharing a root; out of scope for this discoverability-only addition.

Closes #735

## Test plan
- [x] `node tests/lib/install-targets.test.js` (81/81 passing, 5 new Goose cases)
- [x] `node tests/spec/integration-tiers.test.js` (4/4 passing)
- [x] `node tests/run-all.js` full suite: 2704/2728 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native `goose` install target so users can run `egc install --target goose`. It reuses the `~/.agents` root shared with Codex and skips GateGuard hooks; closes #735.

- **New Features**
  - New adapter `goose-home.js` (`id: goose-home`, kind `home`) installs flat skills under `~/.agents/skills/<name>`.
  - Separate install state at `~/.agents/egc/goose-install-state.json` to avoid collisions with Codex metadata.
  - Registry, schemas, and docs updated; EGC now lists 15 harnesses and supports `goose` as a target.
  - Note: `goose` and `codex` share the same directory; uninstalling one may remove files the other needs. Cross-target reference counting is out of scope.

<sup>Written for commit 1de40bd607dd11b42b674a7bffee04958d3f83dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

