### PR TITLE
fix(sonar): node: protocol (EGC-138 5/5) + Python code smells (EGC-140)

### DIFF
--- a/mcp/servers/egc-guardian/src/headroom-client.ts
+++ b/mcp/servers/egc-guardian/src/headroom-client.ts
@@ -1,6 +1,6 @@
-import os from 'os';
-import fs from 'fs';
-import path from 'path';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const PROBE_TIMEOUT_MS = 3_000;
 

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -2,10 +2,10 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema, McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import path from 'path';
-import os from 'os';
-import fs from 'fs';
-import { spawnSync } from 'child_process';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { llmRoute, keywordRoute } from './llm-router.js';
 
 function hideEgcRootOnWindows(): void {

--- a/mcp/servers/egc-guardian/src/learn-writer.ts
+++ b/mcp/servers/egc-guardian/src/learn-writer.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
 

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import os from 'os';
+import path from 'node:path';
+import os from 'node:os';
 
 // Trust level tiers
 export const SAFE_READONLY = ['ls', 'cat', 'grep', 'find', 'stat', 'head', 'git'];

--- a/mcp/servers/egc-memory/src/branch-state.ts
+++ b/mcp/servers/egc-memory/src/branch-state.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
 
 export const DEFAULT_BRANCH_FILE = 'main.md';
 

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
@@ -212,7 +212,7 @@ async function runMigrations(db: Database, dbDir: string) {
   // Remove stale lock from a previous crashed process
   if (fs.existsSync(lockFile)) {
     try {
-      const storedPid = parseInt(fs.readFileSync(lockFile, 'utf-8').trim(), 10);
+      const storedPid = Number.parseInt(fs.readFileSync(lockFile, 'utf-8').trim(), 10);
       if (!isNaN(storedPid) && storedPid !== process.pid) {
         // Check if the PID is still alive (POSIX: signal 0 = probe only)
         let alive = false;
@@ -352,7 +352,7 @@ async function runMigrations(db: Database, dbDir: string) {
     }
 
     const bootRow = await db.get<{value: string}>('SELECT value FROM operational_state WHERE id = ?', ['server_boot_count']);
-    const bootCount = bootRow ? parseInt(bootRow.value, 10) + 1 : 1;
+    const bootCount = bootRow ? Number.parseInt(bootRow.value, 10) + 1 : 1;
     await db.run('INSERT OR REPLACE INTO operational_state (id, value) VALUES (?, ?)', ['server_boot_count', String(bootCount)]);
   } finally {
     try { fs.unlinkSync(lockFile); } catch(e) {

--- a/mcp/servers/egc-memory/src/patterns.ts
+++ b/mcp/servers/egc-memory/src/patterns.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 export interface RuntimeEvent {
   id: string;

--- a/mcp/servers/egc-memory/src/sync/GitBackend.ts
+++ b/mcp/servers/egc-memory/src/sync/GitBackend.ts
@@ -65,7 +65,7 @@ export class GitBackend extends SyncBackend {
     }
 
     const commitCount = await this.git.raw(['rev-list', '--count', 'HEAD']);
-    if (parseInt(commitCount.trim(), 10) <= 1) {
+    if (Number.parseInt(commitCount.trim(), 10) <= 1) {
       const show = await this.git.show(['--name-only', '--pretty=format:', log.latest.hash]);
       return show.split('\n').filter(Boolean);
     }

--- a/scripts/codemaps/generate.ts
+++ b/scripts/codemaps/generate.ts
@@ -20,8 +20,8 @@
  *   docs/CODEMAPS/workers.md
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -221,7 +221,7 @@ ${entrySection}
 
 \`\`\`
 ${area.name} Directory Structure
-${dirSection.replace(/- `/g, '').replace(/`\/$/gm, '/')}
+${dirSection.replaceAll('- `', '').replace(/`\/$/gm, '/')}
 \`\`\`
 
 ## Key Modules

--- a/scripts/codex/merge-codex-config.js
+++ b/scripts/codex/merge-codex-config.js
@@ -11,8 +11,8 @@
  * - Missing tables are appended to the end of the file.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 let TOML;
 try {

--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -17,8 +17,8 @@
  *   node merge-mcp-config.js <config.toml> [--dry-run] [--update-mcp]
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { parseDisabledMcpServers } = require('../lib/mcp-config');
 
 let TOML;
@@ -47,7 +47,7 @@ try {
 let resolvedExecCmd = pmConfig.config.execCmd;
 if (pmConfig.name === 'yarn' && resolvedExecCmd === 'yarn dlx') {
   try {
-    const { execFileSync } = require('child_process');
+    const { execFileSync } = require('node:child_process');
     const ver = execFileSync('yarn', ['--version'], { encoding: 'utf8', timeout: 5000 }).trim();
     if (ver.startsWith('1.')) {
       resolvedExecCmd = 'npx';
@@ -77,7 +77,7 @@ const GH_BOOTSTRAP = `token=$(gh auth token 2>/dev/null || true); if [ -n "$toke
 function dlxServer(name, pkg, extraFields, extraToml) {
   const args = [...PM_EXEC_PARTS.slice(1), pkg];
   const fields = { command: PM_EXEC_PARTS[0], args, ...extraFields };
-  const argsStr = JSON.stringify(args).replace(/,/g, ', ');
+  const argsStr = JSON.stringify(args).replaceAll(',', ', ');
   let toml = `[mcp_servers.${name}]\ncommand = "${PM_EXEC_PARTS[0]}"\nargs = ${argsStr}`;
   if (extraToml) toml += '\n' + extraToml;
   return { fields, toml };

--- a/scripts/execution/agent_registry.py
+++ b/scripts/execution/agent_registry.py
@@ -9,7 +9,6 @@ class AgentRegistry:
         self._index_agents()
 
     def _index_agents(self):
-        # Maps semantic aliases to physical paths
         self.registry = {
             "python-expert": "agents/python-reviewer.md",
             "runtime-engineer": "agents/runtime-guard.md",
@@ -18,16 +17,19 @@ class AgentRegistry:
             "runtime-guard": "agents/runtime-guard.md",
             "security-audit": "agents/security-audit.md"
         }
-        # Scan filesystem to augment registry
         for d in ["agents", ".agents", ".codex/agents"]:
-            path = os.path.join(self.root, d)
-            if os.path.exists(path):
-                for root_dir, _, files in os.walk(path):
-                    for f in files:
-                        if f.endswith(".md"):
-                            name = f.replace(".md", "")
-                            if name not in self.registry:
-                                self.registry[name] = os.path.relpath(os.path.join(root_dir, f), self.root)
+            self._scan_agent_dir(d)
+
+    def _scan_agent_dir(self, d: str):
+        path = os.path.join(self.root, d)
+        if not os.path.exists(path):
+            return
+        for root_dir, _, files in os.walk(path):
+            for f in files:
+                if f.endswith(".md"):
+                    name = f.replace(".md", "")
+                    if name not in self.registry:
+                        self.registry[name] = os.path.relpath(os.path.join(root_dir, f), self.root)
 
     def get_physical_path(self, name: str) -> str:
         return self.registry.get(name, "")

--- a/scripts/execution/tool_runner.py
+++ b/scripts/execution/tool_runner.py
@@ -27,11 +27,7 @@ async def run_command(cmd: List[str], timeout: int = 30, env: Optional[Dict[str,
     """Safely executes a command as a subprocess."""
 
     base_cmd = cmd[0]
-    is_allowed = False
-    for group in ALLOWED_COMMANDS.values():
-        if base_cmd in group:
-            is_allowed = True
-            break
+    is_allowed = any(base_cmd in group for group in ALLOWED_COMMANDS.values())
 
     if not is_allowed:
         logger.error(f"Command blocked: {base_cmd}")
@@ -47,13 +43,14 @@ async def run_command(cmd: List[str], timeout: int = 30, env: Optional[Dict[str,
     )
 
     try:
-        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+        async with asyncio.timeout(timeout):
+            stdout, stderr = await process.communicate()
         return ExecutionResult(
             stdout.decode().strip(),
             stderr.decode().strip(),
             process.returncode
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         process.terminate()
         return ExecutionResult("", "Command timed out", -1, timed_out=True)
     except Exception as e:

--- a/scripts/orchestration/dag_validator.py
+++ b/scripts/orchestration/dag_validator.py
@@ -11,9 +11,6 @@ class DAG_VALIDATOR:
     MAX_RECURSION_DEPTH = 2
     MAX_AGENT_CHAIN = 5
 
-    def __init__(self):
-        pass
-
     def validate_workflow(self, workflow_chain: list) -> bool:
         """
         Validates a proposed agent execution chain.

--- a/scripts/orchestration/fallback.py
+++ b/scripts/orchestration/fallback.py
@@ -40,7 +40,7 @@ class FALLBACK_MANAGER:
 if __name__ == "__main__":
     async def main():
         async def failing_tool():
-            raise Exception("Tool Timeout")
+            raise TimeoutError("Tool Timeout")
 
         fm = FALLBACK_MANAGER()
         try:

--- a/scripts/orchestration/orchestrator.py
+++ b/scripts/orchestration/orchestrator.py
@@ -13,9 +13,9 @@ from typing import Dict, Any, List, Optional
 from execution.tool_runner import run_command, ExecutionResult
 from execution.sandbox import SandboxController
 from execution.agent_executor import AgentExecutor
-from orchestration.router import AGENT_ROUTER
+from orchestration.router import AgentRouter
 from runtime.tracer import TRACER
-from runtime.async_task_queue import EXECUTION_QUEUE
+from runtime.async_task_queue import ExecutionQueue
 
 class TaskState(Enum):
     PENDING = "pending"
@@ -46,17 +46,17 @@ class ExecutionOrchestrator:
         self.root = workspace_root
         self.sandbox = SandboxController(workspace_root)
         self.executor = AgentExecutor(workspace_root)
-        self.router = AGENT_ROUTER(workspace_root)
+        self.router = AgentRouter(workspace_root)
         self.tracer = TRACER(workspace_root)
         self.active_tasks: Dict[str, asyncio.Task] = {}
         self.sessions: Dict[str, ExecutionSession] = {}
-        self.queue = EXECUTION_QUEUE(max_concurrent=max_concurrent)
+        self.queue = ExecutionQueue(max_concurrent=max_concurrent)
         self._worker_count = worker_count
         self._workers: List[asyncio.Task] = []
         self._results: Dict[str, asyncio.Future] = {}
         self._dead_letters: deque = deque(maxlen=100)
 
-    async def dispatch(self, task_description: str) -> Dict[str, Any]:
+    def dispatch(self, task_description: str) -> Dict[str, Any]:
         execution_id = str(uuid.uuid4())
         domain = self.router._detect_domain(task_description)
         agents = self.router.affinity_map.get("domains", {}).get(domain, [])
@@ -178,12 +178,12 @@ class ExecutionOrchestrator:
     def get_dead_letters(self, limit: int = 50) -> List[Dict[str, Any]]:
         return list(self._dead_letters)[-limit:]
 
-    async def _ensure_workers(self) -> None:
+    def _ensure_workers(self) -> None:
         if not self._workers:
-            self._workers = await self.queue.start_workers(self._worker_count)
+            self._workers = self.queue.start_workers(self._worker_count)
 
     async def submit_task(self, task_description: str, agent_id: str, prompt: str, session_id: str, priority: int = 5) -> str:
-        await self._ensure_workers()
+        self._ensure_workers()
         task_id = str(uuid.uuid4())
         loop = asyncio.get_running_loop()
         future = loop.create_future()
@@ -233,7 +233,8 @@ class ExecutionOrchestrator:
             return {"status": "failed", "error": f"Unknown task_id {task_id}"}
         try:
             if timeout is not None:
-                return await asyncio.wait_for(future, timeout=timeout)
+                async with asyncio.timeout(timeout):
+                    return await future
             return await future
         finally:
             self._results.pop(task_id, None)
@@ -282,10 +283,9 @@ class ExecutionOrchestrator:
         for sig in (signal.SIGTERM, signal.SIGINT):
             loop.add_signal_handler(sig, stop_event.set)
 
-        # Logic wrapper
         task = asyncio.create_task(self.execute_task(task_description, agent_id, prompt, session_id))
 
-        done, pending = await asyncio.wait(
+        await asyncio.wait(
             [task, asyncio.create_task(stop_event.wait())],
             return_when=asyncio.FIRST_COMPLETED
         )
@@ -300,3 +300,5 @@ class ExecutionOrchestrator:
 
 
 ORCHESTRATOR = ExecutionOrchestrator
+AGENT_ROUTER = AgentRouter
+EXECUTION_QUEUE = ExecutionQueue

--- a/scripts/orchestration/router.py
+++ b/scripts/orchestration/router.py
@@ -40,14 +40,14 @@ class AGENT_ROUTER:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 return json.load(f)
-        except Exception as e:
-            logger.error(f"Error loading {path}: {str(e)}")
+        except Exception:
+            logger.exception(f"Error loading {path}")
             return {}
 
     def _detect_domain(self, task_description: str) -> str:
         import re
         task_lower = task_description.lower()
-        scores = {domain: 0 for domain in self.domain_keywords}
+        scores = dict.fromkeys(self.domain_keywords, 0)
         
         for domain, keywords in self.domain_keywords.items():
             for kw in keywords:
@@ -61,7 +61,7 @@ class AGENT_ROUTER:
             return "general"
         return best_domain
 
-    def get_best_agent(self, task_description: str, confidence_threshold: int = 1) -> Optional[Dict]:
+    def get_best_agent(self, task_description: str) -> Optional[Dict]:
         """
         Selects the best physical agent for the task.
         """

--- a/scripts/runtime/async_task_queue.py
+++ b/scripts/runtime/async_task_queue.py
@@ -37,13 +37,13 @@ class EXECUTION_QUEUE:
                 self.active_tasks += 1
                 logger.info(f"Worker processing task {task_id} (Priority {priority}). Active: {self.active_tasks}/{self.max_concurrent}")
                 try:
-                    # Timeout management
-                    result = await asyncio.wait_for(coro(*args, **kwargs), timeout=300.0)
+                    async with asyncio.timeout(300.0):
+                        result = await coro(*args, **kwargs)
                     logger.info(f"Task {task_id} completed successfully.")
-                except asyncio.TimeoutError:
-                    logger.error(f"Task {task_id} timed out.")
-                except Exception as e:
-                    logger.error(f"Task {task_id} failed: {str(e)}")
+                except TimeoutError:
+                    logger.exception(f"Task {task_id} timed out.")
+                except Exception:
+                    logger.exception(f"Task {task_id} failed.")
                 finally:
                     self.active_tasks -= 1
                     self.queue.task_done()

--- a/scripts/runtime/discovery.js
+++ b/scripts/runtime/discovery.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { listInstallProfiles, listInstallModules, listInstallComponents } = require('../lib/install-manifests');
 
 const REPO_ROOT = path.join(__dirname, '../..');

--- a/scripts/runtime/egc_orchestrate_cli.py
+++ b/scripts/runtime/egc_orchestrate_cli.py
@@ -12,10 +12,10 @@ def main():
     try:
         import json
         context_data = json.loads(args.context)
-    except:
+    except json.JSONDecodeError:
         context_data = {}
 
-    print(f"\n[EGC Orchestrator] Starting task...\n")
+    print("\n[EGC Orchestrator] Starting task...\n")
     orchestrator = ORCHESTRATOR()
     result = orchestrator.dispatch(args.task, context_data)
 

--- a/scripts/runtime/session_manager.py
+++ b/scripts/runtime/session_manager.py
@@ -73,8 +73,8 @@ class SESSION_MANAGER:
         try:
             with open(self.session_file, "w", encoding="utf-8") as f:
                 json.dump(self.state, f, indent=2)
-        except Exception as e:
-            logger.error(f"Failed to save session state: {e}")
+        except Exception:
+            logger.exception("Failed to save session state")
 
     def close_session(self):
         with self.lock:

--- a/scripts/runtime/tracer.py
+++ b/scripts/runtime/tracer.py
@@ -34,8 +34,8 @@ class TRACER:
             try:
                 with open(self.log_file, "a", encoding="utf-8") as f:
                     f.write(json.dumps(event) + "\n")
-            except Exception as e:
-                logger.error(f"Failed to write trace event: {e}")
+            except Exception:
+                logger.exception("Failed to write trace event")
 
     def get_traces(self, execution_id: Optional[str] = None) -> list:
         """
@@ -52,7 +52,7 @@ class TRACER:
                         entry = json.loads(line)
                         if execution_id is None or entry.get("execution_id") == execution_id:
                             traces.append(entry)
-            except Exception as e:
-                logger.error(f"Failed to read traces: {e}")
+            except Exception:
+                logger.exception("Failed to read traces")
             
         return traces

--- a/scripts/workflows/workflow_engine.py
+++ b/scripts/workflows/workflow_engine.py
@@ -24,7 +24,7 @@ class WorkflowEngine:
     async def run(self, main_task: str, session_id: str, *, parallel: bool = False, max_concurrent: int = 5):
         plan = self.planner.plan(main_task)
         state = WorkflowState()
-        ctx = RuntimeContext(session_id, state.workflow_id)
+        RuntimeContext(session_id, state.workflow_id)
 
         state.state = "running"
 

--- a/src/llm/cli/selector.py
+++ b/src/llm/cli/selector.py
@@ -118,7 +118,7 @@ def interactive_select(
                 name: ModelResolver.menu_choices(name) for name, _ in providers
             }
             # Always offer a symbolic "auto" entry that defers to dynamic routing.
-            for name in list(models_per_provider):
+            for name in models_per_provider:
                 models_per_provider[name].insert(0, ("default", f"Auto - dynamic routing ({ModelResolver.default_model(name)})"))
         else:  # pragma: no cover - only when the resolver cannot be imported
             # Fallback when ModelResolver is unavailable: only offer symbolic "Auto".

--- a/src/llm/core/model_resolver.py
+++ b/src/llm/core/model_resolver.py
@@ -52,9 +52,25 @@ def _first_env(*names: str) -> Optional[str]:
 class ModelResolver:
     """Centralized model resolution / routing layer for EGC."""
 
-    # OpenRouter model IDs that are reused across the registry, fallback
-    # chains and menu_choices() -- centralized here as the single source
-    # of truth to avoid typo-prone string duplication.
+    # Model IDs reused across the registry, fallback chains and menu_choices()
+    # -- centralized here as the single source of truth to avoid typo-prone
+    # string duplication (SonarCloud S1192).
+    _GEMINI_25_PRO = "gemini-2.5-pro"
+    _GEMINI_25_FLASH = "gemini-2.5-flash"
+    _GEMINI_25_FLASH_LITE = "gemini-2.5-flash-lite"
+    _GEMINI_20_FLASH_LITE = "gemini-2.0-flash-lite"
+    _GEMINI_15_FLASH = "gemini-1.5-flash"
+    _GEMINI_15_FLASH_8B = "gemini-1.5-flash-8b"
+    _OPENAI_GPT_4O_MINI = "openai/gpt-4o-mini"
+    _GPT_4O = "gpt-4o"
+    _CLAUDE_SONNET = "claude-sonnet-4-7"
+    _OPENROUTER_AUTO = "openrouter/auto"
+    _OPENAI_GPT_OSS_120B = "openai/gpt-oss-120b"
+    _LLAMA32 = "llama3.2"
+    _GOOGLE_GEMINI_25_FLASH = "google/gemini-2.5-flash"
+    _CLAUDE_HAIKU = "claude-haiku-4-7"
+    _GPT_4O_MINI = "gpt-4o-mini"
+    _OPENAI_GPT_4O_OR = "openai/gpt-4o"
     _DEEPSEEK_CHAT_V3 = "deepseek/deepseek-chat-v3-0324"
     _QWEN3_32B = "qwen/qwen3-32b"
     _LLAMA4_SCOUT = "meta-llama/llama-4-scout"
@@ -75,7 +91,7 @@ class ModelResolver:
                 ModelCapability.LONG_CONTEXT,
                 ModelCapability.CODE,
             ],
-            "fallback": "gemini-2.5-flash",
+            "fallback": _GEMINI_25_FLASH,
             "context_window": 2000000,
             "max_tokens": 65536,
             "supports_vision": True,
@@ -91,7 +107,7 @@ class ModelResolver:
                 ModelCapability.LOW_LATENCY,
                 ModelCapability.COST_EFFICIENT,
             ],
-            "fallback": "gemini-2.5-flash-lite",
+            "fallback": _GEMINI_25_FLASH_LITE,
             "context_window": 1000000,
             "max_tokens": 65536,
             "supports_vision": True,
@@ -105,7 +121,7 @@ class ModelResolver:
                 ModelCapability.COST_EFFICIENT,
                 ModelCapability.TOOL_CALLING,
             ],
-            "fallback": "gemini-2.0-flash-lite",
+            "fallback": _GEMINI_20_FLASH_LITE,
             "context_window": 1000000,
             "max_tokens": 65536,
             "supports_vision": True,
@@ -122,7 +138,7 @@ class ModelResolver:
                 ModelCapability.LOW_LATENCY,
                 ModelCapability.COST_EFFICIENT,
             ],
-            "fallback": "gemini-2.0-flash-lite",
+            "fallback": _GEMINI_20_FLASH_LITE,
             "context_window": 1000000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -136,7 +152,7 @@ class ModelResolver:
                 ModelCapability.COST_EFFICIENT,
                 ModelCapability.TOOL_CALLING,
             ],
-            "fallback": "gemini-1.5-flash",
+            "fallback": _GEMINI_15_FLASH,
             "context_window": 1000000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -151,7 +167,7 @@ class ModelResolver:
                 ModelCapability.TOOL_CALLING,
                 ModelCapability.LONG_CONTEXT,
             ],
-            "fallback": "gemini-2.5-flash",  # Prioritize SOTA flash over legacy flash
+            "fallback": _GEMINI_25_FLASH,  # Prioritize SOTA flash over legacy flash
             "context_window": 2000000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -166,7 +182,7 @@ class ModelResolver:
                 ModelCapability.LOW_LATENCY,
                 ModelCapability.COST_EFFICIENT,
             ],
-            "fallback": "gemini-1.5-flash-8b",
+            "fallback": _GEMINI_15_FLASH_8B,
             "context_window": 1000000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -190,7 +206,7 @@ class ModelResolver:
         "claude-opus-4-5": {
             "provider": "claude",
             "capabilities": [ModelCapability.REASONING, ModelCapability.TOOL_CALLING, ModelCapability.CODE],
-            "fallback": "claude-sonnet-4-7",
+            "fallback": _CLAUDE_SONNET,
             "context_window": 200000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -199,7 +215,7 @@ class ModelResolver:
         "claude-sonnet-4-7": {
             "provider": "claude",
             "capabilities": [ModelCapability.REASONING, ModelCapability.TOOL_CALLING, ModelCapability.CODE],
-            "fallback": "claude-haiku-4-7",
+            "fallback": _CLAUDE_HAIKU,
             "context_window": 200000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -217,7 +233,7 @@ class ModelResolver:
         "gpt-4o": {
             "provider": "openai",
             "capabilities": [ModelCapability.REASONING, ModelCapability.MULTIMODAL, ModelCapability.TOOL_CALLING],
-            "fallback": "gpt-4o-mini",
+            "fallback": _GPT_4O_MINI,
             "context_window": 128000,
             "max_tokens": 16384,
             "supports_vision": True,
@@ -323,7 +339,7 @@ class ModelResolver:
                 ModelCapability.CODE,
                 ModelCapability.COST_EFFICIENT,
             ],
-            "fallback": "openai/gpt-4o-mini",
+            "fallback": _OPENAI_GPT_4O_MINI,
             "context_window": 164000,
             "max_tokens": 8192,
             "supports_vision": False,
@@ -352,7 +368,7 @@ class ModelResolver:
                 ModelCapability.COST_EFFICIENT,
                 ModelCapability.TOOL_CALLING,
             ],
-            "fallback": "openai/gpt-4o-mini",
+            "fallback": _OPENAI_GPT_4O_MINI,
             "context_window": 131072,
             "max_tokens": 8192,
             "supports_vision": False,
@@ -381,7 +397,7 @@ class ModelResolver:
                 ModelCapability.TOOL_CALLING,
                 ModelCapability.LONG_CONTEXT,
             ],
-            "fallback": "openai/gpt-4o-mini",
+            "fallback": _OPENAI_GPT_4O_MINI,
             "context_window": 1048576,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -395,7 +411,7 @@ class ModelResolver:
                 ModelCapability.COST_EFFICIENT,
                 ModelCapability.TOOL_CALLING,
             ],
-            "fallback": "openai/gpt-4o-mini",
+            "fallback": _OPENAI_GPT_4O_MINI,
             "context_window": 131072,
             "max_tokens": 8192,
             "supports_vision": False,
@@ -414,7 +430,7 @@ class ModelResolver:
         "openrouter/auto": {
             "provider": "openrouter",
             "capabilities": [ModelCapability.REASONING, ModelCapability.MULTIMODAL, ModelCapability.TOOL_CALLING],
-            "fallback": "google/gemini-2.5-flash",
+            "fallback": _GOOGLE_GEMINI_25_FLASH,
             "context_window": 128000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -423,7 +439,7 @@ class ModelResolver:
         "google/gemini-2.5-pro": {
             "provider": "openrouter",
             "capabilities": [ModelCapability.REASONING, ModelCapability.MULTIMODAL, ModelCapability.TOOL_CALLING, ModelCapability.LONG_CONTEXT, ModelCapability.CODE],
-            "fallback": "google/gemini-2.5-flash",
+            "fallback": _GOOGLE_GEMINI_25_FLASH,
             "context_window": 1048576,
             "max_tokens": 65536,
             "supports_vision": True,
@@ -432,7 +448,7 @@ class ModelResolver:
         "google/gemini-2.5-flash": {
             "provider": "openrouter",
             "capabilities": [ModelCapability.SPEED, ModelCapability.MULTIMODAL, ModelCapability.TOOL_CALLING, ModelCapability.LOW_LATENCY, ModelCapability.COST_EFFICIENT],
-            "fallback": "openai/gpt-4o-mini",
+            "fallback": _OPENAI_GPT_4O_MINI,
             "context_window": 1048576,
             "max_tokens": 65536,
             "supports_vision": True,
@@ -441,7 +457,7 @@ class ModelResolver:
         "anthropic/claude-sonnet-4.5": {
             "provider": "openrouter",
             "capabilities": [ModelCapability.REASONING, ModelCapability.TOOL_CALLING, ModelCapability.CODE],
-            "fallback": "openai/gpt-4o",
+            "fallback": _OPENAI_GPT_4O_OR,
             "context_window": 200000,
             "max_tokens": 8192,
             "supports_vision": True,
@@ -450,7 +466,7 @@ class ModelResolver:
         "openai/gpt-4o": {
             "provider": "openrouter",
             "capabilities": [ModelCapability.REASONING, ModelCapability.MULTIMODAL, ModelCapability.TOOL_CALLING],
-            "fallback": "openai/gpt-4o-mini",
+            "fallback": _OPENAI_GPT_4O_MINI,
             "context_window": 128000,
             "max_tokens": 16384,
             "supports_vision": True,
@@ -471,45 +487,45 @@ class ModelResolver:
     # previous EGC symbolic names (pro/flash/flash-legacy/ultra) valid.
     _ALIASES: Dict[str, str] = {
         # Generic capability tiers.
-        "reasoning": "gemini-2.5-pro",
-        "balanced": "gemini-2.5-flash",
-        "fast": "gemini-2.5-flash",
-        "low-latency": "gemini-2.5-flash-lite",
-        "low_latency": "gemini-2.5-flash-lite",
-        "cheap": "gemini-2.5-flash-lite",
-        "lite": "gemini-2.5-flash-lite",
+        "reasoning": _GEMINI_25_PRO,
+        "balanced": _GEMINI_25_FLASH,
+        "fast": _GEMINI_25_FLASH,
+        "low-latency": _GEMINI_25_FLASH_LITE,
+        "low_latency": _GEMINI_25_FLASH_LITE,
+        "cheap": _GEMINI_25_FLASH_LITE,
+        "lite": _GEMINI_25_FLASH_LITE,
         # Previous EGC symbolic names.
-        "pro": "gemini-2.5-pro",
-        "flash": "gemini-2.5-flash",
-        "flash-lite": "gemini-2.5-flash-lite",
-        "flash-legacy": "gemini-1.5-flash",
-        "ultra": "gemini-2.5-pro",
+        "pro": _GEMINI_25_PRO,
+        "flash": _GEMINI_25_FLASH,
+        "flash-lite": _GEMINI_25_FLASH_LITE,
+        "flash-legacy": _GEMINI_15_FLASH,
+        "ultra": _GEMINI_25_PRO,
         # Legacy ECC / Anthropic-style tier names used in older agent frontmatter.
-        "opus": "gemini-2.5-pro",
-        "sonnet": "gemini-2.5-flash",
-        "haiku": "gemini-2.5-flash-lite",
+        "opus": _GEMINI_25_PRO,
+        "sonnet": _GEMINI_25_FLASH,
+        "haiku": _GEMINI_25_FLASH_LITE,
         # Common provider defaults referenced symbolically.
-        "default": "gemini-2.5-pro",
-        "gemini": "gemini-2.5-pro",
-        "claude": "claude-sonnet-4-7",
-        "openai": "gpt-4o",
-        "ollama": "llama3.2",
-        "openrouter": "openrouter/auto",
+        "default": _GEMINI_25_PRO,
+        "gemini": _GEMINI_25_PRO,
+        "claude": _CLAUDE_SONNET,
+        "openai": _GPT_4O,
+        "ollama": _LLAMA32,
+        "openrouter": _OPENROUTER_AUTO,
         "mistral": "mistral-large-latest",
-        "groq": "openai/gpt-oss-120b",
+        "groq": _OPENAI_GPT_OSS_120B,
         "cohere": "command-a-plus-05-2026",
     }
 
     # Per-provider default model ID (single place provider defaults live).
     _PROVIDER_DEFAULTS: Dict[str, str] = {
-        "gemini": "gemini-2.5-pro",
-        "claude": "claude-sonnet-4-7",
-        "openai": "gpt-4o",
-        "ollama": "llama3.2",
-        "openrouter": "openrouter/auto",
+        "gemini": _GEMINI_25_PRO,
+        "claude": _CLAUDE_SONNET,
+        "openai": _GPT_4O,
+        "ollama": _LLAMA32,
+        "openrouter": _OPENROUTER_AUTO,
         "mistral": "mistral-large-latest",
         "deepseek": "deepseek-chat",
-        "groq": "openai/gpt-oss-120b",
+        "groq": _OPENAI_GPT_OSS_120B,
         "cohere": "command-a-plus-05-2026",
     }
 
@@ -641,7 +657,7 @@ class ModelResolver:
         for model_id in extra_models:
             if model_id and model_id not in mapping and model_id not in cls._REGISTRY:
                 # Point unknown models at the strongest in-generation fallback.
-                seed = "gemini-2.5-flash" if "gemini" in model_id.lower() else None
+                seed = cls._GEMINI_25_FLASH if "gemini" in model_id.lower() else None
                 if seed and seed in cls._REGISTRY:
                     mapping[model_id] = seed
         return mapping

--- a/src/llm/dispatcher.py
+++ b/src/llm/dispatcher.py
@@ -54,7 +54,7 @@ class Dispatcher:
             with open(hooks_json_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
         except Exception as e:
-            logger.error(f"Failed to load hooks.json: {e}")
+            logger.exception("Failed to load hooks.json")
             return {"hooks": {}}
 
     def _match(self, matcher: str, tool_name: str) -> bool:
@@ -64,6 +64,57 @@ class Dispatcher:
         parts = matcher.split('|')
         return tool_name in parts
 
+    def _build_hook_payload(
+        self,
+        event_type: str,
+        tool_name: str,
+        current_tool_call: Optional[ToolCall],
+        session_id: Optional[str],
+        extra_payload: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "event": event_type,
+            "tool": tool_name,
+            "tool_name": tool_name,
+            "params": current_tool_call.arguments if current_tool_call else {},
+            "tool_input": current_tool_call.arguments if current_tool_call else {},
+            "context": {
+                "session_id": session_id or "default",
+                "runtime_source": "egc-python-dispatcher",
+            },
+        }
+        if extra_payload:
+            payload.update(extra_payload)
+            if "transcript_path" in extra_payload:
+                payload["transcript_path"] = extra_payload["transcript_path"]
+        return payload
+
+    def _apply_hook_result(
+        self,
+        result: HookResult,
+        entry: Dict[str, Any],
+        event_type: str,
+        tool_name: str,
+        current_tool_call: Optional[ToolCall],
+        cumulative_outputs: Dict[str, Any],
+    ) -> tuple:
+        if not result.success:
+            logger.warning(f"Hook {entry.get('id', 'unnamed')} vetoed or failed: {result.error}")
+            self.recorder.record("veto", {"event": event_type, "tool": tool_name, "reason": result.error})
+            return None, current_tool_call, cumulative_outputs
+        if result.data and isinstance(result.data, dict):
+            hook_out = result.data.get("hookSpecificOutput")
+            if hook_out and isinstance(hook_out, dict):
+                cumulative_outputs.update(hook_out)
+        if result.data and current_tool_call:
+            validated = self._validate_and_reconstruct(result.data, current_tool_call)
+            if validated:
+                if validated.arguments != current_tool_call.arguments:
+                    self.recorder.record("mutation", {"original": current_tool_call.arguments, "mutated": validated.arguments})
+                    logger.info(f"Mutation applied by hook {entry.get('id', 'unnamed')}")
+                current_tool_call = validated
+        return True, current_tool_call, cumulative_outputs
+
     def dispatch(self, event_type: str, tool_call: Optional[ToolCall] = None, session_id: Optional[str] = None, extra_payload: Optional[Dict[str, Any]] = None) -> DispatchResult:
         """
         Dispatch an event to the hook mesh.
@@ -71,57 +122,25 @@ class Dispatcher:
         hook-specific outputs, and veto status.
         """
         tool_name = tool_call.name if tool_call else "*"
-        
         trace_id = f"{session_id or 'default'}-{event_type}-{tool_name}-{os.getpid()}"
         trace_uri = f"egc://trace/{trace_id}"
-        
         logger.info(f"Evento: {event_type} | Alvo: {tool_name} | Trace: {format_osc8(trace_id, trace_uri)}")
-        
+
         relevant_hooks = self.hooks_config.get("hooks", {}).get(event_type, [])
-        
         current_tool_call = tool_call
-        cumulative_hook_outputs = {}
+        cumulative_hook_outputs: Dict[str, Any] = {}
 
         for entry in relevant_hooks:
-            matcher = entry.get("matcher", "*")
-            if self._match(matcher, tool_name):
-                for hook_def in entry.get("hooks", []):
-                    payload = {
-                        "event": event_type,
-                        "tool": tool_name,
-                        "tool_name": tool_name, # Mirroring for Node parity
-                        "params": current_tool_call.arguments if current_tool_call else {},
-                        "tool_input": current_tool_call.arguments if current_tool_call else {}, # Mirroring for Node parity
-                        "context": {
-                            "session_id": session_id or "default",
-                            "runtime_source": "egc-python-dispatcher"
-                        }
-                    }
-
-                    if extra_payload:
-                        payload.update(extra_payload)
-                        if "transcript_path" in extra_payload:
-                            payload["transcript_path"] = extra_payload["transcript_path"]
-
-                    result = self._execute_hook_command(hook_def.get("command"), payload, session_id)
-
-                    if not result.success:
-                        logger.warning(f"Hook {entry.get('id', 'unnamed')} vetoed or failed: {result.error}")
-                        self.recorder.record("veto", {"event": event_type, "tool": tool_name, "reason": result.error})
-                        return DispatchResult(vetoed=True, error=result.error)
-
-                    if result.data and isinstance(result.data, dict):
-                        hook_out = result.data.get("hookSpecificOutput")
-                        if hook_out and isinstance(hook_out, dict):
-                            cumulative_hook_outputs.update(hook_out)
-
-                    if result.data and current_tool_call:
-                        validated = self._validate_and_reconstruct(result.data, current_tool_call)
-                        if validated:
-                            if validated.arguments != current_tool_call.arguments:
-                                self.recorder.record("mutation", {"original": current_tool_call.arguments, "mutated": validated.arguments})
-                                logger.info(f"Mutation applied by hook {entry.get('id', 'unnamed')}")
-                            current_tool_call = validated
+            if not self._match(entry.get("matcher", "*"), tool_name):
+                continue
+            for hook_def in entry.get("hooks", []):
+                payload = self._build_hook_payload(event_type, tool_name, current_tool_call, session_id, extra_payload)
+                result = self._execute_hook_command(hook_def.get("command"), payload, session_id)
+                ok, current_tool_call, cumulative_hook_outputs = self._apply_hook_result(
+                    result, entry, event_type, tool_name, current_tool_call, cumulative_hook_outputs
+                )
+                if ok is None:
+                    return DispatchResult(vetoed=True, error=result.error)
 
         return DispatchResult(tool_call=current_tool_call, hook_outputs=cumulative_hook_outputs)
 

--- a/src/llm/paths.py
+++ b/src/llm/paths.py
@@ -54,7 +54,7 @@ def project_root() -> Path:
             text=True
         ).strip()
         return Path(root).resolve()
-    except:
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
         return Path.cwd().resolve()
 
 
@@ -75,7 +75,7 @@ def project_id() -> str:
             stderr=subprocess.DEVNULL,
             text=True
         ).strip()
-    except:
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
         pass
 
     hash_input = remote_url if remote_url else str(root)

--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -59,48 +59,52 @@ class ClaudeProvider(LLMProvider):
             ),
         ]
 
+    @staticmethod
+    def _extract_tool_calls(blocks) -> list[ToolCall] | None:
+        calls = []
+        for block in blocks:
+            if getattr(block, "type", None) != "tool_use":
+                continue
+            tool_input = getattr(block, "input", {})
+            calls.append(ToolCall(
+                id=getattr(block, "id", ""),
+                name=getattr(block, "name", ""),
+                arguments=dict(tool_input) if isinstance(tool_input, dict) else {},
+            ))
+        return calls or None
+
+    @staticmethod
+    def _map_error(e: Exception) -> None:
+        msg = str(e)
+        if "401" in msg or "authentication" in msg.lower():
+            raise AuthenticationError(msg, provider=ProviderType.CLAUDE) from e
+        if "429" in msg or "rate_limit" in msg.lower():
+            raise RateLimitError(msg, provider=ProviderType.CLAUDE) from e
+        if "context" in msg.lower() and "length" in msg.lower():
+            raise ContextLengthError(msg, provider=ProviderType.CLAUDE) from e
+        raise e
+
     def generate(self, input: LLMInput) -> LLMOutput:
         try:
             params: dict[str, Any] = {
                 "model": input.model or self.get_default_model(),
                 "messages": [msg.to_dict() for msg in input.messages],
                 "temperature": input.temperature,
+                "max_tokens": input.max_tokens if input.max_tokens else 8192,
             }
-            if input.max_tokens:
-                params["max_tokens"] = input.max_tokens
-            else:
-                params["max_tokens"] = 8192  # required by Anthropic API
             if input.tools:
                 params["tools"] = [
                     {"name": t.name, "description": t.description, "input_schema": t.parameters}
                     for t in input.tools
                 ]
-
             response = self.client.messages.create(**params)
-
-            tool_calls = []
-            for block in response.content:
-                if getattr(block, "type", None) != "tool_use":
-                    continue
-                tool_input = getattr(block, "input", {})
-                tool_calls.append(
-                    ToolCall(
-                        id=getattr(block, "id", ""),
-                        name=getattr(block, "name", ""),
-                        arguments=dict(tool_input) if isinstance(tool_input, dict) else {},
-                    )
-                )
-            if not tool_calls:
-                tool_calls = None
-
             content = next(
                 (block.text or "" for block in response.content if block.type == "text"),
                 "",
             )
-
             return LLMOutput(
                 content=content,
-                tool_calls=tool_calls,
+                tool_calls=self._extract_tool_calls(response.content),
                 model=response.model,
                 usage={
                     "input_tokens": response.usage.input_tokens,
@@ -109,14 +113,7 @@ class ClaudeProvider(LLMProvider):
                 stop_reason=response.stop_reason,
             )
         except Exception as e:
-            msg = str(e)
-            if "401" in msg or "authentication" in msg.lower():
-                raise AuthenticationError(msg, provider=ProviderType.CLAUDE) from e
-            if "429" in msg or "rate_limit" in msg.lower():
-                raise RateLimitError(msg, provider=ProviderType.CLAUDE) from e
-            if "context" in msg.lower() and "length" in msg.lower():
-                raise ContextLengthError(msg, provider=ProviderType.CLAUDE) from e
-            raise
+            self._map_error(e)
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()

--- a/src/llm/providers/cohere.py
+++ b/src/llm/providers/cohere.py
@@ -98,6 +98,39 @@ class CohereProvider(LLMProvider):
             return None
         return [tool.to_dict() for tool in tools]
 
+    def _parse_tool_calls(self, response) -> list[ToolCall] | None:
+        raw = getattr(response.message, "tool_calls", None)
+        if not raw:
+            return None
+        return [
+            ToolCall(id=tc.id, name=tc.function.name, arguments=_json_loads(tc.function.arguments))
+            for tc in raw
+        ]
+
+    def _parse_usage(self, response) -> dict | None:
+        meta = getattr(response, "usage", None) or getattr(response, "meta", None)
+        tokens = getattr(meta, "tokens", None) if meta else None
+        if tokens is None:
+            return None
+        return {
+            "input_tokens": getattr(tokens, "input_tokens", 0) or 0,
+            "output_tokens": getattr(tokens, "output_tokens", 0) or 0,
+        }
+
+    def _parse_response(self, response, model: str) -> LLMOutput:
+        if response.message is None:
+            raise LLMError("Cohere returned an empty response", provider=ProviderType.COHERE)
+        content_blocks = response.message.content or []
+        text = "".join(block.text for block in content_blocks if getattr(block, "text", None))
+        tool_calls = self._parse_tool_calls(response)
+        return LLMOutput(
+            content=text,
+            tool_calls=tool_calls,
+            model=model,
+            usage=self._parse_usage(response),
+            stop_reason=_map_finish_reason(response.finish_reason, bool(tool_calls)),
+        )
+
     def generate(self, input: LLMInput) -> LLMOutput:  # type: ignore[override]
         try:
             model = ModelResolver.resolve(input.model, provider="cohere")
@@ -112,43 +145,7 @@ class CohereProvider(LLMProvider):
             tools_mapped = self._map_tools(input.tools)
             if tools_mapped:
                 kwargs["tools"] = tools_mapped
-
-            response = self.client.chat(**kwargs)
-
-            if response.message is None:
-                raise LLMError("Cohere returned an empty response", provider=ProviderType.COHERE)
-
-            content_blocks = response.message.content or []
-            text = "".join(block.text for block in content_blocks if getattr(block, "text", None))
-
-            tool_calls: list[ToolCall] | None = None
-            raw_tool_calls = getattr(response.message, "tool_calls", None)
-            if raw_tool_calls:
-                tool_calls = [
-                    ToolCall(
-                        id=tc.id,
-                        name=tc.function.name,
-                        arguments=_json_loads(tc.function.arguments),
-                    )
-                    for tc in raw_tool_calls
-                ]
-
-            usage = None
-            meta = getattr(response, "usage", None) or getattr(response, "meta", None)
-            tokens = getattr(meta, "tokens", None) if meta else None
-            if tokens is not None:
-                usage = {
-                    "input_tokens": getattr(tokens, "input_tokens", 0) or 0,
-                    "output_tokens": getattr(tokens, "output_tokens", 0) or 0,
-                }
-
-            return LLMOutput(
-                content=text,
-                tool_calls=tool_calls,
-                model=model,
-                usage=usage,
-                stop_reason=_map_finish_reason(response.finish_reason, bool(tool_calls)),
-            )
+            return self._parse_response(self.client.chat(**kwargs), model)
         except LLMError:
             raise
         except Exception as exc:

--- a/src/llm/providers/gemini.py
+++ b/src/llm/providers/gemini.py
@@ -36,7 +36,7 @@ class GeminiProvider(LLMProvider):
     def __init__(self, api_key: str | None = None, **kwargs: Any) -> None:
         if genai is None:
             raise ImportError("google-genai package is required to use GeminiProvider")
-        
+
         key = api_key or os.environ.get("GEMINI_API_KEY")
         if not key:
             raise AuthenticationError("No Gemini API key provided", provider=ProviderType.GEMINI)
@@ -50,59 +50,45 @@ class GeminiProvider(LLMProvider):
         self._fallback_chain = ModelResolver.fallback_map(self._default_model)
         self._models = ModelResolver.model_infos("gemini")
 
+    @staticmethod
+    def _build_schema(schema_dict: dict[str, Any]) -> "types.Schema":
+        _type_map = {
+            "OBJECT": types.Type.OBJECT,
+            "ARRAY": types.Type.ARRAY,
+            "STRING": types.Type.STRING,
+            "INTEGER": types.Type.INTEGER,
+            "NUMBER": types.Type.NUMBER,
+            "BOOLEAN": types.Type.BOOLEAN,
+        }
+        schema_type = _type_map.get(schema_dict.get("type", "STRING").upper(), types.Type.STRING)
+        properties = {
+            k: GeminiProvider._build_schema(v)
+            for k, v in schema_dict.get("properties", {}).items()
+        }
+        items = GeminiProvider._build_schema(schema_dict["items"]) if "items" in schema_dict else None
+        return types.Schema(
+            type=schema_type,
+            description=schema_dict.get("description", ""),
+            properties=properties if properties else None,
+            items=items,
+            required=schema_dict.get("required", None),
+            enum=schema_dict.get("enum", None)
+        )
+
     def _map_tools(self, tools: list[ToolDefinition] | None) -> list[types.Tool] | None:
         if not tools:
             return None
-        
         declarations = []
         for tool in tools:
-            schema = tool.parameters
-            
-            def build_schema(schema_dict: dict[str, Any]) -> types.Schema:
-                schema_type_str = schema_dict.get("type", "STRING").upper()
-                if schema_type_str == "OBJECT":
-                    schema_type = types.Type.OBJECT
-                elif schema_type_str == "ARRAY":
-                    schema_type = types.Type.ARRAY
-                elif schema_type_str == "STRING":
-                    schema_type = types.Type.STRING
-                elif schema_type_str == "INTEGER":
-                    schema_type = types.Type.INTEGER
-                elif schema_type_str == "NUMBER":
-                    schema_type = types.Type.NUMBER
-                elif schema_type_str == "BOOLEAN":
-                    schema_type = types.Type.BOOLEAN
-                else:
-                    schema_type = types.Type.STRING
-
-                properties = {}
-                if "properties" in schema_dict:
-                    for k, v in schema_dict["properties"].items():
-                        properties[k] = build_schema(v)
-
-                items = None
-                if "items" in schema_dict:
-                    items = build_schema(schema_dict["items"])
-
-                return types.Schema(
-                    type=schema_type,
-                    description=schema_dict.get("description", ""),
-                    properties=properties if properties else None,
-                    items=items,
-                    required=schema_dict.get("required", None),
-                    enum=schema_dict.get("enum", None)
-                )
-
             func_decl = types.FunctionDeclaration(
                 name=tool.name,
                 description=tool.description,
-                parameters=build_schema(schema) if schema else None
+                parameters=self._build_schema(tool.parameters) if tool.parameters else None
             )
             declarations.append(func_decl)
-            
         return [types.Tool(function_declarations=declarations)]
 
-    def _map_finish_reason(self, reason: types.FinishReason | str | None) -> str | None:
+    def _map_finish_reason(self, reason: "types.FinishReason | str | None") -> str | None:
         if reason is None:
             return None
         reason_str = str(reason).upper()
@@ -112,149 +98,168 @@ class GeminiProvider(LLMProvider):
             return "max_tokens"
         return reason_str.lower()
 
+    def _dispatch_post_tool_results(self, input: LLMInput) -> None:
+        tool_result_msgs = [m for m in input.messages if m.role.value == "tool" and m.content]
+        if not tool_result_msgs:
+            return
+        try:
+            from llm.dispatcher import Dispatcher
+            from llm.session_recorder import SessionRecorder
+            _post_disp = Dispatcher(recorder=SessionRecorder(session_id=input.session_id or "default"))
+            for _trm in tool_result_msgs:
+                try:
+                    _result_payload = json.loads(_trm.content)
+                except Exception:
+                    _result_payload = {"result": _trm.content}
+                _post_disp.dispatch(
+                    "PostToolUse",
+                    ToolCall(id=_trm.tool_call_id or "", name=_trm.name or "unknown_tool",
+                             arguments={"result": _result_payload, "tool_call_id": _trm.tool_call_id}),
+                    session_id=input.session_id,
+                )
+        except Exception as _e:
+            logger.warning("PostToolUse dispatch on tool results failed: %s", _e)
+
+    def _build_contents(self, messages: list) -> tuple[str | None, list]:
+        system_instruction = None
+        contents = []
+        for msg in messages:
+            role = msg.role.value
+            if role == "system":
+                system_instruction = msg.content
+                continue
+            gemini_role = "model" if role == "assistant" else "user"
+            parts = []
+            if role == "tool" and msg.tool_call_id:
+                try:
+                    resp_data = json.loads(msg.content) if msg.content else {}
+                except ValueError:
+                    resp_data = {"result": msg.content or ""}
+                parts.append(types.Part.from_function_response(
+                    name=msg.name or "unknown_tool",
+                    response=resp_data
+                ))
+            elif msg.tool_calls:
+                for tc in msg.tool_calls:
+                    parts.append(types.Part.from_function_call(name=tc.name, args=tc.arguments))
+            else:
+                parts.append(types.Part.from_text(text=msg.content or ""))
+            if parts:
+                contents.append(types.Content(role=gemini_role, parts=parts))
+        return system_instruction, contents
+
+    def _build_config_args(self, input: LLMInput, tools_mapped: list | None) -> dict[str, Any]:
+        config_args: dict[str, Any] = {}
+        if input.temperature is not None:
+            config_args["temperature"] = input.temperature
+        if input.max_tokens is not None:
+            config_args["max_output_tokens"] = input.max_tokens
+        if tools_mapped:
+            config_args["tools"] = tools_mapped
+        return config_args
+
+    def _call_api_with_fallback(self, model_name: str, contents: list, config_args: dict, system_instruction: str | None):
+        if system_instruction:
+            config_args = {**config_args, "system_instruction": system_instruction}
+        current_model = model_name
+        tried_models: set[str] = set()
+        last_exception = None
+        response = None
+
+        while current_model and current_model not in tried_models:
+            tried_models.add(current_model)
+            try:
+                response = self.client.models.generate_content(
+                    model=current_model,
+                    contents=contents,
+                    config=types.GenerateContentConfig(**config_args) if config_args else None
+                )
+                model_name = current_model
+                break
+            except Exception as e:
+                last_exception = e
+                msg = str(e).lower()
+                is_fallback_error = False
+                if isinstance(e, APIError):
+                    status = getattr(e, "code", 500)
+                    if status in (403, 404, 429):
+                        is_fallback_error = True
+                if "403" in msg or "404" in msg or "429" in msg or "quota" in msg or "exhausted" in msg or "not found" in msg or "access" in msg:
+                    is_fallback_error = True
+                next_model = self._fallback_chain.get(current_model) or ModelResolver.get_model_info(current_model).get("fallback")
+                if is_fallback_error and next_model and next_model not in tried_models:
+                    logger.warning("Gemini model %s unavailable (%s); falling back to %s", current_model, type(e).__name__, next_model)
+                    current_model = next_model
+                    continue
+                raise e
+
+        if response is None and last_exception:
+            raise last_exception
+        return response, model_name
+
+    def _extract_response_parts(self, response) -> tuple[str, list[ToolCall]]:
+        extracted_text = ""
+        tool_calls = []
+        if response.candidates and response.candidates[0].content:
+            for part in response.candidates[0].content.parts:
+                if part.text:
+                    extracted_text += part.text
+                elif part.function_call:
+                    args_dict = dict(part.function_call.args) if part.function_call.args else {}
+                    tool_calls.append(ToolCall(
+                        id=f"call_{part.function_call.name}_{len(tool_calls)}",
+                        name=part.function_call.name,
+                        arguments=args_dict,
+                    ))
+        return extracted_text, tool_calls
+
+    def _dispatch_pre_tool_calls(self, tool_calls: list[ToolCall], input: LLMInput) -> list[ToolCall]:
+        from llm.dispatcher import Dispatcher
+        from llm.session_recorder import SessionRecorder
+        recorder = SessionRecorder(session_id=input.session_id or "default")
+        dispatcher = Dispatcher(recorder=recorder)
+        validated_calls = []
+        for tc in tool_calls:
+            dispatch_result = dispatcher.dispatch("PreToolUse", tc, session_id=input.session_id)
+            if not dispatch_result.vetoed:
+                validated_calls.append(dispatch_result.tool_call or tc)
+            else:
+                logger.warning(f"ToolCall {tc.name} vetada pelo Dispatcher (PreToolUse).")
+        return validated_calls
+
+    @staticmethod
+    def _map_api_error(e: Exception) -> None:
+        msg = str(e).lower()
+        if isinstance(e, APIError):
+            status = getattr(e, "code", 500)
+            if status == 401 or status == 403 or "api key" in msg:
+                raise AuthenticationError(str(e), provider=ProviderType.GEMINI) from e
+            if status == 429 or "quota" in msg or "exhausted" in msg:
+                raise RateLimitError(str(e), provider=ProviderType.GEMINI) from e
+            if status == 400 and "token" in msg:
+                raise ContextLengthError(str(e), provider=ProviderType.GEMINI) from e
+        if "401" in msg or "403" in msg or "authentication" in msg:
+            raise AuthenticationError(str(e), provider=ProviderType.GEMINI) from e
+        if "429" in msg or "rate" in msg or "quota" in msg:
+            raise RateLimitError(str(e), provider=ProviderType.GEMINI) from e
+        if "context" in msg and "length" in msg:
+            raise ContextLengthError(str(e), provider=ProviderType.GEMINI) from e
+        if "timeout" in msg:
+            raise LLMError(f"Request timeout: {e}", provider=ProviderType.GEMINI, code="timeout") from e
+        raise LLMError(f"Unexpected provider error: {e}", provider=ProviderType.GEMINI) from e
+
     def generate(self, input: LLMInput) -> LLMOutput:
         try:
             model_name = ModelResolver.resolve(input.model, provider="gemini")
-
-            tool_result_msgs = [m for m in input.messages if m.role.value == "tool" and m.content]
-            if tool_result_msgs:
-                try:
-                    from llm.dispatcher import Dispatcher
-                    from llm.session_recorder import SessionRecorder
-                    _post_disp = Dispatcher(recorder=SessionRecorder(session_id=input.session_id or "default"))
-                    for _trm in tool_result_msgs:
-                        try:
-                            _result_payload = json.loads(_trm.content)
-                        except Exception:
-                            _result_payload = {"result": _trm.content}
-                        dispatch_result = _post_disp.dispatch(
-                            "PostToolUse",
-                            ToolCall(id=_trm.tool_call_id or "", name=_trm.name or "unknown_tool",
-                                     arguments={"result": _result_payload, "tool_call_id": _trm.tool_call_id}),
-                            session_id=input.session_id,
-                        )
-                except Exception as _e:
-                    logger.warning("PostToolUse dispatch on tool results failed: %s", _e)
-
-            system_instruction = None
-            contents = []
-
-            for msg in input.messages:
-                role = msg.role.value
-                if role == "system":
-                    system_instruction = msg.content
-                    continue
-                
-                gemini_role = "user"
-                if role == "assistant":
-                    gemini_role = "model"
-                elif role == "tool":
-                    gemini_role = "user"
-                
-                parts = []
-                if role == "tool" and msg.tool_call_id:
-                    try:
-                        resp_data = json.loads(msg.content) if msg.content else {}
-                    except (json.JSONDecodeError, ValueError):
-                        resp_data = {"result": msg.content or ""}
-                    parts.append(types.Part.from_function_response(
-                        name=msg.name or "unknown_tool",
-                        response=resp_data
-                    ))
-                elif msg.tool_calls:
-                    for tc in msg.tool_calls:
-                        parts.append(types.Part.from_function_call(
-                            name=tc.name,
-                            args=tc.arguments
-                        ))
-                else:
-                    parts.append(types.Part.from_text(text=msg.content or ""))
-                    
-                if parts:
-                    contents.append(types.Content(role=gemini_role, parts=parts))
-
-            config_args: dict[str, Any] = {}
-            if input.temperature is not None:
-                config_args["temperature"] = input.temperature
-            if input.max_tokens is not None:
-                config_args["max_output_tokens"] = input.max_tokens
-            if system_instruction:
-                config_args["system_instruction"] = system_instruction
-                
+            self._dispatch_post_tool_results(input)
+            system_instruction, contents = self._build_contents(input.messages)
             tools_mapped = self._map_tools(input.tools)
-            if tools_mapped:
-                config_args["tools"] = tools_mapped
+            config_args = self._build_config_args(input, tools_mapped)
+            response, model_name = self._call_api_with_fallback(model_name, contents, config_args, system_instruction)
 
-            current_model = model_name
-            response = None
-            last_exception = None
-            tried_models: set[str] = set()
-
-            while current_model and current_model not in tried_models:
-                tried_models.add(current_model)
-                try:
-                    response = self.client.models.generate_content(
-                        model=current_model,
-                        contents=contents,
-                        config=types.GenerateContentConfig(**config_args) if config_args else None
-                    )
-                    model_name = current_model # Update model_name to the one that succeeded
-                    break
-                except Exception as e:
-                    last_exception = e
-                    msg = str(e).lower()
-                    is_fallback_error = False
-                    if isinstance(e, APIError):
-                        status = getattr(e, "code", 500)
-                        if status in (403, 404, 429):
-                            is_fallback_error = True
-                    if "403" in msg or "404" in msg or "429" in msg or "quota" in msg or "exhausted" in msg or "not found" in msg or "access" in msg:
-                        is_fallback_error = True
-
-                    next_model = self._fallback_chain.get(current_model) or ModelResolver.get_model_info(current_model).get("fallback")
-                    if is_fallback_error and next_model and next_model not in tried_models:
-                        logger.warning("Gemini model %s unavailable (%s); falling back to %s", current_model, type(e).__name__, next_model)
-                        current_model = next_model
-                        continue
-                    else:
-                        raise e
-            
-            if response is None and last_exception:
-                raise last_exception
-
-            extracted_text = ""
-            tool_calls = []
-            
-            if response.candidates and response.candidates[0].content:
-                for part in response.candidates[0].content.parts:
-                    if part.text:
-                        extracted_text += part.text
-                    elif part.function_call:
-                        args_dict = dict(part.function_call.args) if part.function_call.args else {}
-                        tool_calls.append(
-                            ToolCall(
-                                id=f"call_{part.function_call.name}_{len(tool_calls)}",
-                                name=part.function_call.name,
-                                arguments=args_dict,
-                            )
-                        )
-
+            extracted_text, tool_calls = self._extract_response_parts(response)
             if tool_calls:
-                from llm.dispatcher import Dispatcher
-                from llm.session_recorder import SessionRecorder
-
-                recorder = SessionRecorder(session_id=input.session_id or "default")
-                dispatcher = Dispatcher(recorder=recorder)
-
-                validated_calls = []
-                for tc in tool_calls:
-                    dispatch_result = dispatcher.dispatch("PreToolUse", tc, session_id=input.session_id)
-                    if not dispatch_result.vetoed:
-                        validated_calls.append(dispatch_result.tool_call or tc)
-                    else:
-                        logger.warning(f"ToolCall {tc.name} vetada pelo Dispatcher (PreToolUse).")
-                tool_calls = validated_calls
-
+                tool_calls = self._dispatch_pre_tool_calls(tool_calls, input)
             if not extracted_text and not tool_calls:
                 extracted_text = " "
 
@@ -268,7 +273,6 @@ class GeminiProvider(LLMProvider):
             stop_reason = None
             if response.candidates:
                 stop_reason = self._map_finish_reason(response.candidates[0].finish_reason)
-                
             if tool_calls and stop_reason != "max_tokens":
                 stop_reason = "tool_use"
 
@@ -279,28 +283,8 @@ class GeminiProvider(LLMProvider):
                 usage=usage,
                 stop_reason=stop_reason,
             )
-
         except Exception as e:
-            msg = str(e).lower()
-            if isinstance(e, APIError):
-                status = getattr(e, "code", 500)
-                if status == 401 or status == 403 or "api key" in msg:
-                    raise AuthenticationError(str(e), provider=ProviderType.GEMINI) from e
-                if status == 429 or "quota" in msg or "exhausted" in msg:
-                    raise RateLimitError(str(e), provider=ProviderType.GEMINI) from e
-                if status == 400 and "token" in msg:
-                    raise ContextLengthError(str(e), provider=ProviderType.GEMINI) from e
-            
-            if "401" in msg or "403" in msg or "authentication" in msg:
-                raise AuthenticationError(str(e), provider=ProviderType.GEMINI) from e
-            if "429" in msg or "rate" in msg or "quota" in msg:
-                raise RateLimitError(str(e), provider=ProviderType.GEMINI) from e
-            if "context" in msg and "length" in msg:
-                raise ContextLengthError(str(e), provider=ProviderType.GEMINI) from e
-            if "timeout" in msg:
-                 raise LLMError(f"Request timeout: {e}", provider=ProviderType.GEMINI, code="timeout") from e
-            
-            raise LLMError(f"Unexpected provider error: {e}", provider=ProviderType.GEMINI) from e
+            self._map_api_error(e)
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -70,6 +70,30 @@ class OpenAIProvider(LLMProvider):
             ),
         ]
 
+    @staticmethod
+    def _extract_tool_calls(choice) -> list[ToolCall] | None:
+        if not choice.message.tool_calls:
+            return None
+        calls = []
+        for tc in choice.message.tool_calls:
+            try:
+                args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+            except json.JSONDecodeError:
+                args = {}
+            calls.append(ToolCall(id=tc.id or "", name=tc.function.name, arguments=args))
+        return calls
+
+    def _map_error(self, e: Exception) -> None:
+        msg = str(e)
+        safe_msg = redact_secrets(msg)
+        if "401" in msg or "authentication" in msg.lower():
+            raise AuthenticationError(safe_msg, provider=self.provider_type) from e
+        if "429" in msg or "rate_limit" in msg.lower():
+            raise RateLimitError(safe_msg, provider=self.provider_type) from e
+        if "context" in msg.lower() and "length" in msg.lower():
+            raise ContextLengthError(safe_msg, provider=self.provider_type) from e
+        raise e
+
     def generate(self, input: LLMInput) -> LLMOutput:
         try:
             params: dict[str, Any] = {
@@ -81,40 +105,16 @@ class OpenAIProvider(LLMProvider):
                 params["max_tokens"] = input.max_tokens
             if input.tools:
                 params["tools"] = [tool.to_dict() for tool in input.tools]
-
             response = self.client.chat.completions.create(**params)
             if not response.choices:
-                raise LLMError(
-                    "The provider returned an empty choices list",
-                    provider=self.provider_type,
-                )
+                raise LLMError("The provider returned an empty choices list", provider=self.provider_type)
             choice = response.choices[0]
-
-            tool_calls = None
-            if choice.message.tool_calls:
-                tool_calls = []
-                for tc in choice.message.tool_calls:
-                    try:
-                        args = json.loads(tc.function.arguments) if tc.function.arguments else {}
-                    except json.JSONDecodeError:
-                        args = {}
-                    tool_calls.append(
-                        ToolCall(
-                            id=tc.id or "",
-                            name=tc.function.name,
-                            arguments=args,
-                        )
-                    )
-
-            # Some responses omit usage entirely (observed on certain
-            # proxy/gateway responses upstream of this provider). Missing
-            # usage stats are a lesser problem than an unclassified
-            # AttributeError bypassing the 401/429/context-length mapping
-            # below — degrade to zeros rather than crash.
+            # Some responses omit usage entirely (proxy/gateway upstream of this provider).
+            # Degrade to zeros rather than crash.
             usage = response.usage
             return LLMOutput(
                 content=choice.message.content or "",
-                tool_calls=tool_calls,
+                tool_calls=self._extract_tool_calls(choice),
                 model=response.model,
                 usage={
                     "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
@@ -124,22 +124,7 @@ class OpenAIProvider(LLMProvider):
                 stop_reason=choice.finish_reason,
             )
         except Exception as e:
-            msg = str(e)
-            # openai SDK exceptions (APIStatusError and friends) can embed
-            # the raw HTTP response body in their message, which may echo
-            # request headers/payloads back — redact before it reaches
-            # LLMError, which downstream code may log or persist verbatim.
-            # Classification below runs on the original msg (a recognizable
-            # secret pattern could in principle overlap "401"/"rate_limit",
-            # so redact only what actually gets stored in the exception).
-            safe_msg = redact_secrets(msg)
-            if "401" in msg or "authentication" in msg.lower():
-                raise AuthenticationError(safe_msg, provider=self.provider_type) from e
-            if "429" in msg or "rate_limit" in msg.lower():
-                raise RateLimitError(safe_msg, provider=self.provider_type) from e
-            if "context" in msg.lower() and "length" in msg.lower():
-                raise ContextLengthError(safe_msg, provider=self.provider_type) from e
-            raise
+            self._map_error(e)
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()

--- a/src/llm/session_paths.py
+++ b/src/llm/session_paths.py
@@ -79,20 +79,22 @@ def migrate_legacy_sessions(dry_run: bool = True) -> Dict[str, object]:
         target.mkdir(parents=True, exist_ok=True)
     for src in sources:
         for f in sorted(src.glob("*.jsonl")):
-            dst = target / f.name
-            rel = str(f)
-            if dst.exists():
-                plan["skipped_existing"].append(rel)  # type: ignore[union-attr]
-                continue
-            if dry_run:
-                plan["would_copy"].append(rel)  # type: ignore[union-attr]
-            else:
-                try:
-                    shutil.copy2(f, dst)
-                    plan["copied"].append(rel)  # type: ignore[union-attr]
-                except Exception as e:  # pragma: no cover - defensive
-                    plan["errors"].append(f"{rel}: {e}")  # type: ignore[union-attr]
+            _copy_session_file(f, target / f.name, plan, dry_run, str(f))
     return plan
+
+
+def _copy_session_file(f: Path, dst: Path, plan: Dict, dry_run: bool, rel: str) -> None:
+    if dst.exists():
+        plan["skipped_existing"].append(rel)  # type: ignore[union-attr]
+        return
+    if dry_run:
+        plan["would_copy"].append(rel)  # type: ignore[union-attr]
+        return
+    try:
+        shutil.copy2(f, dst)
+        plan["copied"].append(rel)  # type: ignore[union-attr]
+    except Exception as e:  # pragma: no cover - defensive
+        plan["errors"].append(f"{rel}: {e}")  # type: ignore[union-attr]
 
 
 __all__ = ["session_root", "legacy_session_dirs", "migrate_legacy_sessions"]

--- a/src/llm/session_recorder.py
+++ b/src/llm/session_recorder.py
@@ -83,9 +83,8 @@ class SessionRecorder:
                 f.write(json.dumps(event) + "\n")
                 f.flush()  # Garantia de persistencia imediata
                 os.fsync(f.fileno())  # Garantia de escrita no disco
-        except Exception as e:
-            logger.error(f"Falha ao persistir evento {event_type}: {e}")
-            # Fail-silent: persistencia falha, mas o runtime continua.
+        except Exception:
+            logger.exception(f"Falha ao persistir evento {event_type}")
 
         # Best-effort tee into the continuous-learning observations log.
         self._tee_observation(event_type, event)


### PR DESCRIPTION
## Summary
- EGC-138 5/5: node: protocol em mcp/servers, scripts/codex, scripts/runtime, scripts/codemaps (12 arquivos)
- EGC-140: 13 regras SonarCloud resolvidas em 21 arquivos Python (S1186, S1192, S3776, S5754, S112, S1172, S3457, S7483, S7503, S7504, S7519, S8572, S1481) -- inclui refactor de complexidade cognitiva em gemini.py, dispatcher.py, model_resolver.py

Commits empilhados na mesma branch por conveniência do agente que executou; ambos os escopos foram revisados e testados juntos antes do push.

## Test plan
- [x] node tests/run-all.js -- 2825/2825 passed
- [x] pytest tests/ -- 114/114 passed (venv isolado)
- [ ] CI green