### PR TITLE
refactor(cc): reduce cognitive complexity in install apply and lifecycle (S3776)

### DIFF
--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -248,41 +248,47 @@ function jsonContainsSubset(actualValue, expectedValue) {
 
 const JSON_REMOVE_SENTINEL = Symbol('json-remove');
 
+function handleNestedPlainObjectRemove(nextValue, key, value) {
+  const nestedValue = deepRemoveJsonSubset(nextValue[key], value);
+  if (nestedValue === JSON_REMOVE_SENTINEL) {
+    delete nextValue[key];
+  } else {
+    nextValue[key] = nestedValue;
+  }
+}
+
+function handleNestedArrayRemove(nextValue, key, value) {
+  if (Array.isArray(nextValue[key]) && jsonContainsSubset(nextValue[key], value)) {
+    delete nextValue[key];
+  }
+}
+
+function removePlainObjectSubset(currentValue, managedValue) {
+  if (!isPlainObject(currentValue)) {
+    return currentValue;
+  }
+
+  const nextValue = { ...currentValue };
+  for (const [key, value] of Object.entries(managedValue)) {
+    if (!Object.hasOwn(nextValue, key)) {
+      continue;
+    }
+
+    if (isPlainObject(value)) {
+      handleNestedPlainObjectRemove(nextValue, key, value);
+    } else if (Array.isArray(value)) {
+      handleNestedArrayRemove(nextValue, key, value);
+    } else if (nextValue[key] === value) {
+      delete nextValue[key];
+    }
+  }
+
+  return Object.keys(nextValue).length === 0 ? JSON_REMOVE_SENTINEL : nextValue;
+}
+
 function deepRemoveJsonSubset(currentValue, managedValue) {
   if (isPlainObject(managedValue)) {
-    if (!isPlainObject(currentValue)) {
-      return currentValue;
-    }
-
-    const nextValue = { ...currentValue };
-    for (const [key, value] of Object.entries(managedValue)) {
-      if (!Object.hasOwn(nextValue, key)) {
-        continue;
-      }
-
-      if (isPlainObject(value)) {
-        const nestedValue = deepRemoveJsonSubset(nextValue[key], value);
-        if (nestedValue === JSON_REMOVE_SENTINEL) {
-          delete nextValue[key];
-        } else {
-          nextValue[key] = nestedValue;
-        }
-        continue;
-      }
-
-      if (Array.isArray(value)) {
-        if (Array.isArray(nextValue[key]) && jsonContainsSubset(nextValue[key], value)) {
-          delete nextValue[key];
-        }
-        continue;
-      }
-
-      if (nextValue[key] === value) {
-        delete nextValue[key];
-      }
-    }
-
-    return Object.keys(nextValue).length === 0 ? JSON_REMOVE_SENTINEL : nextValue;
+    return removePlainObjectSubset(currentValue, managedValue);
   }
 
   if (Array.isArray(managedValue)) {
@@ -334,84 +340,88 @@ function repairClaudeSettingsHook(operation) {
   }
 }
 
+function repairCopyFile(repoRoot, operation) {
+  const sourcePath = resolveOperationSourcePath(repoRoot, operation);
+  if (!sourcePath || !fs.existsSync(sourcePath)) {
+    throw new Error(`Missing source file for repair: ${sourcePath || operation.sourceRelativePath}`);
+  }
+
+  ensureParentDir(operation.destinationPath);
+  fs.copyFileSync(sourcePath, operation.destinationPath);
+}
+
+function repairMergeJson(operation) {
+  const payload = getOperationJsonPayload(operation);
+  if (payload === undefined) {
+    throw new Error(`Missing merge payload for repair: ${operation.destinationPath}`);
+  }
+
+  const currentValue = fs.existsSync(operation.destinationPath)
+    ? readJsonFile(operation.destinationPath)
+    : {};
+  const mergedValue = deepMergeJson(currentValue, payload);
+
+  ensureParentDir(operation.destinationPath);
+  fs.writeFileSync(operation.destinationPath, formatJson(mergedValue));
+}
+
+function repairRemove(operation) {
+  if (!fs.existsSync(operation.destinationPath)) {
+    return;
+  }
+
+  fs.rmSync(operation.destinationPath, { recursive: true, force: true });
+}
+
+function repairMergeYamlReadList(operation) {
+  if (!operation.readEntry) {
+    throw new Error(`Missing readEntry for repair: ${operation.destinationPath}`);
+  }
+  const existingContent = fs.existsSync(operation.destinationPath)
+    ? fs.readFileSync(operation.destinationPath, 'utf8')
+    : null;
+  let nextContent;
+  try {
+    nextContent = mergeAiderConfigReadList(existingContent, operation.readEntry);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse Aider config at ${operation.destinationPath}: ${error.message}`,
+      { cause: error },
+    );
+  }
+  ensureParentDir(operation.destinationPath);
+  fs.writeFileSync(operation.destinationPath, nextContent);
+}
+
+function repairMergeMarkdownIndex(operation) {
+  const existingContent = fs.existsSync(operation.destinationPath)
+    ? fs.readFileSync(operation.destinationPath, 'utf8')
+    : null;
+  const nextContent = mergeSkillIndexEntry(existingContent, {
+    name: operation.skillName,
+    description: operation.skillDescription,
+    relativePath: operation.relativePath,
+  });
+  ensureParentDir(operation.destinationPath);
+  fs.writeFileSync(operation.destinationPath, nextContent);
+}
+
 function executeRepairOperation(repoRoot, operation) {
   if (operation.kind === 'copy-file') {
-    const sourcePath = resolveOperationSourcePath(repoRoot, operation);
-    if (!sourcePath || !fs.existsSync(sourcePath)) {
-      throw new Error(`Missing source file for repair: ${sourcePath || operation.sourceRelativePath}`);
-    }
-
-    ensureParentDir(operation.destinationPath);
-    fs.copyFileSync(sourcePath, operation.destinationPath);
-    return;
-  }
-
-  if (operation.kind === 'merge-json') {
-    const payload = getOperationJsonPayload(operation);
-    if (payload === undefined) {
-      throw new Error(`Missing merge payload for repair: ${operation.destinationPath}`);
-    }
-
-    const currentValue = fs.existsSync(operation.destinationPath)
-      ? readJsonFile(operation.destinationPath)
-      : {};
-    const mergedValue = deepMergeJson(currentValue, payload);
-
-    ensureParentDir(operation.destinationPath);
-    fs.writeFileSync(operation.destinationPath, formatJson(mergedValue));
-    return;
-  }
-
-  if (operation.kind === 'remove') {
-    if (!fs.existsSync(operation.destinationPath)) {
-      return;
-    }
-
-    fs.rmSync(operation.destinationPath, { recursive: true, force: true });
-    return;
-  }
-
-  if (operation.kind === HOOK_OPERATION_KIND) {
+    repairCopyFile(repoRoot, operation);
+  } else if (operation.kind === 'merge-json') {
+    repairMergeJson(operation);
+  } else if (operation.kind === 'remove') {
+    repairRemove(operation);
+  } else if (operation.kind === HOOK_OPERATION_KIND) {
     repairClaudeSettingsHook(operation);
-    return;
+  } else if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
+    repairMergeYamlReadList(operation);
+  } else if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
+    repairMergeMarkdownIndex(operation);
+  } else {
+    throw new Error(`Unsupported repair operation kind: ${operation.kind}`);
   }
-
-  if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
-    if (!operation.readEntry) {
-      throw new Error(`Missing readEntry for repair: ${operation.destinationPath}`);
-    }
-    const existingContent = fs.existsSync(operation.destinationPath)
-      ? fs.readFileSync(operation.destinationPath, 'utf8')
-      : null;
-    let nextContent;
-    try {
-      nextContent = mergeAiderConfigReadList(existingContent, operation.readEntry);
-    } catch (error) {
-      throw new Error(
-        `Failed to parse Aider config at ${operation.destinationPath}: ${error.message}`,
-        { cause: error },
-      );
-    }
-    ensureParentDir(operation.destinationPath);
-    fs.writeFileSync(operation.destinationPath, nextContent);
-    return;
-  }
-
-  if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
-    const existingContent = fs.existsSync(operation.destinationPath)
-      ? fs.readFileSync(operation.destinationPath, 'utf8')
-      : null;
-    const nextContent = mergeSkillIndexEntry(existingContent, {
-      name: operation.skillName,
-      description: operation.skillDescription,
-      relativePath: operation.relativePath,
-    });
-    ensureParentDir(operation.destinationPath);
-    fs.writeFileSync(operation.destinationPath, nextContent);
-    return;
-  }
-
-  throw new Error(`Unsupported repair operation kind: ${operation.kind}`);
 }
 
 function restorePreviousContent(operation) {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -141,6 +141,80 @@ function buildResolvedClaudeHooks(plan) {
   };
 }
 
+function applyHookOperation(operation) {
+  if (operation.hookEvent === STOP_EVENT) {
+    applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
+    applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
+    applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
+  } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
+    applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
+  } else {
+    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+  }
+}
+
+function applyMergeJsonOperation(operation, disabledServers) {
+  const payload = cloneJsonValue(operation.mergePayload);
+  if (payload === undefined) {
+    throw new Error(`Missing merge payload for ${operation.destinationPath}`);
+  }
+
+  const filteredPayload = (
+    isMcpConfigPath(operation.destinationPath) && disabledServers.length > 0
+  )
+    ? filterMcpConfig(payload, disabledServers).config
+    : payload;
+
+  const currentValue = fs.existsSync(operation.destinationPath)
+    ? readJsonObject(operation.destinationPath, 'existing JSON config')
+    : {};
+  const mergedValue = deepMergeJson(currentValue, filteredPayload);
+  fs.writeFileSync(operation.destinationPath, formatJson(mergedValue), 'utf8');
+}
+
+function applyMergeYamlReadListOperation(operation) {
+  if (!operation.readEntry) {
+    throw new Error(`Missing readEntry for ${operation.destinationPath}`);
+  }
+
+  const existingContent = fs.existsSync(operation.destinationPath)
+    ? fs.readFileSync(operation.destinationPath, 'utf8')
+    : null;
+  let nextContent;
+  try {
+    nextContent = mergeAiderConfigReadList(existingContent, operation.readEntry);
+  } catch (error) {
+    // js-yaml's raw SyntaxError gives no indication of which file or
+    // that it's a YAML problem at all — matches readJsonObject's
+    // actionable-error convention above instead of a bare crash.
+    throw new Error(
+      `Failed to parse Aider config at ${operation.destinationPath}: ${error.message}`,
+      { cause: error },
+    );
+  }
+  fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
+}
+
+function applyMergeMarkdownIndexOperation(operation) {
+  const existingContent = fs.existsSync(operation.destinationPath)
+    ? fs.readFileSync(operation.destinationPath, 'utf8')
+    : null;
+  const nextContent = mergeSkillIndexEntry(existingContent, {
+    name: operation.skillName,
+    description: operation.skillDescription,
+    relativePath: operation.relativePath,
+  });
+  fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
+}
+
+function applyMcpCopyFileOperation(operation, disabledServers) {
+  const sourceConfig = readJsonObject(operation.sourcePath, 'MCP config');
+  const filteredConfig = filterMcpConfig(sourceConfig, disabledServers).config;
+  fs.writeFileSync(operation.destinationPath, formatJson(filteredConfig), 'utf8');
+}
+
 function applyInstallPlan(plan) {
   const resolvedClaudeHooksPlan = buildResolvedClaudeHooks(plan);
   const disabledServers = parseDisabledMcpServers(process.env.EGC_DISABLED_MCPS || process.env.ECC_DISABLED_MCPS);
@@ -149,85 +223,18 @@ function applyInstallPlan(plan) {
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
 
     if (operation.kind === HOOK_OPERATION_KIND) {
-      if (operation.hookEvent === STOP_EVENT) {
-        applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
-      } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
-        applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
-      } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
-        applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
-      } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
-        applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-      } else {
-        applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
-      }
-      continue;
+      applyHookOperation(operation);
+    } else if (operation.kind === 'merge-json') {
+      applyMergeJsonOperation(operation, disabledServers);
+    } else if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
+      applyMergeYamlReadListOperation(operation);
+    } else if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
+      applyMergeMarkdownIndexOperation(operation);
+    } else if (operation.kind === 'copy-file' && isMcpConfigPath(operation.destinationPath) && disabledServers.length > 0) {
+      applyMcpCopyFileOperation(operation, disabledServers);
+    } else {
+      fs.copyFileSync(operation.sourcePath, operation.destinationPath);
     }
-
-    if (operation.kind === 'merge-json') {
-      const payload = cloneJsonValue(operation.mergePayload);
-      if (payload === undefined) {
-        throw new Error(`Missing merge payload for ${operation.destinationPath}`);
-      }
-
-      const filteredPayload = (
-        isMcpConfigPath(operation.destinationPath) && disabledServers.length > 0
-      )
-        ? filterMcpConfig(payload, disabledServers).config
-        : payload;
-
-      const currentValue = fs.existsSync(operation.destinationPath)
-        ? readJsonObject(operation.destinationPath, 'existing JSON config')
-        : {};
-      const mergedValue = deepMergeJson(currentValue, filteredPayload);
-      fs.writeFileSync(operation.destinationPath, formatJson(mergedValue), 'utf8');
-      continue;
-    }
-
-    if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
-      if (!operation.readEntry) {
-        throw new Error(`Missing readEntry for ${operation.destinationPath}`);
-      }
-
-      const existingContent = fs.existsSync(operation.destinationPath)
-        ? fs.readFileSync(operation.destinationPath, 'utf8')
-        : null;
-      let nextContent;
-      try {
-        nextContent = mergeAiderConfigReadList(existingContent, operation.readEntry);
-      } catch (error) {
-        // js-yaml's raw SyntaxError gives no indication of which file or
-        // that it's a YAML problem at all — matches readJsonObject's
-        // actionable-error convention above instead of a bare crash.
-        throw new Error(
-          `Failed to parse Aider config at ${operation.destinationPath}: ${error.message}`,
-          { cause: error },
-        );
-      }
-      fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
-      continue;
-    }
-
-    if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
-      const existingContent = fs.existsSync(operation.destinationPath)
-        ? fs.readFileSync(operation.destinationPath, 'utf8')
-        : null;
-      const nextContent = mergeSkillIndexEntry(existingContent, {
-        name: operation.skillName,
-        description: operation.skillDescription,
-        relativePath: operation.relativePath,
-      });
-      fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
-      continue;
-    }
-
-    if (operation.kind === 'copy-file' && isMcpConfigPath(operation.destinationPath) && disabledServers.length > 0) {
-      const sourceConfig = readJsonObject(operation.sourcePath, 'MCP config');
-      const filteredConfig = filterMcpConfig(sourceConfig, disabledServers).config;
-      fs.writeFileSync(operation.destinationPath, formatJson(filteredConfig), 'utf8');
-      continue;
-    }
-
-    fs.copyFileSync(operation.sourcePath, operation.destinationPath);
   }
 
   if (resolvedClaudeHooksPlan) {


### PR DESCRIPTION
Reduces cognitive complexity of 3 functions (install/apply.js:144 CC42, install-lifecycle.js:251 CC33 and :337 CC22). Authored by the squad agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `scripts/lib/install-lifecycle.js` and `scripts/lib/install/apply.js` to reduce cognitive complexity (S3776) by extracting focused helpers and simplifying branching. Improves readability and testability with no behavior changes.

- **Refactors**
  - Split `deepRemoveJsonSubset` into `removePlainObjectSubset`, `handleNestedPlainObjectRemove`, and `handleNestedArrayRemove`.
  - Modularized repair ops into `repairCopyFile`, `repairMergeJson`, `repairRemove`, `repairMergeYamlReadList`, and `repairMergeMarkdownIndex`, invoked by a single dispatcher.
  - Extracted `applyHookOperation`, `applyMergeJsonOperation`, `applyMergeYamlReadListOperation`, `applyMergeMarkdownIndexOperation`, and `applyMcpCopyFileOperation` used by `applyInstallPlan`.
  - Preserved existing error messages and file I/O behavior.

<sup>Written for commit 22072f6346a5bb9c43310be9a8168c29a9ebf1ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

