### PR TITLE
docs(roadmap): remove duplicate Teams entry

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,15 +66,7 @@ Multi-developer workflows and shared context:
 - Per-project skill profiles and overrides
 - OSS-Fuzz integration for continuous fuzz testing
 
-## v2.0.0: Teams
-
-- Shared state between team members (multi-user installations)
-- Team and organization-level installations
-- Cross-project memory federation
-- Stable MCP server API with versioned interfaces
-- egc-guardian and egc-memory promoted to GA
-
-## v3.0.0: Enterprise
+## v2.0.0: Enterprise
 
 - Formal security review by an independent party
 - SBOM (Software Bill of Materials) generation


### PR DESCRIPTION
## Summary
- `docs/ROADMAP.md` had v1.2.0 and v2.0.0 both titled "Teams" with near-identical bullet lists (shared state between team members, org-level installs, cross-project memory federation, stable MCP API, GA promotion) -- an accidental leftover duplicate, not two distinct scopes.
- The `pt` translation's older draft (`translations/pt/docs/ROADMAP.md`) bundles this exact same content into a single item ("v2.0.0: Runtime de Producao"), confirming it was always meant to be one roadmap entry, not two.
- Removed the redundant `v2.0.0: Teams` section (v1.2.0 already owns that scope) and renumbered `v3.0.0: Enterprise` to `v2.0.0: Enterprise` so the roadmap stays version-sequential (v1.2.0 -> v1.3.0 -> v2.0.0).

## Note on the "20 tools" audit finding
This PR only handles the roadmap duplicate. I investigated the "README says 19 / CHANGELOG says 14 / code has 20 supported tools" finding separately and did **not** change README/CHANGELOG: `tests/spec/integration-tiers.test.js` explicitly asserts the real count is 19 harnesses, deliberately excluding the internal `'egc'` pseudo-target from `SUPPORTED_INSTALL_TARGETS` (the test's own comment: `'egc' itself isn't a third-party harness name, so it's excluded from the count`). Changing README to 20 would contradict this enforced, intentional design and make the docs wrong. Flagging this so the original audit finding can be corrected rather than acted on literally.

## Test plan
- [x] `node tests/run-all.js` passes (2622/2622)
- [x] Verified no other `v3.0.0` references exist in the repo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a duplicate “Teams” entry in `docs/ROADMAP.md` and renumbered “Enterprise” from v3.0.0 to v2.0.0 to keep versions sequential. This matches the `pt` translation and clarifies that “Teams” is a single roadmap item.

<sup>Written for commit 529e796ea7a76168295b92c7f9916cc97aadef6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

