### PR TITLE
fix(sonar): clean code smells in scripts root, ci and codex

### DIFF
--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -82,7 +82,7 @@ function deriveRepoRootFromState(state) {
       continue;
     }
     let repoRoot = path.resolve(operation.sourcePath);
-    for (let index = 0; index < relativeParts.length; index += 1) {
+    for (const _segment of relativeParts) {
       repoRoot = path.dirname(repoRoot);
     }
     return repoRoot;

--- a/scripts/budget.js
+++ b/scripts/budget.js
@@ -38,15 +38,15 @@ Examples:
 }
 
 function validateBudgetInput(maxTokens, maxCost, warnAtPercent, action) {
-  if (maxTokens !== undefined && (isNaN(maxTokens) || maxTokens <= 0)) {
+  if (maxTokens !== undefined && (Number.isNaN(maxTokens) || maxTokens <= 0)) {
     console.error('Error: --tokens must be a positive integer');
     process.exit(1);
   }
-  if (maxCost !== undefined && (isNaN(maxCost) || maxCost <= 0)) {
+  if (maxCost !== undefined && (Number.isNaN(maxCost) || maxCost <= 0)) {
     console.error('Error: --cost must be a positive number');
     process.exit(1);
   }
-  if (warnAtPercent !== undefined && (isNaN(warnAtPercent) || warnAtPercent < 1 || warnAtPercent > 100)) {
+  if (warnAtPercent !== undefined && (Number.isNaN(warnAtPercent) || warnAtPercent < 1 || warnAtPercent > 100)) {
     console.error('Error: --warn-at must be between 1 and 100');
     process.exit(1);
   }

--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -67,8 +67,9 @@ function parseArgs(argv) {
 
   parsed.command = args[0];
 
-  for (let index = 1; index < args.length; index += 1) {
-    index = processArg(args, index, parsed);
+  let index = 1;
+  while (index < args.length) {
+    index = processArg(args, index, parsed) + 1;
   }
 
   return parsed;

--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -156,7 +156,7 @@ function removeSectionFromText(text, sectionHeader) {
       skipping = true;
       continue;
     }
-    if (skipping && /^\[/.test(trimmed)) {
+    if (skipping && trimmed.startsWith('[')) {
       skipping = false;
     }
     if (!skipping) {

--- a/scripts/e2e-team-sync-direct.js
+++ b/scripts/e2e-team-sync-direct.js
@@ -20,7 +20,7 @@ const TEAMJSON = path.join(EGCDIR, 'team.json');
 function resolveGitBin() {
   const lookupCmd = process.platform === 'win32' ? 'where' : 'which';
   const output = execFileSync(lookupCmd, ['git'], { encoding: 'utf-8', stdio: 'pipe' });
-  const gitPath = output.split('\n').map(s => s.trim()).filter(Boolean)[0];
+  const gitPath = output.split('\n').map(s => s.trim()).find(Boolean);
   if (!gitPath || !path.isAbsolute(gitPath)) {
     throw new Error(`git executable not found at an absolute path (got: ${gitPath || 'none'})`);
   }

--- a/scripts/e2e-team-sync.js
+++ b/scripts/e2e-team-sync.js
@@ -12,7 +12,7 @@ const PROC_OPTS = { stdio: 'pipe', encoding: 'utf-8' };
 
 function run(file, args = [], opts = {}) {
   console.log(`  $ ${file} ${args.join(' ')}`);
-  return execFileSync(file, args, Object.assign({}, PROC_OPTS, opts));
+  return execFileSync(file, args, { ...PROC_OPTS, ...opts });
 }
 
 function runIn(dir, file, args = []) {

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -67,8 +67,9 @@ function parseArgs(argv) {
     root: path.resolve(process.env.AUDIT_ROOT || process.cwd()),
   };
 
-  for (let index = 0; index < args.length; index += 1) {
-    index = processSingleArg(args[index], index, args, parsed);
+  let index = 0;
+  while (index < args.length) {
+    index = processSingleArg(args[index], index, args, parsed) + 1;
   }
 
   if (!['text', 'json'].includes(parsed.format)) {
@@ -630,7 +631,7 @@ function buildReport(scope, options = {}) {
 
   const failedChecks = checks.filter(check => !check.pass);
   const topActions = failedChecks
-    .sort((left, right) => right.points - left.points)
+    .toSorted((left, right) => right.points - left.points)
     .slice(0, 3)
     .map(check => ({
       action: check.fix,

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -153,7 +153,11 @@ function getNow(options = {}) {
   return now;
 }
 
-function walkJsonlFiles(dir, result = { errors: [], files: [] }) {
+function createWalkResult() {
+  return { errors: [], files: [] };
+}
+
+function walkJsonlFiles(dir, result = createWalkResult()) {
   if (!fs.existsSync(dir)) {
     return result;
   }
@@ -215,7 +219,7 @@ function findTranscriptPaths(options = {}) {
   return {
     errors,
     transcriptPaths: transcriptEntries
-    .sort((left, right) => right.mtimeMs - left.mtimeMs)
+    .toSorted((left, right) => right.mtimeMs - left.mtimeMs)
     .slice(0, normalizedOptions.limit)
     .map(entry => entry.transcriptPath),
   };

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -17,7 +17,7 @@ function resolveGitBin() {
   } catch (err) {
     throw new Error(`git executable not found. Install git and ensure it is on PATH. ${err.message}`, { cause: err });
   }
-  const gitPath = output.split('\n').map(s => s.trim()).filter(Boolean)[0];
+  const gitPath = output.split('\n').map(s => s.trim()).find(Boolean);
   if (!gitPath || !path.isAbsolute(gitPath)) {
     throw new Error(`git executable not found at an absolute path (got: ${gitPath || 'none'})`);
   }


### PR DESCRIPTION
Batch of low-risk fixes in `scripts/` (root, ci, codex), no behavior change:

- **S7773 x3**: `Number.isNaN` (values already numeric via parseInt).
- **S7750 x2**: `Array.find(Boolean)` over `filter(Boolean)[0]`.
- **S6661**: object spread. **S6557**: `String.startsWith('[')`.
- **S2310 x2**: `while` loop for arg parsing instead of reassigning a `for` counter.
- **S4043 x2**: `toSorted()` to avoid mutating arrays before slice.
- **S4138**: `for-of`. **S7737**: factory default for walkJsonlFiles result.

Local suite: 2796 pass, 2 pre-existing failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up Sonar code smells across `scripts/` (root, ci, codex) with small refactors only. No behavior changes; improves clarity and avoids accidental mutations.

- **Refactors**
  - Use Number.isNaN for numeric checks.
  - Prefer Array.find(Boolean) over filter(Boolean)[0] for first truthy match.
  - Replace Object.assign with object spread for options merging.
  - Use for-of and while-based arg parsing instead of index-manipulating loops.
  - Avoid mutations with toSorted before slice; use startsWith('[') instead of regex; add a factory default for walkJsonlFiles results.

<sup>Written for commit 25f09c7a63a07de1a2beeec31a1bb257eaca7dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

