### PR TITLE
docs: update tool count to 20 with JetBrains Junie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ---
 
-EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own, no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, Zed, Warp, VS Code with GitHub Copilot, and more (19 tools total). Works natively with Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere, and Vertex AI, plus OpenRouter for Qwen3, Llama 4, and more.
+EGC is a local runtime that gives every AI coding tool you use a persistent memory. At the end of each session, your AI saves what it learned: decisions made, what failed, your preferences, what to pick up next. At the start of the next session, it loads that state back on its own, no prompting required. Say "let's continue" or "where did we stop?" in any language and your AI already knows what to do. One install covers Claude Code, Cursor, Gemini CLI, Windsurf, Zed, Warp, JetBrains Junie, VS Code with GitHub Copilot, and more (20 tools total). Works natively with Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere, and Vertex AI, plus OpenRouter for Qwen3, Llama 4, and more.
 
 ---
 

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -20,7 +20,7 @@
 
 ---
 
-EGC es un entorno de ejecución local que proporciona memoria persistente a todas las herramientas de programación con IA que utilizas. Al final de cada sesión, la IA guarda lo que aprendió sobre tu proyecto: las decisiones que tomaste, lo que falló, tus preferencias y los siguientes pasos. Al comienzo de la siguiente sesión, vuelve a cargar ese estado por sí sola, sin que tengas que pedirlo. Di "sigamos" o "¿dónde quedamos?" en cualquier idioma y tu IA ya sabe qué hacer. Una sola instalación funciona para Claude Code, Cursor, Gemini CLI, Windsurf, Zed, Warp, VS Code con GitHub Copilot y más (19 herramientas en total). Compatible de forma nativa con Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere y Vertex AI, además de OpenRouter para Qwen3, Llama 4 y más.
+EGC es un entorno de ejecución local que proporciona memoria persistente a todas las herramientas de programación con IA que utilizas. Al final de cada sesión, la IA guarda lo que aprendió sobre tu proyecto: las decisiones que tomaste, lo que falló, tus preferencias y los siguientes pasos. Al comienzo de la siguiente sesión, vuelve a cargar ese estado por sí sola, sin que tengas que pedirlo. Di "sigamos" o "¿dónde quedamos?" en cualquier idioma y tu IA ya sabe qué hacer. Una sola instalación funciona para Claude Code, Cursor, Gemini CLI, Windsurf, Zed, Warp, JetBrains Junie, VS Code con GitHub Copilot y más (20 herramientas en total). Compatible de forma nativa con Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere y Vertex AI, además de OpenRouter para Qwen3, Llama 4 y más.
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -20,7 +20,7 @@
 
 ---
 
-EGC é um runtime local que oferece memória persistente para cada ferramenta de IA que você usa. Ao final de cada sessão, a IA salva o que aprendeu sobre o seu projeto: as decisões tomadas, o que falhou, suas preferências e os próximos passos. No início da próxima sessão, ela carrega esse estado de volta sozinha, sem você pedir nada. Diga "vamos continuar" ou "onde paramos?" em qualquer idioma e sua IA já sabe o que fazer. Uma única instalação cobre Claude Code, Cursor, Gemini CLI, Windsurf, Zed, Warp, VS Code com GitHub Copilot e muito mais (19 ferramentas no total). Compatível nativamente com Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere e Vertex AI, além do OpenRouter para Qwen3, Llama 4 e outros.
+EGC é um runtime local que oferece memória persistente para cada ferramenta de IA que você usa. Ao final de cada sessão, a IA salva o que aprendeu sobre o seu projeto: as decisões tomadas, o que falhou, suas preferências e os próximos passos. No início da próxima sessão, ela carrega esse estado de volta sozinha, sem você pedir nada. Diga "vamos continuar" ou "onde paramos?" em qualquer idioma e sua IA já sabe o que fazer. Uma única instalação cobre Claude Code, Cursor, Gemini CLI, Windsurf, Zed, Warp, JetBrains Junie, VS Code com GitHub Copilot e muito mais (20 ferramentas no total). Compatível nativamente com Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere e Vertex AI, além do OpenRouter para Qwen3, Llama 4 e outros.
 
 ---
 


### PR DESCRIPTION
Follow-up to #849: bumps the supported tool count from 19 to 20 and adds JetBrains Junie to the tool list in the main README and the es/pt translations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JetBrains Junie to the supported tool list and bump the count from 19 to 20 in the main README and the es/pt translations.

<sup>Written for commit 9c6629f79c454456f25665160d505e0dc3f141b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

