### PR TITLE
feat(llm): add native Groq provider

### DIFF
--- a/src/llm/core/model_resolver.py
+++ b/src/llm/core/model_resolver.py
@@ -246,6 +246,21 @@ class ModelResolver:
             "supports_vision": False,   # Large is text-only; Pixtral is the vision model
             "supports_tools": True,
         },
+        # --- Groq ---
+        "openai/gpt-oss-120b": {
+            "provider": "groq",
+            "capabilities": [
+                ModelCapability.REASONING,
+                ModelCapability.TOOL_CALLING,
+                ModelCapability.CODE,
+                ModelCapability.SPEED,
+            ],
+            "fallback": None,
+            "context_window": 131072,
+            "max_tokens": 65536,
+            "supports_vision": False,
+            "supports_tools": True,
+        },
         # --- DeepSeek native (api.deepseek.com) ---
         "deepseek-chat": {
             "provider": "deepseek",
@@ -466,6 +481,7 @@ class ModelResolver:
         "ollama": "llama3.2",
         "openrouter": "openrouter/auto",
         "mistral": "mistral-large-latest",
+        "groq": "openai/gpt-oss-120b",
     }
 
     # Per-provider default model ID (single place provider defaults live).
@@ -477,6 +493,7 @@ class ModelResolver:
         "openrouter": "openrouter/auto",
         "mistral": "mistral-large-latest",
         "deepseek": "deepseek-chat",
+        "groq": "openai/gpt-oss-120b",
     }
 
     _DEFAULT_PROVIDER = "gemini"
@@ -504,7 +521,12 @@ class ModelResolver:
         if info and info.get("provider"):
             return str(info["provider"])
         v = model_id.lower()
-        # OpenRouter brokers everything under "vendor/model" IDs.
+        # OpenRouter brokers everything under "vendor/model" IDs. Note: this is
+        # no longer exclusive to OpenRouter — Groq also hosts "vendor/model"
+        # IDs (e.g. "openai/gpt-oss-120b", registered above). Any *unregistered*
+        # Groq model with a "/" (e.g. a newer "openai/gpt-oss-20b") will still
+        # misroute to "openrouter" here; only registered IDs are exempt via the
+        # _REGISTRY lookup above.
         if "/" in v and not v.startswith("/") and "/models/" not in v:
             return "openrouter"
         if "claude-" in v:
@@ -726,6 +748,7 @@ class ModelResolver:
             "gpt-4o": "GPT-4o - most capable",
             "gpt-4o-mini": "GPT-4o-mini - fast & affordable",
             "mistral-large-latest": "Mistral Large - top-tier reasoning and multilingual capabilities",
+            "openai/gpt-oss-120b": "GPT-OSS 120B via Groq - fast inference, tool calling",
             "llama3.2": "Llama 3.2 - local general purpose",
             "openrouter/auto": "OpenRouter Auto - broker picks the best model",
             "google/gemini-2.5-pro": "Gemini 2.5 Pro via OpenRouter",

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -23,6 +23,7 @@ class ProviderType(str, Enum):
     OPENROUTER = "openrouter"
     DEEPSEEK = "deepseek"
     MISTRAL = "mistral"
+    GROQ = "groq"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -1,6 +1,7 @@
 from llm.providers.claude import ClaudeProvider
 from llm.providers.deepseek import DeepSeekProvider
 from llm.providers.gemini import GeminiProvider
+from llm.providers.groq import GroqProvider
 from llm.providers.mistral import MistralProvider
 from llm.providers.ollama import OllamaProvider
 from llm.providers.openai import OpenAIProvider
@@ -11,6 +12,7 @@ __all__ = (
     "ClaudeProvider",
     "DeepSeekProvider",
     "GeminiProvider",
+    "GroqProvider",
     "MistralProvider",
     "OllamaProvider",
     "OpenAIProvider",

--- a/src/llm/providers/groq.py
+++ b/src/llm/providers/groq.py
@@ -1,0 +1,86 @@
+"""Groq provider adapter.
+
+Groq exposes an OpenAI-compatible Chat Completions API at
+``https://api.groq.com/openai/v1``. This adapter reuses the OpenAI transport
+logic via :class:`OpenAIProvider` and only changes the base URL, API key
+source and default model, so the EGC runtime stays multi-provider without
+re-implementing the wire protocol. All model selection still flows through
+:class:`ModelResolver`.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - SDK optional
+    OpenAI = None  # type: ignore[assignment]
+
+from llm.core.interface import AuthenticationError, LLMError, LLMProvider
+from llm.core.model_resolver import ModelResolver
+from llm.core.types import ModelInfo, ProviderType
+from llm.providers.openai import OpenAIProvider
+
+GROQ_BASE_URL = "https://api.groq.com/openai/v1"
+_DEFAULT_MODEL = "openai/gpt-oss-120b"
+
+
+class GroqProvider(OpenAIProvider):
+    provider_type = ProviderType.GROQ
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None, **kwargs: Any) -> None:
+        if OpenAI is None:  # NOSONAR
+            raise ImportError("openai package is required to use GroqProvider")
+        key = api_key or os.environ.get("GROQ_API_KEY")
+        if not key:
+            raise AuthenticationError("No Groq API key provided", provider=ProviderType.GROQ)
+        self.client = OpenAI(
+            api_key=key,
+            base_url=base_url or os.environ.get("GROQ_BASE_URL") or GROQ_BASE_URL,
+        )
+        self._models = ModelResolver.model_infos("groq") or [
+            ModelInfo(
+                name=_DEFAULT_MODEL,
+                provider=ProviderType.GROQ,
+                supports_tools=True,
+                supports_vision=False,
+                max_tokens=65536,
+                context_window=131072,
+            ),
+        ]
+
+    def generate(self, llm_input: "LLMInput") -> "LLMOutput":  # type: ignore[override]
+        try:
+            return super().generate(llm_input)
+        except LLMError as exc:
+            # Re-tag LLMErrors so telemetry sees ProviderType.GROQ.
+            raise LLMError(
+                str(exc),
+                provider=ProviderType.GROQ,
+            ) from exc
+        except Exception as exc:
+            # Native OpenAI SDK exceptions (RateLimitError, APIConnectionError,
+            # AuthenticationError, etc.) propagate here unwrapped when
+            # OpenAIProvider.generate() hits the bare `raise`. Wrap them so
+            # telemetry always attributes to GROQ, never OPENAI.
+            raise LLMError(
+                str(exc),
+                provider=ProviderType.GROQ,
+            ) from exc
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        api_key = getattr(self.client, "api_key", None)
+        return isinstance(api_key, str) and len(api_key.strip()) > 0
+
+    def get_default_model(self) -> str:
+        resolved = ModelResolver.resolve(None, provider="groq")
+        if resolved and ModelResolver._provider_for(resolved) == "groq":
+            return resolved
+        return _DEFAULT_MODEL
+
+
+__all__ = ["GroqProvider", "GROQ_BASE_URL"]

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -12,6 +12,7 @@ from llm.providers.mistral import MistralProvider
 from llm.providers.ollama import OllamaProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.deepseek import DeepSeekProvider
+from llm.providers.groq import GroqProvider
 from llm.providers.openrouter import OpenRouterProvider
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
@@ -21,7 +22,8 @@ _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.GEMINI: GeminiProvider,
     ProviderType.OPENROUTER: OpenRouterProvider,
     ProviderType.DEEPSEEK: DeepSeekProvider,
-    ProviderType.MISTRAL: MistralProvider, 
+    ProviderType.MISTRAL: MistralProvider,
+    ProviderType.GROQ: GroqProvider,
 }
 
 

--- a/tests/test_groq_provider.py
+++ b/tests/test_groq_provider.py
@@ -1,0 +1,158 @@
+"""Tests for GroqProvider."""
+from unittest.mock import MagicMock, patch
+import pytest
+from llm.core.interface import AuthenticationError, LLMError
+from llm.core.types import LLMInput, Message, ProviderType, Role
+from llm.providers.groq import GROQ_BASE_URL, GroqProvider
+
+
+def _simple_input() -> LLMInput:
+    return LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="openai/gpt-oss-120b",
+    )
+
+
+@pytest.fixture
+def provider() -> GroqProvider:
+    p = GroqProvider.__new__(GroqProvider)
+    p.client = MagicMock()
+    p._models = []
+    return p
+
+
+@pytest.mark.unit
+def test_provider_type_is_groq(provider: GroqProvider) -> None:
+    assert provider.provider_type == ProviderType.GROQ
+
+
+@pytest.mark.unit
+def test_missing_api_key_raises_authentication_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    with pytest.raises(AuthenticationError) as exc:
+        GroqProvider(api_key=None)
+    assert exc.value.provider == ProviderType.GROQ
+
+
+@pytest.mark.unit
+def test_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test-key")
+    with patch("llm.providers.groq.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        provider = GroqProvider()
+    mock_openai.assert_called_once()
+    _, kwargs = mock_openai.call_args
+    assert kwargs["api_key"] == "gsk-test-key"
+    assert kwargs["base_url"] == GROQ_BASE_URL
+
+
+@pytest.mark.unit
+def test_custom_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    with patch("llm.providers.groq.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        GroqProvider(base_url="https://custom.groq.local/v1")
+    _, kwargs = mock_openai.call_args
+    assert kwargs["base_url"] == "https://custom.groq.local/v1"
+
+
+@pytest.mark.unit
+def test_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    monkeypatch.setenv("GROQ_BASE_URL", "https://proxy.internal/v1")
+    with patch("llm.providers.groq.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        GroqProvider()
+    _, kwargs = mock_openai.call_args
+    assert kwargs["base_url"] == "https://proxy.internal/v1"
+
+
+@pytest.mark.unit
+def test_list_models_returns_copy(provider: GroqProvider) -> None:
+    provider._models = [MagicMock()]
+    result = provider.list_models()
+    assert result is not provider._models
+
+
+@pytest.mark.unit
+def test_validate_config_true_when_key_set(provider: GroqProvider) -> None:
+    provider.client.api_key = "gsk-test"
+    assert provider.validate_config() is True
+
+
+@pytest.mark.unit
+def test_validate_config_false_when_no_key(provider: GroqProvider) -> None:
+    provider.client.api_key = None
+    assert provider.validate_config() is False
+
+
+@pytest.mark.unit
+def test_default_models_include_gpt_oss_120b(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    with patch("llm.providers.groq.OpenAI") as mock_openai, \
+         patch("llm.providers.groq.ModelResolver.model_infos", return_value=None):
+        mock_openai.return_value = MagicMock()
+        p = GroqProvider()
+    names = [m.name for m in p._models]
+    assert "openai/gpt-oss-120b" in names
+
+
+@pytest.mark.unit
+def test_empty_choices_raises_llm_error(provider: GroqProvider) -> None:
+    response = MagicMock()
+    response.choices = []
+    provider.client.chat.completions.create.return_value = response
+    with pytest.raises(LLMError) as exc:
+        provider.generate(_simple_input())
+    assert exc.value.provider == ProviderType.GROQ
+
+
+@pytest.mark.unit
+def test_groq_in_provider_type_enum() -> None:
+    assert ProviderType("groq") == ProviderType.GROQ
+
+
+@pytest.mark.unit
+def test_get_provider_resolves_groq(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    from llm.providers.resolver import get_provider
+    with patch("llm.providers.groq.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        p = get_provider("groq")
+    assert isinstance(p, GroqProvider)
+
+
+@pytest.mark.unit
+def test_get_default_model_returns_groq_model_when_resolver_bleeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_default_model must not return a non-groq model."""
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    with patch("llm.providers.groq.OpenAI") as mock_openai, \
+         patch("llm.providers.groq.ModelResolver.resolve", return_value="gemini-2.5-pro"):
+        mock_openai.return_value = MagicMock()
+        p = GroqProvider()
+    assert p.get_default_model() == "openai/gpt-oss-120b"
+
+
+@pytest.mark.unit
+def test_native_sdk_exception_is_retagged_as_groq(provider: GroqProvider) -> None:
+    """Raw SDK exceptions that bypass OpenAIProvider wrapping must still
+    surface as LLMError with provider=GROQ, not as bare SDK errors."""
+    provider.client.chat.completions.create.side_effect = RuntimeError("connection reset")
+    with pytest.raises(LLMError) as exc:
+        provider.generate(_simple_input())
+    assert exc.value.provider == ProviderType.GROQ
+
+
+@pytest.mark.unit
+def test_provider_for_groq_model_name() -> None:
+    from llm.core.model_resolver import ModelResolver
+    assert ModelResolver._provider_for("openai/gpt-oss-120b") == "groq"
+
+
+@pytest.mark.unit
+def test_model_resolver_default_for_groq_provider() -> None:
+    """ModelResolver.resolve(None, provider='groq') must return a groq model,
+    not bleed into gemini or another provider's default."""
+    from llm.core.model_resolver import ModelResolver
+    resolved = ModelResolver.resolve(None, provider="groq")
+    assert ModelResolver._provider_for(resolved) == "groq"


### PR DESCRIPTION
## Summary
- Adds `GroqProvider(OpenAIProvider)` following the DeepSeek/Mistral pattern -- Groq's Chat Completions API is OpenAI-compatible, only `base_url`/API key/default model differ.
- **Default model is `openai/gpt-oss-120b`, not `llama-3.3-70b-versatile`** as the issue suggested: research confirmed Groq deprecated that model on 2026-06-17, with `openai/gpt-oss-120b` as the recommended migration target.
- Registered in the central model catalog (`model_resolver.py`): registry entry, alias, provider default, menu label.
- Added a code comment flagging that the `vendor/model` → OpenRouter routing heuristic in `_provider_for()` isn't exclusive to OpenRouter anymore now that Groq also hosts slash-style IDs; unregistered Groq models would still misroute. Accepted as scope-appropriate (same minimalist single-model registration as Mistral) per review.

Closes #715

## Test plan
- [x] `PYTHONPATH=src pytest tests/test_groq_provider.py -v` (16/16 passing)
- [x] `PYTHONPATH=src pytest tests/` (62/63 passing -- the 1 failure is `test_insaits_security_monitor.py`, confirmed pre-existing on `main` via stash, unrelated to this change)
- [x] `node tests/run-all.js` full suite: 2713/2737 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Groq provider using `openai`-compatible chat completions with Groq’s base URL and API key. It’s registered in the model resolver with tests; the default model is `openai/gpt-oss-120b`.

- New Features
  - Added `GroqProvider(OpenAIProvider)` targeting https://api.groq.com/openai/v1; uses `GROQ_API_KEY` and optional `GROQ_BASE_URL`.
  - Wired into the provider map and model catalog, including menu label and provider default; noted the slash-ID routing caveat in `_provider_for`.
  - Re-tags SDK errors as Groq for correct telemetry; includes model listing and config validation.
  - Tests cover auth, provider resolution, routing, defaults, and error paths.

- Migration
  - Set `GROQ_API_KEY` to enable the provider (optional `GROQ_BASE_URL` for proxies).
  - If you used `llama-3.3-70b-versatile` on Groq, switch to `openai/gpt-oss-120b` (Groq’s recommended replacement).

<sup>Written for commit 99503795d11a71afa0323d15edc9fe44ce09ec01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

