### PR TITLE
feat(install): add native Amazon Q Developer CLI install target

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 15 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 16 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 15 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 15 harnesses
+## The 16 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -31,6 +31,7 @@ EGC supports 15 AI coding tools through 3 distinct integration mechanisms. This 
 | 13 | **Kiro** | 1 | `kiro` | `~/.kiro/skills/<name>/` (home) and `.kiro/skills/<name>/` (project) | Skills installed flat via the unified pipeline; the legacy `.kiro/install.sh` script still handles project-local agents, steering docs, hooks, scripts, and settings (a separate concern from skill distribution, not yet migrated) |
 | 14 | **Trae** | 1 | `trae` | `.trae/skills/<name>/` (project only, no home target) | Skills installed flat via the unified pipeline; the legacy `.trae/install.sh` script still handles commands, agents, rules, and the `~/.trae/MEMORY.md` memory protocol (project-scoped only; `TRAE_ENV=cn` for `~/.trae-cn/`) |
 | 15 | **Goose** | 1 | `goose` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex) | Skills installed flat; no GateGuard hook wiring (Goose has no documented hook API); discoverability-only adapter over the same `~/.agents` root `codex-home.js` already writes to |
+| 16 | **Amazon Q Developer CLI** | 1 | `amazonq` | `.amazonq/rules/` (project only, no home target) | Default scaffold (category preserved), same template as `gemini-project.js`; no hook wiring |
 
 ## Why three tiers (history, not aspiration)
 

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -33,7 +33,8 @@
         "continue",
         "kiro",
         "trae",
-        "goose"
+        "goose",
+        "amazonq"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -62,7 +62,8 @@
                 "continue",
                 "kiro",
                 "trae",
-                "goose"
+                "goose",
+                "amazonq"
               ]
             }
           },

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/amazonq-project.js
+++ b/scripts/lib/install-targets/amazonq-project.js
@@ -1,0 +1,10 @@
+const { createInstallTargetAdapter } = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'amazonq-project',
+  target: 'amazonq',
+  kind: 'project',
+  rootSegments: ['.amazonq', 'rules'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.amazonq',
+});

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -112,6 +112,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   kiro:         { name: 'Kiro',               url: 'https://kiro.dev' },
   trae:         { name: 'Trae',               url: 'https://www.trae.ai' },
   goose:        { name: 'Goose',              url: 'https://block.github.io/goose/' },
+  amazonq:      { name: 'Amazon Q Developer CLI', url: 'https://aws.amazon.com/q/developer/' },
   windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -1,3 +1,4 @@
+const amazonqProject = require('./amazonq-project');
 const antigravityProject = require('./antigravity-project');
 const claudeCodeHome = require('./claude-home');
 const egcHome = require('./gemini-home');
@@ -24,6 +25,7 @@ const ADAPTERS = Object.freeze([
   claudeCodeHome,
   cursorProject,
   antigravityProject,
+  amazonqProject,
   codexHome,
   gooseHome,
   geminiProject,

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1735,6 +1735,56 @@ function runTests() {
     assert.ok(targets.includes('goose'), 'Should include goose target');
   })) passed++; else failed++;
 
+  if (test('resolves amazonq adapter root to .amazonq/rules and install-state path', () => {
+    const adapter = getInstallTargetAdapter('amazonq');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'amazonq-project');
+    assert.strictEqual(adapter.target, 'amazonq');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.amazonq', 'rules'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.amazonq', 'rules', 'egc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('amazonq adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('amazonq');
+    const byId = getInstallTargetAdapter('amazonq-project');
+
+    assert.strictEqual(byTarget.id, 'amazonq-project');
+    assert.strictEqual(byId.id, 'amazonq-project');
+    assert.ok(byTarget.supports('amazonq'));
+    assert.ok(byTarget.supports('amazonq-project'));
+  })) passed++; else failed++;
+
+  if (test('amazonq adapter preserves category structure under .amazonq/rules/ (default scaffold, no flat stripping)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'amazonq',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'amazonq-project');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(projectRoot, '.amazonq', 'rules', 'skills', 'workflow', 'tdd-workflow')
+      )),
+      'Should preserve skills/<category>/<name> structure under .amazonq/rules/, same default scaffold as gemini-project'
+    );
+  })) passed++; else failed++;
+
+  if (test('amazonq adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('amazonq'), 'Should include amazonq target');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -24,13 +24,14 @@ const EXPECTED_HARNESSES = [
   'Kiro',
   'Trae',
   'Goose',
+  'Amazon Q Developer CLI',
   'Windsurf',
   'Amp',
   'VS Code Copilot',
   'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary
- Adds `amazonq-project.js` mirroring `gemini-project.js` exactly (default scaffold, no custom `planOperations`).
- Skills land under `.amazonq/rules/skills/<category>/<name>/SKILL.md`; confirmed via independent review that Amazon Q Developer CLI recursively scans subdirectories under `.amazonq/rules/` (AWS docs recommend nested rule folders), so the category-preserving structure is correct.
- Docs (`docs/spec/integration-tiers.md`) and schemas updated: EGC now supports 16 harnesses.

Closes #738

## Test plan
- [x] `node tests/lib/install-targets.test.js` (85/85 passing, 4 new Amazon Q cases)
- [x] `node tests/spec/integration-tiers.test.js` (4/4 passing)
- [x] `node tests/run-all.js` full suite: 2708/2732 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native install target for Amazon Q Developer CLI (`amazonq`) using the default project scaffold, installing skills under `.amazonq/rules/`. This raises the supported tools to 16 and updates schemas and docs accordingly.

- **New Features**
  - Added `amazonq` project adapter (`amazonq-project`) with root at `.amazonq/rules/` and default scaffold (same as `gemini` project).
  - Preserves `skills/<category>/<name>` structure; Amazon Q CLI scans nested folders in `.amazonq/rules/`.
  - Updated schemas, manifests, and registry to include `amazonq`.
  - Docs: integration tiers updated to 16 harnesses.
  - Tests added for adapter resolution, scaffold planning, and integration lists.

<sup>Written for commit 59db2cdf35c6a985ef011cc54bff3d5785719736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

