### PR TITLE
fix(sonar): resolve S7772, S7786, S7776 and remaining S6582 issues

### DIFF
--- a/scripts/ci/validate-hooks.js
+++ b/scripts/ci/validate-hooks.js
@@ -10,7 +10,7 @@ const Ajv = require('ajv');
 
 const HOOKS_FILE = path.join(__dirname, '../../hooks/hooks.json');
 const HOOKS_SCHEMA_PATH = path.join(__dirname, '../../schemas/hooks.schema.json');
-const VALID_EVENTS = [
+const VALID_EVENTS = new Set([
   'SessionStart',
   'UserPromptSubmit',
   'PreToolUse',
@@ -29,8 +29,8 @@ const VALID_EVENTS = [
   'WorktreeCreate',
   'WorktreeRemove',
   'SessionEnd',
-];
-const VALID_HOOK_TYPES = ['command', 'http', 'prompt', 'agent'];
+]);
+const VALID_HOOK_TYPES = new Set(['command', 'http', 'prompt', 'agent']);
 const EVENTS_WITHOUT_MATCHER = new Set(['UserPromptSubmit', 'Notification', 'Stop', 'SubagentStop']);
 
 function isNonEmptyString(value) {
@@ -139,7 +139,7 @@ function validateHookEntry(hook, label) {
   if (!hook.type || typeof hook.type !== 'string') {
     console.error(`ERROR: ${label} missing or invalid 'type' field`);
     hasErrors = true;
-  } else if (!VALID_HOOK_TYPES.includes(hook.type)) {
+  } else if (!VALID_HOOK_TYPES.has(hook.type)) {
     console.error(`ERROR: ${label} has unsupported hook type '${hook.type}'`);
     hasErrors = true;
   }
@@ -195,7 +195,7 @@ function validateObjectFormat(hooks) {
   let totalMatchers = 0;
 
   for (const [eventType, matchers] of Object.entries(hooks)) {
-    if (!VALID_EVENTS.includes(eventType)) {
+    if (!VALID_EVENTS.has(eventType)) {
       console.error(`ERROR: Invalid event type: ${eventType}`);
       hasErrors = true;
       continue;

--- a/scripts/ci/validate-llm-providers.js
+++ b/scripts/ci/validate-llm-providers.js
@@ -10,8 +10,8 @@
  * new native providers landed within days of each other) — had none.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const README_PATH = path.join(REPO_ROOT, 'README.md');

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -7,10 +7,10 @@
 // Read-only by design: it never executes project code and never fails the
 // session. Missing or unreadable state exits silently with code 0.
 
-const fs = require('fs');
-const http = require('http');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 // Optional libs: minimal installations may lack them, so a failed require
 // resolves to null and the dependent feature is skipped instead of failing
 // session startup. Run `egc repair` to restore missing libs.

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -46,12 +46,12 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 const GUARDIAN_BIN = path.join(ROOT_DIR, 'mcp', 'servers', 'egc-guardian', 'build', 'index.js');
 const MEMORY_BIN = path.join(ROOT_DIR, 'mcp', 'servers', 'egc-memory', 'build', 'index.js');
 
-const args = process.argv.slice(2);
+const args = new Set(process.argv.slice(2));
 const flags = {
-  dryRun: args.includes('--dry-run'),
-  mcpOnly: args.includes('--mcp-only'),
-  yes: args.includes('--yes') || args.includes('-y'),
-  help: args.includes('--help') || args.includes('-h'),
+  dryRun: args.has('--dry-run'),
+  mcpOnly: args.has('--mcp-only'),
+  yes: args.has('--yes') || args.has('-y'),
+  help: args.has('--help') || args.has('-h'),
 };
 
 function showHelp() {

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
@@ -99,7 +99,7 @@ function readModuleTargetsOrThrow(module) {
   const targets = module?.targets;
 
   if (!Array.isArray(targets)) {
-    throw new Error(`Install module ${moduleId} has invalid targets; expected an array of supported target ids`);
+    throw new TypeError(`Install module ${moduleId} has invalid targets; expected an array of supported target ids`);
   }
 
   const normalizedTargets = targets.map(target => (

--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -402,8 +402,8 @@ function getElixirDeps(projectDir) {
   }
 }
 
-const FRONTEND_SIGNALS = ['react', 'vue', 'angular', 'svelte', 'nextjs', 'nuxt', 'astro', 'remix'];
-const BACKEND_SIGNALS = ['django', 'fastapi', 'flask', 'express', 'nestjs', 'rails', 'spring', 'laravel', 'phoenix', 'gin', 'echo', 'actix', 'axum'];
+const FRONTEND_SIGNALS = new Set(['react', 'vue', 'angular', 'svelte', 'nextjs', 'nuxt', 'astro', 'remix']);
+const BACKEND_SIGNALS = new Set(['django', 'fastapi', 'flask', 'express', 'nestjs', 'rails', 'spring', 'laravel', 'phoenix', 'gin', 'echo', 'actix', 'axum']);
 
 function buildDepMap(projectDir) {
   return {
@@ -434,7 +434,7 @@ function determinePrimary(frameworks, languages) {
   } else {
     primary = 'unknown';
   }
-  if (frameworks.some(f => FRONTEND_SIGNALS.includes(f)) && frameworks.some(f => BACKEND_SIGNALS.includes(f))) {
+  if (frameworks.some(f => FRONTEND_SIGNALS.has(f)) && frameworks.some(f => BACKEND_SIGNALS.has(f))) {
     primary = 'fullstack';
   }
   return primary;

--- a/scripts/lib/session-adapters/canonical-session.js
+++ b/scripts/lib/session-adapters/canonical-session.js
@@ -44,7 +44,7 @@ function ensureOptionalString(value, fieldPath) {
 
 function ensureBoolean(value, fieldPath) {
   if (typeof value !== 'boolean') {
-    throw new Error(`Canonical session snapshot requires ${fieldPath} to be a boolean`);
+    throw new TypeError(`Canonical session snapshot requires ${fieldPath} to be a boolean`);
   }
 }
 
@@ -182,7 +182,7 @@ function validateCanonicalSnapshot(snapshot) {
   ensureString(snapshot.session.sourceTarget.value, 'session.sourceTarget.value');
 
   if (!Array.isArray(snapshot.workers)) {
-    throw new Error('Canonical session snapshot requires workers to be an array');
+    throw new TypeError('Canonical session snapshot requires workers to be an array');
   }
 
   snapshot.workers.forEach((worker, index) => {

--- a/scripts/lib/skill-evolution/dashboard.js
+++ b/scripts/lib/skill-evolution/dashboard.js
@@ -332,7 +332,7 @@ function renderDashboard(options = {}) {
   const now = options.now || new Date().toISOString();
   const nowMs = Date.parse(now);
   if (Number.isNaN(nowMs)) {
-    throw new Error(`Invalid now timestamp: ${now}`);
+    throw new TypeError(`Invalid now timestamp: ${now}`);
   }
 
   const dashboardOptions = { ...options, now };

--- a/scripts/lib/skill-evolution/health.js
+++ b/scripts/lib/skill-evolution/health.js
@@ -146,7 +146,7 @@ function collectSkillHealth(options = {}) {
   const now = options.now || new Date().toISOString();
   const nowMs = Date.parse(now);
   if (Number.isNaN(nowMs)) {
-    throw new Error(`Invalid now timestamp: ${now}`);
+    throw new TypeError(`Invalid now timestamp: ${now}`);
   }
 
   const warnThreshold = typeof options.warnThreshold === 'number'

--- a/scripts/lib/skill-evolution/tracker.js
+++ b/scripts/lib/skill-evolution/tracker.js
@@ -28,7 +28,7 @@ function toNullableNumber(value, fieldName) {
 
   const numericValue = Number(value);
   if (!Number.isFinite(numericValue)) {
-    throw new Error(`${fieldName} must be a number`);
+    throw new TypeError(`${fieldName} must be a number`);
   }
 
   return numericValue;
@@ -67,7 +67,7 @@ function normalizeExecutionRecord(input, options = {}) {
   }
 
   if (Number.isNaN(Date.parse(recordedAt))) {
-    throw new Error('recorded_at must be an ISO timestamp');
+    throw new TypeError('recorded_at must be an ISO timestamp');
   }
 
   return {

--- a/scripts/lib/state-store/queries.js
+++ b/scripts/lib/state-store/queries.js
@@ -368,7 +368,7 @@ function normalizeInstinctInput(instinct) {
   let confidence = 0.5;
   if (typeof instinct.confidence === 'number') {
     if (!Number.isFinite(instinct.confidence)) {
-      throw new Error(`Invalid instinct.confidence: must be a finite number (got ${instinct.confidence})`);
+      throw new TypeError(`Invalid instinct.confidence: must be a finite number (got ${instinct.confidence})`);
     }
     confidence = Math.min(1, Math.max(0, instinct.confidence));
   }

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -56,7 +56,7 @@ function readPositiveNumber(value, flagName) {
 function readPositiveInteger(value, flagName) {
   const number = readPositiveNumber(value, flagName);
   if (!Number.isInteger(number)) {
-    throw new Error(`${flagName} must be a positive integer`);
+    throw new TypeError(`${flagName} must be a positive integer`);
   }
   return number;
 }
@@ -148,7 +148,7 @@ function getNow(options = {}) {
     ? new Date(Number(options.now))
     : new Date(options.now);
   if (Number.isNaN(now.getTime())) {
-    throw new Error('--now must be a valid timestamp');
+    throw new TypeError('--now must be a valid timestamp');
   }
   return now;
 }
@@ -237,14 +237,14 @@ function getEntryTimestamp(entry) {
   return parseTimestamp(entry.timestamp)
     || parseTimestamp(entry.createdAt)
     || parseTimestamp(entry.created_at)
-    || parseTimestamp(entry.message && entry.message.timestamp);
+    || parseTimestamp(entry.message?.timestamp);
 }
 
 function getSessionId(entry, transcriptPath) {
   return entry.sessionId
     || entry.session_id
-    || (entry.session && entry.session.id)
-    || (entry.message && entry.message.sessionId)
+    || entry.session?.id
+    || entry.message?.sessionId
     || path.basename(transcriptPath, '.jsonl');
 }
 
@@ -263,7 +263,7 @@ function extractToolUses(entry) {
   const uses = [];
 
   for (const block of getContentBlocks(entry)) {
-    if (block && block.type === 'tool_use' && block.id) {
+    if (block?.type === 'tool_use' && block.id) {
       uses.push({
         id: block.id,
         input: block.input || {},
@@ -273,7 +273,7 @@ function extractToolUses(entry) {
   }
 
   const topLevelUse = entry.tool_use || entry.toolUse;
-  if (topLevelUse && topLevelUse.id) {
+  if (topLevelUse?.id) {
     uses.push({
       id: topLevelUse.id,
       input: topLevelUse.input || {},
@@ -296,7 +296,7 @@ function extractToolResultIds(entry) {
   const resultIds = [];
 
   for (const block of getContentBlocks(entry)) {
-    if (block && block.type === 'tool_result') {
+    if (block?.type === 'tool_result') {
       const toolUseId = block.tool_use_id || block.toolUseId || block.id;
       if (toolUseId) {
         resultIds.push(toolUseId);
@@ -324,7 +324,7 @@ function extractToolResultIds(entry) {
 
 function isAssistantProgressEntry(entry) {
   return entry.type === 'assistant'
-    || (entry.message && entry.message.role === 'assistant')
+    || (entry.message?.role === 'assistant')
     || extractToolUses(entry).length > 0;
 }
 
@@ -455,7 +455,7 @@ function processToolUses(entry, timestamp, lastEventAt, pendingTools, state) {
   for (const toolUse of extractToolUses(entry)) {
     const startedAt = timestamp || lastEventAt;
     pendingTools.set(toolUse.id, {
-      command: toolUse.input && toolUse.input.command ? String(toolUse.input.command) : null,
+      command: toolUse.input?.command ? String(toolUse.input.command) : null,
       input: toolUse.input || {},
       name: toolUse.name,
       startedAt: toIso(startedAt),
@@ -469,7 +469,7 @@ function processToolUses(entry, timestamp, lastEventAt, pendingTools, state) {
         state.latestWake = {
           delaySeconds,
           dueAt: dueAt.toISOString(),
-          reason: toolUse.input && toolUse.input.reason ? String(toolUse.input.reason) : null,
+          reason: toolUse.input?.reason ? String(toolUse.input.reason) : null,
           scheduledAt: startedAt.toISOString(),
           toolUseId: toolUse.id,
         };


### PR DESCRIPTION
Resolves 33 SonarCloud findings: 9x node: protocol imports (S7772), 10x TypeError for type checks (S7786), 5x Set/has conversions with all call sites updated (S7776), 9x remaining optional chains in loop-status.js (S6582). All at the exact flagged lines, behavior preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve 33 SonarCloud findings across scripts by standardizing Node built-in imports, using proper error types, safer lookups, and optional chaining. No behavior changes; improves clarity and static analysis compliance.

- **Refactors**
  - Use `node:fs`, `node:path`, `node:http`, `node:os` imports (S7772).
  - Replace array lookups with `Set.has(...)` for events, hook types, and CLI flags (S7776).
  - Throw `TypeError` for invalid types and timestamps in validators and trackers (S7786).
  - Add optional chaining in `scripts/loop-status.js` for null-safe access (S6582).

<sup>Written for commit 0574d65db116086417e9bfbba3cc6590507ee418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

