### PR TITLE
revert: remove Multica internal data from public context files (#794)

### DIFF
--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -1,56 +1,16 @@
 ---
-description: EGC project memory (auto-updated)
+description: EGC project memory (auto-updated by update_state)
 alwaysApply: true
 ---
 
-<!-- egc:state-updated:2026-07-16T22:37:49.214Z -->
 ## EGC Project Memory
 
-**Context:** EGC - projeto OSS de memoria persistente para AI coding tools. Marco: migracao completa do squad de 97 agentes do Multica pra runtimes sem custo por token (Antigravity/OpenCode), encerrando a fase de otimizacao de custo do EGC-134/144-165
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Bug real encontrado e corrigido: 46 dos 93 agentes migrados pro Antigravity ficaram com combinacao invalida runtime=OpenCode + model=Gemini, porque um script leu snapshot desatualizado de agent_list enquanto outro script ja tinha movido esses agentes pro OpenCode nos minutos anteriores. Corrigido restaurando o modelo correto (nvidia-nim ou sambanova) baseado no log original do rebalanceamento. Confirmado 0 mismatches na frota inteira apos o fix: Explicava os erros genericos 'Unexpected server error' que pareciam ser instabilidade do Multica mas eram config quebrada minha
-- SambaNova removida definitivamente do squad (provider tirado do opencode.json, 24 agentes migrados pro Antigravity/Gemini 3.5 Flash Medium): Rate limit real confirmado no log (AI_APICallError TOO MANY REQUESTS) apos o volume de testes desta sessao; Felipe ja tinha avisado que SambaNova nao e confiavel e pediu remocao assim que confirmado
-- Todos os 97 agentes do workspace Multica migrados do runtime Claude pago: 93 no Antigravity (22 Gemini 3.1 Pro High, 71 Gemini 3.5 Flash Medium), 4 no OpenCode (NVIDIA Nemotron 3 Ultra, SambaNova Llama 3.3 70B). Zero agentes restantes no Claude: Felipe decidiu usar o squad em multiplos projetos de engenharia, nao so EGC; objetivo de parar de gastar o limite pago do Claude Code se cumpriu
-- Dentro do Antigravity, Claude Sonnet/Opus trocado por Gemini 3.1 Pro/3.5 Flash em todos os agentes: Felipe testou empiricamente e confirmou que Claude no plano dele via Antigravity esgota token rapido demais pra terminar uma auditoria completa; Gemini no mesmo plano tem bem mais folego
-- Cerebras removida definitivamente do opencode.json: Rate limit TPM reproduzido de forma consistente e persistente (ate 20min de espera sem nenhuma chamada), isolado como especifico do padrao de chamadas do opencode via curl comparativo
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Estado final confirmado do squad: 71 agentes no Antigravity (Gemini 3.1 Pro High tier critico, Gemini 3.5 Flash Medium tier rotina), 26 no OpenCode (todos NVIDIA Nemotron 3 Ultra agora, SambaNova e Cerebras removidos), 0 no Claude pago, 0 mismatches de config
-- Publicar a atualizacao final da nota Multica-Migracao-Squad-Sem-Custo-Token-2026-07-16.md no Obsidian quando o app abrir (MCP em timeout de novo nesta sessao) -- conteudo completo pronto em /tmp/claude-1000/-home-felipe-Projetos-EGC/788fcf04-c6d7-4f39-b913-dff7b470b074/scratchpad/Multica-OpenCode-env-vars-locais.md
-- Groq nunca foi usado em massa (so testado individualmente, travou 1x) -- nao decidido se mantem ou remove tambem
-- Se quiser mais resiliencia que so 2 canais (Antigravity + NVIDIA), avaliar investigar o erro de autenticacao da Cloudflare Workers AI
-
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.

--- a/.trae/rules/egc-context.md
+++ b/.trae/rules/egc-context.md
@@ -22,55 +22,15 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
 
 <!-- egc:start -->
-<!-- egc:state-updated:2026-07-16T22:37:49.214Z -->
 ## EGC Project Memory
 
-**Context:** EGC - projeto OSS de memoria persistente para AI coding tools. Marco: migracao completa do squad de 97 agentes do Multica pra runtimes sem custo por token (Antigravity/OpenCode), encerrando a fase de otimizacao de custo do EGC-134/144-165
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Bug real encontrado e corrigido: 46 dos 93 agentes migrados pro Antigravity ficaram com combinacao invalida runtime=OpenCode + model=Gemini, porque um script leu snapshot desatualizado de agent_list enquanto outro script ja tinha movido esses agentes pro OpenCode nos minutos anteriores. Corrigido restaurando o modelo correto (nvidia-nim ou sambanova) baseado no log original do rebalanceamento. Confirmado 0 mismatches na frota inteira apos o fix: Explicava os erros genericos 'Unexpected server error' que pareciam ser instabilidade do Multica mas eram config quebrada minha
-- SambaNova removida definitivamente do squad (provider tirado do opencode.json, 24 agentes migrados pro Antigravity/Gemini 3.5 Flash Medium): Rate limit real confirmado no log (AI_APICallError TOO MANY REQUESTS) apos o volume de testes desta sessao; Felipe ja tinha avisado que SambaNova nao e confiavel e pediu remocao assim que confirmado
-- Todos os 97 agentes do workspace Multica migrados do runtime Claude pago: 93 no Antigravity (22 Gemini 3.1 Pro High, 71 Gemini 3.5 Flash Medium), 4 no OpenCode (NVIDIA Nemotron 3 Ultra, SambaNova Llama 3.3 70B). Zero agentes restantes no Claude: Felipe decidiu usar o squad em multiplos projetos de engenharia, nao so EGC; objetivo de parar de gastar o limite pago do Claude Code se cumpriu
-- Dentro do Antigravity, Claude Sonnet/Opus trocado por Gemini 3.1 Pro/3.5 Flash em todos os agentes: Felipe testou empiricamente e confirmou que Claude no plano dele via Antigravity esgota token rapido demais pra terminar uma auditoria completa; Gemini no mesmo plano tem bem mais folego
-- Cerebras removida definitivamente do opencode.json: Rate limit TPM reproduzido de forma consistente e persistente (ate 20min de espera sem nenhuma chamada), isolado como especifico do padrao de chamadas do opencode via curl comparativo
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Estado final confirmado do squad: 71 agentes no Antigravity (Gemini 3.1 Pro High tier critico, Gemini 3.5 Flash Medium tier rotina), 26 no OpenCode (todos NVIDIA Nemotron 3 Ultra agora, SambaNova e Cerebras removidos), 0 no Claude pago, 0 mismatches de config
-- Publicar a atualizacao final da nota Multica-Migracao-Squad-Sem-Custo-Token-2026-07-16.md no Obsidian quando o app abrir (MCP em timeout de novo nesta sessao) -- conteudo completo pronto em /tmp/claude-1000/-home-felipe-Projetos-EGC/788fcf04-c6d7-4f39-b913-dff7b470b074/scratchpad/Multica-OpenCode-env-vars-locais.md
-- Groq nunca foi usado em massa (so testado individualmente, travou 1x) -- nao decidido se mantem ou remove tambem
-- Se quiser mais resiliencia que so 2 canais (Antigravity + NVIDIA), avaliar investigar o erro de autenticacao da Cloudflare Workers AI
-
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,55 +60,15 @@ These calls are automatic and non-negotiable. Never wait for the user to ask.
 Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
 
 <!-- egc:start -->
-<!-- egc:state-updated:2026-07-16T22:37:49.214Z -->
 ## EGC Project Memory
 
-**Context:** EGC - projeto OSS de memoria persistente para AI coding tools. Marco: migracao completa do squad de 97 agentes do Multica pra runtimes sem custo por token (Antigravity/OpenCode), encerrando a fase de otimizacao de custo do EGC-134/144-165
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Bug real encontrado e corrigido: 46 dos 93 agentes migrados pro Antigravity ficaram com combinacao invalida runtime=OpenCode + model=Gemini, porque um script leu snapshot desatualizado de agent_list enquanto outro script ja tinha movido esses agentes pro OpenCode nos minutos anteriores. Corrigido restaurando o modelo correto (nvidia-nim ou sambanova) baseado no log original do rebalanceamento. Confirmado 0 mismatches na frota inteira apos o fix: Explicava os erros genericos 'Unexpected server error' que pareciam ser instabilidade do Multica mas eram config quebrada minha
-- SambaNova removida definitivamente do squad (provider tirado do opencode.json, 24 agentes migrados pro Antigravity/Gemini 3.5 Flash Medium): Rate limit real confirmado no log (AI_APICallError TOO MANY REQUESTS) apos o volume de testes desta sessao; Felipe ja tinha avisado que SambaNova nao e confiavel e pediu remocao assim que confirmado
-- Todos os 97 agentes do workspace Multica migrados do runtime Claude pago: 93 no Antigravity (22 Gemini 3.1 Pro High, 71 Gemini 3.5 Flash Medium), 4 no OpenCode (NVIDIA Nemotron 3 Ultra, SambaNova Llama 3.3 70B). Zero agentes restantes no Claude: Felipe decidiu usar o squad em multiplos projetos de engenharia, nao so EGC; objetivo de parar de gastar o limite pago do Claude Code se cumpriu
-- Dentro do Antigravity, Claude Sonnet/Opus trocado por Gemini 3.1 Pro/3.5 Flash em todos os agentes: Felipe testou empiricamente e confirmou que Claude no plano dele via Antigravity esgota token rapido demais pra terminar uma auditoria completa; Gemini no mesmo plano tem bem mais folego
-- Cerebras removida definitivamente do opencode.json: Rate limit TPM reproduzido de forma consistente e persistente (ate 20min de espera sem nenhuma chamada), isolado como especifico do padrao de chamadas do opencode via curl comparativo
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Estado final confirmado do squad: 71 agentes no Antigravity (Gemini 3.1 Pro High tier critico, Gemini 3.5 Flash Medium tier rotina), 26 no OpenCode (todos NVIDIA Nemotron 3 Ultra agora, SambaNova e Cerebras removidos), 0 no Claude pago, 0 mismatches de config
-- Publicar a atualizacao final da nota Multica-Migracao-Squad-Sem-Custo-Token-2026-07-16.md no Obsidian quando o app abrir (MCP em timeout de novo nesta sessao) -- conteudo completo pronto em /tmp/claude-1000/-home-felipe-Projetos-EGC/788fcf04-c6d7-4f39-b913-dff7b470b074/scratchpad/Multica-OpenCode-env-vars-locais.md
-- Groq nunca foi usado em massa (so testado individualmente, travou 1x) -- nao decidido se mantem ou remove tambem
-- Se quiser mais resiliencia que so 2 canais (Antigravity + NVIDIA), avaliar investigar o erro de autenticacao da Cloudflare Workers AI
-
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -91,55 +91,15 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
 
 <!-- egc:start -->
-<!-- egc:state-updated:2026-07-16T22:37:49.214Z -->
 ## EGC Project Memory
 
-**Context:** EGC - projeto OSS de memoria persistente para AI coding tools. Marco: migracao completa do squad de 97 agentes do Multica pra runtimes sem custo por token (Antigravity/OpenCode), encerrando a fase de otimizacao de custo do EGC-134/144-165
+**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
 
 **Active decisions:**
-- Bug real encontrado e corrigido: 46 dos 93 agentes migrados pro Antigravity ficaram com combinacao invalida runtime=OpenCode + model=Gemini, porque um script leu snapshot desatualizado de agent_list enquanto outro script ja tinha movido esses agentes pro OpenCode nos minutos anteriores. Corrigido restaurando o modelo correto (nvidia-nim ou sambanova) baseado no log original do rebalanceamento. Confirmado 0 mismatches na frota inteira apos o fix: Explicava os erros genericos 'Unexpected server error' que pareciam ser instabilidade do Multica mas eram config quebrada minha
-- SambaNova removida definitivamente do squad (provider tirado do opencode.json, 24 agentes migrados pro Antigravity/Gemini 3.5 Flash Medium): Rate limit real confirmado no log (AI_APICallError TOO MANY REQUESTS) apos o volume de testes desta sessao; Felipe ja tinha avisado que SambaNova nao e confiavel e pediu remocao assim que confirmado
-- Todos os 97 agentes do workspace Multica migrados do runtime Claude pago: 93 no Antigravity (22 Gemini 3.1 Pro High, 71 Gemini 3.5 Flash Medium), 4 no OpenCode (NVIDIA Nemotron 3 Ultra, SambaNova Llama 3.3 70B). Zero agentes restantes no Claude: Felipe decidiu usar o squad em multiplos projetos de engenharia, nao so EGC; objetivo de parar de gastar o limite pago do Claude Code se cumpriu
-- Dentro do Antigravity, Claude Sonnet/Opus trocado por Gemini 3.1 Pro/3.5 Flash em todos os agentes: Felipe testou empiricamente e confirmou que Claude no plano dele via Antigravity esgota token rapido demais pra terminar uma auditoria completa; Gemini no mesmo plano tem bem mais folego
-- Cerebras removida definitivamente do opencode.json: Rate limit TPM reproduzido de forma consistente e persistente (ate 20min de espera sem nenhuma chamada), isolado como especifico do padrao de chamadas do opencode via curl comparativo
+- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
+- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
 
 **Next session:**
-- Estado final confirmado do squad: 71 agentes no Antigravity (Gemini 3.1 Pro High tier critico, Gemini 3.5 Flash Medium tier rotina), 26 no OpenCode (todos NVIDIA Nemotron 3 Ultra agora, SambaNova e Cerebras removidos), 0 no Claude pago, 0 mismatches de config
-- Publicar a atualizacao final da nota Multica-Migracao-Squad-Sem-Custo-Token-2026-07-16.md no Obsidian quando o app abrir (MCP em timeout de novo nesta sessao) -- conteudo completo pronto em /tmp/claude-1000/-home-felipe-Projetos-EGC/788fcf04-c6d7-4f39-b913-dff7b470b074/scratchpad/Multica-OpenCode-env-vars-locais.md
-- Groq nunca foi usado em massa (so testado individualmente, travou 1x) -- nao decidido se mantem ou remove tambem
-- Se quiser mais resiliencia que so 2 canais (Antigravity + NVIDIA), avaliar investigar o erro de autenticacao da Cloudflare Workers AI
-
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
+- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
+- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->


### PR DESCRIPTION
Reverts PR #794. That PR accidentally embedded internal Multica squad configuration (agent counts, provider names, migration decisions) into AGENTS.md, GEMINI.md and IDE rule files that are part of the public EGC repository. This data is private operational context and must not be in the public repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the context update that leaked internal Multica squad details into public files. Removes sensitive operational data and restores a sanitized EGC project memory.

- **Bug Fixes**
  - Removed internal Multica configuration (agent counts, provider names, migration notes) from `AGENTS.md`, `GEMINI.md`, `.cursor/rules/egc-context.mdc`, and `.trae/rules/egc-context.md`.
  - Restored generic, public-safe project state; stripped operational notes and timestamps.
  - Ensures no internal operational context remains in the public repo.

<sup>Written for commit 4131cb464d62086108d5f993724850f75733c101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

