### PR TITLE
fix(sonar): extract nested ternaries (S3358)

### DIFF
--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -23,11 +23,14 @@ const DOCS_ZH_CN_README_PATH = path.join(ROOT, 'docs', 'zh-CN', 'README.md');
 const DOCS_ZH_CN_AGENTS_PATH = path.join(ROOT, 'docs', 'zh-CN', 'AGENTS.md');
 const WRITE_MODE = process.argv.includes('--write');
 
-const OUTPUT_MODE = process.argv.includes('--md')
-  ? 'md'
-  : process.argv.includes('--text')
-    ? 'text'
-    : 'json';
+let OUTPUT_MODE;
+if (process.argv.includes('--md')) {
+  OUTPUT_MODE = 'md';
+} else if (process.argv.includes('--text')) {
+  OUTPUT_MODE = 'text';
+} else {
+  OUTPUT_MODE = 'json';
+}
 
 function normalizePathSegments(relativePath) {
   return relativePath.split(path.sep).join('/');

--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -209,7 +209,14 @@ function resolveServerEntry(name, existing) {
   const aliases = LEGACY_ALIASES[name] || [];
   const legacyName = aliases.find(a => existing[a] && typeof existing[a].command === 'string');
   const hasCanonical = entry && typeof entry.command === 'string';
-  const resolvedEntry = hasCanonical ? entry : legacyName ? existing[legacyName] : null;
+  let resolvedEntry;
+  if (hasCanonical) {
+    resolvedEntry = entry;
+  } else if (legacyName) {
+    resolvedEntry = existing[legacyName];
+  } else {
+    resolvedEntry = null;
+  }
   const urlEntry = !resolvedEntry && entry && typeof entry.url === 'string' ? entry : null;
   return {
     finalEntry: resolvedEntry || urlEntry,

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -27,8 +27,14 @@ function isRunning() {
 
 function openBrowser() {
   const url = `http://localhost:${PORT}`;
-  const cmd = process.platform === 'win32' ? 'start' :
-               process.platform === 'darwin' ? 'open' : 'xdg-open';
+  let cmd;
+  if (process.platform === 'win32') {
+    cmd = 'start';
+  } else if (process.platform === 'darwin') {
+    cmd = 'open';
+  } else {
+    cmd = 'xdg-open';
+  }
   try {
     spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' });
   } catch (_) { /* browser open is best-effort */ }

--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -112,11 +112,14 @@ function normalizeHookResult(previousRaw, output) {
   }
 
   if (output && typeof output === 'object') {
-    const nextRaw = Object.hasOwn(output, 'stdout')
-      ? String(output.stdout ?? '')
-      : !Number.isInteger(output.exitCode) || output.exitCode === 0
-        ? previousRaw
-        : '';
+    let nextRaw;
+    if (Object.hasOwn(output, 'stdout')) {
+      nextRaw = String(output.stdout ?? '');
+    } else if (!Number.isInteger(output.exitCode) || output.exitCode === 0) {
+      nextRaw = previousRaw;
+    } else {
+      nextRaw = '';
+    }
 
     return {
       raw: nextRaw,

--- a/scripts/hooks/doc-file-warning.js
+++ b/scripts/hooks/doc-file-warning.js
@@ -47,9 +47,15 @@ function isSuspiciousDocPath(filePath) {
 function run(inputOrRaw, _options = {}) {
   let input;
   try {
-    input = typeof inputOrRaw === 'string'
-      ? (inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {})
-      : (inputOrRaw || {});
+    if (typeof inputOrRaw === 'string') {
+      if (inputOrRaw.trim()) {
+        input = JSON.parse(inputOrRaw);
+      } else {
+        input = {};
+      }
+    } else {
+      input = inputOrRaw || {};
+    }
   } catch {
     return { exitCode: 0 };
   }

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -552,7 +552,11 @@ async function handlePreToolUse(rawInput, input, target, statePathValue, now) {
   markUnhealthy(state, target.server, now, probe.failureCode, probe.reason);
   saveState(statePathValue, state);
 
-  const reconnectSuffix = reconnect.attempted ? ` Reconnect attempt: ${reconnect.success ? 'ok' : reconnect.reason}.` : '';
+  let reconnectSuffix = '';
+  if (reconnect.attempted) {
+    const statusText = reconnect.success ? 'ok' : reconnect.reason;
+    reconnectSuffix = ` Reconnect attempt: ${statusText}.`;
+  }
   logs.push(`[MCPHealthCheck] ${target.server} is unavailable (${probe.reason}). Blocking ${target.tool || 'tool'} so Gemini can fall back to non-MCP tools.${reconnectSuffix}`);
   return { rawInput, exitCode: shouldFailOpen() ? 0 : 2, logs };
 }

--- a/scripts/hooks/observe-runner.js
+++ b/scripts/hooks/observe-runner.js
@@ -84,9 +84,10 @@ function getTimeoutMs() {
 }
 
 function combineStderr(stderr, message) {
-  const prefix = typeof stderr === 'string' && stderr.length > 0
-    ? stderr.endsWith('\n') ? stderr : `${stderr}\n`
-    : '';
+  let prefix = '';
+  if (typeof stderr === 'string' && stderr.length > 0) {
+    prefix = stderr.endsWith('\n') ? stderr : `${stderr}\n`;
+  }
   return `${prefix}${message}\n`;
 }
 
@@ -154,11 +155,14 @@ function buildSpawnResult(result) {
   }
 
   if (result.error || result.signal || result.status === null) {
-    const reason = result.error
-      ? result.error.message
-      : result.signal
-        ? `terminated by signal ${result.signal}`
-        : 'missing exit status';
+    let reason;
+    if (result.error) {
+      reason = result.error.message;
+    } else if (result.signal) {
+      reason = `terminated by signal ${result.signal}`;
+    } else {
+      reason = 'missing exit status';
+    }
     output.stderr = combineStderr(output.stderr, `[Hook] observe runner failed: ${reason}`);
     output.exitCode = 0;
   }

--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -153,11 +153,14 @@ function main() {
   writeStderr(result.stderr);
 
   if (result.error || result.signal || result.status === null) {
-    const reason = result.error
-      ? result.error.message
-      : result.signal
-        ? `terminated by signal ${result.signal}`
-        : 'missing exit status';
+    let reason;
+    if (result.error) {
+      reason = result.error.message;
+    } else if (result.signal) {
+      reason = `terminated by signal ${result.signal}`;
+    } else {
+      reason = 'missing exit status';
+    }
     writeStderr(`[Hook] bootstrap execution failed: ${reason}\n`);
     process.exit(0);
   }

--- a/scripts/hooks/pre-bash-commit-quality.js
+++ b/scripts/hooks/pre-bash-commit-quality.js
@@ -245,7 +245,14 @@ function reportLintResults(filesToCheck) {
     if (fileIssues.length > 0) {
       console.error(`\n[FILE] ${file}`);
       for (const issue of fileIssues) {
-        const label = issue.severity === 'error' ? 'ERROR' : issue.severity === 'warning' ? 'WARNING' : 'INFO';
+        let label;
+        if (issue.severity === 'error') {
+          label = 'ERROR';
+        } else if (issue.severity === 'warning') {
+          label = 'WARNING';
+        } else {
+          label = 'INFO';
+        }
         console.error(`  ${label} Line ${issue.line}: ${issue.message}`);
         totalIssues++;
         if (issue.severity === 'error') errorCount++;

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -189,11 +189,14 @@ async function executeHook(hookId, scriptPath, pluginRoot, raw, truncated) {
   if (result.stderr) process.stderr.write(result.stderr);
 
   if (result.error || result.signal || result.status === null) {
-    const failureDetail = result.error
-      ? result.error.message
-      : result.signal
-        ? `terminated by signal ${result.signal}`
-        : 'missing exit status';
+    let failureDetail;
+    if (result.error) {
+      failureDetail = result.error.message;
+    } else if (result.signal) {
+      failureDetail = `terminated by signal ${result.signal}`;
+    } else {
+      failureDetail = 'missing exit status';
+    }
     writeStderr(`[Hook] legacy hook execution failed for ${hookId}: ${failureDetail}`);
     process.exit(1);
   }

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -35,11 +35,14 @@ function extractUserMessage(entry) {
     return '';
   }
   const rawContent = entry.message?.content ?? entry.content;
-  const text = typeof rawContent === 'string'
-    ? rawContent
-    : Array.isArray(rawContent)
-      ? rawContent.map(c => c?.text ?? '').join(' ')
-      : '';
+  let text;
+  if (typeof rawContent === 'string') {
+    text = rawContent;
+  } else if (Array.isArray(rawContent)) {
+    text = rawContent.map(c => c?.text ?? '').join(' ');
+  } else {
+    text = '';
+  }
   return stripAnsi(text).trim();
 }
 

--- a/scripts/hooks/session-start-bootstrap.js
+++ b/scripts/hooks/session-start-bootstrap.js
@@ -142,11 +142,14 @@ if (fs.existsSync(script)) {
   }
 
   if (result.error || result.status === null || result.signal) {
-    const reason = result.error
-      ? result.error.message
-      : result.signal
-        ? 'signal ' + result.signal
-        : 'missing exit status';
+    let reason;
+    if (result.error) {
+      reason = result.error.message;
+    } else if (result.signal) {
+      reason = 'signal ' + result.signal;
+    } else {
+      reason = 'missing exit status';
+    }
     process.stderr.write('[SessionStart] ERROR: session-start hook failed: ' + reason + '\n');
     process.exit(1);
   }

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -247,8 +247,14 @@ if (!flags.dryRun) {
     });
     const openBrowser = () => {
       const url = 'http://localhost:7890';
-      const cmd = process.platform === 'win32' ? 'start' :
-                  process.platform === 'darwin' ? 'open' : 'xdg-open';
+      let cmd;
+      if (process.platform === 'win32') {
+        cmd = 'start';
+      } else if (process.platform === 'darwin') {
+        cmd = 'open';
+      } else {
+        cmd = 'xdg-open';
+      }
       try { require('node:child_process').spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) { /* ignore: best-effort browser open, failure is non-fatal */ }
     };
     dashPing.then(already => {

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -124,9 +124,14 @@ function main() {
     const defaultConfigPath = options.configPath || options.languages.length > 0
       ? null
       : findDefaultInstallConfigPath({ cwd: process.cwd() });
-    const config = options.configPath
-      ? loadInstallConfig(options.configPath, { cwd: process.cwd() })
-      : (defaultConfigPath ? loadInstallConfig(defaultConfigPath, { cwd: process.cwd() }) : null);
+    let config;
+    if (options.configPath) {
+      config = loadInstallConfig(options.configPath, { cwd: process.cwd() });
+    } else if (defaultConfigPath) {
+      config = loadInstallConfig(defaultConfigPath, { cwd: process.cwd() });
+    } else {
+      config = null;
+    }
     const request = normalizeInstallRequest({
       ...options,
       config,

--- a/scripts/install-plan.js
+++ b/scripts/install-plan.js
@@ -230,9 +230,14 @@ function main() {
     const defaultConfigPath = options.configPath
       ? null
       : findDefaultInstallConfigPath({ cwd: process.cwd() });
-    const config = options.configPath
-      ? loadInstallConfig(options.configPath, { cwd: process.cwd() })
-      : (defaultConfigPath ? loadInstallConfig(defaultConfigPath, { cwd: process.cwd() }) : null);
+    let config;
+    if (options.configPath) {
+      config = loadInstallConfig(options.configPath, { cwd: process.cwd() });
+    } else if (defaultConfigPath) {
+      config = loadInstallConfig(defaultConfigPath, { cwd: process.cwd() });
+    } else {
+      config = null;
+    }
 
     if (process.argv.length <= 2 && !config) {
       showHelp();

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -661,15 +661,30 @@ function createManifestInstallPlan(options = {}) {
   const requestProfileId = Object.hasOwn(options, 'requestProfileId')
     ? options.requestProfileId
     : (options.profileId || null);
-  const requestModuleIds = Object.hasOwn(options, 'requestModuleIds')
-    ? [...options.requestModuleIds]
-    : (Array.isArray(options.moduleIds) ? [...options.moduleIds] : []);
-  const requestIncludeComponentIds = Object.hasOwn(options, 'requestIncludeComponentIds')
-    ? [...options.requestIncludeComponentIds]
-    : (Array.isArray(options.includeComponentIds) ? [...options.includeComponentIds] : []);
-  const requestExcludeComponentIds = Object.hasOwn(options, 'requestExcludeComponentIds')
-    ? [...options.requestExcludeComponentIds]
-    : (Array.isArray(options.excludeComponentIds) ? [...options.excludeComponentIds] : []);
+  let requestModuleIds;
+  if (Object.hasOwn(options, 'requestModuleIds')) {
+    requestModuleIds = [...options.requestModuleIds];
+  } else if (Array.isArray(options.moduleIds)) {
+    requestModuleIds = [...options.moduleIds];
+  } else {
+    requestModuleIds = [];
+  }
+  let requestIncludeComponentIds;
+  if (Object.hasOwn(options, 'requestIncludeComponentIds')) {
+    requestIncludeComponentIds = [...options.requestIncludeComponentIds];
+  } else if (Array.isArray(options.includeComponentIds)) {
+    requestIncludeComponentIds = [...options.includeComponentIds];
+  } else {
+    requestIncludeComponentIds = [];
+  }
+  let requestExcludeComponentIds;
+  if (Object.hasOwn(options, 'requestExcludeComponentIds')) {
+    requestExcludeComponentIds = [...options.requestExcludeComponentIds];
+  } else if (Array.isArray(options.excludeComponentIds)) {
+    requestExcludeComponentIds = [...options.excludeComponentIds];
+  } else {
+    requestExcludeComponentIds = [];
+  }
   const plan = resolveInstallPlan({
     repoRoot: sourceRoot,
     projectRoot,

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -74,9 +74,14 @@ module.exports = createInstallTargetAdapter({
     return paths.length > 0;
   },
   planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
     const {
       repoRoot,
       projectRoot,

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -97,9 +97,14 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.claude',
   planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -34,9 +34,14 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.codebuddy',
   planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
     const {
       repoRoot,
       projectRoot,

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -81,9 +81,14 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'codex-install-state.json'],
   nativeRootRelativePath: '.agents',
   planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -61,9 +61,14 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.cursor',
   planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
     const seenDestinationPaths = new Set();
     const {
       repoRoot,

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -87,9 +87,14 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.gemini-plugin',
   planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -327,9 +327,14 @@ function planFlatSkillOperation(adapter, moduleId, sourceRelativePath, planningI
  * without a wrapper closure in each adapter file.
  */
 function createFlatSkillPlanOperations(input = {}, adapter) {
-  const modules = Array.isArray(input.modules)
-    ? input.modules
-    : (input.module ? [input.module] : []);
+  let modules;
+  if (Array.isArray(input.modules)) {
+    modules = input.modules;
+  } else if (input.module) {
+    modules = [input.module];
+  } else {
+    modules = [];
+  }
   const planningInput = {
     repoRoot: input.repoRoot,
     projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -15,9 +15,14 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.opencode',
   planOperations(input, adapter) {
-    const modules = Array.isArray(input.modules)
-      ? input.modules
-      : (input.module ? [input.module] : []);
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -426,7 +426,14 @@ function hasDepMatch(rule, depMap) {
 }
 
 function determinePrimary(frameworks, languages) {
-  let primary = frameworks.length > 0 ? frameworks[0] : (languages.length > 0 ? languages[0] : 'unknown');
+  let primary;
+  if (frameworks.length > 0) {
+    primary = frameworks[0];
+  } else if (languages.length > 0) {
+    primary = languages[0];
+  } else {
+    primary = 'unknown';
+  }
   if (frameworks.some(f => FRONTEND_SIGNALS.includes(f)) && frameworks.some(f => BACKEND_SIGNALS.includes(f))) {
     primary = 'fullstack';
   }

--- a/scripts/lib/session-adapters/canonical-session.js
+++ b/scripts/lib/session-adapters/canonical-session.js
@@ -298,6 +298,17 @@ function writeFallbackSessionRecording(snapshot, options = {}) {
   const snapshotChanged = !existing
     || JSON.stringify(existing.latest) !== JSON.stringify(snapshot);
 
+  let resolvedHistory;
+  if (Array.isArray(existing?.history)) {
+    if (snapshotChanged) {
+      resolvedHistory = existing.history.concat([{ recordedAt, snapshot }]);
+    } else {
+      resolvedHistory = existing.history;
+    }
+  } else {
+    resolvedHistory = [{ recordedAt, snapshot }];
+  }
+
   const payload = {
     schemaVersion: SESSION_RECORDING_SCHEMA_VERSION,
     adapterId: snapshot.adapterId,
@@ -307,11 +318,7 @@ function writeFallbackSessionRecording(snapshot, options = {}) {
       : recordedAt,
     updatedAt: recordedAt,
     latest: snapshot,
-    history: Array.isArray(existing?.history)
-      ? (snapshotChanged
-          ? existing.history.concat([{ recordedAt, snapshot }])
-          : existing.history)
-      : [{ recordedAt, snapshot }]
+    history: resolvedHistory
   };
 
   fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/scripts/lib/state-store/db-adapter.js
+++ b/scripts/lib/state-store/db-adapter.js
@@ -32,9 +32,14 @@ class Statement {
   }
 
   all(...args) {
-    const params = args.length === 0 ? undefined
-      : args.length === 1 ? normalizeParams(args[0])
-      : args;
+    let params;
+    if (args.length === 0) {
+      params = undefined;
+    } else if (args.length === 1) {
+      params = normalizeParams(args[0]);
+    } else {
+      params = args;
+    }
     const stmt = this._adapter._db.prepare(this._sql);
     const rows = [];
     try {

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -682,7 +682,13 @@ function getSnapshotPath(outputDir, session, usedNames) {
   let attempt = 0;
 
   while (attempt < 1000) {
-    const suffix = attempt === 0 ? '' : `-${hashSuffix}${attempt === 1 ? '' : `-${attempt}`}`;
+    let suffix;
+    if (attempt === 0) {
+      suffix = '';
+    } else {
+      const innerSuffix = attempt === 1 ? '' : `-${attempt}`;
+      suffix = `-${hashSuffix}${innerSuffix}`;
+    }
     const fileName = `${baseName}${suffix}.json`;
     if (!usedNames.has(fileName)) {
       usedNames.add(fileName);


### PR DESCRIPTION
This PR fixes 31 instances of the javascript:S3358 rule (nested ternary operation) by extracting them into independent variables/statements or if-else blocks. All 2622 tests passed and linting checks are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced nested ternary expressions to comply with Sonar rule javascript:S3358, improving readability across CI, hooks, and install scripts. No behavior changes.

- **Refactors**
  - Extracted complex conditions into variables or if/else blocks across CI scripts, dashboard open-browser logic, multiple `scripts/hooks/*`, install executor/targets, session adapter, and state store.
  - Verified no regressions: all tests pass and lint checks are clean.

<sup>Written for commit 11a0c0666d53f42420a5bd28d3d1c5e763583513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

