### PR TITLE
fix(sonar): use String#replaceAll for literal patterns (S7781)

### DIFF
--- a/scripts/ci/validate-install-manifests.js
+++ b/scripts/ci/validate-install-manifests.js
@@ -32,7 +32,7 @@ function readJson(filePath, label) {
 }
 
 function normalizeRelativePath(relativePath) {
-  return String(relativePath).replace(/\\/g, '/').replace(/\/+$/, '');
+  return String(relativePath).replaceAll('\\', '/').replace(/\/+$/, '');
 }
 
 function validateSchema(ajv, schemaPath, data, label) {

--- a/scripts/claw.js
+++ b/scripts/claw.js
@@ -160,7 +160,7 @@ function searchSessions(query, dir) {
     if (idx >= 0) {
       const start = Math.max(0, idx - 40);
       const end = Math.min(content.length, idx + q.length + 40);
-      const snippet = content.slice(start, end).replace(/\n/g, ' ');
+      const snippet = content.slice(start, end).replaceAll('\n', ' ');
       results.push({ session: name, snippet });
     }
   }

--- a/scripts/e2e-team-sync-direct.js
+++ b/scripts/e2e-team-sync-direct.js
@@ -127,7 +127,7 @@ function ok(cond, msg) { if (cond) { console.log('  PASS: ' + msg); passed++; } 
   try {
     const log = sh(['log', '--oneline', '--all'], REMOTE);
     ok(log.length > 0, 'remote has commits: ' + log);
-    console.log('   Remote log: ' + log.replace(/\n/g, ' | '));
+    console.log('   Remote log: ' + log.replaceAll('\n', ' | '));
   } catch (e) {
     ok(false, 'git log on remote: ' + e.message);
   }

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -53,7 +53,7 @@ function resolveProjectPath(input) {
 // double-hyphen join as branch-state.projectSlug; the previous single-hyphen
 // form never matched the files the memory server actually writes.
 function projectSlug(projectPath) {
-  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  const parts = projectPath.replaceAll('\\', '/').split('/').filter(Boolean);
   return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -24,7 +24,7 @@ function saveIntervalMs() {
 }
 
 function projectSlug(projectPath) {
-  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  const parts = projectPath.replaceAll('\\', '/').split('/').filter(Boolean);
   return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 

--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -104,8 +104,8 @@ function extractSummary(message) {
  * double quotes with curly quotes and strip backslashes before embedding.
  */
 function notifyMacOS(title, body) {
-  const safeBody = body.replace(/\\/g, '').replaceAll('"', '\u201C');
-  const safeTitle = title.replace(/\\/g, '').replaceAll('"', '\u201C');
+  const safeBody = body.replaceAll('\\', '').replaceAll('"', '\u201C');
+  const safeTitle = title.replaceAll('\\', '').replaceAll('"', '\u201C');
   const script = `display notification "${safeBody}" with title "${safeTitle}"`;
   const result = spawnSync('osascript', ['-e', script], { stdio: 'ignore', timeout: 5000 });
   if (result.error || result.status !== 0) {

--- a/scripts/hooks/doc-file-warning.js
+++ b/scripts/hooks/doc-file-warning.js
@@ -25,7 +25,7 @@ const ADHOC_FILENAMES = /^(NOTES|TODO|SCRATCH|TEMP|DRAFT|BRAINSTORM|SPIKE|DEBUG|
 const STRUCTURED_DIRS = /(^|\/)(docs|\.gemini|\.github|commands|skills|benchmarks|templates|\.history|memory)\//;
 
 function isSuspiciousDocPath(filePath) {
-  const normalized = filePath.replace(/\\/g, '/');
+  const normalized = filePath.replaceAll('\\', '/');
   const basename = path.basename(normalized);
 
   // Only inspect .md and .txt files (case-sensitive, consistent with ADHOC_FILENAMES)

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -252,7 +252,7 @@ function sanitizePath(filePath) {
 
 function normalizeForMatch(value) {
   return String(value || '')
-    .replace(/\\/g, '/')
+    .replaceAll('\\', '/')
     .toLowerCase();
 }
 

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -435,7 +435,7 @@ function reconnectCommand(serverName) {
     return null;
   }
 
-  return command.replace(/\{server\}/g, serverName);
+  return command.replaceAll('{server}', serverName);
 }
 
 function attemptReconnect(serverName) {

--- a/scripts/hooks/observe-runner.js
+++ b/scripts/hooks/observe-runner.js
@@ -40,7 +40,7 @@ function toShellPath(filePath) {
 
   return normalized
     .replace(/^([A-Za-z]):[\\/]/, (_, driveLetter) => `/${driveLetter.toLowerCase()}/`)
-    .replace(/\\/g, '/');
+    .replaceAll('\\', '/');
 }
 
 function findShellBinary() {

--- a/scripts/hooks/post-bash-command-log.js
+++ b/scripts/hooks/post-bash-command-log.js
@@ -21,7 +21,7 @@ const MODE_CONFIG = {
 
 function sanitizeCommand(command) {
   return String(command || '')
-    .replace(/\n/g, ' ')
+    .replaceAll('\n', ' ')
     .replace(/--token[= ][^ ]*/g, '--token=<REDACTED>')
     .replace(/Authorization:[: ]*[^ ]*[: ]*[^ ]*/gi, 'Authorization:<REDACTED>')
     .replace(/\bAKIA[A-Z0-9]{16}\b/g, '<REDACTED>')

--- a/scripts/hooks/session-activity-tracker.js
+++ b/scripts/hooks/session-activity-tracker.js
@@ -30,7 +30,7 @@ const FILE_PATH_KEYS = new Set([
 
 function redactSecrets(value) {
   return String(value || '')
-    .replace(/\n/g, ' ')
+    .replaceAll('\n', ' ')
     .replace(/--token[= ][^ ]*/g, '--token=<REDACTED>')
     .replace(/Authorization:[: ]*[^ ]*[: ]*[^ ]*/gi, 'Authorization:<REDACTED>')
     .replace(/\bAKIA[A-Z0-9]{16}\b/g, '<REDACTED>')

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -296,7 +296,7 @@ function buildSummarySection(summary) {
   // Tasks (from user messages: collapse newlines and escape backticks to prevent markdown breaks)
   section += '### Tasks\n';
   for (const msg of summary.userMessages) {
-    section += `- ${msg.replace(/\\/g, '\\\\').replace(/\n/g, ' ').replaceAll('`', '\\`')}\n`;
+    section += `- ${msg.replaceAll('\\', '\\\\').replaceAll('\n', ' ').replaceAll('`', '\\`')}\n`;
   }
   section += '\n';
 
@@ -304,14 +304,14 @@ function buildSummarySection(summary) {
   if (summary.filesModified.length > 0) {
     section += '### Files Modified\n';
     for (const f of summary.filesModified) {
-      section += `- ${f.replace(/\\/g, '\\\\').replaceAll('`', '\\`')}\n`;
+      section += `- ${f.replaceAll('\\', '\\\\').replaceAll('`', '\\`')}\n`;
     }
     section += '\n';
   }
 
   // Tools used
   if (summary.toolsUsed.length > 0) {
-    section += `### Tools Used\n${summary.toolsUsed.map(t => t.replace(/\\/g, '\\\\').replaceAll('`', '\\`')).join(', ')}\n\n`;
+    section += `### Tools Used\n${summary.toolsUsed.map(t => t.replaceAll('\\', '\\\\').replaceAll('`', '\\`')).join(', ')}\n\n`;
   }
 
   section += `### Stats\n- Total user messages: ${summary.totalMessages}\n`;

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -11,12 +11,12 @@ function getStateDir(homeDir) {
 }
 
 function projectSlug(projectPath) {
-  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  const parts = projectPath.replaceAll('\\', '/').split('/').filter(Boolean);
   return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 
 function sanitizeBranchName(branch) {
-  return branch.replace(/\//g, '-').replace(/[^a-zA-Z0-9-_]/g, '_');
+  return branch.replaceAll('/', '-').replace(/[^a-zA-Z0-9-_]/g, '_');
 }
 
 // Validates a resolved absolute path is within a trusted directory root

--- a/scripts/lib/guardian-bin.js
+++ b/scripts/lib/guardian-bin.js
@@ -59,7 +59,7 @@ function fromMcpConfigs() {
       // this whole fallback on Windows. Normalizing the candidate's own
       // separators before comparing means either style in the config matches.
       const indexJs = [server?.command, ...args].find(
-        a => typeof a === 'string' && a.replace(/\\/g, '/').endsWith('egc-guardian/build/index.js'),
+        a => typeof a === 'string' && a.replaceAll('\\', '/').endsWith('egc-guardian/build/index.js'),
       );
       if (!indexJs) continue;
       const candidate = path.resolve(path.dirname(indexJs), 'guardian-cli.js');

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -121,7 +121,7 @@ function listFilesRecursive(dirPath) {
 }
 
 function isGeneratedRuntimeSourcePath(sourceRelativePath) {
-  const normalizedPath = String(sourceRelativePath || '').replace(/\\/g, '/');
+  const normalizedPath = String(sourceRelativePath || '').replaceAll('\\', '/');
   return EXCLUDED_GENERATED_SOURCE_SUFFIXES.some(suffix => normalizedPath.endsWith(suffix));
 }
 

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -13,7 +13,7 @@ const PLATFORM_SOURCE_PATH_OWNERS = Object.freeze({
 
 function normalizeRelativePath(relativePath) {
   return String(relativePath || '')
-    .replace(/\\/g, '/')
+    .replaceAll('\\', '/')
     .replace(/^\.\/+/, '')
     .replace(/\/+$/, '');
 }
@@ -202,7 +202,7 @@ function createNamespacedFlatRuleOperations(adapter, moduleId, sourceRelativePat
     if (entry.isDirectory()) {
       const relativeFiles = listRelativeFiles(entryPath);
       for (const relativeFile of relativeFiles) {
-        const flattenedFileName = `${namespace}-${normalizeRelativePath(relativeFile).replace(/\//g, '-')}`;
+        const flattenedFileName = `${namespace}-${normalizeRelativePath(relativeFile).replaceAll('/', '-')}`;
         const sourceRelativeFile = path.join(normalizedSourcePath, namespace, relativeFile);
         operations.push(createManagedOperation({
           moduleId,
@@ -250,7 +250,7 @@ function createFlatFileOperations({
     if (entry.isDirectory()) {
       const relativeFiles = listRelativeFiles(entryPath);
       for (const relativeFile of relativeFiles) {
-        const defaultFileName = `${namespace}-${normalizeRelativePath(relativeFile).replace(/\//g, '-')}`;
+        const defaultFileName = `${namespace}-${normalizeRelativePath(relativeFile).replaceAll('/', '-')}`;
         const sourceRelativeFile = path.join(normalizedSourcePath, namespace, relativeFile);
         const flattenedFileName = typeof destinationNameTransform === 'function'
           ? destinationNameTransform(defaultFileName, sourceRelativeFile)

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -189,7 +189,7 @@ function registerJson(targetPath, bins) {
  * hex-ish character.
  */
 function tomlEscape(p) {
-  return p.replace(/\\/g, '\\\\');
+  return p.replaceAll('\\', '\\\\');
 }
 
 /**

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -17,7 +17,7 @@ const ISO_DATE_RE = /\b(\d{4})-(\d{2})-(\d{2})\b/;
 const BR_DATE_RE = /\b(\d{2})\/(\d{2})\/(\d{4})\b/;
 
 function projectSlug(projectPath) {
-  const parts = projectPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  const parts = projectPath.replaceAll('\\', '/').split('/').filter(Boolean);
   return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
 }
 

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -326,8 +326,8 @@ function findFiles(dir, pattern, options = {}) {
   // Order matters: escape specials first, then convert * and ? to regex equivalents.
   const regexPattern = pattern
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*/g, '.*')
-    .replace(/\?/g, '.');
+    .replaceAll('*', '.*')
+    .replaceAll('?', '.');
   const regex = new RegExp(`^${regexPattern}$`);
 
   function collectIfInAge(fullPath, stats) {


### PR DESCRIPTION
This PR fixes 28 occurrences of SonarCloud rule javascript:S7781 (Prefer String#replaceAll over String#replace for literal patterns with global regex) in the EGC codebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced global literal String.replace calls with String.replaceAll across scripts to satisfy Sonar rule S7781. Improves readability and consistency for path and text normalization with no behavior changes.

- **Refactors**
  - Updated 28 locations to use replaceAll for literals (e.g., '\\', '\n', '/', '{server}', '*', '?').
  - Changes span CI validation, hooks, and lib utilities to standardize path and text handling.

<sup>Written for commit aef35ffba35bce86947e45f3c16e7a71ad41f8cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

