### PR TITLE
feat(crusher): tier A adapter, silent rewrite through the bash dispatcher

### DIFF
--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -12,6 +12,7 @@ const { run: runGitPushReminder } = require('./pre-bash-git-push-reminder');
 const { run: runCommitQuality } = require('./pre-bash-commit-quality');
 const { run: runVerificationGate } = require('./pre-bash-verification-gate');
 const { run: runGateGuard } = require('./gateguard-fact-force');
+const { run: runCrusherRewrite } = require('./pre-bash-crusher-rewrite');
 const { run: runBudgetCheck } = require('./pre-budget-check');
 const { run: runCommandLog } = require('./post-bash-command-log');
 const { run: runPrCreated } = require('./post-bash-pr-created');
@@ -58,6 +59,11 @@ const PRE_BASH_HOOKS = [
     id: 'pre:bash:gateguard-fact-force',
     profiles: 'standard,strict',
     run: rawInput => runGateGuard(rawInput),
+  },
+  {
+    id: 'pre:bash:crusher-rewrite',
+    profiles: 'standard,strict',
+    run: rawInput => runCrusherRewrite(rawInput),
   },
   {
     id: 'pre:bash:budget-check',

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// PreToolUse rewrite for the Token Crusher: routes crushable commands through
+// `egc run` so noisy output is compressed before it reaches the model. Fail-open
+// everywhere: no engine, no egc CLI, complex shell syntax or an already-wrapped
+// command all pass through untouched. Disable with
+// EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite.
+
+const { spawnSync } = require('node:child_process');
+
+function tryRequire(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+// Repo layout first, flattened install layout second.
+const engine = tryRequire('../lib/crusher/engine') || tryRequire('../lib/crusher-engine');
+
+const WRAPPED_RE = /^\s*(egc|rtk)\s|--raw\b/;
+// Wrapping changes semantics for pipelines, chaining, redirection, substitution
+// and multi-line commands, so those never get rewritten.
+const COMPLEX_SHELL_RE = /[|&;<>$`()\n]/;
+
+let egcAvailable = null;
+function hasEgcCli() {
+  if (process.env.EGC_ASSUME_EGC_CLI === '1') return true;
+  if (process.env.EGC_ASSUME_EGC_CLI === '0') return false;
+  if (egcAvailable === null) {
+    const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['egc'], { encoding: 'utf8' });
+    egcAvailable = probe.status === 0;
+  }
+  return egcAvailable;
+}
+
+function run(rawInput) {
+  try {
+    const input = typeof rawInput === 'string' ? JSON.parse(rawInput) : rawInput;
+    const cmd = input.tool_input?.command || '';
+
+    if (
+      !engine
+      || !cmd
+      || WRAPPED_RE.test(cmd)
+      || COMPLEX_SHELL_RE.test(cmd)
+      || engine.commandKind(cmd) === 'generic'
+      || !hasEgcCli()
+    ) {
+      return JSON.stringify(input);
+    }
+
+    return JSON.stringify({
+      ...input,
+      tool_input: {
+        ...input.tool_input,
+        command: `egc run ${cmd}`,
+      },
+    });
+  } catch {
+    return typeof rawInput === 'string' ? rawInput : JSON.stringify(rawInput);
+  }
+}
+
+module.exports = { run };

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -19,7 +19,7 @@ function tryRequire(modulePath) {
 // Repo layout first, flattened install layout second.
 const engine = tryRequire('../lib/crusher/engine') || tryRequire('../lib/crusher-engine');
 
-const WRAPPED_RE = /^\s*(egc|rtk)\s|--raw\b/;
+const WRAPPED_RE = /(?:^\s*(?:egc|rtk)\s)|(?:--raw\b)/;
 // Wrapping changes semantics for pipelines, chaining, redirection, substitution
 // and multi-line commands, so those never get rewritten.
 const COMPLEX_SHELL_RE = /[|&;<>$`()\n]/;

--- a/tests/hooks/pre-bash-crusher-rewrite.test.js
+++ b/tests/hooks/pre-bash-crusher-rewrite.test.js
@@ -1,0 +1,72 @@
+'use strict';
+/**
+ * Tests for scripts/hooks/pre-bash-crusher-rewrite.js
+ *
+ * Covers the fail-open contract of the Token Crusher rewrite: only simple,
+ * crushable, unwrapped commands are routed through `egc run`, and every
+ * uncertain case passes through untouched.
+ *
+ * Run with: node tests/hooks/pre-bash-crusher-rewrite.test.js
+ */
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { run } = require(path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-crusher-rewrite.js'));
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const runCase = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+function invoke(command) {
+  const out = run(JSON.stringify({ tool_name: 'Bash', tool_input: { command } }));
+  return JSON.parse(out).tool_input.command;
+}
+
+console.log('\n=== Testing pre-bash-crusher-rewrite ===\n');
+
+process.env.EGC_ASSUME_EGC_CLI = '1';
+
+runCase('crushable simple command is routed through egc run', () => {
+  assert.strictEqual(invoke('git log --oneline -200'), 'egc run git log --oneline -200');
+});
+
+runCase('generic command passes through', () => {
+  assert.strictEqual(invoke('ls -la src'), 'ls -la src');
+});
+
+runCase('pipelines and chaining pass through', () => {
+  assert.strictEqual(invoke('git log | head -5'), 'git log | head -5');
+  assert.strictEqual(invoke('git log && echo done'), 'git log && echo done');
+  assert.strictEqual(invoke('git diff > out.txt'), 'git diff > out.txt');
+});
+
+runCase('already wrapped commands pass through', () => {
+  assert.strictEqual(invoke('egc run git log'), 'egc run git log');
+  assert.strictEqual(invoke('rtk git log'), 'rtk git log');
+  assert.strictEqual(invoke('git log --raw'), 'git log --raw');
+});
+
+runCase('malformed input passes through unchanged', () => {
+  assert.strictEqual(run('not json'), 'not json');
+});
+
+runCase('without the egc CLI nothing is rewritten', () => {
+  process.env.EGC_ASSUME_EGC_CLI = '0';
+  assert.strictEqual(invoke('git log --oneline -200'), 'git log --oneline -200');
+  process.env.EGC_ASSUME_EGC_CLI = '1';
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Final implementation piece of the omnipresent-context work: the Token Crusher now engages with zero user action on hook-capable harnesses.

## What changed
- New `pre:bash:crusher-rewrite` hook in the bash dispatcher (standard/strict profiles): crushable simple commands (git log/diff, test runners, package-manager installs, gh --json) are rewritten to `egc run <cmd>` before execution, so output is compressed before it reaches the model.
- Strictly fail-open: pipelines/chaining/redirection/substitution, already-wrapped commands (`egc`/`rtk`/`--raw`), a missing crusher engine or a missing `egc` CLI all pass the command through untouched.
- Opt out with `EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite` (same switch family as every dispatcher hook).
- Ships automatically: the install modules already copy `scripts/hooks` and `scripts/lib` recursively, and the hook resolves the engine in both repo and installed layouts.

## Verification
- `tests/hooks/pre-bash-crusher-rewrite.test.js`: 6/6 (rewrite, pass-through for generic/complex/wrapped/malformed, CLI-absent guard).
- Dispatcher suite 5/5, validate-hooks: 40 matchers OK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically routes crushable bash commands through `egc run` so Token Crusher compresses output with no user action. Behavior is strictly fail-open to avoid changing command semantics.

- **New Features**
  - Added `pre:bash:crusher-rewrite` hook to `standard` and `strict` bash profiles.
  - Rewrites simple crushable commands (e.g., `git log/diff`, test runners, package installs, `gh --json`) to `egc run <cmd>` when the crusher engine and `egc` CLI are available.
  - Passes through complex syntax or wrapped commands (`egc`, `rtk`, `--raw`), and when the engine or `egc` CLI is missing.
  - Ships automatically; works in repo and installed layouts; opt out with `EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite` (control CLI detection via `EGC_ASSUME_EGC_CLI=1|0`).

- **Bug Fixes**
  - Made wrapper-detection regex precedence explicit to prevent mis-matches.

<sup>Written for commit 98ed372f0955dfbec29fe6e3241bfb3606ba5df5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

