### PR TITLE
fix(sonar): resolve shell script code smells

### DIFF
--- a/scripts/codex/check-codex-global-state.sh
+++ b/scripts/codex/check-codex-global-state.sh
@@ -11,9 +11,17 @@ CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 # Use rg if available, otherwise fall back to grep -E.
 # All patterns in this script must be POSIX ERE compatible.
 if command -v rg >/dev/null 2>&1; then
-  search_file() { rg -n "$1" "$2" >/dev/null 2>&1; }
+  search_file() {
+    local pattern="$1"
+    local filepath="$2"
+    rg -n "$pattern" "$filepath" >/dev/null 2>&1
+  }
 else
-  search_file() { grep -En "$1" "$2" >/dev/null 2>&1; }
+  search_file() {
+    local pattern="$1"
+    local filepath="$2"
+    grep -En "$pattern" "$filepath" >/dev/null 2>&1
+  }
 fi
 
 CONFIG_FILE="$CODEX_HOME/config.toml"

--- a/scripts/hooks/git-pre-commit.sh
+++ b/scripts/hooks/git-pre-commit.sh
@@ -13,13 +13,13 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null) || true
-[ -z "$STAGED" ] && exit 0
+[[ -z "$STAGED" ]] && exit 0
 
 EGC_START='<!-- egc:start -->'
 EGC_END='<!-- egc:end -->'
 
 while IFS= read -r FILE; do
-  [ -z "$FILE" ] && continue
+  [[ -z "$FILE" ]] && continue
   case "$FILE" in
     *.md|*.mdx|*.mdc) ;;
     *) continue ;;

--- a/scripts/sync-egc-to-codex.sh
+++ b/scripts/sync-egc-to-codex.sh
@@ -11,11 +11,13 @@ set -euo pipefail
 # - Merges EGC MCP servers into config.toml (add-only via Node TOML parser)
 
 MODE="apply"
+DRY_RUN_MODE="dry-run"
 UPDATE_MCP=""
 for arg in "$@"; do
   case "$arg" in
-    --dry-run)    MODE="dry-run" ;;
+    --dry-run)    MODE="$DRY_RUN_MODE" ;;
     --update-mcp) UPDATE_MCP="--update-mcp" ;;
+    *) ;;
   esac
 done
 
@@ -42,7 +44,7 @@ BACKUP_DIR="$CODEX_HOME/backups/egc-$STAMP"
 log() { printf '[egc-sync] %s\n' "$*"; }
 
 run_or_echo() {
-  if [[ "$MODE" == "dry-run" ]]; then
+  if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
     printf '[dry-run]'
     printf ' %q' "$@"
     printf '\n'
@@ -187,7 +189,7 @@ compose_egc_block() {
 }
 
 log "Merging EGC AGENTS into $AGENTS_FILE (preserving user content)"
-if [[ "$MODE" == "dry-run" ]]; then
+if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
   printf '[dry-run] merge EGC block into %s from %s + %s\n' "$AGENTS_FILE" "$AGENTS_ROOT_SRC" "$AGENTS_CODEX_SUPP_SRC"
 else
   replace_egc_section() {
@@ -252,7 +254,7 @@ else
 fi
 
 log "Merging EGC Codex baseline into $CONFIG_FILE (add-only, preserving user config)"
-if [[ "$MODE" == "dry-run" ]]; then
+if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
   node "$BASELINE_MERGE_SCRIPT" "$CONFIG_FILE" --dry-run
 else
   node "$BASELINE_MERGE_SCRIPT" "$CONFIG_FILE"
@@ -278,7 +280,7 @@ done
 log "Generating prompt files from EGC commands"
 run_or_echo mkdir -p "$PROMPTS_DEST"
 manifest="$PROMPTS_DEST/egc-prompts-manifest.txt"
-if [[ "$MODE" == "dry-run" ]]; then
+if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
   printf '[dry-run] > %s\n' "$manifest"
 else
   : > "$manifest"
@@ -288,7 +290,7 @@ prompt_count=0
 while IFS= read -r -d '' command_file; do
   name="$(basename "$command_file" .md)"
   out="$PROMPTS_DEST/egc-$name.md"
-  if [[ "$MODE" == "dry-run" ]]; then
+  if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
     printf '[dry-run] generate %s from %s\n' "$out" "$command_file"
   else
     generate_prompt_file "$command_file" "$out" "$name"
@@ -303,7 +305,7 @@ fi
 
 log "Generating Codex tool prompts + optional rule-pack prompts"
 extension_manifest="$PROMPTS_DEST/egc-extension-prompts-manifest.txt"
-if [[ "$MODE" == "dry-run" ]]; then
+if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
   printf '[dry-run] > %s\n' "$extension_manifest"
 else
   : > "$extension_manifest"
@@ -314,7 +316,7 @@ extension_count=0
 write_extension_prompt() {
   local name="$1"
   local file="$PROMPTS_DEST/$name"
-  if [[ "$MODE" == "dry-run" ]]; then
+  if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
     printf '[dry-run] generate %s\n' "$file"
   else
     cat > "$file"
@@ -492,14 +494,14 @@ if [[ "$MODE" == "apply" ]]; then
 fi
 
 log "Merging EGC MCP servers into $CONFIG_FILE (add-only, preserving user config)"
-if [[ "$MODE" == "dry-run" ]]; then
+if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
   node "$MCP_MERGE_SCRIPT" "$CONFIG_FILE" --dry-run $UPDATE_MCP
 else
   node "$MCP_MERGE_SCRIPT" "$CONFIG_FILE" $UPDATE_MCP
 fi
 
 log "Installing global git safety hooks"
-if [[ "$MODE" == "dry-run" ]]; then
+if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
   HOME="$HOME" \
   CODEX_HOME="$CODEX_HOME" \
   AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}" \
@@ -514,7 +516,7 @@ else
 fi
 
 log "Running global regression sanity check"
-if [[ "$MODE" == "dry-run" ]]; then
+if [[ "$MODE" == "$DRY_RUN_MODE" ]]; then
   printf '[dry-run] %s\n' "$SANITY_CHECKER"
 else
   HOME="$HOME" \


### PR DESCRIPTION
This PR resolves 8 shell script code smells identified by SonarCloud:

- **shelldre:S7688** (2 occurrences in scripts/hooks/git-pre-commit.sh): Replaced single-bracket tests with double-brackets for bash compatibility.
- **shelldre:S7679** (4 occurrences in scripts/codex/check-codex-global-state.sh): Assigned positional parameters to local variables in search_file functions.
- **shelldre:S131** (1 occurrence in scripts/sync-egc-to-codex.sh): Added a default case (*) to the argument parser switch-case.
- **shelldre:S1192** (1 occurrence in scripts/sync-egc-to-codex.sh): Defined a DRY_RUN_MODE constant instead of repeating the 'dry-run' string literal 11 times.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved 8 SonarCloud shell-script code smells to improve Bash safety and readability across `scripts/hooks/git-pre-commit.sh`, `scripts/codex/check-codex-global-state.sh`, and `scripts/sync-egc-to-codex.sh`.

- **Refactors**
  - Switched single-bracket tests to `[[ ... ]]` in `git-pre-commit.sh`.
  - Assigned positional params to local vars in `search_file` for ripgrep/grep in `check-codex-global-state.sh`.
  - Added a default `case` branch and introduced `DRY_RUN_MODE` constant; updated all dry-run checks to use it in `sync-egc-to-codex.sh`.

<sup>Written for commit 4195746812bec5ed2c5765d8667b52f6961b9b6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

