### PR TITLE
feat(llm): add native Cohere provider

### DIFF
--- a/src/llm/core/model_resolver.py
+++ b/src/llm/core/model_resolver.py
@@ -261,6 +261,21 @@ class ModelResolver:
             "supports_vision": False,
             "supports_tools": True,
         },
+        # --- Cohere ---
+        "command-a-plus-05-2026": {
+            "provider": "cohere",
+            "capabilities": [
+                ModelCapability.REASONING,
+                ModelCapability.TOOL_CALLING,
+                ModelCapability.MULTIMODAL,
+                ModelCapability.LONG_CONTEXT,
+            ],
+            "fallback": None,
+            "context_window": 128000,
+            "max_tokens": 65536,
+            "supports_vision": True,
+            "supports_tools": True,
+        },
         # --- DeepSeek native (api.deepseek.com) ---
         "deepseek-chat": {
             "provider": "deepseek",
@@ -482,6 +497,7 @@ class ModelResolver:
         "openrouter": "openrouter/auto",
         "mistral": "mistral-large-latest",
         "groq": "openai/gpt-oss-120b",
+        "cohere": "command-a-plus-05-2026",
     }
 
     # Per-provider default model ID (single place provider defaults live).
@@ -494,6 +510,7 @@ class ModelResolver:
         "mistral": "mistral-large-latest",
         "deepseek": "deepseek-chat",
         "groq": "openai/gpt-oss-120b",
+        "cohere": "command-a-plus-05-2026",
     }
 
     _DEFAULT_PROVIDER = "gemini"
@@ -510,7 +527,8 @@ class ModelResolver:
             or "claude-" in v
             or "mistral-" in v
             or v.startswith(("gpt-", "o1", "o3", "o4", "ministral-", "codestral-",
-                              "deepseek-"))  # native DeepSeek IDs
+                              "deepseek-",   # native DeepSeek IDs
+                              "command-"))   # native Cohere IDs
             or "/models/" in v          # Vertex AI fully-qualified path
             or ("/" in v and not v.startswith("/"))  # OpenRouter "vendor/model" style
         )
@@ -542,6 +560,11 @@ class ModelResolver:
         # and is resolved via _ALIASES before _provider_for is ever called.
         if v.startswith("deepseek-"):
             return "deepseek"
+        # Native Cohere model IDs: command-a-plus-05-2026, command-r-plus, etc.
+        # The bare alias token "cohere" is excluded — no "-" suffix, resolved
+        # via _ALIASES before _provider_for is ever called.
+        if v.startswith("command-"):
+            return "cohere"
         return cls._DEFAULT_PROVIDER
 
     # ------------------------------------------------------------------ #
@@ -749,6 +772,7 @@ class ModelResolver:
             "gpt-4o-mini": "GPT-4o-mini - fast & affordable",
             "mistral-large-latest": "Mistral Large - top-tier reasoning and multilingual capabilities",
             "openai/gpt-oss-120b": "GPT-OSS 120B via Groq - fast inference, tool calling",
+            "command-a-plus-05-2026": "Command A+ (Cohere) - agentic tool use, vision, multilingual",
             "llama3.2": "Llama 3.2 - local general purpose",
             "openrouter/auto": "OpenRouter Auto - broker picks the best model",
             "google/gemini-2.5-pro": "Gemini 2.5 Pro via OpenRouter",

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -25,6 +25,7 @@ class ProviderType(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     VERTEX_AI = "vertex_ai"
+    COHERE = "cohere"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -1,4 +1,5 @@
 from llm.providers.claude import ClaudeProvider
+from llm.providers.cohere import CohereProvider
 from llm.providers.deepseek import DeepSeekProvider
 from llm.providers.gemini import GeminiProvider
 from llm.providers.groq import GroqProvider
@@ -11,6 +12,7 @@ from llm.providers.vertex_ai import VertexAIProvider
 
 __all__ = (
     "ClaudeProvider",
+    "CohereProvider",
     "DeepSeekProvider",
     "GeminiProvider",
     "GroqProvider",

--- a/src/llm/providers/cohere.py
+++ b/src/llm/providers/cohere.py
@@ -1,0 +1,184 @@
+"""Cohere provider adapter.
+
+Cohere's Chat API (v2) is close to, but not exactly, OpenAI-compatible in
+wire format: tool definitions use the same JSON-schema shape, but the
+response envelope differs (``response.message.content`` is a list of
+content blocks, not a plain string; usage lives under
+``response.usage.tokens``; finish reasons use Cohere's own vocabulary).
+This adapter implements :class:`LLMProvider` directly with Cohere's own
+``cohere`` SDK instead of subclassing :class:`OpenAIProvider`.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+try:
+    import cohere
+except ImportError:  # pragma: no cover - SDK optional
+    cohere = None  # type: ignore[assignment]
+
+from llm.core.interface import AuthenticationError, LLMError, LLMProvider
+from llm.core.model_resolver import ModelResolver
+from llm.core.types import (
+    LLMInput,
+    LLMOutput,
+    Message,
+    ModelInfo,
+    ProviderType,
+    ToolCall,
+    ToolDefinition,
+)
+
+COHERE_DEFAULT_MODEL = "command-a-plus-05-2026"
+
+
+def _map_finish_reason(reason: str | None, has_tool_calls: bool) -> str | None:
+    if has_tool_calls:
+        return "tool_use"
+    if reason is None:
+        return None
+    reason_str = str(reason).upper()
+    if reason_str == "COMPLETE":
+        return "end_turn"
+    if reason_str == "MAX_TOKENS":
+        return "max_tokens"
+    return reason_str.lower()
+
+
+class CohereProvider(LLMProvider):
+    provider_type = ProviderType.COHERE
+
+    def __init__(self, api_key: str | None = None, **kwargs: Any) -> None:
+        if cohere is None:  # NOSONAR
+            raise ImportError("cohere package is required to use CohereProvider")
+        key = api_key or os.environ.get("COHERE_API_KEY")
+        if not key:
+            raise AuthenticationError("No Cohere API key provided", provider=ProviderType.COHERE)
+        self._api_key = key
+        self.client = cohere.ClientV2(api_key=key)
+        self._models = ModelResolver.model_infos("cohere") or [
+            ModelInfo(
+                name=COHERE_DEFAULT_MODEL,
+                provider=ProviderType.COHERE,
+                supports_tools=True,
+                supports_vision=True,
+                max_tokens=65536,
+                context_window=128000,
+            ),
+        ]
+
+    def _map_messages(self, messages: list[Message]) -> list[dict[str, Any]]:
+        mapped: list[dict[str, Any]] = []
+        for msg in messages:
+            role = msg.role.value
+            if role == "tool":
+                mapped.append({
+                    "role": "tool",
+                    "tool_call_id": msg.tool_call_id or "",
+                    "content": msg.content or "",
+                })
+                continue
+            entry: dict[str, Any] = {"role": role, "content": msg.content or ""}
+            if msg.tool_calls:
+                entry["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.name, "arguments": _json_dumps(tc.arguments)},
+                    }
+                    for tc in msg.tool_calls
+                ]
+            mapped.append(entry)
+        return mapped
+
+    def _map_tools(self, tools: list[ToolDefinition] | None) -> list[dict[str, Any]] | None:
+        if not tools:
+            return None
+        return [tool.to_dict() for tool in tools]
+
+    def generate(self, input: LLMInput) -> LLMOutput:  # type: ignore[override]
+        try:
+            model = ModelResolver.resolve(input.model, provider="cohere")
+            kwargs: dict[str, Any] = {
+                "model": model,
+                "messages": self._map_messages(input.messages),
+            }
+            if input.temperature is not None:
+                kwargs["temperature"] = input.temperature
+            if input.max_tokens is not None:
+                kwargs["max_tokens"] = input.max_tokens
+            tools_mapped = self._map_tools(input.tools)
+            if tools_mapped:
+                kwargs["tools"] = tools_mapped
+
+            response = self.client.chat(**kwargs)
+
+            if response.message is None:
+                raise LLMError("Cohere returned an empty response", provider=ProviderType.COHERE)
+
+            content_blocks = response.message.content or []
+            text = "".join(block.text for block in content_blocks if getattr(block, "text", None))
+
+            tool_calls: list[ToolCall] | None = None
+            raw_tool_calls = getattr(response.message, "tool_calls", None)
+            if raw_tool_calls:
+                tool_calls = [
+                    ToolCall(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=_json_loads(tc.function.arguments),
+                    )
+                    for tc in raw_tool_calls
+                ]
+
+            usage = None
+            meta = getattr(response, "usage", None) or getattr(response, "meta", None)
+            tokens = getattr(meta, "tokens", None) if meta else None
+            if tokens is not None:
+                usage = {
+                    "input_tokens": getattr(tokens, "input_tokens", 0) or 0,
+                    "output_tokens": getattr(tokens, "output_tokens", 0) or 0,
+                }
+
+            return LLMOutput(
+                content=text,
+                tool_calls=tool_calls,
+                model=model,
+                usage=usage,
+                stop_reason=_map_finish_reason(response.finish_reason, bool(tool_calls)),
+            )
+        except LLMError:
+            raise
+        except Exception as exc:
+            msg = str(exc).lower()
+            if "unauthorized" in msg or "api key" in msg or "401" in msg:
+                raise AuthenticationError(str(exc), provider=ProviderType.COHERE) from exc
+            raise LLMError(str(exc), provider=ProviderType.COHERE) from exc
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        return isinstance(self._api_key, str) and len(self._api_key.strip()) > 0
+
+    def get_default_model(self) -> str:
+        resolved = ModelResolver.resolve(None, provider="cohere")
+        if resolved and ModelResolver._provider_for(resolved) == "cohere":
+            return resolved
+        return COHERE_DEFAULT_MODEL
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    return json.dumps(value)
+
+
+def _json_loads(value: str) -> dict[str, Any]:
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+__all__ = ["CohereProvider", "COHERE_DEFAULT_MODEL"]

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -11,6 +11,7 @@ from llm.providers.gemini import GeminiProvider
 from llm.providers.mistral import MistralProvider 
 from llm.providers.ollama import OllamaProvider
 from llm.providers.openai import OpenAIProvider
+from llm.providers.cohere import CohereProvider
 from llm.providers.deepseek import DeepSeekProvider
 from llm.providers.groq import GroqProvider
 from llm.providers.openrouter import OpenRouterProvider
@@ -26,6 +27,7 @@ _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.MISTRAL: MistralProvider,
     ProviderType.GROQ: GroqProvider,
     ProviderType.VERTEX_AI: VertexAIProvider,
+    ProviderType.COHERE: CohereProvider,
 }
 
 

--- a/tests/test_cohere_provider.py
+++ b/tests/test_cohere_provider.py
@@ -1,0 +1,185 @@
+"""Tests for CohereProvider."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm.core.interface import AuthenticationError, LLMError
+from llm.core.types import LLMInput, Message, ProviderType, Role, ToolDefinition
+from llm.providers.cohere import COHERE_DEFAULT_MODEL, CohereProvider
+
+
+def _simple_input() -> LLMInput:
+    return LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model=COHERE_DEFAULT_MODEL,
+    )
+
+
+def _text_response(text: str = "hello") -> SimpleNamespace:
+    block = SimpleNamespace(text=text)
+    message = SimpleNamespace(content=[block], tool_calls=None)
+    tokens = SimpleNamespace(input_tokens=10, output_tokens=5)
+    usage = SimpleNamespace(tokens=tokens)
+    return SimpleNamespace(message=message, finish_reason="COMPLETE", usage=usage)
+
+
+def _tool_call_response(name: str = "calculator", tool_id: str = "call_1", arguments: str = '{"expr": "2+2"}') -> SimpleNamespace:
+    function = SimpleNamespace(name=name, arguments=arguments)
+    tool_call = SimpleNamespace(id=tool_id, type="function", function=function)
+    message = SimpleNamespace(content=[], tool_calls=[tool_call])
+    tokens = SimpleNamespace(input_tokens=10, output_tokens=5)
+    usage = SimpleNamespace(tokens=tokens)
+    return SimpleNamespace(message=message, finish_reason=None, usage=usage)
+
+
+@pytest.fixture
+def provider() -> CohereProvider:
+    p = CohereProvider.__new__(CohereProvider)
+    p.client = MagicMock()
+    p._api_key = "test-key"
+    p._models = []
+    return p
+
+
+@pytest.mark.unit
+def test_provider_type_is_cohere(provider: CohereProvider) -> None:
+    assert provider.provider_type == ProviderType.COHERE
+
+
+@pytest.mark.unit
+def test_missing_api_key_raises_authentication_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COHERE_API_KEY", raising=False)
+    with patch("llm.providers.cohere.cohere") as mock_cohere:
+        mock_cohere.ClientV2.return_value = MagicMock()
+        with pytest.raises(AuthenticationError) as exc:
+            CohereProvider(api_key=None)
+    assert exc.value.provider == ProviderType.COHERE
+
+
+@pytest.mark.unit
+def test_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COHERE_API_KEY", "co-test-key")
+    with patch("llm.providers.cohere.cohere") as mock_cohere:
+        mock_cohere.ClientV2.return_value = MagicMock()
+        provider = CohereProvider()
+    mock_cohere.ClientV2.assert_called_once_with(api_key="co-test-key")
+    assert provider._api_key == "co-test-key"
+
+
+@pytest.mark.unit
+def test_validate_config_true_when_key_set(provider: CohereProvider) -> None:
+    assert provider.validate_config() is True
+
+
+@pytest.mark.unit
+def test_validate_config_false_when_no_key(provider: CohereProvider) -> None:
+    provider._api_key = None
+    assert provider.validate_config() is False
+
+    provider._api_key = ""
+    assert provider.validate_config() is False
+
+    provider._api_key = "   "
+    assert provider.validate_config() is False
+
+
+@pytest.mark.unit
+def test_list_models_returns_copy(provider: CohereProvider) -> None:
+    provider._models = [MagicMock()]
+    result = provider.list_models()
+    assert result is not provider._models
+
+
+@pytest.mark.unit
+def test_generate_returns_text_from_content_blocks(provider: CohereProvider) -> None:
+    provider.client.chat.return_value = _text_response("hello cohere")
+    result = provider.generate(_simple_input())
+    assert result.content == "hello cohere"
+    assert result.stop_reason == "end_turn"
+    assert result.usage == {"input_tokens": 10, "output_tokens": 5}
+
+
+@pytest.mark.unit
+def test_generate_extracts_tool_calls(provider: CohereProvider) -> None:
+    provider.client.chat.return_value = _tool_call_response("calculator", "call_99", '{"expr": "2+2"}')
+    result = provider.generate(_simple_input())
+    assert result.tool_calls is not None
+    assert result.tool_calls[0].name == "calculator"
+    assert result.tool_calls[0].arguments == {"expr": "2+2"}
+    assert result.stop_reason == "tool_use"
+
+
+@pytest.mark.unit
+def test_generate_passes_tools_in_openai_json_schema_shape(provider: CohereProvider) -> None:
+    provider.client.chat.return_value = _text_response("ok")
+    tool = ToolDefinition(name="search", description="search docs", parameters={"type": "object", "properties": {}})
+    llm_input = LLMInput(messages=[Message(role=Role.USER, content="hi")], tools=[tool])
+    provider.generate(llm_input)
+    _, kwargs = provider.client.chat.call_args
+    assert kwargs["tools"][0]["function"]["name"] == "search"
+
+
+@pytest.mark.unit
+def test_empty_message_raises_llm_error(provider: CohereProvider) -> None:
+    response = SimpleNamespace(message=None, finish_reason=None, usage=None)
+    provider.client.chat.return_value = response
+    with pytest.raises(LLMError) as exc:
+        provider.generate(_simple_input())
+    assert exc.value.provider == ProviderType.COHERE
+
+
+@pytest.mark.unit
+def test_native_sdk_exception_is_wrapped_as_llm_error(provider: CohereProvider) -> None:
+    provider.client.chat.side_effect = RuntimeError("connection reset")
+    with pytest.raises(LLMError) as exc:
+        provider.generate(_simple_input())
+    assert exc.value.provider == ProviderType.COHERE
+
+
+@pytest.mark.unit
+def test_unauthorized_exception_raises_authentication_error(provider: CohereProvider) -> None:
+    provider.client.chat.side_effect = RuntimeError("401 unauthorized: invalid api key")
+    with pytest.raises(AuthenticationError) as exc:
+        provider.generate(_simple_input())
+    assert exc.value.provider == ProviderType.COHERE
+
+
+@pytest.mark.unit
+def test_cohere_in_provider_type_enum() -> None:
+    assert ProviderType("cohere") == ProviderType.COHERE
+
+
+@pytest.mark.unit
+def test_get_provider_resolves_cohere(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COHERE_API_KEY", "co-test")
+    from llm.providers.resolver import get_provider
+    with patch("llm.providers.cohere.cohere") as mock_cohere:
+        mock_cohere.ClientV2.return_value = MagicMock()
+        p = get_provider("cohere")
+    assert isinstance(p, CohereProvider)
+
+
+@pytest.mark.unit
+def test_get_default_model_returns_cohere_model_when_resolver_bleeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COHERE_API_KEY", "co-test")
+    with patch("llm.providers.cohere.cohere") as mock_cohere, \
+         patch("llm.providers.cohere.ModelResolver.resolve", return_value="gemini-2.5-pro"):
+        mock_cohere.ClientV2.return_value = MagicMock()
+        p = CohereProvider()
+    assert p.get_default_model() == COHERE_DEFAULT_MODEL
+
+
+@pytest.mark.unit
+def test_provider_for_cohere_model_names() -> None:
+    from llm.core.model_resolver import ModelResolver
+    assert ModelResolver._provider_for("command-a-plus-05-2026") == "cohere"
+    assert ModelResolver._provider_for("command-r-plus") == "cohere"
+    assert ModelResolver._provider_for("gemini-2.5-pro") != "cohere"
+
+
+@pytest.mark.unit
+def test_model_resolver_default_for_cohere_provider() -> None:
+    from llm.core.model_resolver import ModelResolver
+    resolved = ModelResolver.resolve(None, provider="cohere")
+    assert ModelResolver._provider_for(resolved) == "cohere"


### PR DESCRIPTION
## Summary
- Adds `CohereProvider(LLMProvider)` implemented from scratch against the ABC, using Cohere's own `cohere.ClientV2` SDK rather than subclassing `OpenAIProvider` -- Cohere's v2 Chat API shares the OpenAI JSON-schema shape for tool definitions/tool_calls, but its response envelope differs (`response.message.content` is a list of blocks, not a plain string; usage lives under `response.usage.tokens`).
- Default model is `command-a-plus-05-2026` (Cohere's May 2026 MoE flagship, their stated "first choice for Agentic Workflows, Tool Use"), 128k context / 64k max output.
- `finish_reason` always resolves to `"tool_use"` when tool_calls are present, matching the same defensive pattern `GeminiProvider` already uses.

Closes #729

## Test plan
- [x] `PYTHONPATH=src pytest tests/test_cohere_provider.py -v` (17/17 passing)
- [x] `PYTHONPATH=src pytest tests/` (92/93 passing -- the 1 failure is `test_insaits_security_monitor.py`, confirmed pre-existing on `main`, unrelated to this change)
- [x] `node tests/run-all.js` full suite: 2713/2737 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Cohere provider using `cohere.ClientV2`, with `command-a-plus-05-2026` as the default model. This satisfies #729 by enabling tool calling, vision, long-context support, and updating model/provider resolution and tests.

- **New Features**
  - New `CohereProvider` (built on `cohere.ClientV2`) that handles content blocks, tool calls, and usage tokens.
  - Resolver updates: default to `command-a-plus-05-2026`, recognize `command-` model IDs, add menu entry and capabilities.
  - Finish reason maps to "tool_use" when tool calls are present; comprehensive tests added.

- **Migration**
  - Install `cohere` and set `COHERE_API_KEY`.
  - No code changes required; `provider="cohere"` or `command-*` model IDs resolve automatically.

<sup>Written for commit 9346dc829775cde2c7c42bb1461038ecc55ae7f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

