### PR TITLE
refactor(cc): reduce cognitive complexity in catalog and consolidate scripts (S3776)

### DIFF
--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -68,32 +68,42 @@ function parseArgs(argv) {
   parsed.command = args[0];
 
   for (let index = 1; index < args.length; index += 1) {
-    const arg = args[index];
-
-    if (arg === '--help' || arg === '-h') {
-      parsed.help = true;
-    } else if (arg === '--json') {
-      parsed.json = true;
-    } else if (arg === '--family') {
-      if (!args[index + 1]) {
-        throw new Error('Missing value for --family');
-      }
-      parsed.family = normalizeFamily(args[index + 1]);
-      index += 1;
-    } else if (arg === '--target') {
-      if (!args[index + 1]) {
-        throw new Error('Missing value for --target');
-      }
-      parsed.target = args[index + 1];
-      index += 1;
-    } else if (parsed.command === 'show' && !parsed.componentId) {
-      parsed.componentId = arg;
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
+    index = processArg(args, index, parsed);
   }
 
   return parsed;
+}
+
+function processArg(args, index, parsed) {
+  const arg = args[index];
+
+  if (arg === '--help' || arg === '-h') {
+    parsed.help = true;
+    return index;
+  }
+  if (arg === '--json') {
+    parsed.json = true;
+    return index;
+  }
+  if (arg === '--family') {
+    if (!args[index + 1]) {
+      throw new Error('Missing value for --family');
+    }
+    parsed.family = normalizeFamily(args[index + 1]);
+    return index + 1;
+  }
+  if (arg === '--target') {
+    if (!args[index + 1]) {
+      throw new Error('Missing value for --target');
+    }
+    parsed.target = args[index + 1];
+    return index + 1;
+  }
+  if (parsed.command === 'show' && !parsed.componentId) {
+    parsed.componentId = arg;
+    return index;
+  }
+  throw new Error(`Unknown argument: ${arg}`);
 }
 
 function printProfiles(profiles) {
@@ -140,46 +150,62 @@ function main() {
       showHelp(0);
     }
 
-    if (options.command === 'profiles') {
-      const profiles = listInstallProfiles();
-      if (options.json) {
-        console.log(JSON.stringify({ profiles }, null, 2));
-      } else {
-        printProfiles(profiles);
-      }
-      return;
-    }
-
-    if (options.command === 'components') {
-      const components = listInstallComponents({
-        family: options.family,
-        target: options.target,
-      });
-      if (options.json) {
-        console.log(JSON.stringify({ components }, null, 2));
-      } else {
-        printComponents(components);
-      }
-      return;
-    }
-
-    if (options.command === 'show') {
-      if (!options.componentId) {
-        throw new Error('Catalog show requires an install component ID');
-      }
-      const component = getInstallComponent(options.componentId);
-      if (options.json) {
-        console.log(JSON.stringify(component, null, 2));
-      } else {
-        printComponent(component);
-      }
-      return;
-    }
-
-    throw new Error(`Unknown catalog command: ${options.command}`);
+    executeCommand(options);
   } catch (error) {
     console.error(`Error: ${error.message}`);
     process.exit(1);
+  }
+}
+
+function executeCommand(options) {
+  if (options.command === 'profiles') {
+    handleProfiles(options);
+    return;
+  }
+
+  if (options.command === 'components') {
+    handleComponents(options);
+    return;
+  }
+
+  if (options.command === 'show') {
+    handleShow(options);
+    return;
+  }
+
+  throw new Error(`Unknown catalog command: ${options.command}`);
+}
+
+function handleProfiles(options) {
+  const profiles = listInstallProfiles();
+  if (options.json) {
+    console.log(JSON.stringify({ profiles }, null, 2));
+  } else {
+    printProfiles(profiles);
+  }
+}
+
+function handleComponents(options) {
+  const components = listInstallComponents({
+    family: options.family,
+    target: options.target,
+  });
+  if (options.json) {
+    console.log(JSON.stringify({ components }, null, 2));
+  } else {
+    printComponents(components);
+  }
+}
+
+function handleShow(options) {
+  if (!options.componentId) {
+    throw new Error('Catalog show requires an install component ID');
+  }
+  const component = getInstallComponent(options.componentId);
+  if (options.json) {
+    console.log(JSON.stringify(component, null, 2));
+  } else {
+    printComponent(component);
   }
 }
 

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -57,30 +57,39 @@ function listSkillsRecursive(skillsRoot) {
   const topLevel = fs.readdirSync(skillsRoot, { withFileTypes: true });
 
   for (const entry of topLevel) {
-    if (!entry.isDirectory()) continue;
-    const entryPath = path.join(skillsRoot, entry.name);
-
-    if (fs.existsSync(path.join(entryPath, 'SKILL.md'))) {
-      found.push(`${entry.name}/SKILL.md`);
-      continue;
-    }
-
-    let children;
-    try {
-      children = fs.readdirSync(entryPath, { withFileTypes: true });
-    } catch (_err) { // NOSONAR: unreadable entry dir is skipped
-      continue;
-    }
-    for (const child of children) {
-      if (!child.isDirectory()) continue;
-      const childPath = path.join(entryPath, child.name);
-      if (fs.existsSync(path.join(childPath, 'SKILL.md'))) {
-        found.push(`${entry.name}/${child.name}/SKILL.md`);
-      }
-    }
+    processTopLevelEntry(entry, skillsRoot, found);
   }
 
   return found.sort((a, b) => a.localeCompare(b));
+}
+
+function processTopLevelEntry(entry, skillsRoot, found) {
+  if (!entry.isDirectory()) {
+    return;
+  }
+  const entryPath = path.join(skillsRoot, entry.name);
+
+  if (fs.existsSync(path.join(entryPath, 'SKILL.md'))) {
+    found.push(`${entry.name}/SKILL.md`);
+    return;
+  }
+
+  const children = getChildrenDirs(entryPath);
+  for (const child of children) {
+    const childPath = path.join(entryPath, child.name);
+    if (fs.existsSync(path.join(childPath, 'SKILL.md'))) {
+      found.push(`${entry.name}/${child.name}/SKILL.md`);
+    }
+  }
+}
+
+function getChildrenDirs(entryPath) {
+  try {
+    return fs.readdirSync(entryPath, { withFileTypes: true })
+      .filter(child => child.isDirectory());
+  } catch (_err) { // NOSONAR: unreadable entry dir is skipped
+    return [];
+  }
 }
 
 function buildCatalog(root = ROOT) {

--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -148,12 +148,7 @@ function main() {
     };
 
     if (!fs.existsSync(stateFile)) {
-      report.status = 'missing';
-      if (options.json) {
-        console.log(JSON.stringify(report, null, 2));
-      } else {
-        printHuman(report);
-      }
+      handleMissingState(report, options);
       return;
     }
 
@@ -165,31 +160,48 @@ function main() {
     report.stats = result.stats;
 
     if (!result.needed && !options.force) {
-      if (options.json) {
-        console.log(JSON.stringify(report, null, 2));
-      } else {
-        printHuman(report);
-      }
+      handleNotNeeded(report, options);
       return;
     }
 
-    report.status = options.dryRun ? 'dry-run' : 'consolidated';
-
-    if (options.dryRun) {
-      report.output = result.output;
-    } else {
-      report.backup = backupStateFile(homeDir, stateFile);
-      fs.writeFileSync(stateFile, result.output, 'utf8');
-    }
-
-    if (options.json) {
-      console.log(JSON.stringify(report, null, 2));
-    } else {
-      printHuman({ ...report, output: result.output });
-    }
+    performConsolidation(report, result, stateFile, homeDir, options);
   } catch (error) {
     console.error(`Error: ${error.message}`);
     process.exit(1);
+  }
+}
+
+function handleMissingState(report, options) {
+  report.status = 'missing';
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+}
+
+function handleNotNeeded(report, options) {
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+}
+
+function performConsolidation(report, result, stateFile, homeDir, options) {
+  report.status = options.dryRun ? 'dry-run' : 'consolidated';
+
+  if (options.dryRun) {
+    report.output = result.output;
+  } else {
+    report.backup = backupStateFile(homeDir, stateFile);
+    fs.writeFileSync(stateFile, result.output, 'utf8');
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman({ ...report, output: result.output });
   }
 }
 


### PR DESCRIPTION
Reduces cognitive complexity of 4 functions (catalog.js:52/:135, ci/catalog.js:51, consolidate.js:129). Authored by the squad agent (tests green locally); PR opened on its behalf (agent runtime blocks gh). An out-of-scope test hunk that would leak local environment naming into the public repo was stripped during review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the catalog, CI catalog, and consolidate scripts to reduce cognitive complexity and clarify control flow. No behavior changes; CLI flags and output stay the same.

- **Refactors**
  - `scripts/catalog.js`: extracted `processArg`, `executeCommand`, `handleProfiles`, `handleComponents`, `handleShow` to simplify branching and keep errors/validation unchanged.
  - `scripts/ci/catalog.js`: extracted `processTopLevelEntry` and `getChildrenDirs`; processes only directories, safely skips unreadable entries, and keeps sorting.
  - `scripts/consolidate.js`: extracted `handleMissingState`, `handleNotNeeded`, `performConsolidation` to centralize JSON vs human output and dry-run handling.

<sup>Written for commit ba17f0ab46f9fc734a16acbec342e93e0536adcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

