### PR TITLE
refactor(install): reduce cyclomatic complexity in manifest resolution and doctor analysis

### DIFF
--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -778,26 +778,8 @@ function determineStatus(issues) {
   return 'ok';
 }
 
-function analyzeRecord(record, context) {
+function checkTargetRootHealth(state, record) {
   const issues = [];
-
-  if (record.error) {
-    issues.push(buildIssue('error', 'invalid-install-state', record.error));
-    return {
-      ...record,
-      status: determineStatus(issues),
-      issues,
-    };
-  }
-
-  const state = record.state;
-  if (!state) {
-    return {
-      ...record,
-      status: 'missing',
-      issues,
-    };
-  }
 
   if (!fs.existsSync(state.target.root)) {
     issues.push(buildIssue(
@@ -831,17 +813,21 @@ function analyzeRecord(record, context) {
     ));
   }
 
+  return issues;
+}
+
+function checkManagedOperationHealth(state, context) {
+  const issues = [];
   const managedOperations = getManagedOperations(state);
   const operationHealth = summarizeManagedOperationHealth(context.repoRoot, managedOperations);
-  const missingManagedOperations = operationHealth.missing;
 
-  if (missingManagedOperations.length > 0) {
+  if (operationHealth.missing.length > 0) {
     issues.push(buildIssue(
       'error',
       'missing-managed-files',
-      `${missingManagedOperations.length} managed file(s) are missing`,
+      `${operationHealth.missing.length} managed file(s) are missing`,
       {
-        paths: missingManagedOperations.map(entry => entry.destinationPath),
+        paths: operationHealth.missing.map(entry => entry.destinationPath),
       }
     ));
   }
@@ -879,6 +865,12 @@ function analyzeRecord(record, context) {
     ));
   }
 
+  return issues;
+}
+
+function checkVersionDrift(state, context) {
+  const issues = [];
+
   if (state.source.manifestVersion !== context.manifestVersion) {
     issues.push(buildIssue(
       'warning',
@@ -899,43 +891,74 @@ function analyzeRecord(record, context) {
     ));
   }
 
-  if (!state.request.legacyMode) {
-    try {
-      const desiredPlan = resolveInstallPlan({
-        repoRoot: context.repoRoot,
-        projectRoot: context.projectRoot,
-        homeDir: context.homeDir,
-        target: record.adapter.target,
-        profileId: state.request.profile || null,
-        moduleIds: state.request.modules || [],
-        includeComponentIds: state.request.includeComponents || [],
-        excludeComponentIds: state.request.excludeComponents || [],
-      });
+  return issues;
+}
 
-      if (
-        !compareStringArrays(desiredPlan.selectedModuleIds, state.resolution.selectedModules)
-        || !compareStringArrays(desiredPlan.skippedModuleIds, state.resolution.skippedModules)
-      ) {
-        issues.push(buildIssue(
-          'warning',
-          'resolution-drift',
-          'Current manifest resolution differs from recorded install-state',
-          {
-            expectedSelectedModules: desiredPlan.selectedModuleIds,
-            recordedSelectedModules: state.resolution.selectedModules,
-            expectedSkippedModules: desiredPlan.skippedModuleIds,
-            recordedSkippedModules: state.resolution.skippedModules,
-          }
-        ));
-      }
-    } catch (error) {
-      issues.push(buildIssue(
-        'error',
-        'resolution-unavailable',
-        error.message
-      ));
-    }
+function checkResolutionDrift(record, state, context) {
+  if (state.request.legacyMode) {
+    return [];
   }
+
+  try {
+    const desiredPlan = resolveInstallPlan({
+      repoRoot: context.repoRoot,
+      projectRoot: context.projectRoot,
+      homeDir: context.homeDir,
+      target: record.adapter.target,
+      profileId: state.request.profile || null,
+      moduleIds: state.request.modules || [],
+      includeComponentIds: state.request.includeComponents || [],
+      excludeComponentIds: state.request.excludeComponents || [],
+    });
+
+    if (
+      !compareStringArrays(desiredPlan.selectedModuleIds, state.resolution.selectedModules)
+      || !compareStringArrays(desiredPlan.skippedModuleIds, state.resolution.skippedModules)
+    ) {
+      return [buildIssue(
+        'warning',
+        'resolution-drift',
+        'Current manifest resolution differs from recorded install-state',
+        {
+          expectedSelectedModules: desiredPlan.selectedModuleIds,
+          recordedSelectedModules: state.resolution.selectedModules,
+          expectedSkippedModules: desiredPlan.skippedModuleIds,
+          recordedSkippedModules: state.resolution.skippedModules,
+        }
+      )];
+    }
+
+    return [];
+  } catch (error) {
+    return [buildIssue('error', 'resolution-unavailable', error.message)];
+  }
+}
+
+function analyzeRecord(record, context) {
+  if (record.error) {
+    const issues = [buildIssue('error', 'invalid-install-state', record.error)];
+    return {
+      ...record,
+      status: determineStatus(issues),
+      issues,
+    };
+  }
+
+  const state = record.state;
+  if (!state) {
+    return {
+      ...record,
+      status: 'missing',
+      issues: [],
+    };
+  }
+
+  const issues = [
+    ...checkTargetRootHealth(state, record),
+    ...checkManagedOperationHealth(state, context),
+    ...checkVersionDrift(state, context),
+    ...checkResolutionDrift(record, state, context),
+  ];
 
   return {
     ...record,

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -371,12 +371,7 @@ function resolveLegacyCompatibilitySelection(options = {}) {
   };
 }
 
-function resolveInstallPlan(options = {}) {
-  const manifests = loadInstallManifests(options);
-  const profileId = options.profileId || null;
-  const explicitModuleIds = dedupeStrings(options.moduleIds);
-  const includedComponentIds = dedupeStrings(options.includeComponentIds);
-  const excludedComponentIds = dedupeStrings(options.excludeComponentIds);
+function collectRequestedModuleIds(options, manifests, profileId) {
   const requestedModuleIds = [];
 
   if (profileId) {
@@ -387,11 +382,18 @@ function resolveInstallPlan(options = {}) {
     requestedModuleIds.push(...profile.modules);
   }
 
-  requestedModuleIds.push(...explicitModuleIds);
-  requestedModuleIds.push(...expandComponentIdsToModuleIds(includedComponentIds, manifests));
+  requestedModuleIds.push(...dedupeStrings(options.moduleIds));
+  requestedModuleIds.push(
+    ...expandComponentIdsToModuleIds(dedupeStrings(options.includeComponentIds), manifests)
+  );
 
+  return requestedModuleIds;
+}
+
+function resolveExcludedModules(excludedComponentIds, manifests) {
   const excludedModuleIds = expandComponentIdsToModuleIds(excludedComponentIds, manifests);
   const excludedModuleOwners = new Map();
+
   for (const componentId of excludedComponentIds) {
     const component = manifests.componentsById.get(componentId);
     if (!component) {
@@ -404,12 +406,16 @@ function resolveInstallPlan(options = {}) {
     }
   }
 
-  const target = options.target || null;
+  return { excludedModuleIds, excludedModuleOwners };
+}
+
+function resolveInstallTargetContext(options, manifests, target) {
   if (target && !SUPPORTED_INSTALL_TARGETS.includes(target)) {
     throw new Error(
       `Unknown install target: ${target}. Expected one of ${SUPPORTED_INSTALL_TARGETS.join(', ')}`
     );
   }
+
   const validatedProjectRoot = readOptionalStringOption(options, 'projectRoot');
   const validatedHomeDir = readOptionalStringOption(options, 'homeDir');
   const targetPlanningInput = target
@@ -421,21 +427,19 @@ function resolveInstallPlan(options = {}) {
     : null;
   const targetAdapter = target ? getInstallTargetAdapter(target) : null;
 
-  const effectiveRequestedIds = dedupeStrings(
-    requestedModuleIds.filter(moduleId => !excludedModuleOwners.has(moduleId))
-  );
+  return { targetPlanningInput, targetAdapter };
+}
 
-  if (requestedModuleIds.length === 0) {
-    throw new Error('No install profile, module IDs, or included component IDs were provided');
-  }
-
-  if (effectiveRequestedIds.length === 0) {
-    throw new Error('Selection excludes every requested install module');
-  }
-
+function resolveModuleDependencyGraph({
+  manifests,
+  target,
+  targetAdapter,
+  targetPlanningInput,
+  excludedModuleOwners,
+  effectiveRequestedIds,
+}) {
   const selectedIds = new Set();
   const skippedTargetIds = new Set();
-  const excludedIds = new Set(excludedModuleIds);
   const visitingIds = new Set();
   const resolvedIds = new Set();
 
@@ -503,6 +507,23 @@ function resolveInstallPlan(options = {}) {
     resolveModule(moduleId, null, moduleId);
   }
 
+  return { selectedIds, skippedTargetIds };
+}
+
+function buildInstallPlanResult({
+  manifests,
+  profileId,
+  target,
+  targetPlanningInput,
+  effectiveRequestedIds,
+  explicitModuleIds,
+  includedComponentIds,
+  excludedComponentIds,
+  excludedModuleIds,
+  selectedIds,
+  skippedTargetIds,
+}) {
+  const excludedIds = new Set(excludedModuleIds);
   const selectedModules = manifests.modules.filter(module => selectedIds.has(module.id));
   const skippedModules = manifests.modules.filter(module => skippedTargetIds.has(module.id));
   const excludedModules = manifests.modules.filter(module => excludedIds.has(module.id));
@@ -536,6 +557,61 @@ function resolveInstallPlan(options = {}) {
     validationIssues: scaffoldPlan ? scaffoldPlan.validationIssues : [],
     operations: scaffoldPlan ? scaffoldPlan.operations : [],
   };
+}
+
+function resolveInstallPlan(options = {}) {
+  const manifests = loadInstallManifests(options);
+  const profileId = options.profileId || null;
+  const explicitModuleIds = dedupeStrings(options.moduleIds);
+  const includedComponentIds = dedupeStrings(options.includeComponentIds);
+  const excludedComponentIds = dedupeStrings(options.excludeComponentIds);
+  const target = options.target || null;
+
+  const requestedModuleIds = collectRequestedModuleIds(options, manifests, profileId);
+  const { excludedModuleIds, excludedModuleOwners } = resolveExcludedModules(
+    excludedComponentIds,
+    manifests
+  );
+  const { targetPlanningInput, targetAdapter } = resolveInstallTargetContext(
+    options,
+    manifests,
+    target
+  );
+
+  const effectiveRequestedIds = dedupeStrings(
+    requestedModuleIds.filter(moduleId => !excludedModuleOwners.has(moduleId))
+  );
+
+  if (requestedModuleIds.length === 0) {
+    throw new Error('No install profile, module IDs, or included component IDs were provided');
+  }
+
+  if (effectiveRequestedIds.length === 0) {
+    throw new Error('Selection excludes every requested install module');
+  }
+
+  const { selectedIds, skippedTargetIds } = resolveModuleDependencyGraph({
+    manifests,
+    target,
+    targetAdapter,
+    targetPlanningInput,
+    excludedModuleOwners,
+    effectiveRequestedIds,
+  });
+
+  return buildInstallPlanResult({
+    manifests,
+    profileId,
+    target,
+    targetPlanningInput,
+    effectiveRequestedIds,
+    explicitModuleIds,
+    includedComponentIds,
+    excludedComponentIds,
+    excludedModuleIds,
+    selectedIds,
+    skippedTargetIds,
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- Splits `resolveInstallPlan` (install-manifests.js, 165 lines) into 5 single-purpose functions: request collection, exclusion resolution, target context, dependency-graph traversal, result assembly.
- Splits `analyzeRecord` (install-lifecycle.js, 166 lines — the largest function in the file) into 4 focused health checks: target root, managed operations, version drift, resolution drift.
- Pure maintainability refactor, no behavior change.

## Test plan
- [x] `tests/lib/install-manifests.test.js` — 31/31 (circular deps, target-scoped skipping, exclusion edge cases)
- [x] `tests/lib/install-lifecycle.test.js`, `doctor.test.js`, `repair.test.js`, `uninstall.test.js` — all green
- [x] Full suite: `node tests/run-all.js` — 2825/2825 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors install planning and doctor analysis to reduce cyclomatic complexity by splitting large functions into small, focused helpers. No behavior changes; the full test suite remains green.

- **Refactors**
  - Split `resolveInstallPlan` into: request collection, exclusion resolution, target context, dependency graph traversal, and result assembly.
  - Split `analyzeRecord` into health checks: target root, managed operations, version drift, and resolution drift.

<sup>Written for commit 12c9815440396f46637b6456d7936b3eb42cbca5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

