### PR TITLE
feat(memory): add jitter and deeper retries to SQLite write arbitration

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { randomInt, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
@@ -177,7 +177,8 @@ class SQLiteArbitrationQueue {
           // Equal jitter: with N MCP server processes (one per IDE/CLI session)
           // colliding on the same ~/.egc database, deterministic backoff wakes
           // them all on the same tick and the collision repeats (thundering herd).
-          backoff = backoff / 2 + Math.random() * (backoff / 2);
+          const half = Math.floor(backoff / 2);
+          backoff = half + randomInt(0, half + 1);
           log('WARN', `Write Collision Detected (SQLITE_BUSY). Arbitration retrying...`, {
             queue_depth: this.queue.length,
             retry_count: task.retries,

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -138,7 +138,7 @@ interface QueueTask<T> {
 class SQLiteArbitrationQueue {
   private readonly queue: QueueTask<unknown>[] = [];
   private isProcessing = false;
-  private readonly MAX_RETRIES = 5;
+  private readonly MAX_RETRIES = 12;
   private readonly BASE_BACKOFF_MS = 50;
   private readonly MAX_BACKOFF_MS = 5000;
 
@@ -174,6 +174,10 @@ class SQLiteArbitrationQueue {
           task.retries++;
           let backoff = Math.pow(2, task.retries) * this.BASE_BACKOFF_MS;
           if (backoff > this.MAX_BACKOFF_MS) backoff = this.MAX_BACKOFF_MS;
+          // Equal jitter: with N MCP server processes (one per IDE/CLI session)
+          // colliding on the same ~/.egc database, deterministic backoff wakes
+          // them all on the same tick and the collision repeats (thundering herd).
+          backoff = backoff / 2 + Math.random() * (backoff / 2);
           log('WARN', `Write Collision Detected (SQLITE_BUSY). Arbitration retrying...`, {
             queue_depth: this.queue.length,
             retry_count: task.retries,

--- a/tests/stress/sqlite-arbitration.stress.js
+++ b/tests/stress/sqlite-arbitration.stress.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { randomInt } = require('node:crypto');
 async function getMockedDb() {
   const store = [];
   
@@ -71,7 +72,8 @@ class SQLiteArbitrationQueue {
           let backoff = Math.pow(2, task.retries) * this.BASE_BACKOFF_MS;
           if (backoff > this.MAX_BACKOFF_MS) backoff = this.MAX_BACKOFF_MS;
           // Equal jitter, mirrors the production queue in egc-memory/src/index.ts
-          backoff = backoff / 2 + Math.random() * (backoff / 2);
+          const half = Math.floor(backoff / 2);
+          backoff = half + randomInt(0, half + 1);
 
           setTimeout(() => {
             this.queue.push(task); // Requeue at the end

--- a/tests/stress/sqlite-arbitration.stress.js
+++ b/tests/stress/sqlite-arbitration.stress.js
@@ -34,7 +34,7 @@ class SQLiteArbitrationQueue {
   constructor() {
     this.queue = [];
     this.isProcessing = false;
-    this.MAX_RETRIES = 5;
+    this.MAX_RETRIES = 12;
     this.BASE_BACKOFF_MS = 10;
     this.MAX_BACKOFF_MS = 50;
   }
@@ -70,6 +70,8 @@ class SQLiteArbitrationQueue {
           task.retries++;
           let backoff = Math.pow(2, task.retries) * this.BASE_BACKOFF_MS;
           if (backoff > this.MAX_BACKOFF_MS) backoff = this.MAX_BACKOFF_MS;
+          // Equal jitter, mirrors the production queue in egc-memory/src/index.ts
+          backoff = backoff / 2 + Math.random() * (backoff / 2);
 
           setTimeout(() => {
             this.queue.push(task); // Requeue at the end


### PR DESCRIPTION
First implementation step of the multi-session concurrency work: prepares the egc-memory write path for 10+ parallel sessions sharing the same ~/.egc database.

## What changed
- MAX_RETRIES raised from 5 to 12 in SQLiteArbitrationQueue: with many concurrent writers, 5 attempts could dead-letter legitimate writes under sustained contention.
- Equal jitter applied to the exponential backoff: deterministic backoff wakes all colliding processes on the same tick (thundering herd), repeating the SQLITE_BUSY collision instead of resolving it.
- Stress test port updated to mirror the production queue.

## Verification
- tests/stress/sqlite-arbitration.stress.js: 100 concurrent writes, 100 successes, 0 failures.
- tsc --noEmit clean on mcp/servers/egc-memory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add equal jitter using `crypto.randomInt` to the SQLite write arbitration backoff and increase retries from 5 to 12 so 10+ sessions can share the `~/.egc` database without dead-lettering. This spreads wakeups to avoid SQLITE_BUSY thundering-herd collisions and updates the stress test to mirror the production queue.

<sup>Written for commit f67a064a43ec49d3082fcaa8ae90e1d849e3b78c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

