### PR TITLE
feat(install): add native OpenHands install target

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 16 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 17 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 16 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 16 harnesses
+## The 17 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -32,6 +32,7 @@ EGC supports 16 AI coding tools through 3 distinct integration mechanisms. This 
 | 14 | **Trae** | 1 | `trae` | `.trae/skills/<name>/` (project only, no home target) | Skills installed flat via the unified pipeline; the legacy `.trae/install.sh` script still handles commands, agents, rules, and the `~/.trae/MEMORY.md` memory protocol (project-scoped only; `TRAE_ENV=cn` for `~/.trae-cn/`) |
 | 15 | **Goose** | 1 | `goose` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex) | Skills installed flat; no GateGuard hook wiring (Goose has no documented hook API); discoverability-only adapter over the same `~/.agents` root `codex-home.js` already writes to |
 | 16 | **Amazon Q Developer CLI** | 1 | `amazonq` | `.amazonq/rules/` (project only, no home target) | Default scaffold (category preserved), same template as `gemini-project.js`; no hook wiring |
+| 17 | **OpenHands** | 1 | `openhands` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex/Goose) | Skills installed flat; no GateGuard hook wiring; discoverability-only adapter -- the issue asked for `.openhands/microagents/`, but current OpenHands docs recommend the AgentSkills-standard `.agents/skills/<name>/SKILL.md` path (legacy `.openhands/microagents/` still works but isn't the documented target), so this mirrors the Goose adapter instead |
 
 ## Why three tiers (history, not aspiration)
 

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -34,7 +34,8 @@
         "kiro",
         "trae",
         "goose",
-        "amazonq"
+        "amazonq",
+        "openhands"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -63,7 +63,8 @@
                 "kiro",
                 "trae",
                 "goose",
-                "amazonq"
+                "amazonq",
+                "openhands"
               ]
             }
           },

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -113,6 +113,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   trae:         { name: 'Trae',               url: 'https://www.trae.ai' },
   goose:        { name: 'Goose',              url: 'https://block.github.io/goose/' },
   amazonq:      { name: 'Amazon Q Developer CLI', url: 'https://aws.amazon.com/q/developer/' },
+  openhands:    { name: 'OpenHands',          url: 'https://docs.openhands.dev' },
   windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },

--- a/scripts/lib/install-targets/openhands-home.js
+++ b/scripts/lib/install-targets/openhands-home.js
@@ -1,0 +1,22 @@
+const {
+  createFlatSkillPlanOperations,
+  createInstallTargetAdapter,
+} = require('./helpers');
+
+// OpenHands' recommended AgentSkills format is .agents/skills/<name>/SKILL.md
+// -- the same shared directory codex-home.js and goose-home.js already write
+// to (confirmed against current OpenHands docs: legacy .openhands/microagents/
+// still works but .agents/skills/ is the documented, recommended path as of
+// 2026). This adapter exists purely for discoverability (`--target openhands`
+// instead of requiring `--target codex`), same shape as goose-home.js. No
+// GateGuard hook wiring: OpenHands has no documented hook API equivalent to
+// ~/.codex/hooks.json.
+module.exports = createInstallTargetAdapter({
+  id: 'openhands-home',
+  target: 'openhands',
+  kind: 'home',
+  rootSegments: ['.agents'],
+  installStatePathSegments: ['egc', 'openhands-install-state.json'],
+  nativeRootRelativePath: '.agents',
+  planOperations: createFlatSkillPlanOperations,
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -8,6 +8,7 @@ const cursorProject = require('./cursor-project');
 const geminiProject = require('./gemini-project');
 const gooseHome = require('./goose-home');
 const kiroHome = require('./kiro-home');
+const openhandsHome = require('./openhands-home');
 const kiroProject = require('./kiro-project');
 const opencodeHome = require('./opencode-home');
 const windsurfHome = require('./windsurf-home');
@@ -28,6 +29,7 @@ const ADAPTERS = Object.freeze([
   amazonqProject,
   codexHome,
   gooseHome,
+  openhandsHome,
   geminiProject,
   opencodeHome,
   codebuddyProject,

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1785,6 +1785,73 @@ function runTests() {
     assert.ok(targets.includes('amazonq'), 'Should include amazonq target');
   })) passed++; else failed++;
 
+  if (test('resolves openhands adapter root to ~/.agents (shared with Codex/Goose) and its own install-state path', () => {
+    const adapter = getInstallTargetAdapter('openhands');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'openhands-home');
+    assert.strictEqual(adapter.target, 'openhands');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.agents'));
+    assert.strictEqual(statePath, path.join(homeDir, '.agents', 'egc', 'openhands-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('openhands adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('openhands');
+    const byId = getInstallTargetAdapter('openhands-home');
+
+    assert.strictEqual(byTarget.id, 'openhands-home');
+    assert.strictEqual(byId.id, 'openhands-home');
+    assert.ok(byTarget.supports('openhands'));
+    assert.ok(byTarget.supports('openhands-home'));
+  })) passed++; else failed++;
+
+  if (test('openhands adapter strips category from skill paths and installs flat under ~/.agents/skills/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'openhands',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'openhands-home');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+        && operation.destinationPath === path.join(homeDir, '.agents', 'skills', 'tdd-workflow')
+      )),
+      'Should strip category and install skill flat under ~/.agents/skills/, same AgentSkills-standard root Codex/Goose write to'
+    );
+  })) passed++; else failed++;
+
+  if (test('openhands adapter has no GateGuard hook wiring', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'openhands',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.ok(
+      !plan.operations.some(operation => operation.kind === 'merge-claude-settings-hooks'),
+      'OpenHands adapter should not register any hook merge operations'
+    );
+  })) passed++; else failed++;
+
+  if (test('openhands adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('openhands'), 'Should include openhands target');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -25,13 +25,14 @@ const EXPECTED_HARNESSES = [
   'Trae',
   'Goose',
   'Amazon Q Developer CLI',
+  'OpenHands',
   'Windsurf',
   'Amp',
   'VS Code Copilot',
   'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary
- Adds `openhands-home.js` pointing at the same `~/.agents` shared root `codex-home.js`/`goose-home.js` already write to.
- **Deviates from the issue's literal request** (`.openhands/microagents/`): research confirmed OpenHands' documented, recommended 2026 format is the AgentSkills-standard `.agents/skills/<name>/SKILL.md` path (legacy `.openhands/microagents/` still works but isn't the current documented target). Mirrors the Goose adapter shape instead.
- Confirmed EGC's `SKILL.md` frontmatter (`name`/`description`/`origin`/`tools`, no `triggers` key) is safe: OpenHands treats skills with no `triggers` field as always-active, ignoring unknown frontmatter fields. No content transformation needed.
- Separate `installStatePathSegments` (`openhands-install-state.json`) so this target's metadata doesn't collide with Codex or Goose's on the same shared directory.
- Docs (`docs/spec/integration-tiers.md`) and schemas updated: EGC now supports 17 harnesses.

Closes #737

## Test plan
- [x] `node tests/lib/install-targets.test.js` (90/90 passing, 5 new OpenHands cases)
- [x] `node tests/spec/integration-tiers.test.js` (4/4 passing)
- [x] `node tests/run-all.js` full suite: 2713/2737 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native OpenHands install target so `egc install --target openhands` installs skills to `~/.agents/skills/<name>/SKILL.md`, sharing the AgentSkills root with Codex and Goose. Uses a separate install-state file to avoid collisions; docs, schemas, and tests updated. Closes #737.

- **New Features**
  - New adapter `openhands-home` for the `openhands` target; installs to `~/.agents/skills/<name>/SKILL.md`.
  - Uses the AgentSkills path instead of legacy `.openhands/microagents/` per current OpenHands docs.
  - No hook wiring; mirrors the Goose adapter; skills installed flat.
  - Separate state file: `~/.agents/egc/openhands-install-state.json`.
  - Updated docs to 17 supported tools; schemas/registry include `openhands`; added tests for adapter and tier listings.

<sup>Written for commit c72195622593c369430b5d401d87236fc5447d32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

