### PR TITLE
fix(sonar): node: protocol e replaceAll em scripts/ci (EGC-138 4/5)

### DIFF
--- a/scripts/ci/capability-graph.js
+++ b/scripts/ci/capability-graph.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const yaml = require('js-yaml');
 
 const ROOT = path.join(__dirname, '../..');

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -12,8 +12,8 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const ROOT = path.join(__dirname, '../..');
 const README_PATH = path.join(ROOT, 'README.md');

--- a/scripts/ci/check-unicode-safety.js
+++ b/scripts/ci/check-unicode-safety.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // EGC_UNICODE_SCAN_ROOT is canonical; ECC_UNICODE_SCAN_ROOT is the legacy bridge.
 const scanRootEnv = process.env.EGC_UNICODE_SCAN_ROOT || process.env.ECC_UNICODE_SCAN_ROOT;

--- a/scripts/ci/runtime-snapshot.js
+++ b/scripts/ci/runtime-snapshot.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { createStateStore } = require('../lib/state-store');
 const { getEGCDir } = require('../lib/utils');

--- a/scripts/ci/runtime-topology.js
+++ b/scripts/ci/runtime-topology.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 

--- a/scripts/ci/validate-agents.js
+++ b/scripts/ci/validate-agents.js
@@ -3,8 +3,8 @@
  * Validate agent markdown files have required frontmatter
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const AGENTS_DIR = path.join(__dirname, '../../agents');
 const REQUIRED_FIELDS = ['model', 'tools'];

--- a/scripts/ci/validate-commands.js
+++ b/scripts/ci/validate-commands.js
@@ -4,8 +4,8 @@
  * and have valid cross-references to other commands, agents, and skills.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const ROOT_DIR = path.join(__dirname, '../..');
 const COMMANDS_DIR = path.join(ROOT_DIR, 'commands');

--- a/scripts/ci/validate-hooks.js
+++ b/scripts/ci/validate-hooks.js
@@ -3,9 +3,9 @@
  * Validate hooks.json schema and hook entry rules.
  */
 
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
 const Ajv = require('ajv');
 
 const HOOKS_FILE = path.join(__dirname, '../../hooks/hooks.json');

--- a/scripts/ci/validate-install-manifests.js
+++ b/scripts/ci/validate-install-manifests.js
@@ -5,8 +5,8 @@
  * (~/.gemini/skills/learned, etc.) are never in manifests.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const Ajv = require('ajv');
 
 const REPO_ROOT = path.join(__dirname, '../..');

--- a/scripts/ci/validate-rules.js
+++ b/scripts/ci/validate-rules.js
@@ -3,8 +3,8 @@
  * Validate rule markdown files
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const RULES_DIR = path.join(__dirname, '../../rules');
 

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -4,8 +4,8 @@
  * from privileged events such as workflow_run or pull_request_target.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const DEFAULT_WORKFLOWS_DIR = path.join(__dirname, '../../.github/workflows');
 


### PR DESCRIPTION
## O que muda

Correções mecânicas de code smells do SonarCloud em **12 arquivos** de `scripts/ci/`, sem alteração de comportamento.

Regras aplicadas:
- **S7772** — `require('fs')` → `require('node:fs')` (e demais módulos nativos)
- **S7781** — `.replace(/literal/g, x)` → `.replaceAll('literal', x)` onde padrão é literal simples

Arquivos excluídos intencionalmente (escopo EGC-136): `validate-skill-frontmatter.js`, `validate-translation-structure.js`.

## Testes

- `eslint scripts/ci/`: 0 erros, 2 warnings pré-existentes
- `node tests/run-all.js`: 2825/2825 passed

Parte de: EGC-138 ([Squad 1/5])

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply SonarCloud cleanup in `scripts/ci`: use `node:` protocol for built-in modules and switch simple global replacements to `replaceAll`. No behavior changes; aligns with EGC-138.

- **Refactors**
  - Updated 12 files in `scripts/ci` for Sonar rules S7772 and S7781.
  - Excluded `validate-skill-frontmatter.js` and `validate-translation-structure.js` (EGC-136).
  - Checks: `eslint scripts/ci/` 0 errors; `node tests/run-all.js` 2825/2825 passed.

<sup>Written for commit 2a300320e3aff7b196c8226519729146fe62dfb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

