### PR TITLE
refactor(cc): reduce cognitive complexity in health, repair and session scripts (S3776)

### DIFF
--- a/scripts/hooks/post-edit-typecheck.js
+++ b/scripts/hooks/post-edit-typecheck.js
@@ -24,6 +24,57 @@ process.stdin.on("data", (chunk) => {
   }
 });
 
+function findTsConfig(startDir) {
+  let dir = startDir;
+  const root = path.parse(dir).root;
+  let depth = 0;
+
+  while (dir !== root && depth < 20) {
+    if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+    depth++;
+  }
+  
+  if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
+    return dir;
+  }
+  return null;
+}
+
+function runTypeCheck(dir, filePath, resolvedPath) {
+  try {
+    const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
+    execFileSync(npxBin, ["tsc", "--noEmit", "--pretty", "false"], {
+      cwd: dir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 30000,
+    });
+  } catch (err) {
+    const output = (err.stdout || "") + (err.stderr || "");
+    const relPath = path.relative(dir, resolvedPath);
+    const candidates = new Set([filePath, resolvedPath, relPath]);
+    const relevantLines = output
+      .split("\n")
+      .filter((line) => {
+        for (const candidate of candidates) {
+          if (line.includes(candidate)) return true;
+        }
+        return false;
+      })
+      .slice(0, 10);
+
+    if (relevantLines.length > 0) {
+      console.error(
+        "[Hook] TypeScript errors in " + path.basename(filePath) + ":",
+      );
+      relevantLines.forEach((line) => console.error(line));
+    }
+  }
+}
+
 process.stdin.on("end", () => {
   try {
     const input = JSON.parse(data);
@@ -35,55 +86,10 @@ process.stdin.on("end", () => {
         process.stdout.write(data);
         process.exit(0);
       }
-      let dir = path.dirname(resolvedPath);
-      const root = path.parse(dir).root;
-      let depth = 0;
-
-      while (dir !== root && depth < 20) {
-        if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
-          break;
-        }
-        dir = path.dirname(dir);
-        depth++;
-      }
-
-      if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
-        try {
-          // Use npx.cmd on Windows to avoid shell: true which enables command injection
-          const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
-          execFileSync(npxBin, ["tsc", "--noEmit", "--pretty", "false"], {
-            cwd: dir,
-            encoding: "utf8",
-            stdio: ["pipe", "pipe", "pipe"],
-            timeout: 30000,
-          });
-        } catch (err) {
-          // tsc exits non-zero when there are errors: filter to edited file
-          const output = (err.stdout || "") + (err.stderr || "");
-          // Compute paths that uniquely identify the edited file.
-          // tsc output uses paths relative to its cwd (the tsconfig dir),
-          // so check for the relative path, absolute path, and original path.
-          // Avoid bare basename matching: it causes false positives when
-          // multiple files share the same name (e.g., src/utils.ts vs tests/utils.ts).
-          const relPath = path.relative(dir, resolvedPath);
-          const candidates = new Set([filePath, resolvedPath, relPath]);
-          const relevantLines = output
-            .split("\n")
-            .filter((line) => {
-              for (const candidate of candidates) {
-                if (line.includes(candidate)) return true;
-              }
-              return false;
-            })
-            .slice(0, 10);
-
-          if (relevantLines.length > 0) {
-            console.error(
-              "[Hook] TypeScript errors in " + path.basename(filePath) + ":",
-            );
-            relevantLines.forEach((line) => console.error(line));
-          }
-        }
+      
+      const tsConfigDir = findTsConfig(path.dirname(resolvedPath));
+      if (tsConfigDir) {
+        runTypeCheck(tsConfigDir, filePath, resolvedPath);
       }
     }
   } catch {

--- a/scripts/hooks/session-start-bootstrap.js
+++ b/scripts/hooks/session-start-bootstrap.js
@@ -69,6 +69,27 @@ function hasRunnerRoot(candidate) {
  *
  * @returns {string}
  */
+function resolveFromCache(claudeDir) {
+  try {
+    for (const slug of CACHE_PLUGIN_SLUGS) {
+      const cacheBase = path.join(claudeDir, 'plugins', 'cache', slug);
+      for (const org of fs.readdirSync(cacheBase, { withFileTypes: true })) {
+        if (!org.isDirectory()) continue;
+        for (const version of fs.readdirSync(path.join(cacheBase, org.name), { withFileTypes: true })) {
+          if (!version.isDirectory()) continue;
+          const candidate = path.join(cacheBase, org.name, version.name);
+          if (hasRunnerRoot(candidate)) {
+            return candidate;
+          }
+        }
+      }
+    }
+  } catch {
+    // cache directory may not exist; that's fine
+  }
+  return null;
+}
+
 function resolvePluginRoot() {
   const envRoot = process.env.GEMINI_PLUGIN_ROOT || '';
   if (hasRunnerRoot(envRoot)) {
@@ -92,24 +113,8 @@ function resolvePluginRoot() {
     }
   }
 
-  // Walk versioned cache: ~/.gemini/plugins/cache/{egc,everything-gemini}/<org>/<version>/
-  try {
-    for (const slug of CACHE_PLUGIN_SLUGS) {
-      const cacheBase = path.join(claudeDir, 'plugins', 'cache', slug);
-      for (const org of fs.readdirSync(cacheBase, { withFileTypes: true })) {
-        if (!org.isDirectory()) continue;
-        for (const version of fs.readdirSync(path.join(cacheBase, org.name), { withFileTypes: true })) {
-          if (!version.isDirectory()) continue;
-          const candidate = path.join(cacheBase, org.name, version.name);
-          if (hasRunnerRoot(candidate)) {
-            return candidate;
-          }
-        }
-      }
-    }
-  } catch {
-    // cache directory may not exist; that's fine
-  }
+  const cachedRoot = resolveFromCache(claudeDir);
+  if (cachedRoot) return cachedRoot;
 
   return claudeDir;
 }

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -186,55 +186,56 @@ function pruneExpiredSessions(searchDirs, retentionDays) {
  *   The best matching session with its cached content and match reason,
  *   or null if the sessions array is empty or all files are unreadable.
  */
+function updateMatchState(session, content, state, normalizedCwd, currentProject) {
+  if (!state.fallbackSession) {
+    state.fallbackSession = session;
+    state.fallbackContent = content;
+  }
+
+  const worktreeMatch = /\*\*Worktree:\*\*\s*(.+)$/m.exec(content); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
+  const sessionWorktree = worktreeMatch ? worktreeMatch[1].trim() : '';
+
+  if (sessionWorktree && normalizePath(sessionWorktree) === normalizedCwd) {
+    return { session, content, matchReason: 'worktree' };
+  }
+
+  if (!state.projectMatch && currentProject) {
+    const projectFieldMatch = /\*\*Project:\*\*\s*(.+)$/m.exec(content); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
+    const sessionProject = projectFieldMatch ? projectFieldMatch[1].trim() : '';
+    if (sessionProject && sessionProject === currentProject) {
+      state.projectMatch = session;
+      state.projectMatchContent = content;
+    }
+  }
+
+  return null;
+}
+
 function selectMatchingSession(sessions, cwd, currentProject) {
   if (sessions.length === 0) return null;
 
-  // Normalize cwd once outside the loop to avoid repeated syscalls
   const normalizedCwd = normalizePath(cwd);
-
-  let projectMatch = null;
-  let projectMatchContent = null;
-  let fallbackSession = null;
-  let fallbackContent = null;
+  const state = {
+    projectMatch: null,
+    projectMatchContent: null,
+    fallbackSession: null,
+    fallbackContent: null
+  };
 
   for (const session of sessions) {
     const content = readFile(session.path);
     if (!content) continue;
 
-    // Cache first readable session+content pair for fallback
-    if (!fallbackSession) {
-      fallbackSession = session;
-      fallbackContent = content;
-    }
-
-    // Extract **Worktree:** field
-    const worktreeMatch = /\*\*Worktree:\*\*\s*(.+)$/m.exec(content); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
-    const sessionWorktree = worktreeMatch ? worktreeMatch[1].trim() : '';
-
-    // Exact worktree match: best possible, return immediately
-    // Normalize both paths to handle symlinks and case-insensitive filesystems
-    if (sessionWorktree && normalizePath(sessionWorktree) === normalizedCwd) {
-      return { session, content, matchReason: 'worktree' };
-    }
-
-    // Project name match: keep searching for a worktree match
-    if (!projectMatch && currentProject) {
-      const projectFieldMatch = /\*\*Project:\*\*\s*(.+)$/m.exec(content); // NOSONAR: superlinear risk accepted: input is repo-owned or local state content, never network-controlled
-      const sessionProject = projectFieldMatch ? projectFieldMatch[1].trim() : '';
-      if (sessionProject && sessionProject === currentProject) {
-        projectMatch = session;
-        projectMatchContent = content;
-      }
-    }
+    const exactMatch = updateMatchState(session, content, state, normalizedCwd, currentProject);
+    if (exactMatch) return exactMatch;
   }
 
-  if (projectMatch) {
-    return { session: projectMatch, content: projectMatchContent, matchReason: 'project' };
+  if (state.projectMatch) {
+    return { session: state.projectMatch, content: state.projectMatchContent, matchReason: 'project' };
   }
 
-  // Fallback: most recent readable session (original behavior)
-  if (fallbackSession) {
-    return { session: fallbackSession, content: fallbackContent, matchReason: 'recency-fallback' };
+  if (state.fallbackSession) {
+    return { session: state.fallbackSession, content: state.fallbackContent, matchReason: 'recency-fallback' };
   }
 
   log('[SessionStart] All session files were unreadable');

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -68,6 +68,31 @@ function printHuman(result) {
   console.log(`\nSummary: checked=${result.summary.checkedCount}, ${result.dryRun ? 'planned' : 'repaired'}=${result.dryRun ? result.summary.plannedRepairCount : result.summary.repairedCount}, errors=${result.summary.errorCount}`);
 }
 
+function executePluginRepairs(options) {
+  if (options.dryRun) return [];
+  const plugins = listInstalledPlugins();
+  if (plugins.length === 0) return [];
+  return reinstallAllPlugins();
+}
+
+function printOutput(result, pluginResults, options) {
+  if (options.json) {
+    if (pluginResults.length > 0) {
+      result.pluginRepairs = pluginResults;
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  printHuman(result);
+  if (pluginResults.length > 0) {
+    console.log('\nPlugin reinstall:\n');
+    for (const p of pluginResults) {
+      const icon = p.success ? '\u2713' : '\u2717';
+      console.log(`  ${icon} ${p.name}${p.success ? '' : ': ' + (p.errors || []).join(', ')}`);
+    }
+  }
+}
+
 function main() {
   try {
     const options = parseArgs(process.argv);
@@ -82,32 +107,11 @@ function main() {
       targets: options.targets,
       dryRun: options.dryRun,
     });
+    
+    const pluginResults = executePluginRepairs(options);
+    printOutput(result, pluginResults, options);
+
     const hasErrors = result.summary.errorCount > 0;
-    let pluginResults = [];
-
-    if (!options.dryRun) {
-      const plugins = listInstalledPlugins();
-      if (plugins.length > 0) {
-        pluginResults = reinstallAllPlugins();
-      }
-    }
-
-    if (options.json) {
-      if (pluginResults.length > 0) {
-        result.pluginRepairs = pluginResults;
-      }
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      printHuman(result);
-      if (pluginResults.length > 0) {
-        console.log('\nPlugin reinstall:\n');
-        for (const p of pluginResults) {
-          const icon = p.success ? '\u2713' : '\u2717';
-          console.log(`  ${icon} ${p.name}${p.success ? '' : ': ' + (p.errors || []).join(', ')}`);
-        }
-      }
-    }
-
     const pluginErrors = pluginResults.filter(p => !p.success).length;
     process.exitCode = (hasErrors || pluginErrors > 0) ? 1 : 0;
   } catch (error) {

--- a/scripts/skills-health.js
+++ b/scripts/skills-health.js
@@ -32,76 +32,72 @@ function requireValue(argv, index, argName) {
   return value;
 }
 
+function applyArg(argv, index, options) {
+  const arg = argv[index];
+
+  if (arg === '--json') {
+    options.json = true;
+    return 1;
+  }
+
+  if (arg === '--help' || arg === '-h') {
+    options.help = true;
+    return 1;
+  }
+
+  if (arg === '--skills-root') {
+    options.skillsRoot = requireValue(argv, index, '--skills-root');
+    return 2;
+  }
+
+  if (arg === '--learned-root') {
+    options.learnedRoot = requireValue(argv, index, '--learned-root');
+    return 2;
+  }
+
+  if (arg === '--imported-root') {
+    options.importedRoot = requireValue(argv, index, '--imported-root');
+    return 2;
+  }
+
+  if (arg === '--home') {
+    options.homeDir = requireValue(argv, index, '--home');
+    return 2;
+  }
+
+  if (arg === '--runs-file') {
+    options.runsFilePath = requireValue(argv, index, '--runs-file');
+    return 2;
+  }
+
+  if (arg === '--now') {
+    options.now = requireValue(argv, index, '--now');
+    return 2;
+  }
+
+  if (arg === '--warn-threshold') {
+    options.warnThreshold = Number(requireValue(argv, index, '--warn-threshold'));
+    return 2;
+  }
+
+  if (arg === '--dashboard') {
+    options.dashboard = true;
+    return 1;
+  }
+
+  if (arg === '--panel') {
+    options.panel = requireValue(argv, index, '--panel');
+    return 2;
+  }
+
+  throw new Error(`Unknown argument: ${arg}`);
+}
+
 function parseArgs(argv) {
   const options = {};
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-
-    if (arg === '--json') {
-      options.json = true;
-      continue;
-    }
-
-    if (arg === '--help' || arg === '-h') {
-      options.help = true;
-      continue;
-    }
-
-    if (arg === '--skills-root') {
-      options.skillsRoot = requireValue(argv, index, '--skills-root');
-      index += 1;
-      continue;
-    }
-
-    if (arg === '--learned-root') {
-      options.learnedRoot = requireValue(argv, index, '--learned-root');
-      index += 1;
-      continue;
-    }
-
-    if (arg === '--imported-root') {
-      options.importedRoot = requireValue(argv, index, '--imported-root');
-      index += 1;
-      continue;
-    }
-
-    if (arg === '--home') {
-      options.homeDir = requireValue(argv, index, '--home');
-      index += 1;
-      continue;
-    }
-
-    if (arg === '--runs-file') {
-      options.runsFilePath = requireValue(argv, index, '--runs-file');
-      index += 1;
-      continue;
-    }
-
-    if (arg === '--now') {
-      options.now = requireValue(argv, index, '--now');
-      index += 1;
-      continue;
-    }
-
-    if (arg === '--warn-threshold') {
-      options.warnThreshold = Number(requireValue(argv, index, '--warn-threshold'));
-      index += 1;
-      continue;
-    }
-
-    if (arg === '--dashboard') {
-      options.dashboard = true;
-      continue;
-    }
-
-    if (arg === '--panel') {
-      options.panel = requireValue(argv, index, '--panel');
-      index += 1;
-      continue;
-    }
-
-    throw new Error(`Unknown argument: ${arg}`);
+  let index = 0;
+  while (index < argv.length) {
+    index += applyArg(argv, index, options);
   }
 
   return options;


### PR DESCRIPTION
Reduces cognitive complexity of 5 functions (skills-health.js:35, repair.js:71, session-start.js:189, session-start-bootstrap.js:72, post-edit-typecheck.js:27). Authored by the squad agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced cognitive complexity across health, repair, and session scripts by extracting small helpers and simplifying control flow. Improves readability and keeps behavior the same.

- **Refactors**
  - `scripts/skills-health.js`: Split arg parsing into `applyArg` with a simple loop; same flags and validation.
  - `scripts/repair.js`: Extracted `executePluginRepairs` and `printOutput`; unchanged output and exit code behavior.
  - `scripts/hooks/session-start.js`: Added `updateMatchState` to centralize worktree/project matching and fallback logic.
  - `scripts/hooks/session-start-bootstrap.js`: Added `resolveFromCache` to isolate cache lookup logic.
  - `scripts/hooks/post-edit-typecheck.js`: Added `findTsConfig` and `runTypeCheck`; keeps Windows `npx.cmd` handling and error filtering to the edited file.

<sup>Written for commit 1d68812351d6c24bd6531419276c3b8ef28e784b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

