### PR TITLE
feat(memory): add user-wide global memory scope to get_state and update_state

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -6,4 +6,8 @@ sonar.sources=src,mcp/servers,scripts
 # These tests run in CI on every push; CI remains their quality gate.
 sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,**/*.tgz,**/legacy-command-shims/**
 sonar.sourceEncoding=UTF-8
-sonar.cpd.exclusions=scripts/lib/branch-state.js,mcp/servers/egc-memory/src/branch-state.ts,mcp/servers/egc-guardian/src/catalog-index.ts
+# branch-state and global-state are deliberate CommonJS mirrors of their TS
+# counterparts: session hooks cannot require the compiled server build.
+# tests/egc-memory-global-state.test.js asserts the global-state pair stays
+# behaviorally identical.
+sonar.cpd.exclusions=scripts/lib/branch-state.js,mcp/servers/egc-memory/src/branch-state.ts,mcp/servers/egc-guardian/src/catalog-index.ts,scripts/lib/global-state.js,mcp/servers/egc-memory/src/global-state.ts

--- a/mcp/servers/egc-memory/src/global-state.ts
+++ b/mcp/servers/egc-memory/src/global-state.ts
@@ -1,0 +1,33 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export const GLOBAL_APPENDIX_SECTIONS: Array<{ heading: string; cap: number }> = [
+  { heading: 'Preferences', cap: 5 },
+  { heading: 'Active Decisions', cap: 5 },
+  { heading: 'Do Not Repeat', cap: 5 }
+];
+
+export function globalStateFilePath(): string {
+  return path.join(os.homedir(), '.egc', 'global', 'state.md');
+}
+
+// Trust-domain isolation: global scope is only written via an explicit
+// scope:"global" call, never derived from project data.
+export function buildGlobalAppendix(
+  globalDoc: Record<string, string[] | string>,
+  projectContent: string
+): string | null {
+  const projectLines = new Set(
+    projectContent.split('\n').map(l => l.replace(/^- /, '').trim()).filter(Boolean)
+  );
+  const parts: string[] = [];
+  for (const { heading, cap } of GLOBAL_APPENDIX_SECTIONS) {
+    const entries = globalDoc[heading];
+    if (!Array.isArray(entries)) continue;
+    const kept = entries.filter(e => e.trim() && !projectLines.has(e.trim())).slice(0, cap);
+    if (kept.length === 0) continue;
+    parts.push(`### ${heading}`, ...kept.map(e => `- ${e}`), '');
+  }
+  if (parts.length === 0) return null;
+  return ['', '## Global Memory (all projects)', '', ...parts].join('\n').trimEnd();
+}

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -12,6 +12,7 @@ import { randomInt, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
+import { buildGlobalAppendix, globalStateFilePath } from './global-state';
 import { loadOrCreateKey, writeHmac, verifyHmac } from './integrity';
 import { loadOrCreateEncKey, readStateFile, writeStateFile, quarantineUndecryptableStateFile } from './encryption';
 import { propagateStateToTools } from './propagate';
@@ -418,6 +419,12 @@ function getStateDir(): string {
   return dir;
 }
 
+function getGlobalStateFile(): string {
+  const file = globalStateFilePath();
+  ensurePrivateDir(path.dirname(file));
+  return file;
+}
+
 function isProtectedPath(p: string): boolean {
   const home = os.homedir();
   const denied = [
@@ -673,7 +680,8 @@ const UpdateStateSchema = z.object({
   })).max(20).optional(),
   preferences: z.array(z.string().max(300)).max(20).optional(),
   next: z.array(z.string().max(500)).max(10).optional(),
-  force: z.boolean().optional()
+  force: z.boolean().optional(),
+  scope: z.enum(['project', 'global']).optional().default('project')
 });
 
 const WorkingMemorySetSchema = z.object({
@@ -722,7 +730,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       { name: "search_history", description: "Keyword search over the decision history with BM25 relevance ranking (SQLite FTS5). Each result includes the decision content, context label, timestamp, and a score normalized to [0, 1] where 1 is the best match in the result set. Use this to find past decisions by topic instead of paging through query_history.", inputSchema: { type: "object", properties: { query: { type: "string", description: "Keywords to search for, e.g. 'authentication jwt'." }, limit: { type: "number", description: "Maximum number of results to return. Defaults to 10." }, min_score: { type: "number", description: "Minimum normalized relevance score between 0 and 1. Defaults to 0." } }, required: ["query"] } },
       {
         name: "get_state",
-        description: "Returns the current project memory: decisions made, preferences established, things to avoid, and what to pick up next. State is scoped to the current git branch when the project is a git repository, falling back to the default branch state and then to the legacy flat state file. Call this at the START of every session to restore context.",
+        description: "Returns the current project memory: decisions made, preferences established, things to avoid, and what to pick up next. State is scoped to the current git branch when the project is a git repository, falling back to the default branch state and then to the legacy flat state file. When user-wide global memory exists (written via update_state with scope 'global'), a deduplicated 'Global Memory' section is appended after the project state; project and branch entries always take precedence. Call this at the START of every session to restore context.",
         inputSchema: {
           type: "object",
           properties: {
@@ -742,7 +750,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             avoid: { type: "array", items: { type: "object", properties: { what: { type: "string" }, why: { type: "string" } }, required: ["what"] }, description: "What failed and should not be repeated." },
             preferences: { type: "array", items: { type: "string" }, description: "Coding style, workflow, or communication preferences discovered." },
             next: { type: "array", items: { type: "string" }, description: "What to pick up in the next session." },
-            force: { type: "boolean", description: "Recover from a state file that cannot be decrypted (corrupted or encrypted with an orphaned key). When true and the existing file fails to decrypt, the corrupted file is renamed to a '.corrupted-backup-<timestamp>' sibling instead of being read, and this call's data becomes the fresh state — nothing is merged in from the unreadable file, and nothing is deleted. Only set this after confirming the failure is persistent, not a transient lock from another process writing at the same moment." }
+            force: { type: "boolean", description: "Recover from a state file that cannot be decrypted (corrupted or encrypted with an orphaned key). When true and the existing file fails to decrypt, the corrupted file is renamed to a '.corrupted-backup-<timestamp>' sibling instead of being read, and this call's data becomes the fresh state — nothing is merged in from the unreadable file, and nothing is deleted. Only set this after confirming the failure is persistent, not a transient lock from another process writing at the same moment." },
+            scope: { type: "string", enum: ["project", "global"], description: "Where to write. 'project' (default) scopes to the current project/branch. 'global' writes to the user-wide memory shared across all projects (~/.egc/global/state.md); use it only for transversal preferences and lessons the user wants everywhere, never for project-specific state." }
           }
         }
       },
@@ -1026,7 +1035,9 @@ async function handleGetState(db: Database, toolArgs: unknown) {
 
   if (resolved.source === 'none') {
     const branchLine = branch ? `Branch: ${branch}\n` : '';
-    return { content: [{ type: "text", text: `No state found for this project yet.\n${branchLine}Path: ${resolved.filePath}\n\nCall update_state at the end of this session to start building project memory.` }] };
+    const emptyStateText = `No state found for this project yet.\n${branchLine}Path: ${resolved.filePath}\n\nCall update_state at the end of this session to start building project memory.`;
+    const appendix = readGlobalAppendix('');
+    return { content: [{ type: "text", text: appendix ? `${emptyStateText}\n${appendix}` : emptyStateText }] };
   }
 
   let content: string;
@@ -1043,7 +1054,19 @@ async function handleGetState(db: Database, toolArgs: unknown) {
   } else {
     log('INFO', 'Project state retrieved', { project: projPath, branch: branch || 'none', source: resolved.source, integrity: 'ok' });
   }
-  return { content: [{ type: "text", text: content }] };
+  const appendix = readGlobalAppendix(content);
+  return { content: [{ type: "text", text: appendix ? `${content}\n${appendix}` : content }] };
+}
+
+function readGlobalAppendix(projectContent: string): string | null {
+  try {
+    const globalFile = getGlobalStateFile();
+    if (!fs.existsSync(globalFile)) return null;
+    return buildGlobalAppendix(readStateDoc(globalFile), projectContent);
+  } catch (err) {
+    log('WARN', 'Failed to read global state, returning project state only', { error: String(err) });
+    return null;
+  }
 }
 
 async function handleUpdateState(db: Database, toolArgs: unknown) {
@@ -1068,6 +1091,28 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
       });
     }
   } catch (_) { /* non-fatal */ } // NOSONAR: legacy flat-state merge is best-effort
+
+  if (args.scope === 'global') {
+    const globalFile = getGlobalStateFile();
+    let existingGlobal: Record<string, string[]|string> = {};
+    try {
+      existingGlobal = readStateDoc(globalFile);
+    } catch (err) {
+      if (args.force && fs.existsSync(globalFile)) {
+        const backupPath = quarantineUndecryptableStateFile(globalFile);
+        log('WARN', 'update_state: force=true, undecryptable global state backed up and replaced', { file: globalFile, backup: backupPath, error: String(err) });
+      } else {
+        log('ERROR', '[EGC encryption] Cannot read existing global state, aborting update to prevent data loss', { file: globalFile, error: String(err) });
+        throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing global state file. The encryption key may have changed. Path: ${globalFile}. Retry with force: true to back up the unreadable file and start fresh.`);
+      }
+    }
+    writeStateDoc(globalFile, 'global', args, existingGlobal, null);
+    const writtenGlobal = readStateFile(globalFile, _encKey);
+    writeHmac(globalFile, writtenGlobal, _integrityKey);
+    log('INFO', 'Global state updated', { decisions: args.decisions?.length || 0 });
+    return { content: [{ type: "text", text: `Global memory updated (shared across all projects).\nFile: ${globalFile}\nDecisions saved: ${args.decisions?.length || 0}` }] };
+  }
+
   // Merge from the same file get_state would read, so the first
   // branch-scoped write inherits the pre-existing flat state
   const resolved = resolveStateRead(getStateDir(), projPath, branch);

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -28,6 +28,7 @@ const projectDetect = tryRequire('../lib/project-detect');
 const branchState = tryRequire('../lib/branch-state');
 const autoConsolidate = tryRequire('../lib/auto-consolidate');
 const stateCrypto = tryRequire('../lib/state-crypto');
+const globalState = tryRequire('../lib/global-state');
 
 function readStdinJson() {
   try {
@@ -214,12 +215,13 @@ function readPlaintextState(stateFile) {
 
 function loadAndPrintState(projectPath) {
   const stateFile = resolveStateFile(projectPath);
-  if (!stateFile) return;
+  let content = null;
+  if (stateFile) {
+    content = readPlaintextState(stateFile);
+    if (content !== null && !content.trim()) content = null;
+  }
 
-  const content = readPlaintextState(stateFile);
-  if (content === null || !content.trim()) return;
-
-  if (propagateStateContent) {
+  if (content && propagateStateContent) {
     try {
       propagateStateContent(projectPath, content);
     } catch (_) { // NOSONAR
@@ -227,7 +229,11 @@ function loadAndPrintState(projectPath) {
     }
   }
 
-  process.stdout.write('EGC persistent memory for this project (restored automatically):\n\n' + content);
+  const appendix = globalState ? globalState.readGlobalAppendix(content || '', stateCrypto) : null;
+  if (!content && !appendix) return;
+
+  const header = 'EGC persistent memory for this project (restored automatically):\n\n';
+  process.stdout.write(header + (content || '') + (appendix ? `\n${appendix}\n` : ''));
 }
 
 function postSessionStart(sessionId) {

--- a/scripts/hooks/egc-memory-load.js
+++ b/scripts/hooks/egc-memory-load.js
@@ -3,6 +3,17 @@
 const fs = require('node:fs');
 const { getStateDir, detectBranch, resolveStateRead } = require('../lib/branch-state');
 
+function tryRequire(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+const globalState = tryRequire('../lib/global-state');
+const stateCrypto = tryRequire('../lib/state-crypto');
+
 function main() {
   let raw = '';
   try {
@@ -25,15 +36,17 @@ function main() {
     const branch = detectBranch(projectPath);
     const resolved = resolveStateRead(getStateDir(), projectPath, branch);
 
-    if (resolved.source === 'none') {
+    const content = resolved.source === 'none' ? '' : fs.readFileSync(resolved.filePath, 'utf8');
+    const appendix = globalState ? globalState.readGlobalAppendix(content, stateCrypto) : null;
+
+    if (!content && !appendix) {
       process.stdout.write(JSON.stringify(input));
       process.exit(0);
     }
 
-    const content = fs.readFileSync(resolved.filePath, 'utf8');
     const prompt =
       'You have persistent memory for this project. Resume exactly where you left off: no need to re-explain anything already decided.\n\n' +
-      content;
+      content + (appendix ? `\n${appendix}\n` : '');
 
     const output = { ...input, promptForAssistant: prompt };
     process.stdout.write(JSON.stringify(output));

--- a/scripts/lib/global-state.js
+++ b/scripts/lib/global-state.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// JS mirror of mcp/servers/egc-memory/src/global-state.ts for session hooks,
+// which cannot require the compiled server build. Keep both in sync.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const GLOBAL_APPENDIX_SECTIONS = [
+  { heading: 'Preferences', cap: 5 },
+  { heading: 'Active Decisions', cap: 5 },
+  { heading: 'Do Not Repeat', cap: 5 },
+];
+
+function globalStateFilePath() {
+  return path.join(os.homedir(), '.egc', 'global', 'state.md');
+}
+
+function parseStateDoc(content) {
+  const result = {};
+  let currentSection = '';
+  for (const line of content.split('\n')) {
+    const h2 = /^## (.+)/.exec(line);
+    if (h2) {
+      currentSection = h2[1].trim();
+      result[currentSection] = result[currentSection] || [];
+      continue;
+    }
+    if (currentSection && line.trim() && !line.startsWith('#')) {
+      const arr = result[currentSection];
+      if (Array.isArray(arr)) arr.push(line.replace(/^- /, '').trim());
+      else result[currentSection] = line.trim();
+    }
+  }
+  return result;
+}
+
+function buildGlobalAppendix(globalDoc, projectContent) {
+  const projectLines = new Set(
+    projectContent.split('\n').map(l => l.replace(/^- /, '').trim()).filter(Boolean)
+  );
+  const parts = [];
+  for (const { heading, cap } of GLOBAL_APPENDIX_SECTIONS) {
+    const entries = globalDoc[heading];
+    if (!Array.isArray(entries)) continue;
+    const kept = entries.filter(e => e.trim() && !projectLines.has(e.trim())).slice(0, cap);
+    if (kept.length === 0) continue;
+    parts.push(`### ${heading}`, ...kept.map(e => `- ${e}`), '');
+  }
+  if (parts.length === 0) return null;
+  return ['', '## Global Memory (all projects)', '', ...parts].join('\n').trimEnd();
+}
+
+// stateCrypto is optional: without it an encrypted global file is skipped
+// instead of leaking ciphertext into the session.
+function readGlobalAppendix(projectContent, stateCrypto) {
+  try {
+    const file = globalStateFilePath();
+    if (!fs.existsSync(file)) return null;
+    const raw = fs.readFileSync(file);
+    const encrypted = stateCrypto
+      ? stateCrypto.isEncryptedBuffer(raw)
+      : raw.subarray(0, 5).toString('utf8') === 'EGC1:';
+    let content;
+    if (encrypted) {
+      if (!stateCrypto) return null;
+      content = stateCrypto.decryptStateBuffer(raw);
+    } else {
+      content = raw.toString('utf8');
+    }
+    if (!content || !content.trim()) return null;
+    return buildGlobalAppendix(parseStateDoc(content), projectContent);
+  } catch (_) { // NOSONAR: global memory is additive; any failure must not break the session
+    return null;
+  }
+}
+
+module.exports = {
+  GLOBAL_APPENDIX_SECTIONS,
+  globalStateFilePath,
+  parseStateDoc,
+  buildGlobalAppendix,
+  readGlobalAppendix,
+};

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -38,6 +38,7 @@ const {
 
 const HOOK_LIB_SOURCES = [
   'scripts/lib/branch-state.js',
+  'scripts/lib/global-state.js',
   'scripts/lib/project-detect.js',
   'scripts/lib/propagate-state.js',
   'scripts/lib/state-crypto.js',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,3 +8,10 @@
 sonar.issue.ignore.multicriteria=t1
 sonar.issue.ignore.multicriteria.t1.ruleKey=javascript:S2187
 sonar.issue.ignore.multicriteria.t1.resourceKey=**/tests/**/*
+
+# scripts/lib/global-state.js is a deliberate CommonJS mirror of
+# mcp/servers/egc-memory/src/global-state.ts: session hooks cannot require the
+# compiled server build. tests/egc-memory-global-state.test.js asserts both
+# implementations produce identical output, so the cross-file duplication
+# between the pair is by design.
+sonar.cpd.exclusions=scripts/lib/global-state.js,mcp/servers/egc-memory/src/global-state.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,10 +8,3 @@
 sonar.issue.ignore.multicriteria=t1
 sonar.issue.ignore.multicriteria.t1.ruleKey=javascript:S2187
 sonar.issue.ignore.multicriteria.t1.resourceKey=**/tests/**/*
-
-# scripts/lib/global-state.js is a deliberate CommonJS mirror of
-# mcp/servers/egc-memory/src/global-state.ts: session hooks cannot require the
-# compiled server build. tests/egc-memory-global-state.test.js asserts both
-# implementations produce identical output, so the cross-file duplication
-# between the pair is by design.
-sonar.cpd.exclusions=scripts/lib/global-state.js,mcp/servers/egc-memory/src/global-state.ts

--- a/tests/egc-memory-global-state.test.js
+++ b/tests/egc-memory-global-state.test.js
@@ -1,0 +1,100 @@
+'use strict';
+/**
+ * Tests for mcp/servers/egc-memory/src/global-state.ts
+ *
+ * Covers the global memory appendix merged into get_state: section caps,
+ * deduplication against project state (project/branch entries win), empty
+ * results collapsing to null, and non-array sections being ignored.
+ *
+ * Run with: node tests/egc-memory-global-state.test.js
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+const buildPath = path.join(
+  __dirname, '..', 'mcp', 'servers', 'egc-memory', 'build', 'global-state.js'
+);
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-memory first.');
+  process.exit(0);
+}
+
+const { buildGlobalAppendix, globalStateFilePath } = require(buildPath);
+
+console.log('\n=== Testing egc-memory global state ===\n');
+
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+run('returns null for an empty global doc', () => {
+  assert.strictEqual(buildGlobalAppendix({}, ''), null);
+});
+
+run('returns null when all global entries already exist in project state', () => {
+  const doc = { Preferences: ['Use yarn', 'No em dashes'] };
+  const project = '## Preferences\n- Use yarn\n- No em dashes\n';
+  assert.strictEqual(buildGlobalAppendix(doc, project), null);
+});
+
+run('renders known sections with heading and bullets', () => {
+  const doc = { Preferences: ['Use yarn'], 'Active Decisions': ['Ship weekly'] };
+  const out = buildGlobalAppendix(doc, '');
+  assert.ok(out.includes('## Global Memory (all projects)'));
+  assert.ok(out.includes('### Preferences'));
+  assert.ok(out.includes('- Use yarn'));
+  assert.ok(out.includes('### Active Decisions'));
+  assert.ok(out.includes('- Ship weekly'));
+});
+
+run('caps each section at 5 entries', () => {
+  const doc = { Preferences: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'] };
+  const out = buildGlobalAppendix(doc, '');
+  assert.ok(out.includes('- p5'));
+  assert.ok(!out.includes('- p6'));
+});
+
+run('dedup happens before the cap so project overlap does not starve the section', () => {
+  const doc = { Preferences: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'] };
+  const project = '## Preferences\n- p1\n- p2\n';
+  const out = buildGlobalAppendix(doc, project);
+  assert.ok(!out.includes('- p1'));
+  assert.ok(out.includes('- p3'));
+  assert.ok(out.includes('- p6'));
+});
+
+run('ignores scalar sections and unknown headings', () => {
+  const doc = { Context: 'a scalar context', Unknown: ['x'], 'Do Not Repeat': ['never force push main'] };
+  const out = buildGlobalAppendix(doc, '');
+  assert.ok(!out.includes('scalar'));
+  assert.ok(!out.includes('- x'));
+  assert.ok(out.includes('### Do Not Repeat'));
+});
+
+run('skips blank entries', () => {
+  const doc = { Preferences: ['  ', ''] };
+  assert.strictEqual(buildGlobalAppendix(doc, ''), null);
+});
+
+run('globalStateFilePath points inside ~/.egc/global', () => {
+  const p = globalStateFilePath();
+  assert.ok(p.endsWith(path.join('.egc', 'global', 'state.md')));
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/egc-memory-global-state.test.js
+++ b/tests/egc-memory-global-state.test.js
@@ -96,5 +96,19 @@ run('globalStateFilePath points inside ~/.egc/global', () => {
   assert.ok(p.endsWith(path.join('.egc', 'global', 'state.md')));
 });
 
+run('JS hook mirror and TS build produce identical output', () => {
+  const jsLib = require(path.join(__dirname, '..', 'scripts', 'lib', 'global-state.js'));
+  const fixtures = [
+    [{}, ''],
+    [{ Preferences: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'], 'Active Decisions': ['d1'], 'Do Not Repeat': ['a1'], Context: 'scalar' }, '## Preferences\n- p2\n'],
+    [{ Preferences: ['only'] }, '## Preferences\n- only\n'],
+    [{ Unknown: ['x'] }, ''],
+  ];
+  for (const [doc, project] of fixtures) {
+    assert.deepStrictEqual(jsLib.buildGlobalAppendix(doc, project), buildGlobalAppendix(doc, project));
+  }
+  assert.strictEqual(jsLib.globalStateFilePath(), globalStateFilePath());
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Second step of the approved omnipresent-memory work (after #853): introduces the user-wide global scope shared across all projects.

## What changed
- New module `global-state.ts`: pure logic for the global appendix (section caps, dedup against project state) plus the `~/.egc/global/state.md` path helper.
- `update_state` accepts `scope: "project" | "global"` (default project). Global writes reuse the existing encryption, HMAC and `force` recovery semantics and are never derived from project data (trust-domain isolation).
- `get_state` appends a deduplicated `## Global Memory (all projects)` section (top 5 per section) after the project state; branch and project entries always take precedence.
- Advertised tool schemas updated accordingly.

## Verification
- New unit suite `tests/egc-memory-global-state.test.js`: 8/8 (build-gated like the sibling memory tests).
- Regression: egc-memory-encryption 9/9, egc-memory-integrity 11/11, sqlite-arbitration stress 100/100.
- Servers rebuilt and verified via `sh install.sh`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user-wide global memory scope to `get_state` and `update_state`, enabling shared preferences and lessons across all projects. Global memory is deduped against project/branch state and appended on read without changing existing project behavior.

- **New Features**
  - Global memory at `~/.egc/global/state.md` with section caps (top 5) for Preferences, Active Decisions, and Do Not Repeat.
  - `update_state` adds `scope: "project" | "global"` (default `project`); global writes reuse encryption, HMAC, and `force`; never derived from project data.
  - `get_state` appends a deduped “## Global Memory (all projects)” after project state; project/branch entries always win.
  - Session hooks surface the global appendix via `scripts/lib/global-state.js`; encrypted global files are skipped when `state-crypto` isn’t available; the lib ships with `claude-home`.
  - Unit tests cover dedup, caps, and section handling.

- **Refactors**
  - Marked the JS/TS global-state mirror as deliberate duplication and excluded it from CPD in both `sonar-project.properties` and `.sonarcloud.properties`; added a sync test to assert identical output across implementations.

<sup>Written for commit dfa35557c272c17af43cacd49dc6be046e186f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

