### PR TITLE
refactor(cc): reduce cognitive complexity in auto-update and sync scripts (S3776)

### DIFF
--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -168,6 +168,80 @@ function runExternalCommand(command, args, options = {}) {
   return result;
 }
 
+function performGitUpdate(repoRoot, env, execute) {
+  const isGitRepo = fs.existsSync(path.join(repoRoot, '.git'));
+  if (!isGitRepo) {
+    // npm-installed: git pull is not applicable. Reinstall from current package.
+    console.log(`EGC is installed via npm (v${PKG_VERSION}).`);
+    console.log('To upgrade to a newer version, run: npm install -g @egchq/egc@latest');
+    console.log('Reinstalling current version into managed targets...\n');
+  } else {
+    execute('git', ['fetch', '--all', '--prune'], { cwd: repoRoot, env });
+    try {
+      execute('git', ['pull', '--ff-only'], { cwd: repoRoot, env });
+    } catch (pullError) {
+      const msg = String(pullError.message || '');
+      if (msg.includes('no tracking information') || msg.includes('set-upstream')) {
+        throw new Error(
+          'git pull failed: no upstream tracking branch configured.\n' +
+          'To update: npm install -g @egchq/egc@latest\n' +
+          'Or set upstream: git branch --set-upstream-to=origin/<branch>',
+          { cause: pullError }
+        );
+      }
+      throw pullError;
+    }
+  }
+}
+
+function applyInstalls(validRecords, options, repoRoot, env, execute) {
+  const results = [];
+  for (const entry of validRecords) {
+    const installArgs = buildInstallApplyArgs(entry.record);
+    const args = [
+      path.join(repoRoot, 'scripts', 'install-apply.js'),
+      ...installArgs,
+      '--json',
+    ];
+
+    if (options.dryRun) {
+      args.push('--dry-run');
+    }
+
+    try {
+      const commandResult = execute(process.execPath, args, {
+        cwd: determineInstallCwd(entry.record, repoRoot),
+        env,
+      });
+
+      let payload = null;
+      if (commandResult.stdout?.trim()) {
+        payload = JSON.parse(commandResult.stdout);
+      }
+
+      results.push({
+        adapter: entry.record.adapter,
+        installStatePath: entry.record.installStatePath,
+        repoRoot,
+        cwd: determineInstallCwd(entry.record, repoRoot),
+        installArgs,
+        status: options.dryRun ? 'planned' : 'updated',
+        payload,
+      });
+    } catch (error) {
+      results.push({
+        adapter: entry.record.adapter,
+        installStatePath: entry.record.installStatePath,
+        repoRoot,
+        installArgs,
+        status: 'error',
+        error: error.message,
+      });
+    }
+  }
+  return results;
+}
+
 function runAutoUpdate(options = {}, dependencies = {}) {
   const discover = dependencies.discoverInstalledStates || discoverInstalledStates;
   const execute = dependencies.runExternalCommand || runExternalCommand;
@@ -243,74 +317,10 @@ function runAutoUpdate(options = {}, dependencies = {}) {
   };
 
   if (!options.dryRun) {
-    const isGitRepo = fs.existsSync(path.join(repoRoot, '.git'));
-    if (!isGitRepo) {
-      // npm-installed: git pull is not applicable. Reinstall from current package.
-      console.log(`EGC is installed via npm (v${PKG_VERSION}).`);
-      console.log('To upgrade to a newer version, run: npm install -g @egchq/egc@latest');
-      console.log('Reinstalling current version into managed targets...\n');
-    } else {
-      execute('git', ['fetch', '--all', '--prune'], { cwd: repoRoot, env });
-      try {
-        execute('git', ['pull', '--ff-only'], { cwd: repoRoot, env });
-      } catch (pullError) {
-        const msg = String(pullError.message || '');
-        if (msg.includes('no tracking information') || msg.includes('set-upstream')) {
-          throw new Error(
-            'git pull failed: no upstream tracking branch configured.\n' +
-            'To update: npm install -g @egchq/egc@latest\n' +
-            'Or set upstream: git branch --set-upstream-to=origin/<branch>',
-            { cause: pullError }
-          );
-        }
-        throw pullError;
-      }
-    }
+    performGitUpdate(repoRoot, env, execute);
   }
 
-  for (const entry of validRecords) {
-    const installArgs = buildInstallApplyArgs(entry.record);
-    const args = [
-      path.join(repoRoot, 'scripts', 'install-apply.js'),
-      ...installArgs,
-      '--json',
-    ];
-
-    if (options.dryRun) {
-      args.push('--dry-run');
-    }
-
-    try {
-      const commandResult = execute(process.execPath, args, {
-        cwd: determineInstallCwd(entry.record, repoRoot),
-        env,
-      });
-
-      let payload = null;
-      if (commandResult.stdout?.trim()) {
-        payload = JSON.parse(commandResult.stdout);
-      }
-
-      results.push({
-        adapter: entry.record.adapter,
-        installStatePath: entry.record.installStatePath,
-        repoRoot,
-        cwd: determineInstallCwd(entry.record, repoRoot),
-        installArgs,
-        status: options.dryRun ? 'planned' : 'updated',
-        payload,
-      });
-    } catch (error) {
-      results.push({
-        adapter: entry.record.adapter,
-        installStatePath: entry.record.installStatePath,
-        repoRoot,
-        installArgs,
-        status: 'error',
-        error: error.message,
-      });
-    }
-  }
+  results.push(...applyInstalls(validRecords, options, repoRoot, env, execute));
 
   return {
     dryRun: Boolean(options.dryRun),

--- a/scripts/ci/capability-graph.js
+++ b/scripts/ci/capability-graph.js
@@ -225,6 +225,17 @@ function buildHookEntry(event, matcher, blockId, h, i) {
   return { id, event, matcher, command, scriptPath };
 }
 
+function processHookBlock(event, block, results) {
+  if (!block || typeof block !== 'object') return;
+  const matcher = typeof block.matcher === 'string' ? block.matcher : null;
+  const blockId = typeof block.id === 'string' ? block.id : null;
+  const handlers = Array.isArray(block.hooks) ? block.hooks : [];
+  for (let i = 0; i < handlers.length; i++) {
+    const entry = buildHookEntry(event, matcher, blockId, handlers[i], i);
+    if (entry) results.push(entry);
+  }
+}
+
 function buildHooks() {
   const raw = readFileSafe(HOOKS_JSON);
   if (!raw) return [];
@@ -240,14 +251,7 @@ function buildHooks() {
     const arr = root[event];
     if (!Array.isArray(arr)) continue;
     for (const block of arr) {
-      if (!block || typeof block !== 'object') continue;
-      const matcher = typeof block.matcher === 'string' ? block.matcher : null;
-      const blockId = typeof block.id === 'string' ? block.id : null;
-      const handlers = Array.isArray(block.hooks) ? block.hooks : [];
-      for (let i = 0; i < handlers.length; i++) {
-        const entry = buildHookEntry(event, matcher, blockId, handlers[i], i);
-        if (entry) results.push(entry);
-      }
+      processHookBlock(event, block, results);
     }
   }
   return results;

--- a/scripts/e2e-team-sync-direct.js
+++ b/scripts/e2e-team-sync-direct.js
@@ -37,44 +37,7 @@ function sh(args, cwd) {
 let passed = 0, failed = 0;
 function ok(cond, msg) { if (cond) { console.log('  PASS: ' + msg); passed++; } else { console.log('  FAIL: ' + msg); failed++; } }
 
-(async () => { try {
-  console.log('=== E2E Direct Module Test ===\n');
-  console.log(`Sandbox home: ${SANDBOX_HOME}`);
-
-  // 1. Create remote bare repo via git
-  fs.mkdirSync(REMOTE, { recursive: true });
-  sh(['init', '--bare'], REMOTE);
-  console.log('1. Remote repo created at ' + REMOTE);
-  ok(fs.existsSync(path.join(REMOTE, 'HEAD')), 'remote git repo initialized');
-
-  // 2. Clean slate in sandbox
-  if (fs.existsSync(SYNCDIR)) fs.rmSync(SYNCDIR, { recursive: true, force: true });
-  if (fs.existsSync(TEAMJSON)) fs.unlinkSync(TEAMJSON);
-  if (fs.existsSync(STATEDIR)) fs.rmSync(STATEDIR, { recursive: true, force: true });
-
-  // 3. Load and test the modules directly (after sandbox env is set)
-  const EGC_ROOT = path.resolve(__dirname, '..');
-  const { teamInit, teamSync, teamStatus, getTeamConfig, writeTeamConfig } = require(path.join(EGC_ROOT, 'mcp/servers/egc-memory/build/sync/TeamSync.js'));
-  const { SyncBackend } = require(path.join(EGC_ROOT, 'mcp/servers/egc-memory/build/sync/SyncBackend.js'));
-  const { GitBackend } = require(path.join(EGC_ROOT, 'mcp/servers/egc-memory/build/sync/GitBackend.js'));
-
-  ok(typeof teamInit === 'function', 'teamInit exports as function');
-  ok(typeof teamSync === 'function', 'teamSync exports as function');
-  ok(typeof teamStatus === 'function', 'teamStatus exports as function');
-  ok(typeof GitBackend === 'function', 'GitBackend class exports');
-
-  // 4. Test getTeamConfig returns null before init
-  ok(getTeamConfig() === null, 'getTeamConfig returns null before init');
-
-  // 5. Test writeTeamConfig / getTeamConfig round-trip
-  writeTeamConfig({ backend: 'git', remote: REMOTE, branch: 'main' });
-  const cfg = getTeamConfig();
-  ok(cfg !== null, 'getTeamConfig returns config after write');
-  ok(cfg.backend === 'git', 'config backend is git');
-  ok(cfg.remote === REMOTE, 'config remote matches');
-  ok(cfg.branch === 'main', 'config branch is main');
-
-  // 6. Test GitBackend directly
+async function runGitBackendTests(GitBackend, REMOTE, SYNCDIR) {
   console.log('\n2. Testing GitBackend directly...');
   const gitBackend = new GitBackend();
   ok(typeof gitBackend.init === 'function', 'GitBackend has init method');
@@ -90,7 +53,9 @@ function ok(cond, msg) { if (cond) { console.log('  PASS: ' + msg); passed++; } 
   const preStatus = await gitBackend.status();
   ok(preStatus.lastSyncTime === null, 'status reports no last sync before first push');
   ok(preStatus.remoteUrl === REMOTE, 'status reports correct remote URL');
+}
 
+async function runTeamSyncTests(teamInit, teamSync, teamStatus, REMOTE, STATEDIR, SYNCDIR, TEAMJSON) {
   // 7. Create state file
   fs.mkdirSync(STATEDIR, { recursive: true });
   const stateContent = [
@@ -143,7 +108,9 @@ function ok(cond, msg) { if (cond) { console.log('  PASS: ' + msg); passed++; } 
   ok(fs.existsSync(syncedStateDir), 'sync repo has state directory');
   const syncedFiles = fs.readdirSync(syncedStateDir);
   ok(syncedFiles.length > 0, 'state files synced to team-sync: ' + syncedFiles.join(', '));
+}
 
+function verifyBuildOutput(EGC_ROOT, SyncBackend) {
   // 13. Test SyncBackend abstract class
   console.log('\n7. Testing SyncBackend abstract class...');
   ok(typeof SyncBackend === 'function', 'SyncBackend class exports');
@@ -158,6 +125,48 @@ function ok(cond, msg) { if (cond) { console.log('  PASS: ' + msg); passed++; } 
   ok(buildIndex.includes('teamInit'), 'build/index.js references teamInit');
   ok(buildIndex.includes('teamSync'), 'build/index.js references teamSync');
   ok(buildIndex.includes('teamStatus'), 'build/index.js references teamStatus');
+}
+
+(async () => { try {
+  console.log('=== E2E Direct Module Test ===\n');
+  console.log(`Sandbox home: ${SANDBOX_HOME}`);
+
+  // 1. Create remote bare repo via git
+  fs.mkdirSync(REMOTE, { recursive: true });
+  sh(['init', '--bare'], REMOTE);
+  console.log('1. Remote repo created at ' + REMOTE);
+  ok(fs.existsSync(path.join(REMOTE, 'HEAD')), 'remote git repo initialized');
+
+  // 2. Clean slate in sandbox
+  if (fs.existsSync(SYNCDIR)) fs.rmSync(SYNCDIR, { recursive: true, force: true });
+  if (fs.existsSync(TEAMJSON)) fs.unlinkSync(TEAMJSON);
+  if (fs.existsSync(STATEDIR)) fs.rmSync(STATEDIR, { recursive: true, force: true });
+
+  // 3. Load and test the modules directly (after sandbox env is set)
+  const EGC_ROOT = path.resolve(__dirname, '..');
+  const { teamInit, teamSync, teamStatus, getTeamConfig, writeTeamConfig } = require(path.join(EGC_ROOT, 'mcp/servers/egc-memory/build/sync/TeamSync.js'));
+  const { SyncBackend } = require(path.join(EGC_ROOT, 'mcp/servers/egc-memory/build/sync/SyncBackend.js'));
+  const { GitBackend } = require(path.join(EGC_ROOT, 'mcp/servers/egc-memory/build/sync/GitBackend.js'));
+
+  ok(typeof teamInit === 'function', 'teamInit exports as function');
+  ok(typeof teamSync === 'function', 'teamSync exports as function');
+  ok(typeof teamStatus === 'function', 'teamStatus exports as function');
+  ok(typeof GitBackend === 'function', 'GitBackend class exports');
+
+  // 4. Test getTeamConfig returns null before init
+  ok(getTeamConfig() === null, 'getTeamConfig returns null before init');
+
+  // 5. Test writeTeamConfig / getTeamConfig round-trip
+  writeTeamConfig({ backend: 'git', remote: REMOTE, branch: 'main' });
+  const cfg = getTeamConfig();
+  ok(cfg !== null, 'getTeamConfig returns config after write');
+  ok(cfg.backend === 'git', 'config backend is git');
+  ok(cfg.remote === REMOTE, 'config remote matches');
+  ok(cfg.branch === 'main', 'config branch is main');
+
+  await runGitBackendTests(GitBackend, REMOTE, SYNCDIR);
+  await runTeamSyncTests(teamInit, teamSync, teamStatus, REMOTE, STATEDIR, SYNCDIR, TEAMJSON);
+  verifyBuildOutput(EGC_ROOT, SyncBackend);
 
   // Cleanup
   console.log('\n--- Cleaning up ---');


### PR DESCRIPTION
Reduces cognitive complexity of 3 functions (auto-update.js:171, e2e-team-sync-direct.js:40, capability-graph.js:228). Authored by the squad agent (2739/2739 tests green locally); PR opened on its behalf (agent runtime blocks gh).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors auto-update, capability-graph, and E2E team sync scripts to lower cognitive complexity (S3776) without changing behavior. Introduces small helpers and clearer error handling for easier maintenance.

- **Refactors**
  - auto-update.js: extracted `performGitUpdate` and `applyInstalls`; improves upstream-not-configured error guidance (includes `@egchq/egc@latest` hint).
  - ci/capability-graph.js: extracted `processHookBlock` and simplified `buildHooks`.
  - e2e-team-sync-direct.js: split monolithic IIFE into `runGitBackendTests`, `runTeamSyncTests`, and `verifyBuildOutput`; keeps test flow intact.

<sup>Written for commit 75c82351846e431384bc8bf7ad24bd8281d7020f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

