### PR TITLE
refactor(hooks): reduce Cognitive Complexity in scripts/hooks/ (S3776)

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -37,6 +37,8 @@ const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
 
 const GIT_CONFIG_KEY_PREFIX = 'core.hooksPath=';
 
+const GIT_GLOBAL_FLAGS_WITH_ARG = new Set(['-c', '-C', '--work-tree', '--git-dir', '--namespace', '--super-prefix']);
+
 const COMMIT_OPTIONS_WITH_VALUE = new Set([
   '-m',
   '--message',
@@ -69,69 +71,53 @@ const COMMIT_OPTIONS_WITH_INLINE_VALUE = [
 
 const COMMIT_SHORT_OPTIONS_WITH_VALUE = new Set(['m', 'F', 'C', 'c']);
 
+function handleQuotedChar(char, i, ref, beginToken) {
+  if (char === ref.quote) { ref.quote = null; return; }
+  if (ref.quote === '"' && char === '\\') { beginToken(i); ref.escaped = true; return; }
+  beginToken(i);
+  ref.value += char;
+}
+
 function tokenizeShellWords(input, start = 0, end = input.length) {
   const tokens = [];
-  let value = '';
+  const ref = { value: '', quote: null, escaped: false };
   let tokenStart = null;
-  let quote = null;
-  let escaped = false;
 
   function beginToken(index) {
-    if (tokenStart === null) {
-      tokenStart = index;
-    }
+    if (tokenStart === null) tokenStart = index;
   }
 
   function pushToken(index) {
-    if (tokenStart === null) {
-      return;
-    }
-
-    tokens.push({
-      value,
-      start: tokenStart,
-      end: index,
-    });
-    value = '';
+    if (tokenStart === null) return;
+    tokens.push({ value: ref.value, start: tokenStart, end: index });
+    ref.value = '';
     tokenStart = null;
   }
 
   for (let i = start; i < end; i++) {
     const char = input.charAt(i);
 
-    if (escaped) {
+    if (ref.escaped) {
       beginToken(i - 1);
-      value += char;
-      escaped = false;
+      ref.value += char;
+      ref.escaped = false;
       continue;
     }
 
-    if (quote) {
-      if (char === quote) {
-        quote = null;
-        continue;
-      }
-
-      if (quote === '"' && char === '\\') {
-        beginToken(i);
-        escaped = true;
-        continue;
-      }
-
-      beginToken(i);
-      value += char;
+    if (ref.quote) {
+      handleQuotedChar(char, i, ref, beginToken);
       continue;
     }
 
     if (char === '"' || char === "'") {
       beginToken(i);
-      quote = char;
+      ref.quote = char;
       continue;
     }
 
     if (char === '\\') {
       beginToken(i);
-      escaped = true;
+      ref.escaped = true;
       continue;
     }
 
@@ -141,12 +127,10 @@ function tokenizeShellWords(input, start = 0, end = input.length) {
     }
 
     beginToken(i);
-    value += char;
+    ref.value += char;
   }
 
-  if (escaped) {
-    value += '\\';
-  }
+  if (ref.escaped) ref.value += '\\';
   pushToken(end);
 
   return tokens;
@@ -306,10 +290,7 @@ function onlyFlagsBeforeCandidate(tokens) {
   for (const t of tokens) {
     if (expectFlagArg) { expectFlagArg = false; continue; }
     if (t.startsWith('-')) {
-      if (t === '-c' || t === '-C' || t === '--work-tree' || t === '--git-dir' ||
-          t === '--namespace' || t === '--super-prefix') {
-        expectFlagArg = true;
-      }
+      if (GIT_GLOBAL_FLAGS_WITH_ARG.has(t)) expectFlagArg = true;
       continue;
     }
     return false;
@@ -387,6 +368,12 @@ function detectGitCommand(input, start = 0) {
   return null;
 }
 
+function getCommitTokenAction(value) {
+  if (commitOptionConsumesNextValue(value)) return 'next';
+  if (commitOptionContainsInlineValue(value)) return 'skip';
+  return null;
+}
+
 /**
  * Check if the input contains a --no-verify flag for a specific git command.
  * Only inspects the portion of the input starting at `offset` (the position
@@ -400,33 +387,15 @@ function hasNoVerifyFlag(input, command, offset) {
 
   for (const token of tokens) {
     const value = token.value;
+    if (skipNext) { skipNext = false; continue; }
+    if (value === '--') break;
 
-    if (skipNext) {
-      skipNext = false;
-      continue;
-    }
-
-    if (value === '--') {
-      break;
-    }
-
-    if (command === 'commit') {
-      if (commitOptionConsumesNextValue(value)) {
-        skipNext = true;
-        continue;
-      }
-
-      if (commitOptionContainsInlineValue(value)) {
-        continue;
-      }
-    }
-
-    if (value === '--no-verify') return true;
+    const commitAction = command === 'commit' ? getCommitTokenAction(value) : null;
+    if (commitAction === 'next') { skipNext = true; continue; }
+    if (commitAction === 'skip') continue;
 
     // For commit, -n is shorthand for --no-verify.
-    if (command === 'commit' && isCommitNoVerifyShortFlag(value)) {
-      return true;
-    }
+    if (value === '--no-verify' || (command === 'commit' && isCommitNoVerifyShortFlag(value))) return true;
   }
 
   return false;

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -142,61 +142,55 @@ function pruneCheckedEntries(checked) {
   return [...preserved, ...cappedSession, ...cappedFiles];
 }
 
+function mergeStateWithDisk(stateFile, checked, lastActive) {
+  try {
+    if (!fs.existsSync(stateFile)) return { checked, lastActive };
+    const diskState = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    return {
+      checked: Array.isArray(diskState.checked) ? Array.from(new Set([...diskState.checked, ...checked])) : checked,
+      lastActive: typeof diskState.last_active === 'number' ? Math.max(lastActive, diskState.last_active) : lastActive,
+    };
+  } catch (_) {
+    return { checked, lastActive };
+  }
+}
+
+function atomicRenameFile(tmpFile, stateFile) {
+  try {
+    fs.renameSync(tmpFile, stateFile);
+  } catch (error) {
+    if (error && (error.code === 'EEXIST' || error.code === 'EPERM')) {
+      try { fs.unlinkSync(stateFile); } catch (_) { /* ignore */ }
+      fs.renameSync(tmpFile, stateFile);
+    } else {
+      throw error;
+    }
+  }
+}
+
 function saveState(state) {
   const stateFile = getStateFile();
   let tmpFile = null;
   try {
     fs.mkdirSync(STATE_DIR, { recursive: true });
 
-    let mergedChecked = Array.isArray(state.checked) ? state.checked : [];
-    let mergedLastActive = typeof state.last_active === 'number' ? state.last_active : 0;
-
-    try {
-      if (fs.existsSync(stateFile)) {
-        const diskState = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
-        if (Array.isArray(diskState.checked)) {
-          mergedChecked = Array.from(new Set([...diskState.checked, ...mergedChecked]));
-        }
-        if (typeof diskState.last_active === 'number') {
-          mergedLastActive = Math.max(mergedLastActive, diskState.last_active);
-        }
-      }
-    } catch (_) {
-      /* ignore malformed or transient disk state */
-    }
+    const rawChecked = Array.isArray(state.checked) ? state.checked : [];
+    const rawLastActive = typeof state.last_active === 'number' ? state.last_active : 0;
+    const merged = mergeStateWithDisk(stateFile, rawChecked, rawLastActive);
 
     const finalState = {
-      checked: pruneCheckedEntries(mergedChecked),
-      last_active: Math.max(mergedLastActive, Date.now())
+      checked: pruneCheckedEntries(merged.checked),
+      last_active: Math.max(merged.lastActive, Date.now()),
     };
 
     // Atomic write: temp file + rename prevents partial reads
     tmpFile = `${stateFile}.tmp.${process.pid}.${crypto.randomBytes(4).toString('hex')}`;
     fs.writeFileSync(tmpFile, JSON.stringify(finalState, null, 2), 'utf8');
-    try {
-      fs.renameSync(tmpFile, stateFile);
-    } catch (error) {
-      if (error && (error.code === 'EEXIST' || error.code === 'EPERM')) {
-        try {
-          fs.unlinkSync(stateFile);
-        } catch (_) {
-          /* ignore */
-        }
-        fs.renameSync(tmpFile, stateFile);
-      } else {
-        throw error;
-      }
-    }
+    atomicRenameFile(tmpFile, stateFile);
     tmpFile = null;
     return true;
   } catch (_) {
-    if (tmpFile) {
-      try {
-        fs.unlinkSync(tmpFile);
-      } catch (_) {
-        /* ignore */
-      }
-    }
+    if (tmpFile) { try { fs.unlinkSync(tmpFile); } catch (_2) { /* ignore */ } }
     return false;
   }
 }
@@ -267,45 +261,24 @@ function isClaudeSettingsPath(filePath) {
   return /(^|\/)\.gemini\/settings(?:\.[^/]+)?\.json$/.test(normalized);
 }
 
+const SAFE_GIT_SUBCOMMANDS = {
+  status: (args) => args.every(arg => ['--porcelain', '--short', '--branch'].includes(arg)),
+  diff: (args) => args.length <= 1 && args.every(arg => ['--name-only', '--name-status'].includes(arg)),
+  log: (args) => args.every(arg => arg === '--oneline' || /^--max-count=\d+$/.test(arg)),
+  show: (args) => args.length === 1 && !args[0].startsWith('--') && /^[a-zA-Z0-9._:/-]+$/.test(args[0]),
+  branch: (args) => args.length === 1 && args[0] === '--show-current',
+  'rev-parse': (args) => args.length === 2 && args[0] === '--abbrev-ref' && /^head$/i.test(args[1]),
+};
+
 function isReadOnlyGitIntrospection(command) {
   const trimmed = String(command || '').trim();
-  if (!trimmed || /[\r\n;&|><`$()]/.test(trimmed)) {
-    return false;
-  }
+  if (!trimmed || /[\r\n;&|><`$()]/.test(trimmed)) return false;
 
   const tokens = trimmed.split(/\s+/);
-  if (tokens[0] !== 'git' || tokens.length < 2) {
-    return false;
-  }
+  if (tokens[0] !== 'git' || tokens.length < 2) return false;
 
-  const subcommand = tokens[1].toLowerCase();
-  const args = tokens.slice(2);
-
-  if (subcommand === 'status') {
-    return args.every(arg => ['--porcelain', '--short', '--branch'].includes(arg));
-  }
-
-  if (subcommand === 'diff') {
-    return args.length <= 1 && args.every(arg => ['--name-only', '--name-status'].includes(arg));
-  }
-
-  if (subcommand === 'log') {
-    return args.every(arg => arg === '--oneline' || /^--max-count=\d+$/.test(arg));
-  }
-
-  if (subcommand === 'show') {
-    return args.length === 1 && !args[0].startsWith('--') && /^[a-zA-Z0-9._:/-]+$/.test(args[0]);
-  }
-
-  if (subcommand === 'branch') {
-    return args.length === 1 && args[0] === '--show-current';
-  }
-
-  if (subcommand === 'rev-parse') {
-    return args.length === 2 && args[0] === '--abbrev-ref' && /^head$/i.test(args[1]);
-  }
-
-  return false;
+  const checker = SAFE_GIT_SUBCOMMANDS[tokens[1].toLowerCase()];
+  return checker ? checker(tokens.slice(2)) : false;
 }
 
 // --- Gate messages ---

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -312,119 +312,78 @@ function requestHttp(urlString, headers, timeoutMs) {
   });
 }
 
-function probeCommandServer(serverName, config) {
-  return new Promise(resolve => {
-    const command = config.command;
-    const args = Array.isArray(config.args) ? config.args.map(arg => String(arg)) : [];
-    const timeoutMs = envNumber('EGC_MCP_HEALTH_TIMEOUT_MS', DEFAULT_TIMEOUT_MS);
-    const mergedEnv = {
-      ...process.env,
-      ...(config.env && typeof config.env === 'object' && !Array.isArray(config.env) ? config.env : {})
-    };
-
-    let stderr = '';
-    let done = false;
-    let timer = null;
-    let exited = false;
-
-    function finish(result) {
-      if (done) return;
-      done = true;
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
+function createProbeState(resolve) {
+  const ps = {
+    done: false,
+    timer: null,
+    finish(result) {
+      if (ps.done) return;
+      ps.done = true;
+      if (ps.timer) { clearTimeout(ps.timer); ps.timer = null; }
       resolve(result);
     }
+  };
+  return ps;
+}
+
+function isValidEnvObject(env) {
+  return env && typeof env === 'object' && !Array.isArray(env);
+}
+
+function scheduleGraceTimer(timeoutMs, child, serverName, ps) {
+  const graceTimer = setTimeout(() => {
+    if (ps.done) return;
+    // Process survived the full grace window: healthy stdio server.
+    try { child.kill('SIGTERM'); } catch { /* ignore */ }
+    const killTimer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch { /* ignore */ }
+    }, 200);
+    if (typeof killTimer.unref === 'function') killTimer.unref();
+    ps.finish({ ok: true, statusCode: null, reason: `${serverName} accepted a new stdio process` });
+  }, timeoutMs);
+  if (typeof graceTimer.unref === 'function') graceTimer.unref();
+}
+
+function probeCommandServer(serverName, config) {
+  return new Promise(resolve => {
+    const args = Array.isArray(config.args) ? config.args.map(arg => String(arg)) : [];
+    const timeoutMs = envNumber('EGC_MCP_HEALTH_TIMEOUT_MS', DEFAULT_TIMEOUT_MS);
+    const mergedEnv = { ...process.env, ...(isValidEnvObject(config.env) ? config.env : {}) };
+    const ps = createProbeState(resolve);
+    let stderr = '';
+    let exited = false;
 
     let child;
     try {
-      child = spawn(command, args, {
-        env: mergedEnv,
-        cwd: process.cwd(),
-        stdio: ['pipe', 'ignore', 'pipe']
-      });
+      child = spawn(config.command, args, { env: mergedEnv, cwd: process.cwd(), stdio: ['pipe', 'ignore', 'pipe'] });
     } catch (error) {
-      finish({
-        ok: false,
-        statusCode: null,
-        reason: error.message
-      });
+      ps.finish({ ok: false, statusCode: null, reason: error.message });
       return;
     }
 
     child.stderr.on('data', chunk => {
-      if (stderr.length < 4000) {
-        const remaining = 4000 - stderr.length;
-        stderr += String(chunk).slice(0, remaining);
-      }
+      if (stderr.length < 4000) stderr += String(chunk).slice(0, 4000 - stderr.length);
     });
 
-    child.on('error', error => {
-      exited = true;
-      finish({
-        ok: false,
-        statusCode: null,
-        reason: error.message
-      });
-    });
+    child.on('error', error => { exited = true; ps.finish({ ok: false, statusCode: null, reason: error.message }); });
 
     child.on('exit', (code, signal) => {
       exited = true;
-      finish({
-        ok: false,
-        statusCode: code,
-        reason: stderr.trim() || `process exited before handshake (${signal || code || 'unknown'})`
-      });
+      ps.finish({ ok: false, statusCode: code, reason: stderr.trim() || `process exited before handshake (${signal || code || 'unknown'})` });
     });
 
-    timer = setTimeout(() => {
-      // If the process already exited (exit event fired before timer), mark unhealthy.
+    // If the process already exited (exit event fired before timer), mark unhealthy.
+    // Otherwise allow an additional grace window before declaring healthy: any non-zero
+    // exit during the grace period is treated as an early failure. See scheduleGraceTimer.
+    ps.timer = setTimeout(() => {
       if (exited || child.exitCode !== null || child.signalCode !== null) {
-        finish({
-          ok: false,
-          statusCode: child.exitCode,
-          reason: stderr.trim() || `process exited before handshake (${child.signalCode || child.exitCode || 'unknown'})`
-        });
+        ps.finish({ ok: false, statusCode: child.exitCode, reason: stderr.trim() || `process exited before handshake (${child.signalCode || child.exitCode || 'unknown'})` });
         return;
       }
-
-      // The process appears alive at timeout. On loaded machines or with slow-starting
-      // runtimes (e.g. Node.js on cold CI), the process may still be in its startup
-      // phase and about to exit with a non-zero code. Allow an additional grace window
-      // equal to timeoutMs before declaring healthy: any non-zero exit during the
-      // grace period is treated as an early failure, preserving correct classification
-      // without blocking indefinitely.
-      const graceTimer = setTimeout(() => {
-        if (done) return;
-        // Process survived the full grace window: healthy stdio server.
-        try {
-          child.kill('SIGTERM');
-        } catch {
-          // ignore
-        }
-        setTimeout(() => {
-          try {
-            child.kill('SIGKILL');
-          } catch {
-            // ignore
-          }
-        }, 200).unref?.();
-        finish({
-          ok: true,
-          statusCode: null,
-          reason: `${serverName} accepted a new stdio process`
-        });
-      }, timeoutMs);
-
-      if (typeof graceTimer.unref === 'function') {
-        graceTimer.unref();
-      }
+      scheduleGraceTimer(timeoutMs, child, serverName, ps);
     }, timeoutMs);
 
-    if (typeof timer.unref === 'function') {
-      timer.unref();
-    }
+    if (typeof ps.timer.unref === 'function') ps.timer.unref();
   });
 }
 
@@ -545,6 +504,17 @@ async function attemptRecovery(serverName, resolvedConfig, state, statePathValue
   return { restored: false, reconnect, reprobeReason: reprobe.reason };
 }
 
+async function tryRecoveryAfterProbeFailure(probe, target, resolvedConfig, state, statePathValue, now, previousStatus) {
+  if (!probe.failureCode && previousStatus !== 'unhealthy') {
+    return { recovered: false, reconnect: { attempted: false, success: false, reason: 'probe failed' } };
+  }
+  const recovery = await attemptRecovery(target.server, resolvedConfig, state, statePathValue, now);
+  if (recovery.reprobeReason) {
+    probe.reason = `${probe.reason}; reconnect reprobe failed: ${recovery.reprobeReason}`;
+  }
+  return { recovered: recovery.restored, reconnect: recovery.reconnect };
+}
+
 async function handlePreToolUse(rawInput, input, target, statePathValue, now) {
   const logs = [];
   const state = loadState(statePathValue);
@@ -555,9 +525,7 @@ async function handlePreToolUse(rawInput, input, target, statePathValue, now) {
   }
 
   if (previous.status === 'unhealthy' && Number(previous.nextRetryAt || 0) > now) {
-    logs.push(
-      `[MCPHealthCheck] ${target.server} is marked unhealthy until ${new Date(previous.nextRetryAt).toISOString()}; skipping ${target.tool || 'tool'}`
-    );
+    logs.push(`[MCPHealthCheck] ${target.server} is marked unhealthy until ${new Date(previous.nextRetryAt).toISOString()}; skipping ${target.tool || 'tool'}`);
     return { rawInput, exitCode: shouldFailOpen() ? 0 : 2, logs };
   }
 
@@ -571,37 +539,21 @@ async function handlePreToolUse(rawInput, input, target, statePathValue, now) {
   if (probe.ok) {
     markHealthy(state, target.server, now, { source: resolvedConfig.source });
     saveState(statePathValue, state);
-
-    if (previous.status === 'unhealthy') {
-      logs.push(`[MCPHealthCheck] ${target.server} connection restored`);
-    }
-
+    if (previous.status === 'unhealthy') logs.push(`[MCPHealthCheck] ${target.server} connection restored`);
     return { rawInput, exitCode: 0, logs };
   }
 
-  let reconnect = { attempted: false, success: false, reason: 'probe failed' };
-  if (probe.failureCode || previous.status === 'unhealthy') {
-    const recovery = await attemptRecovery(target.server, resolvedConfig, state, statePathValue, now);
-    if (recovery.restored) {
-      logs.push(`[MCPHealthCheck] ${target.server} connection restored after reconnect`);
-      return { rawInput, exitCode: 0, logs };
-    }
-    reconnect = recovery.reconnect;
-    if (recovery.reprobeReason) {
-      probe.reason = `${probe.reason}; reconnect reprobe failed: ${recovery.reprobeReason}`;
-    }
+  const { recovered, reconnect } = await tryRecoveryAfterProbeFailure(probe, target, resolvedConfig, state, statePathValue, now, previous.status);
+  if (recovered) {
+    logs.push(`[MCPHealthCheck] ${target.server} connection restored after reconnect`);
+    return { rawInput, exitCode: 0, logs };
   }
 
   markUnhealthy(state, target.server, now, probe.failureCode, probe.reason);
   saveState(statePathValue, state);
 
-  const reconnectSuffix = reconnect.attempted
-    ? ` Reconnect attempt: ${reconnect.success ? 'ok' : reconnect.reason}.`
-    : '';
-  logs.push(
-    `[MCPHealthCheck] ${target.server} is unavailable (${probe.reason}). Blocking ${target.tool || 'tool'} so Gemini can fall back to non-MCP tools.${reconnectSuffix}`
-  );
-
+  const reconnectSuffix = reconnect.attempted ? ` Reconnect attempt: ${reconnect.success ? 'ok' : reconnect.reason}.` : '';
+  logs.push(`[MCPHealthCheck] ${target.server} is unavailable (${probe.reason}). Blocking ${target.tool || 'tool'} so Gemini can fall back to non-MCP tools.${reconnectSuffix}`);
   return { rawInput, exitCode: shouldFailOpen() ? 0 : 2, logs };
 }
 

--- a/scripts/hooks/pre-bash-commit-quality.js
+++ b/scripts/hooks/pre-bash-commit-quality.js
@@ -282,69 +282,72 @@ function reportCommitMessageIssues(messageValidation) {
   return { totalIssues, warningCount };
 }
 
+function tryRunPylint(pyFiles) {
+  try {
+    const pylintPath = resolveCommand('pylint');
+    if (!pylintPath) return null;
+    const result = runLinterCommand(pylintPath, ['--output-format=text', ...pyFiles]);
+    return { success: result.status === 0, output: commandOutput(result) };
+  } catch {
+    return null;
+  }
+}
+
+function tryRunGolint(goFiles) {
+  try {
+    const golintPath = resolveCommand('golint');
+    if (!golintPath) return null;
+    const result = runLinterCommand(golintPath, goFiles);
+    return { success: !result.stdout || result.stdout.trim() === '', output: commandOutput(result) };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Run linter on staged files
- * @param {string[]} files 
+ * @param {string[]} files
  * @returns {object} Lint results
  */
 function runLinter(files) {
   const jsFiles = files.filter(f => /\.(js|jsx|ts|tsx)$/.test(f));
-  const pyFiles = files.filter(f => f.endsWith('.py'));
-  const goFiles = files.filter(f => f.endsWith('.go'));
-  
-  const results = {
-    eslint: null,
-    pylint: null,
-    golint: null
-  };
-  
+  const results = { eslint: null, pylint: null, golint: null };
+
   if (jsFiles.length > 0) {
     const eslintBin = process.platform === 'win32' ? 'eslint.cmd' : 'eslint';
     const eslintPath = path.join(process.cwd(), 'node_modules', '.bin', eslintBin);
     if (fs.existsSync(eslintPath)) {
       const result = runLinterCommand(eslintPath, ['--format', 'compact', ...jsFiles]);
-      results.eslint = {
-        success: result.status === 0,
-        output: commandOutput(result)
-      };
+      results.eslint = { success: result.status === 0, output: commandOutput(result) };
     }
   }
-  
-  if (pyFiles.length > 0) {
-    try {
-      const pylintPath = resolveCommand('pylint');
-      if (!pylintPath) {
-        results.pylint = null;
-      } else {
-        const result = runLinterCommand(pylintPath, ['--output-format=text', ...pyFiles]);
-        results.pylint = {
-          success: result.status === 0,
-          output: commandOutput(result)
-        };
-      }
-    } catch {
-      // Pylint not available
-    }
-  }
-  
-  if (goFiles.length > 0) {
-    try {
-      const golintPath = resolveCommand('golint');
-      if (!golintPath) {
-        results.golint = null;
-      } else {
-        const result = runLinterCommand(golintPath, goFiles);
-        results.golint = {
-          success: !result.stdout || result.stdout.trim() === '',
-          output: commandOutput(result)
-        };
-      }
-    } catch {
-      // golint not available
-    }
-  }
-  
+
+  const pyFiles = files.filter(f => f.endsWith('.py'));
+  if (pyFiles.length > 0) results.pylint = tryRunPylint(pyFiles);
+
+  const goFiles = files.filter(f => f.endsWith('.go'));
+  if (goFiles.length > 0) results.golint = tryRunGolint(goFiles);
+
   return results;
+}
+
+function reportLinterErrors(lintResults) {
+  let totalIssues = 0;
+  let errorCount = 0;
+  const linters = [
+    { key: 'eslint', label: 'ESLint' },
+    { key: 'pylint', label: 'Pylint' },
+    { key: 'golint', label: 'golint' },
+  ];
+  for (const { key, label } of linters) {
+    if (lintResults[key] && !lintResults[key].success) {
+      console.error(`\n${label} Issues:`);
+      console.error(lintResults[key].output);
+      totalIssues++;
+      errorCount++;
+    }
+  }
+  return { totalIssues, errorCount };
 }
 
 /**
@@ -389,48 +392,26 @@ function evaluate(rawInput) {
     warningCount += msgCounts.warningCount;
     
     const lintResults = runLinter(filesToCheck);
-    
-    if (lintResults.eslint && !lintResults.eslint.success) {
-      console.error('\nESLint Issues:');
-      console.error(lintResults.eslint.output);
-      totalIssues++;
-      errorCount++;
-    }
-    
-    if (lintResults.pylint && !lintResults.pylint.success) {
-      console.error('\nPylint Issues:');
-      console.error(lintResults.pylint.output);
-      totalIssues++;
-      errorCount++;
-    }
-    
-    if (lintResults.golint && !lintResults.golint.success) {
-      console.error('\ngolint Issues:');
-      console.error(lintResults.golint.output);
-      totalIssues++;
-      errorCount++;
-    }
-    
-    // Summary
+    const linterErrors = reportLinterErrors(lintResults);
+    totalIssues += linterErrors.totalIssues;
+    errorCount += linterErrors.errorCount;
+
     if (totalIssues > 0) {
       console.error(`\nSummary: ${totalIssues} issue(s) found (${errorCount} error(s), ${warningCount} warning(s), ${infoCount} info)`);
-      
       if (errorCount > 0) {
         console.error('\n[Hook] ERROR: Commit blocked due to critical issues. Fix them before committing.');
         return { output: rawInput, exitCode: 2 };
-      } else {
-        console.error('\n[Hook] WARNING: Warnings found. Consider fixing them, but commit is allowed.');
-        console.error('[Hook] To bypass these checks, use: git commit --no-verify');
       }
+      console.error('\n[Hook] WARNING: Warnings found. Consider fixing them, but commit is allowed.');
+      console.error('[Hook] To bypass these checks, use: git commit --no-verify');
     } else {
       console.error('\n[Hook] PASS: All checks passed!');
     }
-    
+
   } catch (error) {
     console.error(`[Hook] Error: ${error.message}`);
-    // Non-blocking on error
   }
-  
+
   return { output: rawInput, exitCode: 0 };
 }
 

--- a/scripts/hooks/session-activity-tracker.js
+++ b/scripts/hooks/session-activity-tracker.js
@@ -467,10 +467,20 @@ function enrichFileEventFromWorkingTree(toolName, event) {
   return event;
 }
 
-function collectFileEvents(toolName, value, events, key = null, parentValue = null) {
-  if (!value) {
-    return;
+function collectFileEventsFromObject(toolName, value, events) {
+  for (const [nestedKey, nested] of Object.entries(value)) {
+    if (FILE_PATH_KEYS.has(nestedKey)) {
+      collectFileEvents(toolName, nested, events, nestedKey, value);
+      continue;
+    }
+    if (nested && (Array.isArray(nested) || typeof nested === 'object')) {
+      collectFileEvents(toolName, nested, events, null, nested);
+    }
   }
+}
+
+function collectFileEvents(toolName, value, events, key = null, parentValue = null) {
+  if (!value) return;
 
   if (Array.isArray(value)) {
     for (const entry of value) {
@@ -482,31 +492,14 @@ function collectFileEvents(toolName, value, events, key = null, parentValue = nu
   if (typeof value === 'string') {
     if (key && FILE_PATH_KEYS.has(key)) {
       const action = actionForFileKey(toolName, key);
-      pushFileEvent(
-        events,
-        value,
-        action,
-        fileEventDiffPreview(toolName, parentValue, action),
-        fileEventPatchPreview(parentValue, action)
-      );
+      pushFileEvent(events, value, action, fileEventDiffPreview(toolName, parentValue, action), fileEventPatchPreview(parentValue, action));
     }
     return;
   }
 
-  if (typeof value !== 'object') {
-    return;
-  }
+  if (typeof value !== 'object') return;
 
-  for (const [nestedKey, nested] of Object.entries(value)) {
-    if (FILE_PATH_KEYS.has(nestedKey)) {
-      collectFileEvents(toolName, nested, events, nestedKey, value);
-      continue;
-    }
-
-    if (nested && (Array.isArray(nested) || typeof nested === 'object')) {
-      collectFileEvents(toolName, nested, events, null, nested);
-    }
-  }
+  collectFileEventsFromObject(toolName, value, events);
 }
 
 function extractFileEvents(toolName, toolInput) {
@@ -518,29 +511,25 @@ function extractFileEvents(toolName, toolInput) {
   return events;
 }
 
-function summarizeInput(toolName, toolInput, filePaths) {
-  if (toolName === 'Bash') {
-    return truncateSummary(toolInput?.command || 'bash');
-  }
-
-  if (filePaths.length > 0) {
-    return truncateSummary(`${toolName} ${filePaths.join(', ')}`);
-  }
-
-  if (toolInput && typeof toolInput === 'object') {
-    const shallow = {};
-    for (const [key, value] of Object.entries(toolInput)) {
-      if (value === null || value === undefined) {
-        continue;
-      }
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        shallow[key] = value;
-      }
+function buildShallowParams(toolInput) {
+  const shallow = {};
+  for (const [key, value] of Object.entries(toolInput)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      shallow[key] = value;
     }
+  }
+  return shallow;
+}
+
+function summarizeInput(toolName, toolInput, filePaths) {
+  if (toolName === 'Bash') return truncateSummary(toolInput?.command || 'bash');
+  if (filePaths.length > 0) return truncateSummary(`${toolName} ${filePaths.join(', ')}`);
+  if (toolInput && typeof toolInput === 'object') {
+    const shallow = buildShallowParams(toolInput);
     const serialized = Object.keys(shallow).length > 0 ? JSON.stringify(shallow) : toolName;
     return truncateSummary(serialized);
   }
-
   return truncateSummary(toolName);
 }
 

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -180,27 +180,22 @@ function mergeSessionHeader(content, today, currentTime, metadata) {
   return `${nextHeader}${SESSION_SEPARATOR}${body}`;
 }
 
-async function main() {
+function resolveTranscriptPath(stdin) {
   // Parse stdin JSON to get transcript_path; fall back to env var on missing,
   // empty, or non-string values as well as on malformed JSON.
-  let transcriptPath = null;
   try {
-    const input = JSON.parse(stdinData);
+    const input = JSON.parse(stdin);
     if (input && typeof input.transcript_path === 'string' && input.transcript_path.length > 0) {
-      transcriptPath = input.transcript_path;
+      return input.transcript_path;
     }
   } catch {
     // Malformed stdin: fall through to the env-var fallback below.
   }
-  if (!transcriptPath) {
-    const envTranscriptPath = process.env.GEMINI_TRANSCRIPT_PATH;
-    if (typeof envTranscriptPath === 'string' && envTranscriptPath.length > 0) {
-      transcriptPath = envTranscriptPath;
-    }
-  }
+  const envPath = process.env.GEMINI_TRANSCRIPT_PATH;
+  return typeof envPath === 'string' && envPath.length > 0 ? envPath : null;
+}
 
-  const sessionsDir = getSessionsDir();
-  const today = getDateString();
+function resolveShortId(transcriptPath) {
   // Derive shortId from transcript_path UUID when available, using the SAME
   // last-8-chars convention as getSessionIdShort(sessionId.slice(-8)). This keeps
   // backward compatibility for normal sessions (the derived shortId matches what
@@ -210,15 +205,66 @@ async function main() {
   // Without this, a parent session and any `egc -p ...` subprocess spawned by
   // another Stop hook share the project-name fallback filename, and the subprocess
   // overwrites the parent's summary. See issue #1494 for full repro details.
-  let shortId = null;
   if (transcriptPath) {
     const m = path.basename(transcriptPath).match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i);
     if (m) {
-      // getSessionIdShort(sessionId.slice(-8)).
-      shortId = sanitizeSessionId(m[1].slice(-8).toLowerCase());
+      return sanitizeSessionId(m[1].slice(-8).toLowerCase());
     }
   }
-  if (!shortId) { shortId = getSessionIdShort(); }
+  return getSessionIdShort();
+}
+
+function injectSummaryIntoContent(updatedContent, summary) {
+  const summaryBlock = buildSummaryBlock(summary);
+  if (updatedContent.includes(SUMMARY_START_MARKER) && updatedContent.includes(SUMMARY_END_MARKER)) {
+    return updatedContent.replace(
+      new RegExp(`${escapeRegExp(SUMMARY_START_MARKER)}[\\s\\S]*?${escapeRegExp(SUMMARY_END_MARKER)}`),
+      summaryBlock
+    );
+  }
+  // Migration path for files created before summary markers existed.
+  return updatedContent.replace(
+    /## (?:Session Summary|Current State)[\s\S]*?$/,
+    `${summaryBlock}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\`\n`
+  );
+}
+
+function updateExistingSession(sessionFile, today, currentTime, sessionMetadata, summary) {
+  const existing = readFile(sessionFile);
+  let updatedContent = existing;
+
+  if (existing) {
+    const merged = mergeSessionHeader(existing, today, currentTime, sessionMetadata);
+    if (merged) {
+      updatedContent = merged;
+    } else {
+      log('[SessionEnd] Failed to normalize session file header');
+    }
+  }
+
+  if (summary && updatedContent) {
+    updatedContent = injectSummaryIntoContent(updatedContent, summary);
+  }
+
+  if (updatedContent) writeFile(sessionFile, updatedContent);
+  log('[SessionEnd] Updated session file');
+}
+
+function createNewSession(sessionFile, today, currentTime, sessionMetadata, summary) {
+  const summarySection = summary
+    ? `${buildSummaryBlock(summary)}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\``
+    : `## Current State\n\n[Session context goes here]\n\n### Completed\n- [ ]\n\n### In Progress\n- [ ]\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\``;
+
+  const template = `${buildSessionHeader(today, currentTime, sessionMetadata)}${SESSION_SEPARATOR}${summarySection}\n`;
+  writeFile(sessionFile, template);
+  log('[SessionEnd] Created session file');
+}
+
+async function main() {
+  const transcriptPath = resolveTranscriptPath(stdinData);
+  const sessionsDir = getSessionsDir();
+  const today = getDateString();
+  const shortId = resolveShortId(transcriptPath);
   const sessionFile = path.join(sessionsDir, `${today}-${shortId}-session.tmp`);
   const sessionMetadata = getSessionMetadata();
 
@@ -226,9 +272,7 @@ async function main() {
 
   const currentTime = getTimeString();
 
-  // Try to extract summary from transcript
   let summary = null;
-
   if (transcriptPath) {
     if (fs.existsSync(transcriptPath)) {
       summary = extractSessionSummary(transcriptPath);
@@ -238,50 +282,9 @@ async function main() {
   }
 
   if (fs.existsSync(sessionFile)) {
-    const existing = readFile(sessionFile);
-    let updatedContent = existing;
-
-    if (existing) {
-      const merged = mergeSessionHeader(existing, today, currentTime, sessionMetadata);
-      if (merged) {
-        updatedContent = merged;
-      } else {
-        log('[SessionEnd] Failed to normalize session file header');
-      }
-    }
-
-    if (summary && updatedContent) {
-      const summaryBlock = buildSummaryBlock(summary);
-
-      if (updatedContent.includes(SUMMARY_START_MARKER) && updatedContent.includes(SUMMARY_END_MARKER)) {
-        updatedContent = updatedContent.replace(
-          new RegExp(`${escapeRegExp(SUMMARY_START_MARKER)}[\\s\\S]*?${escapeRegExp(SUMMARY_END_MARKER)}`),
-          summaryBlock
-        );
-      } else {
-        // Migration path for files created before summary markers existed.
-        updatedContent = updatedContent.replace(
-          /## (?:Session Summary|Current State)[\s\S]*?$/,
-          `${summaryBlock}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\`\n`
-        );
-      }
-    }
-
-    if (updatedContent) {
-      writeFile(sessionFile, updatedContent);
-    }
-
-    log('[SessionEnd] Updated session file');
+    updateExistingSession(sessionFile, today, currentTime, sessionMetadata, summary);
   } else {
-    const summarySection = summary
-      ? `${buildSummaryBlock(summary)}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\``
-      : `## Current State\n\n[Session context goes here]\n\n### Completed\n- [ ]\n\n### In Progress\n- [ ]\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\``;
-
-    const template = `${buildSessionHeader(today, currentTime, sessionMetadata)}${SESSION_SEPARATOR}${summarySection}
-`;
-
-    writeFile(sessionFile, template);
-    log('[SessionEnd] Created session file');
+    createNewSession(sessionFile, today, currentTime, sessionMetadata, summary);
   }
 
   process.exit(0);

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -116,43 +116,47 @@ function limitSessionStartContext(additionalContext, maxChars = getSessionStartM
   return `${context.slice(0, prefixLength).trimEnd()}${marker}`.slice(0, maxChars);
 }
 
+function tryPruneFile(fullPath) {
+  try {
+    const stats = fs.statSync(fullPath);
+    return stats;
+  } catch {
+    return null;
+  }
+}
+
+function pruneDir(dir, retentionDays) {
+  if (!fs.existsSync(dir)) return 0;
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('-session.tmp')) continue;
+    const fullPath = path.join(dir, entry.name);
+    const stats = tryPruneFile(fullPath);
+    if (!stats) continue;
+    const ageInDays = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60 * 24);
+    if (ageInDays <= retentionDays) continue;
+    try {
+      fs.rmSync(fullPath, { force: true });
+      removed += 1;
+    } catch (error) {
+      log(`[SessionStart] Warning: failed to prune expired session ${fullPath}: ${error.message}`);
+    }
+  }
+  return removed;
+}
+
 function pruneExpiredSessions(searchDirs, retentionDays) {
   const uniqueDirs = Array.from(new Set(searchDirs.filter(dir => typeof dir === 'string' && dir.length > 0)));
   let removed = 0;
-
   for (const dir of uniqueDirs) {
-    if (!fs.existsSync(dir)) continue;
-
-    let entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('-session.tmp')) continue;
-
-      const fullPath = path.join(dir, entry.name);
-      let stats;
-      try {
-        stats = fs.statSync(fullPath);
-      } catch {
-        continue;
-      }
-
-      const ageInDays = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60 * 24);
-      if (ageInDays <= retentionDays) continue;
-
-      try {
-        fs.rmSync(fullPath, { force: true });
-        removed += 1;
-      } catch (error) {
-        log(`[SessionStart] Warning: failed to prune expired session ${fullPath}: ${error.message}`);
-      }
-    }
+    removed += pruneDir(dir, retentionDays);
   }
-
   return removed;
 }
 
@@ -237,6 +241,29 @@ function selectMatchingSession(sessions, cwd, currentProject) {
   return null;
 }
 
+function flushInstinct(current, contentLines, instincts) {
+  if (current && current.id) {
+    current.content = contentLines.join('\n').trim();
+    instincts.push(current);
+  }
+}
+
+function parseFrontmatterField(line, current) {
+  const separatorIndex = line.indexOf(':');
+  if (separatorIndex === -1) return;
+  const key = line.slice(0, separatorIndex).trim();
+  let value = line.slice(separatorIndex + 1).trim();
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+  if (key === 'confidence') {
+    const parsed = Number.parseFloat(value);
+    current[key] = Number.isFinite(parsed) ? parsed : 0.5;
+  } else {
+    current[key] = value;
+  }
+}
+
 function parseInstinctFile(content) {
   const instincts = [];
   let current = null;
@@ -248,10 +275,7 @@ function parseInstinctFile(content) {
       if (inFrontmatter) {
         inFrontmatter = false;
       } else {
-        if (current && current.id) {
-          current.content = contentLines.join('\n').trim();
-          instincts.push(current);
-        }
+        flushInstinct(current, contentLines, instincts);
         current = {};
         contentLines = [];
         inFrontmatter = true;
@@ -260,29 +284,13 @@ function parseInstinctFile(content) {
     }
 
     if (inFrontmatter) {
-      const separatorIndex = line.indexOf(':');
-      if (separatorIndex === -1) continue;
-      const key = line.slice(0, separatorIndex).trim();
-      let value = line.slice(separatorIndex + 1).trim();
-      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-        value = value.slice(1, -1);
-      }
-      if (key === 'confidence') {
-        const parsed = Number.parseFloat(value);
-        current[key] = Number.isFinite(parsed) ? parsed : 0.5;
-      } else {
-        current[key] = value;
-      }
+      parseFrontmatterField(line, current);
     } else if (current) {
       contentLines.push(line);
     }
   }
 
-  if (current && current.id) {
-    current.content = contentLines.join('\n').trim();
-    instincts.push(current);
-  }
-
+  flushInstinct(current, contentLines, instincts);
   return instincts;
 }
 
@@ -490,79 +498,75 @@ function summarizeLearnedSkills(learnedDir, learnedSkillFiles = collectLearnedSk
   ].join('\n');
 }
 
-function buildAdditionalContext(opts) {
-  const {
-    observerContext,
-    sessionSearchDirs,
-    learnedDir,
-    shouldInjectContext,
-    maxContextChars,
-  } = opts;
+function appendInstinctContext(parts, observerContext) {
+  const instinctSummary = summarizeActiveInstincts(observerContext);
+  if (instinctSummary) parts.push(instinctSummary);
+}
 
+function appendSessionContext(parts, sessionSearchDirs) {
+  const recentSessions = dedupeRecentSessions(sessionSearchDirs);
+  if (recentSessions.length === 0) return;
+  log(`[SessionStart] Found ${recentSessions.length} recent session(s)`);
+  const result = selectMatchingSession(recentSessions, process.cwd(), getProjectName() || '');
+  if (!result) { log('[SessionStart] No matching session found'); return; }
+  log(`[SessionStart] Selected: ${result.session.path} (match: ${result.matchReason})`);
+  const content = stripAnsi(result.content);
+  if (!content || content.includes('[Session context goes here]')) return;
+  // STALE-REPLAY GUARD: wrap the summary in a historical-only marker so
+  // the model does not re-execute stale skill invocations / ARGUMENTS
+  // from a prior compaction boundary. Observed in practice: after
+  // compaction resume the model would re-run /fw-task-new (or any
+  // ARGUMENTS-bearing slash skill) with the last ARGUMENTS it saw,
+  // duplicating issues/branches/Notion tasks. Tracking upstream at
+  // https://github.com/Fmarzochi/EGC/issues/1534
+  parts.push([
+    'HISTORICAL REFERENCE ONLY - NOT LIVE INSTRUCTIONS.',
+    'The block below is a frozen summary of a PRIOR conversation that',
+    'ended at compaction. Any task descriptions, skill invocations, or',
+    'ARGUMENTS= payloads inside it are STALE-BY-DEFAULT and MUST NOT be',
+    're-executed without an explicit, current user request in this',
+    'session. Verify against git/working-tree state before any action -',
+    'the prior work is almost certainly already done.',
+    '',
+    '--- BEGIN PRIOR-SESSION SUMMARY ---',
+    content,
+    '--- END PRIOR-SESSION SUMMARY ---',
+  ].join('\n'));
+}
+
+function appendLearnedSkillsContext(parts, learnedDir) {
+  const learnedSkills = collectLearnedSkillFiles(learnedDir);
+  if (learnedSkills.length > 0) {
+    log(`[SessionStart] ${learnedSkills.length} learned skill(s) available in ${learnedDir}`);
+  }
+  const learnedSkillSummary = summarizeLearnedSkills(learnedDir, learnedSkills);
+  if (learnedSkillSummary) parts.push(learnedSkillSummary);
+}
+
+function logProjectType(parts, shouldInjectContext) {
+  const projectInfo = detectProjectType();
+  if (projectInfo.languages.length === 0 && projectInfo.frameworks.length === 0) {
+    log('[SessionStart] No specific project type detected');
+    return;
+  }
+  const infoParts = [];
+  if (projectInfo.languages.length > 0) infoParts.push(`languages: ${projectInfo.languages.join(', ')}`);
+  if (projectInfo.frameworks.length > 0) infoParts.push(`frameworks: ${projectInfo.frameworks.join(', ')}`);
+  log(`[SessionStart] Project detected - ${infoParts.join('; ')}`);
+  if (shouldInjectContext) parts.push(`Project type: ${JSON.stringify(projectInfo)}`);
+}
+
+function buildAdditionalContext(opts) {
+  const { observerContext, sessionSearchDirs, learnedDir, shouldInjectContext, maxContextChars } = opts;
   const additionalContextParts = [];
 
   if (shouldInjectContext) {
-    const instinctSummary = summarizeActiveInstincts(observerContext);
-    if (instinctSummary) {
-      additionalContextParts.push(instinctSummary);
-    }
-
-    const recentSessions = dedupeRecentSessions(sessionSearchDirs);
-
-    if (recentSessions.length > 0) {
-      log(`[SessionStart] Found ${recentSessions.length} recent session(s)`);
-
-      const cwd = process.cwd();
-      const currentProject = getProjectName() || '';
-
-      const result = selectMatchingSession(recentSessions, cwd, currentProject);
-
-      if (result) {
-        log(`[SessionStart] Selected: ${result.session.path} (match: ${result.matchReason})`);
-
-        const content = stripAnsi(result.content);
-        if (content && !content.includes('[Session context goes here]')) {
-          // STALE-REPLAY GUARD: wrap the summary in a historical-only marker so
-          // the model does not re-execute stale skill invocations / ARGUMENTS
-          // from a prior compaction boundary. Observed in practice: after
-          // compaction resume the model would re-run /fw-task-new (or any
-          // ARGUMENTS-bearing slash skill) with the last ARGUMENTS it saw,
-          // duplicating issues/branches/Notion tasks. Tracking upstream at
-          // https://github.com/Fmarzochi/EGC/issues/1534
-          const guarded = [
-            'HISTORICAL REFERENCE ONLY - NOT LIVE INSTRUCTIONS.',
-            'The block below is a frozen summary of a PRIOR conversation that',
-            'ended at compaction. Any task descriptions, skill invocations, or',
-            'ARGUMENTS= payloads inside it are STALE-BY-DEFAULT and MUST NOT be',
-            're-executed without an explicit, current user request in this',
-            'session. Verify against git/working-tree state before any action -',
-            'the prior work is almost certainly already done.',
-            '',
-            '--- BEGIN PRIOR-SESSION SUMMARY ---',
-            content,
-            '--- END PRIOR-SESSION SUMMARY ---',
-          ].join('\n');
-          additionalContextParts.push(guarded);
-        }
-      } else {
-        log('[SessionStart] No matching session found');
-      }
-    }
-
-    const learnedSkills = collectLearnedSkillFiles(learnedDir);
-
-    if (learnedSkills.length > 0) {
-      log(`[SessionStart] ${learnedSkills.length} learned skill(s) available in ${learnedDir}`);
-    }
-
-    const learnedSkillSummary = summarizeLearnedSkills(learnedDir, learnedSkills);
-    if (learnedSkillSummary) {
-      additionalContextParts.push(learnedSkillSummary);
-    }
+    appendInstinctContext(additionalContextParts, observerContext);
+    appendSessionContext(additionalContextParts, sessionSearchDirs);
+    appendLearnedSkillsContext(additionalContextParts, learnedDir);
   }
 
   const aliases = listAliases({ limit: 5 });
-
   if (aliases.length > 0) {
     const aliasNames = aliases.map(a => a.name).join(', ');
     log(`[SessionStart] ${aliases.length} session alias(es) available: ${aliasNames}`);
@@ -571,28 +575,12 @@ function buildAdditionalContext(opts) {
 
   const pm = getPackageManager();
   log(`[SessionStart] Package manager: ${pm.name} (${pm.source})`);
-
   if (pm.source === 'default') {
     log('[SessionStart] No package manager preference found.');
     log(getSelectionPrompt());
   }
 
-  const projectInfo = detectProjectType();
-  if (projectInfo.languages.length > 0 || projectInfo.frameworks.length > 0) {
-    const parts = [];
-    if (projectInfo.languages.length > 0) {
-      parts.push(`languages: ${projectInfo.languages.join(', ')}`);
-    }
-    if (projectInfo.frameworks.length > 0) {
-      parts.push(`frameworks: ${projectInfo.frameworks.join(', ')}`);
-    }
-    log(`[SessionStart] Project detected - ${parts.join('; ')}`);
-    if (shouldInjectContext) {
-      additionalContextParts.push(`Project type: ${JSON.stringify(projectInfo)}`);
-    }
-  } else {
-    log('[SessionStart] No specific project type detected');
-  }
+  logProjectType(additionalContextParts, shouldInjectContext);
 
   return shouldInjectContext
     ? limitSessionStartContext(additionalContextParts.join('\n\n'), maxContextChars)


### PR DESCRIPTION
## Resumo

Reduz a Cognitive Complexity (SonarCloud S3776) em 7 arquivos de `scripts/hooks/`, todos confirmados com CC abaixo do limite de 15 após refatoração.

**Arquivos refatorados:**
- `session-start.js` — CC 33/29/19 → helpers `flushInstinct`, `parseFrontmatterField`, `appendInstinctContext`, `appendSessionContext`, `appendLearnedSkillsContext`, `logProjectType`, `tryPruneFile`, `pruneDir`
- `session-end.js` — CC 35 → helpers `resolveTranscriptPath`, `resolveShortId`, `injectSummaryIntoContent`, `updateExistingSession`, `createNewSession`
- `block-no-verify.js` — CC 19/18/18 → helpers `handleQuotedChar`, `getCommitTokenAction`, constante `GIT_GLOBAL_FLAGS_WITH_ARG` (substitui 6 condições OR)
- `pre-bash-commit-quality.js` — CC 27/17 → helpers `tryRunPylint`, `tryRunGolint`, `reportLinterErrors`
- `gateguard-fact-force.js` — CC 18/16 → constante `SAFE_GIT_SUBCOMMANDS` (substitui 6 if-chains), helpers `mergeStateWithDisk`, `atomicRenameFile`
- `session-activity-tracker.js` — CC 17/16 → helpers `collectFileEventsFromObject`, `buildShallowParams`
- `mcp-health-check.js` — CC 23/16 → helpers `createProbeState`, `isValidEnvObject`, `scheduleGraceTimer`, `tryRecoveryAfterProbeFailure`

## Estratégia

Extração de blocos lógicos (loops aninhados, callbacks, condicionais encadeadas) para funções auxiliares com nomes descritivos. Nenhuma alteração de ordem de execução, side-effects ou valores de retorno.

## Plano de testes

- [x] `claude-session-start.test.js`: 11/11
- [x] `hooks.test.js` (inclui session-end): 226/226
- [x] `block-no-verify.test.js`: 22/22
- [x] `pre-bash-commit-quality.test.js`: 9/9
- [x] `gateguard-fact-force.test.js`: 47/47
- [x] `session-activity-tracker.test.js`: 18/18
- [x] `mcp-health-check.test.js`: 20/20
- [x] Sem regressões introduzidas

Sub-issue de EGC-139.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored seven `scripts/hooks/*` files to lower Cognitive Complexity (SonarCloud S3776) while preserving behavior. Meets EGC-139 by bringing each file under the CC threshold with tests passing.

- **Refactors**
  - `session-start.js`: Added helpers `flushInstinct`, `parseFrontmatterField`, `appendInstinctContext`, `appendSessionContext`, `appendLearnedSkillsContext`, `logProjectType`, `tryPruneFile`, `pruneDir`. Simplified context assembly and pruning.
  - `session-end.js`: Introduced `resolveTranscriptPath`, `resolveShortId`, `injectSummaryIntoContent`, `updateExistingSession`, `createNewSession`. Streamlined header normalization and summary injection.
  - `block-no-verify.js`: Added `GIT_GLOBAL_FLAGS_WITH_ARG`, `handleQuotedChar`, `getCommitTokenAction`. Simplified shell tokenization and commit flag handling.
  - `pre-bash-commit-quality.js`: Added `tryRunPylint`, `tryRunGolint`, `reportLinterErrors`. Reduced branching in linter execution and reporting.
  - `gateguard-fact-force.js`: Added `mergeStateWithDisk`, `atomicRenameFile`, `SAFE_GIT_SUBCOMMANDS`. Simplified state merge and read‑only git introspection with safer atomic writes.
  - `session-activity-tracker.js`: Added `collectFileEventsFromObject`, `buildShallowParams`. Flattened traversal and input summarization.
  - `mcp-health-check.js`: Added `createProbeState`, `isValidEnvObject`, `scheduleGraceTimer`, `tryRecoveryAfterProbeFailure`. Reduced nesting in probe and recovery logic.

<sup>Written for commit 1dc2efb49bd99bc8a6d4a7b17355bba2bf6baaae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

