### PR TITLE
feat(privacy): add git clean filter for memory propagation files

### DIFF
--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -114,6 +114,15 @@ function main() {
     return;
   }
 
+  // Git clean-filter mode: stdin in, zeroed content out. Wired by
+  // memory-filters.js as filter.egc-memory.clean so populated memory is
+  // stripped from the staged blob even when local hooks are bypassed.
+  if (mode === '--filter-clean') {
+    const stdin = fs.readFileSync(0, 'utf8');
+    process.stdout.write(cleanContent(stdin));
+    return;
+  }
+
   const leaks = mode === '--staged' ? checkStaged() : checkTree();
   if (leaks.length === 0) {
     console.log('state-leak check: clean');

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -146,6 +146,29 @@ function registerMcpServers() {
   );
 }
 
+function configureCommitPrivacyFilter() {
+  let configureMemoryFilters;
+  try {
+    ({ configureMemoryFilters } = require('./lib/memory-filters'));
+  } catch {
+    skip('commit-privacy filter', 'memory-filters lib not available');
+    return;
+  }
+
+  const scriptPath = path.join(ROOT_DIR, 'scripts', 'check-state-leak.js');
+  logAction('configuring commit-privacy filter (planned changes below)...');
+  const plan = configureMemoryFilters({ projectDir: process.cwd(), scriptPath, dryRun: true });
+  if (!plan.configured) {
+    skip('commit-privacy filter', plan.reason);
+    return;
+  }
+  for (const action of plan.actions) logAction(action);
+  if (flags.dryRun) return;
+
+  const result = configureMemoryFilters({ projectDir: process.cwd(), scriptPath, dryRun: false });
+  ok('commit-privacy filter', `populated memory is stripped from staged blobs (${result.actions.length} change(s), local repo only)`);
+}
+
 function runStateDbBootstrap() {
   const bootstrapScript = path.join(ROOT_DIR, 'scripts', 'bootstrap-state-db.js');
   if (!fs.existsSync(bootstrapScript)) return;
@@ -231,6 +254,7 @@ checkMcpBuilds();
 runBootstrap();
 registerMcpServers();
 runStateDbBootstrap();
+configureCommitPrivacyFilter();
 runDoctor();
 
 console.log('');

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// Configures the git clean filter that strips populated EGC memory from the
+// propagation files at staging time. Everything stays local to the repo:
+// filter config goes to .git/config and the file bindings to
+// .git/info/attributes, so nothing the user commits is touched. The caller
+// prints every action returned here before applying (installer transparency
+// requirement: no silent global changes).
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const FILTER_NAME = 'egc-memory';
+const PROPAGATION_FILES = [
+  'AGENTS.md',
+  'GEMINI.md',
+  '.cursor/rules/egc-context.mdc',
+  '.trae/rules/egc-context.md',
+];
+
+function gitDir(projectDir) {
+  try {
+    return execFileSync('git', ['rev-parse', '--git-dir'], {
+      cwd: projectDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Returns the action plan without touching anything when dryRun is true.
+function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
+  const resolvedGitDir = gitDir(projectDir);
+  if (!resolvedGitDir) {
+    return { configured: false, reason: 'not a git repository', actions: [] };
+  }
+
+  const absoluteGitDir = path.isAbsolute(resolvedGitDir)
+    ? resolvedGitDir
+    : path.join(projectDir, resolvedGitDir);
+  const attributesFile = path.join(absoluteGitDir, 'info', 'attributes');
+  const cleanCommand = `node "${scriptPath}" --filter-clean`;
+
+  const actions = [
+    `git config filter.${FILTER_NAME}.clean '${cleanCommand}' (local repo config)`,
+  ];
+
+  let existing = '';
+  try {
+    existing = fs.readFileSync(attributesFile, 'utf8');
+  } catch { /* first configuration: attributes file does not exist yet */ }
+
+  const missingBindings = PROPAGATION_FILES.filter(
+    file => !existing.includes(`${file} filter=${FILTER_NAME}`)
+  );
+  for (const file of missingBindings) {
+    actions.push(`bind ${file} to filter=${FILTER_NAME} (.git/info/attributes)`);
+  }
+
+  if (!dryRun) {
+    execFileSync('git', ['config', `filter.${FILTER_NAME}.clean`, cleanCommand], {
+      cwd: projectDir,
+      encoding: 'utf8',
+    });
+    if (missingBindings.length > 0) {
+      fs.mkdirSync(path.dirname(attributesFile), { recursive: true });
+      const header = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+      const lines = missingBindings.map(f => `${f} filter=${FILTER_NAME}\n`).join('');
+      fs.appendFileSync(attributesFile, header + lines);
+    }
+  }
+
+  return { configured: true, actions, attributesFile };
+}
+
+module.exports = { FILTER_NAME, PROPAGATION_FILES, configureMemoryFilters };

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -11,6 +11,14 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
+// S4036: prefer fixed git locations over a PATH lookup; the bare name is the
+// last resort for layouts like nix or Windows portable installs.
+const GIT_BIN = [
+  '/usr/bin/git',
+  '/usr/local/bin/git',
+  'C:\\Program Files\\Git\\cmd\\git.exe',
+].find(p => fs.existsSync(p)) || 'git';
+
 const FILTER_NAME = 'egc-memory';
 const PROPAGATION_FILES = [
   'AGENTS.md',
@@ -21,7 +29,7 @@ const PROPAGATION_FILES = [
 
 function gitDir(projectDir) {
   try {
-    return execFileSync('git', ['rev-parse', '--git-dir'], {
+    return execFileSync(GIT_BIN, ['rev-parse', '--git-dir'], {
       cwd: projectDir,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -61,7 +69,7 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
   }
 
   if (!dryRun) {
-    execFileSync('git', ['config', `filter.${FILTER_NAME}.clean`, cleanCommand], {
+    execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.clean`, cleanCommand], {
       cwd: projectDir,
       encoding: 'utf8',
     });

--- a/tests/memory-filters.test.js
+++ b/tests/memory-filters.test.js
@@ -1,0 +1,124 @@
+'use strict';
+/**
+ * Tests for scripts/lib/memory-filters.js and the --filter-clean mode of
+ * scripts/check-state-leak.js
+ *
+ * Proves the complementary privacy layer end to end: after egc init
+ * configures the clean filter, `git add` on a populated propagation file
+ * stages a zeroed blob, with all bindings kept local to .git (nothing the
+ * user commits is touched). Idempotency and the non-git fallback are covered.
+ *
+ * Run with: node tests/memory-filters.test.js
+ */
+const assert = require('node:assert');
+const { execFileSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const LEAK_SCRIPT = path.join(REPO_ROOT, 'scripts', 'check-state-leak.js');
+const { configureMemoryFilters, FILTER_NAME } = require(path.join(REPO_ROOT, 'scripts', 'lib', 'memory-filters.js'));
+
+const POPULATED = [
+  '# EGC: Agent Catalog',
+  '',
+  '<!-- egc:start -->',
+  '<!-- egc:state-updated:2026-07-18T05:15:28.038Z -->',
+  '## EGC Project Memory',
+  '',
+  '**Context:** secret local context that must never ship.',
+  '',
+  '**Active decisions:**',
+  '- private decision one',
+  '',
+  '## EGC Triggers',
+  '<!-- egc:end -->',
+  '',
+].join('\n');
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-filter-test-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  return { dir, git };
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing memory filters (clean/smudge layer) ===\n');
+
+run('--filter-clean zeroes stdin and preserves structure', () => {
+  const res = spawnSync('node', [LEAK_SCRIPT, '--filter-clean'], { input: POPULATED, encoding: 'utf8' });
+  assert.strictEqual(res.status, 0, res.stderr);
+  assert.ok(res.stdout.includes('## EGC Project Memory'), 'structure survives');
+  assert.ok(!res.stdout.includes('secret local context'), 'context stripped');
+  assert.ok(!res.stdout.includes('state-updated'), 'stamp stripped');
+});
+
+run('dry run reports the plan without touching the repo', () => {
+  const { dir } = makeRepo();
+  const plan = configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: true });
+  assert.strictEqual(plan.configured, true);
+  assert.ok(plan.actions.length >= 5, 'filter config plus four bindings');
+  assert.ok(!fs.existsSync(path.join(dir, '.git', 'info', 'attributes')), 'nothing written on dry run');
+});
+
+run('configure writes local config and attributes only', () => {
+  const { dir, git } = makeRepo();
+  const result = configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  assert.strictEqual(result.configured, true);
+  const cleanCmd = git('config', `filter.${FILTER_NAME}.clean`).trim();
+  assert.ok(cleanCmd.includes('--filter-clean'));
+  const attrs = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf8');
+  assert.ok(attrs.includes(`AGENTS.md filter=${FILTER_NAME}`));
+  assert.ok(attrs.includes(`.trae/rules/egc-context.md filter=${FILTER_NAME}`));
+  assert.strictEqual(fs.readdirSync(dir).filter(f => f !== '.git').length, 0, 'no tracked files created');
+});
+
+run('configure is idempotent', () => {
+  const { dir } = makeRepo();
+  configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  const attrs = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf8');
+  const bindings = attrs.split('\n').filter(l => l.includes('AGENTS.md'));
+  assert.strictEqual(bindings.length, 1, 'no duplicate bindings');
+});
+
+run('git add stages a zeroed blob for a populated propagation file', () => {
+  const { dir, git } = makeRepo();
+  configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  fs.writeFileSync(path.join(dir, 'AGENTS.md'), POPULATED);
+  git('add', 'AGENTS.md');
+  const staged = git('show', ':0:AGENTS.md');
+  assert.ok(!staged.includes('secret local context'), 'staged blob is clean');
+  assert.ok(staged.includes('## EGC Project Memory'), 'staged blob keeps the structure');
+  const working = fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf8');
+  assert.ok(working.includes('secret local context'), 'working tree keeps the populated memory');
+});
+
+run('non-git directory is skipped with a reason', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-nongit-'));
+  const plan = configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: true });
+  assert.strictEqual(plan.configured, false);
+  assert.ok(plan.reason.includes('not a git repository'));
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Third privacy layer for the commit-privacy rule, complementing the pre-commit hook and the CI guard shipped in #856:

- `check-state-leak.js` gains a `--filter-clean` mode: stdin in, zeroed content out, suitable as a git clean filter.
- New `scripts/lib/memory-filters.js` configures `filter.egc-memory.clean` in the local repo config and binds the four propagation files (AGENTS.md, GEMINI.md, .cursor/rules/egc-context.mdc, .trae/rules/egc-context.md) in `.git/info/attributes`. Nothing tracked is touched; everything stays local to `.git`.
- `egc init` runs the new `configureCommitPrivacyFilter` step, printing the action plan before applying it (installer transparency requirement), honoring `--dry-run`, and skipping with a reason outside a git repository.

With this in place, `git add` on a populated propagation file stages a zeroed blob while the working tree keeps the memory, so a leak cannot reach a commit even when local hooks are bypassed with `--no-verify`.

## Tests

- `tests/memory-filters.test.js` (new, 6 cases): filter-clean output, dry-run plan, local-only writes, idempotency, end-to-end staged-blob check inside a temp repo, non-git fallback.
- `tests/check-state-leak.test.js` regression: 5/5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a git clean filter that zeroes EGC memory in propagation files at staging time. Prevents accidental memory commits even when hooks are bypassed.

- **New Features**
  - `--filter-clean` mode in `scripts/check-state-leak.js`: stdin in, zeroed content out (used as a git clean filter).
  - `scripts/lib/memory-filters.js` + `egc init`: configure local `filter.egc-memory.clean` and bind propagation files in `.git/info/attributes`; prints plan, honors `--dry-run`, idempotent, skips outside git.

- **Bug Fixes**
  - Resolve git binary via fixed paths with a PATH fallback in `memory-filters` for reliable execution.

<sup>Written for commit 31ca5648e01bc0e921aa9b04daf488fb03abb6d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

