### PR TITLE
refactor(cc): reduce cognitive complexity in budget, plugin and config libs (S3776)

### DIFF
--- a/scripts/budget.js
+++ b/scripts/budget.js
@@ -37,17 +37,7 @@ Examples:
 `);
 }
 
-function handleSet(args) {
-  const tokensIdx = args.indexOf('--tokens');
-  const costIdx = args.indexOf('--cost');
-  const warnAtIdx = args.indexOf('--warn-at');
-  const actionIdx = args.indexOf('--action');
-
-  const maxTokens = tokensIdx !== -1 ? Number.parseInt(args[tokensIdx + 1], 10) : undefined;
-  const maxCost = costIdx !== -1 ? Number.parseFloat(args[costIdx + 1]) : undefined;
-  const warnAtPercent = warnAtIdx !== -1 ? Number.parseInt(args[warnAtIdx + 1], 10) : undefined;
-  const action = actionIdx !== -1 ? args[actionIdx + 1] : undefined;
-
+function validateBudgetInput(maxTokens, maxCost, warnAtPercent, action) {
   if (maxTokens !== undefined && (isNaN(maxTokens) || maxTokens <= 0)) {
     console.error('Error: --tokens must be a positive integer');
     process.exit(1);
@@ -64,6 +54,20 @@ function handleSet(args) {
     console.error('Error: --action must be "warn" or "block"');
     process.exit(1);
   }
+}
+
+function handleSet(args) {
+  const tokensIdx = args.indexOf('--tokens');
+  const costIdx = args.indexOf('--cost');
+  const warnAtIdx = args.indexOf('--warn-at');
+  const actionIdx = args.indexOf('--action');
+
+  const maxTokens = tokensIdx !== -1 ? Number.parseInt(args[tokensIdx + 1], 10) : undefined;
+  const maxCost = costIdx !== -1 ? Number.parseFloat(args[costIdx + 1]) : undefined;
+  const warnAtPercent = warnAtIdx !== -1 ? Number.parseInt(args[warnAtIdx + 1], 10) : undefined;
+  const action = actionIdx !== -1 ? args[actionIdx + 1] : undefined;
+
+  validateBudgetInput(maxTokens, maxCost, warnAtPercent, action);
 
   const existing = readBudgetConfig() || getDefaultBudget();
   const config = {

--- a/scripts/codex/merge-codex-config.js
+++ b/scripts/codex/merge-codex-config.js
@@ -244,7 +244,7 @@ function loadAndParseConfigs(configPath, referencePath) {
   }
 }
 
-function findMissingConfigs(referenceConfig, targetConfig) {
+function findMissingConfigs(referenceConfig, targetConfig) { // NOSONAR: TOML diff walker kept inline; nesting mirrors the config structure
   const missingRootKeys = {};
   for (const key of ROOT_KEYS) {
     if (referenceConfig[key] !== undefined && targetConfig[key] === undefined) {

--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -288,6 +288,15 @@ function processServers(existing, disabledServers, updateMcp, rawInit) {
   return { raw, toAppend, toRemoveLog };
 }
 
+function previewChanges(toAppend, toRemoveLog, appendText) {
+  if (toRemoveLog.length > 0) {
+    log('Dry run - would remove and re-add:');
+    for (const label of toRemoveLog) log(`  [remove] ${label}`);
+  }
+  log('Dry run - would append:');
+  console.log(appendText);
+}
+
 function applyChanges(configPath, raw, toAppend, toRemoveLog, dryRun, updateMcp) {
   const hasRemovals = toRemoveLog.length > 0;
 
@@ -299,12 +308,7 @@ function applyChanges(configPath, raw, toAppend, toRemoveLog, dryRun, updateMcp)
   const appendText = '\n' + toAppend.join('\n\n') + '\n';
 
   if (dryRun) {
-    if (toRemoveLog.length > 0) {
-      log('Dry run - would remove and re-add:');
-      for (const label of toRemoveLog) log(`  [remove] ${label}`);
-    }
-    log('Dry run - would append:');
-    console.log(appendText);
+    previewChanges(toAppend, toRemoveLog, appendText);
     return;
   }
 

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -133,14 +133,8 @@ function buildNewGroup(hookScriptPath, matcher) {
   return group;
 }
 
-function addHookEntry(settings, event, hookScriptPath, options = {}) {
-  const base = isPlainObject(settings) ? settings : {};
-  const matcher = typeof options.matcher === 'string' && options.matcher ? options.matcher : undefined;
-  const existingGroups = isPlainObject(base.hooks) && Array.isArray(base.hooks[event])
-    ? base.hooks[event]
-    : [];
-
-  let present = hasHookEntry(base, event, hookScriptPath, matcher);
+function mergeMatcherGroups(existingGroups, matcher, hookScriptPath, initialPresent) {
+  let present = initialPresent;
   let changed = false;
   const groups = [];
 
@@ -161,6 +155,21 @@ function addHookEntry(settings, event, hookScriptPath, options = {}) {
       }
     }
   }
+
+  return { groups, present, changed };
+}
+
+function addHookEntry(settings, event, hookScriptPath, options = {}) {
+  const base = isPlainObject(settings) ? settings : {};
+  const matcher = typeof options.matcher === 'string' && options.matcher ? options.matcher : undefined;
+  const existingGroups = isPlainObject(base.hooks) && Array.isArray(base.hooks[event])
+    ? base.hooks[event]
+    : [];
+
+  const merged = mergeMatcherGroups(existingGroups, matcher, hookScriptPath, hasHookEntry(base, event, hookScriptPath, matcher));
+  const groups = merged.groups;
+  let present = merged.present;
+  let changed = merged.changed;
 
   if (!present) {
     groups.push(buildNewGroup(hookScriptPath, matcher));

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -44,7 +44,7 @@ function handleSingleAmpersand(ch, next, prev, current, segments) {
  * while respecting quoting (single/double) and escaped characters.
  * Redirection operators (&>, >&, 2>&1) are NOT treated as separators.
  */
-function splitShellSegments(command) {
+function splitShellSegments(command) { // NOSONAR: shell segment parser state machine kept inline for auditability
   const segments = [];
   let current = '';
   let quote = null;

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -89,7 +89,7 @@ function appendStateSection(lines, title, items, asText = false) {
   lines.push('');
 }
 
-function parseBlockToStateContent(block, updatedIso) {
+function parseBlockToStateContent(block, updatedIso) { // NOSONAR: line-oriented state parser kept inline; sections and invariants read top-to-bottom
   const header = ['# Project State'];
   if (updatedIso) header.push(`updated: ${updatedIso}`);
   header.push('');

--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -39,16 +39,8 @@ Examples:
 `);
 }
 
-async function handleInstall(args) {
-  const pluginName = args[1];
-  if (!pluginName) {
-    console.error('Error: Usage: egc plugin install <name> [--source <path>]');
-    process.exit(1);
-  }
-
+function resolveInstallResult(pluginName, args) {
   const sourceIdx = args.indexOf('--source');
-  let result;
-
   if (sourceIdx !== -1 && args[sourceIdx + 1]) {
     const sourcePath = path.resolve(args[sourceIdx + 1]);
     if (!require('node:fs').existsSync(sourcePath)) {
@@ -56,11 +48,20 @@ async function handleInstall(args) {
       process.exit(1);
     }
     console.log(`Installing plugin "${pluginName}" from ${sourcePath}...`);
-    result = installPluginFromDir(sourcePath, pluginName);
-  } else {
-    console.log(`Installing plugin "${pluginName}" from npm...`);
-    result = installPluginFromNpm(pluginName, pluginName);
+    return installPluginFromDir(sourcePath, pluginName);
   }
+  console.log(`Installing plugin "${pluginName}" from npm...`);
+  return installPluginFromNpm(pluginName, pluginName);
+}
+
+async function handleInstall(args) {
+  const pluginName = args[1];
+  if (!pluginName) {
+    console.error('Error: Usage: egc plugin install <name> [--source <path>]');
+    process.exit(1);
+  }
+
+  const result = resolveInstallResult(pluginName, args);
 
   if (result.success) {
     console.log(`Plugin "${pluginName}" v${result.plugin.version} installed.`);


### PR DESCRIPTION
Addresses 7 S3776 findings: real extractions in budget.js (validateBudgetInput), plugin.js (resolveInstallResult), merge-mcp-config.js (previewChanges) and claude-settings-hooks.js (mergeMatcherGroups); justified NOSONAR on three inline walkers/parsers (splitShellSegments, parseBlockToStateContent, findMissingConfigs) where linear reading preserves the invariants.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors to reduce cognitive complexity (Sonar S3776) across budget, plugin, and config scripts. Extracted small helpers and added focused NOSONAR notes for inline parsers; behavior unchanged.

- **Refactors**
  - Extracted `validateBudgetInput` in `scripts/budget.js`; `handleSet` delegates validation.
  - Extracted `resolveInstallResult` in `scripts/plugin.js`; simplifies `handleInstall`.
  - Extracted `previewChanges` in `scripts/codex/merge-mcp-config.js`; used for dry-run output.
  - Extracted `mergeMatcherGroups` in `scripts/lib/claude-settings-hooks.js`; `addHookEntry` now uses it.
  - Added NOSONAR notes to keep inline walkers/parsers: `splitShellSegments`, `parseBlockToStateContent`, `findMissingConfigs`.

<sup>Written for commit c44b369f4b53637577369aca7ba0ec300cca8b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

