### PR TITLE
fix(sonar): use concise regex character classes (S6353)

### DIFF
--- a/scripts/gemini-adapt-agents.js
+++ b/scripts/gemini-adapt-agents.js
@@ -84,7 +84,7 @@ function adaptToolName(toolName) {
     return toolName
       .replace(/^mcp__/, 'mcp_')
       .replaceAll('__', '_')
-      .replace(/[^A-Za-z0-9_]/g, '_')
+      .replace(/\W/g, '_')
       .toLowerCase();
   }
 

--- a/scripts/hooks/governance-capture.js
+++ b/scripts/hooks/governance-capture.js
@@ -28,7 +28,7 @@ const SECRET_PATTERNS = [
   { name: 'generic_secret', pattern: /(?:secret|password|token|api[_-]?key)\s*[:=]\s*["'][^"']{8,}/i },
   { name: 'private_key', pattern: /-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----/ },
   { name: 'jwt', pattern: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/ },
-  { name: 'github_token', pattern: /gh[pousr]_[A-Za-z0-9_]{36,}/ },
+  { name: 'github_token', pattern: /gh[pousr]_\w{36,}/ },
 ];
 
 // Tool names that represent security-relevant operations

--- a/scripts/hooks/post-bash-command-log.js
+++ b/scripts/hooks/post-bash-command-log.js
@@ -27,10 +27,10 @@ function sanitizeCommand(command) {
     .replace(/\bAKIA[A-Z0-9]{16}\b/g, '<REDACTED>')
     .replace(/\bASIA[A-Z0-9]{16}\b/g, '<REDACTED>')
     .replace(/password[= ][^ ]*/gi, 'password=<REDACTED>')
-    .replace(/\bghp_[A-Za-z0-9_]+\b/g, '<REDACTED>')
-    .replace(/\bgho_[A-Za-z0-9_]+\b/g, '<REDACTED>')
-    .replace(/\bghs_[A-Za-z0-9_]+\b/g, '<REDACTED>')
-    .replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, '<REDACTED>');
+    .replace(/\bghp_\w+\b/g, '<REDACTED>')
+    .replace(/\bgho_\w+\b/g, '<REDACTED>')
+    .replace(/\bghs_\w+\b/g, '<REDACTED>')
+    .replace(/\bgithub_pat_\w+\b/g, '<REDACTED>');
 }
 
 function appendLine(filePath, line) {

--- a/scripts/hooks/pre-bash-dev-server-block.js
+++ b/scripts/hooks/pre-bash-dev-server-block.js
@@ -123,7 +123,7 @@ function getLeadingCommandWord(segment) {
       continue;
     }
 
-    if (/^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token)) continue;
+    if (/^[A-Za-z_]\w*=.*/.test(token)) continue;
 
     const normalizedToken = normalizeCommandWord(token);
 

--- a/scripts/hooks/pre-bash-guardian-validate.js
+++ b/scripts/hooks/pre-bash-guardian-validate.js
@@ -49,7 +49,7 @@ function extractSegments(command) {
   const segments = [];
   for (const rawSegment of command.split(SEGMENT_SEPARATORS)) {
     let tokens = rawSegment.trim().split(/\s+/).filter(Boolean);
-    while (tokens.length > 0 && (LEADING_WRAPPERS.has(tokens[0]) || /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]))) {
+    while (tokens.length > 0 && (LEADING_WRAPPERS.has(tokens[0]) || /^[A-Za-z_]\w*=/.test(tokens[0]))) {
       tokens = tokens.slice(1);
     }
     if (tokens.length > 0) segments.push(tokens.join(' '));

--- a/scripts/hooks/session-activity-tracker.js
+++ b/scripts/hooks/session-activity-tracker.js
@@ -36,10 +36,10 @@ function redactSecrets(value) {
     .replace(/\bAKIA[A-Z0-9]{16}\b/g, '<REDACTED>')
     .replace(/\bASIA[A-Z0-9]{16}\b/g, '<REDACTED>')
     .replace(/password[= ][^ ]*/gi, 'password=<REDACTED>')
-    .replace(/\bghp_[A-Za-z0-9_]+\b/g, '<REDACTED>')
-    .replace(/\bgho_[A-Za-z0-9_]+\b/g, '<REDACTED>')
-    .replace(/\bghs_[A-Za-z0-9_]+\b/g, '<REDACTED>')
-    .replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, '<REDACTED>');
+    .replace(/\bghp_\w+\b/g, '<REDACTED>')
+    .replace(/\bgho_\w+\b/g, '<REDACTED>')
+    .replace(/\bghs_\w+\b/g, '<REDACTED>')
+    .replace(/\bgithub_pat_\w+\b/g, '<REDACTED>');
 }
 
 function truncateSummary(value, maxLength = 220) {

--- a/scripts/lib/observer-sessions.js
+++ b/scripts/lib/observer-sessions.js
@@ -144,7 +144,7 @@ function stopObserverForContext(context) {
   if (!fs.existsSync(pidFile)) return false;
 
   const pid = (fs.readFileSync(pidFile, 'utf8') || '').trim();
-  if (!/^[0-9]+$/.test(pid) || pid === '0' || pid === '1') {
+  if (!/^\d+$/.test(pid) || pid === '0' || pid === '1') {
     fs.rmSync(pidFile, { force: true });
     return false;
   }

--- a/scripts/lib/session-manager.js
+++ b/scripts/lib/session-manager.js
@@ -24,7 +24,7 @@ const {
 // Matches: "2026-02-01-session.tmp", "2026-02-01-a1b2c3d4-session.tmp",
 // "2026-02-01-frontend-worktree-1-session.tmp", and
 // "2026-02-01-ChezMoi_2-session.tmp"
-const SESSION_FILENAME_REGEX = /^(\d{4}-\d{2}-\d{2})(?:-([a-zA-Z0-9_][a-zA-Z0-9_-]*))?-session\.tmp$/;
+const SESSION_FILENAME_REGEX = /^(\d{4}-\d{2}-\d{2})(?:-(\w[a-zA-Z0-9_-]*))?-session\.tmp$/;
 
 /**
  * Parse session filename to extract metadata


### PR DESCRIPTION
Resolves all 14 SonarCloud S6353 findings: literal character classes replaced by their exact concise equivalents (\\w, \\W, \\d) at the exact lines flagged. Definitionally equivalent in JS regex.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace verbose regex classes with `\w`, `\W`, and `\d` to satisfy SonarCloud rule S6353 without changing behavior. Resolves 14 S6353 findings and slightly simplifies secret redaction and command parsing.

- **Refactors**
  - Unified GitHub token redaction/detection to `\w+` in `post-bash-command-log.js`, `session-activity-tracker.js`, and `governance-capture.js`.
  - Simplified env var/command parsing with `/^[A-Za-z_]\w*=/` in `pre-bash-dev-server-block.js` and `pre-bash-guardian-validate.js`.
  - Minor regex cleanups: tool name sanitization now uses `/\W/g`; PID check uses `/^\d+$/`; session filename uses a leading `\w` segment.

<sup>Written for commit f63d22b32eef99725db5b9f31152407b58b92c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

