### PR TITLE
fix(dashboard): telemetria e custo zerados em 100% das sessoes (EGC-131) [final]

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -368,12 +368,12 @@ const grandTotal = Object.values(byIde).reduce(
 
     const egcStats = queryEgcStats();
     if (egcStats) {
-      stats.decisions = egcStats.decisions;
+      stats.decisions = egcStats.decisions || countStateFileDecisions();
       stats.lessons   = egcStats.lessons;
       stats.patterns  = egcStats.patterns;
+    } else {
+      stats.decisions = countStateFileDecisions();
     }
-    // Also count decisions from markdown state files (written by update_state).
-    stats.decisions += countStateFileDecisions();
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(stats));

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -35,20 +35,40 @@ const EGC_DB_CANDIDATES = [
 function queryEgcStats() {
   for (const dbPath of EGC_DB_CANDIDATES) {
     if (!fs.existsSync(dbPath)) continue;
-    try {
-      const q = (sql) => {
-        const out = execSync(`sqlite3 "${dbPath.replace(/"/g, '')}" "${sql}"`,
-          { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'] });
+    const q = (sql) => {
+      try {
+        const out = execFileSync('sqlite3', ['-readonly', dbPath, sql],
+          { encoding: 'utf8', timeout: 500, stdio: ['ignore', 'pipe', 'ignore'] });
         return parseInt(out.trim(), 10) || 0;
-      };
-      return {
-        decisions: q('SELECT COUNT(*) FROM decisions'),
-        lessons:   q('SELECT COUNT(*) FROM lessons WHERE archived = 0'),
-        patterns:  q('SELECT COUNT(*) FROM patterns'),
-      };
-    } catch (_) {}
+      } catch (_) { return 0; }
+    };
+    return {
+      decisions: q('SELECT COUNT(*) FROM decisions'),
+      lessons:   q('SELECT COUNT(*) FROM lessons WHERE archived = 0'),
+      patterns:  q('SELECT COUNT(*) FROM patterns'),
+    };
   }
   return null;
+}
+
+// Count decisions from ## Active Decisions section in egc-memory state files.
+// update_state writes decisions here; store_decision writes to SQLite.
+function countStateFileDecisions() {
+  try {
+    const dir = path.join(os.homedir(), '.egc', 'state');
+    if (!fs.existsSync(dir)) return 0;
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.md')).slice(0, 6);
+    let d = 0;
+    for (const f of files) {
+      const c = fs.readFileSync(path.join(dir, f), 'utf8');
+      for (const section of c.split(/^## /m)) {
+        if (section.startsWith('Active Decisions')) {
+          d += (section.match(/^- /gm) || []).length;
+        }
+      }
+    }
+    return d;
+  } catch (_) { return 0; }
 }
 
 function buildStaticManifest(dir) {
@@ -352,6 +372,8 @@ const grandTotal = Object.values(byIde).reduce(
       stats.lessons   = egcStats.lessons;
       stats.patterns  = egcStats.patterns;
     }
+    // Also count decisions from markdown state files (written by update_state).
+    stats.decisions += countStateFileDecisions();
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(stats));

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -5,7 +5,7 @@ const http    = require('http');
 const path    = require('path');
 const fs      = require('fs');
 const os      = require('os');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const { createAccumulator } = require('./accumulator');
 
 const PORT   = 7890;
@@ -23,6 +23,33 @@ const MIME = {
 };
 
 const SERVER_START = Date.now();
+
+const EGC_DB_CANDIDATES = [
+  path.join(os.homedir(), '.claude', 'egc', 'state.db'),
+  path.join(os.homedir(), '.gemini', 'egc', 'state.db'),
+  path.join(os.homedir(), '.egc', 'egc', 'state.db'),
+  path.join(os.homedir(), '.cursor', 'egc', 'state.db'),
+  path.join(os.homedir(), '.kiro', 'egc', 'state.db'),
+];
+
+function queryEgcStats() {
+  for (const dbPath of EGC_DB_CANDIDATES) {
+    if (!fs.existsSync(dbPath)) continue;
+    try {
+      const q = (sql) => {
+        const out = execSync(`sqlite3 "${dbPath.replace(/"/g, '')}" "${sql}"`,
+          { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'] });
+        return parseInt(out.trim(), 10) || 0;
+      };
+      return {
+        decisions: q('SELECT COUNT(*) FROM decisions'),
+        lessons:   q('SELECT COUNT(*) FROM lessons WHERE archived = 0'),
+        patterns:  q('SELECT COUNT(*) FROM patterns'),
+      };
+    } catch (_) {}
+  }
+  return null;
+}
 
 function buildStaticManifest(dir) {
   const manifest = new Map();
@@ -319,22 +346,12 @@ const grandTotal = Object.values(byIde).reduce(
       longTermPct: null, workingPct: null,
     };
 
-    try {
-      const dir = path.join(os.homedir(), '.egc', 'state');
-      if (fs.existsSync(dir)) {
-        const files = fs.readdirSync(dir).filter(f => f.endsWith('.md')).slice(0, 6);
-        let d = 0, l = 0, p = 0;
-        for (const f of files) {
-          const c = fs.readFileSync(path.join(dir, f), 'utf8');
-          d += (c.match(/^- What:/gm)      || []).length;
-          l += (c.match(/^- Lesson:/gm)    || []).length;
-          p += (c.match(/^- Pattern:/gm)   || []).length;
-        }
-        stats.decisions = d;
-        stats.lessons   = l;
-        stats.patterns  = p;
-      }
-    } catch (_) {}
+    const egcStats = queryEgcStats();
+    if (egcStats) {
+      stats.decisions = egcStats.decisions;
+      stats.lessons   = egcStats.lessons;
+      stats.patterns  = egcStats.patterns;
+    }
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(stats));

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -8,6 +8,7 @@
 // session. Missing or unreadable state exits silently with code 0.
 
 const fs = require('fs');
+const http = require('http');
 const os = require('os');
 const path = require('path');
 // Optional libs: minimal installations may lack them, so a failed require
@@ -227,9 +228,23 @@ function loadAndPrintState(projectPath) {
   process.stdout.write('EGC persistent memory for this project (restored automatically):\n\n' + content);
 }
 
+function postSessionStart(sessionId) {
+  const body = JSON.stringify({ ide: 'claude', event: 'session_start', session_id: sessionId });
+  const req = http.request(
+    { hostname: '127.0.0.1', port: 7890, path: '/event', method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+      timeout: 200 },
+    () => process.exit(0)
+  );
+  req.on('error', () => process.exit(0));
+  req.on('timeout', () => { req.destroy(); process.exit(0); });
+  req.end(body);
+}
+
 function main() {
+  let input = {};
   try {
-    const input = readStdinJson();
+    input = readStdinJson();
     const projectPath = resolveProjectPath(input);
     loadAndPrintState(projectPath);
     emitStackBriefing(projectPath);
@@ -237,7 +252,7 @@ function main() {
     // Never break session startup because of memory loading.
   }
 
-  process.exit(0);
+  postSessionStart(input.session_id || null);
 }
 
 main();

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -71,6 +71,26 @@ function post(ev, done) {
   req.end(body);
 }
 
+// The Claude Code Stop hook payload does not include usage or model.
+// Extract them from the last assistant message in the transcript JSONL.
+function readTranscriptLast(transcriptPath) {
+  if (typeof transcriptPath !== 'string' || !transcriptPath) return {};
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      let entry;
+      try { entry = JSON.parse(lines[i]); } catch { continue; }
+      const msg = entry.message || entry;
+      const usage = msg.usage;
+      if (usage && typeof usage.input_tokens === 'number') {
+        return { usage, model: typeof msg.model === 'string' ? msg.model : null };
+      }
+    }
+  } catch { /* unreadable or missing transcript */ }
+  return {};
+}
+
 function main() {
   let raw = '';
   try {
@@ -95,6 +115,8 @@ function main() {
     ? { ...input, promptForAssistant: prompt }
     : { ...input };
 
+  const transcript = readTranscriptLast(input.transcript_path);
+
   // Write the assistant prompt to stdout first (synchronous, always completes).
   // Then post the session_end event and exit only after the dashboard has
   // acknowledged it (or the 300ms timeout fires). This prevents process.exit()
@@ -106,7 +128,8 @@ function main() {
     agent: 'main',
     session_id: input.session_id,
     stop_reason: input.stop_reason || null,
-    usage: input.usage || null,
+    model: input.model || transcript.model || null,
+    usage: input.usage || transcript.usage || null,
   }, () => process.exit(0));
 }
 

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -73,11 +73,24 @@ function post(ev, done) {
 
 // The Claude Code Stop hook payload does not include usage or model.
 // Extract them from the last assistant message in the transcript JSONL.
+const SAFE_TRANSCRIPT_ROOTS = [
+  path.join(os.homedir(), '.claude', 'projects'),
+];
+const MAX_TRANSCRIPT_TAIL = 64 * 1024; // read at most 64 KB from end
+
 function readTranscriptLast(transcriptPath) {
   if (typeof transcriptPath !== 'string' || !transcriptPath) return {};
+  const resolved = path.resolve(transcriptPath);
+  if (!SAFE_TRANSCRIPT_ROOTS.some(r => resolved.startsWith(r + path.sep) || resolved.startsWith(r + '/'))) return {};
   try {
-    const content = fs.readFileSync(transcriptPath, 'utf8');
-    const lines = content.trim().split('\n').filter(Boolean);
+    const stat = fs.statSync(resolved);
+    const readSize = Math.min(stat.size, MAX_TRANSCRIPT_TAIL);
+    const offset = stat.size - readSize;
+    const buf = Buffer.alloc(readSize);
+    const fd = fs.openSync(resolved, 'r');
+    fs.readSync(fd, buf, 0, readSize, offset);
+    fs.closeSync(fd);
+    const lines = buf.toString('utf8').split('\n').filter(Boolean);
     for (let i = lines.length - 1; i >= 0; i--) {
       let entry;
       try { entry = JSON.parse(lines[i]); } catch { continue; }

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -83,6 +83,10 @@ function readTranscriptLast(transcriptPath) {
   const resolved = path.resolve(transcriptPath);
   if (!SAFE_TRANSCRIPT_ROOTS.some(r => resolved.startsWith(r + path.sep) || resolved.startsWith(r + '/'))) return {};
   try {
+    const real = fs.realpathSync(resolved);
+    if (!SAFE_TRANSCRIPT_ROOTS.some(r => real.startsWith(r + path.sep) || real.startsWith(r + '/'))) return {};
+  } catch { return {}; }
+  try {
     const stat = fs.statSync(resolved);
     const readSize = Math.min(stat.size, MAX_TRANSCRIPT_TAIL);
     const offset = stat.size - readSize;


### PR DESCRIPTION
Supersedes #776. Same content, rebased cleanly onto current main (this branch's earlier ancestor predated PR #773, causing SonarCloud to flag scripts/install-plan.js as having 'new' unsuppressed lines that were actually already fixed on main -- git recognized the duplicate commit and dropped it automatically on this rebase). Original diagnosis in #774.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EGC-131 by restoring accurate dashboard telemetry and costs. Sessions now report start/stop, model, and token usage, and /stats reads real EGC memory data without double counting.

- **Bug Fixes**
  - Sessions: emit `session_start`; on `session_end`, fill model and token usage by parsing the transcript JSONL tail with safe roots, realpath revalidation, and a 64KB read cap.
  - `/stats`: query EGC SQLite via `sqlite3 -readonly` across common locations, with a markdown fallback only when SQLite returns 0 to avoid double counting.
  - Security: switch to `execFileSync`, validate inputs/paths, and block symlink path traversal.

<sup>Written for commit 64f307f9f81ba843c17d2801a3a3ef68d3007bb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

