### PR TITLE
feat(install): add native Aider install target

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 17 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 18 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 17 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 17 harnesses
+## The 18 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -33,6 +33,7 @@ EGC supports 17 AI coding tools through 3 distinct integration mechanisms. This 
 | 15 | **Goose** | 1 | `goose` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex) | Skills installed flat; no GateGuard hook wiring (Goose has no documented hook API); discoverability-only adapter over the same `~/.agents` root `codex-home.js` already writes to |
 | 16 | **Amazon Q Developer CLI** | 1 | `amazonq` | `.amazonq/rules/` (project only, no home target) | Default scaffold (category preserved), same template as `gemini-project.js`; no hook wiring |
 | 17 | **OpenHands** | 1 | `openhands` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex/Goose) | Skills installed flat; no GateGuard hook wiring; discoverability-only adapter -- the issue asked for `.openhands/microagents/`, but current OpenHands docs recommend the AgentSkills-standard `.agents/skills/<name>/SKILL.md` path (legacy `.openhands/microagents/` still works but isn't the documented target), so this mirrors the Goose adapter instead |
+| 18 | **Aider** | 1 | `aider` | `.aider/skills/<name>.md` (project only, no home target) | Skills copied flat as single `.md` files (Aider does not scan a skill-folder convention); each file's path is merged into the `read:` list of `.aider.conf.yml` via a new `merge-yaml-read-list` operation kind, preserving any unrelated existing keys; install/repair/uninstall all wired |
 
 ## Why three tiers (history, not aspiration)
 

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -35,7 +35,8 @@
         "trae",
         "goose",
         "amazonq",
-        "openhands"
+        "openhands",
+        "aider"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -64,7 +64,8 @@
                 "trae",
                 "goose",
                 "amazonq",
-                "openhands"
+                "openhands",
+                "aider"
               ]
             }
           },

--- a/scripts/lib/aider-config-merge.js
+++ b/scripts/lib/aider-config-merge.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const yaml = require('js-yaml');
+
+const MERGE_YAML_READ_LIST_KIND = 'merge-yaml-read-list';
+
+// Aider's .aider.conf.yml read: key accepts a list of file paths that get
+// loaded into every session's context. Adding an entry must never touch any
+// other key already in the file (model settings, lint commands, etc).
+function mergeAiderConfigReadList(existingContent, readEntry) {
+  const parsed = existingContent ? yaml.load(existingContent) : null;
+  const config = (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : {};
+
+  const existingList = Array.isArray(config.read) ? config.read.slice() : [];
+  if (!existingList.includes(readEntry)) {
+    existingList.push(readEntry);
+  }
+
+  const merged = { ...config, read: existingList };
+  return yaml.dump(merged);
+}
+
+const REMOVE_SENTINEL = Symbol('aider-config-remove-file');
+
+// Inverse of mergeAiderConfigReadList: strips only the given entry from the
+// read: list. If that leaves the config with no read: entries and no other
+// keys (i.e. this file only ever existed because EGC created it), signals
+// the caller to delete the file instead of leaving an empty stub behind.
+function removeAiderConfigReadEntry(existingContent, readEntry) {
+  if (!existingContent) {
+    return REMOVE_SENTINEL;
+  }
+
+  const parsed = yaml.load(existingContent);
+  const config = (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : {};
+  const existingList = Array.isArray(config.read) ? config.read : [];
+  const nextList = existingList.filter(entry => entry !== readEntry);
+
+  const nextConfig = { ...config };
+  if (nextList.length > 0) {
+    nextConfig.read = nextList;
+  } else {
+    delete nextConfig.read;
+  }
+
+  if (Object.keys(nextConfig).length === 0) {
+    return REMOVE_SENTINEL;
+  }
+
+  return yaml.dump(nextConfig);
+}
+
+module.exports = {
+  MERGE_YAML_READ_LIST_KIND,
+  REMOVE_SENTINEL,
+  mergeAiderConfigReadList,
+  removeAiderConfigReadEntry,
+};

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -13,6 +13,7 @@ const {
 } = require('./install-manifests');
 const { getInstallTargetAdapter } = require('./install-targets/registry');
 const { HOOK_OPERATION_KIND } = require('./claude-settings-hooks');
+const { MERGE_YAML_READ_LIST_KIND } = require('./aider-config-merge');
 
 const LANGUAGE_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const GEMINI_EGC_NAMESPACE = 'egc';
@@ -586,6 +587,10 @@ function createLegacyCompatInstallPlan(options = {}) {
 
 function materializeScaffoldOperation(sourceRoot, operation) {
   if (operation.kind === HOOK_OPERATION_KIND) {
+    return [{ ...operation, scaffoldOnly: false }];
+  }
+
+  if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
     return [{ ...operation, scaffoldOnly: false }];
   }
 

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -30,6 +30,12 @@ const {
   removeSessionStartHookFromFile,
   removeStopHookFromFile,
 } = require('./claude-settings-hooks');
+const {
+  MERGE_YAML_READ_LIST_KIND,
+  REMOVE_SENTINEL: AIDER_REMOVE_SENTINEL,
+  mergeAiderConfigReadList,
+  removeAiderConfigReadEntry,
+} = require('./aider-config-merge');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
 
@@ -394,6 +400,19 @@ function executeRepairOperation(repoRoot, operation) {
     return;
   }
 
+  if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
+    if (!operation.readEntry) {
+      throw new Error(`Missing readEntry for repair: ${operation.destinationPath}`);
+    }
+    const existingContent = fs.existsSync(operation.destinationPath)
+      ? fs.readFileSync(operation.destinationPath, 'utf8')
+      : null;
+    const nextContent = mergeAiderConfigReadList(existingContent, operation.readEntry);
+    ensureParentDir(operation.destinationPath);
+    fs.writeFileSync(operation.destinationPath, nextContent);
+    return;
+  }
+
   throw new Error(`Unsupported repair operation kind: ${operation.kind}`);
 }
 
@@ -474,6 +493,29 @@ function uninstallRemove(operation) {
   return { removedPaths: [], cleanupTargets: [] };
 }
 
+function uninstallAiderConfigReadList(operation) {
+  // Strips only the EGC-added read: entry. .aider.conf.yml is only deleted
+  // if EGC's entry was the last thing keeping it non-empty -- the user's own
+  // model settings, lint commands, etc are never touched.
+  if (!operation.readEntry || !fs.existsSync(operation.destinationPath)) {
+    return { removedPaths: [], cleanupTargets: [] };
+  }
+
+  const existingContent = fs.readFileSync(operation.destinationPath, 'utf8');
+  const nextContent = removeAiderConfigReadEntry(existingContent, operation.readEntry);
+  if (nextContent === AIDER_REMOVE_SENTINEL) {
+    fs.rmSync(operation.destinationPath, { force: true });
+    return {
+      removedPaths: [operation.destinationPath],
+      cleanupTargets: [operation.destinationPath],
+    };
+  }
+
+  ensureParentDir(operation.destinationPath);
+  fs.writeFileSync(operation.destinationPath, nextContent);
+  return { removedPaths: [], cleanupTargets: [] };
+}
+
 function uninstallClaudeSettingsHook(operation) {
   // Strips only the EGC-managed hook entry. The settings file itself is never
   // deleted because Claude Code and the user own its other keys.
@@ -495,6 +537,7 @@ const UNINSTALL_HANDLERS = {
   'merge-json': uninstallMergeJson,
   'remove': uninstallRemove,
   [HOOK_OPERATION_KIND]: uninstallClaudeSettingsHook,
+  [MERGE_YAML_READ_LIST_KIND]: uninstallAiderConfigReadList,
 };
 
 function executeUninstallOperation(operation) {

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands', 'aider'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/aider-project.js
+++ b/scripts/lib/install-targets/aider-project.js
@@ -1,0 +1,72 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createManagedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+const { MERGE_YAML_READ_LIST_KIND } = require('../aider-config-merge');
+
+// Aider does not scan a skills directory: it loads context via a `read:`
+// key inside .aider.conf.yml (searched in three locations and merged --
+// home dir, git repo root, cwd -- per https://aider.chat/docs/config/aider_conf.html).
+// So this adapter does two things per skill: (1) copy the skill's SKILL.md
+// into .aider/skills/<name>.md (flat, single file -- Aider reads plain
+// markdown, not a skill-folder-with-assets convention), and (2) emit a
+// 'merge-yaml-read-list' operation that adds that file's path into the
+// `read:` list of the project's .aider.conf.yml without touching any of the
+// user's own existing keys (model settings, lint commands, etc).
+
+function createAiderPlanOperations(input, adapter) {
+  const modules = Array.isArray(input.modules) ? input.modules : [];
+  const planningInput = {
+    repoRoot: input.repoRoot,
+    projectRoot: input.projectRoot,
+    homeDir: input.homeDir,
+  };
+  const targetRoot = adapter.resolveRoot(planningInput);
+  const projectRoot = input.projectRoot || input.repoRoot;
+  const aiderConfigPath = path.join(projectRoot, '.aider.conf.yml');
+
+  return modules.flatMap(module => {
+    const paths = Array.isArray(module.paths) ? module.paths : [];
+    return paths
+      .filter(p => !isForeignPlatformPath(p, adapter.target))
+      .filter(p => normalizeRelativePath(p).startsWith('skills/'))
+      .flatMap(sourceRelativePath => {
+        const normalized = normalizeRelativePath(sourceRelativePath);
+        const skillName = normalized.split('/').pop();
+        const destinationPath = path.join(targetRoot, 'skills', `${skillName}.md`);
+
+        const copyOperation = createManagedOperation({
+          moduleId: module.id,
+          sourceRelativePath: path.join(normalized, 'SKILL.md'),
+          destinationPath,
+          strategy: 'preserve-relative-path',
+        });
+
+        const mergeOperation = {
+          kind: MERGE_YAML_READ_LIST_KIND,
+          moduleId: module.id,
+          destinationPath: aiderConfigPath,
+          strategy: MERGE_YAML_READ_LIST_KIND,
+          ownership: 'managed',
+          scaffoldOnly: false,
+          readEntry: path.relative(projectRoot, destinationPath),
+        };
+
+        return [copyOperation, mergeOperation];
+      });
+  });
+}
+
+module.exports = createInstallTargetAdapter({
+  id: 'aider-project',
+  target: 'aider',
+  kind: 'project',
+  rootSegments: ['.aider'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.aider',
+  planOperations: createAiderPlanOperations,
+});

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -114,6 +114,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   goose:        { name: 'Goose',              url: 'https://block.github.io/goose/' },
   amazonq:      { name: 'Amazon Q Developer CLI', url: 'https://aws.amazon.com/q/developer/' },
   openhands:    { name: 'OpenHands',          url: 'https://docs.openhands.dev' },
+  aider:        { name: 'Aider',              url: 'https://aider.chat' },
   windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -1,3 +1,4 @@
+const aiderProject = require('./aider-project');
 const amazonqProject = require('./amazonq-project');
 const antigravityProject = require('./antigravity-project');
 const claudeCodeHome = require('./claude-home');
@@ -27,6 +28,7 @@ const ADAPTERS = Object.freeze([
   cursorProject,
   antigravityProject,
   amazonqProject,
+  aiderProject,
   codexHome,
   gooseHome,
   openhandsHome,

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -21,6 +21,10 @@ const {
   PRE_WRITE_CODE_EVENT,
   applyWindsurfGateGuardHookToFile,
 } = require('../windsurf-gateguard-hooks');
+const {
+  MERGE_YAML_READ_LIST_KIND,
+  mergeAiderConfigReadList,
+} = require('../aider-config-merge');
 
 const WINDSURF_HOOK_EVENTS = new Set([PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT]);
 
@@ -172,6 +176,19 @@ function applyInstallPlan(plan) {
         : {};
       const mergedValue = deepMergeJson(currentValue, filteredPayload);
       fs.writeFileSync(operation.destinationPath, formatJson(mergedValue), 'utf8');
+      continue;
+    }
+
+    if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
+      if (!operation.readEntry) {
+        throw new Error(`Missing readEntry for ${operation.destinationPath}`);
+      }
+
+      const existingContent = fs.existsSync(operation.destinationPath)
+        ? fs.readFileSync(operation.destinationPath, 'utf8')
+        : null;
+      const nextContent = mergeAiderConfigReadList(existingContent, operation.readEntry);
+      fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
       continue;
     }
 

--- a/tests/lib/aider-config-merge.test.js
+++ b/tests/lib/aider-config-merge.test.js
@@ -1,0 +1,174 @@
+/**
+ * Tests for scripts/lib/aider-config-merge.js and its wiring into
+ * install/apply.js (real file writes) -- covers the two scenarios required
+ * by issue #736: creating .aider.conf.yml from scratch, and merging into an
+ * existing one without touching unrelated keys.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const {
+  MERGE_YAML_READ_LIST_KIND,
+  REMOVE_SENTINEL,
+  mergeAiderConfigReadList,
+  removeAiderConfigReadEntry,
+} = require('../../scripts/lib/aider-config-merge');
+const { applyInstallPlan } = require('../../scripts/lib/install-executor');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing aider-config-merge ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  // --- Pure function: mergeAiderConfigReadList ---
+
+  if (test('creates a fresh config with the correct read: list when no existing content', () => {
+    const result = mergeAiderConfigReadList(null, '.aider/skills/tdd-workflow.md');
+    const parsed = yaml.load(result);
+    assert.deepStrictEqual(parsed, { read: ['.aider/skills/tdd-workflow.md'] });
+  })) passed++; else failed++;
+
+  if (test('preserves unrelated existing keys and only adds read:', () => {
+    const existing = yaml.dump({ model: 'gpt-4o', 'auto-commits': false });
+    const result = mergeAiderConfigReadList(existing, '.aider/skills/tdd-workflow.md');
+    const parsed = yaml.load(result);
+    assert.deepStrictEqual(parsed, {
+      model: 'gpt-4o',
+      'auto-commits': false,
+      read: ['.aider/skills/tdd-workflow.md'],
+    });
+  })) passed++; else failed++;
+
+  if (test('appends to an existing read: list without duplicating or dropping entries', () => {
+    const existing = yaml.dump({ read: ['docs/CONVENTIONS.md'] });
+    const result = mergeAiderConfigReadList(existing, '.aider/skills/tdd-workflow.md');
+    const parsed = yaml.load(result);
+    assert.deepStrictEqual(parsed.read, ['docs/CONVENTIONS.md', '.aider/skills/tdd-workflow.md']);
+  })) passed++; else failed++;
+
+  if (test('is idempotent: re-adding the same entry does not duplicate it', () => {
+    const once = mergeAiderConfigReadList(null, '.aider/skills/tdd-workflow.md');
+    const twice = mergeAiderConfigReadList(once, '.aider/skills/tdd-workflow.md');
+    const parsed = yaml.load(twice);
+    assert.deepStrictEqual(parsed.read, ['.aider/skills/tdd-workflow.md']);
+  })) passed++; else failed++;
+
+  // --- Pure function: removeAiderConfigReadEntry ---
+
+  if (test('removes only the given entry, keeping other read: entries and keys', () => {
+    const existing = yaml.dump({ model: 'gpt-4o', read: ['docs/CONVENTIONS.md', '.aider/skills/tdd-workflow.md'] });
+    const result = removeAiderConfigReadEntry(existing, '.aider/skills/tdd-workflow.md');
+    const parsed = yaml.load(result);
+    assert.deepStrictEqual(parsed, { model: 'gpt-4o', read: ['docs/CONVENTIONS.md'] });
+  })) passed++; else failed++;
+
+  if (test('signals file removal when EGC entry was the only content', () => {
+    const existing = yaml.dump({ read: ['.aider/skills/tdd-workflow.md'] });
+    const result = removeAiderConfigReadEntry(existing, '.aider/skills/tdd-workflow.md');
+    assert.strictEqual(result, REMOVE_SENTINEL);
+  })) passed++; else failed++;
+
+  if (test('signals file removal when existing content is empty/falsy', () => {
+    const result = removeAiderConfigReadEntry(null, '.aider/skills/tdd-workflow.md');
+    assert.strictEqual(result, REMOVE_SENTINEL);
+  })) passed++; else failed++;
+
+  // --- Real install application via applyInstallPlan ---
+
+  function buildMinimalPlan(destinationPath, readEntry, installStatePath) {
+    return {
+      operations: [
+        {
+          kind: MERGE_YAML_READ_LIST_KIND,
+          moduleId: 'workflow',
+          destinationPath,
+          strategy: MERGE_YAML_READ_LIST_KIND,
+          ownership: 'managed',
+          scaffoldOnly: false,
+          readEntry,
+        },
+      ],
+      installStatePath,
+      statePreview: {
+        schemaVersion: 'egc.install.v1',
+        installedAt: new Date().toISOString(),
+        target: { id: 'aider-project', target: 'aider', kind: 'project', root: path.dirname(destinationPath), installStatePath },
+        request: { profile: null, modules: [], includeComponents: [], excludeComponents: [], legacyLanguages: [], legacyMode: false },
+        resolution: { selectedModules: ['workflow'], skippedModules: [] },
+        source: { repoVersion: null, repoCommit: null, manifestVersion: 1 },
+        operations: [],
+      },
+    };
+  }
+
+  if (test('applyInstallPlan creates .aider.conf.yml from scratch with the correct read: list', () => {
+    const projectRoot = createTempDir('aider-apply-fresh-');
+    try {
+      const destinationPath = path.join(projectRoot, '.aider.conf.yml');
+      const installStatePath = path.join(projectRoot, '.aider', 'egc-install-state.json');
+      const plan = buildMinimalPlan(destinationPath, '.aider/skills/tdd-workflow.md', installStatePath);
+
+      applyInstallPlan(plan);
+
+      assert.ok(fs.existsSync(destinationPath));
+      const parsed = yaml.load(fs.readFileSync(destinationPath, 'utf8'));
+      assert.deepStrictEqual(parsed, { read: ['.aider/skills/tdd-workflow.md'] });
+    } finally {
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('applyInstallPlan merges into an existing .aider.conf.yml without touching unrelated keys', () => {
+    const projectRoot = createTempDir('aider-apply-existing-');
+    try {
+      const destinationPath = path.join(projectRoot, '.aider.conf.yml');
+      fs.writeFileSync(destinationPath, yaml.dump({
+        model: 'gpt-4o',
+        'auto-commits': false,
+        read: ['docs/CONVENTIONS.md'],
+      }));
+      const installStatePath = path.join(projectRoot, '.aider', 'egc-install-state.json');
+      const plan = buildMinimalPlan(destinationPath, '.aider/skills/tdd-workflow.md', installStatePath);
+
+      applyInstallPlan(plan);
+
+      const parsed = yaml.load(fs.readFileSync(destinationPath, 'utf8'));
+      assert.deepStrictEqual(parsed, {
+        model: 'gpt-4o',
+        'auto-commits': false,
+        read: ['docs/CONVENTIONS.md', '.aider/skills/tdd-workflow.md'],
+      });
+    } finally {
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1852,6 +1852,63 @@ function runTests() {
     assert.ok(targets.includes('openhands'), 'Should include openhands target');
   })) passed++; else failed++;
 
+  if (test('resolves aider adapter root and install-state path from project root', () => {
+    const adapter = getInstallTargetAdapter('aider');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'aider-project');
+    assert.strictEqual(adapter.target, 'aider');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.aider'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.aider', 'egc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('aider adapter emits a flat skill copy plus a merge-yaml-read-list operation per skill', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'aider',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'aider-project');
+
+    const copyOp = plan.operations.find(op => op.kind === 'copy-path');
+    assert.ok(copyOp, 'Should emit a copy-path operation for the skill file');
+    assert.strictEqual(normalizedRelativePath(copyOp.sourceRelativePath), 'skills/workflow/tdd-workflow/SKILL.md');
+    assert.strictEqual(copyOp.destinationPath, path.join(projectRoot, '.aider', 'skills', 'tdd-workflow.md'));
+
+    const mergeOp = plan.operations.find(op => op.kind === 'merge-yaml-read-list');
+    assert.ok(mergeOp, 'Should emit a merge-yaml-read-list operation for .aider.conf.yml');
+    assert.strictEqual(mergeOp.destinationPath, path.join(projectRoot, '.aider.conf.yml'));
+    assert.strictEqual(mergeOp.readEntry, path.join('.aider', 'skills', 'tdd-workflow.md'));
+  })) passed++; else failed++;
+
+  if (test('aider adapter filters out non-skill module paths (rules, agents, commands)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'aider',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'rules-core', paths: ['rules'] }],
+    });
+
+    assert.strictEqual(plan.operations.length, 0, 'Non-skill module paths should not produce operations');
+  })) passed++; else failed++;
+
+  if (test('aider adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('aider'), 'Should include aider target');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -26,13 +26,14 @@ const EXPECTED_HARNESSES = [
   'Goose',
   'Amazon Q Developer CLI',
   'OpenHands',
+  'Aider',
   'Windsurf',
   'Amp',
   'VS Code Copilot',
   'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands', 'aider'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary
- Adds `aider-project.js`. Aider loads context via a `read:` key inside `.aider.conf.yml` rather than scanning a skills directory, so this adapter emits two operations per skill: a flat copy of `SKILL.md` into `.aider/skills/<name>.md`, and a new `merge-yaml-read-list` operation that adds that file's path into the `read:` list without touching the user's existing keys.
- **Touches shared infrastructure** used by all 18 other harnesses: `install-executor.js` (materialization pass-through), `install/apply.js` (real install-time handler), `install-lifecycle.js` (repair + uninstall handlers) -- following the exact precedent `HOOK_OPERATION_KIND`/`merge-json` already established, so no other harness's operation kind is affected.
- The actual YAML merge/remove logic lives in an isolated pure module (`scripts/lib/aider-config-merge.js`); the shared files just dispatch to it.

Closes #736

## Test plan
- [x] `node tests/lib/aider-config-merge.test.js` (9/9 passing -- covers both required scenarios: fresh `.aider.conf.yml` creation and merging into an existing one without touching unrelated keys, via real `applyInstallPlan` file writes)
- [x] `node tests/lib/install-targets.test.js` (94/94 passing, 4 new Aider cases)
- [x] `node tests/spec/integration-tiers.test.js` (4/4 passing)
- [x] `node tests/run-all.js` full suite: 2726/2750 passing, same 24 pre-existing failures as on `main` (unrelated hook-flags issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Aider install target that installs skills as flat `.md` files and wires them into `.aider.conf.yml` via a new `merge-yaml-read-list` operation. This fulfills #736 and raises support to 18 tools without touching users’ existing Aider settings.

- **New Features**
  - New `aider-project` adapter: copies each `SKILL.md` to `.aider/skills/<name>.md` and adds it to the Aider `read:` list.
  - New `merge-yaml-read-list` operation: merges into `.aider.conf.yml` without modifying unrelated keys; idempotent and order-safe.
  - Install lifecycle wiring: apply/repair/uninstall handlers merge or remove only the EGC-added entry; delete the config file only if it becomes empty.
  - Shared infra updates: executor pass-through and lifecycle dispatch for the new operation kind; no changes to other targets’ behavior.
  - Registry/schemas/docs updated to include `aider` and reflect 18 harnesses; tests added for YAML merge logic and adapter planning.

<sup>Written for commit ae31b9342ce371909d01bb33b83d13f29d3f3160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

