### PR TITLE
chore(sonar): stop declaring tests/ as Sonar test sources

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,6 +1,9 @@
 sonar.sources=src,mcp/servers,scripts
-sonar.tests=tests
+# tests/ is intentionally not declared as test sources: the custom
+# zero-dependency runner (tests/run-all.js) uses plain named functions that
+# SonarJS cannot recognize as test cases, so every *.test.js file was
+# flagged by S2187 ("add some tests to this file") as a false positive.
+# These tests run in CI on every push; CI remains their quality gate.
 sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,**/*.tgz,**/legacy-command-shims/**
-sonar.test.inclusions=tests/**/*.js,tests/**/*.ts
 sonar.sourceEncoding=UTF-8
 sonar.cpd.exclusions=scripts/lib/branch-state.js,mcp/servers/egc-memory/src/branch-state.ts,mcp/servers/egc-guardian/src/catalog-index.ts


### PR DESCRIPTION
Closes the last eight code-quality findings of the zero-issues campaign.

SonarCloud **Automatic Analysis reads `.sonarcloud.properties`** and ignores `sonar-project.properties` (which only applies to CI-based analysis; kept in the repo for a future migration). The existing file declared `sonar.tests=tests`, so SonarJS analyzed every `*.test.js` as a test file and flagged all eight with **S2187** ("add some tests to this file"): the custom zero-dependency runner (`tests/run-all.js`) drives plain named functions that SonarJS cannot recognize as test cases, so the rule can never pass on this repository.

`tests/` was already absent from `sonar.sources`; dropping the test-source declaration (and its `sonar.test.inclusions`) removes the eight false positives at the next analysis. The full suite still runs in CI on every push, which remains the actual quality gate for test code. `sonar.cpd.exclusions` and the main-source scope are unchanged.

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating `tests/` as Sonar test sources in `.sonarcloud.properties` to remove eight S2187 false positives from SonarCloud Automatic Analysis. CI continues to run the full test suite; source and CPD scopes are unchanged.

- **Bug Fixes**
  - Removed `sonar.tests` and `sonar.test.inclusions` from `.sonarcloud.properties`.
  - Rationale: the custom runner (`tests/run-all.js`) uses plain named functions that SonarJS cannot detect as test cases, causing false positives.

<sup>Written for commit 425bdef5d20d14318e08e579c5d48a3cd192a3d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

