### PR TITLE
fix(sonar): document accepted superlinear regex findings (S8786)

### DIFF
--- a/scripts/build-skill-index.js
+++ b/scripts/build-skill-index.js
@@ -57,7 +57,7 @@ for (const f of walkMd(rulesRoot)) {
   try {
     if (path.basename(f) === 'README.md') continue;
     const content = fs.readFileSync(f, 'utf8');
-    const h1 = content.match(/^#\s+(.+)$/m);
+    const h1 = content.match(/^#\s+(.+)$/m); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     if (!h1) continue;
     const rel = path.relative(rulesRoot, f);
     const name = rel.replace(/[\\/]/g, '-').replace(/\.md$/, '').toLowerCase();

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -209,19 +209,19 @@ function parseAgentsDocExpectations(agentsContent) {
     {
       category: 'agents',
       mode: 'exact',
-      regex: /^\s*agents\/\s*[,:–-]\s*(\d+)\s+specialized subagents\s*$/im,
+      regex: /^\s*agents\/\s*[,:–-]\s*(\d+)\s+specialized subagents\s*$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       source: 'AGENTS.md project structure'
     },
     {
       category: 'skills',
       mode: 'minimum',
-      regex: /^\s*skills\/\s*[,:–-]\s*(\d+)(\+)?\s+workflow skills and domain knowledge\s*$/im,
+      regex: /^\s*skills\/\s*[,:–-]\s*(\d+)(\+)?\s+workflow skills and domain knowledge\s*$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       source: 'AGENTS.md project structure'
     },
     {
       category: 'commands',
       mode: 'exact',
-      regex: /^\s*commands\/\s*[,:–-]\s*(\d+)\s+slash commands\s*$/im,
+      regex: /^\s*commands\/\s*[,:–-]\s*(\d+)\s+slash commands\s*$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       source: 'AGENTS.md project structure'
     }
   ];
@@ -264,19 +264,19 @@ function parseZhAgentsDocExpectations(agentsContent) {
     {
       category: 'agents',
       mode: 'exact',
-      regex: /^\s*agents\/\s*[,:–-]\s*(\d+)\s+个专业子代理\s*$/im,
+      regex: /^\s*agents\/\s*[,:–-]\s*(\d+)\s+个专业子代理\s*$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       source: 'docs/zh-CN/AGENTS.md project structure'
     },
     {
       category: 'skills',
       mode: 'minimum',
-      regex: /^\s*skills\/\s*[,:–-]\s*(\d+)(\+)?\s+个工作流技能和领域知识\s*$/im,
+      regex: /^\s*skills\/\s*[,:–-]\s*(\d+)(\+)?\s+个工作流技能和领域知识\s*$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       source: 'docs/zh-CN/AGENTS.md project structure'
     },
     {
       category: 'commands',
       mode: 'exact',
-      regex: /^\s*commands\/\s*[,:–-]\s*(\d+)\s+个斜杠命令\s*$/im,
+      regex: /^\s*commands\/\s*[,:–-]\s*(\d+)\s+个斜杠命令\s*$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       source: 'docs/zh-CN/AGENTS.md project structure'
     }
   ];
@@ -361,19 +361,19 @@ function syncEnglishAgents(content, catalog) {
   );
   nextContent = replaceOrThrow(
     nextContent,
-    /^(\s*agents\/\s*[,:–-]\s*)(\d+)(\s+specialized subagents\s*)$/im,
+    /^(\s*agents\/\s*[,:–-]\s*)(\d+)(\s+specialized subagents\s*)$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     (_, prefix, __, suffix) => `${prefix}${catalog.agents.count}${suffix}`,
     'AGENTS.md project structure (agents)'
   );
   nextContent = replaceOrThrow(
     nextContent,
-    /^(\s*skills\/\s*[,:–-]\s*)(\d+)(\+?)(\s+workflow skills and domain knowledge\s*)$/im,
+    /^(\s*skills\/\s*[,:–-]\s*)(\d+)(\+?)(\s+workflow skills and domain knowledge\s*)$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     (_, prefix, __, plus, suffix) => `${prefix}${catalog.skills.count}${plus}${suffix}`,
     'AGENTS.md project structure (skills)'
   );
   nextContent = replaceOrThrow(
     nextContent,
-    /^(\s*commands\/\s*[,:–-]\s*)(\d+)(\s+slash commands\s*)$/im,
+    /^(\s*commands\/\s*[,:–-]\s*)(\d+)(\s+slash commands\s*)$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     (_, prefix, __, suffix) => `${prefix}${catalog.commands.count}${suffix}`,
     'AGENTS.md project structure (commands)'
   );
@@ -434,19 +434,19 @@ function syncZhAgents(content, catalog) {
   );
   nextContent = replaceOrThrow(
     nextContent,
-    /^(\s*agents\/\s*[,:–-]\s*)(\d+)(\s+个专业子代理\s*)$/im,
+    /^(\s*agents\/\s*[,:–-]\s*)(\d+)(\s+个专业子代理\s*)$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     (_, prefix, __, suffix) => `${prefix}${catalog.agents.count}${suffix}`,
     'docs/zh-CN/AGENTS.md project structure (agents)'
   );
   nextContent = replaceOrThrow(
     nextContent,
-    /^(\s*skills\/\s*[,:–-]\s*)(\d+)(\+?)(\s+个工作流技能和领域知识\s*)$/im,
+    /^(\s*skills\/\s*[,:–-]\s*)(\d+)(\+?)(\s+个工作流技能和领域知识\s*)$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     (_, prefix, __, plus, suffix) => `${prefix}${catalog.skills.count}${plus}${suffix}`,
     'docs/zh-CN/AGENTS.md project structure (skills)'
   );
   nextContent = replaceOrThrow(
     nextContent,
-    /^(\s*commands\/\s*[,:–-]\s*)(\d+)(\s+个斜杠命令\s*)$/im,
+    /^(\s*commands\/\s*[,:–-]\s*)(\d+)(\s+个斜杠命令\s*)$/im, // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     (_, prefix, __, suffix) => `${prefix}${catalog.commands.count}${suffix}`,
     'docs/zh-CN/AGENTS.md project structure (commands)'
   );

--- a/scripts/ci/check-unicode-safety.js
+++ b/scripts/ci/check-unicode-safety.js
@@ -167,7 +167,7 @@ function sanitizeText(text, { preserveEmoji = false } = {}) {
   next = next.replace(/^>\s{2,}/gm, '> ');
   next = next.replace(/^-\s{2,}/gm, '- ');
   next = next.replace(/^(\d+\.)\s{2,}/gm, '$1 ');
-  next = next.replace(/[ \t]+$/gm, '');
+  next = next.replace(/[ \t]+$/gm, ''); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
 
   return next;
 }

--- a/scripts/ci/validate-commands.js
+++ b/scripts/ci/validate-commands.js
@@ -31,7 +31,7 @@ function validateFrontmatter(file, content) {
       continue;
     }
 
-    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     if (!match) {
       errors.push(`${file} - invalid frontmatter line: ${rawLine}`);
       continue;
@@ -119,7 +119,7 @@ function checkSkillDirXrefs(file, contentNoCodeBlocks, validSkills) {
 function checkWorkflowXrefs(file, contentNoCodeBlocks, validAgents) {
   const errors = [];
   for (const match of contentNoCodeBlocks.matchAll(/^([a-z][-a-z0-9]*(?:\s*->\s*[a-z][-a-z0-9]*)+)$/gm)) {
-    for (const agent of match[1].split(/\s*->\s*/)) {
+    for (const agent of match[1].split(/\s*->\s*/)) { // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       if (!validAgents.has(agent)) {
         errors.push(`${file} - workflow references non-existent agent "${agent}"`);
       }

--- a/scripts/ci/validate-install-manifests.js
+++ b/scripts/ci/validate-install-manifests.js
@@ -32,7 +32,7 @@ function readJson(filePath, label) {
 }
 
 function normalizeRelativePath(relativePath) {
-  return String(relativePath).replaceAll('\\', '/').replace(/\/+$/, '');
+  return String(relativePath).replaceAll('\\', '/').replace(/\/+$/, ''); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
 }
 
 function validateSchema(ajv, schemaPath, data, label) {

--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -310,7 +310,7 @@ function applyChanges(configPath, raw, toAppend, toRemoveLog, dryRun, updateMcp)
 
   if (updateMcp || hasRemovals) {
     for (const label of toRemoveLog) log(`  [update] ${label}`);
-    const cleaned = raw.replace(/\n+$/, '\n');
+    const cleaned = raw.replace(/\n+$/, '\n'); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     fs.writeFileSync(configPath, cleaned + (toAppend.length > 0 ? appendText : ''), 'utf8');
   } else {
     fs.appendFileSync(configPath, appendText, 'utf8');

--- a/scripts/hooks/governance-capture.js
+++ b/scripts/hooks/governance-capture.js
@@ -38,7 +38,7 @@ const SECURITY_RELEVANT_TOOLS = new Set([
 
 // Commands that require governance approval
 const APPROVAL_COMMANDS = [
-  /git\s+push\s+.*--force/,
+  /git\s+push\s+.*--force/, // NOSONAR: superlinear risk accepted: input is the local user's own command or CLI output
   /git\s+reset\s+--hard/,
   /rm\s+-rf?\s/,
   /DROP\s+(?:TABLE|DATABASE)/i,

--- a/scripts/hooks/post-bash-pr-created.js
+++ b/scripts/hooks/post-bash-pr-created.js
@@ -15,7 +15,7 @@ function run(rawInput) {
       if (match) {
         const prUrl = match[0];
         const repo = prUrl.replace(/https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/, '$1');
-        const prNum = prUrl.replace(/.+\/pull\/(\d+)/, '$1');
+        const prNum = prUrl.replace(/.+\/pull\/(\d+)/, '$1'); // NOSONAR: superlinear risk accepted: input is the local user's own command or CLI output
         return {
           stdout: typeof rawInput === 'string' ? rawInput : JSON.stringify(rawInput),
           stderr: [

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -154,7 +154,7 @@ function extractHeaderField(header, label) {
 }
 
 function buildSessionHeader(today, currentTime, metadata, existingContent = '') {
-  const headingMatch = existingContent.match(/^#\s+.+$/m);
+  const headingMatch = existingContent.match(/^#\s+.+$/m); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   const heading = headingMatch ? headingMatch[0] : `# Session: ${today}`;
   const date = extractHeaderField(existingContent, 'Date') || today;
   const started = extractHeaderField(existingContent, 'Started') || currentTime;

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -208,7 +208,7 @@ function selectMatchingSession(sessions, cwd, currentProject) {
     }
 
     // Extract **Worktree:** field
-    const worktreeMatch = /\*\*Worktree:\*\*\s*(.+)$/m.exec(content);
+    const worktreeMatch = /\*\*Worktree:\*\*\s*(.+)$/m.exec(content); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     const sessionWorktree = worktreeMatch ? worktreeMatch[1].trim() : '';
 
     // Exact worktree match: best possible, return immediately
@@ -219,7 +219,7 @@ function selectMatchingSession(sessions, cwd, currentProject) {
 
     // Project name match: keep searching for a worktree match
     if (!projectMatch && currentProject) {
-      const projectFieldMatch = /\*\*Project:\*\*\s*(.+)$/m.exec(content);
+      const projectFieldMatch = /\*\*Project:\*\*\s*(.+)$/m.exec(content); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
       const sessionProject = projectFieldMatch ? projectFieldMatch[1].trim() : '';
       if (sessionProject && sessionProject === currentProject) {
         projectMatch = session;
@@ -322,7 +322,7 @@ function readInstinctsFromDir(directory, scope) {
 }
 
 function extractInstinctAction(content) {
-  const actionMatch = /## Action\s*\n+([\s\S]+?)(?:\n## |\n---|$)/.exec(String(content || ''));
+  const actionMatch = /## Action\s*\n+([\s\S]+?)(?:\n## |\n---|$)/.exec(String(content || '')); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   const actionBlock = (actionMatch ? actionMatch[1] : String(content || '')).trim();
   const firstLine = actionBlock
     .split('\n')
@@ -390,7 +390,7 @@ function stripMarkdownInline(value) {
     .replace(/`([^`]+)`/g, '$1')
     .replace(/\*\*([^*]+)\*\*/g, '$1')
     .replace(/\*([^*]+)\*/g, '$1')
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     .trim();
 }
 
@@ -407,7 +407,7 @@ function truncateSummary(value, maxLength = MAX_LEARNED_SKILL_SUMMARY_CHARS) {
 }
 
 function extractMarkdownHeading(content) {
-  const match = /^#\s+(.+)$/m.exec(String(content || ''));
+  const match = /^#\s+(.+)$/m.exec(String(content || '')); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   return match ? stripMarkdownInline(match[1]) : '';
 }
 
@@ -418,7 +418,7 @@ function extractSection(content, headingPattern) {
 }
 
 function extractFirstParagraph(content) {
-  const withoutHeading = String(content || '').replace(/^#\s+.+$/m, '').trim();
+  const withoutHeading = String(content || '').replace(/^#\s+.+$/m, '').trim(); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   return withoutHeading
     .split(/\n\s*\n/)
     .map(paragraph => paragraph.trim())

--- a/scripts/lib/agent-compress.js
+++ b/scripts/lib/agent-compress.js
@@ -95,7 +95,7 @@ function extractSummary(body, maxSentences = 1) {
   const firstParagraph = paragraphs.find(p => p.length > 0);
   if (!firstParagraph) return '';
 
-  const sentences = firstParagraph.match(/[^.!?]+[.!?]+/g) || [firstParagraph];
+  const sentences = firstParagraph.match(/[^.!?]+[.!?]+/g) || [firstParagraph]; // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   return sentences.slice(0, maxSentences).map(s => s.trim()).join(' ').trim();
 }
 

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -84,7 +84,7 @@ function hasHookEntry(settings, event, hookScriptPath, matcherFilter) {
 }
 
 function extractScriptBasename(command) {
-  const scriptPaths = String(command).match(/[^\s"']+\.js\b/g);
+  const scriptPaths = String(command).match(/[^\s"']+\.js\b/g); // NOSONAR: superlinear risk accepted: input is the local user's own command or CLI output
   if (!scriptPaths || scriptPaths.length === 0) {
     return null;
   }

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -15,7 +15,7 @@ function normalizeRelativePath(relativePath) {
   return String(relativePath || '')
     .replaceAll('\\', '/')
     .replace(/^\.\/+/, '')
-    .replace(/\/+$/, '');
+    .replace(/\/+$/, ''); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
 }
 
 function isForeignPlatformPath(sourceRelativePath, adapterTarget) {

--- a/scripts/lib/orchestration-session.js
+++ b/scripts/lib/orchestration-session.js
@@ -79,7 +79,7 @@ function parseWorkerStatus(content) {
   }
 
   for (const line of content.split('\n')) {
-    const match = /^- ([A-Za-z ]+):\s*(.+)$/.exec(line);
+    const match = /^- ([A-Za-z ]+):\s*(.+)$/.exec(line); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
     if (!match) continue;
 
     const key = match[1].trim().toLowerCase().replace(/\s+/g, '');

--- a/scripts/lib/session-adapters/canonical-session.js
+++ b/scripts/lib/session-adapters/canonical-session.js
@@ -16,7 +16,7 @@ function sanitizePathSegment(value) {
   return String(value || 'unknown')
     .trim()
     .replace(/[^A-Za-z0-9._-]+/g, '_')
-    .replace(/^_+|_+$/g, '') || 'unknown';
+    .replace(/^_+|_+$/g, '') || 'unknown'; // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
 }
 
 function parseContextSeedPaths(context) {

--- a/scripts/lib/session-manager.js
+++ b/scripts/lib/session-manager.js
@@ -243,13 +243,13 @@ function parseSessionMetadata(content) {
 
   if (!content) return metadata;
 
-  metadata.title = extractField(content, /^#\s+(.+)$/m);
+  metadata.title = extractField(content, /^#\s+(.+)$/m); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   metadata.date = extractField(content, /\*\*Date:\*\*\s*(\d{4}-\d{2}-\d{2})/);
   metadata.started = extractField(content, /\*\*Started:\*\*\s*([\d:]+)/);
   metadata.lastUpdated = extractField(content, /\*\*Last Updated:\*\*\s*([\d:]+)/);
-  metadata.project = extractField(content, /\*\*Project:\*\*\s*(.+)$/m);
-  metadata.branch = extractField(content, /\*\*Branch:\*\*\s*(.+)$/m);
-  metadata.worktree = extractField(content, /\*\*Worktree:\*\*\s*(.+)$/m);
+  metadata.project = extractField(content, /\*\*Project:\*\*\s*(.+)$/m); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
+  metadata.branch = extractField(content, /\*\*Branch:\*\*\s*(.+)$/m); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
+  metadata.worktree = extractField(content, /\*\*Worktree:\*\*\s*(.+)$/m); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
 
   metadata.completed = extractListItems(
     content,

--- a/scripts/lib/state-overview.js
+++ b/scripts/lib/state-overview.js
@@ -5,8 +5,8 @@ const path = require('node:path');
 
 const { DEFAULT_BRANCH_FILE, getStateDir } = require('./branch-state');
 
-const HEADER_FIELD_REGEX = /^(project|branch|updated):\s*(.+)$/;
-const SECTION_HEADING_REGEX = /^##\s+(.+)$/;
+const HEADER_FIELD_REGEX = /^(project|branch|updated):\s*(.+)$/; // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
+const SECTION_HEADING_REGEX = /^##\s+(.+)$/; // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
 
 /**
  * Parses one project-state Markdown file produced by the egc-memory

--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -9,7 +9,7 @@ function slugify(value, fallback = 'worker') {
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/^-+|-+$/g, ''); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   return normalized || fallback;
 }
 

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -261,7 +261,7 @@ function sanitizeSessionId(raw) {
   const sanitized = normalized
     .replace(/[^a-zA-Z0-9_-]/g, '-')
     .replace(/-{2,}/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/^-+|-+$/g, ''); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
 
   if (sanitized.length > 0) {
     const suffix = crypto.createHash('sha256').update(normalized).digest('hex').slice(0, 6);

--- a/scripts/lib/warp-agents-merge.js
+++ b/scripts/lib/warp-agents-merge.js
@@ -78,7 +78,7 @@ function mergeSkillIndexEntry(existingContent, entry) {
     return nextLines.join('\n');
   }
 
-  const trimmedOriginal = original.replace(/\n+$/, '');
+  const trimmedOriginal = original.replace(/\n+$/, ''); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   const prefix = trimmedOriginal.length > 0 ? `${trimmedOriginal}\n\n` : '';
   return `${prefix}${blockLines.join('\n')}\n`;
 }

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -647,7 +647,7 @@ function isWindowsReservedBasename(value) {
 
 function sanitizeSnapshotName(value, fallback = 'session') {
   const raw = String(value || '').trim() || fallback;
-  const sanitized = raw.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^_+|_+$/g, '');
+  const sanitized = raw.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^_+|_+$/g, ''); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   if (sanitized && sanitized.length <= 96 && !isWindowsReservedBasename(sanitized)) {
     return sanitized;
   }
@@ -660,7 +660,7 @@ function sanitizeSnapshotName(value, fallback = 'session') {
     return `${sanitized.slice(0, firstDotIndex)}-${hashSuffix}${sanitized.slice(firstDotIndex)}`;
   }
 
-  const prefix = sanitized ? sanitized.slice(0, 48).replace(/[._-]+$/g, '') : fallback;
+  const prefix = sanitized ? sanitized.slice(0, 48).replace(/[._-]+$/g, '') : fallback; // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
   return `${prefix || fallback}-${hashString(raw).slice(0, 12)}`;
 }
 


### PR DESCRIPTION
Resolves all 43 SonarCloud S8786 findings. Case-by-case trust-boundary analysis: every flagged regex processes repo-owned files, local state, or the local user's own command text - none receive network-controlled input, so the superlinear worst case is not exploitable. Each line now carries a NOSONAR with the specific justification, following repo precedent (#772/#773). Comment-only diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and suppresses 43 SonarCloud S8786 “superlinear regex” findings by adding per-line `NOSONAR` comments with clear trust-boundary justifications. All affected regexes only process repo-owned files, local state, or the user’s CLI output; no network-controlled input and no behavior changes.

<sup>Written for commit d70485f79f1e5dea7e0d33f70c753fef17baeaa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

