### PR TITLE
feat(crusher): Token Crusher phase 1, native shell-output compression

### DIFF
--- a/scripts/crush-run.js
+++ b/scripts/crush-run.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+'use strict';
+
+// egc run <command...>: executes the command, crushes noisy output before it
+// reaches the model, and records the savings locally. Exit code, stderr and
+// small outputs pass through untouched. `egc run --raw <command...>` is the
+// escape hatch that skips crushing entirely.
+
+const { spawnSync } = require('node:child_process');
+const { crushOutput } = require('./lib/crusher/engine');
+const { record } = require('./lib/crusher/metrics');
+
+function main() {
+  const args = process.argv.slice(2);
+  const raw = args[0] === '--raw';
+  const commandArgs = raw ? args.slice(1) : args;
+
+  if (commandArgs.length === 0 || commandArgs[0] === '--help') {
+    console.log('Usage: egc run [--raw] <command> [args...]\n\nRuns the command and compresses noisy output before it reaches the model.\n--raw skips compression.');
+    process.exit(commandArgs.length === 0 ? 1 : 0);
+  }
+
+  const result = spawnSync(commandArgs[0], commandArgs.slice(1), {
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'inherit'],
+    maxBuffer: 64 * 1024 * 1024,
+    shell: false,
+  });
+
+  if (result.error) {
+    console.error(`egc run: ${result.error.message}`);
+    process.exit(127);
+  }
+
+  const stdout = result.stdout || '';
+  const commandLine = commandArgs.join(' ');
+  const crushed = raw ? null : crushOutput(commandLine, stdout);
+
+  if (crushed) {
+    process.stdout.write(crushed.crushed + '\n');
+    record({
+      cmd: commandArgs[0],
+      kind: crushed.kind,
+      bytesIn: crushed.bytesIn,
+      bytesOut: crushed.bytesOut,
+      tokensSaved: crushed.tokensSaved,
+    });
+  } else if (stdout) {
+    process.stdout.write(stdout);
+  }
+
+  process.exit(typeof result.status === 'number' ? result.status : 1);
+}
+
+main();

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -121,6 +121,14 @@ const COMMANDS = {
     script: 'plugin.js',
     description: 'Plugin registry: install, list, remove, update EGC plugins from npm or local path.',
   },
+  run: {
+    script: 'crush-run.js',
+    description: 'Run a command through the Token Crusher (compresses noisy output; --raw skips it)',
+  },
+  saved: {
+    script: 'saved.js',
+    description: 'Show accumulated Token Crusher savings (local ledger, zero token cost)',
+  },
 };
 
 const PRIMARY_COMMANDS = [
@@ -148,6 +156,8 @@ const PRIMARY_COMMANDS = [
   'team',
   'budget',
   'plugin',
+  'run',
+  'saved',
 ];
 
 const TELEMETRY_COMMANDS = new Set(['install', 'doctor', 'init']);
@@ -201,6 +211,9 @@ Examples:
   egc watch --project /path/to/project --quiet
   egc telemetry status
   egc telemetry off
+  egc run git diff
+  egc run --raw git diff
+  egc saved
 `);
 
   process.exit(exitCode);

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -70,7 +70,7 @@ function crushTestRunner(output) {
   const lines = output.split('\n');
   const kept = lines.filter(l =>
     KEEP_LINE_RE.test(l)
-    || /^\s*(Tests|Test Suites|Snapshots|Time|Ran all|passed|failed|✕|✗|✖|FAIL|PASS:?\s*$)/i.test(l.trim())
+    || /^\s*(Tests|Test Suites|Snapshots|Time|Ran all|passed|failed|\u2715|\u2717|\u2716|FAIL|PASS:?\s*$)/i.test(l.trim())
     || /^\s*\d+ (passed|failed|skipped|pending)/i.test(l)
   );
   const summaryTail = lines.slice(-5).filter(l => l.trim());

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -1,0 +1,133 @@
+'use strict';
+
+// Token Crusher engine: compresses shell command output before it reaches the
+// model. Conservative by design: errors, warnings and failures are never
+// dropped, small outputs pass through untouched, and every crushed payload
+// carries the CRUSH_MARKER so downstream reducers can no-op instead of
+// compressing twice.
+
+const CRUSH_MARKER = '[egc-crusher]';
+const MIN_BYTES_TO_CRUSH = 2048;
+const GIT_LOG_MAX_LINES = 40;
+const GIT_DIFF_MAX_BYTES = 8192;
+
+function estimateTokens(text) {
+  return Math.ceil(Buffer.byteLength(text, 'utf8') / 4);
+}
+
+function tryRequire(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+// Reuses the SmartCrusher from egc-guardian when its build is present; JSON
+// payloads stay uncompressed otherwise rather than duplicating that logic.
+const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-array-crusher.js');
+
+const KEEP_LINE_RE = /\b(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception)\b/i;
+
+function commandKind(command) {
+  const normalized = command.trim().replace(/^rtk\s+/, '');
+  if (/^git\s+log\b/.test(normalized)) return 'git-log';
+  if (/^git\s+diff\b/.test(normalized)) return 'git-diff';
+  if (/\b(jest|vitest|pytest|mocha)\b/.test(normalized) || /npm\s+(run\s+)?test\b/.test(normalized) || /node\s+\S*tests?\//.test(normalized)) return 'test-runner';
+  if (/^(npm|yarn|pnpm|bun)\s+(install|ci|add|i)\b/.test(normalized)) return 'pm-install';
+  if (/^gh\b.*--json\b/.test(normalized)) return 'gh-json';
+  return 'generic';
+}
+
+function headTail(lines, head, tail) {
+  if (lines.length <= head + tail + 1) return lines;
+  return [
+    ...lines.slice(0, head),
+    `... (${lines.length - head - tail} lines omitted)`,
+    ...lines.slice(-tail),
+  ];
+}
+
+function crushGitLog(output) {
+  const lines = output.split('\n');
+  if (lines.length <= GIT_LOG_MAX_LINES) return null;
+  return [...lines.slice(0, GIT_LOG_MAX_LINES), `... (${lines.length - GIT_LOG_MAX_LINES} more commits)`].join('\n');
+}
+
+function crushGitDiff(output) {
+  if (Buffer.byteLength(output, 'utf8') <= GIT_DIFF_MAX_BYTES) return null;
+  const lines = output.split('\n');
+  const fileHeaders = lines.filter(l => l.startsWith('diff --git') || l.startsWith('+++ ') || l.startsWith('@@'));
+  const additions = lines.filter(l => l.startsWith('+') && !l.startsWith('+++')).length;
+  const deletions = lines.filter(l => l.startsWith('-') && !l.startsWith('---')).length;
+  return [
+    `diff too large for context: +${additions}/-${deletions} across ${lines.filter(l => l.startsWith('diff --git')).length} file(s)`,
+    ...headTail(fileHeaders, 30, 10),
+  ].join('\n');
+}
+
+function crushTestRunner(output) {
+  const lines = output.split('\n');
+  const kept = lines.filter(l =>
+    KEEP_LINE_RE.test(l)
+    || /^\s*(Tests|Test Suites|Snapshots|Time|Ran all|passed|failed|✕|✗|✖|FAIL|PASS:?\s*$)/i.test(l.trim())
+    || /^\s*\d+ (passed|failed|skipped|pending)/i.test(l)
+  );
+  const summaryTail = lines.slice(-5).filter(l => l.trim());
+  const merged = [...new Set([...kept, ...summaryTail])];
+  if (merged.length >= lines.length) return null;
+  return merged.join('\n');
+}
+
+function crushPmInstall(output) {
+  const lines = output.split('\n');
+  const kept = lines.filter(l => KEEP_LINE_RE.test(l));
+  const tail = lines.slice(-6).filter(l => l.trim());
+  const merged = [...new Set([...kept, ...tail])];
+  if (merged.length >= lines.length) return null;
+  return merged.join('\n');
+}
+
+function crushGhJson(output) {
+  if (!arrayCrusher || typeof arrayCrusher.reduceJsonArray !== 'function') return null;
+  const result = arrayCrusher.reduceJsonArray(output);
+  if (!result) return null;
+  return `${result.crushed}\n(${result.rows_before} rows reduced to ${result.rows_after})`;
+}
+
+const CRUSHERS = {
+  'git-log': crushGitLog,
+  'git-diff': crushGitDiff,
+  'test-runner': crushTestRunner,
+  'pm-install': crushPmInstall,
+  'gh-json': crushGhJson,
+  generic: () => null,
+};
+
+// Returns { crushed, kind, bytesIn, bytesOut, tokensSaved } or null when the
+// output should pass through untouched.
+function crushOutput(command, output) {
+  if (!output || Buffer.byteLength(output, 'utf8') < MIN_BYTES_TO_CRUSH) return null;
+  if (output.includes(CRUSH_MARKER)) return null;
+
+  const kind = commandKind(command);
+  const crushed = CRUSHERS[kind](output);
+  if (crushed === null || Buffer.byteLength(crushed, 'utf8') >= Buffer.byteLength(output, 'utf8')) {
+    return null;
+  }
+
+  const bytesIn = Buffer.byteLength(output, 'utf8');
+  const bytesOut = Buffer.byteLength(crushed, 'utf8');
+  const tokensSaved = estimateTokens(output) - estimateTokens(crushed);
+  const stamped = `${crushed}\n${CRUSH_MARKER} saved ~${tokensSaved} tokens (full output: rerun with --raw)`;
+
+  return { crushed: stamped, kind, bytesIn, bytesOut, tokensSaved };
+}
+
+module.exports = {
+  CRUSH_MARKER,
+  MIN_BYTES_TO_CRUSH,
+  commandKind,
+  crushOutput,
+  estimateTokens,
+};

--- a/scripts/lib/crusher/metrics.js
+++ b/scripts/lib/crusher/metrics.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Local, zero-cost savings ledger for the Token Crusher. Records are JSONL in
+// ~/.egc/metrics/crusher.jsonl so reading or reporting them never touches a
+// model context. The unified metrics.db aggregation across all compression
+// layers builds on top of this file later without a schema migration.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function metricsFilePath() {
+  return path.join(os.homedir(), '.egc', 'metrics', 'crusher.jsonl');
+}
+
+function record(entry) {
+  try {
+    const file = metricsFilePath();
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    fs.appendFileSync(file, JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n');
+  } catch { // NOSONAR: accounting must never break the command being run
+    // ignore: savings accounting is best-effort
+  }
+}
+
+function readAll() {
+  try {
+    const raw = fs.readFileSync(metricsFilePath(), 'utf8');
+    return raw.split('\n').filter(Boolean).map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    }).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function aggregate(entries) {
+  const totals = { runs: 0, bytesIn: 0, bytesOut: 0, tokensSaved: 0, byKind: {} };
+  for (const e of entries) {
+    totals.runs += 1;
+    totals.bytesIn += e.bytesIn || 0;
+    totals.bytesOut += e.bytesOut || 0;
+    totals.tokensSaved += e.tokensSaved || 0;
+    const kind = e.kind || 'generic';
+    totals.byKind[kind] = totals.byKind[kind] || { runs: 0, tokensSaved: 0 };
+    totals.byKind[kind].runs += 1;
+    totals.byKind[kind].tokensSaved += e.tokensSaved || 0;
+  }
+  return totals;
+}
+
+module.exports = { metricsFilePath, record, readAll, aggregate };

--- a/scripts/saved.js
+++ b/scripts/saved.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+'use strict';
+
+// egc saved: prints the accumulated Token Crusher savings. Everything here is
+// read from the local JSONL ledger and printed to the terminal only, so the
+// report itself costs zero tokens.
+
+const { readAll, aggregate, metricsFilePath } = require('./lib/crusher/metrics');
+
+function formatBytes(n) {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function main() {
+  const json = process.argv.includes('--json');
+  const entries = readAll();
+  const totals = aggregate(entries);
+
+  if (json) {
+    console.log(JSON.stringify(totals, null, 2));
+    return;
+  }
+
+  if (totals.runs === 0) {
+    console.log('Token Crusher: no crushed runs recorded yet.\nRoute commands through "egc run <cmd>" to start saving.');
+    return;
+  }
+
+  const pct = totals.bytesIn > 0 ? Math.round((1 - totals.bytesOut / totals.bytesIn) * 100) : 0;
+  console.log('Token Crusher savings (local ledger, zero token cost)');
+  console.log('');
+  console.log(`  Crushed runs:   ${totals.runs}`);
+  console.log(`  Output size:    ${formatBytes(totals.bytesIn)} -> ${formatBytes(totals.bytesOut)} (${pct}% smaller)`);
+  console.log(`  Tokens saved:   ~${totals.tokensSaved}`);
+  console.log('');
+  for (const [kind, k] of Object.entries(totals.byKind)) {
+    console.log(`  ${kind.padEnd(12)} ${String(k.runs).padStart(4)} runs   ~${k.tokensSaved} tokens`);
+  }
+  console.log('');
+  console.log(`  Ledger: ${metricsFilePath()}`);
+}
+
+main();

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -1,0 +1,123 @@
+'use strict';
+/**
+ * Tests for scripts/lib/crusher/engine.js and scripts/lib/crusher/metrics.js
+ *
+ * Covers the Token Crusher conservativeness contract: small outputs pass
+ * through, errors and failures survive crushing, already-crushed output is
+ * never crushed twice, and the savings ledger aggregates correctly.
+ *
+ * Run with: node tests/crusher-engine.test.js
+ */
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { CRUSH_MARKER, commandKind, crushOutput, estimateTokens } = require(
+  path.join(__dirname, '..', 'scripts', 'lib', 'crusher', 'engine.js')
+);
+const { aggregate } = require(
+  path.join(__dirname, '..', 'scripts', 'lib', 'crusher', 'metrics.js')
+);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing Token Crusher engine ===\n');
+
+run('classifies commands into kinds', () => {
+  assert.strictEqual(commandKind('git log --oneline'), 'git-log');
+  assert.strictEqual(commandKind('git diff HEAD~1'), 'git-diff');
+  assert.strictEqual(commandKind('npx jest --ci'), 'test-runner');
+  assert.strictEqual(commandKind('npm test'), 'test-runner');
+  assert.strictEqual(commandKind('yarn install'), 'pm-install');
+  assert.strictEqual(commandKind('gh pr list --json number'), 'gh-json');
+  assert.strictEqual(commandKind('ls -la'), 'generic');
+  assert.strictEqual(commandKind('rtk git log'), 'git-log');
+});
+
+run('small outputs pass through untouched', () => {
+  assert.strictEqual(crushOutput('git log', 'short output'), null);
+});
+
+run('generic commands never crush', () => {
+  assert.strictEqual(crushOutput('cat somefile', 'x'.repeat(10000)), null);
+});
+
+run('git log beyond the cap is truncated with a count', () => {
+  const output = Array.from({ length: 200 }, (_, i) => `commit${i} message ${'x'.repeat(30)}`).join('\n');
+  const result = crushOutput('git log --oneline', output);
+  assert.ok(result);
+  assert.ok(result.crushed.includes('more commits'));
+  assert.ok(result.crushed.includes(CRUSH_MARKER));
+  assert.ok(result.tokensSaved > 0);
+});
+
+run('test-runner output keeps failures and summary, drops noise', () => {
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
+  lines.push('  FAIL src/thing.test.js broke badly');
+  lines.push('  Error: expected 1 to be 2');
+  lines.push('Tests: 1 failed, 300 passed, 301 total');
+  const result = crushOutput('npx jest', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('broke badly'), 'failure line survives');
+  assert.ok(result.crushed.includes('Error: expected'), 'error detail survives');
+  assert.ok(result.crushed.includes('Tests: 1 failed'), 'summary survives');
+  assert.ok(!result.crushed.includes('number 42 does something fine'), 'noise dropped');
+});
+
+run('pm install keeps warnings and the tail summary', () => {
+  const lines = [];
+  for (let i = 0; i < 400; i++) lines.push(`added package-${i}`);
+  lines.splice(200, 0, 'npm WARN deprecated something@1.0.0');
+  lines.push('added 400 packages in 12s');
+  const result = crushOutput('npm install', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('WARN deprecated'));
+  assert.ok(result.crushed.includes('added 400 packages in 12s'));
+});
+
+run('already-crushed output is never crushed twice', () => {
+  const output = `${'x\n'.repeat(3000)}${CRUSH_MARKER} saved ~100 tokens`;
+  assert.strictEqual(crushOutput('git log', output), null);
+});
+
+run('oversized git diff collapses to a summary', () => {
+  const hunk = 'diff --git a/f.js b/f.js\n+++ b/f.js\n@@ -1,3 +1,3 @@\n' + '+added line\n-removed line\n'.repeat(1000);
+  const result = crushOutput('git diff', hunk);
+  assert.ok(result);
+  assert.ok(result.crushed.includes('diff too large'));
+  assert.ok(result.crushed.includes('+1000/-1000'));
+});
+
+run('token estimate is bytes over four, rounded up', () => {
+  assert.strictEqual(estimateTokens('abcd'), 1);
+  assert.strictEqual(estimateTokens('abcde'), 2);
+});
+
+run('ledger aggregation sums totals and per-kind buckets', () => {
+  const totals = aggregate([
+    { kind: 'git-log', bytesIn: 1000, bytesOut: 100, tokensSaved: 225 },
+    { kind: 'git-log', bytesIn: 500, bytesOut: 50, tokensSaved: 100 },
+    { kind: 'test-runner', bytesIn: 2000, bytesOut: 200, tokensSaved: 450 },
+  ]);
+  assert.strictEqual(totals.runs, 3);
+  assert.strictEqual(totals.tokensSaved, 775);
+  assert.strictEqual(totals.byKind['git-log'].runs, 2);
+  assert.strictEqual(totals.byKind['test-runner'].tokensSaved, 450);
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Item 5 (phase 1) of the approved omnipresent-context work: the Token Crusher engine, native in the package, no MCP, clean-room design.

## What changed
- `scripts/lib/crusher/engine.js`: conservative per-command compression: git log cap, oversized git diff summary, test-runner noise stripping (failures, errors and summaries always survive), package-manager install filtering, and `gh --json` reduction reusing the guardian SmartCrusher build when present (no logic duplication). Outputs under 2KB pass through; the `[egc-crusher]` marker makes double compression a no-op, per the approved coexistence plan.
- `scripts/lib/crusher/metrics.js`: zero-cost local ledger (`~/.egc/metrics/crusher.jsonl`, 0700) feeding the future unified metrics aggregation.
- `egc run <cmd>`: executes through the crusher, preserves exit code and stderr; `--raw` is the escape hatch.
- `egc saved`: accumulated savings report printed to the terminal only, zero token cost.

## Verification
- `tests/crusher-engine.test.js`: 10/10 (kind routing, pass-through floor, failure preservation, anti-double-compression, diff summary, ledger aggregation).
- Real E2E on this repo with isolated HOME: `egc run git log --oneline -200` produced 81% smaller output (~3251 tokens saved) and `egc saved` reported it from the ledger.
- CLI suites: egc.test.js 18/18, npm-publish-surface 2/2, install-readme-clarity 6/6.

Phase 2 (separate PR): harness adapters (PreToolUse rewrite), the `egc init` status line, installer-side clean/smudge complement and README docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Token Crusher phase 1 to `egc`: compresses noisy shell output to cut token usage, while preserving errors, exit codes, and small outputs. New `egc run` routes commands through the crusher and `egc saved` reports local savings.

- **New Features**
  - Conservative per-command compression: cap `git log`, summarize large `git diff`, strip test-runner noise, filter package-manager installs, and reduce `gh --json` via the `egc-guardian` SmartCrusher when present.
  - 2 KB pass-through floor and `[egc-crusher]` marker to prevent double compression.
  - `egc run [--raw] <cmd>` executes through the crusher; `--raw` disables it.
  - Local JSONL ledger at `~/.egc/metrics/crusher.jsonl`; `egc saved` shows totals (supports `--json`).

- **Bug Fixes**
  - Use Unicode escapes in the test-runner regex to satisfy the unicode-safety gate.

<sup>Written for commit c393f028ea41ee7f331fe56e450864e28bb40fd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

