### PR TITLE
fix(deps): bump pytest floor to 9.0.3 to resolve CVE-2025-71176

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ openai>=2.0,<3
 cohere>=5.0,<6
 google-genai>=2.0,<3
 
-pytest>=8,<10
+pytest>=9.0.3,<10


### PR DESCRIPTION
## Summary
- Raises the pytest floor in `requirements.txt` from `>=8,<10` to `>=9.0.3,<10`
- Resolves GHSA-6w46-j5rx-g56g (tmpdir handling vulnerability in pytest <9.0.3), code scanning alert #215
- Range already permitted 9.0.3, so this only tightens the minimum

Supersedes #781 (closed after a branch recreation to fix a DCO-failing merge commit; this PR has the same single signed-off commit rebased cleanly on main).

## Test plan
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the minimum `pytest` version to 9.0.3 to fix the tmpdir handling vulnerability (CVE-2025-71176 / GHSA-6w46-j5rx-g56g).
Updates `requirements.txt` from `pytest>=8,<10` to `pytest>=9.0.3,<10`; the upper bound is unchanged.

<sup>Written for commit 7ddec6c9e540b5e1be2a39b8fb1cf6f0d326e696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

