### PR TITLE
fix(sonar): resolve remaining findings in scripts/hooks and tests

### DIFF
--- a/scripts/hooks/design-quality-check.js
+++ b/scripts/hooks/design-quality-check.js
@@ -18,7 +18,7 @@ const MAX_STDIN = 1024 * 1024;
 const GENERIC_SIGNALS = [
   { pattern: /\bget started\b/i, label: '"Get Started" CTA copy' },
   { pattern: /\blearn more\b/i, label: '"Learn more" CTA copy' },
-  { pattern: /\bgrid-cols-(3|4)\b/, label: 'uniform multi-card grid' },
+  { pattern: /\bgrid-cols-[34]\b/, label: 'uniform multi-card grid' },
   { pattern: /\bbg-gradient-to-[trbl]/, label: 'stock gradient utility usage' },
   { pattern: /\btext-center\b/, label: 'centered default layout cues' },
   { pattern: /\bfont-(sans|inter)\b/i, label: 'default font utility' },

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -44,7 +44,24 @@ const EDIT_WRITE_HOOK_ID = 'pre:edit-write:gateguard-fact-force';
 const BASH_HOOK_ID = 'pre:bash:gateguard-fact-force';
 const EGC_DISABLE_VALUES = new Set(['0', 'false', 'off', 'disabled', 'disable']);
 
-const DESTRUCTIVE_BASH = /\b(rm\s+-rf|git\s+reset\s+--hard|git\s+checkout\s+--|git\s+clean\s+-f|drop\s+table|delete\s+from|truncate|git\s+push\s+--force(?!-with-lease)|git\s+commit\s+--amend|dd\s+if=)\b/i;
+// One pattern per destructive command; each keeps the same word boundaries
+// the former single alternation applied around the matched command.
+const DESTRUCTIVE_BASH_PATTERNS = [
+  /\brm\s+-rf\b/i,
+  /\bgit\s+reset\s+--hard\b/i,
+  /\bgit\s+checkout\s+--\b/i,
+  /\bgit\s+clean\s+-f\b/i,
+  /\bdrop\s+table\b/i,
+  /\bdelete\s+from\b/i,
+  /\btruncate\b/i,
+  /\bgit\s+push\s+--force(?!-with-lease)\b/i,
+  /\bgit\s+commit\s+--amend\b/i,
+  /\bdd\s+if=\b/i,
+];
+
+function isDestructiveBash(command) {
+  return DESTRUCTIVE_BASH_PATTERNS.some((pattern) => pattern.test(command));
+}
 
 // --- State management (per-session, atomic writes, bounded) ---
 
@@ -504,7 +521,7 @@ function handleBash(rawInput, toolName, toolInput) {
     return rawInput;
   }
 
-  if (DESTRUCTIVE_BASH.test(command)) {
+  if (isDestructiveBash(command)) {
     const key = '__destructive__' + crypto.createHash('sha256').update(command).digest('hex').slice(0, 16);
     if (!isChecked(key)) {
       if (!markChecked(key)) {

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -346,7 +346,7 @@ function scheduleGraceTimer(timeoutMs, child, serverName, ps) {
 
 function probeCommandServer(serverName, config) {
   return new Promise(resolve => {
-    const args = Array.isArray(config.args) ? config.args.map(arg => String(arg)) : [];
+    const args = Array.isArray(config.args) ? config.args.map(String) : [];
     const timeoutMs = envNumber('EGC_MCP_HEALTH_TIMEOUT_MS', DEFAULT_TIMEOUT_MS);
     const mergedEnv = { ...process.env, ...(isValidEnvObject(config.env) ? config.env : {}) };
     const ps = createProbeState(resolve);

--- a/scripts/hooks/quality-gate.js
+++ b/scripts/hooks/quality-gate.js
@@ -90,25 +90,29 @@ function runPrettier(filePath, projectRoot, fix, strict) {
 }
 
 /**
- * Run gofmt on a .go file.
+ * Format a .go file in place with gofmt.
  *
  * @param {string} filePath - Absolute path to the file
- * @param {boolean} fix - Whether to auto-fix
  * @param {boolean} strict - Whether to log failures
  */
-function runGoFmt(filePath, fix, strict) {
-  if (fix) {
-    const r = exec('gofmt', ['-w', filePath]);
-    if (r.status !== 0 && strict) {
-      log(`[QualityGate] gofmt failed for ${filePath}`);
-    }
-  } else if (strict) {
-    const r = exec('gofmt', ['-l', filePath]);
-    if (r.status !== 0) {
-      log(`[QualityGate] gofmt failed for ${filePath}`);
-    } else if (r.stdout?.trim()) {
-      log(`[QualityGate] gofmt check failed for ${filePath}`);
-    }
+function formatGoFile(filePath, strict) {
+  const r = exec('gofmt', ['-w', filePath]);
+  if (r.status !== 0 && strict) {
+    log(`[QualityGate] gofmt failed for ${filePath}`);
+  }
+}
+
+/**
+ * Check a .go file with gofmt without modifying it.
+ *
+ * @param {string} filePath - Absolute path to the file
+ */
+function checkGoFile(filePath) {
+  const r = exec('gofmt', ['-l', filePath]);
+  if (r.status !== 0) {
+    log(`[QualityGate] gofmt failed for ${filePath}`);
+  } else if (r.stdout?.trim()) {
+    log(`[QualityGate] gofmt check failed for ${filePath}`);
   }
 }
 
@@ -166,7 +170,11 @@ function maybeRunQualityGate(filePath) {
   }
 
   if (ext === '.go') {
-    runGoFmt(filePath, fix, strict);
+    if (fix) {
+      formatGoFile(filePath, strict);
+    } else if (strict) {
+      checkGoFile(filePath);
+    }
     return;
   }
 

--- a/scripts/hooks/session-end-marker.js
+++ b/scripts/hooks/session-end-marker.js
@@ -18,8 +18,7 @@ function log(message) {
   process.stderr.write(`[SessionEnd] ${message}\n`);
 }
 
-function run(rawInput) {
-  const output = rawInput || '';
+function run(output = '') {
   const sessionId = resolveSessionId();
 
   if (!sessionId) {

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -227,7 +227,7 @@ function injectSummaryIntoContent(updatedContent, summary) {
   }
   // Migration path for files created before summary markers existed.
   return updatedContent.replace(
-    /## (?:Session Summary|Current State)[\s\S]*?$/,
+    /## (?:Session Summary|Current State)[\s\S]*$/,
     `${summaryBlock}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\`\n`
   );
 }

--- a/scripts/hooks/session-start-bootstrap.js
+++ b/scripts/hooks/session-start-bootstrap.js
@@ -69,19 +69,26 @@ function hasRunnerRoot(candidate) {
  *
  * @returns {string}
  */
+function findRunnerRootInCacheBase(cacheBase) {
+  for (const org of fs.readdirSync(cacheBase, { withFileTypes: true })) {
+    if (!org.isDirectory()) continue;
+    for (const version of fs.readdirSync(path.join(cacheBase, org.name), { withFileTypes: true })) {
+      if (!version.isDirectory()) continue;
+      const candidate = path.join(cacheBase, org.name, version.name);
+      if (hasRunnerRoot(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
 function resolveFromCache(claudeDir) {
   try {
     for (const slug of CACHE_PLUGIN_SLUGS) {
-      const cacheBase = path.join(claudeDir, 'plugins', 'cache', slug);
-      for (const org of fs.readdirSync(cacheBase, { withFileTypes: true })) {
-        if (!org.isDirectory()) continue;
-        for (const version of fs.readdirSync(path.join(cacheBase, org.name), { withFileTypes: true })) {
-          if (!version.isDirectory()) continue;
-          const candidate = path.join(cacheBase, org.name, version.name);
-          if (hasRunnerRoot(candidate)) {
-            return candidate;
-          }
-        }
+      const found = findRunnerRootInCacheBase(path.join(claudeDir, 'plugins', 'cache', slug));
+      if (found) {
+        return found;
       }
     }
   } catch {

--- a/tests/lib/session-manager.test.js
+++ b/tests/lib/session-manager.test.js
@@ -1113,11 +1113,9 @@ src/main.ts
   if (test('handles old-format filename without session ID', () => {
     // The regex match[2] is undefined for old format → shortId defaults to 'no-id'
     const result = sessionManager.parseSessionFilename('2026-02-13-session.tmp');
-    if (result) {
-      assert.strictEqual(result.shortId, 'no-id', 'Should default to no-id');
-    }
     // Either null (regex doesn't match) or has no-id: both are acceptable
-    assert.ok(true, 'Old format handled without crash');
+    assert.ok(result === null || result.shortId === 'no-id',
+      'Old format yields null or a no-id shortId');
   })) passed++; else failed++;
 
   // ── Round 33: birthtime / createdTime fallback ──
@@ -2031,7 +2029,6 @@ file.ts
   if (test('appendSessionContent returns false when file is read-only (EACCES)', () => {
     if (process.platform === 'win32') {
       // chmod doesn't work reliably on Windows: skip
-      assert.ok(true, 'Skipped on Windows');
       return;
     }
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'r112-readonly-'));


### PR DESCRIPTION
Companion batch to #836 for the SonarCloud zero-issues campaign: the remaining findings in `scripts/hooks/` plus the two always-true test assertions. No behavior change.

- **S5843**: the `DESTRUCTIVE_BASH` regex in `gateguard-fact-force.js` (complexity 39) becomes one pattern per destructive command, each keeping the exact word boundaries the single alternation applied, matched via `Array#some`. Same commands blocked, same edge behavior.
- **S3776**: extract `findRunnerRootInCacheBase` from `resolveFromCache` in `session-start-bootstrap.js` (cognitive complexity 18 -> under 15). The `try` still wraps the whole slug loop, so a missing cache base aborts the remaining slugs exactly as before.
- **S2301**: `runGoFmt(filePath, fix, strict)` used a boolean selector to pick between two unrelated code paths. Split into `formatGoFile` and `checkGoFile`; the extension dispatcher branches at the call site with the same fix/strict semantics.
- **S6019**: `[\s\S]*?$` -> `[\s\S]*$` in the session-end migration regex (reluctant quantifier before the end anchor).
- **S6035**: `(3|4)` -> `[34]` in `design-quality-check.js`.
- **S7760**: `function run(rawInput) { const output = rawInput || ''; }` -> `function run(output = '')` in `session-end-marker.js`.
- **S7770**: `args.map(arg => String(arg))` -> `args.map(String)` in `mcp-health-check.js`.
- **S5914 x2** in `tests/lib/session-manager.test.js`: the old-format filename test now asserts the documented disjunction (`result === null || result.shortId === 'no-id'`) instead of `assert.ok(true)`; the Windows skip path returns without a fake assertion.

Validation: `node --check` on all touched files; full test suite A/B against main baseline is identical (137 known environment-only failures in the sandbox clone, zero new - including the session-end and session-manager suites covering the regex and assertion changes).

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve remaining SonarCloud findings across `scripts/hooks` and tests. Improves readability and maintainability without changing behavior.

- **Refactors**
  - Split destructive command detection in `gateguard-fact-force.js` into per-command regexes checked with `some()`.
  - Extract `findRunnerRootInCacheBase()` in `session-start-bootstrap.js` to reduce cognitive complexity.
  - Replace `runGoFmt()` with `formatGoFile()` and `checkGoFile()`; dispatcher branches on `fix`/`strict`.
  - Tighten regexes: session-end migration end anchor and `grid-cols-[34]`.
  - Use a default parameter in `session-end-marker.js` instead of `rawInput || ''`.
  - Simplify arg mapping to `config.args.map(String)` in `mcp-health-check.js`.
  - Replace always-true assertions in `session-manager.test.js` with real checks and a clean Windows skip.

<sup>Written for commit 16eb67111212202cdc45ab7b78ee021e6f1e9b09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

