### PR TITLE
fix(sonar): resolve S107 and S5843 in scripts/ci

### DIFF
--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -81,11 +81,10 @@ function deriveRepoRootFromState(state) {
     if (relativeParts.length === 0) {
       continue;
     }
-    let repoRoot = path.resolve(operation.sourcePath);
-    for (const _segment of relativeParts) {
-      repoRoot = path.dirname(repoRoot);
-    }
-    return repoRoot;
+    return relativeParts.reduce(
+      (dir) => path.dirname(dir),
+      path.resolve(operation.sourcePath)
+    );
   }
 
   throw new Error('Unable to infer EGC repo root from install-state operations');

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -364,8 +364,10 @@ function syncEnglishAgents(content, catalog) {
   nextContent = replaceOrThrow(
     nextContent,
     /(providing\s+)(\d+)(\s+specialized agents,\s+)(\d+)(\+?)(\s+skills,\s+)(\d+)(\s+commands)/i,
-    (_, prefix, __, agentsSuffix, ___, skillsPlus, skillsSuffix, ____, commandsSuffix) =>
-      `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsPlus}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`,
+    (...args) => {
+      const [, prefix, , agentsSuffix, , skillsPlus, skillsSuffix, , commandsSuffix] = args;
+      return `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsPlus}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`;
+    },
     'AGENTS.md summary'
   );
   nextContent = replaceOrThrow(
@@ -394,8 +396,10 @@ function syncZhRootReadme(content, catalog) {
   return replaceOrThrow(
     content,
     /(你现在可以使用\s+)(\d+)(\s+个代理、\s*)(\d+)(\s*个技能和\s*)(\d+)(\s*个命令[。.!！]?)/i,
-    (_, prefix, __, agentsSuffix, ___, skillsSuffix, ____, commandsSuffix) =>
-      `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`,
+    (...args) => {
+      const [, prefix, , agentsSuffix, , skillsSuffix, , commandsSuffix] = args;
+      return `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`;
+    },
     'README.zh-CN.md quick-start summary'
   );
 }
@@ -406,8 +410,10 @@ function syncZhDocsReadme(content, catalog) {
   nextContent = replaceOrThrow(
     nextContent,
     /(你现在可以使用\s+)(\d+)(\s+个智能体、\s*)(\d+)(\s*项技能和\s*)(\d+)(\s*个命令了[。.!！]?)/i,
-    (_, prefix, __, agentsSuffix, ___, skillsSuffix, ____, commandsSuffix) =>
-      `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`,
+    (...args) => {
+      const [, prefix, , agentsSuffix, , skillsSuffix, , commandsSuffix] = args;
+      return `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`;
+    },
     'README.zh-CN.md quick-start summary'
   );
   nextContent = replaceOrThrow(
@@ -437,8 +443,10 @@ function syncZhAgents(content, catalog) {
   nextContent = replaceOrThrow(
     nextContent,
     /(提供\s+)(\d+)(\s+个专业代理、\s*)(\d+)(\+?)(\s*项技能、\s*)(\d+)(\s+条命令)/i,
-    (_, prefix, __, agentsSuffix, ___, skillsPlus, skillsSuffix, ____, commandsSuffix) =>
-      `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsPlus}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`,
+    (...args) => {
+      const [, prefix, , agentsSuffix, , skillsPlus, skillsSuffix, , commandsSuffix] = args;
+      return `${prefix}${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsPlus}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`;
+    },
     'docs/zh-CN/AGENTS.md summary'
   );
   nextContent = replaceOrThrow(

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -14,13 +14,18 @@ const RULES = [
     event: 'workflow_run',
     eventPattern: /\bworkflow_run\s*:/m,
     description: 'workflow_run must not checkout an untrusted workflow_run head ref/repository',
-    expressionPattern: /\$\{\{\s*github\.event\.workflow_run\.(?:head_branch|head_sha|head_repository(?:\.[A-Za-z0-9_.]+)?)\s*\}\}|\$\{\{\s*github\.event\.workflow_run\.pull_requests\[\d+\]\.head\.(?:ref|sha|repo\.full_name)\s*\}\}/g,
+    expressionPatterns: [
+      /\$\{\{\s*github\.event\.workflow_run\.(?:head_branch|head_sha|head_repository(?:\.[A-Za-z0-9_.]+)?)\s*\}\}/g,
+      /\$\{\{\s*github\.event\.workflow_run\.pull_requests\[\d+\]\.head\.(?:ref|sha|repo\.full_name)\s*\}\}/g,
+    ],
   },
   {
     event: 'pull_request_target',
     eventPattern: /\bpull_request_target\s*:/m,
     description: 'pull_request_target must not checkout an untrusted pull_request head ref/repository',
-    expressionPattern: /\$\{\{\s*github\.event\.pull_request\.head\.(?:ref|sha|repo\.full_name)\s*\}\}/g,
+    expressionPatterns: [
+      /\$\{\{\s*github\.event\.pull_request\.head\.(?:ref|sha|repo\.full_name)\s*\}\}/g,
+    ],
   },
 ];
 
@@ -88,7 +93,11 @@ function findViolations(filePath, source) {
     }
 
     for (const step of checkoutSteps) {
-      for (const match of step.text.matchAll(rule.expressionPattern)) {
+      // Scan each pattern, then sort by match position so the report keeps
+      // the same document order the former single alternation produced.
+      const matches = rule.expressionPatterns.flatMap(pattern => [...step.text.matchAll(pattern)]);
+      matches.sort((a, b) => a.index - b.index);
+      for (const match of matches) {
         violations.push({
           filePath,
           event: rule.event,


### PR DESCRIPTION
Last unclaimed batch of the SonarCloud zero-issues campaign: `scripts/ci/`. No behavior change.

- **S107 x4**: the four `replaceOrThrow` replacer arrows in `catalog.js` received 8-9 positional capture-group parameters. They now take `(...args)` and destructure the groups by position with the same names, so each replacement string is unchanged character for character.
- **S5843**: the `workflow_run` expression regex in `validate-workflow-security.js` was a double alternation with complexity 25. It becomes an `expressionPatterns` array (one regex per source shape, complexity under 20 each); per checkout step the matches from both patterns are collected and re-sorted by match position, so reported violations keep the exact former document order. The `pull_request_target` rule moves to the same array shape for consistency.

Validation: `node --check` on both files; dedicated `tests/ci/validate-workflow-security.test.js` 4/4 green (it exercises the script as a black box via spawnSync); full test suite A/B against main baseline identical (137 known environment-only failures, zero new).

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve SonarCloud rules S107, S5843, and S1481 with no behavior change. Reduces parameters in replacers, splits a complex regex to keep report order, and removes an unused loop variable.

- **Refactors**
  - In `scripts/ci/catalog.js`, changed four `replaceOrThrow` replacers to use `(...args)` with positional destructuring so replacements stay identical.
  - In `scripts/ci/validate-workflow-security.js`, split the `workflow_run` expression into an `expressionPatterns` array and sort matches by index to keep output order; applied the same shape to `pull_request_target`.
  - In `scripts/auto-update.js`, replaced the for-of loop with `reduce` to apply `path.dirname` per segment and remove the unused `_segment` variable; output is unchanged.

<sup>Written for commit 19b61c663150f044bf608521706e30e3a7eaab9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

