### PR TITLE
chore(sonar): ignore S2187 false positives from the custom test runner

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+# SonarCloud analysis configuration.
+#
+# The repository uses a custom zero-dependency test runner (tests/run-all.js):
+# test cases are plain named functions invoked by the runner, not describe/it
+# blocks from a known framework. Rule S2187 ("test files should contain tests")
+# cannot detect this pattern and reports false positives on files whose tests
+# do run in CI, so it is ignored for the tests/ tree.
+sonar.issue.ignore.multicriteria=t1
+sonar.issue.ignore.multicriteria.t1.ruleKey=javascript:S2187
+sonar.issue.ignore.multicriteria.t1.resourceKey=tests/**


### PR DESCRIPTION
The repo's zero-dependency test runner invokes plain named test functions, which rule S2187 cannot detect - it flags 8 files whose tests demonstrably run in CI. This ignores S2187 under tests/ via sonar-project.properties. If SonarCloud automatic analysis does not honor the property, fallback is bulk-accepting the 8 findings in the UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Sonar rule S2187 for files under tests/** to stop false positives from our custom zero-dependency test runner (named functions instead of describe/it).
Adds sonar-project.properties with a multicriteria exclusion for S2187 on the tests tree.

<sup>Written for commit 264337170ac99f959f057d5b3bf3e45cea15616a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

