### PR TITLE
fix(sonar): node: protocol, Number.parseInt, replaceAll em scripts/ raiz (EGC-138 3/5)

### DIFF
--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const { spawnSync } = require('child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { version: PKG_VERSION } = require('../package.json');
 
 const { discoverInstalledStates } = require('./lib/install-lifecycle');

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs   = require('fs');
-const path = require('path');
-const os   = require('os');
+const fs   = require('node:fs');
+const path = require('node:path');
+const os   = require('node:os');
 
 const MARKER = '<!-- egc-memory-protocol -->';
 

--- a/scripts/budget.js
+++ b/scripts/budget.js
@@ -53,9 +53,9 @@ async function main() {
       const warnAtIdx = args.indexOf('--warn-at');
       const actionIdx = args.indexOf('--action');
 
-      const maxTokens = tokensIdx !== -1 ? parseInt(args[tokensIdx + 1], 10) : undefined;
-      const maxCost = costIdx !== -1 ? parseFloat(args[costIdx + 1]) : undefined;
-      const warnAtPercent = warnAtIdx !== -1 ? parseInt(args[warnAtIdx + 1], 10) : undefined;
+      const maxTokens = tokensIdx !== -1 ? Number.parseInt(args[tokensIdx + 1], 10) : undefined;
+      const maxCost = costIdx !== -1 ? Number.parseFloat(args[costIdx + 1]) : undefined;
+      const warnAtPercent = warnAtIdx !== -1 ? Number.parseInt(args[warnAtIdx + 1], 10) : undefined;
       const action = actionIdx !== -1 ? args[actionIdx + 1] : undefined;
 
       if (maxTokens !== undefined && (isNaN(maxTokens) || maxTokens <= 0)) {

--- a/scripts/build-skill-index.js
+++ b/scripts/build-skill-index.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const root = path.resolve(__dirname, '..');
 const outFile = path.join(root, 'mcp', 'servers', 'egc-guardian', 'src', 'catalog-index.ts');

--- a/scripts/claw.js
+++ b/scripts/claw.js
@@ -7,11 +7,11 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { spawnSync } = require('child_process');
-const readline = require('readline');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+const readline = require('node:readline');
 
 const SESSION_NAME_RE = /^[a-zA-Z0-9][-a-zA-Z0-9]*$/;
 const DEFAULT_MODEL = process.env.CLAW_MODEL || 'gemini-2.0-flash';

--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const {
   DEFAULT_THRESHOLD,
   WORKING_WINDOW_DAYS,

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 'use strict';
 
-const { spawnSync, spawn } = require('child_process');
-const path = require('path');
-const http = require('http');
-const fs = require('fs');
+const { spawnSync, spawn } = require('node:child_process');
+const path = require('node:path');
+const http = require('node:http');
+const fs = require('node:fs');
 
 const PORT = 7890;
 const DASHBOARD_DIR = path.join(__dirname, '..', 'dashboard');
 const SERVER_SCRIPT = path.join(DASHBOARD_DIR, 'server.js');
-const PID_FILE = path.join(require('os').homedir(), '.egc', 'dashboard.pid');
+const PID_FILE = path.join(require('node:os').homedir(), '.egc', 'dashboard.pid');
 
 const args = process.argv.slice(2);
 const flag = args[0];
@@ -42,7 +42,7 @@ function writePid(pid) {
 }
 
 function readPid() {
-  try { return parseInt(fs.readFileSync(PID_FILE, 'utf8').trim(), 10); } catch (_) { return null; }
+  try { return Number.parseInt(fs.readFileSync(PID_FILE, 'utf8').trim(), 10); } catch (_) { return null; }
 }
 
 async function start() {

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const os = require('os');
-const path = require('path');
-const fs = require('fs');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
 const { buildDoctorReport } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { getEGCDir } = require('./lib/utils');

--- a/scripts/e2e-team-sync-direct.js
+++ b/scripts/e2e-team-sync-direct.js
@@ -1,7 +1,7 @@
-const { execFileSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
 
 const TMP = path.join(os.tmpdir(), 'egc-e2e-' + Date.now());
 const REMOTE = path.join(TMP, 'remote.git');

--- a/scripts/e2e-team-sync.js
+++ b/scripts/e2e-team-sync.js
@@ -1,7 +1,7 @@
-const { execFileSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
 
 const TMP = path.join(os.tmpdir(), 'egc-e2e-team-' + Date.now());
 const REMOTE_REPO = path.join(TMP, 'remote-repo');

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const _nodeMajor = parseInt(process.versions.node, 10);
+const _nodeMajor = Number.parseInt(process.versions.node, 10);
 if (_nodeMajor < 20) {
   process.stderr.write(
     `EGC requires Node.js 20 or later (found: ${process.version}).\n` +
@@ -9,8 +9,8 @@ if (_nodeMajor < 20) {
   process.exit(1);
 }
 
-const { spawnSync } = require('child_process');
-const path = require('path');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
 const { version: PACKAGE_VERSION } = require('../package.json');
 const { listAvailableLanguages } = require('./lib/install-executor');
 const { formatOSC8 } = require('./lib/utils');

--- a/scripts/gemini-adapt-agents.js
+++ b/scripts/gemini-adapt-agents.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const TOOL_NAME_MAP = new Map([
   ['Read', 'read_file'],
@@ -83,7 +83,7 @@ function adaptToolName(toolName) {
   if (toolName.startsWith('mcp__')) {
     return toolName
       .replace(/^mcp__/, 'mcp_')
-      .replace(/__/g, '_')
+      .replaceAll('__', '_')
       .replace(/[^A-Za-z0-9_]/g, '_')
       .toLowerCase();
   }

--- a/scripts/gemini.js
+++ b/scripts/gemini.js
@@ -8,9 +8,9 @@
 
 'use strict';
 
-const { spawnSync } = require('child_process');
-const path = require('path');
-const os = require('os');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const os = require('node:os');
 
 function main() {
   const pluginRoot = path.resolve(__dirname, '..');

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const CATEGORIES = [
   'Tool Coverage',

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -22,11 +22,11 @@
  *   --help        Show usage
  */
 
-const fs = require('fs');
-const path = require('path');
-const http = require('http');
-const { spawnSync, spawn } = require('child_process');
-const os = require('os');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const { spawnSync, spawn } = require('node:child_process');
+const os = require('node:os');
 
 const { version: PKG_VERSION } = require('../package.json');
 const { registerMcpServers: runMcpRegistration } = require('./lib/mcp-register');
@@ -86,7 +86,7 @@ function logDry(msg) { if (flags.dryRun) console.log(`  ${c.dim}[dry-run] ${msg}
 function logAction(msg) { console.log(`  ${c.dim}${flags.dryRun ? '[dry-run] ' : ''}${msg}${c.reset}`); }
 
 function checkNode() {
-  const major = parseInt(process.versions.node.split('.')[0], 10);
+  const major = Number.parseInt(process.versions.node.split('.')[0], 10);
   if (major < 20) {
     console.error(`Error: Node.js 20 or later is required (found: ${process.version}).`);
     if (major === 18) {
@@ -153,7 +153,7 @@ function runStateDbBootstrap() {
   if (flags.dryRun) return;
   const result = spawnSync(process.execPath, [bootstrapScript], { stdio: ['ignore', 'ignore', 'pipe'], encoding: 'utf8' });
   const output = (result.stderr || '').trim();
-  if (output) console.log('  ' + output.split('\n').join('\n  '));
+  if (output) console.log('  ' + output.replaceAll('\n', '\n  '));
 }
 
 /**
@@ -249,7 +249,7 @@ if (!flags.dryRun) {
       const url = 'http://localhost:7890';
       const cmd = process.platform === 'win32' ? 'start' :
                   process.platform === 'darwin' ? 'open' : 'xdg-open';
-      try { require('child_process').spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) { /* best-effort */ }
+      try { require('node:child_process').spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) { /* best-effort */ }
     };
     dashPing.then(already => {
       if (already) {

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -6,7 +6,7 @@
  * target-specific mutation logic into testable Node code.
  */
 
-const os = require('os');
+const os = require('node:os');
 
 
 const {

--- a/scripts/list-installed.js
+++ b/scripts/list-installed.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const os = require('os');
+const os = require('node:os');
 const { discoverInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const crypto = require('crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
 
 const DEFAULT_BASH_TIMEOUT_SECONDS = 30 * 60;
 const DEFAULT_LIMIT = 10;

--- a/scripts/orchestrate-worktrees.js
+++ b/scripts/orchestrate-worktrees.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
   buildOrchestrationPlan,

--- a/scripts/orchestration-status.js
+++ b/scripts/orchestration-status.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { inspectSessionTarget } = require('./lib/session-adapters/registry');
 

--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const path = require('path');
+const path = require('node:path');
 const {
   installPluginFromDir,
   installPluginFromNpm,
@@ -61,7 +61,7 @@ async function main() {
 
       if (sourceIdx !== -1 && args[sourceIdx + 1]) {
         const sourcePath = path.resolve(args[sourceIdx + 1]);
-        if (!require('fs').existsSync(sourcePath)) {
+        if (!require('node:fs').existsSync(sourcePath)) {
           console.error(`Error: Source path does not exist: ${sourcePath}`);
           process.exit(1);
         }

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const _nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
+const _nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
 if (_nodeMajor < 20) {
   process.stderr.write(
     '\n' +
@@ -17,8 +17,8 @@ if (_nodeMajor < 20) {
 
 if (process.platform === 'win32') process.exit(0);
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 if (process.env.npm_config_global !== 'true') process.exit(0);
 

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const os = require('os');
+const os = require('node:os');
 const { repairInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { reinstallAllPlugins, listInstalledPlugins } = require('./lib/plugin-registry');
@@ -76,7 +76,7 @@ function main() {
     }
 
     const result = repairInstalledStates({
-      repoRoot: require('path').join(__dirname, '..'),
+      repoRoot: require('node:path').join(__dirname, '..'),
       homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,

--- a/scripts/replay.js
+++ b/scripts/replay.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const http = require('http');
-const { execSync } = require('child_process');
+const http = require('node:http');
+const { execSync } = require('node:child_process');
 
 const DASHBOARD_URL = 'http://localhost:7890';
 

--- a/scripts/session-inspect.js
+++ b/scripts/session-inspect.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { createAdapterRegistry, inspectSessionTarget } = require('./lib/session-adapters/registry');
 const { readSkillObservations } = require('./lib/skill-improvement/observations');

--- a/scripts/sessions-cli.js
+++ b/scripts/sessions-cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const os = require('os');
+const os = require('node:os');
 const { createStateStore } = require('./lib/state-store');
 const { formatOSC8 } = require('./lib/utils');
 

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const os = require('os');
+const os = require('node:os');
 const { createStateStore } = require('./lib/state-store');
 const { getStateDir, projectSlug, detectBranch, resolveStateRead } = require('./lib/branch-state');
 

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
-const { spawnSync, execFileSync } = require('child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { spawnSync, execFileSync } = require('node:child_process');
 
 const MEMORY_SERVER_SCRIPT = path.join(__dirname, '..', 'mcp', 'servers', 'egc-memory', 'build', 'index.js');
 const TEAM_CONFIG_PATH = path.join(os.homedir(), '.egc', 'team.json');

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const os = require('os');
+const os = require('node:os');
 const { uninstallInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
-const fs   = require("fs");
-const path = require("path");
+const fs   = require("node:fs");
+const path = require("node:path");
 
 const LANGUAGE_NAMES = {
   pt: "Português (Brasil)",

--- a/scripts/verify-team-sync.js
+++ b/scripts/verify-team-sync.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const BUILD_DIR = path.join(__dirname, '..', 'mcp', 'servers', 'egc-memory', 'build');
 


### PR DESCRIPTION
## O que muda

Correções mecânicas de code smells do SonarCloud em **31 arquivos** de `scripts/` (nível raiz), sem alteração de comportamento.

Regras aplicadas:
- **S7772** — `require('fs')` → `require('node:fs')` (e demais módulos nativos)
- **S7773** — `parseInt(...)` → `Number.parseInt(...)`
- **S7781** — `.replace(/literal/g, x)` → `.replaceAll('literal', x)` onde padrão é literal simples

## Testes

- `eslint scripts/*.js`: 0 erros, 7 warnings pré-existentes (complexity)
- `node tests/run-all.js`: **2825/2825 passed, 0 failed**

Parte de: EGC-138 ([Squad 1/5])

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mechanical SonarCloud fixes across 31 scripts in the repo root to standardize Node built-ins, number parsing, and string replacement per EGC-138. No behavior changes; all tests pass.

- **Refactors**
  - Prefix native `require()` calls with `node:` (e.g., `node:fs`, `node:path`) [S7772]
  - Use `Number.parseInt`/`Number.parseFloat` instead of global `parseInt`/`parseFloat` [S7773]
  - Replace `.replace(/literal/g, ...)` with `.replaceAll('literal', ...)` for simple literal patterns [S7781]

<sup>Written for commit 97b6961f484854e1da5463c0d6cf19a6688adb6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

