### PR TITLE
refactor(cc): reduce cognitive complexity in scripts/ci (S3776)

### DIFF
--- a/scripts/ci/capability-graph.js
+++ b/scripts/ci/capability-graph.js
@@ -215,6 +215,16 @@ function buildCommands() {
   return commands;
 }
 
+function buildHookEntry(event, matcher, blockId, h, i) {
+  if (!h || typeof h !== 'object') return null;
+  const command = typeof h.command === 'string' ? h.command : '';
+  const handlerId = typeof h.id === 'string' ? h.id : null;
+  const id = handlerId || blockId || `${event.toLowerCase()}:${matcher || 'any'}:${i}`;
+  const scriptMatch = command.match(HOOK_SCRIPT_RE);
+  const scriptPath = scriptMatch ? `scripts/hooks/${scriptMatch[1]}` : null;
+  return { id, event, matcher, command, scriptPath };
+}
+
 function buildHooks() {
   const raw = readFileSafe(HOOKS_JSON);
   if (!raw) return [];
@@ -235,20 +245,8 @@ function buildHooks() {
       const blockId = typeof block.id === 'string' ? block.id : null;
       const handlers = Array.isArray(block.hooks) ? block.hooks : [];
       for (let i = 0; i < handlers.length; i++) {
-        const h = handlers[i];
-        if (!h || typeof h !== 'object') continue;
-        const command = typeof h.command === 'string' ? h.command : '';
-        const handlerId = typeof h.id === 'string' ? h.id : null;
-        const id = handlerId || blockId || `${event.toLowerCase()}:${matcher || 'any'}:${i}`;
-        const scriptMatch = command.match(HOOK_SCRIPT_RE);
-        const scriptPath = scriptMatch ? `scripts/hooks/${scriptMatch[1]}` : null;
-        results.push({
-          id,
-          event,
-          matcher,
-          command,
-          scriptPath
-        });
+        const entry = buildHookEntry(event, matcher, blockId, handlers[i], i);
+        if (entry) results.push(entry);
       }
     }
   }

--- a/scripts/ci/runtime-snapshot.js
+++ b/scripts/ci/runtime-snapshot.js
@@ -103,6 +103,26 @@ function buildTracerBlock(opts) {
     };
 }
 
+function queryDatabaseTables(db) {
+    const tableRows = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+        .all();
+    const tables = [];
+    for (const row of tableRows) {
+        const name = row && row.name ? String(row.name) : null;
+        if (!name) continue;
+        let rowCount = null;
+        try {
+            const countRow = db.prepare(`SELECT COUNT(*) AS c FROM "${name}"`).get();
+            rowCount = countRow && typeof countRow.c === 'number' ? countRow.c : Number(countRow ? countRow.c : 0);
+        } catch (_err) {
+            rowCount = null;
+        }
+        tables.push({ name, rowCount });
+    }
+    return tables;
+}
+
 async function buildStateStoreBlock(opts) {
     const dbPath = opts.dbPath
         ? path.resolve(opts.dbPath)
@@ -117,24 +137,7 @@ async function buildStateStoreBlock(opts) {
     let store = null;
     try {
         store = await createStateStore({ dbPath });
-        const db = store._database;
-        const tableRows = db
-            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
-            .all();
-        const tables = [];
-        for (const row of tableRows) {
-            const name = row && row.name ? String(row.name) : null;
-            if (!name) continue;
-            let rowCount = null;
-            try {
-                const countRow = db.prepare(`SELECT COUNT(*) AS c FROM "${name}"`).get();
-                rowCount = countRow && typeof countRow.c === 'number' ? countRow.c : Number(countRow ? countRow.c : 0);
-            } catch (_err) {
-                rowCount = null;
-            }
-            tables.push({ name, rowCount });
-        }
-        block.tables = tables;
+        block.tables = queryDatabaseTables(store._database);
     } catch (err) {
         block.error = err && err.message ? String(err.message) : String(err);
     } finally {

--- a/scripts/ci/runtime-snapshot.js
+++ b/scripts/ci/runtime-snapshot.js
@@ -111,7 +111,7 @@ function queryDatabaseTables(db) {
     for (const row of tableRows) {
         const name = row && row.name ? String(row.name) : null;
         if (!name) continue;
-        let rowCount = null;
+        let rowCount;
         try {
             const countRow = db.prepare(`SELECT COUNT(*) AS c FROM "${name}"`).get();
             rowCount = countRow && typeof countRow.c === 'number' ? countRow.c : Number(countRow ? countRow.c : 0);

--- a/scripts/ci/validate-agents.js
+++ b/scripts/ci/validate-agents.js
@@ -35,6 +35,30 @@ function extractFrontmatter(content) {
   return frontmatter;
 }
 
+function readAgentContent(file, filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    console.error(`ERROR: ${file} - ${err.message}`);
+    return null;
+  }
+}
+
+function validateAgentFrontmatter(file, frontmatter) {
+  let hasErrors = false;
+  for (const field of REQUIRED_FIELDS) {
+    if (!frontmatter[field] || (typeof frontmatter[field] === 'string' && !frontmatter[field].trim())) {
+      console.error(`ERROR: ${file} - Missing required field: ${field}`);
+      hasErrors = true;
+    }
+  }
+  if (frontmatter.model && !VALID_MODELS.includes(frontmatter.model)) {
+    console.error(`ERROR: ${file} - Invalid model '${frontmatter.model}'. Must be one of: ${VALID_MODELS.join(', ')}`);
+    hasErrors = true;
+  }
+  return hasErrors;
+}
+
 function validateAgents() {
   if (!fs.existsSync(AGENTS_DIR)) {
     console.log('No agents directory found, skipping validation');
@@ -45,34 +69,17 @@ function validateAgents() {
   let hasErrors = false;
 
   for (const file of files) {
-    const filePath = path.join(AGENTS_DIR, file);
-    let content;
-    try {
-      content = fs.readFileSync(filePath, 'utf-8');
-    } catch (err) {
-      console.error(`ERROR: ${file} - ${err.message}`);
-      hasErrors = true;
-      continue;
-    }
-    const frontmatter = extractFrontmatter(content);
+    const content = readAgentContent(file, path.join(AGENTS_DIR, file));
+    if (content === null) { hasErrors = true; continue; }
 
+    const frontmatter = extractFrontmatter(content);
     if (!frontmatter) {
       console.error(`ERROR: ${file} - Missing frontmatter`);
       hasErrors = true;
       continue;
     }
 
-    for (const field of REQUIRED_FIELDS) {
-      if (!frontmatter[field] || (typeof frontmatter[field] === 'string' && !frontmatter[field].trim())) {
-        console.error(`ERROR: ${file} - Missing required field: ${field}`);
-        hasErrors = true;
-      }
-    }
-
-    if (frontmatter.model && !VALID_MODELS.includes(frontmatter.model)) {
-      console.error(`ERROR: ${file} - Invalid model '${frontmatter.model}'. Must be one of: ${VALID_MODELS.join(', ')}`);
-      hasErrors = true;
-    }
+    if (validateAgentFrontmatter(file, frontmatter)) hasErrors = true;
   }
 
   if (hasErrors) {

--- a/scripts/ci/validate-commands.js
+++ b/scripts/ci/validate-commands.js
@@ -59,6 +59,120 @@ function validateFrontmatter(file, content) {
   return errors;
 }
 
+const RESERVED_SKILL_ROOTS = new Set(['learned', 'imported']);
+
+function collectValidAgents() {
+  const validAgents = new Set();
+  if (!fs.existsSync(AGENTS_DIR)) return validAgents;
+  for (const f of fs.readdirSync(AGENTS_DIR)) {
+    if (f.endsWith('.md')) validAgents.add(f.replace(/\.md$/, ''));
+  }
+  return validAgents;
+}
+
+function collectValidSkills() {
+  const validSkills = new Set();
+  if (!fs.existsSync(SKILLS_DIR)) return validSkills;
+  for (const f of fs.readdirSync(SKILLS_DIR)) {
+    const skillPath = path.join(SKILLS_DIR, f);
+    try {
+      if (fs.statSync(skillPath).isDirectory()) validSkills.add(f);
+    } catch {
+      // skip unreadable entries
+    }
+  }
+  return validSkills;
+}
+
+function checkCommandXrefs(file, contentNoCodeBlocks, validCommands) {
+  const errors = [];
+  for (const line of contentNoCodeBlocks.split('\n')) {
+    if (/creates:|would create:/i.test(line)) continue;
+    for (const match of line.matchAll(/`\/([a-z][-a-z0-9]*)`/g)) {
+      if (!validCommands.has(match[1])) {
+        errors.push(`${file} - references non-existent command /${match[1]}`);
+      }
+    }
+  }
+  return errors;
+}
+
+function checkAgentPathXrefs(file, contentNoCodeBlocks, validAgents) {
+  const errors = [];
+  for (const match of contentNoCodeBlocks.matchAll(/agents\/([a-z][-a-z0-9]*)\.md/g)) {
+    if (!validAgents.has(match[1])) {
+      errors.push(`${file} - references non-existent agent agents/${match[1]}.md`);
+    }
+  }
+  return errors;
+}
+
+function checkSkillDirXrefs(file, contentNoCodeBlocks, validSkills) {
+  const warns = [];
+  for (const match of contentNoCodeBlocks.matchAll(/skills\/([a-z][-a-z0-9]*)\//g)) {
+    if (RESERVED_SKILL_ROOTS.has(match[1]) || validSkills.has(match[1])) continue;
+    warns.push(`${file} - references skill directory skills/${match[1]}/ (not found locally)`);
+  }
+  return warns;
+}
+
+function checkWorkflowXrefs(file, contentNoCodeBlocks, validAgents) {
+  const errors = [];
+  for (const match of contentNoCodeBlocks.matchAll(/^([a-z][-a-z0-9]*(?:\s*->\s*[a-z][-a-z0-9]*)+)$/gm)) {
+    for (const agent of match[1].split(/\s*->\s*/)) {
+      if (!validAgents.has(agent)) {
+        errors.push(`${file} - workflow references non-existent agent "${agent}"`);
+      }
+    }
+  }
+  return errors;
+}
+
+function validateCommandFile(file, validCommands, validAgents, validSkills) {
+  const filePath = path.join(COMMANDS_DIR, file);
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    console.error(`ERROR: ${file} - ${err.message}`);
+    return { hasErrors: true, warnCount: 0 };
+  }
+
+  if (content.trim().length === 0) {
+    console.error(`ERROR: ${file} - Empty command file`);
+    return { hasErrors: true, warnCount: 0 };
+  }
+
+  let hasErrors = false;
+  for (const error of validateFrontmatter(file, content)) {
+    console.error(`ERROR: ${error}`);
+    hasErrors = true;
+  }
+
+  // Strip fenced code blocks before checking cross-references.
+  // Examples/templates inside ``` blocks are not real references.
+  const contentNoCodeBlocks = content.replace(/```[\s\S]*?```/g, '');
+
+  for (const error of checkCommandXrefs(file, contentNoCodeBlocks, validCommands)) {
+    console.error(`ERROR: ${error}`);
+    hasErrors = true;
+  }
+  for (const error of checkAgentPathXrefs(file, contentNoCodeBlocks, validAgents)) {
+    console.error(`ERROR: ${error}`);
+    hasErrors = true;
+  }
+  const warns = checkSkillDirXrefs(file, contentNoCodeBlocks, validSkills);
+  for (const warn of warns) {
+    console.warn(`WARN: ${warn}`);
+  }
+  for (const error of checkWorkflowXrefs(file, contentNoCodeBlocks, validAgents)) {
+    console.error(`ERROR: ${error}`);
+    hasErrors = true;
+  }
+
+  return { hasErrors, warnCount: warns.length };
+}
+
 function validateCommands() {
   if (!fs.existsSync(COMMANDS_DIR)) {
     console.log('No commands directory found, skipping validation');
@@ -66,107 +180,17 @@ function validateCommands() {
   }
 
   const files = fs.readdirSync(COMMANDS_DIR).filter(f => f.endsWith('.md'));
+  const validCommands = new Set(files.map(f => f.replace(/\.md$/, '')));
+  const validAgents = collectValidAgents();
+  const validSkills = collectValidSkills();
+
   let hasErrors = false;
   let warnCount = 0;
 
-  const validCommands = new Set(files.map(f => f.replace(/\.md$/, '')));
-
-  const validAgents = new Set();
-  if (fs.existsSync(AGENTS_DIR)) {
-    for (const f of fs.readdirSync(AGENTS_DIR)) {
-      if (f.endsWith('.md')) {
-        validAgents.add(f.replace(/\.md$/, ''));
-      }
-    }
-  }
-
-  const validSkills = new Set();
-  if (fs.existsSync(SKILLS_DIR)) {
-    for (const f of fs.readdirSync(SKILLS_DIR)) {
-      const skillPath = path.join(SKILLS_DIR, f);
-      try {
-        if (fs.statSync(skillPath).isDirectory()) {
-          validSkills.add(f);
-        }
-      } catch {
-        // skip unreadable entries
-      }
-    }
-  }
-
   for (const file of files) {
-    const filePath = path.join(COMMANDS_DIR, file);
-    let content;
-    try {
-      content = fs.readFileSync(filePath, 'utf-8');
-    } catch (err) {
-      console.error(`ERROR: ${file} - ${err.message}`);
-      hasErrors = true;
-      continue;
-    }
-
-    if (content.trim().length === 0) {
-      console.error(`ERROR: ${file} - Empty command file`);
-      hasErrors = true;
-      continue;
-    }
-
-    for (const error of validateFrontmatter(file, content)) {
-      console.error(`ERROR: ${error}`);
-      hasErrors = true;
-    }
-
-    // Strip fenced code blocks before checking cross-references.
-    // Examples/templates inside ``` blocks are not real references.
-    const contentNoCodeBlocks = content.replace(/```[\s\S]*?```/g, '');
-
-    // Check cross-references to other commands (e.g., `/build-fix`)
-    // Skip lines that describe hypothetical output (e.g., "→ Creates: `/new-table`")
-    // (previous anchored regex /^.*`\/...`.*$/gm only matched the last ref per line)
-    for (const line of contentNoCodeBlocks.split('\n')) {
-      if (/creates:|would create:/i.test(line)) continue;
-      const lineRefs = line.matchAll(/`\/([a-z][-a-z0-9]*)`/g);
-      for (const match of lineRefs) {
-        const refName = match[1];
-        if (!validCommands.has(refName)) {
-          console.error(`ERROR: ${file} - references non-existent command /${refName}`);
-          hasErrors = true;
-        }
-      }
-    }
-
-    // Check agent references (e.g., "agents/planner.md" or "`planner` agent")
-    const agentPathRefs = contentNoCodeBlocks.matchAll(/agents\/([a-z][-a-z0-9]*)\.md/g);
-    for (const match of agentPathRefs) {
-      const refName = match[1];
-      if (!validAgents.has(refName)) {
-        console.error(`ERROR: ${file} - references non-existent agent agents/${refName}.md`);
-        hasErrors = true;
-      }
-    }
-
-    // Check skill directory references (e.g., "skills/testing/tdd-workflow/")
-    // learned and imported are reserved roots (~/.gemini/skills/); no local dir expected
-    const reservedSkillRoots = new Set(['learned', 'imported']);
-    const skillRefs = contentNoCodeBlocks.matchAll(/skills\/([a-z][-a-z0-9]*)\//g);
-    for (const match of skillRefs) {
-      const refName = match[1];
-      if (reservedSkillRoots.has(refName) || validSkills.has(refName)) continue;
-      console.warn(`WARN: ${file} - references skill directory skills/${refName}/ (not found locally)`);
-      warnCount++;
-    }
-
-    // Check agent name references in workflow diagrams (e.g., "planner -> tdd-guide")
-    const workflowLines = contentNoCodeBlocks.matchAll(/^([a-z][-a-z0-9]*(?:\s*->\s*[a-z][-a-z0-9]*)+)$/gm);
-    for (const match of workflowLines) {
-      const agents = match[1].split(/\s*->\s*/);
-      for (const agent of agents) {
-        if (!validAgents.has(agent)) {
-          console.error(`ERROR: ${file} - workflow references non-existent agent "${agent}"`);
-          hasErrors = true;
-        }
-      }
-    }
+    const result = validateCommandFile(file, validCommands, validAgents, validSkills);
+    if (result.hasErrors) hasErrors = true;
+    warnCount += result.warnCount;
   }
 
   if (hasErrors) {

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -19,6 +19,22 @@ function isCategoryRoot(dir) {
   }
 }
 
+function collectSkillEntriesFromCategory(entryPath, entryName) {
+  const leaves = [];
+  const skillEntries = fs.readdirSync(entryPath, { withFileTypes: true });
+  for (const skill of skillEntries) {
+    if (!skill.isDirectory()) continue;
+    const skillPath = path.join(entryPath, skill.name);
+    const relPath = path.join(entryName, skill.name);
+    if (hasSkillMd(skillPath)) {
+      leaves.push({ relPath, fullPath: skillPath });
+    } else {
+      leaves.push({ relPath, fullPath: skillPath, missing: true });
+    }
+  }
+  return leaves;
+}
+
 function listSkillLeaves(root) {
   const leaves = [];
   const entries = fs.readdirSync(root, { withFileTypes: true });
@@ -33,31 +49,11 @@ function listSkillLeaves(root) {
     }
 
     if (isCategoryRoot(entryPath)) {
-      const skillEntries = fs.readdirSync(entryPath, { withFileTypes: true });
-      for (const skill of skillEntries) {
-        if (!skill.isDirectory()) continue;
-        const skillPath = path.join(entryPath, skill.name);
-        if (hasSkillMd(skillPath)) {
-          leaves.push({
-            relPath: path.join(entry.name, skill.name),
-            fullPath: skillPath,
-          });
-        } else {
-          leaves.push({
-            relPath: path.join(entry.name, skill.name),
-            fullPath: skillPath,
-            missing: true,
-          });
-        }
-      }
+      leaves.push(...collectSkillEntriesFromCategory(entryPath, entry.name));
       continue;
     }
 
-    leaves.push({
-      relPath: entry.name,
-      fullPath: entryPath,
-      missing: true,
-    });
+    leaves.push({ relPath: entry.name, fullPath: entryPath, missing: true });
   }
 
   return leaves;


### PR DESCRIPTION
## Resumo

Reduz a Cognitive Complexity (SonarCloud S3776) em 5 arquivos de `scripts/ci/`, todos com CC acima do limite de 15 antes da refatoração.

**Arquivos refatorados:**
- `validate-commands.js` — CC >15 em `validateCommands` → helpers `collectValidAgents`, `collectValidSkills`, `checkCommandXrefs`, `checkAgentPathXrefs`, `checkSkillDirXrefs`, `checkWorkflowXrefs`, `validateCommandFile`
- `validate-agents.js` — CC ~15 em `validateAgents` → helpers `readAgentContent`, `validateAgentFrontmatter`
- `validate-skills.js` — CC ~12 em `listSkillLeaves` → helper `collectSkillEntriesFromCategory`
- `capability-graph.js` — CC ~12 em `buildHooks` → helper `buildHookEntry`
- `runtime-snapshot.js` — CC ~12 em `buildStateStoreBlock` → helper `queryDatabaseTables`

## Estratégia

Extração de blocos lógicos (loops aninhados, try/catch, condicionais encadeadas) para funções auxiliares com nomes descritivos. Nenhuma alteração de ordem de execução, side-effects ou valores de retorno.

## Plano de testes

- [x] `tests/ci/validators.test.js`: 112/112 (55 pré-existentes de validate-hooks.js mantidos)
- [x] `tests/ci/catalog.test.js`: 5/5
- [x] `buildGraph()` manual: hooks/agents/skills/commands contagens corretas
- [x] Sem regressões introduzidas

Sub-issue de EGC-139.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `scripts/ci/` to lower Cognitive Complexity (Sonar S3776) by extracting helper functions across five files, with no behavior changes. Supports Linear EGC-139 and keeps all tests passing.

- **Refactors**
  - `validate-commands.js`: extracted helpers for agent/skill discovery, xref checks, and per-file validation.
  - `validate-agents.js`: added `readAgentContent` and `validateAgentFrontmatter`.
  - `validate-skills.js`: added `collectSkillEntriesFromCategory`.
  - `capability-graph.js`: added `buildHookEntry`.
  - `runtime-snapshot.js`: added `queryDatabaseTables` and removed a useless initializer to satisfy lint.

<sup>Written for commit c938835a8f81ba000dcfee0e6b79f34af24aa573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

