### PR TITLE
fix(sonar): resolve S7780 issues

### DIFF
--- a/scripts/ci/check-unicode-safety.js
+++ b/scripts/ci/check-unicode-safety.js
@@ -77,8 +77,8 @@ const allowedSymbolCodePoints = new Set([
 ]);
 
 const targetedReplacements = [
-  [new RegExp(`${String.fromCodePoint(0x26A0)}(?:\\uFE0F)?`, 'gu'), 'WARNING:'],
-  [new RegExp(`${String.fromCodePoint(0x23ED)}(?:\\uFE0F)?`, 'gu'), 'SKIPPED:'],
+  [new RegExp(String.raw`${String.fromCodePoint(0x26A0)}(?:\uFE0F)?`, 'gu'), 'WARNING:'],
+  [new RegExp(String.raw`${String.fromCodePoint(0x23ED)}(?:\uFE0F)?`, 'gu'), 'SKIPPED:'],
   [new RegExp(String.fromCodePoint(0x2705), 'gu'), 'PASS:'],
   [new RegExp(String.fromCodePoint(0x274C), 'gu'), 'FAIL:'],
   [new RegExp(String.fromCodePoint(0x2728), 'gu'), ''],

--- a/scripts/ci/runtime-topology.js
+++ b/scripts/ci/runtime-topology.js
@@ -331,7 +331,7 @@ function toDot(graph) {
       '  node [shape=box, fontname="Helvetica"];'
     );
     for (const node of graph.nodes) {
-        const label = `${node.id}\\n[${node.class}/${node.kind}]`;
+        const label = String.raw`${node.id}\n[${node.class}/${node.kind}]`;
         lines.push(`  "${node.id}" [label="${label}"];`);
     }
     for (const edge of graph.edges) {

--- a/scripts/codex/merge-codex-config.js
+++ b/scripts/codex/merge-codex-config.js
@@ -72,8 +72,8 @@ function findFirstTableIndex(raw) {
 }
 
 function findTableRange(raw, tablePath) {
-  const escaped = tablePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const headerPattern = new RegExp(`^[ \\t]*\\[${escaped}\\][ \\t]*(?:#.*)?$`, 'm');
+  const escaped = tablePath.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  const headerPattern = new RegExp(String.raw`^[ \t]*\[${escaped}\][ \t]*(?:#.*)?$`, 'm');
   const match = headerPattern.exec(raw);
   if (!match) {
     return null;
@@ -126,11 +126,11 @@ function updateInlineTableKeys(raw, tablePath, missingKeys) {
   }
 
   const tableKey = pathParts[pathParts.length - 1];
-  const escapedKey = tableKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedKey = tableKey.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
   const body = raw.slice(parentRange.bodyStart, parentRange.bodyEnd);
   const lines = body.split('\n');
   for (let index = 0; index < lines.length; index += 1) {
-    const inlinePattern = new RegExp(`^(\\s*${escapedKey}\\s*=\\s*\\{)(.*?)(\\}\\s*(?:#.*)?)$`);
+    const inlinePattern = new RegExp(String.raw`^(\s*${escapedKey}\s*=\s*\{)(.*?)(\}\s*(?:#.*)?)$`);
     const match = inlinePattern.exec(lines[index]);
     if (!match) {
       continue;

--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -145,8 +145,8 @@ function configDiffers(existing, recommended) {
  * Returns the text with the section removed.
  */
 function removeSectionFromText(text, sectionHeader) {
-  const escaped = sectionHeader.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const headerPattern = new RegExp(`^${escaped}(\\s*(#.*)?)?$`);
+  const escaped = sectionHeader.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  const headerPattern = new RegExp(String.raw`^${escaped}(\s*(#.*)?)?$`);
   const lines = text.split('\n');
   const result = [];
   let skipping = false;

--- a/scripts/hooks/auto-tmux-dev.js
+++ b/scripts/hooks/auto-tmux-dev.js
@@ -62,7 +62,7 @@ function run(rawInput) {
         const tmuxCheck = spawnSync('which', ['tmux'], { encoding: 'utf8' });
         if (tmuxCheck.status === 0) {
           // Escape single quotes for shell safety: 'text' -> 'text'\''text'
-          const escapedCmd = cmd.replaceAll("'", "'\\''");
+          const escapedCmd = cmd.replaceAll("'", String.raw`'\''`);
 
           // 1. Kill existing session (silent if doesn't exist)
           // 2. Create new detached session with the dev command

--- a/scripts/hooks/check-console-log.js
+++ b/scripts/hooks/check-console-log.js
@@ -44,7 +44,7 @@ process.stdin.on('end', () => {
       process.exit(0);
     }
 
-    const files = getGitModifiedFiles(['\\.tsx?$', '\\.jsx?$'])
+    const files = getGitModifiedFiles([String.raw`\.tsx?$`, String.raw`\.jsx?$`])
       .filter(f => fs.existsSync(f))
       .filter(f => !EXCLUDED_PATTERNS.some(pattern => pattern.test(f)));
 

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -149,7 +149,7 @@ function getSessionMetadata() {
 }
 
 function extractHeaderField(header, label) {
-  const match = header.match(new RegExp(`\\*\\*${escapeRegExp(label)}:\\*\\*\\s*(.+)$`, 'm'));
+  const match = header.match(new RegExp(String.raw`\*\*${escapeRegExp(label)}:\*\*\s*(.+)$`, 'm'));
   return match ? match[1].trim() : null;
 }
 
@@ -221,7 +221,7 @@ function injectSummaryIntoContent(updatedContent, summary) {
   const summaryBlock = buildSummaryBlock(summary);
   if (updatedContent.includes(SUMMARY_START_MARKER) && updatedContent.includes(SUMMARY_END_MARKER)) {
     return updatedContent.replace(
-      new RegExp(`${escapeRegExp(SUMMARY_START_MARKER)}[\\s\\S]*?${escapeRegExp(SUMMARY_END_MARKER)}`),
+      new RegExp(String.raw`${escapeRegExp(SUMMARY_START_MARKER)}[\s\S]*?${escapeRegExp(SUMMARY_END_MARKER)}`),
       summaryBlock
     );
   }
@@ -327,5 +327,5 @@ function buildSummaryBlock(summary) {
 }
 
 function escapeRegExp(value) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -413,7 +413,7 @@ function extractMarkdownHeading(content) {
 
 function extractSection(content, headingPattern) {
   const source = String(content || '');
-  const match = source.match(new RegExp(`^##\\s+${headingPattern}\\s*\\n+([\\s\\S]+?)(?:\\n##\\s+|$)`, 'im'));
+  const match = source.match(new RegExp(String.raw`^##\s+${headingPattern}\s*\n+([\s\S]+?)(?:\n##\s+|$)`, 'im'));
   return match ? match[1].trim() : '';
 }
 

--- a/scripts/lib/package-manager.js
+++ b/scripts/lib/package-manager.js
@@ -359,7 +359,7 @@ function getSelectionPrompt() {
 
 // Escape regex metacharacters in a string before interpolating into a pattern
 function escapeRegex(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return str.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 /**

--- a/scripts/lib/state-snapshot.js
+++ b/scripts/lib/state-snapshot.js
@@ -64,11 +64,11 @@ function writeSnapshotToDisk(projectPath = process.env.PWD || process.cwd()) {
 }
 
 function escapeRegExp(text) {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 function extractSection(content, heading) {
-  const re = new RegExp(`^${escapeRegExp(heading)}\\n([\\s\\S]*?)(?=^## |\\Z)`, 'm');
+  const re = new RegExp(String.raw`^${escapeRegExp(heading)}\n([\s\S]*?)(?=^## |\Z)`, 'm');
   const match = content.match(re);
   return match ? match[1].trim() : '';
 }
@@ -82,7 +82,7 @@ function appendToSection(content, heading, lines) {
   const escaped = escapeRegExp(heading);
   if (new RegExp(`^${escaped}$`, 'm').test(content)) {
     const updated = content.replace(
-      new RegExp(`^(${escaped}\\n)`, 'm'),
+      new RegExp(String.raw`^(${escaped}\n)`, 'm'),
       `$1${block}`,
     );
     return { content: updated, added: fresh.length };

--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -27,7 +27,7 @@ function renderTemplate(template, variables) {
 }
 
 function shellQuote(value) {
-  return `'${String(value).replaceAll("'", "'\\''")}'`;
+  return `'${String(value).replaceAll("'", String.raw`'\''`)}'`;
 }
 
 function formatCommand(program, args) {
@@ -47,7 +47,7 @@ function buildTemplateVariables(values) {
 }
 
 function buildSessionBannerCommand(sessionName, coordinationDir) {
-  return `printf '%s\\n' ${shellQuote('Session: ' + sessionName)} ${shellQuote('Coordination: ' + coordinationDir)}`;
+  return String.raw`printf '%s\n' ${shellQuote('Session: ' + sessionName)} ${shellQuote('Coordination: ' + coordinationDir)}`;
 }
 
 function normalizeSeedPaths(seedPaths, repoRoot) {

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -325,7 +325,7 @@ function findFiles(dir, pattern, options = {}) {
   // Escape all regex special characters, then convert glob wildcards.
   // Order matters: escape specials first, then convert * and ? to regex equivalents.
   const regexPattern = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/[.+^${}()|[\]\\]/g, String.raw`\$&`)
     .replaceAll('*', '.*')
     .replaceAll('?', '.');
   const regex = new RegExp(`^${regexPattern}$`);


### PR DESCRIPTION
Resolves ~22 SonarCloud issues of rule javascript:S7780 (String.raw). Replaces #811: same content rebased onto current main with the tmux-worktree-orchestrator.js conflict resolved combining S7780 (String.raw) and S4624 (no nested templates) fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ~22 SonarCloud `javascript:S7780` issues by switching regex/template patterns to `String.raw` across scripts. Prevents mis-escaped backslashes and newlines without changing runtime behavior.

- **Bug Fixes**
  - Use `String.raw` in `RegExp` and template literals for patterns like `\n`, `\s`, and `[\s\S]`.
  - Standardize escape helpers to return `String.raw`\$&` for safe metacharacter escaping.
  - Improve shell quoting for tmux commands using `String.raw` `'\''` and literal `\n` in `printf`.
  - Update file-matching and labels to use literal escapes (e.g., `\.tsx?`, `\.jsx?`).

<sup>Written for commit 6473ec3adf01a9d7d28ffcaeb186a19c27602176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

