### PR TITLE
fix(sonar): modernize and clean code smells in scripts/lib

### DIFF
--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -88,7 +88,7 @@ function extractScriptBasename(command) {
   if (!scriptPaths || scriptPaths.length === 0) {
     return null;
   }
-  return path.basename(scriptPaths[scriptPaths.length - 1]);
+  return path.basename(scriptPaths.at(-1));
 }
 
 function isStaleEgcHookEntry(entry, hookScriptPath) {

--- a/scripts/lib/inspection.js
+++ b/scripts/lib/inspection.js
@@ -82,7 +82,7 @@ function detectPatterns(skillRuns, options = {}) {
       (a, b) => (b.createdAt || '').localeCompare(a.createdAt || '')
     );
 
-    const firstSeen = sortedRuns[sortedRuns.length - 1].createdAt || null;
+    const firstSeen = sortedRuns.at(-1).createdAt || null;
     const lastSeen = sortedRuns[0].createdAt || null;
     const sessionIds = [...new Set(sortedRuns.map(r => r.sessionId).filter(Boolean))];
     const versions = [...new Set(sortedRuns.map(r => r.skillVersion).filter(Boolean))];

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -122,7 +122,7 @@ function cloneJsonValue(value) {
     return undefined;
   }
 
-  return JSON.parse(JSON.stringify(value));
+  return structuredClone(value);
 }
 
 function parseJsonLikeValue(value, label) {

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -80,7 +80,7 @@ function dedupeStrings(values) {
 
 function readOptionalStringOption(options, key) {
   if (
-    !Object.prototype.hasOwnProperty.call(options, key)
+    !Object.hasOwn(options, key)
     || options[key] === null
     || options[key] === undefined
   ) {

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -20,7 +20,7 @@ function cloneJsonValue(value) {
     return undefined;
   }
 
-  return JSON.parse(JSON.stringify(value));
+  return structuredClone(value);
 }
 
 function readJson(filePath, label) {

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -326,7 +326,8 @@ function planFlatSkillOperation(adapter, moduleId, sourceRelativePath, planningI
  * assigned directly (e.g. `planOperations: createFlatSkillPlanOperations`)
  * without a wrapper closure in each adapter file.
  */
-function createFlatSkillPlanOperations(input = {}, adapter) {
+function createFlatSkillPlanOperations(rawInput, adapter) {
+  const input = rawInput ?? {};
   let modules;
   if (Array.isArray(input.modules)) {
     modules = input.modules;

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -52,7 +52,7 @@ function cloneJsonValue(value) {
     return undefined;
   }
 
-  return JSON.parse(JSON.stringify(value));
+  return structuredClone(value);
 }
 
 function isPlainObject(value) {

--- a/scripts/lib/resolve-egc-root.js
+++ b/scripts/lib/resolve-egc-root.js
@@ -129,6 +129,6 @@ const INLINE_RESOLVE = '(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC
 
 module.exports = {
   resolveEGCRoot,
-  resolveEccRoot,
+  resolveEccRoot, // NOSONAR: deprecated ECC-era alias kept as a public export for backward compatibility
   INLINE_RESOLVE,
 };

--- a/scripts/lib/session-adapters/registry.js
+++ b/scripts/lib/session-adapters/registry.js
@@ -21,7 +21,7 @@ function buildDefaultAdapterOptions(options, adapterId) {
 
   return {
     ...sharedOptions,
-    ...(options.adapterOptions?.[adapterId] ?? {})
+    ...options.adapterOptions?.[adapterId]
   };
 }
 

--- a/scripts/lib/skill-evolution/tracker.js
+++ b/scripts/lib/skill-evolution/tracker.js
@@ -22,7 +22,7 @@ function getRunsFilePath(options = {}) {
 }
 
 function toNullableNumber(value, fieldName) {
-  if (value === null || typeof value === 'undefined') {
+  if (value === null || value === undefined) {
     return null;
   }
 

--- a/scripts/lib/state-consolidate.js
+++ b/scripts/lib/state-consolidate.js
@@ -154,7 +154,7 @@ function parseStateDocument(content) {
     current.lines.push(line);
   }
 
-  while (header.length > 0 && header[header.length - 1].trim() === '') {
+  while (header.length > 0 && header.at(-1).trim() === '') {
     header.pop();
   }
 

--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -27,7 +27,8 @@ function renderTemplate(template, variables) {
 }
 
 function shellQuote(value) {
-  return `'${String(value).replaceAll("'", String.raw`'\''`)}'`;
+  const escaped = String(value).replaceAll("'", String.raw`'\''`);
+  return `'${escaped}'`;
 }
 
 function formatCommand(program, args) {

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -767,7 +767,7 @@ module.exports = {
   // Directories
   getHomeDir,
   getEGCDir,
-  getClaudeDir,
+  getClaudeDir, // NOSONAR: deprecated alias kept as a public export for backward compatibility
   getSessionsDir,
   getLegacySessionsDir,
   getSessionSearchDirs,

--- a/scripts/lib/warp-agents-merge.js
+++ b/scripts/lib/warp-agents-merge.js
@@ -89,7 +89,7 @@ function mergeSkillIndexEntry(existingContent, entry) {
 // be empty. See module comment above for why.
 function removeSkillIndexEntry(existingContent, name) {
   if (!existingContent) {
-    return existingContent || '';
+    return '';
   }
 
   const lines = existingContent.split('\n');

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -221,7 +221,7 @@ class StateWatcher {
   }
 
   _reattach(tool, filePath, oldWatcher) {
-    if (oldWatcher) { try { oldWatcher.close(); } catch (e) { void e; } }
+    if (oldWatcher) { try { oldWatcher.close(); } catch { /* watcher already closed */ } }
     this._watchers.delete(tool);
     this._watchFile(tool, filePath);
     this._schedule(tool, filePath);
@@ -240,8 +240,8 @@ class StateWatcher {
       // Windows emits 'error' (EPERM) instead of 'rename' on atomic file replacement
       watcher.on('error', () => setTimeout(() => this._reattach(tool, filePath, null), 150));
       this._watchers.set(tool, watcher);
-    } catch (e) {
-      void e; // File may have been deleted -- skip silently
+    } catch {
+      // File may have been deleted -- skip silently
     }
   }
 


### PR DESCRIPTION
Batch of low-risk fixes in `scripts/lib/`, no behavior change:

- **S7755 x3**: `Array.prototype.at(-1)` over `arr[arr.length-1]`.
- **S7784 x3**: `structuredClone()` over `JSON.parse(JSON.stringify())` (inputs are JSON-safe config).
- **S3735 x2**: optional catch binding over `void e`.
- **S6653**: `Object.hasOwn()`. **S7741**: `=== undefined`.
- **S1788**: keep the fixed `(input, adapter)` contract, normalize via const.
- **S2589**: return `''` directly in the falsy branch.
- **S4624**: extract nested template literal. **S7744**: drop useless `?? {}`.
- **S1874 x2**: NOSONAR on deprecated compat aliases (resolveEccRoot, getClaudeDir).

Local suite: 2796 pass, 2 pre-existing failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernizes `scripts/lib` to resolve Sonar code smells without changing behavior. Replaces legacy patterns with built-in APIs and simplifies small utilities.

- **Refactors**
  - Adopt modern APIs: `Array.prototype.at(-1)`, `structuredClone()`, `Object.hasOwn()`, and strict `=== undefined` checks.
  - Simplify error handling with optional catch binding (drop unused error vars).
  - Preserve adapter contract by normalizing input in `createFlatSkillPlanOperations`.
  - Minor cleanups: return `''` directly, extract `shellQuote` interpolation, remove redundant `?? {}` before spread, and add NOSONAR notes for deprecated exports.

<sup>Written for commit 76956f9dd196b238ae2b67489e4408dd93d8e026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

