### PR TITLE
refactor(cc): reduce cognitive complexity of plugin, team and budget commands (S3776)

### DIFF
--- a/scripts/budget.js
+++ b/scripts/budget.js
@@ -37,6 +37,98 @@ Examples:
 `);
 }
 
+function handleSet(args) {
+  const tokensIdx = args.indexOf('--tokens');
+  const costIdx = args.indexOf('--cost');
+  const warnAtIdx = args.indexOf('--warn-at');
+  const actionIdx = args.indexOf('--action');
+
+  const maxTokens = tokensIdx !== -1 ? Number.parseInt(args[tokensIdx + 1], 10) : undefined;
+  const maxCost = costIdx !== -1 ? Number.parseFloat(args[costIdx + 1]) : undefined;
+  const warnAtPercent = warnAtIdx !== -1 ? Number.parseInt(args[warnAtIdx + 1], 10) : undefined;
+  const action = actionIdx !== -1 ? args[actionIdx + 1] : undefined;
+
+  if (maxTokens !== undefined && (isNaN(maxTokens) || maxTokens <= 0)) {
+    console.error('Error: --tokens must be a positive integer');
+    process.exit(1);
+  }
+  if (maxCost !== undefined && (isNaN(maxCost) || maxCost <= 0)) {
+    console.error('Error: --cost must be a positive number');
+    process.exit(1);
+  }
+  if (warnAtPercent !== undefined && (isNaN(warnAtPercent) || warnAtPercent < 1 || warnAtPercent > 100)) {
+    console.error('Error: --warn-at must be between 1 and 100');
+    process.exit(1);
+  }
+  if (action !== undefined && action !== 'warn' && action !== 'block') {
+    console.error('Error: --action must be "warn" or "block"');
+    process.exit(1);
+  }
+
+  const existing = readBudgetConfig() || getDefaultBudget();
+  const config = {
+    max_tokens: maxTokens !== undefined ? maxTokens : existing.max_tokens,
+    max_cost_usd: maxCost !== undefined ? maxCost : existing.max_cost_usd,
+    warn_at_percent: warnAtPercent !== undefined ? warnAtPercent : existing.warn_at_percent,
+    action: action !== undefined ? action : existing.action,
+  };
+
+  writeBudgetConfig(config);
+  console.log('Budget config saved:');
+  console.log(`  Max tokens: ${config.max_tokens !== null ? config.max_tokens.toLocaleString() : 'not set'}`);
+  console.log(`  Max cost:   ${config.max_cost_usd !== null ? `$${config.max_cost_usd.toFixed(2)}` : 'not set'}`);
+  console.log(`  Warn at:    ${config.warn_at_percent}%`);
+  console.log(`  Action:     ${config.action}`);
+}
+
+function handleStatus() {
+  const config = readBudgetConfig();
+  if (!config) {
+    console.log('Budget guardian: not configured');
+    console.log('Set a budget with: egc budget set --tokens 100000');
+    process.exit(0);
+  }
+
+  const usage = readBudgetUsage();
+  const maxTokens = config.max_tokens;
+  const maxCost = config.max_cost_usd;
+
+  console.log('Budget Config:');
+  if (maxTokens) {
+    const pct = Math.round((usage.tokens_used / maxTokens) * 100);
+    console.log(`  Tokens:     ${usage.tokens_used.toLocaleString()} / ${maxTokens.toLocaleString()} (${pct}%)`);
+  } else {
+    console.log(`  Tokens:     ${usage.tokens_used.toLocaleString()} (no limit)`);
+  }
+  if (maxCost) {
+    const pct = Math.round((usage.cost_usd / maxCost) * 100);
+    console.log(`  Cost:       $${usage.cost_usd.toFixed(4)} / $${maxCost.toFixed(2)} (${pct}%)`);
+  } else {
+    console.log(`  Cost:       $${usage.cost_usd.toFixed(4)} (no limit)`);
+  }
+  console.log(`  Tool calls: ${usage.tool_calls}`);
+  console.log(`  Warn at:    ${config.warn_at_percent}%`);
+  console.log(`  Action:     ${config.action}`);
+  console.log(`  Session:    ${usage.session_start}`);
+
+  const check = checkBudget();
+  if (check.block) {
+    console.log(`\n  Status:     BLOCKED — ${check.reason}`);
+  } else if (check.warn) {
+    console.log(`\n  Status:     WARNING — ${check.reason}`);
+  } else if (config.max_tokens || config.max_cost_usd) {
+    console.log(`\n  Status:     OK — within budget`);
+  }
+}
+
+function handleReset() {
+  resetBudgetUsage();
+  console.log('Session budget usage reset.');
+  console.log(`  Tokens:     0`);
+  console.log(`  Cost:       $0.00`);
+  console.log(`  Tool calls: 0`);
+}
+
 async function main() {
   const args = process.argv.slice(3);
   const firstArg = args[0];
@@ -47,100 +139,17 @@ async function main() {
   }
 
   switch (firstArg) {
-    case 'set': {
-      const tokensIdx = args.indexOf('--tokens');
-      const costIdx = args.indexOf('--cost');
-      const warnAtIdx = args.indexOf('--warn-at');
-      const actionIdx = args.indexOf('--action');
-
-      const maxTokens = tokensIdx !== -1 ? Number.parseInt(args[tokensIdx + 1], 10) : undefined;
-      const maxCost = costIdx !== -1 ? Number.parseFloat(args[costIdx + 1]) : undefined;
-      const warnAtPercent = warnAtIdx !== -1 ? Number.parseInt(args[warnAtIdx + 1], 10) : undefined;
-      const action = actionIdx !== -1 ? args[actionIdx + 1] : undefined;
-
-      if (maxTokens !== undefined && (isNaN(maxTokens) || maxTokens <= 0)) {
-        console.error('Error: --tokens must be a positive integer');
-        process.exit(1);
-      }
-      if (maxCost !== undefined && (isNaN(maxCost) || maxCost <= 0)) {
-        console.error('Error: --cost must be a positive number');
-        process.exit(1);
-      }
-      if (warnAtPercent !== undefined && (isNaN(warnAtPercent) || warnAtPercent < 1 || warnAtPercent > 100)) {
-        console.error('Error: --warn-at must be between 1 and 100');
-        process.exit(1);
-      }
-      if (action !== undefined && action !== 'warn' && action !== 'block') {
-        console.error('Error: --action must be "warn" or "block"');
-        process.exit(1);
-      }
-
-      const existing = readBudgetConfig() || getDefaultBudget();
-      const config = {
-        max_tokens: maxTokens !== undefined ? maxTokens : existing.max_tokens,
-        max_cost_usd: maxCost !== undefined ? maxCost : existing.max_cost_usd,
-        warn_at_percent: warnAtPercent !== undefined ? warnAtPercent : existing.warn_at_percent,
-        action: action !== undefined ? action : existing.action,
-      };
-
-      writeBudgetConfig(config);
-      console.log('Budget config saved:');
-      console.log(`  Max tokens: ${config.max_tokens !== null ? config.max_tokens.toLocaleString() : 'not set'}`);
-      console.log(`  Max cost:   ${config.max_cost_usd !== null ? `$${config.max_cost_usd.toFixed(2)}` : 'not set'}`);
-      console.log(`  Warn at:    ${config.warn_at_percent}%`);
-      console.log(`  Action:     ${config.action}`);
+    case 'set':
+      handleSet(args);
       break;
-    }
 
-    case 'status': {
-      const config = readBudgetConfig();
-      if (!config) {
-        console.log('Budget guardian: not configured');
-        console.log('Set a budget with: egc budget set --tokens 100000');
-        process.exit(0);
-      }
-
-      const usage = readBudgetUsage();
-      const maxTokens = config.max_tokens;
-      const maxCost = config.max_cost_usd;
-
-      console.log('Budget Config:');
-      if (maxTokens) {
-        const pct = Math.round((usage.tokens_used / maxTokens) * 100);
-        console.log(`  Tokens:     ${usage.tokens_used.toLocaleString()} / ${maxTokens.toLocaleString()} (${pct}%)`);
-      } else {
-        console.log(`  Tokens:     ${usage.tokens_used.toLocaleString()} (no limit)`);
-      }
-      if (maxCost) {
-        const pct = Math.round((usage.cost_usd / maxCost) * 100);
-        console.log(`  Cost:       $${usage.cost_usd.toFixed(4)} / $${maxCost.toFixed(2)} (${pct}%)`);
-      } else {
-        console.log(`  Cost:       $${usage.cost_usd.toFixed(4)} (no limit)`);
-      }
-      console.log(`  Tool calls: ${usage.tool_calls}`);
-      console.log(`  Warn at:    ${config.warn_at_percent}%`);
-      console.log(`  Action:     ${config.action}`);
-      console.log(`  Session:    ${usage.session_start}`);
-
-      const check = checkBudget();
-      if (check.block) {
-        console.log(`\n  Status:     BLOCKED — ${check.reason}`);
-      } else if (check.warn) {
-        console.log(`\n  Status:     WARNING — ${check.reason}`);
-      } else if (config.max_tokens || config.max_cost_usd) {
-        console.log(`\n  Status:     OK — within budget`);
-      }
+    case 'status':
+      handleStatus();
       break;
-    }
 
-    case 'reset': {
-      resetBudgetUsage();
-      console.log('Session budget usage reset.');
-      console.log(`  Tokens:     0`);
-      console.log(`  Cost:       $0.00`);
-      console.log(`  Tool calls: 0`);
+    case 'reset':
+      handleReset();
       break;
-    }
 
     default:
       console.error(`Unknown budget subcommand: ${firstArg}`);

--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -39,6 +39,129 @@ Examples:
 `);
 }
 
+async function handleInstall(args) {
+  const pluginName = args[1];
+  if (!pluginName) {
+    console.error('Error: Usage: egc plugin install <name> [--source <path>]');
+    process.exit(1);
+  }
+
+  const sourceIdx = args.indexOf('--source');
+  let result;
+
+  if (sourceIdx !== -1 && args[sourceIdx + 1]) {
+    const sourcePath = path.resolve(args[sourceIdx + 1]);
+    if (!require('node:fs').existsSync(sourcePath)) {
+      console.error(`Error: Source path does not exist: ${sourcePath}`);
+      process.exit(1);
+    }
+    console.log(`Installing plugin "${pluginName}" from ${sourcePath}...`);
+    result = installPluginFromDir(sourcePath, pluginName);
+  } else {
+    console.log(`Installing plugin "${pluginName}" from npm...`);
+    result = installPluginFromNpm(pluginName, pluginName);
+  }
+
+  if (result.success) {
+    console.log(`Plugin "${pluginName}" v${result.plugin.version} installed.`);
+    if (result.plugin.skills.length) {
+      console.log(`  Skills: ${result.plugin.skills.join(', ')}`);
+    }
+    if (result.plugin.agents.length) {
+      console.log(`  Agents: ${result.plugin.agents.join(', ')}`);
+    }
+    if (result.plugin.rules.length) {
+      console.log(`  Rules: ${result.plugin.rules.join(', ')}`);
+    }
+  } else {
+    console.error(`Failed to install plugin "${pluginName}":`);
+    for (const err of result.errors) {
+      console.error(`  - ${err}`);
+    }
+    process.exit(1);
+  }
+}
+
+function handleList() {
+  const plugins = listInstalledPlugins();
+  if (plugins.length === 0) {
+    console.log('No plugins installed.');
+    console.log('Install one with: egc plugin install <name>');
+    process.exit(0);
+  }
+
+  console.log(`Installed plugins (${plugins.length}):\n`);
+  for (const p of plugins) {
+    console.log(`  ${p.name}`);
+    console.log(`    Version:    ${p.version}`);
+    console.log(`    Description: ${p.description || '-'}`);
+    console.log(`    Installed:  ${p.installedAt}`);
+    if (p.skills.length) console.log(`    Skills:     ${p.skills.join(', ')}`);
+    if (p.agents.length) console.log(`    Agents:     ${p.agents.join(', ')}`);
+    if (p.rules.length) console.log(`    Rules:      ${p.rules.join(', ')}`);
+    console.log('');
+  }
+}
+
+function handleRemove(args) {
+  const pluginName = args[1];
+  if (!pluginName) {
+    console.error('Error: Usage: egc plugin remove <name>');
+    process.exit(1);
+  }
+
+  const existing = getInstalledPlugin(pluginName);
+  if (!existing) {
+    console.error(`Plugin "${pluginName}" is not installed.`);
+    process.exit(1);
+  }
+
+  const result = removePlugin(pluginName);
+  if (result.success) {
+    console.log(`Plugin "${pluginName}" removed.`);
+  } else {
+    console.error(`Failed to remove plugin: ${result.errors.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+function handleUpdate(args) {
+  const pluginName = args[1];
+
+  if (pluginName) {
+    const existing = getInstalledPlugin(pluginName);
+    if (!existing) {
+      console.error(`Plugin "${pluginName}" is not installed.`);
+      process.exit(1);
+    }
+    console.log(`Updating plugin "${pluginName}"...`);
+    const result = updatePlugin(pluginName);
+    if (result.success) {
+      console.log(`Plugin "${pluginName}" updated.`);
+    } else {
+      console.error(`Failed to update plugin: ${result.errors.join(', ')}`);
+      process.exit(1);
+    }
+  } else {
+    const { reinstallAllPlugins } = require('./lib/plugin-registry');
+    console.log('Updating all plugins...');
+    const results = reinstallAllPlugins();
+    let ok = 0;
+    let fail = 0;
+    for (const r of results) {
+      if (r.success) {
+        console.log(`  \u2713 ${r.name}`);
+        ok++;
+      } else {
+        console.log(`  \u2717 ${r.name}: ${(r.errors || []).join(', ')}`);
+        fail++;
+      }
+    }
+    console.log(`\n${ok} updated, ${fail} failed`);
+    if (fail > 0) process.exit(1);
+  }
+}
+
 async function main() {
   const args = process.argv.slice(3);
   const firstArg = args[0];
@@ -49,132 +172,21 @@ async function main() {
   }
 
   switch (firstArg) {
-    case 'install': {
-      const pluginName = args[1];
-      if (!pluginName) {
-        console.error('Error: Usage: egc plugin install <name> [--source <path>]');
-        process.exit(1);
-      }
-
-      const sourceIdx = args.indexOf('--source');
-      let result;
-
-      if (sourceIdx !== -1 && args[sourceIdx + 1]) {
-        const sourcePath = path.resolve(args[sourceIdx + 1]);
-        if (!require('node:fs').existsSync(sourcePath)) {
-          console.error(`Error: Source path does not exist: ${sourcePath}`);
-          process.exit(1);
-        }
-        console.log(`Installing plugin "${pluginName}" from ${sourcePath}...`);
-        result = installPluginFromDir(sourcePath, pluginName);
-      } else {
-        console.log(`Installing plugin "${pluginName}" from npm...`);
-        result = installPluginFromNpm(pluginName, pluginName);
-      }
-
-      if (result.success) {
-        console.log(`Plugin "${pluginName}" v${result.plugin.version} installed.`);
-        if (result.plugin.skills.length) {
-          console.log(`  Skills: ${result.plugin.skills.join(', ')}`);
-        }
-        if (result.plugin.agents.length) {
-          console.log(`  Agents: ${result.plugin.agents.join(', ')}`);
-        }
-        if (result.plugin.rules.length) {
-          console.log(`  Rules: ${result.plugin.rules.join(', ')}`);
-        }
-      } else {
-        console.error(`Failed to install plugin "${pluginName}":`);
-        for (const err of result.errors) {
-          console.error(`  - ${err}`);
-        }
-        process.exit(1);
-      }
+    case 'install':
+      await handleInstall(args);
       break;
-    }
 
-    case 'list': {
-      const plugins = listInstalledPlugins();
-      if (plugins.length === 0) {
-        console.log('No plugins installed.');
-        console.log('Install one with: egc plugin install <name>');
-        process.exit(0);
-      }
-
-      console.log(`Installed plugins (${plugins.length}):\n`);
-      for (const p of plugins) {
-        console.log(`  ${p.name}`);
-        console.log(`    Version:    ${p.version}`);
-        console.log(`    Description: ${p.description || '-'}`);
-        console.log(`    Installed:  ${p.installedAt}`);
-        if (p.skills.length) console.log(`    Skills:     ${p.skills.join(', ')}`);
-        if (p.agents.length) console.log(`    Agents:     ${p.agents.join(', ')}`);
-        if (p.rules.length) console.log(`    Rules:      ${p.rules.join(', ')}`);
-        console.log('');
-      }
+    case 'list':
+      handleList();
       break;
-    }
 
-    case 'remove': {
-      const pluginName = args[1];
-      if (!pluginName) {
-        console.error('Error: Usage: egc plugin remove <name>');
-        process.exit(1);
-      }
-
-      const existing = getInstalledPlugin(pluginName);
-      if (!existing) {
-        console.error(`Plugin "${pluginName}" is not installed.`);
-        process.exit(1);
-      }
-
-      const result = removePlugin(pluginName);
-      if (result.success) {
-        console.log(`Plugin "${pluginName}" removed.`);
-      } else {
-        console.error(`Failed to remove plugin: ${result.errors.join(', ')}`);
-        process.exit(1);
-      }
+    case 'remove':
+      handleRemove(args);
       break;
-    }
 
-    case 'update': {
-      const pluginName = args[1];
-
-      if (pluginName) {
-        const existing = getInstalledPlugin(pluginName);
-        if (!existing) {
-          console.error(`Plugin "${pluginName}" is not installed.`);
-          process.exit(1);
-        }
-        console.log(`Updating plugin "${pluginName}"...`);
-        const result = updatePlugin(pluginName);
-        if (result.success) {
-          console.log(`Plugin "${pluginName}" updated.`);
-        } else {
-          console.error(`Failed to update plugin: ${result.errors.join(', ')}`);
-          process.exit(1);
-        }
-      } else {
-        const { reinstallAllPlugins } = require('./lib/plugin-registry');
-        console.log('Updating all plugins...');
-        const results = reinstallAllPlugins();
-        let ok = 0;
-        let fail = 0;
-        for (const r of results) {
-          if (r.success) {
-            console.log(`  \u2713 ${r.name}`);
-            ok++;
-          } else {
-            console.log(`  \u2717 ${r.name}: ${(r.errors || []).join(', ')}`);
-            fail++;
-          }
-        }
-        console.log(`\n${ok} updated, ${fail} failed`);
-        if (fail > 0) process.exit(1);
-      }
+    case 'update':
+      handleUpdate(args);
       break;
-    }
 
     default:
       console.error(`Unknown plugin subcommand: ${firstArg}`);

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -134,6 +134,99 @@ function callMcpTool(toolName, args) {
   throw new Error('No response from memory server');
 }
 
+function handleInit(args) {
+  const backendIdx = args.indexOf('--backend');
+  const remoteIdx = args.indexOf('--remote');
+  const branchIdx = args.indexOf('--branch');
+
+  const backend = backendIdx !== -1 ? args[backendIdx + 1] : 'git';
+  const remote = remoteIdx !== -1 ? args[remoteIdx + 1] : null;
+  const branch = branchIdx !== -1 ? args[branchIdx + 1] : 'main';
+
+  if (!remote) {
+    console.error('Error: --remote is required for team init');
+    process.exit(1);
+  }
+
+  const config = { backend, remote, branch };
+  fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+  console.log(`Team initialized:
+  Backend: ${backend}
+  Remote:  ${remote}
+  Branch:  ${branch}
+  Config:  ${TEAM_CONFIG_PATH}`);
+
+  // Now try to connect and set up via MCP tool.
+  try {
+    const result = callMcpTool('team_init', { backend, remote, branch });
+    if (result) {
+      console.log('Sync backend configured successfully.');
+    }
+  } catch (err) {
+    console.log(`Note: Memory server setup returned: ${err.message}`);
+    console.log('The config file is saved. Run "egc team sync" to start syncing.');
+  }
+}
+
+async function handleSync() {
+  const config = getTeamConfig();
+  if (!config) {
+    console.error('Error: Team not initialized. Run "egc team init" first.');
+    process.exit(1);
+  }
+
+  console.log('Syncing team memory...');
+  try {
+    const result = callMcpTool('team_sync', {});
+    console.log('Sync complete:');
+    if (result.pulledCount !== undefined) console.log(`  Pulled: ${result.pulledCount} files`);
+    if (result.pushedCount !== undefined) console.log(`  Pushed: ${result.pushedCount} commits`);
+    if (result.conflictCount !== undefined && result.conflictCount > 0) {
+      console.log(`  Conflicts: ${result.conflictCount} (resolve manually in ~/.egc/team-sync/)`);
+    }
+    if (result.errors && result.errors.length > 0) {
+      console.log(`  Errors: ${result.errors.join(', ')}`);
+    }
+  } catch (err) {
+    // Fallback: use direct git operations.
+    console.log(`MCP tool failed: ${err.message}`);
+    console.log('Falling back to direct sync...');
+    await directSync(config);
+  }
+}
+
+function handleStatus() {
+  const config = getTeamConfig();
+  if (!config) {
+    console.error('Error: Team not initialized. Run "egc team init" first.');
+    process.exit(1);
+  }
+
+  try {
+    const result = callMcpTool('team_status', {});
+    if (result.lastSyncTime) console.log(`Last sync: ${result.lastSyncTime}`);
+    if (result.hasUncommittedChanges !== undefined) console.log(`Uncommitted changes: ${result.hasUncommittedChanges}`);
+    if (result.conflictCount !== undefined && result.conflictCount > 0) console.log(`Conflicts: ${result.conflictCount}`);
+    console.log(`Remote: ${result.remoteUrl || config.remote}`);
+  } catch {
+    // Fallback: read config.
+    console.log(`Backend: ${config.backend}`);
+    console.log(`Remote:  ${config.remote}`);
+    console.log(`Branch:  ${config.branch}`);
+    const syncDir = path.join(os.homedir(), '.egc', 'team-sync');
+    const isRepo = fs.existsSync(path.join(syncDir, '.git'));
+    console.log(`Repo:    ${isRepo ? 'initialized' : 'not initialized'}`);
+    if (isRepo) {
+      try {
+        const log = safeGit(['log', '-1', '--format=%ai'], syncDir);
+        if (log) console.log(`Last commit: ${log}`);
+      } catch {
+        // no commits yet
+      }
+    }
+  }
+}
+
 async function main() {
   const args = process.argv.slice(3); // skip "node team.js" or "egc team"
   const firstArg = args[0];
@@ -144,101 +237,17 @@ async function main() {
   }
 
   switch (firstArg) {
-    case 'init': {
-      const backendIdx = args.indexOf('--backend');
-      const remoteIdx = args.indexOf('--remote');
-      const branchIdx = args.indexOf('--branch');
-
-      const backend = backendIdx !== -1 ? args[backendIdx + 1] : 'git';
-      const remote = remoteIdx !== -1 ? args[remoteIdx + 1] : null;
-      const branch = branchIdx !== -1 ? args[branchIdx + 1] : 'main';
-
-      if (!remote) {
-        console.error('Error: --remote is required for team init');
-        process.exit(1);
-      }
-
-      const config = { backend, remote, branch };
-      fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
-      console.log(`Team initialized:
-  Backend: ${backend}
-  Remote:  ${remote}
-  Branch:  ${branch}
-  Config:  ${TEAM_CONFIG_PATH}`);
-
-      // Now try to connect and set up via MCP tool.
-      try {
-        const result = callMcpTool('team_init', { backend, remote, branch });
-        if (result) {
-          console.log('Sync backend configured successfully.');
-        }
-      } catch (err) {
-        console.log(`Note: Memory server setup returned: ${err.message}`);
-        console.log('The config file is saved. Run "egc team sync" to start syncing.');
-      }
+    case 'init':
+      handleInit(args);
       break;
-    }
 
-    case 'sync': {
-      const config = getTeamConfig();
-      if (!config) {
-        console.error('Error: Team not initialized. Run "egc team init" first.');
-        process.exit(1);
-      }
-
-      console.log('Syncing team memory...');
-      try {
-        const result = callMcpTool('team_sync', {});
-        console.log('Sync complete:');
-        if (result.pulledCount !== undefined) console.log(`  Pulled: ${result.pulledCount} files`);
-        if (result.pushedCount !== undefined) console.log(`  Pushed: ${result.pushedCount} commits`);
-        if (result.conflictCount !== undefined && result.conflictCount > 0) {
-          console.log(`  Conflicts: ${result.conflictCount} (resolve manually in ~/.egc/team-sync/)`);
-        }
-        if (result.errors && result.errors.length > 0) {
-          console.log(`  Errors: ${result.errors.join(', ')}`);
-        }
-      } catch (err) {
-        // Fallback: use direct git operations.
-        console.log(`MCP tool failed: ${err.message}`);
-        console.log('Falling back to direct sync...');
-        await directSync(config);
-      }
+    case 'sync':
+      await handleSync();
       break;
-    }
 
-    case 'status': {
-      const config = getTeamConfig();
-      if (!config) {
-        console.error('Error: Team not initialized. Run "egc team init" first.');
-        process.exit(1);
-      }
-
-      try {
-        const result = callMcpTool('team_status', {});
-        if (result.lastSyncTime) console.log(`Last sync: ${result.lastSyncTime}`);
-        if (result.hasUncommittedChanges !== undefined) console.log(`Uncommitted changes: ${result.hasUncommittedChanges}`);
-        if (result.conflictCount !== undefined && result.conflictCount > 0) console.log(`Conflicts: ${result.conflictCount}`);
-        console.log(`Remote: ${result.remoteUrl || config.remote}`);
-      } catch {
-        // Fallback: read config.
-        console.log(`Backend: ${config.backend}`);
-        console.log(`Remote:  ${config.remote}`);
-        console.log(`Branch:  ${config.branch}`);
-        const syncDir = path.join(os.homedir(), '.egc', 'team-sync');
-        const isRepo = fs.existsSync(path.join(syncDir, '.git'));
-        console.log(`Repo:    ${isRepo ? 'initialized' : 'not initialized'}`);
-        if (isRepo) {
-          try {
-            const log = safeGit(['log', '-1', '--format=%ai'], syncDir);
-            if (log) console.log(`Last commit: ${log}`);
-          } catch {
-            // no commits yet
-          }
-        }
-      }
+    case 'status':
+      handleStatus();
       break;
-    }
 
     default:
       console.error(`Unknown team subcommand: ${firstArg}`);


### PR DESCRIPTION
This PR refactors the 3 worst JavaScript functions in the repository in terms of cognitive complexity, targeting rule **javascript:S3776**.

### Refactored Functions:
1. **`scripts/plugin.js`**: `main`
   - **Before:** Cognitive Complexity = 67
   - **After:** Extracted subcommand handlers (`handleInstall`, `handleList`, `handleRemove`, `handleUpdate`), reducing main routing function complexity.
2. **`scripts/team.js`**: `main`
   - **Before:** Cognitive Complexity = 53
   - **After:** Extracted subcommand handlers (`handleInit`, `handleSync`, `handleStatus`), reducing main routing function complexity.
3. **`scripts/budget.js`**: `main`
   - **Before:** Cognitive Complexity = 46
   - **After:** Extracted subcommand handlers (`handleSet`, `handleStatus`, `handleReset`), reducing main routing function complexity.

All project tests passed (2622/2622) and linting issues are clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the `plugin`, `team`, and `budget` CLI commands to reduce cognitive complexity (Sonar rule `javascript:S3776`) by moving subcommand logic into small handler functions. Improves maintainability with no behavior changes.

- **Refactors**
  - `scripts/plugin.js`: Introduces `handleInstall`, `handleList`, `handleRemove`, `handleUpdate`; keeps help/exit behavior and update-all flow.
  - `scripts/team.js`: Adds `handleInit`, `handleSync`, `handleStatus`; preserves MCP tool usage and git fallback.
  - `scripts/budget.js`: Adds `handleSet`, `handleStatus`, `handleReset`; retains argument validation and messages.
  - All tests pass (2622/2622) and lints are clean.

<sup>Written for commit 45b98aa8ed75451bc847f7bc7267d058c420ae11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

