### PR TITLE
fix(sonar): remove unused loop variable in auto-update (S1481)

### DIFF
--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -81,10 +81,10 @@ function deriveRepoRootFromState(state) {
     if (relativeParts.length === 0) {
       continue;
     }
-    let repoRoot = path.resolve(operation.sourcePath);
-    for (const _segment of relativeParts) {
-      repoRoot = path.dirname(repoRoot);
-    }
+    const repoRoot = relativeParts.reduce(
+      (current) => path.dirname(current),
+      path.resolve(operation.sourcePath)
+    );
     return repoRoot;
   }
 


### PR DESCRIPTION
Follow-up to the S4138 fix in #837: the `for (const _segment of relativeParts)` left an unused binding (S1481). Replaced with `Array.reduce` over the path segments, applying `path.dirname` once per segment. Resolves both S4138 and S1481 with no unused variable.

Local suite: 2796 pass, 2 pre-existing failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the for-of loop in `scripts/auto-update.js` with a `reduce` to remove the unused loop variable. This applies `path.dirname` once per segment and resolves Sonar rules S1481 and S4138 with no behavior change.

<sup>Written for commit 147ea308d79d569afb42164a2834d5b2fa615e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

