### PR TITLE
docs(readme): refresh tool/provider highlights and count

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ---
 
-EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own, no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, Zed, VS Code with GitHub Copilot, and more. Works with Claude, GPT-4o, Gemini, and OpenRouter models including DeepSeek, Qwen3, and Llama 4.
+EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own, no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, Zed, Warp, VS Code with GitHub Copilot, and more (19 tools total). Works natively with Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere, and Vertex AI, plus OpenRouter for Qwen3, Llama 4, and more.
 
 ---
 


### PR DESCRIPTION
## Summary

The hero paragraph in README.md hadn't been touched since before this session's batch of 5 install targets (Kiro, Trae, Goose, Amazon Q, OpenHands, Aider, Warp) and 3 LLM providers (Groq, Vertex AI, Cohere) landed. It still named the same 6 tools and 3 models it always had, with no indication of the current 19-tool / native multi-provider reality.

- Adds Warp to the named highlight tools and states the explicit 19-tool count (verified against `SUPPORTED_INSTALL_TARGETS` / `docs/spec/integration-tiers.md`, already updated and test-covered this session).
- Calls out the newly-native providers (DeepSeek, Mistral, Groq, Cohere, Vertex AI) instead of only mentioning them as OpenRouter-reachable models.
- Pushing to main will trigger the existing Crowdin sync workflow (`.github/workflows/crowdin-sync.yml`, triggers on `README.md` changes to main) to propagate this to the 7 translations automatically -- no manual translation edits made here.

## Test plan

- [x] Single-line prose change, no functional code touched
- [x] Cross-checked "19 tools" and the named native providers against `docs/spec/integration-tiers.md` and `src/llm/providers/*.py`, both already current

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README hero to reflect current support. Adds Warp, states 19 tools total, and lists new native providers (DeepSeek, Mistral, Groq, Cohere, Vertex AI) while keeping OpenRouter for others.

<sup>Written for commit 7ebae03234ee56f2c88ebb8316a77a382dd3085f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

