### PR TITLE
feat(privacy): block populated memory from ever being committed

### DIFF
--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -4,13 +4,3 @@ alwaysApply: true
 ---
 
 ## EGC Project Memory
-
-**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
-
-**Active decisions:**
-- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
-- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
-
-**Next session:**
-- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
-- Nenhuma pendencia critica ou de seguranca restante do EGC-128.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Blocks commits that would leak populated EGC memory from propagation files.
+if command -v node >/dev/null 2>&1; then
+  node "$(git rev-parse --show-toplevel)/scripts/check-state-leak.js" --staged || exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,10 @@ jobs:
         run: node scripts/ci/check-unicode-safety.js
         continue-on-error: false
 
+      - name: Check for leaked memory state
+        run: node scripts/check-state-leak.js --tree
+        continue-on-error: false
+
   security:
     name: Security Scan
     uses: ./.github/workflows/reusable-security-audit.yml

--- a/.trae/rules/egc-context.md
+++ b/.trae/rules/egc-context.md
@@ -24,13 +24,4 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
-
-**Active decisions:**
-- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
-- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
-
-**Next session:**
-- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
-- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,13 +62,4 @@ Skipping any of these breaks the EGC contract. There are no exceptions for "simp
 <!-- egc:start -->
 ## EGC Project Memory
 
-**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
-
-**Active decisions:**
-- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
-- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
-
-**Next session:**
-- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
-- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -93,13 +93,4 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-**Context:** EGC main: PR #769 mergeado (squash e25baa74) fechando a auditoria de seguranca EGC-128 por completo (47/47 achados: 8 criticos, 10 altos, todos os medios exceto 2 refactors de manutenibilidade adiados de proposito, todos os baixos). 2825 testes JS + 114 Python verdes em main.
-
-**Active decisions:**
-- EGC-128 encerrada. Branch fix/guardian-audit-critical-security deletada (local e remota) apos squash-merge.
-- 2 refactors medios de manutenibilidade (resolveInstallPlan em install-manifests.js, funcao grande em install-lifecycle.js) permanecem pendentes, recomendados para sessao dedicada.
-
-**Next session:**
-- Se Felipe autorizar, abrir sessao dedicada para os 2 refactors medios de complexidade.
-- Nenhuma pendencia critica ou de seguranca restante do EGC-128.
 <!-- egc:end -->

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -22,8 +22,16 @@ const POPULATED_SIGNATURES = [
   /^\*\*Next session:\*\*/m,
 ];
 
+// S4036: prefer fixed git locations over a PATH lookup; the bare name is the
+// last resort for layouts like nix or Windows portable installs.
+const GIT_BIN = [
+  '/usr/bin/git',
+  '/usr/local/bin/git',
+  'C:\\Program Files\\Git\\cmd\\git.exe',
+].find(p => fs.existsSync(p)) || 'git';
+
 function git(args, options) {
-  return execFileSync('git', args, { encoding: 'utf8', ...options });
+  return execFileSync(GIT_BIN, args, { encoding: 'utf8', ...options });
 }
 
 function isMarkdownPath(p) {
@@ -63,7 +71,7 @@ function checkStaged() {
     .split('\n').filter(Boolean).filter(isMarkdownPath);
   const leaks = [];
   for (const file of staged) {
-    let content = '';
+    let content;
     try {
       content = git(['show', `:0:${file}`]);
     } catch {
@@ -78,7 +86,7 @@ function checkTree() {
   const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(isMarkdownPath);
   const leaks = [];
   for (const file of tracked) {
-    let content = '';
+    let content;
     try {
       content = fs.readFileSync(file, 'utf8');
     } catch {

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+'use strict';
+
+// Guards the commit-privacy rule for EGC memory propagation files
+// (AGENTS.md, GEMINI.md, .cursor/rules/egc-context.mdc, .trae/rules/egc-context.md):
+// the managed "## EGC Project Memory" structure may be committed, populated
+// memory content may not.
+//
+// Modes:
+//   --staged        check staged blobs (pre-commit hook)
+//   --tree          check tracked markdown files on disk (CI guard)
+//   --clean <file>  rewrite files in place with the memory section zeroed
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+
+const SECTION_HEADING = '## EGC Project Memory';
+const POPULATED_SIGNATURES = [
+  /^<!-- egc:state-updated:\S+ -->$/m,
+  /^\*\*Context:\*\*/m,
+  /^\*\*Active decisions:\*\*/m,
+  /^\*\*Next session:\*\*/m,
+];
+
+function git(args, options) {
+  return execFileSync('git', args, { encoding: 'utf8', ...options });
+}
+
+function isMarkdownPath(p) {
+  return p.endsWith('.md') || p.endsWith('.mdc') || p.endsWith('.markdown');
+}
+
+function findLeak(content) {
+  if (!content.includes(SECTION_HEADING)) return null;
+  const matched = POPULATED_SIGNATURES.filter(re => re.test(content));
+  return matched.length > 0 ? matched.map(re => re.source) : null;
+}
+
+function cleanContent(content) {
+  const lines = content.split('\n');
+  const out = [];
+  let dropping = false;
+  for (const line of lines) {
+    if (/^<!-- egc:state-updated:\S+ -->$/.test(line)) continue;
+    if (/^\*\*(Context|Active decisions|Next session):\*\*/.test(line)) {
+      dropping = true;
+      continue;
+    }
+    if (dropping) {
+      if (line.startsWith('- ') || line.trim() === '' ) {
+        if (line.trim() === '') dropping = false;
+        continue;
+      }
+      dropping = false;
+    }
+    out.push(line);
+  }
+  return out.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+function checkStaged() {
+  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACM'])
+    .split('\n').filter(Boolean).filter(isMarkdownPath);
+  const leaks = [];
+  for (const file of staged) {
+    let content = '';
+    try {
+      content = git(['show', `:0:${file}`]);
+    } catch {
+      continue;
+    }
+    if (findLeak(content)) leaks.push(file);
+  }
+  return leaks;
+}
+
+function checkTree() {
+  const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(isMarkdownPath);
+  const leaks = [];
+  for (const file of tracked) {
+    let content = '';
+    try {
+      content = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (findLeak(content)) leaks.push(file);
+  }
+  return leaks;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const mode = args[0];
+
+  if (mode === '--clean') {
+    const files = args.slice(1);
+    if (files.length === 0) {
+      console.error('usage: check-state-leak.js --clean <file...>');
+      process.exit(2);
+    }
+    for (const file of files) {
+      fs.writeFileSync(file, cleanContent(fs.readFileSync(file, 'utf8')));
+      console.log(`cleaned: ${file}`);
+    }
+    return;
+  }
+
+  const leaks = mode === '--staged' ? checkStaged() : checkTree();
+  if (leaks.length === 0) {
+    console.log('state-leak check: clean');
+    return;
+  }
+
+  console.error('BLOCKED: populated EGC memory must never be committed. Leaking files:');
+  for (const file of leaks) console.error(`  - ${file}`);
+  console.error('\nZero the memory section before committing:');
+  console.error(`  node scripts/check-state-leak.js --clean ${leaks.join(' ')}`);
+  console.error('Local sessions repopulate these files automatically; only the empty structure ships.');
+  process.exit(1);
+}
+
+main();

--- a/tests/check-state-leak.test.js
+++ b/tests/check-state-leak.test.js
@@ -1,0 +1,130 @@
+'use strict';
+/**
+ * Tests for scripts/check-state-leak.js
+ *
+ * Covers the commit-privacy guard: populated EGC memory in propagation files
+ * must be caught in staged blobs (--staged), in the tracked tree (--tree),
+ * and --clean must zero the section so the same content passes.
+ *
+ * Run with: node tests/check-state-leak.test.js
+ */
+const assert = require('node:assert');
+const { execFileSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'check-state-leak.js');
+
+const POPULATED = [
+  '# EGC: Agent Catalog',
+  '',
+  '<!-- egc:start -->',
+  '<!-- egc:state-updated:2026-07-18T05:15:28.038Z -->',
+  '## EGC Project Memory',
+  '',
+  '**Context:** secret local context that must never ship.',
+  '',
+  '**Active decisions:**',
+  '- private decision one',
+  '',
+  '**Next session:**',
+  '- private next step',
+  '',
+  '## EGC Triggers',
+  '<!-- egc:end -->',
+  '',
+].join('\n');
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-leak-test-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(dir, 'scripts', 'check-state-leak.js'));
+  return { dir, git };
+}
+
+function runScript(dir, ...args) {
+  return spawnSync('node', [path.join(dir, 'scripts', 'check-state-leak.js'), ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+  });
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing check-state-leak ===\n');
+
+run('staged populated propagation file is blocked', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'AGENTS.md'), POPULATED);
+  git('add', 'AGENTS.md');
+  const res = runScript(dir, '--staged');
+  assert.strictEqual(res.status, 1, `expected exit 1, got ${res.status}: ${res.stderr}`);
+  assert.ok(res.stderr.includes('AGENTS.md'));
+});
+
+run('cleaned file passes staged check and keeps structure', () => {
+  const { dir, git } = makeRepo();
+  const file = path.join(dir, 'AGENTS.md');
+  fs.writeFileSync(file, POPULATED);
+  const cleanRes = runScript(dir, '--clean', 'AGENTS.md');
+  assert.strictEqual(cleanRes.status, 0, cleanRes.stderr);
+  const cleaned = fs.readFileSync(file, 'utf8');
+  assert.ok(cleaned.includes('## EGC Project Memory'), 'structure heading survives');
+  assert.ok(!cleaned.includes('secret local context'), 'context content removed');
+  assert.ok(!cleaned.includes('private decision'), 'decisions removed');
+  assert.ok(!cleaned.includes('state-updated'), 'stamp removed');
+  git('add', 'AGENTS.md');
+  const res = runScript(dir, '--staged');
+  assert.strictEqual(res.status, 0, res.stderr);
+});
+
+run('tree mode flags committed populated file', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'GEMINI.md'), POPULATED);
+  git('add', '.');
+  git('commit', '-q', '-m', 'seed', '--no-verify');
+  const res = runScript(dir, '--tree');
+  assert.strictEqual(res.status, 1);
+  assert.ok(res.stderr.includes('GEMINI.md'));
+});
+
+run('markdown without the managed section is ignored', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'README.md'), '# Readme\n\n**Context:** docs example\n');
+  git('add', '.');
+  const staged = runScript(dir, '--staged');
+  assert.strictEqual(staged.status, 0, staged.stderr);
+  git('commit', '-q', '-m', 'seed', '--no-verify');
+  const tree = runScript(dir, '--tree');
+  assert.strictEqual(tree.status, 0, tree.stderr);
+});
+
+run('non-markdown staged files are ignored', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'propagate.js'), `const s = '<!-- egc:state-updated:x -->';\nconst h = '## EGC Project Memory';\n`);
+  git('add', 'propagate.js');
+  const res = runScript(dir, '--staged');
+  assert.strictEqual(res.status, 0, res.stderr);
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Item 4 of the approved omnipresent-memory work: the commit-privacy guarantee. Populated EGC memory must never reach the public repo; only the zeroed structure ships.

## What changed
- `scripts/check-state-leak.js`: detects populated state (update stamp, Context, Active decisions, Next session) in files carrying the managed `## EGC Project Memory` structure. Modes: `--staged` (pre-commit), `--tree` (CI), `--clean` (zero the section in place).
- `.githooks/pre-commit` (tracked 100755): blocks leaking commits for anyone on the repo hooksPath.
- CI `validate` job gains a tree-wide `--tree` guard: bypassed local hooks, API commits and fork PRs are caught server-side, per the security study's blocking requirement.
- Committed baseline cleaned: AGENTS.md, GEMINI.md, .cursor and .trae rules previously shipped populated state from an old session; they now ship the zeroed structure only. Local sessions repopulate them automatically and the new guards keep them local.

## Verification
- `tests/check-state-leak.test.js`: 5/5 in isolated temp repos (staged block, clean-then-pass, tree flag, non-managed markdown ignored, non-markdown ignored).
- `node scripts/check-state-leak.js --tree` on this branch: clean.
- The commit for this PR itself ran the new pre-commit hook and passed with the cleaned baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks commits that include populated EGC memory in propagation files. Adds a script, pre-commit hook, and CI check so only the empty `## EGC Project Memory` structure is committed.

- **New Features**
  - Added `scripts/check-state-leak.js` with `--staged`, `--tree`, and `--clean` modes to detect and zero populated memory, and hardened Git resolution (fixed locations before PATH) to satisfy S4036 and lint cleanup.
  - Added `.githooks/pre-commit` to block staged leaks.
  - CI `validate` job runs the tree-wide check to catch bypassed hooks and fork PRs.
  - Cleaned baseline for `AGENTS.md`, `GEMINI.md`, `.cursor/rules/egc-context.mdc`, `.trae/rules/egc-context.md`.
  - Added `tests/check-state-leak.test.js`.

- **Migration**
  - Ensure local hooks are active: `git config core.hooksPath .githooks`.
  - If blocked, run `node scripts/check-state-leak.js --clean <files>` and re-commit.

<sup>Written for commit 8a00e969e4d8cc7a9245e54fac0bea92a27e756f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

