### PR TITLE
fix(sonar): node: protocol, replaceAll, Number.parseInt, Object.hasOwn em scripts/hooks (EGC-138 2/5)

### DIFF
--- a/scripts/hooks/auto-tmux-dev.js
+++ b/scripts/hooks/auto-tmux-dev.js
@@ -25,8 +25,8 @@
  * - Allows multiple dev servers to run simultaneously
  */
 
-const path = require('path');
-const { spawnSync } = require('child_process');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const MAX_STDIN = 1024 * 1024; // 1MB limit
 let data = '';
@@ -49,7 +49,7 @@ function run(rawInput) {
       if (process.platform === 'win32') {
         // Windows: open in a new cmd window (non-blocking)
         // Escape double quotes in cmd for cmd /k syntax
-        const escapedCmd = cmd.replace(/"/g, '""');
+        const escapedCmd = cmd.replaceAll('"', '""');
         return JSON.stringify({
           ...input,
           tool_input: {
@@ -62,7 +62,7 @@ function run(rawInput) {
         const tmuxCheck = spawnSync('which', ['tmux'], { encoding: 'utf8' });
         if (tmuxCheck.status === 0) {
           // Escape single quotes for shell safety: 'text' -> 'text'\''text'
-          const escapedCmd = cmd.replace(/'/g, "'\\''");
+          const escapedCmd = cmd.replaceAll("'", "'\\''");
 
           // 1. Kill existing session (silent if doesn't exist)
           // 2. Create new detached session with the dev command

--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -112,7 +112,7 @@ function normalizeHookResult(previousRaw, output) {
   }
 
   if (output && typeof output === 'object') {
-    const nextRaw = Object.prototype.hasOwnProperty.call(output, 'stdout')
+    const nextRaw = Object.hasOwn(output, 'stdout')
       ? String(output.stdout ?? '')
       : !Number.isInteger(output.exitCode) || output.exitCode === 0
         ? previousRaw

--- a/scripts/hooks/check-console-log.js
+++ b/scripts/hooks/check-console-log.js
@@ -13,7 +13,7 @@
  * console.log is often intentional).
  */
 
-const fs = require('fs');
+const fs = require('node:fs');
 const { isGitRepo, getGitModifiedFiles, readFile, log } = require('../lib/utils');
 
 // Files where console.log is expected and should not trigger warnings

--- a/scripts/hooks/config-protection.js
+++ b/scripts/hooks/config-protection.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 const MAX_STDIN = 1024 * 1024;
 let raw = '';

--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 const {
   ensureDir,
   appendFile,

--- a/scripts/hooks/design-quality-check.js
+++ b/scripts/hooks/design-quality-check.js
@@ -9,8 +9,8 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const FRONTEND_EXTENSIONS = /\.(astro|css|html|jsx|scss|svelte|tsx|vue)$/i;
 const MAX_STDIN = 1024 * 1024;

--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const { spawnSync } = require('child_process');
+const { spawnSync } = require('node:child_process');
 const { isMacOS, log } = require('../lib/utils');
 
 const TITLE = 'Gemini Code';
@@ -27,7 +27,7 @@ const MAX_BODY_LENGTH = 100;
 let isWSL = false;
 if (process.platform === 'linux') {
   try {
-    isWSL = require('fs').readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
+    isWSL = require('node:fs').readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
   } catch {
     isWSL = false;
   }
@@ -67,8 +67,8 @@ function findPowerShell() {
  * reason is null on success, or contains error detail on failure.
  */
 function notifyWindows(pwshPath, title, body) {
-  const safeBody = body.replace(/'/g, "''");
-  const safeTitle = title.replace(/'/g, "''");
+  const safeBody = body.replaceAll("'", "''");
+  const safeTitle = title.replaceAll("'", "''");
   const command = `Import-Module BurntToast; New-BurntToastNotification -Text '${safeTitle}', '${safeBody}'`;
   const result = spawnSync(pwshPath, ['-Command', command],
     { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000 });
@@ -104,8 +104,8 @@ function extractSummary(message) {
  * double quotes with curly quotes and strip backslashes before embedding.
  */
 function notifyMacOS(title, body) {
-  const safeBody = body.replace(/\\/g, '').replace(/"/g, '\u201C');
-  const safeTitle = title.replace(/\\/g, '').replace(/"/g, '\u201C');
+  const safeBody = body.replace(/\\/g, '').replaceAll('"', '\u201C');
+  const safeTitle = title.replace(/\\/g, '').replaceAll('"', '\u201C');
   const script = `display notification "${safeBody}" with title "${safeTitle}"`;
   const result = spawnSync('osascript', ['-e', script], { stdio: 'ignore', timeout: 5000 });
   if (result.error || result.status !== 0) {

--- a/scripts/hooks/doc-file-warning.js
+++ b/scripts/hooks/doc-file-warning.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 const MAX_STDIN = 1024 * 1024;
 let data = '';

--- a/scripts/hooks/egc-memory-load.js
+++ b/scripts/hooks/egc-memory-load.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('node:fs');
 const { getStateDir, detectBranch, resolveStateRead } = require('../lib/branch-state');
 
 function main() {

--- a/scripts/hooks/egc-memory-save.js
+++ b/scripts/hooks/egc-memory-save.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('node:fs');
 const { writeSnapshotToDisk } = require('../lib/state-snapshot');
 
 function main() {

--- a/scripts/hooks/egc-session-bridge.js
+++ b/scripts/hooks/egc-session-bridge.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
-const { spawnSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const HOOK_ID = 'egc-session-bridge';
 const DEFAULT_TIMEOUT_MS = 5000;

--- a/scripts/hooks/evaluate-session.js
+++ b/scripts/hooks/evaluate-session.js
@@ -12,8 +12,8 @@
  * - UserPromptSubmit runs every message (heavy, adds latency)
  */
 
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 const {
   getLearnedSkillsDir,
   ensureDir,
@@ -64,7 +64,7 @@ async function main() {
       minSessionLength = config.min_session_length ?? 10;
 
       if (config.learned_skills_path) {
-        learnedSkillsPath = config.learned_skills_path.replace(/^~/, require('os').homedir());
+        learnedSkillsPath = config.learned_skills_path.replace(/^~/, require('node:os').homedir());
       }
     } catch (err) {
       log(`[ContinuousLearning] Failed to parse config: ${err.message}, using defaults`);

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -24,9 +24,9 @@
 
 'use strict';
 
-const crypto = require('crypto');
-const fs = require('fs');
-const path = require('path');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // Session state: scoped per session to avoid cross-session races.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
@@ -635,7 +635,7 @@ if (require.main === module) {
         process.stderr.write(output.stderr.endsWith('\n') ? output.stderr : `${output.stderr}\n`);
       }
 
-      if (Object.prototype.hasOwnProperty.call(output, 'stdout')) {
+      if (Object.hasOwn(output, 'stdout')) {
         process.stdout.write(String(output.stdout ?? ''));
       } else if (!Number.isInteger(output.exitCode) || output.exitCode === 0) {
         process.stdout.write(raw);

--- a/scripts/hooks/governance-capture.js
+++ b/scripts/hooks/governance-capture.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 
 const MAX_STDIN = 1024 * 1024;
 

--- a/scripts/hooks/insaits-security-wrapper.js
+++ b/scripts/hooks/insaits-security-wrapper.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const path = require('path');
-const { spawnSync } = require('child_process');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const MAX_STDIN = 1024 * 1024;
 const WINDOWS_SHELL_UNSAFE_PATH_CHARS = /[&|<>^%!]/;

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -12,12 +12,12 @@
  * survives compaction and later turns.
  */
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const http = require('http');
-const https = require('https');
-const { spawn, spawnSync } = require('child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const { spawn, spawnSync } = require('node:child_process');
 
 const MAX_STDIN = 1024 * 1024;
 const DEFAULT_TTL_MS = 2 * 60 * 1000;

--- a/scripts/hooks/observe-runner.js
+++ b/scripts/hooks/observe-runner.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync, spawn } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync, spawn } = require('node:child_process');
 
 const OBSERVE_RELATIVE_PATH = path.join('skills', 'ai', 'continuous-learning-v2', 'hooks', 'observe.sh');
 const DEFAULT_TIMEOUT_MS = 9000;
@@ -213,7 +213,7 @@ function emitHookResult(raw, output) {
     if (output.stderr) {
       process.stderr.write(String(output.stderr).endsWith('\n') ? String(output.stderr) : `${output.stderr}\n`);
     }
-    if (Object.prototype.hasOwnProperty.call(output, 'stdout')) {
+    if (Object.hasOwn(output, 'stdout')) {
       process.stdout.write(String(output.stdout ?? ''));
     } else if (!Number.isInteger(output.exitCode) || output.exitCode === 0) {
       process.stdout.write(raw);

--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const SAFE_SHELL_BASENAMES = new Set(['bash', 'bash.exe', 'sh', 'sh.exe']);
 

--- a/scripts/hooks/post-bash-command-log.js
+++ b/scripts/hooks/post-bash-command-log.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const MAX_STDIN = 1024 * 1024;
 let raw = '';

--- a/scripts/hooks/post-edit-accumulator.js
+++ b/scripts/hooks/post-edit-accumulator.js
@@ -14,10 +14,10 @@
 
 'use strict';
 
-const crypto = require('crypto');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const MAX_STDIN = 1024 * 1024;
 

--- a/scripts/hooks/post-edit-format.js
+++ b/scripts/hooks/post-edit-format.js
@@ -17,8 +17,8 @@
  * Fails silently if no formatter is found or installed.
  */
 
-const { execFileSync, spawnSync } = require('child_process');
-const path = require('path');
+const { execFileSync, spawnSync } = require('node:child_process');
+const path = require('node:path');
 
 // Shell metacharacters that cmd.exe interprets as command separators/operators.
 // Includes spaces and parentheses to guard paths like "C:\Users\John Doe\...".

--- a/scripts/hooks/post-edit-typecheck.js
+++ b/scripts/hooks/post-edit-typecheck.js
@@ -9,9 +9,9 @@
  * and reports only errors related to the edited file.
  */
 
-const { execFileSync } = require("child_process");
-const fs = require("fs");
-const path = require("path");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const MAX_STDIN = 1024 * 1024; // 1MB limit
 let data = "";

--- a/scripts/hooks/pre-bash-commit-quality.js
+++ b/scripts/hooks/pre-bash-commit-quality.js
@@ -15,9 +15,9 @@
  *   2 - Block commit (quality issues found)
  */
 
-const { spawnSync } = require('child_process');
-const path = require('path');
-const fs = require('fs');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
 
 const MAX_STDIN = 1024 * 1024; // 1MB limit
 

--- a/scripts/hooks/pre-bash-dev-server-block.js
+++ b/scripts/hooks/pre-bash-dev-server-block.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const MAX_STDIN = 1024 * 1024;
-const path = require('path');
+const path = require('node:path');
 const { splitShellSegments } = require('../lib/shell-split');
 
 const DEV_COMMAND_WORDS = new Set([

--- a/scripts/hooks/pre-compact.js
+++ b/scripts/hooks/pre-compact.js
@@ -8,8 +8,8 @@
  * preserve important state that might get lost in summarization.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
   getSessionsDir,
   getDateTimeString,

--- a/scripts/hooks/quality-gate.js
+++ b/scripts/hooks/quality-gate.js
@@ -14,9 +14,9 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const { findProjectRoot, detectFormatter, resolveFormatterBin } = require('../lib/resolve-formatter');
 

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -8,9 +8,9 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { isHookEnabled } = require('../lib/hook-flags');
 
 const MAX_STDIN = 1024 * 1024;
@@ -53,7 +53,7 @@ function emitHookResult(raw, output) {
   if (output && typeof output === 'object') {
     writeStderr(output.stderr);
 
-    if (Object.prototype.hasOwnProperty.call(output, 'stdout')) {
+    if (Object.hasOwn(output, 'stdout')) {
       process.stdout.write(String(output.stdout ?? ''));
     } else if (!Number.isInteger(output.exitCode) || output.exitCode === 0) {
       process.stdout.write(raw);

--- a/scripts/hooks/session-activity-tracker.js
+++ b/scripts/hooks/session-activity-tracker.js
@@ -8,9 +8,9 @@
 
 'use strict';
 
-const crypto = require('crypto');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const crypto = require('node:crypto');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const {
   appendFile,
   getEGCDir,

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -9,8 +9,8 @@
  * session file for cross-session continuity.
  */
 
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 const {
   getSessionsDir,
   getDateString,
@@ -293,7 +293,7 @@ function buildSummarySection(summary) {
   // Tasks (from user messages: collapse newlines and escape backticks to prevent markdown breaks)
   section += '### Tasks\n';
   for (const msg of summary.userMessages) {
-    section += `- ${msg.replace(/\\/g, '\\\\').replace(/\n/g, ' ').replace(/`/g, '\\`')}\n`;
+    section += `- ${msg.replace(/\\/g, '\\\\').replace(/\n/g, ' ').replaceAll('`', '\\`')}\n`;
   }
   section += '\n';
 
@@ -301,14 +301,14 @@ function buildSummarySection(summary) {
   if (summary.filesModified.length > 0) {
     section += '### Files Modified\n';
     for (const f of summary.filesModified) {
-      section += `- ${f.replace(/\\/g, '\\\\').replace(/`/g, '\\`')}\n`;
+      section += `- ${f.replace(/\\/g, '\\\\').replaceAll('`', '\\`')}\n`;
     }
     section += '\n';
   }
 
   // Tools used
   if (summary.toolsUsed.length > 0) {
-    section += `### Tools Used\n${summary.toolsUsed.map(t => t.replace(/\\/g, '\\\\').replace(/`/g, '\\`')).join(', ')}\n\n`;
+    section += `### Tools Used\n${summary.toolsUsed.map(t => t.replace(/\\/g, '\\\\').replaceAll('`', '\\`')).join(', ')}\n\n`;
   }
 
   section += `### Stats\n- Total user messages: ${summary.totalMessages}\n`;

--- a/scripts/hooks/session-start-bootstrap.js
+++ b/scripts/hooks/session-start-bootstrap.js
@@ -26,9 +26,9 @@
  *      through unchanged so Gemini Code can continue normally.
  */
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const CURRENT_PLUGIN_SLUG = 'egc';
 const LEGACY_PLUGIN_SLUG = 'everything-gemini';
@@ -75,7 +75,7 @@ function resolvePluginRoot() {
     return path.resolve(envRoot.trim());
   }
 
-  const home = require('os').homedir();
+  const home = require('node:os').homedir();
   const claudeDir = path.join(home, '.gemini');
 
   if (hasRunnerRoot(claudeDir)) {

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -25,8 +25,8 @@ const { resolveProjectContext, writeSessionLease, resolveSessionId } = require('
 const { getPackageManager, getSelectionPrompt } = require('../lib/package-manager');
 const { listAliases } = require('../lib/session-aliases');
 const { detectProjectType } = require('../lib/project-detect');
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 
 const INSTINCT_CONFIDENCE_THRESHOLD = 0.7;
 const MAX_INJECTED_INSTINCTS = 6;

--- a/scripts/hooks/state-db-writer.js
+++ b/scripts/hooks/state-db-writer.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const crypto = require('crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
 const { getEGCDir } = require(path.join(__dirname, '..', 'lib', 'utils.js'));
 
 function resolveStateDbPath() {

--- a/scripts/hooks/stop-format-typecheck.js
+++ b/scripts/hooks/stop-format-typecheck.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-const crypto = require('crypto');
-const { execFileSync, spawnSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const crypto = require('node:crypto');
+const { execFileSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const { findProjectRoot, detectFormatter, resolveFormatterBin } = require('../lib/resolve-formatter');
 

--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -13,8 +13,8 @@
  * - Compact after completing a milestone, before starting next
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
   getTempDir,
   writeFile,
@@ -27,7 +27,7 @@ async function main() {
   // or parent PID as fallback
   const sessionId = (process.env.EGC_SESSION_ID || process.env.ECC_SESSION_ID || 'default').replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
   const counterFile = path.join(getTempDir(), `egc-tool-count-${sessionId}`);
-  const rawThreshold = parseInt(process.env.COMPACT_THRESHOLD || '50', 10);
+  const rawThreshold = Number.parseInt(process.env.COMPACT_THRESHOLD || '50', 10);
   const threshold = Number.isFinite(rawThreshold) && rawThreshold > 0 && rawThreshold <= 10000
     ? rawThreshold
     : 50;
@@ -42,9 +42,9 @@ async function main() {
       const buf = Buffer.alloc(64);
       const bytesRead = fs.readSync(fd, buf, 0, 64, 0);
       if (bytesRead > 0) {
-        const parsed = parseInt(buf.toString('utf8', 0, bytesRead).trim(), 10);
+        const parsed = Number.parseInt(buf.toString('utf8', 0, bytesRead).trim(), 10);
         // Clamp to reasonable range: corrupted files could contain huge values
-        // that pass Number.isFinite() (e.g., parseInt('9'.repeat(30)) => 1e+29)
+        // that pass Number.isFinite() (e.g., Number.parseInt('9'.repeat(30)) => 1e+29)
         count = (Number.isFinite(parsed) && parsed > 0 && parsed <= 1000000)
           ? parsed + 1
           : 1;


### PR DESCRIPTION
## O que muda

Correções mecânicas de code smells do SonarCloud em **34 arquivos** de `scripts/hooks/`, sem alteração de comportamento.

Regras aplicadas:
- **S7772** — `require('fs')` → `require('node:fs')` (e demais módulos nativos)
- **S7773** — `parseInt(...)` → `Number.parseInt(...)` / `parseFloat(...)` → `Number.parseFloat(...)`
- **S6653** — `Object.prototype.hasOwnProperty.call(o, k)` → `Object.hasOwn(o, k)`
- **S7781** — `.replace(/literal/g, x)` → `.replaceAll('literal', x)` onde padrão é literal simples

## Testes

- `eslint scripts/hooks/`: 0 erros, 5 warnings pré-existentes (complexity)
- `node tests/run-all.js`: **2825/2825 passed, 0 failed**

Parte de: EGC-138 ([Squad 1/5])

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mechanical SonarCloud cleanup in 34 `scripts/hooks` files with no behavior changes; aligns with EGC-138.

- **Refactors**
  - Prefix native Node modules with `node:` (e.g., `node:fs`, `node:path`).
  - Replace global `parseInt`/`parseFloat` with `Number.parseInt`/`Number.parseFloat`.
  - Use `Object.hasOwn(...)` instead of `Object.prototype.hasOwnProperty.call(...)`.
  - Replace `replace(/literal/g, ...)` with `replaceAll('literal', ...)` for simple literals.

<sup>Written for commit 6fde3c5c98456124c6ff4fae4e9fe1c8334c7eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

