### PR TITLE
refactor(cc): reduce cognitive complexity in REPL, Codex config and loop status (S3776)

### DIFF
--- a/scripts/claw.js
+++ b/scripts/claw.js
@@ -279,6 +279,139 @@ function handleHelp() {
   console.log('  exit                           Quit the REPL');
 }
 
+function handleModelCommand(line, state) {
+  const model = line.replace('/model', '').trim();
+  if (!model) {
+    console.log(`Current model: ${state.model}`);
+  } else {
+    state.model = model;
+    console.log(`Model set to: ${state.model}`);
+  }
+}
+
+function handleLoadCommand(line, state) {
+  const skill = line.replace('/load', '').trim();
+  if (!skill) {
+    console.log('Usage: /load <skill-name>');
+    return;
+  }
+  if (!skillExists(skill)) {
+    console.log(`Skill not found: ${skill}`);
+    return;
+  }
+
+  if (!state.skills.includes(skill)) {
+    state.skills.push(skill);
+  }
+  state.egcContext = loadEGCContext(state.skills);
+  console.log(`Loaded skill: ${skill}`);
+}
+
+function handleBranchCommand(line, state) {
+  const target = line.replace('/branch', '').trim();
+  const result = branchSession(state.sessionPath, target);
+  if (!result.ok) {
+    console.log(result.message);
+    return;
+  }
+
+  state.sessionName = result.session;
+  state.sessionPath = result.path;
+  console.log(`Branched to session: ${state.sessionName}`);
+}
+
+function handleSearchCommand(line) {
+  const query = line.replace('/search', '').trim();
+  const matches = searchSessions(query);
+  if (matches.length === 0) {
+    console.log('(no matches)');
+    return;
+  }
+  console.log(`Found ${matches.length} match(es):`);
+  for (const match of matches) {
+    console.log(`- ${match.session}: ${match.snippet}`);
+  }
+}
+
+function handleExportCommand(line, state) {
+  const parts = line.split(/\s+/).filter(Boolean);
+  const format = parts[1];
+  const outputPath = parts[2];
+  if (!format) {
+    console.log('Usage: /export <md|json|txt> [path]');
+    return;
+  }
+  const result = exportSession(state.sessionPath, format, outputPath);
+  if (!result.ok) {
+    console.log(result.message);
+  } else {
+    console.log(`Exported: ${result.path}`);
+  }
+}
+
+function handleMetricsCommand(state) {
+  const m = getSessionMetrics(state.sessionPath);
+  console.log(`Session: ${state.sessionName}`);
+  console.log(`Model: ${state.model}`);
+  console.log(`Turns: ${m.turns} (user ${m.userTurns}, assistant ${m.assistantTurns})`);
+  console.log(`Chars: ${m.charCount}`);
+  console.log(`Estimated tokens: ${m.tokenEstimate}`);
+}
+
+function handleReplCommand(line, state, rl) {
+  if (line === 'exit') {
+    console.log('Goodbye.');
+    rl.close();
+    return 'exit';
+  }
+  if (line === '/help') {
+    handleHelp();
+    return 'prompt';
+  }
+  if (line === '/clear') {
+    handleClear(state.sessionPath);
+    return 'prompt';
+  }
+  if (line === '/history') {
+    handleHistory(state.sessionPath);
+    return 'prompt';
+  }
+  if (line === '/sessions') {
+    handleSessions();
+    return 'prompt';
+  }
+  if (line.startsWith('/model')) {
+    handleModelCommand(line, state);
+    return 'prompt';
+  }
+  if (line.startsWith('/load ')) {
+    handleLoadCommand(line, state);
+    return 'prompt';
+  }
+  if (line.startsWith('/branch ')) {
+    handleBranchCommand(line, state);
+    return 'prompt';
+  }
+  if (line.startsWith('/search ')) {
+    handleSearchCommand(line);
+    return 'prompt';
+  }
+  if (line === '/compact') {
+    const changed = compactSession(state.sessionPath);
+    console.log(changed ? 'Session compacted.' : 'No compaction needed.');
+    return 'prompt';
+  }
+  if (line.startsWith('/export ')) {
+    handleExportCommand(line, state);
+    return 'prompt';
+  }
+  if (line === '/metrics') {
+    handleMetricsCommand(state);
+    return 'prompt';
+  }
+  return 'send';
+}
+
 function main() {
   const initialSessionName = process.env.CLAW_SESSION || 'default';
   if (!isValidSessionName(initialSessionName)) {
@@ -293,9 +426,8 @@ function main() {
     sessionPath: getSessionPath(initialSessionName),
     model: DEFAULT_MODEL,
     skills: normalizeSkillList(process.env.CLAW_SKILLS || ''),
+    egcContext: loadEGCContext(normalizeSkillList(process.env.CLAW_SKILLS || '')),
   };
-
-  let egcContext = loadEGCContext(state.skills);
 
   const loadedCount = state.skills.filter(skillExists).length;
 
@@ -313,127 +445,13 @@ function main() {
       const line = input.trim();
       if (!line) return prompt();
 
-      if (line === 'exit') {
-        console.log('Goodbye.');
-        rl.close();
-        return;
-      }
+      const action = handleReplCommand(line, state, rl);
+      if (action === 'exit') return;
+      if (action === 'prompt') return prompt();
 
-      if (line === '/help') {
-        handleHelp();
-        return prompt();
-      }
-
-      if (line === '/clear') {
-        handleClear(state.sessionPath);
-        return prompt();
-      }
-
-      if (line === '/history') {
-        handleHistory(state.sessionPath);
-        return prompt();
-      }
-
-      if (line === '/sessions') {
-        handleSessions();
-        return prompt();
-      }
-
-      if (line.startsWith('/model')) {
-        const model = line.replace('/model', '').trim();
-        if (!model) {
-          console.log(`Current model: ${state.model}`);
-        } else {
-          state.model = model;
-          console.log(`Model set to: ${state.model}`);
-        }
-        return prompt();
-      }
-
-      if (line.startsWith('/load ')) {
-        const skill = line.replace('/load', '').trim();
-        if (!skill) {
-          console.log('Usage: /load <skill-name>');
-          return prompt();
-        }
-        if (!skillExists(skill)) {
-          console.log(`Skill not found: ${skill}`);
-          return prompt();
-        }
-
-        if (!state.skills.includes(skill)) {
-          state.skills.push(skill);
-        }
-        egcContext = loadEGCContext(state.skills);
-        console.log(`Loaded skill: ${skill}`);
-        return prompt();
-      }
-
-      if (line.startsWith('/branch ')) {
-        const target = line.replace('/branch', '').trim();
-        const result = branchSession(state.sessionPath, target);
-        if (!result.ok) {
-          console.log(result.message);
-          return prompt();
-        }
-
-        state.sessionName = result.session;
-        state.sessionPath = result.path;
-        console.log(`Branched to session: ${state.sessionName}`);
-        return prompt();
-      }
-
-      if (line.startsWith('/search ')) {
-        const query = line.replace('/search', '').trim();
-        const matches = searchSessions(query);
-        if (matches.length === 0) {
-          console.log('(no matches)');
-          return prompt();
-        }
-        console.log(`Found ${matches.length} match(es):`);
-        for (const match of matches) {
-          console.log(`- ${match.session}: ${match.snippet}`);
-        }
-        return prompt();
-      }
-
-      if (line === '/compact') {
-        const changed = compactSession(state.sessionPath);
-        console.log(changed ? 'Session compacted.' : 'No compaction needed.');
-        return prompt();
-      }
-
-      if (line.startsWith('/export ')) {
-        const parts = line.split(/\s+/).filter(Boolean);
-        const format = parts[1];
-        const outputPath = parts[2];
-        if (!format) {
-          console.log('Usage: /export <md|json|txt> [path]');
-          return prompt();
-        }
-        const result = exportSession(state.sessionPath, format, outputPath);
-        if (!result.ok) {
-          console.log(result.message);
-        } else {
-          console.log(`Exported: ${result.path}`);
-        }
-        return prompt();
-      }
-
-      if (line === '/metrics') {
-        const m = getSessionMetrics(state.sessionPath);
-        console.log(`Session: ${state.sessionName}`);
-        console.log(`Model: ${state.model}`);
-        console.log(`Turns: ${m.turns} (user ${m.userTurns}, assistant ${m.assistantTurns})`);
-        console.log(`Chars: ${m.charCount}`);
-        console.log(`Estimated tokens: ${m.tokenEstimate}`);
-        return prompt();
-      }
-
-      // Regular message
       const history = loadHistory(state.sessionPath);
       appendTurn(state.sessionPath, 'User', line);
-      const response = askGemini(egcContext, history, line, state.model);
+      const response = askGemini(state.egcContext, history, line, state.model);
       console.log(`\n${response}\n`);
       appendTurn(state.sessionPath, 'Assistant', response);
       prompt();

--- a/scripts/codex/merge-codex-config.js
+++ b/scripts/codex/merge-codex-config.js
@@ -209,8 +209,7 @@ function stringifyTableKeys(tableValue) {
   return lines.join('\n');
 }
 
-function main() {
-  const args = process.argv.slice(2);
+function parseCommandLineArgs(args) {
   const configPath = args.find(arg => !arg.startsWith('-'));
   const dryRun = args.includes('--dry-run');
 
@@ -218,8 +217,10 @@ function main() {
     console.error('Usage: merge-codex-config.js <config.toml> [--dry-run]');
     process.exit(1);
   }
+  return { configPath, dryRun };
+}
 
-  const referencePath = path.join(__dirname, '..', '..', '.codex', 'config.toml');
+function loadAndParseConfigs(configPath, referencePath) {
   if (!fs.existsSync(referencePath)) {
     console.error(`[egc-codex] Reference config not found: ${referencePath}`);
     process.exit(1);
@@ -233,16 +234,17 @@ function main() {
   const raw = fs.readFileSync(configPath, 'utf8');
   const referenceRaw = fs.readFileSync(referencePath, 'utf8');
 
-  let targetConfig;
-  let referenceConfig;
   try {
-    targetConfig = TOML.parse(raw);
-    referenceConfig = TOML.parse(referenceRaw);
+    const targetConfig = TOML.parse(raw);
+    const referenceConfig = TOML.parse(referenceRaw);
+    return { targetConfig, referenceConfig, raw };
   } catch (error) {
     console.error(`[egc-codex] Failed to parse TOML: ${error.message}`);
     process.exit(1);
   }
+}
 
+function findMissingConfigs(referenceConfig, targetConfig) {
   const missingRootKeys = {};
   for (const key of ROOT_KEYS) {
     if (referenceConfig[key] !== undefined && targetConfig[key] === undefined) {
@@ -280,15 +282,11 @@ function main() {
     }
   }
 
-  if (
-    Object.keys(missingRootKeys).length === 0 &&
-    missingTables.length === 0 &&
-    missingTableKeys.length === 0
-  ) {
-    log('All baseline Codex settings already present. Nothing to do.');
-    return;
-  }
+  return { missingRootKeys, missingTables, missingTableKeys };
+}
 
+function mergeBaselineSettings(raw, missingConfigs, referenceConfig) {
+  const { missingRootKeys, missingTables, missingTableKeys } = missingConfigs;
   let nextRaw = raw;
   if (Object.keys(missingRootKeys).length > 0) {
     log(`  [add-root] ${Object.keys(missingRootKeys).join(', ')}`);
@@ -304,6 +302,28 @@ function main() {
     log(`  [add-table] [${tablePath}]`);
     nextRaw = appendBlock(nextRaw, stringifyTable(tablePath, getNested(referenceConfig, tablePath.split('.'))));
   }
+  return nextRaw;
+}
+
+function main() {
+  const { configPath, dryRun } = parseCommandLineArgs(process.argv.slice(2));
+  const referencePath = path.join(__dirname, '..', '..', '.codex', 'config.toml');
+
+  const { targetConfig, referenceConfig, raw } = loadAndParseConfigs(configPath, referencePath);
+
+  const missingConfigs = findMissingConfigs(referenceConfig, targetConfig);
+  const { missingRootKeys, missingTables, missingTableKeys } = missingConfigs;
+
+  if (
+    Object.keys(missingRootKeys).length === 0 &&
+    missingTables.length === 0 &&
+    missingTableKeys.length === 0
+  ) {
+    log('All baseline Codex settings already present. Nothing to do.');
+    return;
+  }
+
+  const nextRaw = mergeBaselineSettings(raw, missingConfigs, referenceConfig);
 
   if (dryRun) {
     log('Dry run: would write the merged Codex baseline.');

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -435,61 +435,91 @@ function buildRecommendation(signals) {
   return 'No stale ScheduleWakeup or Bash waits detected.';
 }
 
+function updateTimestamps(entry, state) {
+  const timestamp = getEntryTimestamp(entry);
+  if (!timestamp) return null;
+
+  if (!state.lastEventAt || timestamp.getTime() > state.lastEventAt.getTime()) {
+    state.lastEventAt = timestamp;
+  }
+  if (
+    isAssistantProgressEntry(entry)
+    && (!state.latestAssistantProgressAt || timestamp.getTime() > state.latestAssistantProgressAt.getTime())
+  ) {
+    state.latestAssistantProgressAt = timestamp;
+  }
+  return timestamp;
+}
+
+function processToolUses(entry, timestamp, lastEventAt, pendingTools, state) {
+  for (const toolUse of extractToolUses(entry)) {
+    const startedAt = timestamp || lastEventAt;
+    pendingTools.set(toolUse.id, {
+      command: toolUse.input && toolUse.input.command ? String(toolUse.input.command) : null,
+      input: toolUse.input || {},
+      name: toolUse.name,
+      startedAt: toIso(startedAt),
+      toolUseId: toolUse.id,
+    });
+
+    if (toolUse.name === 'ScheduleWakeup') {
+      const delaySeconds = readDelaySeconds(toolUse.input);
+      if (delaySeconds && startedAt) {
+        const dueAt = new Date(startedAt.getTime() + delaySeconds * 1000);
+        state.latestWake = {
+          delaySeconds,
+          dueAt: dueAt.toISOString(),
+          reason: toolUse.input && toolUse.input.reason ? String(toolUse.input.reason) : null,
+          scheduledAt: startedAt.toISOString(),
+          toolUseId: toolUse.id,
+        };
+      }
+    }
+  }
+}
+
+function processTranscriptEntries(entries, absoluteTranscriptPath) {
+  const pendingTools = new Map();
+  const state = {
+    lastEventAt: null,
+    latestAssistantProgressAt: null,
+    latestWake: null,
+    sessionId: path.basename(absoluteTranscriptPath, '.jsonl')
+  };
+
+  for (const entry of entries) {
+    state.sessionId = getSessionId(entry, absoluteTranscriptPath) || state.sessionId;
+    const timestamp = updateTimestamps(entry, state);
+    processToolUses(entry, timestamp, state.lastEventAt, pendingTools, state);
+
+    for (const toolUseId of extractToolResultIds(entry)) {
+      pendingTools.delete(toolUseId);
+    }
+  }
+
+  return {
+    sessionId: state.sessionId,
+    lastEventAt: state.lastEventAt,
+    latestAssistantProgressAt: state.latestAssistantProgressAt,
+    pendingTools,
+    latestWake: state.latestWake
+  };
+}
+
 function analyzeTranscript(transcriptPath, options = {}) {
   const normalizedOptions = normalizeOptions(options);
   const absoluteTranscriptPath = path.resolve(transcriptPath);
   const now = normalizedOptions.nowDate || getNow(normalizedOptions);
   const nowMs = now.getTime();
   const { entries, parseErrors } = readJsonlEntries(absoluteTranscriptPath);
-  const pendingTools = new Map();
-  let latestAssistantProgressAt = null;
-  let lastEventAt = null;
-  let latestWake = null;
-  let sessionId = path.basename(absoluteTranscriptPath, '.jsonl');
 
-  for (const entry of entries) {
-    sessionId = getSessionId(entry, absoluteTranscriptPath) || sessionId;
-    const timestamp = getEntryTimestamp(entry);
-    if (timestamp && (!lastEventAt || timestamp.getTime() > lastEventAt.getTime())) {
-      lastEventAt = timestamp;
-    }
-    if (
-      timestamp
-      && isAssistantProgressEntry(entry)
-      && (!latestAssistantProgressAt || timestamp.getTime() > latestAssistantProgressAt.getTime())
-    ) {
-      latestAssistantProgressAt = timestamp;
-    }
-
-    for (const toolUse of extractToolUses(entry)) {
-      const startedAt = timestamp || lastEventAt;
-      pendingTools.set(toolUse.id, {
-        command: toolUse.input && toolUse.input.command ? String(toolUse.input.command) : null,
-        input: toolUse.input || {},
-        name: toolUse.name,
-        startedAt: toIso(startedAt),
-        toolUseId: toolUse.id,
-      });
-
-      if (toolUse.name === 'ScheduleWakeup') {
-        const delaySeconds = readDelaySeconds(toolUse.input);
-        if (delaySeconds && startedAt) {
-          const dueAt = new Date(startedAt.getTime() + delaySeconds * 1000);
-          latestWake = {
-            delaySeconds,
-            dueAt: dueAt.toISOString(),
-            reason: toolUse.input && toolUse.input.reason ? String(toolUse.input.reason) : null,
-            scheduledAt: startedAt.toISOString(),
-            toolUseId: toolUse.id,
-          };
-        }
-      }
-    }
-
-    for (const toolUseId of extractToolResultIds(entry)) {
-      pendingTools.delete(toolUseId);
-    }
-  }
+  const {
+    sessionId,
+    lastEventAt,
+    latestAssistantProgressAt,
+    pendingTools,
+    latestWake
+  } = processTranscriptEntries(entries, absoluteTranscriptPath);
 
   const pendingToolList = Array.from(pendingTools.values()).map(tool => {
     const startedAt = parseTimestamp(tool.startedAt);


### PR DESCRIPTION
This PR refactors the top 3 worst cognitive complexity issues in the EGC codebase to satisfy rule S3776.

### Refactored Functions:
1. **File:** `scripts/claw.js`
   - **Function:** `main()` / nested `prompt()`
   - **Cognitive Complexity:** Before: 35 | After: < 15
2. **File:** `scripts/codex/merge-codex-config.js`
   - **Function:** `main()`
   - **Cognitive Complexity:** Before: 30 | After: < 15
3. **File:** `scripts/loop-status.js`
   - **Function:** `analyzeTranscript()`
   - **Cognitive Complexity:** Before: 30 | After: < 15

All 2622 EGC tests have passed, and no eslint warnings/errors remain on these files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the REPL, Codex config merge, and loop-status analysis to meet Sonar rule S3776 by reducing cognitive complexity without changing behavior. All tests pass and lint warnings for these files are cleared.

- **Refactors**
  - `scripts/claw.js`: Extracted command handlers and centralized routing in `handleReplCommand`; moved EGC context into `state.egcContext`; simplified the prompt loop.
  - `scripts/codex/merge-codex-config.js`: Split logic into `parseCommandLineArgs`, `loadAndParseConfigs`, `findMissingConfigs`, and `mergeBaselineSettings` with a clear early-exit path.
  - `scripts/loop-status.js`: Broke up `analyzeTranscript` into `updateTimestamps`, `processToolUses`, and `processTranscriptEntries` to isolate state handling and tool tracking.

<sup>Written for commit 637fa7959ab9bfc80fec5641982ee7962e6f4fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

