### PR TITLE
fix(sonar): node: protocol, replaceAll, Number.parseInt, Object.hasOwn em scripts/lib (EGC-138 1/5)

### DIFF
--- a/scripts/lib/agent-compress.js
+++ b/scripts/lib/agent-compress.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /**
  * Parse YAML frontmatter from a markdown string.

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const DEFAULT_BRANCH_FILE = 'main.md';
 

--- a/scripts/lib/budget-tracker.js
+++ b/scripts/lib/budget-tracker.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
 
 const BUDGET_CONFIG_PATH = path.join(os.homedir(), '.egc', 'budget.json');
 const BUDGET_USAGE_PATH = path.join(os.homedir(), '.egc', 'state', 'budget-usage.json');
@@ -76,7 +76,7 @@ function recordToolCall(toolName, extraTokens) {
   const cost = getToolCost(toolName);
   const tokens = cost.tokens + (extraTokens || 0);
   usage.tokens_used += tokens;
-  usage.cost_usd = parseFloat((usage.cost_usd + cost.cost).toFixed(6));
+  usage.cost_usd = Number.parseFloat((usage.cost_usd + cost.cost).toFixed(6));
   usage.tool_calls += 1;
   writeBudgetUsage(usage);
   return usage;

--- a/scripts/lib/cursor-agent-names.js
+++ b/scripts/lib/cursor-agent-names.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 function toCursorAgentFileName(fileName) {
   if (!fileName || fileName.startsWith('egc-')) {

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -1,7 +1,7 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const { execFileSync } = require('child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 
 const { toCursorAgentRelativePath } = require('./cursor-agent-names');
 const { LEGACY_INSTALL_TARGETS, parseInstallArgs } = require('./install/request');

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const { resolveInstallPlan, loadInstallManifests } = require('./install-manifests');
 const { readInstallState, writeInstallState } = require('./install-state');
@@ -230,7 +230,7 @@ function jsonContainsSubset(actualValue, expectedValue) {
     }
 
     return Object.entries(expectedValue).every(([key, value]) => (
-      Object.prototype.hasOwnProperty.call(actualValue, key)
+      Object.hasOwn(actualValue, key)
       && jsonContainsSubset(actualValue[key], value)
     ));
   }
@@ -256,7 +256,7 @@ function deepRemoveJsonSubset(currentValue, managedValue) {
 
     const nextValue = { ...currentValue };
     for (const [key, value] of Object.entries(managedValue)) {
-      if (!Object.prototype.hasOwnProperty.call(nextValue, key)) {
+      if (!Object.hasOwn(nextValue, key)) {
         continue;
       }
 

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 let Ajv = null;
 try {
@@ -96,7 +96,7 @@ function validateStateRequest(request, pushError) {
     ['profile', 'modules', 'includeComponents', 'excludeComponents', 'legacyLanguages', 'legacyMode'],
     pushError
   );
-  if (!(Object.prototype.hasOwnProperty.call(request, 'profile') && (request.profile === null || typeof request.profile === 'string'))) {
+  if (!(Object.hasOwn(request, 'profile') && (request.profile === null || typeof request.profile === 'string'))) {
     pushError('/request/profile', 'must be string or null');
   }
   validateStringArray(request.modules, '/request/modules', pushError);

--- a/scripts/lib/install-targets/aider-project.js
+++ b/scripts/lib/install-targets/aider-project.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 const {
   createInstallTargetAdapter,

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 const {
   createInstallTargetAdapter,

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { toCursorAgentFileName } = require('../cursor-agent-names');
 const {

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const PLATFORM_SOURCE_PATH_OWNERS = Object.freeze({
   '.gemini-plugin': 'egc',

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 const {
   createInstallTargetAdapter,

--- a/scripts/lib/install-targets/warp-project.js
+++ b/scripts/lib/install-targets/warp-project.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const yaml = require('js-yaml');
 
 const {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { writeInstallState } = require('../install-state');
 const { syncInstallStateToStore } = require('../install-state-store-sync');

--- a/scripts/lib/install/config.js
+++ b/scripts/lib/install/config.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const Ajv = require('ajv');
 
 const DEFAULT_INSTALL_CONFIG = 'egc-install.json';

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -14,8 +14,8 @@
  * instead.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 let TOML = null;
 try {

--- a/scripts/lib/mvg_guards.js
+++ b/scripts/lib/mvg_guards.js
@@ -4,7 +4,7 @@
  * MVG Guards - Pragmatic runtime protection for EGC
  */
 
-const fs = require('fs');
+const fs = require('node:fs');
 const { log } = require('./utils');
 
 const MAX_ACTIVATION_DEPTH = 3;
@@ -21,7 +21,7 @@ function checkRecursion(sessionId) {
 
   try {
     if (fs.existsSync(lockFile)) {
-      depth = parseInt(fs.readFileSync(lockFile, 'utf8')) || 0;
+      depth = Number.parseInt(fs.readFileSync(lockFile, 'utf8')) || 0;
     }
 
     if (depth >= MAX_ACTIVATION_DEPTH) {

--- a/scripts/lib/observer-sessions.js
+++ b/scripts/lib/observer-sessions.js
@@ -1,7 +1,7 @@
-const fs = require('fs');
-const path = require('path');
-const crypto = require('crypto');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
 const { getEGCDir, ensureDir, sanitizeSessionId } = require('./utils');
 
 function getHomunculusDir() {

--- a/scripts/lib/orchestration-session.js
+++ b/scripts/lib/orchestration-session.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 function stripCodeTicks(value) {
   if (typeof value !== 'string') {

--- a/scripts/lib/package-manager.js
+++ b/scripts/lib/package-manager.js
@@ -5,8 +5,8 @@
  * Supports: npm, pnpm, yarn, bun
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { commandExists, getEGCDir, readFile, writeFile } = require('./utils');
 
 // Package manager definitions

--- a/scripts/lib/plugin-registry.js
+++ b/scripts/lib/plugin-registry.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
 
 const PLUGINS_DIR = path.join(os.homedir(), '.egc', 'plugins');
 const PLUGINS_LOCK_PATH = path.join(PLUGINS_DIR, 'plugins.json');

--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -7,8 +7,8 @@
  * Resolves: https://github.com/Fmarzochi/EGC/issues/293
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /**
  * Language detection rules.
@@ -245,7 +245,7 @@ function getPythonDeps(projectDir) {
         const block = depMatches[1];
         block.match(/"([^"]+)"/g)?.forEach(m => {
           const name = m
-            .replace(/"/g, '')
+            .replaceAll('"', '')
             .split(/[>=<![;]/)[0]
             .trim()
             .toLowerCase();

--- a/scripts/lib/resolve-egc-root.js
+++ b/scripts/lib/resolve-egc-root.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
 
 const CURRENT_PLUGIN_SLUG = 'egc';
 const LEGACY_PLUGIN_SLUG = 'everything-gemini';

--- a/scripts/lib/resolve-formatter.js
+++ b/scripts/lib/resolve-formatter.js
@@ -8,8 +8,8 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // ── Caches (per-process, cleared on next hook invocation) ───────────
 const projectRootCache = new Map();

--- a/scripts/lib/session-adapters/canonical-session.js
+++ b/scripts/lib/session-adapters/canonical-session.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const SESSION_SCHEMA_VERSION = 'egc.session.v1';
 const SESSION_RECORDING_SCHEMA_VERSION = 'egc.session.recording.v1';

--- a/scripts/lib/session-adapters/dmux-tmux.js
+++ b/scripts/lib/session-adapters/dmux-tmux.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { collectSessionSnapshot } = require('../orchestration-session');
 const { normalizeDmuxSnapshot, persistCanonicalSnapshot } = require('./canonical-session');

--- a/scripts/lib/session-adapters/egc-history.js
+++ b/scripts/lib/session-adapters/egc-history.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const sessionManager = require('../session-manager');
 const sessionAliases = require('../session-aliases');

--- a/scripts/lib/session-aliases.js
+++ b/scripts/lib/session-aliases.js
@@ -3,8 +3,8 @@
  * Manages session aliases stored in ~/.gemini/session-aliases.json
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
   getEGCDir,

--- a/scripts/lib/session-manager.js
+++ b/scripts/lib/session-manager.js
@@ -8,8 +8,8 @@
  * - YYYY-MM-DD-<short-id>-session.tmp (new format)
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
   getSessionsDir,

--- a/scripts/lib/skill-evolution/health.js
+++ b/scripts/lib/skill-evolution/health.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const provenance = require('./provenance');
 const tracker = require('./tracker');

--- a/scripts/lib/skill-evolution/provenance.js
+++ b/scripts/lib/skill-evolution/provenance.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const { ensureDir } = require('../utils');
 

--- a/scripts/lib/skill-evolution/tracker.js
+++ b/scripts/lib/skill-evolution/tracker.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const { appendFile } = require('../utils');
 

--- a/scripts/lib/skill-evolution/versioning.js
+++ b/scripts/lib/skill-evolution/versioning.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { appendFile, ensureDir } = require('../utils');
 

--- a/scripts/lib/skill-improvement/observations.js
+++ b/scripts/lib/skill-improvement/observations.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
 
 const OBSERVATION_SCHEMA_VERSION = 'egc.skill-observation.v1';
 

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { ensurePrivateDir } = require('./utils');
 
 const DEFAULT_THRESHOLD = 40;

--- a/scripts/lib/state-overview.js
+++ b/scripts/lib/state-overview.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { DEFAULT_BRANCH_FILE, getStateDir } = require('./branch-state');
 

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 let _SQL = null;
 

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 const { applyMigrations, getAppliedMigrations } = require('./migrations');
 const { createQueryApi } = require('./queries');

--- a/scripts/lib/state-store/schema.js
+++ b/scripts/lib/state-store/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const Ajv = require('ajv');
 
 const SCHEMA_PATH = path.join(__dirname, '..', '..', '..', 'schemas', 'state-store.schema.json');

--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -9,10 +9,10 @@
  * the file.
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const readline = require('readline');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const readline = require('node:readline');
 const { ensurePrivateDir } = require('./utils');
 
 const TELEMETRY_FILE = path.join(

--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 function slugify(value, fallback = 'worker') {
   const normalized = String(value || '')
@@ -27,7 +27,7 @@ function renderTemplate(template, variables) {
 }
 
 function shellQuote(value) {
-  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+  return `'${String(value).replaceAll("'", `'\\''`)}'`;
 }
 
 function formatCommand(program, args) {

--- a/scripts/lib/utils.d.ts
+++ b/scripts/lib/utils.d.ts
@@ -3,7 +3,7 @@
  * Works on Windows, macOS, and Linux.
  */
 
-import type { ExecSyncOptions } from 'child_process';
+import type { ExecSyncOptions } from 'node:child_process';
 
 // Platform detection
 export const isWindows: boolean;

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -3,11 +3,11 @@
  * Works on Windows, macOS, and Linux
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const crypto = require('crypto');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
 
 // Platform detection
 const isWindows = process.platform === 'win32';


### PR DESCRIPTION
## O que muda

Correções mecânicas de code smells do SonarCloud em **43 arquivos** de `scripts/lib/`, sem alteração de comportamento.

Regras aplicadas:
- **S7772** — `require('fs')` → `require('node:fs')` (e demais módulos nativos: path, os, crypto, child_process, readline)
- **S7773** — `parseInt(...)` → `Number.parseInt(...)` e `parseFloat(...)` → `Number.parseFloat(...)`
- **S6653** — `Object.prototype.hasOwnProperty.call(o, k)` → `Object.hasOwn(o, k)`
- **S7781** — `.replace(/literal/g, x)` → `.replaceAll('literal', x)` onde o padrão é string literal simples

Arquivos excluídos intencionalmente (escopo EGC-136): `guardian-bin.js`, `install-manifests.js`.

## Testes

- `npm run lint` (via `node_modules/.bin/eslint`): 0 erros, 8 warnings pré-existentes (complexity/eqeqeq)
- `node tests/run-all.js`: **2825/2825 passed, 0 failed**

## Checklist

- [x] Apenas substitutions mecânicas, sem mudança de lógica
- [x] Módulos npm de terceiros **não** foram prefixados com `node:`
- [x] Arquivos do EGC-136 **não** foram tocados
- [x] Lint e testes passando

Parte de: EGC-138 ([Squad 1/5])

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mechanical SonarCloud cleanup across `scripts/lib` to standardize native module imports and common APIs with no behavior change. Part of EGC-138.

- **Refactors**
  - Standardizes: `require('node:*')` for core modules, `Number.parseInt/parseFloat`, `Object.hasOwn`, and `String.prototype.replaceAll` for simple literal patterns.
  - Scope: 43 files under `scripts/lib/**`; excludes `guardian-bin.js` and `install-manifests.js` (EGC-136).
  - Lint and tests pass.

<sup>Written for commit 22cc760e95f3e19b491f4d454cb2896a48b7c225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

