### PR TITLE
feat(install): add native Warp install target

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 18 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 19 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 18 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 18 harnesses
+## The 19 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -34,6 +34,7 @@ EGC supports 18 AI coding tools through 3 distinct integration mechanisms. This 
 | 16 | **Amazon Q Developer CLI** | 1 | `amazonq` | `.amazonq/rules/` (project only, no home target) | Default scaffold (category preserved), same template as `gemini-project.js`; no hook wiring |
 | 17 | **OpenHands** | 1 | `openhands` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex/Goose) | Skills installed flat; no GateGuard hook wiring; discoverability-only adapter -- the issue asked for `.openhands/microagents/`, but current OpenHands docs recommend the AgentSkills-standard `.agents/skills/<name>/SKILL.md` path (legacy `.openhands/microagents/` still works but isn't the documented target), so this mirrors the Goose adapter instead |
 | 18 | **Aider** | 1 | `aider` | `.aider/skills/<name>.md` (project only, no home target) | Skills copied flat as single `.md` files (Aider does not scan a skill-folder convention); each file's path is merged into the `read:` list of `.aider.conf.yml` via a new `merge-yaml-read-list` operation kind, preserving any unrelated existing keys; install/repair/uninstall all wired |
+| 19 | **Warp** | 1 | `warp` | `.warp/skills/<name>.md` + index in project root `AGENTS.md` (project only, no home target) | Warp only discovers a single root `AGENTS.md`/`WARP.md` file as project rules, not a directory of skill files -- confirmed a plain `AGENTS.md` is sufficient (Warp's own docs call it the default project rules file; `WARP.md` is legacy and only takes priority if both exist). Full skill content is copied flat to `.warp/skills/<name>.md` (read on demand); a short index (name + one-line description + path) is merged into a marked block inside `AGENTS.md` via a new `merge-markdown-skill-index` operation kind, since concatenating all 230+ skills (~2MB) into the always-loaded rules file would blow the context budget. Install/repair/uninstall all wired; uninstall never deletes `AGENTS.md` itself, only the EGC block |
 
 ## Why three tiers (history, not aspiration)
 
@@ -45,7 +46,7 @@ Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude
 
 ## What "supported" guarantees
 
-For all 14 harnesses, EGC guarantees:
+For all 19 harnesses, EGC guarantees:
 
 - The install path is documented above
 - MCP server registration (if the tool supports MCP)

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -36,7 +36,8 @@
         "goose",
         "amazonq",
         "openhands",
-        "aider"
+        "aider",
+        "warp"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -65,7 +65,8 @@
                 "goose",
                 "amazonq",
                 "openhands",
-                "aider"
+                "aider",
+                "warp"
               ]
             }
           },

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -14,6 +14,7 @@ const {
 const { getInstallTargetAdapter } = require('./install-targets/registry');
 const { HOOK_OPERATION_KIND } = require('./claude-settings-hooks');
 const { MERGE_YAML_READ_LIST_KIND } = require('./aider-config-merge');
+const { MERGE_MARKDOWN_INDEX_KIND } = require('./warp-agents-merge');
 
 const LANGUAGE_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const GEMINI_EGC_NAMESPACE = 'egc';
@@ -591,6 +592,10 @@ function materializeScaffoldOperation(sourceRoot, operation) {
   }
 
   if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
+    return [{ ...operation, scaffoldOnly: false }];
+  }
+
+  if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
     return [{ ...operation, scaffoldOnly: false }];
   }
 

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -36,6 +36,11 @@ const {
   mergeAiderConfigReadList,
   removeAiderConfigReadEntry,
 } = require('./aider-config-merge');
+const {
+  MERGE_MARKDOWN_INDEX_KIND,
+  mergeSkillIndexEntry,
+  removeSkillIndexEntry,
+} = require('./warp-agents-merge');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
 
@@ -413,6 +418,20 @@ function executeRepairOperation(repoRoot, operation) {
     return;
   }
 
+  if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
+    const existingContent = fs.existsSync(operation.destinationPath)
+      ? fs.readFileSync(operation.destinationPath, 'utf8')
+      : null;
+    const nextContent = mergeSkillIndexEntry(existingContent, {
+      name: operation.skillName,
+      description: operation.skillDescription,
+      relativePath: operation.relativePath,
+    });
+    ensureParentDir(operation.destinationPath);
+    fs.writeFileSync(operation.destinationPath, nextContent);
+    return;
+  }
+
   throw new Error(`Unsupported repair operation kind: ${operation.kind}`);
 }
 
@@ -516,6 +535,22 @@ function uninstallAiderConfigReadList(operation) {
   return { removedPaths: [], cleanupTargets: [] };
 }
 
+function uninstallWarpAgentsIndexEntry(operation) {
+  // Strips only the EGC-added index entry from the marked block. AGENTS.md
+  // itself is never deleted, even if the block becomes empty -- it is an
+  // increasingly common cross-tool convention file the user's other tools
+  // may also rely on.
+  if (!operation.skillName || !fs.existsSync(operation.destinationPath)) {
+    return { removedPaths: [], cleanupTargets: [] };
+  }
+
+  const existingContent = fs.readFileSync(operation.destinationPath, 'utf8');
+  const nextContent = removeSkillIndexEntry(existingContent, operation.skillName);
+  ensureParentDir(operation.destinationPath);
+  fs.writeFileSync(operation.destinationPath, nextContent);
+  return { removedPaths: [], cleanupTargets: [] };
+}
+
 function uninstallClaudeSettingsHook(operation) {
   // Strips only the EGC-managed hook entry. The settings file itself is never
   // deleted because Claude Code and the user own its other keys.
@@ -538,6 +573,7 @@ const UNINSTALL_HANDLERS = {
   'remove': uninstallRemove,
   [HOOK_OPERATION_KIND]: uninstallClaudeSettingsHook,
   [MERGE_YAML_READ_LIST_KIND]: uninstallAiderConfigReadList,
+  [MERGE_MARKDOWN_INDEX_KIND]: uninstallWarpAgentsIndexEntry,
 };
 
 function executeUninstallOperation(operation) {

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands', 'aider'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands', 'aider', 'warp'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -115,6 +115,7 @@ const IDE_INSTALL_URLS = Object.freeze({
   amazonq:      { name: 'Amazon Q Developer CLI', url: 'https://aws.amazon.com/q/developer/' },
   openhands:    { name: 'OpenHands',          url: 'https://docs.openhands.dev' },
   aider:        { name: 'Aider',              url: 'https://aider.chat' },
+  warp:         { name: 'Warp',               url: 'https://www.warp.dev' },
   windsurf:     { name: 'Windsurf',           url: 'https://windsurf.ai' },
   amp:          { name: 'Amp',                url: 'https://ampcode.com' },
   copilot:      { name: 'VS Code Copilot',    url: 'https://code.visualstudio.com' },

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -21,6 +21,7 @@ const zedHome = require('./zed-home');
 const continueHome = require('./continue-home');
 const continueProject = require('./continue-project');
 const traeProject = require('./trae-project');
+const warpProject = require('./warp-project');
 
 const ADAPTERS = Object.freeze([
   egcHome,
@@ -46,6 +47,7 @@ const ADAPTERS = Object.freeze([
   continueHome,
   continueProject,
   traeProject,
+  warpProject,
 ]);
 
 function listInstallTargetAdapters() {

--- a/scripts/lib/install-targets/warp-project.js
+++ b/scripts/lib/install-targets/warp-project.js
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const {
+  createInstallTargetAdapter,
+  createManagedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+const { MERGE_MARKDOWN_INDEX_KIND } = require('../warp-agents-merge');
+
+const MAX_DESCRIPTION_LENGTH = 110;
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+// Warp has no directory-of-files skill discovery: it only reads a single
+// root AGENTS.md (or legacy WARP.md) as project rules. So this adapter does
+// two things per skill: (1) copy the skill's SKILL.md into
+// .warp/skills/<name>.md (flat, full content, read on demand -- Warp's agent
+// has normal filesystem access), and (2) emit a 'merge-markdown-skill-index'
+// operation that adds a one-line index entry (name + short description +
+// path) into a marked block inside the project's AGENTS.md, without
+// touching any of the user's own content in that file.
+
+// Truncates on Unicode code points, not UTF-16 code units, so a surrogate
+// pair (e.g. an emoji used in a skill description) is never split in half.
+function truncateDescription(text) {
+  const codePoints = Array.from(text);
+  if (codePoints.length <= MAX_DESCRIPTION_LENGTH) {
+    return text;
+  }
+  return `${codePoints.slice(0, MAX_DESCRIPTION_LENGTH - 1).join('')}…`;
+}
+
+function readSkillDescription(sourcePath) {
+  let content;
+  try {
+    content = fs.readFileSync(sourcePath, 'utf8');
+  } catch (_error) {
+    return '';
+  }
+
+  const frontmatterMatch = FRONTMATTER_PATTERN.exec(content);
+  if (!frontmatterMatch) {
+    return '';
+  }
+
+  let frontmatter;
+  try {
+    frontmatter = yaml.load(frontmatterMatch[1]);
+  } catch (_error) {
+    return '';
+  }
+
+  if (!frontmatter || typeof frontmatter.description !== 'string') {
+    return '';
+  }
+
+  return truncateDescription(frontmatter.description.trim().replace(/\s+/g, ' '));
+}
+
+function createWarpPlanOperations(input, adapter) {
+  const modules = Array.isArray(input.modules) ? input.modules : [];
+  const planningInput = {
+    repoRoot: input.repoRoot,
+    projectRoot: input.projectRoot,
+    homeDir: input.homeDir,
+  };
+  const targetRoot = adapter.resolveRoot(planningInput);
+  const projectRoot = input.projectRoot || input.repoRoot;
+  const agentsFilePath = path.join(projectRoot, 'AGENTS.md');
+
+  return modules.flatMap(module => {
+    const paths = Array.isArray(module.paths) ? module.paths : [];
+    return paths
+      .filter(p => !isForeignPlatformPath(p, adapter.target))
+      .filter(p => normalizeRelativePath(p).startsWith('skills/'))
+      .flatMap(sourceRelativePath => {
+        const normalized = normalizeRelativePath(sourceRelativePath);
+        const skillName = normalized.split('/').pop();
+        const destinationPath = path.join(targetRoot, 'skills', `${skillName}.md`);
+        const sourceSkillPath = path.join(input.repoRoot || '', normalized, 'SKILL.md');
+
+        const copyOperation = createManagedOperation({
+          moduleId: module.id,
+          sourceRelativePath: path.join(normalized, 'SKILL.md'),
+          destinationPath,
+          strategy: 'preserve-relative-path',
+        });
+
+        const mergeOperation = {
+          kind: MERGE_MARKDOWN_INDEX_KIND,
+          moduleId: module.id,
+          destinationPath: agentsFilePath,
+          strategy: MERGE_MARKDOWN_INDEX_KIND,
+          ownership: 'managed',
+          scaffoldOnly: false,
+          skillName,
+          skillDescription: readSkillDescription(sourceSkillPath),
+          relativePath: path.relative(projectRoot, destinationPath),
+        };
+
+        return [copyOperation, mergeOperation];
+      });
+  });
+}
+
+module.exports = createInstallTargetAdapter({
+  id: 'warp-project',
+  target: 'warp',
+  kind: 'project',
+  rootSegments: ['.warp'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.warp',
+  planOperations: createWarpPlanOperations,
+});

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -25,6 +25,10 @@ const {
   MERGE_YAML_READ_LIST_KIND,
   mergeAiderConfigReadList,
 } = require('../aider-config-merge');
+const {
+  MERGE_MARKDOWN_INDEX_KIND,
+  mergeSkillIndexEntry,
+} = require('../warp-agents-merge');
 
 const WINDSURF_HOOK_EVENTS = new Set([PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT]);
 
@@ -188,6 +192,19 @@ function applyInstallPlan(plan) {
         ? fs.readFileSync(operation.destinationPath, 'utf8')
         : null;
       const nextContent = mergeAiderConfigReadList(existingContent, operation.readEntry);
+      fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
+      continue;
+    }
+
+    if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
+      const existingContent = fs.existsSync(operation.destinationPath)
+        ? fs.readFileSync(operation.destinationPath, 'utf8')
+        : null;
+      const nextContent = mergeSkillIndexEntry(existingContent, {
+        name: operation.skillName,
+        description: operation.skillDescription,
+        relativePath: operation.relativePath,
+      });
       fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
       continue;
     }

--- a/scripts/lib/warp-agents-merge.js
+++ b/scripts/lib/warp-agents-merge.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const MERGE_MARKDOWN_INDEX_KIND = 'merge-markdown-skill-index';
+
+const BLOCK_START = '<!-- egc-skills-index:start -->';
+const BLOCK_END = '<!-- egc-skills-index:end -->';
+const BLOCK_HEADING = '## EGC Skills';
+const BLOCK_INTRO = 'Skills installed by EGC for this project. Read the referenced file when a task matches its description.';
+const ENTRY_LINE_PATTERN = /^- \*\*(.+?)\*\*: (.*)$/;
+
+// Warp only discovers a single root-level AGENTS.md (or legacy WARP.md) as
+// project rules -- there is no per-skill file discovery like Kiro/Trae/
+// OpenHands. With 230+ skills (~2MB of raw content), concatenating everything
+// into that one always-loaded file would blow the user's context budget on
+// every session regardless of relevance. So EGC maintains a short index
+// inside a marked block instead: one line per skill (name, one-line
+// description, path to the full file under .warp/skills/), letting Warp's
+// agent read the full content on demand. The block is delimited so
+// reinstall/uninstall never touches the user's own AGENTS.md content outside
+// it -- AGENTS.md is an increasingly common cross-tool convention file other
+// tools may also write to.
+
+function buildEntryLine(entry) {
+  return `- **${entry.name}**: ${entry.description} (\`${entry.relativePath}\`)`;
+}
+
+function parseEntryLine(line) {
+  const match = ENTRY_LINE_PATTERN.exec(line.trim());
+  if (!match) {
+    return null;
+  }
+  return { name: match[1], line: line.trim() };
+}
+
+function findBlockRange(lines) {
+  const startIndex = lines.indexOf(BLOCK_START);
+  if (startIndex === -1) {
+    return null;
+  }
+  const endIndex = lines.indexOf(BLOCK_END, startIndex + 1);
+  if (endIndex === -1) {
+    return null;
+  }
+  return { startIndex, endIndex };
+}
+
+function extractEntries(lines, range) {
+  const entries = new Map();
+  for (let i = range.startIndex + 1; i < range.endIndex; i++) {
+    const parsed = parseEntryLine(lines[i]);
+    if (parsed) {
+      entries.set(parsed.name, parsed.line);
+    }
+  }
+  return entries;
+}
+
+function renderBlock(entries) {
+  return [BLOCK_START, BLOCK_HEADING, '', BLOCK_INTRO, '', ...entries.values(), BLOCK_END];
+}
+
+function mergeSkillIndexEntry(existingContent, entry) {
+  const original = existingContent || '';
+  const lines = original.length > 0 ? original.split('\n') : [];
+  const range = findBlockRange(lines);
+
+  const entries = range ? extractEntries(lines, range) : new Map();
+  entries.set(entry.name, buildEntryLine(entry));
+
+  const blockLines = renderBlock(entries);
+
+  if (range) {
+    const nextLines = [
+      ...lines.slice(0, range.startIndex),
+      ...blockLines,
+      ...lines.slice(range.endIndex + 1),
+    ];
+    return nextLines.join('\n');
+  }
+
+  const trimmedOriginal = original.replace(/\n+$/, '');
+  const prefix = trimmedOriginal.length > 0 ? `${trimmedOriginal}\n\n` : '';
+  return `${prefix}${blockLines.join('\n')}\n`;
+}
+
+// Removes only the given skill's entry from the marked block. If that empties
+// the block, the block itself is dropped -- but the rest of the file (and the
+// file itself) is always preserved, even if EGC created it and it would now
+// be empty. See module comment above for why.
+function removeSkillIndexEntry(existingContent, name) {
+  if (!existingContent) {
+    return existingContent || '';
+  }
+
+  const lines = existingContent.split('\n');
+  const range = findBlockRange(lines);
+  if (!range) {
+    return existingContent;
+  }
+
+  const entries = extractEntries(lines, range);
+  entries.delete(name);
+
+  const before = lines.slice(0, range.startIndex);
+  const after = lines.slice(range.endIndex + 1);
+
+  if (entries.size === 0) {
+    while (before.length > 0 && before[before.length - 1] === '') {
+      before.pop();
+    }
+    const nextLines = after.length > 0 ? [...before, '', ...after] : before;
+    return nextLines.length > 0 ? `${nextLines.join('\n')}\n` : '';
+  }
+
+  const blockLines = renderBlock(entries);
+  return [...before, ...blockLines, ...after].join('\n');
+}
+
+module.exports = {
+  MERGE_MARKDOWN_INDEX_KIND,
+  mergeSkillIndexEntry,
+  removeSkillIndexEntry,
+};

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1909,6 +1909,99 @@ function runTests() {
     assert.ok(targets.includes('aider'), 'Should include aider target');
   })) passed++; else failed++;
 
+  if (test('resolves warp adapter root and install-state path from project root', () => {
+    const adapter = getInstallTargetAdapter('warp');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'warp-project');
+    assert.strictEqual(adapter.target, 'warp');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.warp'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.warp', 'egc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('warp adapter emits a flat skill copy plus a merge-markdown-skill-index operation per skill', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'warp',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'testing', paths: ['skills/testing/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'warp-project');
+
+    const copyOp = plan.operations.find(op => op.kind === 'copy-path');
+    assert.ok(copyOp, 'Should emit a copy-path operation for the skill file');
+    assert.strictEqual(normalizedRelativePath(copyOp.sourceRelativePath), 'skills/testing/tdd-workflow/SKILL.md');
+    assert.strictEqual(copyOp.destinationPath, path.join(projectRoot, '.warp', 'skills', 'tdd-workflow.md'));
+
+    const mergeOp = plan.operations.find(op => op.kind === 'merge-markdown-skill-index');
+    assert.ok(mergeOp, 'Should emit a merge-markdown-skill-index operation for AGENTS.md');
+    assert.strictEqual(mergeOp.destinationPath, path.join(projectRoot, 'AGENTS.md'));
+    assert.strictEqual(mergeOp.skillName, 'tdd-workflow');
+    assert.strictEqual(mergeOp.relativePath, path.join('.warp', 'skills', 'tdd-workflow.md'));
+    assert.ok(mergeOp.skillDescription.startsWith('Use this skill when writing new features'));
+    assert.ok(mergeOp.skillDescription.length <= 110, 'Description should be truncated to the shared max length');
+  })) passed++; else failed++;
+
+  if (test('warp adapter extracts a description from a multiline YAML block-scalar frontmatter field', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'warp',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'ai', paths: ['skills/ai/token-budget-advisor'] }],
+    });
+
+    const mergeOp = plan.operations.find(op => op.kind === 'merge-markdown-skill-index');
+    assert.ok(mergeOp, 'Should emit a merge operation for a skill with a block-scalar description');
+    assert.ok(mergeOp.skillDescription.length > 0, 'Description should not be empty for a valid block scalar');
+    assert.ok(!mergeOp.skillDescription.includes('\n'), 'Description should be collapsed onto one line');
+  })) passed++; else failed++;
+
+  if (test('warp adapter falls back to an empty description when SKILL.md has no frontmatter', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'warp',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'workflow', paths: ['skills/workflow/nonexistent-skill'] }],
+    });
+
+    const mergeOp = plan.operations.find(op => op.kind === 'merge-markdown-skill-index');
+    assert.ok(mergeOp, 'Should still emit a merge operation even without a real source file');
+    assert.strictEqual(mergeOp.skillDescription, '');
+  })) passed++; else failed++;
+
+  if (test('warp adapter filters out non-skill module paths (rules, agents, commands)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'warp',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'rules-core', paths: ['rules'] }],
+    });
+
+    assert.strictEqual(plan.operations.length, 0, 'Non-skill module paths should not produce operations');
+  })) passed++; else failed++;
+
+  if (test('warp adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(a => a.target);
+    assert.ok(targets.includes('warp'), 'Should include warp target');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/warp-agents-merge.test.js
+++ b/tests/lib/warp-agents-merge.test.js
@@ -1,0 +1,197 @@
+/**
+ * Tests for scripts/lib/warp-agents-merge.js and its wiring into
+ * install/apply.js (real file writes) -- covers the scenarios required by
+ * issue #739: creating AGENTS.md from scratch, merging into an existing one
+ * without touching unrelated content, and never deleting the file on
+ * uninstall even if the EGC block becomes empty.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  MERGE_MARKDOWN_INDEX_KIND,
+  mergeSkillIndexEntry,
+  removeSkillIndexEntry,
+} = require('../../scripts/lib/warp-agents-merge');
+const { applyInstallPlan } = require('../../scripts/lib/install-executor');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing warp-agents-merge ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  const tddEntry = {
+    name: 'tdd-workflow',
+    description: 'TDD workflow guidance',
+    relativePath: '.warp/skills/tdd-workflow.md',
+  };
+
+  // --- Pure function: mergeSkillIndexEntry ---
+
+  if (test('creates a fresh block with a single entry when no existing content', () => {
+    const result = mergeSkillIndexEntry(null, tddEntry);
+    assert.ok(result.includes('<!-- egc-skills-index:start -->'));
+    assert.ok(result.includes('<!-- egc-skills-index:end -->'));
+    assert.ok(result.includes('- **tdd-workflow**: TDD workflow guidance (`.warp/skills/tdd-workflow.md`)'));
+  })) passed++; else failed++;
+
+  if (test('preserves unrelated existing content and appends the block', () => {
+    const existing = '# My Project\n\nSome custom rules the user wrote.\n';
+    const result = mergeSkillIndexEntry(existing, tddEntry);
+    assert.ok(result.startsWith('# My Project\n\nSome custom rules the user wrote.'));
+    assert.ok(result.includes('<!-- egc-skills-index:start -->'));
+  })) passed++; else failed++;
+
+  if (test('appends a second entry into the existing block without duplicating the first', () => {
+    const once = mergeSkillIndexEntry(null, tddEntry);
+    const twice = mergeSkillIndexEntry(once, {
+      name: 'kotlin-patterns',
+      description: 'Idiomatic Kotlin patterns',
+      relativePath: '.warp/skills/kotlin-patterns.md',
+    });
+    assert.ok(twice.includes('- **tdd-workflow**:'));
+    assert.ok(twice.includes('- **kotlin-patterns**:'));
+    assert.strictEqual((twice.match(/<!-- egc-skills-index:start -->/g) || []).length, 1);
+  })) passed++; else failed++;
+
+  if (test('is idempotent: re-adding the same entry does not duplicate it', () => {
+    const once = mergeSkillIndexEntry(null, tddEntry);
+    const twice = mergeSkillIndexEntry(once, tddEntry);
+    assert.strictEqual((twice.match(/^- \*\*tdd-workflow\*\*:/gm) || []).length, 1);
+  })) passed++; else failed++;
+
+  if (test('upserts an entry when the description changes on reinstall', () => {
+    const once = mergeSkillIndexEntry(null, tddEntry);
+    const updated = mergeSkillIndexEntry(once, { ...tddEntry, description: 'Updated description' });
+    assert.ok(updated.includes('- **tdd-workflow**: Updated description'));
+    assert.ok(!updated.includes('TDD workflow guidance'));
+  })) passed++; else failed++;
+
+  // --- Pure function: removeSkillIndexEntry ---
+
+  if (test('removes only the given entry, keeping other entries and the block', () => {
+    const withTwo = mergeSkillIndexEntry(
+      mergeSkillIndexEntry(null, tddEntry),
+      { name: 'kotlin-patterns', description: 'Idiomatic Kotlin patterns', relativePath: '.warp/skills/kotlin-patterns.md' }
+    );
+    const result = removeSkillIndexEntry(withTwo, 'tdd-workflow');
+    assert.ok(!result.includes('tdd-workflow'));
+    assert.ok(result.includes('kotlin-patterns'));
+    assert.ok(result.includes('<!-- egc-skills-index:start -->'));
+  })) passed++; else failed++;
+
+  if (test('drops the block but keeps the rest of the file when the last entry is removed', () => {
+    const existing = mergeSkillIndexEntry('# My Project\n\nCustom rules.\n', tddEntry);
+    const result = removeSkillIndexEntry(existing, 'tdd-workflow');
+    assert.ok(!result.includes('egc-skills-index'));
+    assert.ok(result.includes('# My Project'));
+    assert.ok(result.includes('Custom rules.'));
+  })) passed++; else failed++;
+
+  if (test('never deletes the file even when EGC was the only content', () => {
+    const existing = mergeSkillIndexEntry(null, tddEntry);
+    const result = removeSkillIndexEntry(existing, 'tdd-workflow');
+    assert.strictEqual(typeof result, 'string');
+    assert.ok(!result.includes('egc-skills-index'));
+  })) passed++; else failed++;
+
+  if (test('returns existing content unchanged when there is no block to remove from', () => {
+    const existing = '# My Project\n';
+    const result = removeSkillIndexEntry(existing, 'tdd-workflow');
+    assert.strictEqual(result, existing);
+  })) passed++; else failed++;
+
+  // --- Real install application via applyInstallPlan ---
+
+  function buildMinimalPlan(destinationPath, entry, installStatePath) {
+    return {
+      operations: [
+        {
+          kind: MERGE_MARKDOWN_INDEX_KIND,
+          moduleId: 'workflow',
+          destinationPath,
+          strategy: MERGE_MARKDOWN_INDEX_KIND,
+          ownership: 'managed',
+          scaffoldOnly: false,
+          skillName: entry.name,
+          skillDescription: entry.description,
+          relativePath: entry.relativePath,
+        },
+      ],
+      installStatePath,
+      statePreview: {
+        schemaVersion: 'egc.install.v1',
+        installedAt: new Date().toISOString(),
+        target: { id: 'warp-project', target: 'warp', kind: 'project', root: path.dirname(destinationPath), installStatePath },
+        request: { profile: null, modules: [], includeComponents: [], excludeComponents: [], legacyLanguages: [], legacyMode: false },
+        resolution: { selectedModules: ['workflow'], skippedModules: [] },
+        source: { repoVersion: null, repoCommit: null, manifestVersion: 1 },
+        operations: [],
+      },
+    };
+  }
+
+  if (test('applyInstallPlan creates AGENTS.md from scratch with the correct index entry', () => {
+    const projectRoot = createTempDir('warp-apply-fresh-');
+    try {
+      const destinationPath = path.join(projectRoot, 'AGENTS.md');
+      const installStatePath = path.join(projectRoot, '.warp', 'egc-install-state.json');
+      const plan = buildMinimalPlan(destinationPath, tddEntry, installStatePath);
+
+      applyInstallPlan(plan);
+
+      assert.ok(fs.existsSync(destinationPath));
+      const content = fs.readFileSync(destinationPath, 'utf8');
+      assert.ok(content.includes('- **tdd-workflow**: TDD workflow guidance (`.warp/skills/tdd-workflow.md`)'));
+    } finally {
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('applyInstallPlan merges into an existing AGENTS.md without touching unrelated content', () => {
+    const projectRoot = createTempDir('warp-apply-existing-');
+    try {
+      const destinationPath = path.join(projectRoot, 'AGENTS.md');
+      fs.writeFileSync(destinationPath, '# My Project\n\nCustom rules the user wrote.\n');
+      const installStatePath = path.join(projectRoot, '.warp', 'egc-install-state.json');
+      const plan = buildMinimalPlan(destinationPath, tddEntry, installStatePath);
+
+      applyInstallPlan(plan);
+
+      const content = fs.readFileSync(destinationPath, 'utf8');
+      assert.ok(content.includes('# My Project'));
+      assert.ok(content.includes('Custom rules the user wrote.'));
+      assert.ok(content.includes('- **tdd-workflow**:'));
+    } finally {
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -27,13 +27,14 @@ const EXPECTED_HARNESSES = [
   'Amazon Q Developer CLI',
   'OpenHands',
   'Aider',
+  'Warp',
   'Windsurf',
   'Amp',
   'VS Code Copilot',
   'Continue.dev',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands', 'aider'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'goose', 'amazonq', 'openhands', 'aider', 'warp'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## Summary

Closes #739. Adds the Warp (agentic terminal) install target -- the last of the 10 backlog issues.

Warp has no directory-of-files skill discovery (unlike Kiro/Trae/OpenHands/Amazon Q): it reads a single root `AGENTS.md` (or legacy `WARP.md`) as project rules. Research on Warp's own docs confirmed:
- A plain `AGENTS.md` is sufficient -- it's the documented *default* project rules file. `WARP.md` is legacy and only takes priority when both exist.
- With 230+ skills (~2MB raw content), concatenating everything into that single always-loaded file would blow context budget on every session regardless of relevance.

## Design

- Full skill content is copied flat to `.warp/skills/<name>.md` (Warp's agent has normal filesystem access and reads on demand).
- A short index entry (name + one-line description + path) is merged into a marked block (`<!-- egc-skills-index:start/end -->`) inside the project's `AGENTS.md`, leaving any of the user's own content untouched.
- New `merge-markdown-skill-index` operation kind, mirroring the `merge-yaml-read-list` precedent from the Aider target (#736): pure logic isolated in `scripts/lib/warp-agents-merge.js`, with dispatch pass-throughs in `install-executor.js`, `install/apply.js`, and `install-lifecycle.js`.
- Description extraction uses `js-yaml` against the frontmatter block (not a hand-rolled regex), so quoted and multiline YAML block-scalar descriptions (12 skills use `>-`/`|`) parse correctly. Truncation to 110 chars is done on Unicode code points so multi-byte characters are never split mid-character.
- Uninstall only ever strips the EGC block, never deletes `AGENTS.md` itself -- it's an increasingly common cross-tool convention file other tools may also rely on.

## Test plan

- [x] `node tests/lib/warp-agents-merge.test.js` -- 11/11 (pure functions + 2 real `applyInstallPlan` integration tests)
- [x] `node tests/lib/install-targets.test.js` -- 100/100 (6 new Warp adapter cases, including a dedicated multiline-frontmatter case)
- [x] `node tests/spec/integration-tiers.test.js` -- 4/4 (19 harnesses now documented and target-list-verified)
- [x] Full JS suite `node tests/run-all.js` -- 2743/2767 (24 pre-existing unrelated failures in `tests/hooks/*`, confirmed via `git stash` before starting)
- [x] Python suite unchanged (this issue doesn't touch `src/llm/`) -- 92/93 (1 pre-existing unrelated failure)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Warp install target that copies skills to `.warp/skills/<name>.md` and maintains a small, EGC-managed index in `AGENTS.md` to avoid context bloat. Implements the requirements in #739 and brings supported tools to 19.

- **New Features**
  - New `warp` (project-only) target with flat skill files under `.warp/skills/` and an index block in `AGENTS.md`.
  - New operation kind `merge-markdown-skill-index` to add/update a delimited EGC block without touching user content.
  - Skill descriptions parsed from `SKILL.md` frontmatter via `js-yaml`, collapsed to one line and truncated to 110 Unicode chars.
  - Uninstall removes only the EGC block; `AGENTS.md` is never deleted.
  - Schemas, registry, helpers, and docs updated to include `warp`; tests added for the adapter and merge logic.

<sup>Written for commit 5c49721a99f4663eed8306e7adfeb134e774b77a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

