### PR TITLE
fix(sonar): resolve S6594 issues

### DIFF
--- a/scripts/hooks/post-bash-pr-created.js
+++ b/scripts/hooks/post-bash-pr-created.js
@@ -11,7 +11,7 @@ function run(rawInput) {
 
     if (/\bgh\s+pr\s+create\b/.test(cmd)) {
       const out = String(input.tool_output?.output || '');
-      const match = out.match(/https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/);
+      const match = /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.exec(out);
       if (match) {
         const prUrl = match[0];
         const repo = prUrl.replace(/https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/, '$1');

--- a/scripts/hooks/pre-bash-commit-quality.js
+++ b/scripts/hooks/pre-bash-commit-quality.js
@@ -136,7 +136,7 @@ function findFileIssues(filePath) {
  */
 function validateCommitMessage(command) {
   // Extract commit message from command
-  const messageMatch = command.match(/(?:-m|--message)[=\s]+["']?([^"']+)["']?/);
+  const messageMatch = /(?:-m|--message)[=\s]+["']?([^"']+)["']?/.exec(command);
   if (!messageMatch) return null;
   
   const message = messageMatch[1];

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -149,7 +149,7 @@ function getSessionMetadata() {
 }
 
 function extractHeaderField(header, label) {
-  const match = new RegExp(`\\*\\*${escapeRegExp(label)}\\*\\*\\s*(.+)$`, 'm').exec(header);
+  const match = new RegExp(`\\*\\*${escapeRegExp(label)}:\\*\\*\\s*(.+)$`, 'm').exec(header);
   return match ? match[1].trim() : null;
 }
 

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -149,7 +149,7 @@ function getSessionMetadata() {
 }
 
 function extractHeaderField(header, label) {
-  const match = header.match(new RegExp(`\\*\\*${escapeRegExp(label)}:\\*\\*\\s*(.+)$`, 'm'));
+  const match = new RegExp(`\\*\\*${escapeRegExp(label)}\\*\\*\\s*(.+)$`, 'm').exec(header);
   return match ? match[1].trim() : null;
 }
 

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -208,7 +208,7 @@ function selectMatchingSession(sessions, cwd, currentProject) {
     }
 
     // Extract **Worktree:** field
-    const worktreeMatch = content.match(/\*\*Worktree:\*\*\s*(.+)$/m);
+    const worktreeMatch = /\*\*Worktree:\*\*\s*(.+)$/m.exec(content);
     const sessionWorktree = worktreeMatch ? worktreeMatch[1].trim() : '';
 
     // Exact worktree match: best possible, return immediately
@@ -219,7 +219,7 @@ function selectMatchingSession(sessions, cwd, currentProject) {
 
     // Project name match: keep searching for a worktree match
     if (!projectMatch && currentProject) {
-      const projectFieldMatch = content.match(/\*\*Project:\*\*\s*(.+)$/m);
+      const projectFieldMatch = /\*\*Project:\*\*\s*(.+)$/m.exec(content);
       const sessionProject = projectFieldMatch ? projectFieldMatch[1].trim() : '';
       if (sessionProject && sessionProject === currentProject) {
         projectMatch = session;
@@ -322,7 +322,7 @@ function readInstinctsFromDir(directory, scope) {
 }
 
 function extractInstinctAction(content) {
-  const actionMatch = String(content || '').match(/## Action\s*\n+([\s\S]+?)(?:\n## |\n---|$)/);
+  const actionMatch = /## Action\s*\n+([\s\S]+?)(?:\n## |\n---|$)/.exec(String(content || ''));
   const actionBlock = (actionMatch ? actionMatch[1] : String(content || '')).trim();
   const firstLine = actionBlock
     .split('\n')
@@ -407,13 +407,13 @@ function truncateSummary(value, maxLength = MAX_LEARNED_SKILL_SUMMARY_CHARS) {
 }
 
 function extractMarkdownHeading(content) {
-  const match = String(content || '').match(/^#\s+(.+)$/m);
+  const match = /^#\s+(.+)$/m.exec(String(content || ''));
   return match ? stripMarkdownInline(match[1]) : '';
 }
 
 function extractSection(content, headingPattern) {
   const source = String(content || '');
-  const match = source.match(new RegExp(`^##\\s+${headingPattern}\\s*\\n+([\\s\\S]+?)(?:\\n##\\s+|$)`, 'im'));
+  const match = new RegExp(`^##\\s+${headingPattern}\\s*\\n+([\\s\\S]+?)(?:\\n##\\s+|$)`, 'im').exec(source);
   return match ? match[1].trim() : '';
 }
 

--- a/scripts/lib/orchestration-session.js
+++ b/scripts/lib/orchestration-session.js
@@ -79,7 +79,7 @@ function parseWorkerStatus(content) {
   }
 
   for (const line of content.split('\n')) {
-    const match = line.match(/^- ([A-Za-z ]+):\s*(.+)$/);
+    const match = /^- ([A-Za-z ]+):\s*(.+)$/.exec(line);
     if (!match) continue;
 
     const key = match[1].trim().toLowerCase().replace(/\s+/g, '');

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -103,7 +103,7 @@ function upsertEgcSection(existing, block) {
 const STATE_UPDATED_RE = /<!-- egc:state-updated:(\S+) -->/;
 
 function extractStateUpdated(content) {
-  const match = typeof content === 'string' ? content.match(STATE_UPDATED_RE) : null;
+  const match = typeof content === 'string' ? STATE_UPDATED_RE.exec(content) : null;
   return match ? match[1] : '';
 }
 

--- a/scripts/lib/session-manager.js
+++ b/scripts/lib/session-manager.js
@@ -33,7 +33,7 @@ const SESSION_FILENAME_REGEX = /^(\d{4}-\d{2}-\d{2})(?:-([a-zA-Z0-9_][a-zA-Z0-9_
  */
 function parseSessionFilename(filename) {
   if (!filename || typeof filename !== 'string') return null;
-  const match = filename.match(SESSION_FILENAME_REGEX);
+  const match = SESSION_FILENAME_REGEX.exec(filename);
   if (!match) return null;
 
   const dateStr = match[1];
@@ -215,7 +215,7 @@ function getSessionContent(sessionPath) {
  * @returns {object} Parsed metadata
  */
 function extractField(content, regex, group = 1) {
-  const m = content.match(regex);
+  const m = regex.exec(content);
   return m ? m[group].trim() : null;
 }
 

--- a/scripts/lib/state-overview.js
+++ b/scripts/lib/state-overview.js
@@ -19,7 +19,7 @@ function parseStateFile(content) {
   let currentSection = null;
 
   for (const line of lines) {
-    const headingMatch = line.match(SECTION_HEADING_REGEX);
+    const headingMatch = SECTION_HEADING_REGEX.exec(line);
     if (headingMatch) {
       currentSection = headingMatch[1].trim();
       sections[currentSection] = [];
@@ -27,7 +27,7 @@ function parseStateFile(content) {
     }
 
     if (!currentSection) {
-      const fieldMatch = line.match(HEADER_FIELD_REGEX);
+      const fieldMatch = HEADER_FIELD_REGEX.exec(line);
       if (fieldMatch) {
         header[fieldMatch[1]] = fieldMatch[2].trim();
       }

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -151,8 +151,8 @@ function mergeBlockIntoStateFile(stateFilePath, block) {
   const existing = rawState.toString('utf-8');
 
   // Only update Context and Next Session sections if they differ
-  const contextMatch = parsed.match(/## Context\n([^\n]+)/);
-  const nextMatch = parsed.match(/## Next Session\n([\s\S]*?)(?=\n##|$)/);
+  const contextMatch = /## Context\n([^\n]+)/.exec(parsed);
+  const nextMatch = /## Next Session\n([\s\S]*?)(?=\n##|$)/.exec(parsed);
 
   if (!contextMatch && !nextMatch) return false;
 


### PR DESCRIPTION
Resolves 16 S6594 issues reported by SonarCloud.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized regex usage across hooks and lib modules to resolve 16 SonarCloud S6594 issues by replacing `String.match(...)` with `RegExp.exec(...)`. No behavior changes; URL, commit message, header, section, and state parsing work as before.

- **Bug Fixes**
  - Restored the colon in `extractHeaderField` regex to keep header parsing correct.

- **Refactors**
  - Replaced `.match(...)` with `.exec(...)` in PR URL extraction, commit message parsing, markdown header/section parsing, and state file merging.
  - Reused regex constants and tightened null checks for consistent results across scripts.

<sup>Written for commit b5a47970773f17e63473ac1f1253b6b8522f0ed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

