### PR TITLE
docs: document global memory, session bus and Token Crusher across the repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ update_state({
 
 `update_state` merges with existing state: it does not erase previous memory. Only include fields that changed this session. Leave out fields with nothing new.
 
+Pass `scope: "global"` to write to the user-wide memory shared across all projects; use it only for transversal preferences and lessons, never for project-specific state. `get_state` appends that global memory automatically, with project and branch entries taking precedence.
+
+## Parallel sessions
+
+When more than one session works on this project at the same time, coordinate through the session bus: call `session_announce` at start (registers presence and territory, doubles as heartbeat), check `session_peers` before picking work, and `claim_path` before editing shared files. A refused claim means another live session holds that path: coordinate or work elsewhere, never retry in a loop.
+
 ## Where state is stored
 
 `~/.egc/state/<project-slug>/<branch>.md`: one file per project branch (flat `<project-slug>.md` files from older versions are still read). Files are encrypted at rest with AES-256-GCM (key at `~/.egc/encryption.key`); the memory server and session hooks decrypt them transparently.
@@ -58,7 +64,7 @@ update_state({
 Both servers must be registered in your MCP config (`.mcp.json`):
 
 - `egc-guardian`: `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task`
-- `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`
+- `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`, `session_announce`, `session_peers`, `claim_path`, `release_path`
 
 Run `sh install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,18 @@ What shipped in the 1.1.x patch series:
 - Community translations: Arabic, Hindi, Korean, Russian, Japanese, Spanish, Portuguese -- 8 languages total
 - 14 supported AI coding tools
 
+## v1.1.12: Omnipresent Context (Released 2026-07-18)
+
+Memory everywhere, tokens crushed, sessions coordinated:
+
+- User-wide global memory: `update_state` with `scope: "global"` shares preferences and lessons across every project; `get_state` and the session-start hooks append a deduplicated Global Memory section with strict project-over-global precedence (#855)
+- Session Bus MVP: `session_announce`, `session_peers`, `claim_path`, `release_path` -- parallel sessions split territory with fail-fast cooperative locks, dead sessions swept after 10 minutes (#858)
+- Commit privacy enforced in three layers: `check-state-leak.js`, tracked pre-commit hook, and a CI tree guard; the public baseline of the propagation files now ships zeroed (#856)
+- Token Crusher: native shell-output compression engine with `egc run` and the zero-cost `egc saved` report (#857), silent tier A rewrite in the bash dispatcher (#860), status line at `egc init` (#859)
+- Multi-session SQLite write arbitration hardened with equal jitter and deeper retries (#853)
+- Zero-friction DCO finally works: the prepare-commit-msg hook shipped without its executable bit since #719 (#854)
+- 20 supported AI coding tools
+
 ## v1.2.0: Teams
 
 Multi-developer workflows and shared context:

--- a/docs/guides/token-optimization.md
+++ b/docs/guides/token-optimization.md
@@ -61,6 +61,18 @@ Switch models mid-session:
 
 ---
 
+## Token Crusher (built into EGC)
+
+Since v1.1.12 the biggest lever ships with the package: the Token Crusher compresses noisy shell output before it reaches the model. Long `git log`/`git diff`, test-runner noise, package-manager installs and large `gh --json` payloads shrink by up to 90%, with errors, warnings and failures always preserved.
+
+| Command | What it does |
+|---------|--------------|
+| `egc run <cmd>` | Runs the command and crushes the output before the model reads it |
+| `egc run --raw <cmd>` | Escape hatch: full output when you need every line |
+| `egc saved` | Accumulated savings report, computed locally at zero token cost |
+
+On hook-capable harnesses eligible simple commands are routed through `egc run` automatically by the bash dispatcher; opt out with `EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite`.
+
 ## Context Management
 
 ### Commands

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -186,6 +186,30 @@ With a provider API key (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`
 
 ---
 
+## Global memory and parallel sessions
+
+Since v1.1.12 memory has two scopes. Project scope works exactly as before (one state per project branch). The new user-wide global scope is shared across every project: save transversal preferences and lessons once with `update_state` and `scope: "global"`, and every `get_state` in every project appends a deduplicated `Global Memory` section after the project state. Project and branch entries always take precedence, and global memory is only ever written by an explicit global call, never derived from project data.
+
+Parallel sessions coordinate through the session bus. A session announces itself with `session_announce` (presence plus an optional territory, doubling as heartbeat), inspects who else is active with `session_peers`, and takes cooperative locks with `claim_path` before editing shared files. Claims are fail-fast: a conflicting live lock is refused with the holder's identity instead of queued. Sessions silent for 10 minutes are swept and their locks released, so a crashed session never blocks the others.
+
+Populated memory never reaches a commit. The propagation files (AGENTS.md, GEMINI.md, editor rules) ship as empty structure; local sessions repopulate them, a pre-commit hook blocks accidental staging, and a CI guard catches anything that slips past local hooks.
+
+---
+
+## Token Crusher
+
+The Token Crusher compresses noisy shell output before it reaches the model: long `git log` and `git diff` output, test-runner noise, package-manager installs, and large `gh --json` payloads shrink by up to 90%, while errors, warnings and failures always survive. It ships with the package, announces itself once at the end of `egc init`, and stays silent afterwards.
+
+```bash
+egc run git log        # any command, crushed output
+egc run --raw git log  # escape hatch: full output
+egc saved              # accumulated savings report, computed locally at zero token cost
+```
+
+On hook-capable harnesses the bash dispatcher routes eligible simple commands through `egc run` automatically. The rewrite is strictly fail-open: pipelines, chaining, redirection, already-wrapped commands, or a missing `egc` CLI all pass through untouched. Opt out anytime with `EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite`.
+
+---
+
 ## Troubleshooting
 
 See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues including permission errors, Node.js version mismatches, and manual MCP registration steps.


### PR DESCRIPTION
Documentation sweep for the omnipresent-context delivery, covering every doc surface in the repo:

- `docs/installation.md`: new sections on global memory and parallel-session coordination, commit privacy, and the Token Crusher (`egc run`, `egc saved`, automatic rewrite, opt-out).
- `docs/ROADMAP.md`: v1.1.12 release section recording everything shipped today (#853-#860).
- `docs/guides/token-optimization.md`: the built-in Token Crusher now leads the guide.
- `CLAUDE.md`: teaches `scope: "global"` writes and the session-bus coordination protocol (announce, peers, claim, fail-fast).

## Verification
- All docs and spec suites green locally; state-leak guard clean on the commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents global memory, the session bus, and the built-in Token Crusher for the Omnipresent Context release. Clarifies commands, safety guarantees, and defaults across install, guides, and the Claude spec, and records v1.1.12 in the roadmap.

- **New Features**
  - Global memory: write with `scope: "global"`; `get_state` auto-appends; project/branch always override.
  - Parallel sessions: `session_announce`, `session_peers`, `claim_path`, `release_path`; fail-fast locks; 10‑min stale sweep.
  - Token Crusher: compresses noisy shell output; `egc run`, `egc run --raw`, `egc saved`; auto rewrite via bash dispatcher; opt out with `EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite`.
  - Commit privacy: propagation files ship empty; pre-commit hook and CI guard block leaks.

<sup>Written for commit ad92af50f5937d976e85eea9efecaf1d70aa195f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

