### PR TITLE
chore(memory): sync EGC project memory to tool config files

### DIFF
--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -5,13 +5,12 @@ alwaysApply: true
 
 ## EGC Project Memory
 
-**Context:** EGC branch fix/guardian-audit-critical-security: correção completa dos 47 achados da auditoria EGC-128 (8 críticos, 10 altos, todos os médios exceto 2 refactors de manutenibilidade adiados, quase todos os baixos). 28 commits, 2825 testes JS + 114 Python verdes. Auditoria final via Antigravity (agy) em andamento antes de decidir push/PR.
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Todos os itens baixos da auditoria resolvidos: DANGEROUS list (dd/shred/truncate), dead code render-template removido, pip-audit no CI, JA/KO/RU traducoes ja estavam corretas, resolver-bleed dedup (tag_as param em ModelResolver.model_infos), cwd threading no guardian (isProtectedPath/validateCommand agora resolvem paths relativos contra o cwd real do hook, nao process.cwd()), tags do lesson_save aceitam array alem de string (sem migracao destrutiva, 81 linhas existentes preservadas).
-- 2 refactors medios (funcao de 166 linhas em install-manifests.js resolveInstallPlan, funcao grande em install-lifecycle.js) deliberadamente NAO feitos nesta sessao.
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Aguardar resultado da auditoria final via agy --print (rodando em background) sobre o diff completo main...fix/guardian-audit-critical-security.
-- Decidir com Felipe: push + PR da branch fix/guardian-audit-critical-security.
-- Se Felipe autorizar, fazer os 2 refactors medios pendentes em sessao dedicada.
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.

--- a/.trae/rules/egc-context.md
+++ b/.trae/rules/egc-context.md
@@ -24,14 +24,13 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-**Context:** EGC branch fix/guardian-audit-critical-security: correção completa dos 47 achados da auditoria EGC-128 (8 críticos, 10 altos, todos os médios exceto 2 refactors de manutenibilidade adiados, quase todos os baixos). 28 commits, 2825 testes JS + 114 Python verdes. Auditoria final via Antigravity (agy) em andamento antes de decidir push/PR.
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Todos os itens baixos da auditoria resolvidos: DANGEROUS list (dd/shred/truncate), dead code render-template removido, pip-audit no CI, JA/KO/RU traducoes ja estavam corretas, resolver-bleed dedup (tag_as param em ModelResolver.model_infos), cwd threading no guardian (isProtectedPath/validateCommand agora resolvem paths relativos contra o cwd real do hook, nao process.cwd()), tags do lesson_save aceitam array alem de string (sem migracao destrutiva, 81 linhas existentes preservadas).
-- 2 refactors medios (funcao de 166 linhas em install-manifests.js resolveInstallPlan, funcao grande em install-lifecycle.js) deliberadamente NAO feitos nesta sessao.
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Aguardar resultado da auditoria final via agy --print (rodando em background) sobre o diff completo main...fix/guardian-audit-critical-security.
-- Decidir com Felipe: push + PR da branch fix/guardian-audit-critical-security.
-- Se Felipe autorizar, fazer os 2 refactors medios pendentes em sessao dedicada.
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,13 @@ Skipping any of these breaks the EGC contract. There are no exceptions for "simp
 <!-- egc:start -->
 ## EGC Project Memory
 
-**Context:** EGC branch fix/guardian-audit-critical-security: correção completa dos 47 achados da auditoria EGC-128 (8 críticos, 10 altos, todos os médios exceto 2 refactors de manutenibilidade adiados, quase todos os baixos). 28 commits, 2825 testes JS + 114 Python verdes. Auditoria final via Antigravity (agy) em andamento antes de decidir push/PR.
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Todos os itens baixos da auditoria resolvidos: DANGEROUS list (dd/shred/truncate), dead code render-template removido, pip-audit no CI, JA/KO/RU traducoes ja estavam corretas, resolver-bleed dedup (tag_as param em ModelResolver.model_infos), cwd threading no guardian (isProtectedPath/validateCommand agora resolvem paths relativos contra o cwd real do hook, nao process.cwd()), tags do lesson_save aceitam array alem de string (sem migracao destrutiva, 81 linhas existentes preservadas).
-- 2 refactors medios (funcao de 166 linhas em install-manifests.js resolveInstallPlan, funcao grande em install-lifecycle.js) deliberadamente NAO feitos nesta sessao.
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Aguardar resultado da auditoria final via agy --print (rodando em background) sobre o diff completo main...fix/guardian-audit-critical-security.
-- Decidir com Felipe: push + PR da branch fix/guardian-audit-critical-security.
-- Se Felipe autorizar, fazer os 2 refactors medios pendentes em sessao dedicada.
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -93,14 +93,13 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-**Context:** EGC branch fix/guardian-audit-critical-security: correção completa dos 47 achados da auditoria EGC-128 (8 críticos, 10 altos, todos os médios exceto 2 refactors de manutenibilidade adiados, quase todos os baixos). 28 commits, 2825 testes JS + 114 Python verdes. Auditoria final via Antigravity (agy) em andamento antes de decidir push/PR.
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Todos os itens baixos da auditoria resolvidos: DANGEROUS list (dd/shred/truncate), dead code render-template removido, pip-audit no CI, JA/KO/RU traducoes ja estavam corretas, resolver-bleed dedup (tag_as param em ModelResolver.model_infos), cwd threading no guardian (isProtectedPath/validateCommand agora resolvem paths relativos contra o cwd real do hook, nao process.cwd()), tags do lesson_save aceitam array alem de string (sem migracao destrutiva, 81 linhas existentes preservadas).
-- 2 refactors medios (funcao de 166 linhas em install-manifests.js resolveInstallPlan, funcao grande em install-lifecycle.js) deliberadamente NAO feitos nesta sessao.
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Aguardar resultado da auditoria final via agy --print (rodando em background) sobre o diff completo main...fix/guardian-audit-critical-security.
-- Decidir com Felipe: push + PR da branch fix/guardian-audit-critical-security.
-- Se Felipe autorizar, fazer os 2 refactors medios pendentes em sessao dedicada.
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->


### PR DESCRIPTION
Routine sync of the EGC project-memory excerpt embedded in AGENTS.md, GEMINI.md, .cursor/rules/egc-context.mdc, and .trae/rules/egc-context.md, refreshed after PR #769 merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced the EGC Project Memory excerpt across `AGENTS.md`, `GEMINI.md`, `.cursor/rules/egc-context.mdc`, and `.trae/rules/egc-context.md` to reflect PR #769 merged on main and the closure of audit EGC-128. Updated context, active decisions (branch deleted; two medium refactors remain), and next-session notes to drop pre-merge steps and note no remaining security issues.

<sup>Written for commit 4262c74490f13d7f46c3e63106b9360c377f9b00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

