### PR TITLE
fix(sonar): apply optional chaining (S6582) batch 2

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -79,7 +79,7 @@ function hashSessionKey(prefix, value) {
 }
 
 function resolveSessionKey(data) {
-  const directCandidates = [data && data.session_id, data && data.sessionId, data && data.session && data.session.id, process.env.EGC_SESSION_ID, process.env.ECC_SESSION_ID];
+  const directCandidates = [data?.session_id, data?.sessionId, data?.session?.id, process.env.EGC_SESSION_ID, process.env.ECC_SESSION_ID];
 
   for (const candidate of directCandidates) {
     const sanitized = sanitizeSessionKey(candidate);

--- a/scripts/hooks/insaits-security-wrapper.js
+++ b/scripts/hooks/insaits-security-wrapper.js
@@ -59,13 +59,13 @@ function spawnPythonMonitor(pyScript, input) {
     });
 
     // ENOENT means binary not found - try next candidate
-    if (result.error && result.error.code === 'ENOENT') {
+    if (result.error?.code === 'ENOENT') {
       continue;
     }
     break;
   }
 
-  if (!result || (result.error && result.error.code === 'ENOENT')) {
+  if (!result || result.error?.code === 'ENOENT') {
     return null;
   }
 

--- a/scripts/hooks/observe-runner.js
+++ b/scripts/hooks/observe-runner.js
@@ -14,7 +14,7 @@ function getPluginRoot(options = {}) {
     return String(options.pluginRoot).trim();
   }
   const root = process.env.EGC_PLUGIN_ROOT || process.env.ECC_PLUGIN_ROOT || process.env.GEMINI_PLUGIN_ROOT;
-  if (root && root.trim()) {
+  if (root?.trim()) {
     return root.trim();
   }
   return path.resolve(__dirname, '..', '..');
@@ -45,7 +45,7 @@ function toShellPath(filePath) {
 
 function findShellBinary() {
   const candidates = [];
-  if (process.env.BASH && process.env.BASH.trim()) {
+  if (process.env.BASH?.trim()) {
     const trimmed = process.env.BASH.trim();
     if (SAFE_SHELL_BASENAMES.has(path.basename(trimmed).toLowerCase())) {
       candidates.push(trimmed);
@@ -226,7 +226,7 @@ function emitHookResult(raw, output) {
 }
 
 function teeEventToStateDb(raw) {
-  if (!raw || !raw.trim()) return;
+  if (!raw?.trim()) return;
   const writerPath = path.join(__dirname, 'state-db-writer.js');
   if (!fs.existsSync(writerPath)) return;
   try {

--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -47,7 +47,7 @@ function resolveTarget(rootDir, relPath) {
 
 function findShellBinary() {
   const candidates = [];
-  if (process.env.BASH && process.env.BASH.trim()) {
+  if (process.env.BASH?.trim()) {
     const trimmed = process.env.BASH.trim();
     if (SAFE_SHELL_BASENAMES.has(path.basename(trimmed).toLowerCase())) {
       candidates.push(trimmed);

--- a/scripts/hooks/pre-bash-dev-server-block.js
+++ b/scripts/hooks/pre-bash-dev-server-block.js
@@ -87,7 +87,7 @@ function readToken(input, startIndex) {
 function shouldSkipOptionValue(wrapper, optionToken) {
   if (!wrapper || !optionToken || optionToken.includes('=')) return false;
   const optionSet = PREFIX_OPTION_VALUE_WORDS[wrapper];
-  return Boolean(optionSet && optionSet.has(optionToken));
+  return Boolean(optionSet?.has(optionToken));
 }
 
 function isOptionToken(token) {

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -80,7 +80,7 @@ function writeLegacySpawnOutput(raw, result) {
 
 function getPluginRoot() {
   const root = process.env.EGC_PLUGIN_ROOT || process.env.ECC_PLUGIN_ROOT || process.env.GEMINI_PLUGIN_ROOT;
-  if (root && root.trim()) {
+  if (root?.trim()) {
     return root.trim();
   }
   return path.resolve(__dirname, '..', '..');

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -242,7 +242,7 @@ function selectMatchingSession(sessions, cwd, currentProject) {
 }
 
 function flushInstinct(current, contentLines, instincts) {
-  if (current && current.id) {
+  if (current?.id) {
     current.content = contentLines.join('\n').trim();
     instincts.push(current);
   }

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -81,7 +81,7 @@ function compareStringArrays(left, right) {
 }
 
 function getManagedOperations(state) {
-  return Array.isArray(state && state.operations)
+  return Array.isArray(state?.operations)
     ? state.operations.filter(operation => operation.ownership === 'managed')
     : [];
 }

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -95,8 +95,8 @@ function readOptionalStringOption(options, key) {
 }
 
 function readModuleTargetsOrThrow(module) {
-  const moduleId = module && module.id ? module.id : '<unknown>';
-  const targets = module && module.targets;
+  const moduleId = module?.id ? module.id : '<unknown>';
+  const targets = module?.targets;
 
   if (!Array.isArray(targets)) {
     throw new Error(`Install module ${moduleId} has invalid targets; expected an array of supported target ids`);

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -70,7 +70,7 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.agents'],
   installStatePathSegments: ['egc-install-state.json'],
   supportsModule(module) {
-    const paths = Array.isArray(module && module.paths) ? module.paths : [];
+    const paths = Array.isArray(module?.paths) ? module.paths : [];
     return paths.length > 0;
   },
   planOperations(input, adapter) {

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -114,7 +114,7 @@ module.exports = createInstallTargetAdapter({
 
     function takeUniqueOperations(operations) {
       return operations.filter(operation => {
-        if (!operation || !operation.destinationPath) {
+        if (!operation?.destinationPath) {
           return false;
         }
 

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -115,7 +115,7 @@ function isMcpConfigPath(filePath) {
 }
 
 function buildResolvedClaudeHooks(plan) {
-  if (!plan.adapter || plan.adapter.target !== 'egc') {
+  if (plan.adapter?.target !== 'egc') {
     return null;
   }
 

--- a/scripts/lib/package-manager.js
+++ b/scripts/lib/package-manager.js
@@ -212,7 +212,7 @@ function getPackageManager(options = {}) {
 
   // 5. Check global user preference
   const globalConfig = loadConfig();
-  if (globalConfig && globalConfig.packageManager && PACKAGE_MANAGERS[globalConfig.packageManager]) {
+  if (globalConfig?.packageManager && PACKAGE_MANAGERS[globalConfig.packageManager]) {
     return {
       name: globalConfig.packageManager,
       config: PACKAGE_MANAGERS[globalConfig.packageManager],

--- a/scripts/lib/session-adapters/canonical-session.js
+++ b/scripts/lib/session-adapters/canonical-session.js
@@ -69,7 +69,7 @@ function parseUpdatedMs(updated) {
 }
 
 function deriveWorkerHealth(rawWorker) {
-  const state = (rawWorker.status && rawWorker.status.state) || 'unknown';
+  const state = rawWorker.status?.state || 'unknown';
   const completedStates = ['completed', 'succeeded', 'success', 'done'];
   const failedStates = ['failed', 'error'];
 
@@ -78,9 +78,9 @@ function deriveWorkerHealth(rawWorker) {
 
   if (state === 'running' || state === 'active') {
     const pane = rawWorker.pane;
-    if (pane && pane.dead) return 'degraded';
+    if (pane?.dead) return 'degraded';
 
-    const updatedMs = parseUpdatedMs(rawWorker.status && rawWorker.status.updated);
+    const updatedMs = parseUpdatedMs(rawWorker.status?.updated);
     if (updatedMs === null) return 'stale';
     if (Date.now() - updatedMs > STALE_THRESHOLD_MS) return 'stale';
     return 'healthy';
@@ -115,7 +115,7 @@ function summarizeRawWorkerStates(snapshot) {
   }
 
   return (snapshot.workers || []).reduce((counts, worker) => {
-    const state = worker && worker.status && worker.status.state
+    const state = worker?.status?.state
       ? worker.status.state
       : 'unknown';
     counts[state] = (counts[state] || 0) + 1;
@@ -307,7 +307,7 @@ function writeFallbackSessionRecording(snapshot, options = {}) {
       : recordedAt,
     updatedAt: recordedAt,
     latest: snapshot,
-    history: Array.isArray(existing && existing.history)
+    history: Array.isArray(existing?.history)
       ? (snapshotChanged
           ? existing.history.concat([{ recordedAt, snapshot }])
           : existing.history)
@@ -334,8 +334,7 @@ function loadStateStore(options = {}) {
   try {
     return loadStateStoreImpl();
   } catch (error) {
-    const missingRequestedModule = error
-      && error.code === 'MODULE_NOT_FOUND'
+    const missingRequestedModule = error?.code === 'MODULE_NOT_FOUND'
       && typeof error.message === 'string'
       && error.message.includes('../state-store');
 
@@ -360,19 +359,19 @@ function resolveStateStoreWriter(stateStore) {
     { owner: stateStore, fn: stateStore.writeSessionSnapshot },
     {
       owner: stateStore.sessions,
-      fn: stateStore.sessions && stateStore.sessions.persistCanonicalSessionSnapshot
+      fn: stateStore.sessions?.persistCanonicalSessionSnapshot
     },
     {
       owner: stateStore.sessions,
-      fn: stateStore.sessions && stateStore.sessions.recordCanonicalSessionSnapshot
+      fn: stateStore.sessions?.recordCanonicalSessionSnapshot
     },
     {
       owner: stateStore.sessions,
-      fn: stateStore.sessions && stateStore.sessions.persistSessionSnapshot
+      fn: stateStore.sessions?.persistSessionSnapshot
     },
     {
       owner: stateStore.sessions,
-      fn: stateStore.sessions && stateStore.sessions.recordSessionSnapshot
+      fn: stateStore.sessions?.recordSessionSnapshot
     }
   ];
 

--- a/scripts/lib/session-adapters/registry.js
+++ b/scripts/lib/session-adapters/registry.js
@@ -21,9 +21,7 @@ function buildDefaultAdapterOptions(options, adapterId) {
 
   return {
     ...sharedOptions,
-    ...(options.adapterOptions && options.adapterOptions[adapterId]
-      ? options.adapterOptions[adapterId]
-      : {})
+    ...(options.adapterOptions?.[adapterId] ?? {})
   };
 }
 

--- a/scripts/lib/session-aliases.js
+++ b/scripts/lib/session-aliases.js
@@ -247,7 +247,7 @@ function listAliases(options = {}) {
     const searchLower = search.toLowerCase();
     aliases = aliases.filter(a =>
       a.name.toLowerCase().includes(searchLower) ||
-      (a.title && a.title.toLowerCase().includes(searchLower))
+      (a.title?.toLowerCase() || '').includes(searchLower)
     );
   }
 

--- a/scripts/lib/skill-improvement/evaluate.js
+++ b/scripts/lib/skill-improvement/evaluate.js
@@ -8,7 +8,7 @@ function roundRate(value) {
 
 function summarize(records) {
   const runs = records.length;
-  const successes = records.filter(record => record.outcome && record.outcome.success).length;
+  const successes = records.filter(record => record.outcome?.success).length;
   const failures = runs - successes;
   return {
     runs,
@@ -21,10 +21,10 @@ function summarize(records) {
 function buildSkillEvaluationScaffold(skillId, records, options = {}) {
   const minimumRunsPerVariant = options.minimumRunsPerVariant || 2;
   const amendmentId = options.amendmentId || null;
-  const filtered = records.filter(record => record.skill && record.skill.id === skillId);
-  const baseline = filtered.filter(record => !record.run || record.run.variant !== 'amended');
-  const amended = filtered.filter(record => record.run && record.run.variant === 'amended')
-    .filter(record => !amendmentId || record.run.amendmentId === amendmentId);
+  const filtered = records.filter(record => record.skill?.id === skillId);
+  const baseline = filtered.filter(record => record.run?.variant !== 'amended');
+  const amended = filtered.filter(record => record.run?.variant === 'amended')
+    .filter(record => !amendmentId || record.run?.amendmentId === amendmentId);
 
   const baselineSummary = summarize(baseline);
   const amendedSummary = summarize(amended);

--- a/scripts/lib/skill-improvement/health.js
+++ b/scripts/lib/skill-improvement/health.js
@@ -14,13 +14,13 @@ function rankCounts(values) {
 
 function summarizeVariantRuns(records) {
   return records.reduce((accumulator, record) => {
-    const key = record.run && record.run.variant ? record.run.variant : 'baseline';
+    const key = record.run?.variant ?? 'baseline';
     if (!accumulator[key]) {
       accumulator[key] = { runs: 0, successes: 0, failures: 0 };
     }
 
     accumulator[key].runs += 1;
-    if (record.outcome && record.outcome.success) {
+    if (record.outcome?.success) {
       accumulator[key].successes += 1;
     } else {
       accumulator[key].failures += 1;
@@ -46,11 +46,11 @@ function deriveSkillStatus(skillSummary, options = {}) {
 function buildSkillHealthReport(records, options = {}) {
   const filterSkillId = options.skillId || null;
   const filtered = filterSkillId
-    ? records.filter(record => record.skill && record.skill.id === filterSkillId)
+    ? records.filter(record => record.skill?.id === filterSkillId)
     : records.slice();
 
   const grouped = filtered.reduce((accumulator, record) => {
-    const skillId = record.skill.id;
+    const skillId = record.skill?.id;
     if (!accumulator.has(skillId)) {
       accumulator.set(skillId, []);
     }
@@ -60,7 +60,7 @@ function buildSkillHealthReport(records, options = {}) {
 
   const skills = Array.from(grouped.entries())
     .map(([skillId, skillRecords]) => {
-      const successes = skillRecords.filter(record => record.outcome && record.outcome.success).length;
+      const successes = skillRecords.filter(record => record.outcome?.success).length;
       const failures = skillRecords.length - successes;
       const recurringErrors = new Map();
       const recurringTasks = new Map();
@@ -85,7 +85,7 @@ function buildSkillHealthReport(records, options = {}) {
       const summary = {
         skill: {
           id: skillId,
-          path: skillRecords[0].skill.path || null
+          path: skillRecords[0]?.skill?.path ?? null
         },
         totalRuns: skillRecords.length,
         successes,

--- a/scripts/lib/skill-improvement/observations.js
+++ b/scripts/lib/skill-improvement/observations.js
@@ -32,8 +32,8 @@ function createObservationId() {
 
 function createSkillObservation(input) {
   const task = ensureString(input.task, 'task');
-  const skillId = ensureString(input.skill && input.skill.id, 'skill.id');
-  const skillPath = typeof input.skill.path === 'string' && input.skill.path.trim().length > 0
+  const skillId = ensureString(input.skill?.id, 'skill.id');
+  const skillPath = typeof input.skill?.path === 'string' && input.skill.path.trim().length > 0
     ? input.skill.path.trim()
     : null;
   const success = Boolean(input.success);
@@ -94,7 +94,7 @@ function readSkillObservations(options = {}) {
         return null;
       }
     })
-    .filter(record => record && record.schemaVersion === OBSERVATION_SCHEMA_VERSION);
+    .filter(record => record?.schemaVersion === OBSERVATION_SCHEMA_VERSION);
 }
 
 module.exports = {

--- a/scripts/lib/state-store/queries.js
+++ b/scripts/lib/state-store/queries.js
@@ -51,7 +51,7 @@ function mapSessionRow(row) {
     startedAt: row.started_at,
     endedAt: row.ended_at,
     snapshot,
-    workerCount: Array.isArray(snapshot && snapshot.workers) ? snapshot.workers.length : 0,
+    workerCount: Array.isArray(snapshot?.workers) ? snapshot.workers.length : 0,
     inputTokens: row.input_tokens ?? null,
     outputTokens: row.output_tokens ?? null,
     totalTokens: row.total_tokens ?? null,
@@ -894,7 +894,7 @@ function createQueryApi(db) {
       return null;
     }
 
-    const workers = Array.isArray(session.snapshot && session.snapshot.workers)
+    const workers = Array.isArray(session.snapshot?.workers)
       ? session.snapshot.workers.map(worker => ({ ...worker }))
       : [];
 

--- a/scripts/lib/state-store/schema.js
+++ b/scripts/lib/state-store/schema.js
@@ -51,7 +51,7 @@ function getEntityValidator(entityName) {
   const schema = readSchema();
   const definitionName = ENTITY_DEFINITIONS[entityName];
 
-  if (!definitionName || !schema.$defs || !schema.$defs[definitionName]) {
+  if (!definitionName || !schema.$defs?.[definitionName]) {
     throw new Error(`Unknown state-store schema entity: ${entityName}`);
   }
 


### PR DESCRIPTION
Applies optional chaining (rule javascript:S6582) across 20 script files, batch 2 - continuation of #797. Replaces #802 (identical content, recreated so the code-scanning merge analysis is computed against the current main). Resolves ~22 SonarCloud issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied optional chaining across 20 scripts to comply with Sonar rule `javascript:S6582`. Improves null-safety and reduces runtime errors; resolves ~22 SonarCloud issues.

- **Refactors**
  - Replaced `x && x.y` patterns with `x?.y`, `x?.[k]`, and `??` across hooks, install targets, package manager, session adapters/registry, skill-improvement, and state-store modules.
  - Hardened env/option reads and error/schema checks (e.g., `root?.trim()`, `process.env.BASH?.trim()`, `result.error?.code`, `error?.code === 'MODULE_NOT_FOUND'`, `schema.$defs?.[...]`, `Array.isArray(snapshot?.workers)`, `record.run?.variant`, `sessions?.persist...`); no behavior changes expected.

<sup>Written for commit 7a0c90b9b662a4fb090cbf9df8446d93d0ca04e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

