### PR TITLE
fix(memory): prevent branch state filename collisions

### DIFF
--- a/mcp/servers/egc-memory/src/branch-state.ts
+++ b/mcp/servers/egc-memory/src/branch-state.ts
@@ -1,7 +1,9 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 
 export const DEFAULT_BRANCH_FILE = 'main.md';
+const BRANCH_FILE_PREFIX_LENGTH = 120;
 
 export type StateSource = 'branch' | 'default-branch' | 'flat' | 'none';
 
@@ -18,6 +20,15 @@ export function projectSlug(projectPath: string): string {
 
 export function sanitizeBranchName(branch: string): string {
   return branch.replaceAll('/', '-').replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+// Sanitization alone is not injective: feature/auth and feature-auth both
+// become feature-auth. Keep a readable prefix, then bind it to the exact ref.
+export function branchStateKey(branch: string): string {
+  const branchName = String(branch || '');
+  const readablePrefix = sanitizeBranchName(branchName).slice(0, BRANCH_FILE_PREFIX_LENGTH) || 'branch';
+  const digest = createHash('sha256').update(branchName, 'utf8').digest('hex');
+  return `${readablePrefix}--${digest}`;
 }
 
 // Branch detection reads .git/HEAD instead of spawning git: no PATH
@@ -58,6 +69,10 @@ export function flatStateFile(stateDir: string, projectPath: string): string {
 }
 
 export function branchStateFile(stateDir: string, projectPath: string, branch: string): string {
+  return path.join(stateDir, projectSlug(projectPath), `${branchStateKey(branch)}.md`);
+}
+
+export function legacyBranchStateFile(stateDir: string, projectPath: string, branch: string): string {
   return path.join(stateDir, projectSlug(projectPath), `${sanitizeBranchName(branch)}.md`);
 }
 
@@ -66,6 +81,10 @@ export function resolveStateRead(stateDir: string, projectPath: string, branch: 
     const branchFile = branchStateFile(stateDir, projectPath, branch);
     if (fs.existsSync(branchFile)) {
       return { filePath: branchFile, source: 'branch', branch };
+    }
+    const legacyBranchFile = legacyBranchStateFile(stateDir, projectPath, branch);
+    if (fs.existsSync(legacyBranchFile)) {
+      return { filePath: legacyBranchFile, source: 'branch', branch };
     }
     const defaultFile = path.join(stateDir, projectSlug(projectPath), DEFAULT_BRANCH_FILE);
     if (fs.existsSync(defaultFile)) {

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -3,8 +3,10 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { createHash } = require('node:crypto');
 
 const DEFAULT_BRANCH_FILE = 'main.md';
+const BRANCH_FILE_PREFIX_LENGTH = 120;
 
 function getStateDir(homeDir) {
   return path.join(homeDir || os.homedir(), '.egc', 'state');
@@ -17,6 +19,15 @@ function projectSlug(projectPath) {
 
 function sanitizeBranchName(branch) {
   return branch.replaceAll('/', '-').replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+// Sanitization alone is not injective: feature/auth and feature-auth both
+// become feature-auth. Keep a readable prefix, then bind it to the exact ref.
+function branchStateKey(branch) {
+  const branchName = String(branch || '');
+  const readablePrefix = sanitizeBranchName(branchName).slice(0, BRANCH_FILE_PREFIX_LENGTH) || 'branch';
+  const digest = createHash('sha256').update(branchName, 'utf8').digest('hex');
+  return `${readablePrefix}--${digest}`;
 }
 
 // Validates a resolved absolute path is within a trusted directory root
@@ -76,6 +87,10 @@ function flatStateFile(stateDir, projectPath) {
 }
 
 function branchStateFile(stateDir, projectPath, branch) {
+  return path.join(stateDir, projectSlug(projectPath), `${branchStateKey(branch)}.md`);
+}
+
+function legacyBranchStateFile(stateDir, projectPath, branch) {
   return path.join(stateDir, projectSlug(projectPath), `${sanitizeBranchName(branch)}.md`);
 }
 
@@ -84,6 +99,10 @@ function resolveStateRead(stateDir, projectPath, branch) {
     const branchFile = branchStateFile(stateDir, projectPath, branch);
     if (fs.existsSync(branchFile)) {
       return { filePath: branchFile, source: 'branch', branch };
+    }
+    const legacyBranchFile = legacyBranchStateFile(stateDir, projectPath, branch);
+    if (fs.existsSync(legacyBranchFile)) {
+      return { filePath: legacyBranchFile, source: 'branch', branch };
     }
     const defaultFile = path.join(stateDir, projectSlug(projectPath), DEFAULT_BRANCH_FILE);
     if (fs.existsSync(defaultFile)) {
@@ -113,9 +132,11 @@ module.exports = {
   getStateDir,
   projectSlug,
   sanitizeBranchName,
+  branchStateKey,
   detectBranch,
   flatStateFile,
   branchStateFile,
+  legacyBranchStateFile,
   resolveStateRead,
   resolveStateWrite,
 };

--- a/scripts/lib/watch-state.js
+++ b/scripts/lib/watch-state.js
@@ -5,7 +5,12 @@ const path = require('node:path');
 const os = require('node:os');
 
 const { propagateStateContent } = require('./propagate-state');
-const { projectSlug, sanitizeBranchName, detectBranch } = require('./branch-state');
+const {
+  projectSlug,
+  detectBranch,
+  branchStateFile,
+  legacyBranchStateFile,
+} = require('./branch-state');
 const { isEncryptedBuffer } = require('./state-crypto');
 
 const EGC_START = '<!-- egc:start -->';
@@ -127,8 +132,11 @@ function resolveStateFilePath(projectPath) {
   const branch = detectBranch(projectPath);
 
   if (branch) {
-    const branchFile = path.join(stateDir, slug, `${sanitizeBranchName(branch)}.md`);
+    const branchFile = branchStateFile(stateDir, projectPath, branch);
     if (fs.existsSync(branchFile)) return branchFile;
+
+    const legacyBranchFile = legacyBranchStateFile(stateDir, projectPath, branch);
+    if (fs.existsSync(legacyBranchFile)) return legacyBranchFile;
   }
 
   const defaultFile = path.join(stateDir, slug, 'main.md');

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -10,9 +10,11 @@ const {
   getStateDir,
   projectSlug,
   sanitizeBranchName,
+  branchStateKey,
   detectBranch,
   flatStateFile,
   branchStateFile,
+  legacyBranchStateFile,
   resolveStateRead,
   resolveStateWrite,
 } = require('../../scripts/lib/branch-state');
@@ -86,6 +88,12 @@ function runTests() {
     assert.strictEqual(sanitizeBranchName('fix/issue#137'), 'fix-issue_137');
   })) passed++; else failed++;
 
+  if (test('branchStateKey prevents collisions after filename sanitization', () => {
+    assert.match(branchStateKey('feature/auth'), /^feature-auth--[0-9a-f]{64}$/);
+    assert.notStrictEqual(branchStateKey('feature/auth'), branchStateKey('feature-auth'));
+    assert.notStrictEqual(branchStateKey('release/1.0'), branchStateKey('release-1_0'));
+  })) passed++; else failed++;
+
   if (test('getStateDir resolves under the provided home directory', () => {
     assert.strictEqual(getStateDir('/tmp/fake-home'), path.join('/tmp/fake-home', '.egc', 'state'));
   })) passed++; else failed++;
@@ -115,8 +123,21 @@ function runTests() {
     );
     assert.strictEqual(
       branchStateFile(stateDir, project, 'feature/auth'),
-      path.join(stateDir, 'Projects--my-app', 'feature-auth.md')
+      path.join(stateDir, 'Projects--my-app', `${branchStateKey('feature/auth')}.md`)
     );
+  })) passed++; else failed++;
+
+  if (test('colliding legacy branch names write to independent state files', () => {
+    const stateDir = makeTmpDir('egc-branch-state-collision-');
+    const project = '/home/user/Projects/my-app';
+    const slashBranchFile = branchStateFile(stateDir, project, 'feature/auth');
+    const dashBranchFile = branchStateFile(stateDir, project, 'feature-auth');
+
+    assert.notStrictEqual(slashBranchFile, dashBranchFile);
+    writeState(slashBranchFile, 'slash branch');
+    writeState(dashBranchFile, 'dash branch');
+    assert.match(fs.readFileSync(slashBranchFile, 'utf8'), /slash branch/);
+    assert.match(fs.readFileSync(dashBranchFile, 'utf8'), /dash branch/);
   })) passed++; else failed++;
 
   if (test('resolveStateRead prefers the current branch file', () => {
@@ -139,6 +160,22 @@ function runTests() {
     const resolved = resolveStateRead(stateDir, project, 'feature/auth');
     assert.strictEqual(resolved.source, 'default-branch');
     assert.strictEqual(resolved.filePath, path.join(stateDir, 'Projects--my-app', 'main.md'));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead migrates safely from legacy branch filenames', () => {
+    const stateDir = makeTmpDir('egc-branch-state-legacy-');
+    const project = '/home/user/Projects/my-app';
+    const legacyFile = legacyBranchStateFile(stateDir, project, 'feature/auth');
+    const currentFile = branchStateFile(stateDir, project, 'feature/auth');
+    writeState(legacyFile, 'legacy branch state');
+
+    const fromLegacy = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(fromLegacy.source, 'branch');
+    assert.strictEqual(fromLegacy.filePath, legacyFile);
+
+    writeState(currentFile, 'current branch state');
+    const fromCurrent = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(fromCurrent.filePath, currentFile);
   })) passed++; else failed++;
 
   if (test('resolveStateRead falls back to the legacy flat file', () => {

--- a/tests/scripts/egc-memory-branch-state.test.js
+++ b/tests/scripts/egc-memory-branch-state.test.js
@@ -68,9 +68,11 @@ async function runTests() {
   const {
     projectSlug,
     sanitizeBranchName,
+    branchStateKey,
     detectBranch,
     flatStateFile,
     branchStateFile,
+    legacyBranchStateFile,
     resolveStateRead,
     resolveStateWrite,
   } = api;
@@ -88,6 +90,11 @@ async function runTests() {
   if (test('sanitizeBranchName produces safe filenames', () => {
     assert.strictEqual(sanitizeBranchName('feature/auth'), 'feature-auth');
     assert.strictEqual(sanitizeBranchName('release/1.0.8'), 'release-1_0_8');
+  })) passed++; else failed++;
+
+  if (test('branchStateKey distinguishes names with the same legacy filename', () => {
+    assert.notStrictEqual(branchStateKey('feature/auth'), branchStateKey('feature-auth'));
+    assert.notStrictEqual(branchStateKey('release/1.0'), branchStateKey('release-1_0'));
   })) passed++; else failed++;
 
   if (test('detectBranch returns the current branch and null outside repos', () => {
@@ -121,6 +128,17 @@ async function runTests() {
     const fromFlat = resolveStateRead(stateDir, project, 'feature/auth');
     assert.strictEqual(fromFlat.source, 'flat');
     assert.strictEqual(fromFlat.filePath, flatStateFile(stateDir, project));
+  })) passed++; else failed++;
+
+  if (test('resolveStateRead supports legacy sanitized branch filenames', () => {
+    const stateDir = makeTmpDir('egc-memory-legacy-');
+    const project = '/home/user/Projects/my-app';
+    const legacyFile = legacyBranchStateFile(stateDir, project, 'feature/auth');
+    writeState(legacyFile, 'legacy branch');
+
+    const resolved = resolveStateRead(stateDir, project, 'feature/auth');
+    assert.strictEqual(resolved.source, 'branch');
+    assert.strictEqual(resolved.filePath, legacyFile);
   })) passed++; else failed++;
 
   if (test('resolveStateRead reports none when no state exists', () => {

--- a/tests/scripts/watch-state.test.js
+++ b/tests/scripts/watch-state.test.js
@@ -236,28 +236,56 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('resolveStateFilePath prefers hashed branch state and falls back to legacy', () => {
+    const projectDir = mktemp();
+    const homeDir = mktemp();
+    const originalHomedir = os.homedir;
+    const {
+      branchStateFile,
+      legacyBranchStateFile,
+    } = require('../../scripts/lib/branch-state');
+
+    try {
+      os.homedir = () => homeDir;
+      const gitDir = path.join(projectDir, '.git');
+      fs.mkdirSync(gitDir);
+      fs.writeFileSync(path.join(gitDir, 'HEAD'), 'ref: refs/heads/feature/auth\n');
+
+      const stateDir = path.join(homeDir, '.egc', 'state');
+      const legacyFile = legacyBranchStateFile(stateDir, projectDir, 'feature/auth');
+      const currentFile = branchStateFile(stateDir, projectDir, 'feature/auth');
+      fs.mkdirSync(path.dirname(legacyFile), { recursive: true });
+      fs.writeFileSync(legacyFile, '# Legacy state\n');
+      assert.strictEqual(resolveStateFilePath(projectDir), legacyFile);
+
+      fs.writeFileSync(currentFile, '# Current state\n');
+      assert.strictEqual(resolveStateFilePath(projectDir), currentFile);
+    } finally {
+      os.homedir = originalHomedir;
+      cleanup(projectDir);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
   if (await test('resolveStateFilePath without branch finds main.md', () => {
     const projectDir = mktemp();
-    const stateDir = path.join(os.homedir(), '.egc', 'state');
+    const homeDir = mktemp();
+    const originalHomedir = os.homedir;
+    const stateDir = path.join(homeDir, '.egc', 'state');
     const slug = require('../../scripts/lib/branch-state').projectSlug(projectDir);
     const slugDir = path.join(stateDir, slug);
-    let createdSlugDir = false;
     const mainMd = path.join(slugDir, 'main.md');
 
     try {
-      if (!fs.existsSync(slugDir)) {
-        fs.mkdirSync(slugDir, { recursive: true });
-        createdSlugDir = true;
-      }
+      os.homedir = () => homeDir;
+      fs.mkdirSync(slugDir, { recursive: true });
       fs.writeFileSync(mainMd, '# State\n');
       const result = resolveStateFilePath(projectDir);
       assert.strictEqual(result, mainMd, 'should resolve to main.md when no branch (detached HEAD or non-git dir)');
     } finally {
-      try { fs.unlinkSync(mainMd); } catch (_) { /* may not exist if test failed early */ }
-      if (createdSlugDir) {
-        try { fs.rmdirSync(slugDir); } catch (_) { /* may fail if dir still has files */ }
-      }
+      os.homedir = originalHomedir;
       cleanup(projectDir);
+      cleanup(homeDir);
     }
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary

- derive branch-state filenames from a readable prefix plus a SHA-256 digest of the exact Git ref
- keep legacy sanitized branch filenames readable, while new writes use collision-resistant paths
- keep `egc watch` aligned with the same current-first, legacy-fallback resolution
- add regression coverage for colliding branch names and legacy state migration

## Root cause

Branch filenames were produced by replacing `/` with `-` and all other unsupported characters with `_`. That mapping is not one-to-one, so distinct valid refs such as `feature/auth` and `feature-auth` both resolved to `feature-auth.md`. Updates from either branch could therefore read, merge, or overwrite the other branch's memory.

## Compatibility

Existing branch state files are not renamed or deleted. Reads prefer the new hashed filename, then fall back to the legacy sanitized filename. The next state update reads the legacy content and writes it to the new collision-resistant path.

## Validation

- `npm run build` in `mcp/servers/egc-memory`
- `node tests/lib/branch-state.test.js` - 24 passed
- `node tests/scripts/egc-memory-branch-state.test.js` - 9 passed
- `node tests/scripts/watch-state.test.js` - 18 passed
- `node tests/hooks/claude-session-start.test.js` - 11 passed
- `node tests/hooks/egc-memory-save.test.js` - 12 passed
- `npm run lint` - 0 errors (existing warnings remain)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent branch-state filename collisions by deriving filenames from a readable prefix plus a SHA-256 of the exact Git ref. Reads prefer the new hashed path with legacy fallback, and `egc watch` follows the same order.

- **Bug Fixes**
  - Introduced `branchStateKey` and write branch files as `<prefix>--<sha256>.md`.
  - Kept legacy sanitized filenames readable; reads fall back, next write migrates to the new path.
  - Updated `watch-state` to prefer hashed branch files and fall back to legacy.
  - Added regression tests for colliding branch names and legacy migration.

<sup>Written for commit 075a3d7356d8fc392e67bb7ae5173cf05dd2a3af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

