### PR TITLE
refactor(cc): reduce cognitive complexity in scripts/lib (S3776, EGC-139)

### DIFF
--- a/scripts/lib/agent-compress.js
+++ b/scripts/lib/agent-compress.js
@@ -41,6 +41,24 @@ function parseFrontmatter(content) {
   return { frontmatter, body: match[2] || '' };
 }
 
+function isSkippableLine(trimmed) {
+  return (
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('- ') ||
+    trimmed.startsWith('* ') ||
+    /^\d+\.\s/.test(trimmed) ||
+    trimmed.startsWith('|')
+  );
+}
+
+function flushParagraph(current, paragraphs) {
+  if (current.length > 0) {
+    paragraphs.push(current.join(' '));
+    return [];
+  }
+  return current;
+}
+
 /**
  * Extract the first meaningful paragraph from agent body as a summary.
  * Skips headings, list items, code blocks, and table rows.
@@ -54,7 +72,6 @@ function extractSummary(body, maxSentences = 1) {
   for (const line of lines) {
     const trimmed = line.trim();
 
-    // Track fenced code blocks
     if (trimmed.startsWith('```')) {
       inCodeBlock = !inCodeBlock;
       continue;
@@ -62,33 +79,18 @@ function extractSummary(body, maxSentences = 1) {
     if (inCodeBlock) continue;
 
     if (trimmed === '') {
-      if (current.length > 0) {
-        paragraphs.push(current.join(' '));
-        current = [];
-      }
+      current = flushParagraph(current, paragraphs);
       continue;
     }
 
-    // Skip headings, list items (bold, plain, asterisk), numbered lists, table rows
-    if (
-      trimmed.startsWith('#') ||
-      trimmed.startsWith('- ') ||
-      trimmed.startsWith('* ') ||
-      /^\d+\.\s/.test(trimmed) ||
-      trimmed.startsWith('|')
-    ) {
-      if (current.length > 0) {
-        paragraphs.push(current.join(' '));
-        current = [];
-      }
+    if (isSkippableLine(trimmed)) {
+      current = flushParagraph(current, paragraphs);
       continue;
     }
 
     current.push(trimmed);
   }
-  if (current.length > 0) {
-    paragraphs.push(current.join(' '));
-  }
+  flushParagraph(current, paragraphs);
 
   const firstParagraph = paragraphs.find(p => p.length > 0);
   if (!firstParagraph) return '';

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -122,6 +122,17 @@ function migrateStaleGroupEntries(group, hookScriptPath, alreadyPresent) {
   return { entries, groupChanged, present };
 }
 
+function isMatcherGroup(group, matcher) {
+  if (!isPlainObject(group) || !Array.isArray(group.hooks)) return false;
+  return matcher === undefined ? group?.matcher === undefined : group?.matcher === matcher;
+}
+
+function buildNewGroup(hookScriptPath, matcher) {
+  const group = { hooks: [{ type: 'command', command: buildHookCommand(hookScriptPath) }] };
+  if (matcher) group.matcher = matcher;
+  return group;
+}
+
 function addHookEntry(settings, event, hookScriptPath, options = {}) {
   const base = isPlainObject(settings) ? settings : {};
   const matcher = typeof options.matcher === 'string' && options.matcher ? options.matcher : undefined;
@@ -134,10 +145,7 @@ function addHookEntry(settings, event, hookScriptPath, options = {}) {
   const groups = [];
 
   for (const group of existingGroups) {
-    const sameMatcher = matcher === undefined
-      ? group?.matcher === undefined
-      : group?.matcher === matcher;
-    if (!isPlainObject(group) || !Array.isArray(group.hooks) || !sameMatcher) {
+    if (!isMatcherGroup(group, matcher)) {
       groups.push(group);
       continue;
     }
@@ -155,11 +163,7 @@ function addHookEntry(settings, event, hookScriptPath, options = {}) {
   }
 
   if (!present) {
-    const group = { hooks: [{ type: 'command', command: buildHookCommand(hookScriptPath) }] };
-    if (matcher) {
-      group.matcher = matcher;
-    }
-    groups.push(group);
+    groups.push(buildNewGroup(hookScriptPath, matcher));
     changed = true;
   }
 

--- a/scripts/lib/init-remediation.js
+++ b/scripts/lib/init-remediation.js
@@ -2,6 +2,30 @@
 
 const RESOLUTION_DRIFT_ISSUE_CODE = 'resolution-drift';
 
+function hasDriftIssue(result) {
+  const issues = Array.isArray(result.issues) ? result.issues : [];
+  return issues.some(issue => issue.code === RESOLUTION_DRIFT_ISSUE_CODE);
+}
+
+function buildModuleArgs(request) {
+  if (request.profile) return ['--profile', request.profile];
+  if (Array.isArray(request.modules) && request.modules.length > 0) {
+    return ['--modules', request.modules.join(',')];
+  }
+  return null;
+}
+
+function buildComponentFlags(request) {
+  const flags = [];
+  for (const componentId of request.includeComponents || []) {
+    flags.push('--with', componentId);
+  }
+  for (const componentId of request.excludeComponents || []) {
+    flags.push('--without', componentId);
+  }
+  return flags;
+}
+
 /**
  * Builds install-apply argv for every doctor result whose issues include
  * resolution drift. Recorded-content repair restores files but never
@@ -15,36 +39,14 @@ function planDriftReinstalls(report) {
   for (const result of results) {
     const request = result?.state?.request;
     const target = result?.adapter?.target;
-    if (!request || !target || request.legacyMode) {
-      continue;
-    }
+    if (!request || !target || request.legacyMode) continue;
+    if (!hasDriftIssue(result)) continue;
 
-    const issues = Array.isArray(result.issues) ? result.issues : [];
-    if (!issues.some(issue => issue.code === RESOLUTION_DRIFT_ISSUE_CODE)) {
-      continue;
-    }
+    const moduleArgs = buildModuleArgs(request);
+    if (!moduleArgs) continue;
 
-    const args = ['--target', target];
-    if (request.profile) {
-      args.push('--profile', request.profile);
-    } else if (Array.isArray(request.modules) && request.modules.length > 0) {
-      args.push('--modules', request.modules.join(','));
-    } else {
-      continue;
-    }
-
-    for (const componentId of request.includeComponents || []) {
-      args.push('--with', componentId);
-    }
-    for (const componentId of request.excludeComponents || []) {
-      args.push('--without', componentId);
-    }
-
-    plans.push({
-      adapterId: result.adapter.id,
-      target,
-      args,
-    });
+    const args = ['--target', target, ...moduleArgs, ...buildComponentFlags(request)];
+    plans.push({ adapterId: result.adapter.id, target, args });
   }
 
   return plans;

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -133,6 +133,26 @@ function validateStateSource(source, pushError) {
   }
 }
 
+const OPERATION_STRING_FIELDS = [
+  'kind',
+  'moduleId',
+  'sourceRelativePath',
+  'destinationPath',
+  'strategy',
+  'ownership',
+];
+
+function validateOperation(operation, instancePath, pushError) {
+  for (const field of OPERATION_STRING_FIELDS) {
+    if (!isNonEmptyString(operation[field])) {
+      pushError(`${instancePath}/${field}`, 'must be non-empty string');
+    }
+  }
+  if (typeof operation.scaffoldOnly !== 'boolean') {
+    pushError(`${instancePath}/scaffoldOnly`, 'must be boolean');
+  }
+}
+
 function validateStateOperations(operations, pushError) {
   if (!Array.isArray(operations)) {
     pushError('/operations', 'must be array');
@@ -148,27 +168,7 @@ function validateStateOperations(operations, pushError) {
       continue;
     }
 
-    if (!isNonEmptyString(operation.kind)) {
-      pushError(`${instancePath}/kind`, 'must be non-empty string');
-    }
-    if (!isNonEmptyString(operation.moduleId)) {
-      pushError(`${instancePath}/moduleId`, 'must be non-empty string');
-    }
-    if (!isNonEmptyString(operation.sourceRelativePath)) {
-      pushError(`${instancePath}/sourceRelativePath`, 'must be non-empty string');
-    }
-    if (!isNonEmptyString(operation.destinationPath)) {
-      pushError(`${instancePath}/destinationPath`, 'must be non-empty string');
-    }
-    if (!isNonEmptyString(operation.strategy)) {
-      pushError(`${instancePath}/strategy`, 'must be non-empty string');
-    }
-    if (!isNonEmptyString(operation.ownership)) {
-      pushError(`${instancePath}/ownership`, 'must be non-empty string');
-    }
-    if (typeof operation.scaffoldOnly !== 'boolean') {
-      pushError(`${instancePath}/scaffoldOnly`, 'must be boolean');
-    }
+    validateOperation(operation, instancePath, pushError);
   }
 }
 

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -318,6 +318,24 @@ function registerZedContextServers(targetPath, bins) {
   return true;
 }
 
+const FORMAT_HANDLERS = {
+  'json': registerJson,
+  'toml': registerToml,
+  'continue-yaml': registerContinueYaml,
+  'zed-context-servers': registerZedContextServers,
+};
+
+function registerTarget(target, bins, onRegister, onWarn) {
+  const handler = FORMAT_HANDLERS[target.format];
+  if (!handler) return;
+  try {
+    const registered = handler(target.path, bins);
+    if (registered && onRegister) onRegister(target);
+  } catch (err) {
+    if (onWarn) onWarn(target, err);
+  }
+}
+
 /**
  * Walks every gated target for homeDir and registers egc-guardian /
  * egc-memory into whichever tools are actually installed. Callbacks let the
@@ -334,21 +352,7 @@ function registerMcpServers(homeDir, bins, callbacks = {}) {
       if (onSkip) onSkip(target);
       continue;
     }
-    try {
-      let registered = false;
-      if (target.format === 'json') {
-        registered = registerJson(target.path, bins);
-      } else if (target.format === 'toml') {
-        registered = registerToml(target.path, bins);
-      } else if (target.format === 'continue-yaml') {
-        registered = registerContinueYaml(target.path, bins);
-      } else if (target.format === 'zed-context-servers') {
-        registered = registerZedContextServers(target.path, bins);
-      }
-      if (registered && onRegister) onRegister(target);
-    } catch (err) {
-      if (onWarn) onWarn(target, err);
-    }
+    registerTarget(target, bins, onRegister, onWarn);
   }
 
   return targets;

--- a/scripts/lib/orchestration-session.js
+++ b/scripts/lib/orchestration-session.js
@@ -55,6 +55,15 @@ function parseBullets(section) {
     .map(line => stripCodeTicks(line.replace(/^- /, '').trim()));
 }
 
+const STATUS_FIELD_MAP = {
+  state: 'state',
+  updated: 'updated',
+  branch: 'branch',
+  worktree: 'worktree',
+  taskfile: 'taskFile',
+  handofffile: 'handoffFile',
+};
+
 function parseWorkerStatus(content) {
   const status = {
     state: null,
@@ -71,19 +80,11 @@ function parseWorkerStatus(content) {
 
   for (const line of content.split('\n')) {
     const match = line.match(/^- ([A-Za-z ]+):\s*(.+)$/);
-    if (!match) {
-      continue;
-    }
+    if (!match) continue;
 
     const key = match[1].trim().toLowerCase().replace(/\s+/g, '');
-    const value = stripCodeTicks(match[2]);
-
-    if (key === 'state') status.state = value;
-    if (key === 'updated') status.updated = value;
-    if (key === 'branch') status.branch = value;
-    if (key === 'worktree') status.worktree = value;
-    if (key === 'taskfile') status.taskFile = value;
-    if (key === 'handofffile') status.handoffFile = value;
+    const field = STATUS_FIELD_MAP[key];
+    if (field) status[field] = stripCodeTicks(match[2]);
   }
 
   return status;

--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -402,6 +402,37 @@ function getElixirDeps(projectDir) {
   }
 }
 
+const FRONTEND_SIGNALS = ['react', 'vue', 'angular', 'svelte', 'nextjs', 'nuxt', 'astro', 'remix'];
+const BACKEND_SIGNALS = ['django', 'fastapi', 'flask', 'express', 'nestjs', 'rails', 'spring', 'laravel', 'phoenix', 'gin', 'echo', 'actix', 'axum'];
+
+function buildDepMap(projectDir) {
+  return {
+    python: getPythonDeps(projectDir),
+    typescript: getPackageJsonDeps(projectDir),
+    javascript: getPackageJsonDeps(projectDir),
+    golang: getGoDeps(projectDir),
+    rust: getRustDeps(projectDir),
+    php: getComposerDeps(projectDir),
+    elixir: getElixirDeps(projectDir),
+    dart: getDartDeps(projectDir),
+    cpp: getCppDeps(projectDir),
+  };
+}
+
+function hasDepMatch(rule, depMap) {
+  if (rule.packageKeys.length === 0) return false;
+  const depList = depMap[rule.language] || [];
+  return rule.packageKeys.some(key => depList.some(dep => dep.toLowerCase().includes(key.toLowerCase())));
+}
+
+function determinePrimary(frameworks, languages) {
+  let primary = frameworks.length > 0 ? frameworks[0] : (languages.length > 0 ? languages[0] : 'unknown');
+  if (frameworks.some(f => FRONTEND_SIGNALS.includes(f)) && frameworks.some(f => BACKEND_SIGNALS.includes(f))) {
+    primary = 'fullstack';
+  }
+  return primary;
+}
+
 /**
  * Detect project languages and frameworks
  * @param {string} [projectDir] - Project directory (defaults to cwd)
@@ -412,94 +443,30 @@ function detectProjectType(projectDir) {
   const languages = [];
   const frameworks = [];
 
-  // Step 1: Detect languages
   for (const rule of LANGUAGE_RULES) {
     const hasMarker = rule.markers.some(m => fileExists(projectDir, m));
     const hasExt = rule.extensions.length > 0 && hasFileWithExtension(projectDir, rule.extensions);
-
-    if (hasMarker || hasExt) {
-      languages.push(rule.type);
-    }
+    if (hasMarker || hasExt) languages.push(rule.type);
   }
 
-  // Deduplicate: if both typescript and javascript detected, keep typescript
   if (languages.includes('typescript') && languages.includes('javascript')) {
     const idx = languages.indexOf('javascript');
     if (idx !== -1) languages.splice(idx, 1);
   }
 
-  // Step 2: Detect frameworks based on markers and dependencies
-  const npmDeps = getPackageJsonDeps(projectDir);
-  const pyDeps = getPythonDeps(projectDir);
-  const goDeps = getGoDeps(projectDir);
-  const rustDeps = getRustDeps(projectDir);
-  const composerDeps = getComposerDeps(projectDir);
-  const elixirDeps = getElixirDeps(projectDir);
-  const dartDeps = getDartDeps(projectDir);
-  const cppDeps = getCppDeps(projectDir);
+  const depMap = buildDepMap(projectDir);
 
   for (const rule of FRAMEWORK_RULES) {
     const hasMarker = rule.markers.some(m => fileExists(projectDir, m));
-
-    let hasDep = false;
-    if (rule.packageKeys.length > 0) {
-      let depList = [];
-      switch (rule.language) {
-        case 'python':
-          depList = pyDeps;
-          break;
-        case 'typescript':
-        case 'javascript':
-          depList = npmDeps;
-          break;
-        case 'golang':
-          depList = goDeps;
-          break;
-        case 'rust':
-          depList = rustDeps;
-          break;
-        case 'php':
-          depList = composerDeps;
-          break;
-        case 'elixir':
-          depList = elixirDeps;
-          break;
-        case 'dart':
-          depList = dartDeps;
-          break;
-        case 'cpp':
-          depList = cppDeps;
-          break;
-      }
-      hasDep = rule.packageKeys.some(key => depList.some(dep => dep.toLowerCase().includes(key.toLowerCase())));
-    }
-
-    if (hasMarker || hasDep) {
+    if (hasMarker || hasDepMatch(rule, depMap)) {
       frameworks.push(rule.framework);
     }
-  }
-
-  // Step 3: Determine primary type
-  let primary = 'unknown';
-  if (frameworks.length > 0) {
-    primary = frameworks[0];
-  } else if (languages.length > 0) {
-    primary = languages[0];
-  }
-
-  const frontendSignals = ['react', 'vue', 'angular', 'svelte', 'nextjs', 'nuxt', 'astro', 'remix'];
-  const backendSignals = ['django', 'fastapi', 'flask', 'express', 'nestjs', 'rails', 'spring', 'laravel', 'phoenix', 'gin', 'echo', 'actix', 'axum'];
-  const hasFrontend = frameworks.some(f => frontendSignals.includes(f));
-  const hasBackend = frameworks.some(f => backendSignals.includes(f));
-
-  if (hasFrontend && hasBackend) {
-    primary = 'fullstack';
   }
 
   return {
     languages,
     frameworks,
-    primary,
+    primary: determinePrimary(frameworks, languages),
     projectDir
   };
 }

--- a/scripts/lib/resolve-egc-root.js
+++ b/scripts/lib/resolve-egc-root.js
@@ -35,14 +35,48 @@ const PLUGIN_ROOT_SEGMENTS = [
  *                                    contains EGC scripts. Default: 'scripts/lib/utils.js'
  * @returns {string} Resolved EGC root path
  */
-function resolveEGCRoot(options = {}) {
+function getEnvRoot(options) {
   const envRoot = options.envRoot !== undefined
     ? options.envRoot
     : (process.env.EGC_PLUGIN_ROOT || process.env.ECC_PLUGIN_ROOT || process.env.GEMINI_PLUGIN_ROOT || '');
+  return envRoot && envRoot.trim() ? envRoot.trim() : null;
+}
 
-  if (envRoot && envRoot.trim()) {
-    return envRoot.trim();
+function findInOrgDir(orgPath, probe) {
+  let versionDirs;
+  try {
+    versionDirs = fs.readdirSync(orgPath, { withFileTypes: true });
+  } catch {
+    return null;
   }
+  for (const verEntry of versionDirs) {
+    if (!verEntry.isDirectory()) continue;
+    const candidate = path.join(orgPath, verEntry.name);
+    if (fs.existsSync(path.join(candidate, probe))) return candidate;
+  }
+  return null;
+}
+
+function findInPluginCache(claudeDir, probe) {
+  try {
+    for (const slug of PLUGIN_CACHE_SLUGS) {
+      const cacheBase = path.join(claudeDir, 'plugins', 'cache', slug);
+      const orgDirs = fs.readdirSync(cacheBase, { withFileTypes: true });
+      for (const orgEntry of orgDirs) {
+        if (!orgEntry.isDirectory()) continue;
+        const found = findInOrgDir(path.join(cacheBase, orgEntry.name), probe);
+        if (found) return found;
+      }
+    }
+  } catch {
+    // Plugin cache doesn't exist or isn't readable: continue to fallback
+  }
+  return null;
+}
+
+function resolveEGCRoot(options = {}) {
+  const envRoot = getEnvRoot(options);
+  if (envRoot) return envRoot;
 
   const homeDir = options.homeDir || os.homedir();
   const claudeDir = path.join(homeDir, '.gemini');
@@ -55,46 +89,15 @@ function resolveEGCRoot(options = {}) {
 
   // Exact legacy plugin install locations. These preserve backwards
   // compatibility without scanning arbitrary plugin trees.
-  const legacyPluginRoots = PLUGIN_ROOT_SEGMENTS.map((segments) =>
-    path.join(claudeDir, 'plugins', ...segments)
-  );
-
-  for (const candidate of legacyPluginRoots) {
-    if (fs.existsSync(path.join(candidate, probe))) {
-      return candidate;
-    }
+  for (const segments of PLUGIN_ROOT_SEGMENTS) {
+    const candidate = path.join(claudeDir, 'plugins', ...segments);
+    if (fs.existsSync(path.join(candidate, probe))) return candidate;
   }
 
   // Plugin cache: Gemini Code stores marketplace plugins under
   // ~/.gemini/plugins/cache/<plugin-name>/<org>/<version>/
-  try {
-    for (const slug of PLUGIN_CACHE_SLUGS) {
-      const cacheBase = path.join(claudeDir, 'plugins', 'cache', slug);
-      const orgDirs = fs.readdirSync(cacheBase, { withFileTypes: true });
-
-      for (const orgEntry of orgDirs) {
-        if (!orgEntry.isDirectory()) continue;
-        const orgPath = path.join(cacheBase, orgEntry.name);
-
-        let versionDirs;
-        try {
-          versionDirs = fs.readdirSync(orgPath, { withFileTypes: true });
-        } catch {
-          continue;
-        }
-
-        for (const verEntry of versionDirs) {
-          if (!verEntry.isDirectory()) continue;
-          const candidate = path.join(orgPath, verEntry.name);
-          if (fs.existsSync(path.join(candidate, probe))) {
-            return candidate;
-          }
-        }
-      }
-    }
-  } catch {
-    // Plugin cache doesn't exist or isn't readable: continue to fallback
-  }
+  const cacheFound = findInPluginCache(claudeDir, probe);
+  if (cacheFound) return cacheFound;
 
   return claudeDir;
 }

--- a/scripts/lib/session-manager.js
+++ b/scripts/lib/session-manager.js
@@ -68,68 +68,69 @@ function getSessionPath(filename) {
   return path.join(getSessionsDir(), filename);
 }
 
-function getSessionCandidates(options = {}) {
-  const {
-    date = null,
-    search = null
-  } = options;
+function tryReadDir(sessionsDir) {
+  try {
+    return fs.readdirSync(sessionsDir, { withFileTypes: true });
+  } catch (error) {
+    log(`[SessionManager] Error reading sessions directory ${sessionsDir}: ${error.message}`);
+    return null;
+  }
+}
 
+function tryStatFile(sessionPath) {
+  try {
+    return fs.statSync(sessionPath);
+  } catch (error) {
+    log(`[SessionManager] Error stating session ${sessionPath}: ${error.message}`);
+    return null;
+  }
+}
+
+function collectCandidatesFromDir(sessionsDir, date, search) {
+  const collected = [];
+  if (!fs.existsSync(sessionsDir)) return collected;
+
+  const entries = tryReadDir(sessionsDir);
+  if (!entries) return collected;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
+
+    const metadata = parseSessionFilename(entry.name);
+    if (!metadata) continue;
+    if (date && metadata.date !== date) continue;
+    if (search && !metadata.shortId.includes(search)) continue;
+
+    const sessionPath = path.join(sessionsDir, entry.name);
+    const stats = tryStatFile(sessionPath);
+    if (!stats) continue;
+
+    collected.push({
+      ...metadata,
+      sessionPath,
+      hasContent: stats.size > 0,
+      size: stats.size,
+      modifiedTime: stats.mtime,
+      createdTime: stats.birthtime || stats.ctime
+    });
+  }
+  return collected;
+}
+
+function getSessionCandidates(options = {}) {
+  const { date = null, search = null } = options;
   const candidates = [];
 
   for (const sessionsDir of getSessionSearchDirs()) {
-    if (!fs.existsSync(sessionsDir)) {
-      continue;
-    }
-
-    let entries;
-    try {
-      entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
-    } catch (error) {
-      log(`[SessionManager] Error reading sessions directory ${sessionsDir}: ${error.message}`);
-      continue;
-    }
-
-    for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
-
-      const filename = entry.name;
-      const metadata = parseSessionFilename(filename);
-
-      if (!metadata) continue;
-      if (date && metadata.date !== date) continue;
-      if (search && !metadata.shortId.includes(search)) continue;
-
-      const sessionPath = path.join(sessionsDir, filename);
-
-      let stats;
-      try {
-        stats = fs.statSync(sessionPath);
-      } catch (error) {
-        log(`[SessionManager] Error stating session ${sessionPath}: ${error.message}`);
-        continue;
-      }
-
-      candidates.push({
-        ...metadata,
-        sessionPath,
-        hasContent: stats.size > 0,
-        size: stats.size,
-        modifiedTime: stats.mtime,
-        createdTime: stats.birthtime || stats.ctime
-      });
-    }
+    candidates.push(...collectCandidatesFromDir(sessionsDir, date, search));
   }
 
-  const deduped = [];
   const seenFilenames = new Set();
-
-  for (const session of candidates) {
-    if (seenFilenames.has(session.filename)) {
-      continue;
-    }
-    seenFilenames.add(session.filename);
-    deduped.push(session);
-  }
+  const deduped = candidates.filter(s => {
+    if (seenFilenames.has(s.filename)) return false;
+    seenFilenames.add(s.filename);
+    return true;
+  });
 
   deduped.sort((a, b) => b.modifiedTime - a.modifiedTime);
   return deduped;
@@ -163,44 +164,36 @@ function sessionMatchesId(metadata, normalizedSessionId) {
   return shortIdMatch || filenameMatch || noIdMatch;
 }
 
+function collectMatchingFromDir(sessionsDir, normalizedSessionId, seenFilenames) {
+  const found = [];
+  if (!fs.existsSync(sessionsDir)) return found;
+
+  const entries = tryReadDir(sessionsDir);
+  if (!entries) return found;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
+
+    const metadata = parseSessionFilename(entry.name);
+    if (!metadata || !sessionMatchesId(metadata, normalizedSessionId)) continue;
+    if (seenFilenames.has(metadata.filename)) continue;
+
+    const sessionPath = path.join(sessionsDir, metadata.filename);
+    const sessionRecord = buildSessionRecord(sessionPath, metadata);
+    if (!sessionRecord) continue;
+
+    seenFilenames.add(metadata.filename);
+    found.push(sessionRecord);
+  }
+  return found;
+}
+
 function getMatchingSessionCandidates(normalizedSessionId) {
-  const matches = [];
   const seenFilenames = new Set();
+  const matches = [];
 
   for (const sessionsDir of getSessionSearchDirs()) {
-    if (!fs.existsSync(sessionsDir)) {
-      continue;
-    }
-
-    let entries;
-    try {
-      entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
-    } catch (error) {
-      log(`[SessionManager] Error reading sessions directory ${sessionsDir}: ${error.message}`);
-      continue;
-    }
-
-    for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
-
-      const metadata = parseSessionFilename(entry.name);
-      if (!metadata || !sessionMatchesId(metadata, normalizedSessionId)) {
-        continue;
-      }
-
-      if (seenFilenames.has(metadata.filename)) {
-        continue;
-      }
-
-      const sessionPath = path.join(sessionsDir, metadata.filename);
-      const sessionRecord = buildSessionRecord(sessionPath, metadata);
-      if (!sessionRecord) {
-        continue;
-      }
-
-      seenFilenames.add(metadata.filename);
-      matches.push(sessionRecord);
-    }
+    matches.push(...collectMatchingFromDir(sessionsDir, normalizedSessionId, seenFilenames));
   }
 
   matches.sort((a, b) => b.modifiedTime - a.modifiedTime);
@@ -221,6 +214,18 @@ function getSessionContent(sessionPath) {
  * @param {string} content - Session markdown content
  * @returns {object} Parsed metadata
  */
+function extractField(content, regex, group = 1) {
+  const m = content.match(regex);
+  return m ? m[group].trim() : null;
+}
+
+function extractListItems(content, sectionRegex, itemRegex, strip) {
+  const section = content.match(sectionRegex);
+  if (!section) return [];
+  const items = section[1].match(itemRegex);
+  return items ? items.map(item => item.replace(strip, '').trim()) : [];
+}
+
 function parseSessionMetadata(content) {
   const metadata = {
     title: null,
@@ -238,66 +243,32 @@ function parseSessionMetadata(content) {
 
   if (!content) return metadata;
 
-  const titleMatch = content.match(/^#\s+(.+)$/m);
-  if (titleMatch) {
-    metadata.title = titleMatch[1].trim();
-  }
+  metadata.title = extractField(content, /^#\s+(.+)$/m);
+  metadata.date = extractField(content, /\*\*Date:\*\*\s*(\d{4}-\d{2}-\d{2})/);
+  metadata.started = extractField(content, /\*\*Started:\*\*\s*([\d:]+)/);
+  metadata.lastUpdated = extractField(content, /\*\*Last Updated:\*\*\s*([\d:]+)/);
+  metadata.project = extractField(content, /\*\*Project:\*\*\s*(.+)$/m);
+  metadata.branch = extractField(content, /\*\*Branch:\*\*\s*(.+)$/m);
+  metadata.worktree = extractField(content, /\*\*Worktree:\*\*\s*(.+)$/m);
 
-  const dateMatch = content.match(/\*\*Date:\*\*\s*(\d{4}-\d{2}-\d{2})/);
-  if (dateMatch) {
-    metadata.date = dateMatch[1];
-  }
-
-  const startedMatch = content.match(/\*\*Started:\*\*\s*([\d:]+)/);
-  if (startedMatch) {
-    metadata.started = startedMatch[1];
-  }
-
-  const updatedMatch = content.match(/\*\*Last Updated:\*\*\s*([\d:]+)/);
-  if (updatedMatch) {
-    metadata.lastUpdated = updatedMatch[1];
-  }
-
-  const projectMatch = content.match(/\*\*Project:\*\*\s*(.+)$/m);
-  if (projectMatch) {
-    metadata.project = projectMatch[1].trim();
-  }
-
-  const branchMatch = content.match(/\*\*Branch:\*\*\s*(.+)$/m);
-  if (branchMatch) {
-    metadata.branch = branchMatch[1].trim();
-  }
-
-  const worktreeMatch = content.match(/\*\*Worktree:\*\*\s*(.+)$/m);
-  if (worktreeMatch) {
-    metadata.worktree = worktreeMatch[1].trim();
-  }
-
-  const completedSection = content.match(/### Completed\s*\n([\s\S]*?)(?=###|\n\n|$)/);
-  if (completedSection) {
-    const items = completedSection[1].match(/- \[x\]\s*(.+)/g);
-    if (items) {
-      metadata.completed = items.map(item => item.replace(/- \[x\]\s*/, '').trim());
-    }
-  }
-
-  const progressSection = content.match(/### In Progress\s*\n([\s\S]*?)(?=###|\n\n|$)/);
-  if (progressSection) {
-    const items = progressSection[1].match(/- \[ \]\s*(.+)/g);
-    if (items) {
-      metadata.inProgress = items.map(item => item.replace(/- \[ \]\s*/, '').trim());
-    }
-  }
+  metadata.completed = extractListItems(
+    content,
+    /### Completed\s*\n([\s\S]*?)(?=###|\n\n|$)/,
+    /- \[x\]\s*(.+)/g,
+    /- \[x\]\s*/
+  );
+  metadata.inProgress = extractListItems(
+    content,
+    /### In Progress\s*\n([\s\S]*?)(?=###|\n\n|$)/,
+    /- \[ \]\s*(.+)/g,
+    /- \[ \]\s*/
+  );
 
   const notesSection = content.match(/### Notes for Next Session\s*\n([\s\S]*?)(?=###|\n\n|$)/);
-  if (notesSection) {
-    metadata.notes = notesSection[1].trim();
-  }
+  if (notesSection) metadata.notes = notesSection[1].trim();
 
   const contextSection = content.match(/### Context to Load\s*\n```\n([\s\S]*?)```/);
-  if (contextSection) {
-    metadata.context = contextSection[1].trim();
-  }
+  if (contextSection) metadata.context = contextSection[1].trim();
 
   return metadata;
 }

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -4,6 +4,41 @@ function pushSegment(current, segments) {
   if (current.trim()) segments.push(current.trim());
 }
 
+function handleInsideQuotes(ch, i, command, quote) {
+  if (ch === '\\' && i + 1 < command.length) {
+    return { chars: ch + command[i + 1], advance: 1, closeQuote: false };
+  }
+  return { chars: ch, advance: 0, closeQuote: ch === quote };
+}
+
+function handleEscape(ch, i, command) {
+  if (ch === '\\' && i + 1 < command.length) {
+    return { chars: ch + command[i + 1], advance: 1, handled: true };
+  }
+  return { handled: false };
+}
+
+function handleDoubleOperator(ch, next, current, segments) {
+  if (ch === '&' && next === '&') {
+    pushSegment(current, segments);
+    return { current: '', advance: 1, handled: true };
+  }
+  if (ch === '|' && next === '|') {
+    pushSegment(current, segments);
+    return { current: '', advance: 1, handled: true };
+  }
+  return { handled: false };
+}
+
+function handleSingleAmpersand(ch, next, prev, current, segments) {
+  if (ch !== '&') return { handled: false };
+  if (next === '>' || prev === '>') {
+    return { current: current + ch, handled: true };
+  }
+  pushSegment(current, segments);
+  return { current: '', handled: true };
+}
+
 /**
  * Split a shell command into segments by operators (&&, ||, ;, &)
  * while respecting quoting (single/double) and escaped characters.
@@ -17,26 +52,21 @@ function splitShellSegments(command) {
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
 
-    // Inside quotes: handle escapes and closing quote
     if (quote) {
-      if (ch === '\\' && i + 1 < command.length) {
-        current += ch + command[i + 1];
-        i++;
-        continue;
-      }
-      if (ch === quote) quote = null;
-      current += ch;
+      const r = handleInsideQuotes(ch, i, command, quote);
+      current += r.chars;
+      i += r.advance;
+      if (r.closeQuote) quote = null;
       continue;
     }
 
-    // Backslash escape outside quotes
-    if (ch === '\\' && i + 1 < command.length) {
-      current += ch + command[i + 1];
-      i++;
+    const esc = handleEscape(ch, i, command);
+    if (esc.handled) {
+      current += esc.chars;
+      i += esc.advance;
       continue;
     }
 
-    // Opening quote
     if (ch === '"' || ch === "'") {
       quote = ch;
       current += ch;
@@ -46,37 +76,22 @@ function splitShellSegments(command) {
     const next = command[i + 1] || '';
     const prev = i > 0 ? command[i - 1] : '';
 
-    // && operator
-    if (ch === '&' && next === '&') {
-      pushSegment(current, segments);
-      current = '';
-      i++;
+    const dbl = handleDoubleOperator(ch, next, current, segments);
+    if (dbl.handled) {
+      current = dbl.current;
+      i += dbl.advance;
       continue;
     }
 
-    // || operator
-    if (ch === '|' && next === '|') {
-      pushSegment(current, segments);
-      current = '';
-      i++;
-      continue;
-    }
-
-    // ; separator
     if (ch === ';') {
       pushSegment(current, segments);
       current = '';
       continue;
     }
 
-    // Single &: but skip redirection patterns (&>, >&, digit>&)
-    if (ch === '&' && next !== '&') {
-      if (next === '>' || prev === '>') {
-        current += ch;
-        continue;
-      }
-      pushSegment(current, segments);
-      current = '';
+    const amp = handleSingleAmpersand(ch, next, prev, current, segments);
+    if (amp.handled) {
+      current = amp.current;
       continue;
     }
 

--- a/scripts/lib/skill-evolution/dashboard.js
+++ b/scripts/lib/skill-evolution/dashboard.js
@@ -219,22 +219,16 @@ function renderFailureClusterPanel(records, options = {}) {
   };
 }
 
-function renderAmendmentPanel(skillsById, options = {}) {
-  const width = options.width || DEFAULT_PANEL_WIDTH;
+function collectPendingAmendments(skillsById) {
   const amendments = [];
-
   for (const [skillId, skill] of skillsById) {
-    if (!skill.skill_dir) {
-      continue;
-    }
-
+    if (!skill.skill_dir) continue;
     const log = versioning.getEvolutionLog(skill.skill_dir, 'amendments');
     for (const entry of log) {
       const status = typeof entry.status === 'string' ? entry.status : null;
       const isPending = status
         ? health.PENDING_AMENDMENT_STATUSES.has(status)
         : entry.event === 'proposal';
-
       if (isPending) {
         amendments.push({
           skill_id: skillId,
@@ -245,12 +239,17 @@ function renderAmendmentPanel(skillsById, options = {}) {
       }
     }
   }
-
   amendments.sort((a, b) => {
     const timeA = a.created_at ? Date.parse(a.created_at) : 0;
     const timeB = b.created_at ? Date.parse(b.created_at) : 0;
     return timeB - timeA;
   });
+  return amendments;
+}
+
+function renderAmendmentPanel(skillsById, options = {}) {
+  const width = options.width || DEFAULT_PANEL_WIDTH;
+  const amendments = collectPendingAmendments(skillsById);
 
   const lines = [];
   if (amendments.length === 0) {
@@ -263,7 +262,6 @@ function renderAmendmentPanel(skillsById, options = {}) {
       const time = amendment.created_at ? amendment.created_at.slice(0, 19) : '-';
       lines.push(`${name} ${event} ${status} ${time}`);
     }
-
     lines.push('');
     lines.push(`${amendments.length} amendment${amendments.length === 1 ? '' : 's'} pending review`);
   }
@@ -274,28 +272,23 @@ function renderAmendmentPanel(skillsById, options = {}) {
   };
 }
 
-function renderVersionTimelinePanel(skillsById, options = {}) {
-  const width = options.width || DEFAULT_PANEL_WIDTH;
+function buildReasonMap(skillDir) {
+  const reasonByVersion = new Map();
+  for (const entry of versioning.getEvolutionLog(skillDir, 'amendments')) {
+    if (entry.version && entry.reason) {
+      reasonByVersion.set(entry.version, entry.reason);
+    }
+  }
+  return reasonByVersion;
+}
+
+function collectSkillVersionHistory(skillsById) {
   const skillVersions = [];
-
   for (const [skillId, skill] of skillsById) {
-    if (!skill.skill_dir) {
-      continue;
-    }
-
+    if (!skill.skill_dir) continue;
     const versions = versioning.listVersions(skill.skill_dir);
-    if (versions.length === 0) {
-      continue;
-    }
-
-    const amendmentLog = versioning.getEvolutionLog(skill.skill_dir, 'amendments');
-    const reasonByVersion = new Map();
-    for (const entry of amendmentLog) {
-      if (entry.version && entry.reason) {
-        reasonByVersion.set(entry.version, entry.reason);
-      }
-    }
-
+    if (versions.length === 0) continue;
+    const reasonByVersion = buildReasonMap(skill.skill_dir);
     skillVersions.push({
       skill_id: skillId,
       versions: versions.map(v => ({
@@ -305,8 +298,13 @@ function renderVersionTimelinePanel(skillsById, options = {}) {
       })),
     });
   }
-
   skillVersions.sort((a, b) => a.skill_id.localeCompare(b.skill_id));
+  return skillVersions;
+}
+
+function renderVersionTimelinePanel(skillsById, options = {}) {
+  const width = options.width || DEFAULT_PANEL_WIDTH;
+  const skillVersions = collectSkillVersionHistory(skillsById);
 
   const lines = [];
   if (skillVersions.length === 0) {

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -161,25 +161,22 @@ function parseStateDocument(content) {
   return { header, sections };
 }
 
-function consolidateSection(section, now, stats) {
-  const bodyLines = section.lines.filter(line => line.trim() !== '');
-
-  if (VERBATIM_SECTIONS.has(section.title) || bodyLines.some(line => !line.startsWith('- '))) {
-    const seen = new Set();
-    const kept = [];
-    for (const line of bodyLines) {
-      const key = normalizeKey(line.replace(/^- /, ''));
-      if (seen.has(key)) {
-        stats.duplicatesRemoved += 1;
-        continue;
-      }
-      seen.add(key);
-      kept.push(line);
-    }
-    return kept;
-  }
-
+function deduplicateLines(bodyLines, stats) {
   const seen = new Set();
+  const kept = [];
+  for (const line of bodyLines) {
+    const key = normalizeKey(line.replace(/^- /, ''));
+    if (seen.has(key)) {
+      stats.duplicatesRemoved += 1;
+      continue;
+    }
+    seen.add(key);
+    kept.push(line);
+  }
+  return kept;
+}
+
+function bucketLines(bodyLines, now, seen, stats) {
   const working = [];
   const episodicByWeek = new Map();
   const semantic = [];
@@ -205,6 +202,38 @@ function consolidateSection(section, now, stats) {
       semantic.push(coreFact(text));
     }
   }
+  return { working, episodicByWeek, semantic };
+}
+
+function buildSemanticOutput(semantic, stats) {
+  const out = [];
+  const seen = new Set();
+  const deduped = [];
+  for (const fact of semantic) {
+    const key = normalizeKey(fact);
+    if (!fact || seen.has(key)) {
+      if (fact) stats.duplicatesRemoved += 1;
+      continue;
+    }
+    seen.add(key);
+    deduped.push(fact);
+  }
+  for (const group of chunk(deduped, SEMANTIC_FACTS_PER_LINE)) {
+    out.push(`- ${group.join('; ')}`);
+  }
+  stats.semanticFacts += deduped.length;
+  return out;
+}
+
+function consolidateSection(section, now, stats) {
+  const bodyLines = section.lines.filter(line => line.trim() !== '');
+
+  if (VERBATIM_SECTIONS.has(section.title) || bodyLines.some(line => !line.startsWith('- '))) {
+    return deduplicateLines(bodyLines, stats);
+  }
+
+  const seen = new Set();
+  const { working, episodicByWeek, semantic } = bucketLines(bodyLines, now, seen, stats);
 
   const output = [...working];
 
@@ -214,22 +243,7 @@ function consolidateSection(section, now, stats) {
     stats.episodicWeeks += 1;
   }
 
-  const semanticDeduped = [];
-  const semanticSeen = new Set();
-  for (const fact of semantic) {
-    const key = normalizeKey(fact);
-    if (!fact || semanticSeen.has(key)) {
-      if (fact) stats.duplicatesRemoved += 1;
-      continue;
-    }
-    semanticSeen.add(key);
-    semanticDeduped.push(fact);
-  }
-
-  for (const group of chunk(semanticDeduped, SEMANTIC_FACTS_PER_LINE)) {
-    output.push(`- ${group.join('; ')}`);
-  }
-  stats.semanticFacts += semanticDeduped.length;
+  output.push(...buildSemanticOutput(semantic, stats));
 
   return output;
 }

--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -423,6 +423,33 @@ function cleanupExisting(plan) {
   }
 }
 
+function tryRun(fn, errors) {
+  try {
+    fn();
+  } catch (error) {
+    errors.push(error.message);
+  }
+}
+
+function rollbackSingleWorker(workerPlan, repoRoot, runCommandImpl, listWorktreesImpl, branchExistsImpl, errors) {
+  const expectedWorktreePath = canonicalizePath(workerPlan.worktreePath);
+  const existingWorktree = listWorktreesImpl(repoRoot).find(
+    worktree => worktree.canonicalPath === expectedWorktreePath
+  );
+
+  if (existingWorktree) {
+    tryRun(() => runCommandImpl('git', ['worktree', 'remove', '--force', existingWorktree.listedPath], { cwd: repoRoot }), errors);
+  } else if (fs.existsSync(workerPlan.worktreePath)) {
+    fs.rmSync(workerPlan.worktreePath, { force: true, recursive: true });
+  }
+
+  tryRun(() => runCommandImpl('git', ['worktree', 'prune', '--expire', 'now'], { cwd: repoRoot }), errors);
+
+  if (branchExistsImpl(repoRoot, workerPlan.branchName)) {
+    tryRun(() => runCommandImpl('git', ['branch', '-D', workerPlan.branchName], { cwd: repoRoot }), errors);
+  }
+}
+
 function rollbackCreatedResources(plan, createdState, runtime = {}) {
   const runCommandImpl = runtime.runCommand || runCommand;
   const listWorktreesImpl = runtime.listWorktrees || listWorktrees;
@@ -430,44 +457,11 @@ function rollbackCreatedResources(plan, createdState, runtime = {}) {
   const errors = [];
 
   if (createdState.sessionCreated) {
-    try {
-      runCommandImpl('tmux', ['kill-session', '-t', plan.sessionName], { cwd: plan.repoRoot });
-    } catch (error) {
-      errors.push(error.message);
-    }
+    tryRun(() => runCommandImpl('tmux', ['kill-session', '-t', plan.sessionName], { cwd: plan.repoRoot }), errors);
   }
 
   for (const workerPlan of [...createdState.workerPlans].reverse()) {
-    const expectedWorktreePath = canonicalizePath(workerPlan.worktreePath);
-    const existingWorktree = listWorktreesImpl(plan.repoRoot).find(
-      worktree => worktree.canonicalPath === expectedWorktreePath
-    );
-
-    if (existingWorktree) {
-      try {
-        runCommandImpl('git', ['worktree', 'remove', '--force', existingWorktree.listedPath], {
-          cwd: plan.repoRoot
-        });
-      } catch (error) {
-        errors.push(error.message);
-      }
-    } else if (fs.existsSync(workerPlan.worktreePath)) {
-      fs.rmSync(workerPlan.worktreePath, { force: true, recursive: true });
-    }
-
-    try {
-      runCommandImpl('git', ['worktree', 'prune', '--expire', 'now'], { cwd: plan.repoRoot });
-    } catch (error) {
-      errors.push(error.message);
-    }
-
-    if (branchExistsImpl(plan.repoRoot, workerPlan.branchName)) {
-      try {
-        runCommandImpl('git', ['branch', '-D', workerPlan.branchName], { cwd: plan.repoRoot });
-      } catch (error) {
-        errors.push(error.message);
-      }
-    }
+    rollbackSingleWorker(workerPlan, plan.repoRoot, runCommandImpl, listWorktreesImpl, branchExistsImpl, errors);
   }
 
   if (createdState.removeCoordinationDir && fs.existsSync(plan.coordinationDir)) {

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -330,6 +330,15 @@ function findFiles(dir, pattern, options = {}) {
     .replace(/\?/g, '.');
   const regex = new RegExp(`^${regexPattern}$`);
 
+  function collectIfInAge(fullPath, stats) {
+    if (maxAge === null) {
+      results.push({ path: fullPath, mtime: stats.mtimeMs });
+      return;
+    }
+    const ageInDays = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60 * 24);
+    if (ageInDays <= maxAge) results.push({ path: fullPath, mtime: stats.mtimeMs });
+  }
+
   function searchDir(currentDir) {
     try {
       const entries = fs.readdirSync(currentDir, { withFileTypes: true });
@@ -342,17 +351,9 @@ function findFiles(dir, pattern, options = {}) {
           try {
             stats = fs.statSync(fullPath);
           } catch {
-            continue; // File deleted between readdir and stat
+            continue;
           }
-
-          if (maxAge !== null) {
-            const ageInDays = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60 * 24);
-            if (ageInDays <= maxAge) {
-              results.push({ path: fullPath, mtime: stats.mtimeMs });
-            }
-          } else {
-            results.push({ path: fullPath, mtime: stats.mtimeMs });
-          }
+          collectIfInAge(fullPath, stats);
         } else if (entry.isDirectory() && recursive) {
           searchDir(fullPath);
         }

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -69,50 +69,54 @@ function extractEgcBlock(content) {
   return content.slice(start + EGC_START.length, end).trim();
 }
 
-function parseBlockToStateContent(block, updatedIso) {
-  const lines = ['# Project State'];
-  if (updatedIso) lines.push(`updated: ${updatedIso}`);
+function processH2Line(h2, state) {
+  const key = h2[1].trim();
+  const val = h2[2].trim();
+  if (key === 'Context') { state.context = val; state.section = 'context'; return true; }
+  if (key === 'Active decisions') { state.section = 'decisions'; return true; }
+  if (key === 'Next session') { state.section = 'next'; return true; }
+  return false;
+}
+
+function appendStateSection(lines, title, items, asText = false) {
+  if (!items || (Array.isArray(items) ? items.length === 0 : !items)) return;
+  lines.push(`## ${title}`);
+  if (asText) {
+    lines.push(items);
+  } else {
+    for (const item of items) lines.push(`- ${item}`);
+  }
   lines.push('');
-  let context = '';
+}
+
+function parseBlockToStateContent(block, updatedIso) {
+  const header = ['# Project State'];
+  if (updatedIso) header.push(`updated: ${updatedIso}`);
+  header.push('');
+
+  const state = { context: '', section: '' };
   const decisions = [];
   const next = [];
 
-  let section = '';
   for (const line of block.split('\n')) {
     if (line.trimStart().startsWith('<!--')) continue;
     const h2 = line.match(/^\*\*(.+?):\*\*\s*(.*)/);
-    if (h2) {
-      const key = h2[1].trim();
-      const val = h2[2].trim();
-      if (key === 'Context') { context = val; section = 'context'; continue; }
-      if (key === 'Active decisions') { section = 'decisions'; continue; }
-      if (key === 'Next session') { section = 'next'; continue; }
-    }
-    if (section === 'context' && !context && line.trim()) {
-      context = line.trim();
+    if (h2 && processH2Line(h2, state)) continue;
+
+    if (state.section === 'context' && !state.context && line.trim()) {
+      state.context = line.trim();
       continue;
     }
     const item = line.replace(/^-\s*/, '').trim();
     if (!item) continue;
-    if (section === 'decisions') decisions.push(item);
-    if (section === 'next') next.push(item);
+    if (state.section === 'decisions') decisions.push(item);
+    if (state.section === 'next') next.push(item);
   }
 
-  if (context) {
-    lines.push('## Context');
-    lines.push(context);
-    lines.push('');
-  }
-  if (decisions.length > 0) {
-    lines.push('## Active Decisions');
-    for (const d of decisions) lines.push(`- ${d}`);
-    lines.push('');
-  }
-  if (next.length > 0) {
-    lines.push('## Next Session');
-    for (const n of next) lines.push(`- ${n}`);
-    lines.push('');
-  }
+  const lines = [...header];
+  appendStateSection(lines, 'Context', state.context, true);
+  appendStateSection(lines, 'Active Decisions', decisions);
+  appendStateSection(lines, 'Next Session', next);
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Resumo

Reduz a Cognitive Complexity (SonarCloud S3776) em 15 funções de `scripts/lib/`, todas confirmadas como abaixo do limite de 15 após extração de helpers.

**Arquivos refatorados (28 issues resolvidas):**
- `shell-split.js` — CC 31 → helpers `handleInsideQuotes`, `handleEscape`, `handleDoubleOperator`, `handleSingleAmpersand`
- `session-manager.js` — CC 27/19/16 → helpers `collectCandidatesFromDir`, `collectMatchingFromDir`, `extractField`, `extractListItems`
- `watch-state.js` — CC 31 → helpers `processH2Line`, `appendStateSection`
- `resolve-egc-root.js` — CC 28 → helpers `getEnvRoot`, `findInOrgDir`, `findInPluginCache`
- `state-consolidate.js` — CC 24 → helpers `deduplicateLines`, `bucketLines`, `buildSemanticOutput`
- `skill-evolution/dashboard.js` — CC 23/22 → helpers `collectPendingAmendments`, `collectSkillVersionHistory`, `buildReasonMap`
- `claude-settings-hooks.js` — CC 21 → helpers `isMatcherGroup`, `buildNewGroup`
- `mcp-register.js` — CC 21 → lookup `FORMAT_HANDLERS`, helper `registerTarget`
- `project-detect.js` — CC 20 → helpers `buildDepMap`, `hasDepMatch`, `determinePrimary`
- `tmux-worktree-orchestrator.js` — CC 20 → helpers `tryRun`, `rollbackSingleWorker`
- `orchestration-session.js` — CC 16 → lookup `STATUS_FIELD_MAP`
- `install-state.js` — CC 18 → helpers `OPERATION_STRING_FIELDS`, `validateOperation`
- `utils.js` — CC 18 → helper `collectIfInAge`
- `agent-compress.js` — CC 17 → helpers `isSkippableLine`, `flushParagraph`
- `init-remediation.js` — CC 17 → helpers `hasDriftIssue`, `buildModuleArgs`, `buildComponentFlags`

## Estratégia

Extração de blocos lógicos (loops aninhados, condicionais, try/catch) para funções auxiliares com nomes descritivos. Nenhuma alteração de ordem de execução, side-effects ou valores de retorno.

## Plano de testes

- [x] Todos os testes unitários existentes passam (verificado arquivo a arquivo antes do commit)
- [x] 1 falha pré-existente em `mcp-register.test.js` (bug EGC-128, sem relação com estas mudanças)
- [x] Sem regressões introduzidas

Sub-issue de EGC-139.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `scripts/lib` to reduce cognitive complexity (SonarCloud S3776) across 15 functions, meeting the <15 threshold and aligning with EGC-139. Changes extract small helpers and lookup maps without altering behavior; existing tests pass.

- **Refactors**
  - Split heavy logic into helpers (e.g., `handleInsideQuotes` in `shell-split`, `collectCandidatesFromDir` in `session-manager`, `getEnvRoot`/`findInPluginCache` in `resolve-egc-root`).
  - Introduced lookups to replace conditionals (`FORMAT_HANDLERS` in `mcp-register`, `STATUS_FIELD_MAP` in `orchestration-session`, `OPERATION_STRING_FIELDS` in `install-state`).
  - Centralized parsing/aggregation helpers (`deduplicateLines`/`bucketLines` in `state-consolidate`, `processH2Line`/`appendStateSection` in `watch-state`, `buildDepMap`/`determinePrimary` in `project-detect`, `buildReasonMap` in `skill-evolution/dashboard`).

<sup>Written for commit 3abcd42369e1a2085f2125bb0f209dfae7b4adf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

