### PR TITLE
fix(sonar): resolve S7778 issues

### DIFF
--- a/scripts/ci/runtime-topology.js
+++ b/scripts/ci/runtime-topology.js
@@ -325,9 +325,11 @@ function buildGraph() {
 
 function toDot(graph) {
     const lines = [];
-    lines.push('digraph EGCRuntime {');
-    lines.push('  rankdir=LR;');
-    lines.push('  node [shape=box, fontname="Helvetica"];');
+    lines.push(
+      'digraph EGCRuntime {',
+      '  rankdir=LR;',
+      '  node [shape=box, fontname="Helvetica"];'
+    );
     for (const node of graph.nodes) {
         const label = `${node.id}\\n[${node.class}/${node.kind}]`;
         lines.push(`  "${node.id}" [label="${label}"];`);

--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -179,8 +179,10 @@ function findSubSections(serverObj, prefix) {
     const val = serverObj[key];
     if (val && typeof val === 'object' && !Array.isArray(val)) {
       const subPath = `${prefix}.${key}`;
-      sections.push(subPath);
-      sections.push(...findSubSections(val, subPath));
+      sections.push(
+        subPath,
+        ...findSubSections(val, subPath)
+      );
     }
   }
   return sections;

--- a/scripts/consult.js
+++ b/scripts/consult.js
@@ -383,30 +383,40 @@ function formatText(payload) {
   ];
 
   if (payload.matches.length === 0) {
-    lines.push('No strong component matches found.');
-    lines.push('Try: npx egc catalog components');
+    lines.push(
+      'No strong component matches found.',
+      'Try: npx egc catalog components'
+    );
   } else {
     lines.push('Recommended components:');
     payload.matches.forEach((match, index) => {
-      lines.push(`${index + 1}. ${match.componentId} [${match.family}]`);
-      lines.push(`   ${match.description}`);
-      lines.push(`   Install: ${match.installCommand}`);
-      lines.push(`   Preview: ${match.planCommand}`);
-      lines.push(`   Why: ${match.reasons.join('; ')}`);
+      lines.push(
+        `${index + 1}. ${match.componentId} [${match.family}]`,
+        `   ${match.description}`,
+        `   Install: ${match.installCommand}`,
+        `   Preview: ${match.planCommand}`,
+        `   Why: ${match.reasons.join('; ')}`
+      );
     });
   }
 
   if (payload.profiles.length > 0) {
-    lines.push('');
-    lines.push('Related profiles:');
+    lines.push(
+      '',
+      'Related profiles:'
+    );
     payload.profiles.forEach(profile => {
-      lines.push(`- ${profile.id}: ${profile.description}`);
-      lines.push(`  Install: ${profile.installCommand}`);
+      lines.push(
+        `- ${profile.id}: ${profile.description}`,
+        `  Install: ${profile.installCommand}`
+      );
     });
   }
 
-  lines.push('');
-  lines.push('Next steps:');
+  lines.push(
+    '',
+    'Next steps:'
+  );
   payload.nextSteps.forEach(step => lines.push(`- ${step}`));
 
   return `${lines.join('\n')}\n`;

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -146,9 +146,11 @@ function buildBriefingLines(stack, stackSpecific, generic, missing) {
     }
   }
 
-  lines.push('Skill: coding-standards (cyclomatic complexity) - apply to all code written this session');
-  lines.push('===');
-  lines.push('');
+  lines.push(
+    'Skill: coding-standards (cyclomatic complexity) - apply to all code written this session',
+    '===',
+    ''
+  );
   return lines;
 }
 

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -382,8 +382,8 @@ function collectRequestedModuleIds(options, manifests, profileId) {
     requestedModuleIds.push(...profile.modules);
   }
 
-  requestedModuleIds.push(...dedupeStrings(options.moduleIds));
   requestedModuleIds.push(
+    ...dedupeStrings(options.moduleIds),
     ...expandComponentIdsToModuleIds(dedupeStrings(options.includeComponentIds), manifests)
   );
 

--- a/scripts/lib/skill-evolution/dashboard.js
+++ b/scripts/lib/skill-evolution/dashboard.js
@@ -262,8 +262,10 @@ function renderAmendmentPanel(skillsById, options = {}) {
       const time = amendment.created_at ? amendment.created_at.slice(0, 19) : '-';
       lines.push(`${name} ${event} ${status} ${time}`);
     }
-    lines.push('');
-    lines.push(`${amendments.length} amendment${amendments.length === 1 ? '' : 's'} pending review`);
+    lines.push(
+      '',
+      `${amendments.length} amendment${amendments.length === 1 ? '' : 's'} pending review`
+    );
   }
 
   return {

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -251,9 +251,11 @@ function consolidateSection(section, now, stats) {
 function renderDocument(header, sectionOutputs) {
   const lines = [...header, ''];
   for (const section of sectionOutputs) {
-    lines.push(`## ${section.title}`);
-    lines.push(...section.lines);
-    lines.push('');
+    lines.push(
+      `## ${section.title}`,
+      ...section.lines,
+      ''
+    );
   }
   return lines.join('\n');
 }

--- a/scripts/lib/state-overview.js
+++ b/scripts/lib/state-overview.js
@@ -186,16 +186,20 @@ function renderOverviewMarkdown(overview) {
   const readable = overview.entries.filter(entry => !entry.error);
   const failed = overview.entries.filter(entry => entry.error);
 
-  lines.push('# EGC State Overview');
-  lines.push('');
-  lines.push(`State root: ${overview.stateDir}`);
-  lines.push(`Projects: ${readable.length}`);
-  lines.push('');
+  lines.push(
+    '# EGC State Overview',
+    '',
+    `State root: ${overview.stateDir}`,
+    `Projects: ${readable.length}`,
+    ''
+  );
 
   for (const entry of readable) {
-    lines.push(`## ${entry.project}`);
-    lines.push(`- Branch: ${entry.branch || 'n/a'} (${entry.branchStateCount} state file${entry.branchStateCount === 1 ? '' : 's'}, ${entry.layout} layout)`);
-    lines.push(`- Updated: ${entry.updated}`);
+    lines.push(
+      `## ${entry.project}`,
+      `- Branch: ${entry.branch || 'n/a'} (${entry.branchStateCount} state file${entry.branchStateCount === 1 ? '' : 's'}, ${entry.layout} layout)`,
+      `- Updated: ${entry.updated}`
+    );
     if (entry.context) {
       lines.push(`- Context: ${entry.context}`);
     }

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -610,22 +610,28 @@ function formatText(payload) {
         : `No Gemini transcript JSONL files found under ${payload.source.transcriptRoot}.`,
     ];
     if (skippedLines.length > 0) {
-      lines.push('Skipped transcript errors:');
-      lines.push(...skippedLines);
+      lines.push(
+        'Skipped transcript errors:',
+        ...skippedLines
+      );
     }
     return lines.join('\n');
   }
 
   const lines = [`EGC loop status (${payload.generatedAt})`];
   for (const session of payload.sessions) {
-    lines.push(`- ${session.sessionId} [${session.state}] ${session.transcriptPath}`);
-    lines.push(`  last event: ${session.lastEventAt || 'unknown'}; events: ${session.eventCount}`);
-    lines.push(`  signals: ${formatSignals(session.signals)}`);
-    lines.push(`  action: ${session.recommendedAction}`);
+    lines.push(
+      `- ${session.sessionId} [${session.state}] ${session.transcriptPath}`,
+      `  last event: ${session.lastEventAt || 'unknown'}; events: ${session.eventCount}`,
+      `  signals: ${formatSignals(session.signals)}`,
+      `  action: ${session.recommendedAction}`
+    );
   }
   if (skippedLines.length > 0) {
-    lines.push('Skipped transcript errors:');
-    lines.push(...skippedLines);
+    lines.push(
+      'Skipped transcript errors:',
+      ...skippedLines
+    );
   }
   return lines.join('\n');
 }


### PR DESCRIPTION
Resolves 28 SonarCloud issues of rule javascript:S7778. Authored by the squad agent (lint 0 errors, 2622/2622 tests passing locally); PR opened on its behalf because the agent runtime blocks gh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 28 SonarCloud `javascript:S7778` issues by grouping consecutive array pushes into single calls across `scripts/**`. No behavior changes.

- **Refactors**
  - Consolidated repeated `push()` calls into single calls with multiple args or spreads for arrays like `lines`.
  - Applied across: `scripts/ci/runtime-topology.js`, `scripts/consult.js`, `scripts/loop-status.js`, `scripts/lib/state-overview.js`, `scripts/lib/state-consolidate.js`, `scripts/lib/skill-evolution/dashboard.js`, `scripts/codex/merge-mcp-config.js`, `scripts/hooks/claude-session-start.js`, `scripts/lib/install-manifests.js`.
  - Minor ordering tweak in `collectRequestedModuleIds` to append all items together; output remains the same.

<sup>Written for commit 8af580f53fed9ae7d900a0c9127dfa42d740ebc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

