### PR TITLE
refactor(sonar): resolve the final three findings (S3776 x2, S107)

### DIFF
--- a/scripts/codex/merge-mcp-config.js
+++ b/scripts/codex/merge-mcp-config.js
@@ -241,7 +241,7 @@ function processDisabledServer(name, resolved, raw, existing, toRemoveLog) {
   return updatedRaw;
 }
 
-function processExistingServer(name, spec, resolved, updateMcp, raw, existing, toRemoveLog, toAppend) {
+function processExistingServer({ name, spec, resolved, updateMcp, raw, existing, toRemoveLog, toAppend }) {
   let updatedRaw = raw;
   if (updateMcp) {
     toRemoveLog.push(`mcp_servers.${resolved.resolvedLabel}`);
@@ -278,7 +278,7 @@ function processServers(existing, disabledServers, updateMcp, rawInit) {
     }
 
     if (resolved.finalEntry) {
-      raw = processExistingServer(name, spec, resolved, updateMcp, raw, existing, toRemoveLog, toAppend);
+      raw = processExistingServer({ name, spec, resolved, updateMcp, raw, existing, toRemoveLog, toAppend });
     } else {
       log(`  [add] mcp_servers.${name}`);
       toAppend.push(spec.toml);

--- a/scripts/e2e-team-sync-direct.js
+++ b/scripts/e2e-team-sync-direct.js
@@ -127,6 +127,25 @@ function verifyBuildOutput(EGC_ROOT, SyncBackend) {
   ok(buildIndex.includes('teamStatus'), 'build/index.js references teamStatus');
 }
 
+function cleanSandboxState() {
+  if (fs.existsSync(SYNCDIR)) fs.rmSync(SYNCDIR, { recursive: true, force: true });
+  if (fs.existsSync(TEAMJSON)) fs.unlinkSync(TEAMJSON);
+  if (fs.existsSync(STATEDIR)) fs.rmSync(STATEDIR, { recursive: true, force: true });
+}
+
+function cleanSandboxAll() {
+  cleanSandboxState();
+  if (fs.existsSync(TMP)) fs.rmSync(TMP, { recursive: true, force: true });
+}
+
+// Each removal keeps its own try so one failure never blocks the next path.
+function cleanSandboxAllBestEffort() {
+  try { if (fs.existsSync(SYNCDIR)) fs.rmSync(SYNCDIR, { recursive: true, force: true }); } catch { /* best-effort */ }
+  try { if (fs.existsSync(TEAMJSON)) fs.unlinkSync(TEAMJSON); } catch { /* best-effort */ }
+  try { if (fs.existsSync(STATEDIR)) fs.rmSync(STATEDIR, { recursive: true, force: true }); } catch { /* best-effort */ }
+  try { if (fs.existsSync(TMP)) fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
 (async () => { try {
   console.log('=== E2E Direct Module Test ===\n');
   console.log(`Sandbox home: ${SANDBOX_HOME}`);
@@ -138,9 +157,7 @@ function verifyBuildOutput(EGC_ROOT, SyncBackend) {
   ok(fs.existsSync(path.join(REMOTE, 'HEAD')), 'remote git repo initialized');
 
   // 2. Clean slate in sandbox
-  if (fs.existsSync(SYNCDIR)) fs.rmSync(SYNCDIR, { recursive: true, force: true });
-  if (fs.existsSync(TEAMJSON)) fs.unlinkSync(TEAMJSON);
-  if (fs.existsSync(STATEDIR)) fs.rmSync(STATEDIR, { recursive: true, force: true });
+  cleanSandboxState();
 
   // 3. Load and test the modules directly (after sandbox env is set)
   const EGC_ROOT = path.resolve(__dirname, '..');
@@ -170,10 +187,7 @@ function verifyBuildOutput(EGC_ROOT, SyncBackend) {
 
   // Cleanup
   console.log('\n--- Cleaning up ---');
-  if (fs.existsSync(SYNCDIR)) fs.rmSync(SYNCDIR, { recursive: true, force: true });
-  if (fs.existsSync(TEAMJSON)) fs.unlinkSync(TEAMJSON);
-  if (fs.existsSync(STATEDIR)) fs.rmSync(STATEDIR, { recursive: true, force: true });
-  if (fs.existsSync(TMP)) fs.rmSync(TMP, { recursive: true, force: true });
+  cleanSandboxAll();
 
   console.log('\n' + '='.repeat(50));
   console.log('E2E Results: ' + passed + ' passed, ' + failed + ' failed');
@@ -183,10 +197,6 @@ function verifyBuildOutput(EGC_ROOT, SyncBackend) {
 } catch (e) {
   console.error('\nFATAL: ' + e.message);
   console.error(e.stack);
-  // Cleanup
-  try { if (fs.existsSync(SYNCDIR)) fs.rmSync(SYNCDIR, { recursive: true, force: true }); } catch { /* best-effort */ }
-  try { if (fs.existsSync(TEAMJSON)) fs.unlinkSync(TEAMJSON); } catch { /* best-effort */ }
-  try { if (fs.existsSync(STATEDIR)) fs.rmSync(STATEDIR, { recursive: true, force: true }); } catch { /* best-effort */ }
-  try { if (fs.existsSync(TMP)) fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+  cleanSandboxAllBestEffort();
   process.exit(1);
 }})();

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -70,39 +70,51 @@ function getTeamConfig() {
   }
 }
 
+function parseJsonOrRaw(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Parse one JSONL line of MCP output. Returns { value } when the line holds
+ * a text result, null when the line should be skipped (not JSON, or no text
+ * content), and throws when the line carries an MCP error payload.
+ */
+function extractMcpLineResult(line) {
+  let parsed;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (parsed.result?.content) {
+    for (const content of parsed.result.content) {
+      if (content.type === 'text') {
+        return { value: parseJsonOrRaw(content.text) };
+      }
+    }
+  }
+  if (parsed.error) {
+    throw new Error(parsed.error.message || 'MCP tool call failed');
+  }
+  return null;
+}
+
 function parseMcpResponse(stdout) {
   const lines = stdout.split('\n').filter(Boolean);
   for (const line of lines) {
-    try {
-      const parsed = JSON.parse(line);
-      if (parsed.result?.content) {
-        for (const content of parsed.result.content) {
-          if (content.type === 'text') {
-            try {
-              return JSON.parse(content.text);
-            } catch {
-              return content.text;
-            }
-          }
-        }
-      }
-      if (parsed.error) {
-        throw new Error(parsed.error.message || 'MCP tool call failed');
-      }
-    } catch (e) {
-      if (e.message && !e.message.includes('Unexpected token')) {
-        throw e;
-      }
+    const result = extractMcpLineResult(line);
+    if (result) {
+      return result.value;
     }
   }
 
   const stdoutTrimmed = stdout.trim();
   if (stdoutTrimmed) {
-    try {
-      return JSON.parse(stdoutTrimmed);
-    } catch {
-      return stdoutTrimmed;
-    }
+    return parseJsonOrRaw(stdoutTrimmed);
   }
 
   throw new Error('No response from memory server');


### PR DESCRIPTION
Recreation of #843 from current main (its code-scanning rule evaluation was stuck at BLOCKED with every check green, the pattern already seen in this campaign; same commit, cherry-picked).

The last three code findings of the SonarCloud zero-issues campaign. No behavior change.

- **S3776 (CC 26)** `scripts/team.js`: `parseMcpResponse` now delegates one-line parsing to `extractMcpLineResult` (returns `{ value }`, null to skip, or throws on an MCP error payload) and JSON-or-raw fallback to `parseJsonOrRaw`. Non-JSON lines are skipped exactly as the former "Unexpected token" swallow did; error payloads still propagate.
- **S3776 (CC 25)** `scripts/e2e-team-sync-direct.js`: the main IIFE delegates sandbox cleanup to `cleanSandboxState` / `cleanSandboxAll` / `cleanSandboxAllBestEffort`. The best-effort variant keeps one `try` per removal, preserving the original property that one failed removal never blocks the next.
- **S107** `scripts/codex/merge-mcp-config.js`: `processExistingServer` takes a single destructured options object instead of eight positional parameters; its lone call site passes the same names.

Validation: `node --check` on all three; full test suite A/B against main baseline identical (137 known environment-only failures in the sandbox clone, zero new).

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the final three SonarCloud findings (S3776 x2, S107) by reducing complexity and consolidating parameters. No behavior changes.

- **Refactors**
  - scripts/team.js: Extracted `parseJsonOrRaw` and `extractMcpLineResult`; `parseMcpResponse` now delegates. Skips non-JSON lines; MCP error payloads still throw.
  - scripts/e2e-team-sync-direct.js: Moved sandbox cleanup into `cleanSandboxState`, `cleanSandboxAll`, and `cleanSandboxAllBestEffort`. Best-effort cleanup keeps per-path try blocks.
  - scripts/codex/merge-mcp-config.js: `processExistingServer` now takes a single options object; updated the call site.

<sup>Written for commit f6bfd5ca585f0ce0b58bf0c877fbcdbc492b64f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

