### PR TITLE
chore(sonar): fix S2187 exclusion pattern for custom test runner

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,4 +7,4 @@
 # do run in CI, so it is ignored for the tests/ tree.
 sonar.issue.ignore.multicriteria=t1
 sonar.issue.ignore.multicriteria.t1.ruleKey=javascript:S2187
-sonar.issue.ignore.multicriteria.t1.resourceKey=tests/**
+sonar.issue.ignore.multicriteria.t1.resourceKey=**/tests/**/*


### PR DESCRIPTION
The `resourceKey=tests/**` pattern did not reliably match leaf test files in SonarCloud's wildcard engine, leaving the 8 S2187 false positives (custom zero-dependency runner) open. Switched to the canonical `**/tests/**/*` pattern that matches the component keys (`tests/<dir>/<file>.test.js`).

No code change; config only. Expected effect: 8 S2187 issues drop off the main scan after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update SonarCloud config to use `**/tests/**/*` for `javascript:S2187` ignores. This correctly matches leaf test files and should remove the 8 false positives from the custom test runner.

<sup>Written for commit 995dd5952363c2ac8a3fc2ae3d008bebdeba6799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

