### PR TITLE
fix(install-plan): suppress second SonarCloud false-positive sink

### DIFF
--- a/scripts/install-plan.js
+++ b/scripts/install-plan.js
@@ -160,7 +160,7 @@ function printPlan(plan) {
 
   if (plan.skippedModuleIds.length > 0) {
     console.log('');
-    console.log(`Skipped for target ${plan.target} (${plan.skippedModuleIds.length}):`);
+    console.log(`Skipped for target ${plan.target} (${plan.skippedModuleIds.length}):`); // NOSONAR jssecurity:S8689
     for (const module of plan.skippedModules) {
       console.log(`- ${module.id} [${module.kind}]`);
     }


### PR DESCRIPTION
## Summary
- PR #772 fixed the false-positive `jssecurity:S8689` at install-plan.js:146, but main was still red after merging: SonarCloud found a second sink at line 163 (`Skipped for target ${plan.target}...`), same taint path, same false positive (plan.target is a CLI selector string, never a secret).
- Grepped the whole file for `plan.target` to confirm there are exactly these two occurrences, both now suppressed.

## Test plan
- [x] No behavior change (comment-only diff)
- [x] `grep -n "plan\.target\b" scripts/install-plan.js` confirms both occurrences now carry the suppression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress the second SonarCloud `jssecurity:S8689` false positive in `scripts/install-plan.js` by annotating the `console.log` that prints `plan.target`. No behavior change; unblocks Sonar checks on main.

- **Bug Fixes**
  - Marked the "Skipped for target ${plan.target}..." log as safe with `// NOSONAR jssecurity:S8689`.
  - Confirmed only two uses of `plan.target` exist; both are now suppressed.

<sup>Written for commit 18ac0248106c45a437a92aca7a16c86a31b66f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

