### PR TITLE
fix(ci): resolve ENOTDIR in DCO and gate comment workflows

### DIFF
--- a/.github/workflows/dco-comment.yml
+++ b/.github/workflows/dco-comment.yml
@@ -32,10 +32,17 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
-            const resultDir = fs.readdirSync('/tmp/dco-result')[0];
-            const result = JSON.parse(
-              fs.readFileSync(path.join('/tmp/dco-result', resultDir, 'result.json'), 'utf8')
-            );
+            // download-artifact extracts a single-file artifact directly
+            // into the download path (no per-artifact subdirectory) when
+            // exactly one artifact matches the pattern, which is always the
+            // case here (one dco-result-<PR#> artifact per workflow run).
+            // Handle both shapes defensively: a bare result.json, or a
+            // subdirectory (named for the artifact) containing it.
+            const firstEntry = path.join('/tmp/dco-result', fs.readdirSync('/tmp/dco-result')[0]);
+            const resultJsonPath = fs.statSync(firstEntry).isDirectory()
+              ? path.join(firstEntry, 'result.json')
+              : firstEntry;
+            const result = JSON.parse(fs.readFileSync(resultJsonPath, 'utf8'));
             if (result.missing !== '1') return;
 
             // The PR number in the artifact is untrusted: it is produced by

--- a/.github/workflows/first-time-contributor-gate-comment.yml
+++ b/.github/workflows/first-time-contributor-gate-comment.yml
@@ -34,10 +34,17 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
-            const resultDir = fs.readdirSync('/tmp/gate-result')[0];
-            const result = JSON.parse(
-              fs.readFileSync(path.join('/tmp/gate-result', resultDir, 'result.json'), 'utf8')
-            );
+            // download-artifact extracts a single-file artifact directly
+            // into the download path (no per-artifact subdirectory) when
+            // exactly one artifact matches the pattern, which is always the
+            // case here (one gate-result-<PR#> artifact per workflow run).
+            // Handle both shapes defensively: a bare result.json, or a
+            // subdirectory (named for the artifact) containing it.
+            const firstEntry = path.join('/tmp/gate-result', fs.readdirSync('/tmp/gate-result')[0]);
+            const resultJsonPath = fs.statSync(firstEntry).isDirectory()
+              ? path.join(firstEntry, 'result.json')
+              : firstEntry;
+            const result = JSON.parse(fs.readFileSync(resultJsonPath, 'utf8'));
 
             // The PR number in the artifact is untrusted: it is produced by
             // the unprivileged pull_request job, whose own workflow YAML is


### PR DESCRIPTION
## Summary
- Both `DCO Comment` and `First-Time Contributor Gate Comment` workflows have failed on every run for the last several PRs with `Error: ENOTDIR: not a directory, open '/tmp/dco-result/result.json/result.json'`.
- Root cause: `download-artifact` extracts a single-file artifact directly into the download path (no per-artifact subdirectory) when exactly one artifact matches the pattern -- which is always the case here (one `dco-result-<PR#>`/`gate-result-<PR#>` artifact per run). The scripts assumed a subdirectory always existed and joined `result.json` onto it a second time.
- Fix: detect whether the first entry under the download path is a file or directory and read `result.json` accordingly, so both artifact layouts work.

## Test plan
- [x] `node tests/run-all.js` passes (2622/2622)
- [x] YAML syntax validated for both edited workflow files
- [x] Confirmed the exact failure via `gh run view <run-id> --log-failed` before fixing
- [ ] Next real PR against `main` will exercise both workflows end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ENOTDIR failures in the DCO and first-time contributor gate comment workflows. Handles `download-artifact` single-file extraction so `result.json` is read correctly and comments post again.

- **Bug Fixes**
  - Detects whether the first entry under `/tmp/dco-result` or `/tmp/gate-result` is a file or a directory, then resolves the `result.json` path accordingly.
  - Supports both artifact layouts (bare `result.json` or subfolder), preventing paths like `/tmp/.../result.json/result.json` and the resulting ENOTDIR error.

<sup>Written for commit 42f7a7bdcc5e62be1110110bb6f632aa82798cb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

