### PR TITLE
feat(memory): Session Bus MVP, presence and cooperative path locks

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -13,6 +13,15 @@ import { z } from 'zod';
 import { createSearchIndex, rebuildSearchIndex, searchDecisions, createLessonsSearchIndex, rebuildLessonsSearchIndex, searchLessons } from './search.js';
 import { detectBranch, resolveStateRead, resolveStateWrite } from './branch-state';
 import { buildGlobalAppendix, globalStateFilePath } from './global-state';
+import {
+  announce as busAnnounce,
+  claimPath as busClaimPath,
+  createSessionBusTables,
+  listLocks as busListLocks,
+  listPeers as busListPeers,
+  releasePath as busReleasePath,
+  sweepDead as busSweepDead,
+} from './session-bus';
 import { loadOrCreateKey, writeHmac, verifyHmac } from './integrity';
 import { loadOrCreateEncKey, readStateFile, writeStateFile, quarantineUndecryptableStateFile } from './encryption';
 import { propagateStateToTools } from './propagate';
@@ -361,6 +370,13 @@ async function runMigrations(db: Database, dbDir: string) {
       await db.run('INSERT INTO schema_migrations (version) VALUES (9)');
     }
 
+    // Migration 10: session bus tables for presence and cooperative path locks.
+    const hasV10 = await db.get('SELECT version FROM schema_migrations WHERE version = 10');
+    if (!hasV10) {
+      await createSessionBusTables(db);
+      await db.run('INSERT INTO schema_migrations (version) VALUES (10)');
+    }
+
     const bootRow = await db.get<{value: string}>('SELECT value FROM operational_state WHERE id = ?', ['server_boot_count']);
     const bootCount = bootRow ? Number.parseInt(bootRow.value, 10) + 1 : 1;
     await db.run('INSERT OR REPLACE INTO operational_state (id, value) VALUES (?, ?)', ['server_boot_count', String(bootCount)]);
@@ -684,6 +700,27 @@ const UpdateStateSchema = z.object({
   scope: z.enum(['project', 'global']).optional().default('project')
 });
 
+const SessionAnnounceSchema = z.object({
+  session_id: z.string().min(1).max(200).optional(),
+  project_path: z.string().optional(),
+  territory: z.string().max(500).optional()
+});
+
+const ClaimPathSchema = z.object({
+  session_id: z.string().min(1).max(200).optional(),
+  path: z.string().min(1).max(1000),
+  ttl_seconds: z.number().int().min(1).max(3600).optional()
+});
+
+const ReleasePathSchema = z.object({
+  session_id: z.string().min(1).max(200).optional(),
+  path: z.string().min(1).max(1000)
+});
+
+const SessionPeersSchema = z.object({
+  project_path: z.string().optional()
+});
+
 const WorkingMemorySetSchema = z.object({
   project_path: z.string().optional(),
   key: z.string().min(1).max(200),
@@ -752,6 +789,53 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             next: { type: "array", items: { type: "string" }, description: "What to pick up in the next session." },
             force: { type: "boolean", description: "Recover from a state file that cannot be decrypted (corrupted or encrypted with an orphaned key). When true and the existing file fails to decrypt, the corrupted file is renamed to a '.corrupted-backup-<timestamp>' sibling instead of being read, and this call's data becomes the fresh state — nothing is merged in from the unreadable file, and nothing is deleted. Only set this after confirming the failure is persistent, not a transient lock from another process writing at the same moment." },
             scope: { type: "string", enum: ["project", "global"], description: "Where to write. 'project' (default) scopes to the current project/branch. 'global' writes to the user-wide memory shared across all projects (~/.egc/global/state.md); use it only for transversal preferences and lessons the user wants everywhere, never for project-specific state." }
+          }
+        }
+      },
+      {
+        name: "session_announce",
+        description: "Announce this session on the session bus: registers presence with an optional territory (folder or theme this session will work on) and doubles as heartbeat. Call at session start and periodically during long work. Sessions without a heartbeat for 10 minutes are swept and their locks released. Returns the list of live peer sessions for the project so parallel sessions can split territory instead of colliding.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            session_id: { type: "string", description: "Stable identifier for this session. Defaults to the id opened by get_state, falling back to a process-scoped id." },
+            project_path: { type: "string", description: "Absolute path to the project root. Defaults to current working directory." },
+            territory: { type: "string", description: "Folder or theme this session is claiming informally, e.g. 'scripts/lib' or 'docs sweep'." }
+          }
+        }
+      },
+      {
+        name: "claim_path",
+        description: "Cooperatively lock a path on the session bus before editing it. Fail-fast: if another live session holds the lock the claim is refused and the holder is returned; coordinate or pick another territory instead of retrying in a loop. Locks expire after ttl_seconds (default 900, max 3600) and die with their session.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            session_id: { type: "string", description: "Session id acquiring the lock. Defaults to the current session." },
+            path: { type: "string", description: "Repo-relative or absolute path (file or folder) to lock." },
+            ttl_seconds: { type: "number", description: "Lock lifetime in seconds (1-3600, default 900)." }
+          },
+          required: ["path"]
+        }
+      },
+      {
+        name: "release_path",
+        description: "Release a path lock held by this session on the session bus. Only the holder can release; returns whether a lock was actually removed.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            session_id: { type: "string", description: "Session id releasing the lock. Defaults to the current session." },
+            path: { type: "string", description: "The locked path to release." }
+          },
+          required: ["path"]
+        }
+      },
+      {
+        name: "session_peers",
+        description: "List live sessions and active path locks on the session bus. Use before starting parallel work to see who is active and which territories are taken.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            project_path: { type: "string", description: "Filter sessions to one project. Omit for all projects." }
           }
         }
       },
@@ -1151,6 +1235,59 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
   return { content: [{ type: "text", text: `Project memory updated.\n${branchLine}${toolsLine}File: ${filePath}\nDecisions saved: ${args.decisions?.length || 0}\nNext session items: ${args.next?.length || 0}` }] };
 }
 
+async function resolveBusSessionId(db: Database, provided?: string): Promise<string> {
+  if (provided) return provided;
+  const current = await getMaintenanceState(db, 'current_session_id');
+  return current || `bus-${process.pid}`;
+}
+
+async function handleSessionAnnounce(db: Database, toolArgs: unknown) {
+  const args = SessionAnnounceSchema.parse(toolArgs || {});
+  const projPath = resolveProjectPath(args.project_path);
+  const sessionId = await resolveBusSessionId(db, args.session_id);
+  await writeArbitrator.enqueue(async () => {
+    await busSweepDead(db);
+    await busAnnounce(db, { sessionId, projectPath: projPath, territory: args.territory });
+  });
+  const peers = await busListPeers(db, projPath);
+  const peerLines = peers
+    .filter(p => p.id !== sessionId)
+    .map(p => `- ${p.id}${p.territory ? ` (territory: ${p.territory})` : ''}`);
+  log('INFO', 'Session announced on bus', { session: sessionId, project: projPath, peers: peerLines.length });
+  return { content: [{ type: "text", text: `Session ${sessionId} announced.\nLive peers in this project: ${peerLines.length === 0 ? 'none' : '\n' + peerLines.join('\n')}` }] };
+}
+
+async function handleClaimPath(db: Database, toolArgs: unknown) {
+  const args = ClaimPathSchema.parse(toolArgs || {});
+  const sessionId = await resolveBusSessionId(db, args.session_id);
+  const result = await writeArbitrator.enqueue(async () => {
+    await busSweepDead(db);
+    return busClaimPath(db, { sessionId, path: args.path, ttlSeconds: args.ttl_seconds });
+  });
+  if (!result.ok) {
+    return { content: [{ type: "text", text: `Claim REFUSED: ${args.path} is locked by live session ${result.holder}${result.holderTerritory ? ` (territory: ${result.holderTerritory})` : ''}.\nCoordinate with that session or work elsewhere; do not retry in a loop.` }] };
+  }
+  return { content: [{ type: "text", text: `Path claimed by ${sessionId}: ${args.path}` }] };
+}
+
+async function handleReleasePath(db: Database, toolArgs: unknown) {
+  const args = ReleasePathSchema.parse(toolArgs || {});
+  const sessionId = await resolveBusSessionId(db, args.session_id);
+  const released = await writeArbitrator.enqueue(async () => busReleasePath(db, { sessionId, path: args.path }));
+  return { content: [{ type: "text", text: released ? `Lock released: ${args.path}` : `No lock held by ${sessionId} on ${args.path}; nothing released.` }] };
+}
+
+async function handleSessionPeers(db: Database, toolArgs: unknown) {
+  const args = SessionPeersSchema.parse(toolArgs || {});
+  await writeArbitrator.enqueue(async () => busSweepDead(db));
+  const projPath = args.project_path ? resolveProjectPath(args.project_path) : undefined;
+  const peers = await busListPeers(db, projPath);
+  const locks = await busListLocks(db);
+  const peerLines = peers.map(p => `- ${p.id}${p.project_path ? ` [${p.project_path}]` : ''}${p.territory ? ` (territory: ${p.territory})` : ''} since ${p.started_at}`);
+  const lockLines = locks.map(l => `- ${l.path} held by ${l.session_id} (ttl ${l.ttl_seconds}s)`);
+  return { content: [{ type: "text", text: `Live sessions: ${peers.length}\n${peerLines.join('\n') || '(none)'}\n\nActive locks: ${locks.length}\n${lockLines.join('\n') || '(none)'}` }] };
+}
+
 async function handleDetectPatterns(db: Database, toolArgs: unknown) {
   const { window_days, min_occurrences } = DetectPatternsSchema.parse(toolArgs || {});
   const cutoff = new Date(Date.now() - window_days * 24 * 60 * 60 * 1000).toISOString();
@@ -1365,6 +1502,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "get_state": return await handleGetState(db, request.params.arguments);
 
       case "update_state": return await handleUpdateState(db, request.params.arguments);
+      case "session_announce": return await handleSessionAnnounce(db, request.params.arguments);
+      case "claim_path": return await handleClaimPath(db, request.params.arguments);
+      case "release_path": return await handleReleasePath(db, request.params.arguments);
+      case "session_peers": return await handleSessionPeers(db, request.params.arguments);
 
       case "working_memory_set": {
         const args = WorkingMemorySetSchema.parse(request.params.arguments || {});

--- a/mcp/servers/egc-memory/src/session-bus.ts
+++ b/mcp/servers/egc-memory/src/session-bus.ts
@@ -1,0 +1,111 @@
+// Session Bus MVP: presence and cooperative path locks for parallel sessions
+// sharing one ~/.egc store. This is the minimum that prevents duplicated work
+// and state corruption; messaging and guardian enforcement build on top later.
+
+export interface BusDb {
+  run(sql: string, ...params: unknown[]): Promise<unknown>;
+  get(sql: string, ...params: unknown[]): Promise<Record<string, unknown> | undefined>;
+  all(sql: string, ...params: unknown[]): Promise<Record<string, unknown>[]>;
+  exec(sql: string): Promise<unknown>;
+}
+
+export const SESSION_TTL_SECONDS = 600;
+export const DEFAULT_LOCK_TTL_SECONDS = 900;
+export const MAX_LOCK_TTL_SECONDS = 3600;
+
+export async function createSessionBusTables(db: BusDb): Promise<void> {
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS bus_sessions (
+      id TEXT PRIMARY KEY,
+      project_path TEXT,
+      territory TEXT,
+      started_at TEXT NOT NULL,
+      heartbeat_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS bus_locks (
+      path TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      acquired_at TEXT NOT NULL,
+      ttl_seconds INTEGER NOT NULL
+    );
+  `);
+}
+
+// Lazy GC: dead sessions release their presence and every lock they held.
+// Clock skew is irrelevant because all timestamps come from this machine.
+export async function sweepDead(db: BusDb, nowMs: number = Date.now()): Promise<void> {
+  const cutoff = new Date(nowMs - SESSION_TTL_SECONDS * 1000).toISOString();
+  await db.run('DELETE FROM bus_locks WHERE session_id IN (SELECT id FROM bus_sessions WHERE heartbeat_at < ?)', cutoff);
+  await db.run('DELETE FROM bus_sessions WHERE heartbeat_at < ?', cutoff);
+  await db.run(
+    "DELETE FROM bus_locks WHERE (julianday('now') - julianday(acquired_at)) * 86400 > ttl_seconds"
+  );
+}
+
+export async function announce(
+  db: BusDb,
+  input: { sessionId: string; projectPath?: string; territory?: string },
+  nowMs: number = Date.now()
+): Promise<void> {
+  const now = new Date(nowMs).toISOString();
+  await db.run(
+    `INSERT INTO bus_sessions (id, project_path, territory, started_at, heartbeat_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       project_path = excluded.project_path,
+       territory = COALESCE(excluded.territory, bus_sessions.territory),
+       heartbeat_at = excluded.heartbeat_at`,
+    input.sessionId, input.projectPath || null, input.territory || null, now, now
+  );
+}
+
+export async function listPeers(db: BusDb, projectPath?: string): Promise<Record<string, unknown>[]> {
+  if (projectPath) {
+    return db.all('SELECT * FROM bus_sessions WHERE project_path = ? ORDER BY started_at', projectPath);
+  }
+  return db.all('SELECT * FROM bus_sessions ORDER BY started_at');
+}
+
+export interface ClaimResult {
+  ok: boolean;
+  holder?: string;
+  holderTerritory?: string;
+}
+
+// Fail-fast claim: a conflicting live lock is reported, never queued.
+export async function claimPath(
+  db: BusDb,
+  input: { sessionId: string; path: string; ttlSeconds?: number },
+  nowMs: number = Date.now()
+): Promise<ClaimResult> {
+  const ttl = Math.min(Math.max(input.ttlSeconds || DEFAULT_LOCK_TTL_SECONDS, 1), MAX_LOCK_TTL_SECONDS);
+  const existing = await db.get('SELECT session_id FROM bus_locks WHERE path = ?', input.path);
+  if (existing && existing.session_id !== input.sessionId) {
+    const holder = await db.get('SELECT id, territory FROM bus_sessions WHERE id = ?', existing.session_id);
+    if (holder) {
+      return { ok: false, holder: String(holder.id), holderTerritory: holder.territory ? String(holder.territory) : undefined };
+    }
+    await db.run('DELETE FROM bus_locks WHERE path = ?', input.path);
+  }
+  await db.run(
+    `INSERT INTO bus_locks (path, session_id, acquired_at, ttl_seconds)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET
+       session_id = excluded.session_id,
+       acquired_at = excluded.acquired_at,
+       ttl_seconds = excluded.ttl_seconds`,
+    input.path, input.sessionId, new Date(nowMs).toISOString(), ttl
+  );
+  return { ok: true };
+}
+
+export async function releasePath(db: BusDb, input: { sessionId: string; path: string }): Promise<boolean> {
+  const existing = await db.get('SELECT session_id FROM bus_locks WHERE path = ?', input.path);
+  if (!existing || existing.session_id !== input.sessionId) return false;
+  await db.run('DELETE FROM bus_locks WHERE path = ?', input.path);
+  return true;
+}
+
+export async function listLocks(db: BusDb): Promise<Record<string, unknown>[]> {
+  return db.all('SELECT * FROM bus_locks ORDER BY acquired_at');
+}

--- a/tests/egc-memory-session-bus.test.js
+++ b/tests/egc-memory-session-bus.test.js
@@ -1,0 +1,119 @@
+'use strict';
+/**
+ * Tests for mcp/servers/egc-memory/src/session-bus.ts
+ *
+ * Covers the Session Bus MVP invariants: presence with heartbeat, fail-fast
+ * path claims, holder-only release, and lazy sweep of dead sessions freeing
+ * their locks. Runs against an in-memory SQLite database using the memory
+ * server's own driver; skips when the server build or driver is absent.
+ *
+ * Run with: node tests/egc-memory-session-bus.test.js
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const serverDir = path.join(__dirname, '..', 'mcp', 'servers', 'egc-memory');
+const buildPath = path.join(serverDir, 'build', 'session-bus.js');
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-memory first.');
+  process.exit(0);
+}
+
+let sqlite3;
+let open;
+try {
+  sqlite3 = require(path.join(serverDir, 'node_modules', 'sqlite3'));
+  ({ open } = require(path.join(serverDir, 'node_modules', 'sqlite')));
+} catch {
+  console.log('[SKIP] sqlite driver not installed. Run sh install.sh first.');
+  process.exit(0);
+}
+
+const bus = require(buildPath);
+
+function test(name, fn) {
+  return fn().then(
+    () => { console.log(`  PASS ${name}`); return true; },
+    err => { console.log(`  FAIL ${name}`); console.log(`    ${err.message}`); return false; }
+  );
+}
+
+async function freshDb() {
+  const db = await open({ filename: ':memory:', driver: sqlite3.Database });
+  await bus.createSessionBusTables(db);
+  return db;
+}
+
+async function main() {
+  console.log('\n=== Testing egc-memory session bus ===\n');
+  let passed = 0;
+  let failed = 0;
+  const run = async (name, fn) => { (await test(name, fn)) ? passed++ : failed++; };
+
+  await run('announce registers presence and doubles as heartbeat', async () => {
+    const db = await freshDb();
+    await bus.announce(db, { sessionId: 's1', projectPath: '/p', territory: 'scripts/' });
+    await bus.announce(db, { sessionId: 's1', projectPath: '/p' });
+    const peers = await bus.listPeers(db, '/p');
+    assert.strictEqual(peers.length, 1);
+    assert.strictEqual(peers[0].territory, 'scripts/', 'territory survives heartbeat without territory');
+  });
+
+  await run('claim is fail-fast against a live holder', async () => {
+    const db = await freshDb();
+    await bus.announce(db, { sessionId: 's1', projectPath: '/p', territory: 'docs' });
+    await bus.announce(db, { sessionId: 's2', projectPath: '/p' });
+    const first = await bus.claimPath(db, { sessionId: 's1', path: 'src/index.ts' });
+    assert.strictEqual(first.ok, true);
+    const second = await bus.claimPath(db, { sessionId: 's2', path: 'src/index.ts' });
+    assert.strictEqual(second.ok, false);
+    assert.strictEqual(second.holder, 's1');
+    assert.strictEqual(second.holderTerritory, 'docs');
+  });
+
+  await run('holder can re-claim its own path and only the holder releases', async () => {
+    const db = await freshDb();
+    await bus.announce(db, { sessionId: 's1', projectPath: '/p' });
+    await bus.claimPath(db, { sessionId: 's1', path: 'a.js' });
+    const reclaim = await bus.claimPath(db, { sessionId: 's1', path: 'a.js' });
+    assert.strictEqual(reclaim.ok, true);
+    assert.strictEqual(await bus.releasePath(db, { sessionId: 's2', path: 'a.js' }), false);
+    assert.strictEqual(await bus.releasePath(db, { sessionId: 's1', path: 'a.js' }), true);
+    assert.strictEqual((await bus.listLocks(db)).length, 0);
+  });
+
+  await run('dead sessions are swept and their locks freed', async () => {
+    const db = await freshDb();
+    const past = Date.now() - (bus.SESSION_TTL_SECONDS + 60) * 1000;
+    await bus.announce(db, { sessionId: 'dead', projectPath: '/p' }, past);
+    await bus.claimPath(db, { sessionId: 'dead', path: 'x.js' }, past);
+    await bus.announce(db, { sessionId: 'alive', projectPath: '/p' });
+    await bus.sweepDead(db);
+    const peers = await bus.listPeers(db);
+    assert.strictEqual(peers.length, 1);
+    assert.strictEqual(peers[0].id, 'alive');
+    const claim = await bus.claimPath(db, { sessionId: 'alive', path: 'x.js' });
+    assert.strictEqual(claim.ok, true, 'lock freed by sweep is claimable');
+  });
+
+  await run('a lock from a vanished session does not block a live claim', async () => {
+    const db = await freshDb();
+    await bus.announce(db, { sessionId: 'alive', projectPath: '/p' });
+    await db.run(
+      "INSERT INTO bus_locks (path, session_id, acquired_at, ttl_seconds) VALUES ('y.js', 'ghost', ?, 900)",
+      new Date().toISOString()
+    );
+    const claim = await bus.claimPath(db, { sessionId: 'alive', path: 'y.js' });
+    assert.strictEqual(claim.ok, true);
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('[FAIL]', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Item 6 of the approved omnipresent-context work: the minimum Session Bus that stops parallel sessions from duplicating work and corrupting shared state (the real incident that motivated it: duplicated PR #840/#841 plus a state-file corruption from concurrent writes).

## What changed
- New `session-bus.ts` module in egc-memory, wired as schema migration 10 (tables `bus_sessions`, `bus_locks`).
- `session_announce`: presence + territory, doubles as heartbeat; returns live peers for the project.
- `claim_path` / `release_path`: cooperative locks, fail-fast on conflict with holder info (never queued), TTL-bounded (default 900s, max 3600s), holder-only release.
- `session_peers`: live sessions and active locks overview.
- Lazy sweep: sessions silent for 10 minutes are removed and every lock they held is released; a lock whose holder vanished never blocks a live claim.
- All writes go through the existing SQLite write arbitrator (jitter + retries from #853).

## Verification
- `tests/egc-memory-session-bus.test.js`: 5/5 against in-memory SQLite with the server's own driver (skips cleanly where the build is absent, same pattern as the sibling memory suites).
- Regression: encryption, integrity and global-state suites all green; tsc --noEmit clean.

Guardian enforcement (validate_write refusing writes on paths locked by another live session) is the follow-up layer and intentionally out of this MVP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimum Session Bus to `egc-memory` to stop parallel sessions from duplicating work and corrupting shared state. Provides presence with heartbeat and cooperative, fail-fast path locks.

- **New Features**
  - `session-bus.ts` module with presence (`session_announce`) and territory hints.
  - Cooperative path locks: `claim_path` and `release_path` with TTL (default 900s, max 3600s) and holder-only release.
  - Fail-fast claims return current holder and territory; no queuing or retries.
  - Lazy sweep removes sessions silent for 10 minutes and releases their locks.
  - `session_peers` lists live sessions and active locks for coordination.

- **Migration**
  - Schema migration 10 adds `bus_sessions` and `bus_locks` (auto-applied).

<sup>Written for commit 108d72558835b9766ce1ab5d1b66892a8c2fbaad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

