### PR TITLE
fix(sonar): resolve S4624 issues

### DIFF
--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -162,7 +162,7 @@ function runExternalCommand(command, args, options = {}) {
 
   if (typeof result.status === 'number' && result.status !== 0) {
     const errorOutput = (result.stderr || result.stdout || '').trim();
-    throw new Error(`${command} ${args.join(' ')} failed${errorOutput ? `: ${errorOutput}` : ''}`);
+    throw new Error(`${command} ${args.join(' ')} failed${errorOutput ? ': ' + errorOutput : ''}`);
   }
 
   return result;

--- a/scripts/budget.js
+++ b/scripts/budget.js
@@ -76,7 +76,7 @@ function handleSet(args) {
   writeBudgetConfig(config);
   console.log('Budget config saved:');
   console.log(`  Max tokens: ${config.max_tokens !== null ? config.max_tokens.toLocaleString() : 'not set'}`);
-  console.log(`  Max cost:   ${config.max_cost_usd !== null ? `$${config.max_cost_usd.toFixed(2)}` : 'not set'}`);
+  console.log(`  Max cost:   ${config.max_cost_usd !== null ? '$' + config.max_cost_usd.toFixed(2) : 'not set'}`);
   console.log(`  Warn at:    ${config.warn_at_percent}%`);
   console.log(`  Action:     ${config.action}`);
 }

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -126,7 +126,7 @@ async function status() {
   const running = await isRunning();
   const pid = readPid();
   if (running) {
-    console.log(`running  http://localhost:${PORT}${pid ? `  (pid ${pid})` : ''}`);
+    console.log(`running  http://localhost:${PORT}${pid ? '  (pid ' + pid + ')' : ''}`);
   } else {
     console.log('stopped');
   }

--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -109,7 +109,7 @@ function notifyMacOS(title, body) {
   const script = `display notification "${safeBody}" with title "${safeTitle}"`;
   const result = spawnSync('osascript', ['-e', script], { stdio: 'ignore', timeout: 5000 });
   if (result.error || result.status !== 0) {
-    log(`[DesktopNotify] osascript failed: ${result.error ? result.error.message : `exit ${result.status}`}`);
+    log(`[DesktopNotify] osascript failed: ${result.error ? result.error.message : 'exit ' + result.status}`);
   }
 }
 

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -78,9 +78,9 @@ Examples:
 
 if (flags.help) showHelp();
 
-function ok(label, detail = '')  { console.log(`  ${c.green}${c.bold}✓${c.reset}  ${c.bold}${label}${c.reset}${detail ? `  ${c.dim}${detail}${c.reset}` : ''}`); }
-function skip(label, reason = '') { console.log(`  ${c.dim}-  ${label}${reason ? `  (${reason})` : ''}${c.reset}`); }
-function warn(label, reason = '') { console.log(`  ${c.yellow}!${c.reset}  ${label}${reason ? `  ${c.dim}${reason}${c.reset}` : ''}`); }
+function ok(label, detail = '')  { console.log(`  ${c.green}${c.bold}✓${c.reset}  ${c.bold}${label}${c.reset}${detail ? '  ' + c.dim + detail + c.reset : ''}`); }
+function skip(label, reason = '') { console.log(`  ${c.dim}-  ${label}${reason ? '  (' + reason + ')' : ''}${c.reset}`); }
+function warn(label, reason = '') { console.log(`  ${c.yellow}!${c.reset}  ${label}${reason ? '  ' + c.dim + reason + c.reset : ''}`); }
 function log(msg) { console.log(msg); }
 function logDry(msg) { if (flags.dryRun) console.log(`  ${c.dim}[dry-run] ${msg}${c.reset}`); }
 function logAction(msg) { console.log(`  ${c.dim}${flags.dryRun ? '[dry-run] ' : ''}${msg}${c.reset}`); }

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -453,7 +453,7 @@ function resolveModuleDependencyGraph({
       if (dependencyOf) {
         const owners = excludedModuleOwners.get(moduleId) || [];
         throw new Error(
-          `Module ${dependencyOf} depends on excluded module ${moduleId}${owners.length > 0 ? ` (excluded by ${owners.join(', ')})` : ''}`
+          `Module ${dependencyOf} depends on excluded module ${moduleId}${owners.length > 0 ? ' (excluded by ' + owners.join(', ') + ')' : ''}`
         );
       }
       return;

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -252,7 +252,7 @@ function validateInstallState(state) {
 function assertValidInstallState(state, label) {
   const result = validateInstallState(state);
   if (!result.valid) {
-    throw new Error(`Invalid install-state${label ? ` (${label})` : ''}: ${formatValidationErrors(result.errors)}`);
+    throw new Error(`Invalid install-state${label ? ' (' + label + ')' : ''}: ${formatValidationErrors(result.errors)}`);
   }
 }
 

--- a/scripts/lib/state-store/schema.js
+++ b/scripts/lib/state-store/schema.js
@@ -83,7 +83,7 @@ function validateEntity(entityName, payload) {
 function assertValidEntity(entityName, payload, label) {
   const result = validateEntity(entityName, payload);
   if (!result.valid) {
-    throw new Error(`Invalid ${entityName}${label ? ` (${label})` : ''}: ${formatValidationErrors(result.errors)}`);
+    throw new Error(`Invalid ${entityName}${label ? ' (' + label + ')' : ''}: ${formatValidationErrors(result.errors)}`);
   }
 }
 

--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -27,7 +27,7 @@ function renderTemplate(template, variables) {
 }
 
 function shellQuote(value) {
-  return `'${String(value).replaceAll("'", `'\\''`)}'`;
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
 
 function formatCommand(program, args) {
@@ -47,7 +47,7 @@ function buildTemplateVariables(values) {
 }
 
 function buildSessionBannerCommand(sessionName, coordinationDir) {
-  return `printf '%s\\n' ${shellQuote(`Session: ${sessionName}`)} ${shellQuote(`Coordination: ${coordinationDir}`)}`;
+  return `printf '%s\\n' ${shellQuote('Session: ' + sessionName)} ${shellQuote('Coordination: ' + coordinationDir)}`;
 }
 
 function normalizeSeedPaths(seedPaths, repoRoot) {
@@ -333,7 +333,7 @@ function runCommand(program, args, options = {}) {
   }
   if (result.status !== 0) {
     const stderr = (result.stderr || '').trim();
-    throw new Error(`${program} ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`);
+    throw new Error(`${program} ${args.join(' ')} failed${stderr ? ': ' + stderr : ''}`);
   }
   return result;
 }

--- a/scripts/skill-create-output.js
+++ b/scripts/skill-create-output.js
@@ -138,7 +138,7 @@ ${chalk.bold('Files Tracked:')}    ${chalk.green(data.files)}
   instincts(instincts) {
     console.log('\n');
     console.log(box('Instincts Generated', instincts.map((inst, i) =>
-      `${chalk.yellow(`${i + 1}.`)} ${chalk.bold(inst.name)} ${chalk.gray(`(${Math.round(inst.confidence * 100)}%)`)}`
+      `${chalk.yellow((i + 1) + '.')} ${chalk.bold(inst.name)} ${chalk.gray('(' + Math.round(inst.confidence * 100) + '%)')}`
     ).join('\n')));
   }
 


### PR DESCRIPTION
This PR resolves 16 nested template literals issues matching SonarCloud rule javascript:S4624.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve SonarCloud rule `javascript:S4624` by removing nested template literals across scripts. Reduces 16 issues with no behavior changes.

- **Refactors**
  - Replace conditional template fragments with string concatenation in errors and logs across `scripts/*`.
  - Normalize shell quoting and session banner strings in `lib/tmux-worktree-orchestrator`.

<sup>Written for commit 6470f2fd081a4fd6eb5592c6e69df088ab138eed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

