### PR TITLE
fix(install-plan): suppress SonarCloud false positive breaking main's Quality Gate

### DIFF
--- a/scripts/install-plan.js
+++ b/scripts/install-plan.js
@@ -143,7 +143,7 @@ function printPlan(plan) {
     'Note: target filtering and operation output currently reflect scaffold-level adapter planning, not a byte-for-byte mirror of legacy install.sh copy paths.\n'
   );
   console.log(`Profile: ${plan.profileId || '(custom modules)'}`); // NOSONAR jssecurity:S8689
-  console.log(`Target: ${plan.target || '(all targets)'}`);
+  console.log(`Target: ${plan.target || '(all targets)'}`); // NOSONAR jssecurity:S8689
   console.log(`Included components: ${plan.includedComponentIds.join(', ') || '(none)'}`);
   console.log(`Excluded components: ${plan.excludedComponentIds.join(', ') || '(none)'}`);
   console.log(`Requested: ${plan.requestedModuleIds.join(', ')}`);


### PR DESCRIPTION
## Summary
- `main` Quality Gate went red after PR #771: SonarCloud's `jssecurity:S8689` flagged `plan.target` (the CLI install target string) as confidential credential data leaking into logs.
- False positive: `plan.target` is just the `--target` selector (`claude`, `cursor`, etc.), never a secret. The refactor in #771 changed the function boundaries this value flows through in `install-manifests.js`, which made SonarCloud's "New Code" scope re-flag an old dataflow path.
- The sibling `Profile:` log line one line above already carries this exact suppression (`// NOSONAR jssecurity:S8689`, added 2026-06-16, commit d7870a52). This applies the same precedent to the `Target:` line.

## Test plan
- [x] No behavior change (comment-only diff)
- [x] Confirmed no real credential handling anywhere in the taint path (`scripts/lib/install/config.js`, `scripts/lib/install/request.js`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress a SonarCloud false positive on the install plan "Target:" log line to restore main’s Quality Gate. Adds `// NOSONAR jssecurity:S8689` next to `plan.target` (a non-secret CLI selector), matching the existing suppression on the "Profile:" line.

<sup>Written for commit 09eefc98de02a4c2ae1d3162895425caf4f58409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

