### PR TITLE
feat(llm): add native Vertex AI provider

### DIFF
--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -24,6 +24,7 @@ class ProviderType(str, Enum):
     DEEPSEEK = "deepseek"
     MISTRAL = "mistral"
     GROQ = "groq"
+    VERTEX_AI = "vertex_ai"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -7,6 +7,7 @@ from llm.providers.ollama import OllamaProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.openrouter import OpenRouterProvider
 from llm.providers.resolver import get_provider, register_provider
+from llm.providers.vertex_ai import VertexAIProvider
 
 __all__ = (
     "ClaudeProvider",
@@ -17,6 +18,7 @@ __all__ = (
     "OllamaProvider",
     "OpenAIProvider",
     "OpenRouterProvider",
+    "VertexAIProvider",
     "get_provider",
     "register_provider",
 )

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -14,6 +14,7 @@ from llm.providers.openai import OpenAIProvider
 from llm.providers.deepseek import DeepSeekProvider
 from llm.providers.groq import GroqProvider
 from llm.providers.openrouter import OpenRouterProvider
+from llm.providers.vertex_ai import VertexAIProvider
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.CLAUDE: ClaudeProvider,
@@ -24,6 +25,7 @@ _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.DEEPSEEK: DeepSeekProvider,
     ProviderType.MISTRAL: MistralProvider,
     ProviderType.GROQ: GroqProvider,
+    ProviderType.VERTEX_AI: VertexAIProvider,
 }
 
 

--- a/src/llm/providers/vertex_ai.py
+++ b/src/llm/providers/vertex_ai.py
@@ -1,0 +1,72 @@
+"""Vertex AI provider adapter.
+
+Vertex AI is Google's enterprise access path to the same Gemini model
+family :class:`GeminiProvider` already talks to via the direct API. The
+``google-genai`` SDK supports both modes through the same client class --
+``genai.Client(vertexai=True, project=..., location=...)`` instead of
+``genai.Client(api_key=...)`` -- so this adapter subclasses
+:class:`GeminiProvider` and only swaps client construction and auth source.
+Model IDs, generation logic, and the model catalog are shared with
+:class:`GeminiProvider`: Vertex AI serves the identical Gemini model family,
+just through GCP service-account/ADC auth instead of an API key.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    from google import genai
+except ImportError:  # pragma: no cover - SDK optional
+    genai = None  # type: ignore[assignment]
+
+from llm.core.interface import AuthenticationError, LLMError
+from llm.core.model_resolver import ModelResolver
+from llm.core.types import LLMInput, LLMOutput, ProviderType
+from llm.providers.gemini import GeminiProvider
+
+_DEFAULT_LOCATION = "us-central1"
+
+
+class VertexAIProvider(GeminiProvider):
+    provider_type = ProviderType.VERTEX_AI
+
+    def __init__(self, project: str | None = None, location: str | None = None, **kwargs: Any) -> None:
+        if genai is None:  # NOSONAR
+            raise ImportError("google-genai package is required to use VertexAIProvider")
+
+        self._project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        self._location = location or os.environ.get("GOOGLE_CLOUD_LOCATION") or _DEFAULT_LOCATION
+        if not self._project:
+            raise AuthenticationError(
+                "No Google Cloud project configured for Vertex AI (set GOOGLE_CLOUD_PROJECT)",
+                provider=ProviderType.VERTEX_AI,
+            )
+
+        self.client = genai.Client(vertexai=True, project=self._project, location=self._location)
+
+        # Vertex AI serves the same Gemini model family/catalog: reuse it
+        # instead of duplicating registry entries under a second provider key.
+        self._default_model = ModelResolver.default_model("gemini")
+        self._fallback_chain = ModelResolver.fallback_map(self._default_model)
+        self._models = ModelResolver.model_infos("gemini")
+
+    def generate(self, input: LLMInput) -> LLMOutput:  # type: ignore[override]
+        try:
+            return super().generate(input)
+        except LLMError as exc:
+            # GeminiProvider.generate() raises with provider=ProviderType.GEMINI
+            # baked in at raise time. Re-tag in place so telemetry attributes
+            # to VERTEX_AI while preserving the original exception subclass
+            # (AuthenticationError, RateLimitError, ContextLengthError, ...).
+            exc.provider = ProviderType.VERTEX_AI
+            raise
+
+    def validate_config(self) -> bool:
+        return bool(self._project) and bool(self._location)
+
+    def get_default_model(self) -> str:
+        return ModelResolver.resolve(None, provider="gemini")
+
+
+__all__ = ["VertexAIProvider"]

--- a/tests/test_vertex_ai_provider.py
+++ b/tests/test_vertex_ai_provider.py
@@ -1,0 +1,159 @@
+"""Tests for VertexAIProvider."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm.core.interface import AuthenticationError, LLMError
+from llm.core.types import LLMInput, Message, ProviderType, Role
+from llm.providers import gemini as gemini_module
+from llm.providers.vertex_ai import VertexAIProvider
+
+
+class _PartStub:
+    @staticmethod
+    def from_text(text: str | None) -> SimpleNamespace:
+        if text is None:
+            raise TypeError("argument of type 'NoneType' is not iterable")
+        return SimpleNamespace(text=text, function_call=None)
+
+
+class _TypesStub:
+    Part = _PartStub
+    Content = SimpleNamespace
+    GenerateContentConfig = SimpleNamespace
+
+
+def _simple_input() -> LLMInput:
+    return LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="gemini-2.5-pro",
+    )
+
+
+def _gemini_response(text: str = "ok") -> SimpleNamespace:
+    part = SimpleNamespace(text=text, function_call=None)
+    content = SimpleNamespace(parts=[part])
+    candidate = SimpleNamespace(content=content, finish_reason="STOP")
+    return SimpleNamespace(candidates=[candidate], usage_metadata=None)
+
+
+@pytest.fixture
+def provider() -> VertexAIProvider:
+    """Build a VertexAIProvider with a mocked genai client — no real SDK calls."""
+    p = VertexAIProvider.__new__(VertexAIProvider)
+    p.client = MagicMock()
+    p._project = "test-project"
+    p._location = "us-central1"
+    p._fallback_chain = {}
+    p._models = []
+    return p
+
+
+@pytest.mark.unit
+def test_provider_type_is_vertex_ai(provider: VertexAIProvider) -> None:
+    assert provider.provider_type == ProviderType.VERTEX_AI
+
+
+@pytest.mark.unit
+def test_missing_project_raises_authentication_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    with patch("llm.providers.vertex_ai.genai") as mock_genai:
+        mock_genai.Client.return_value = MagicMock()
+        with pytest.raises(AuthenticationError) as exc:
+            VertexAIProvider(project=None)
+    assert exc.value.provider == ProviderType.VERTEX_AI
+
+
+@pytest.mark.unit
+def test_project_and_location_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "europe-west4")
+    with patch("llm.providers.vertex_ai.genai") as mock_genai:
+        mock_genai.Client.return_value = MagicMock()
+        provider = VertexAIProvider()
+    mock_genai.Client.assert_called_once_with(
+        vertexai=True, project="my-gcp-project", location="europe-west4"
+    )
+    assert provider._project == "my-gcp-project"
+    assert provider._location == "europe-west4"
+
+
+@pytest.mark.unit
+def test_location_defaults_to_us_central1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+    with patch("llm.providers.vertex_ai.genai") as mock_genai:
+        mock_genai.Client.return_value = MagicMock()
+        provider = VertexAIProvider()
+    assert provider._location == "us-central1"
+
+
+@pytest.mark.unit
+def test_explicit_project_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+    with patch("llm.providers.vertex_ai.genai") as mock_genai:
+        mock_genai.Client.return_value = MagicMock()
+        provider = VertexAIProvider(project="explicit-project")
+    assert provider._project == "explicit-project"
+
+
+@pytest.mark.unit
+def test_validate_config_true_when_project_and_location_set(provider: VertexAIProvider) -> None:
+    assert provider.validate_config() is True
+
+
+@pytest.mark.unit
+def test_validate_config_false_when_no_project(provider: VertexAIProvider) -> None:
+    provider._project = None
+    assert provider.validate_config() is False
+
+
+@pytest.mark.unit
+def test_validate_config_false_when_no_location(provider: VertexAIProvider) -> None:
+    provider._location = None
+    assert provider.validate_config() is False
+
+
+@pytest.mark.unit
+def test_generate_returns_text_via_shared_gemini_logic(provider: VertexAIProvider) -> None:
+    """generate() reuses GeminiProvider's message/response handling."""
+    with patch.object(gemini_module, "types", _TypesStub):
+        provider.client.models.generate_content.return_value = _gemini_response("hello vertex")
+        result = provider.generate(_simple_input())
+    assert result.content == "hello vertex"
+
+
+@pytest.mark.unit
+def test_empty_choices_style_error_is_retagged_as_vertex_ai(provider: VertexAIProvider) -> None:
+    """Errors raised by the inherited generate() must be re-tagged to VERTEX_AI,
+    not left as GEMINI, while preserving the original exception subclass."""
+    with patch.object(gemini_module, "types", _TypesStub):
+        provider.client.models.generate_content.side_effect = RuntimeError("401 unauthorized")
+        with pytest.raises(LLMError) as exc:
+            provider.generate(_simple_input())
+    assert exc.value.provider == ProviderType.VERTEX_AI
+    assert isinstance(exc.value, AuthenticationError)
+
+
+@pytest.mark.unit
+def test_vertex_ai_in_provider_type_enum() -> None:
+    assert ProviderType("vertex_ai") == ProviderType.VERTEX_AI
+
+
+@pytest.mark.unit
+def test_get_provider_resolves_vertex_ai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    from llm.providers.resolver import get_provider
+    with patch("llm.providers.vertex_ai.genai") as mock_genai:
+        mock_genai.Client.return_value = MagicMock()
+        p = get_provider("vertex_ai")
+    assert isinstance(p, VertexAIProvider)
+
+
+@pytest.mark.unit
+def test_get_default_model_reuses_gemini_catalog(provider: VertexAIProvider) -> None:
+    """Vertex AI serves the same Gemini model family; get_default_model()
+    must not return a hardcoded or separate model ID."""
+    from llm.core.model_resolver import ModelResolver
+    assert provider.get_default_model() == ModelResolver.resolve(None, provider="gemini")


### PR DESCRIPTION
## Summary
- Adds `VertexAIProvider(GeminiProvider)`, authenticated via GCP service-account/ADC (`GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`) instead of an API key -- the `google-genai` SDK supports both auth modes through the same client class.
- Vertex AI serves the identical Gemini model family, so `get_default_model()` and the model catalog delegate to `ModelResolver`'s existing `"gemini"` registrations instead of duplicating entries under a separate `"vertex_ai"` key.
- `generate()` catches errors from the inherited `GeminiProvider` logic and mutates the caught exception's `.provider` attribute to `VERTEX_AI` in place before re-raising, preserving the original exception subclass (`AuthenticationError`, `RateLimitError`, `ContextLengthError`) instead of reconstructing a generic `LLMError`.

Closes #728

## Test plan
- [x] `PYTHONPATH=src pytest tests/test_vertex_ai_provider.py -v` (13/13 passing)
- [x] `PYTHONPATH=src pytest tests/` (75/76 passing -- the 1 failure is `test_insaits_security_monitor.py`, confirmed pre-existing on `main`, unrelated to this change)
- [x] `node tests/run-all.js` full suite: 2713/2737 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Vertex AI provider for the Gemini model family. It uses GCP ADC/service-account auth and reuses the existing Gemini model catalog.

- **New Features**
  - New `VertexAIProvider` extends `GeminiProvider` and builds `genai.Client(vertexai=True, project, location)` from `google-genai`.
  - Auth via `GOOGLE_CLOUD_PROJECT` and optional `GOOGLE_CLOUD_LOCATION` (defaults to `us-central1`).
  - Reuses Gemini model registrations; `get_default_model()` delegates to the Gemini resolver.
  - Errors from `generate()` are re-tagged to `VERTEX_AI` while keeping the original exception type.
  - Added `ProviderType.VERTEX_AI` and resolver exports.

- **Migration**
  - Set `GOOGLE_CLOUD_PROJECT` (and `GOOGLE_CLOUD_LOCATION` if not `us-central1`).
  - Use provider `"vertex_ai"` via the resolver or import `VertexAIProvider`.
  - Keep using existing `gemini-*` model IDs; no catalog changes needed.

<sup>Written for commit 7f8f899715bc73b98ed8c27bee727eb17951cfe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

