### PR TITLE
docs: add changelog entries for 1.1.11 through 1.1.13, document clean filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to EGC are documented here.
 
+## [1.1.13] - 2026-07-18
+
+### New Features
+
+- **Commit privacy completed with a git clean filter**: `egc init` now configures `filter.egc-memory.clean` in the local repo config and binds the four memory propagation files (AGENTS.md, GEMINI.md, `.cursor/rules/egc-context.mdc`, `.trae/rules/egc-context.md`) in `.git/info/attributes`. `git add` stages a zeroed blob even when local hooks are bypassed with `--no-verify`, while the working tree keeps the populated memory. Everything stays local to `.git`, nothing tracked is modified, the installer prints the action plan before applying it, and `--dry-run` is honored. Outside a git repository the step is skipped with a reason. (#863)
+
+## [1.1.12] - 2026-07-18
+
+### New Features
+
+- **User-wide global memory**: `update_state` accepts `scope: "global"` to share transversal preferences and lessons across every project; `get_state` and the session-start hooks append a deduplicated `Global Memory` section with strict project-over-global precedence. (#855)
+- **Token Crusher**: native shell-output compression built into the package. `egc run <cmd>` crushes long `git log`/`git diff` output, test-runner noise, package-manager installs and large `gh --json` payloads by up to 90% while always preserving errors and warnings; `egc saved` reports accumulated savings locally at zero token cost; on hook-capable harnesses the bash dispatcher silently routes eligible simple commands through `egc run`, strictly fail-open, opt-out via `EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite`. Announced once at the end of `egc init`. (#857, #859, #860)
+- **Session Bus MVP**: `session_announce`, `session_peers`, `claim_path` and `release_path` let parallel sessions register presence, split territory and take fail-fast cooperative path locks; sessions silent for 10 minutes are swept and their locks released. (#858)
+
+### Security
+
+- **Commit privacy enforced in layers**: `check-state-leak.js` blocks populated memory in staged blobs (pre-commit hook) and in the tracked tree (CI guard); the public baseline of the propagation files now ships zeroed. (#856)
+
+### Bug Fixes
+
+- **Multi-session SQLite write arbitration hardened**: equal jitter (via `crypto.randomInt`) and deeper retries eliminate lock-step collisions between concurrent sessions. (#853)
+- **Zero-friction DCO finally works**: the `prepare-commit-msg` hook had shipped without its executable bit since #719; restored with mode 100755. (#854)
+
+## [1.1.11] - 2026-07-16
+
+### Bug Fixes
+
+- **Dashboard telemetry and cost showing zero in nearly every session**: traced to four root causes: missing PreToolUse/PostToolUse hook wiring for `claude.running`, the Stop hook not forwarding the model field, Claude Code omitting token usage from the Stop payload (now read from the session transcript instead), and the `/stats` regexes never matching the real state-file format (now queried directly from SQLite).
+
+### Maintenance
+
+- **Cyclomatic complexity reduced** in `resolveInstallPlan` and `analyzeRecord`, the two largest functions flagged by the EGC-128 security audit, each split into focused single-purpose helpers with the full test suite kept green.
+
 ## [1.1.9] - 2026-07-11
 
 ### Security

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -192,7 +192,7 @@ Since v1.1.12 memory has two scopes. Project scope works exactly as before (one 
 
 Parallel sessions coordinate through the session bus. A session announces itself with `session_announce` (presence plus an optional territory, doubling as heartbeat), inspects who else is active with `session_peers`, and takes cooperative locks with `claim_path` before editing shared files. Claims are fail-fast: a conflicting live lock is refused with the holder's identity instead of queued. Sessions silent for 10 minutes are swept and their locks released, so a crashed session never blocks the others.
 
-Populated memory never reaches a commit. The propagation files (AGENTS.md, GEMINI.md, editor rules) ship as empty structure; local sessions repopulate them, a pre-commit hook blocks accidental staging, and a CI guard catches anything that slips past local hooks.
+Populated memory never reaches a commit. The propagation files (AGENTS.md, GEMINI.md, editor rules) ship as empty structure; local sessions repopulate them, a pre-commit hook blocks accidental staging, and a CI guard catches anything that slips past local hooks. Since v1.1.13 `egc init` adds a third local layer: a git clean filter (`filter.egc-memory.clean`) bound to the propagation files in `.git/info/attributes`, so `git add` stages a zeroed blob even when hooks are bypassed with `--no-verify`. The filter configuration stays entirely inside `.git` (nothing tracked is modified), the working tree keeps the populated memory, and the installer prints the exact actions before applying them, honoring `--dry-run`.
 
 ---
 


### PR DESCRIPTION
## Summary

- CHANGELOG.md had stopped at 1.1.10; adds the missing 1.1.11, 1.1.12 and 1.1.13 entries.
- installation.md: the commit-privacy paragraph now covers the git clean filter layer shipped in v1.1.13 (#863).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CHANGELOG entries for 1.1.11–1.1.13 and updates installation docs to cover the v1.1.13 commit-privacy clean filter.

Documents `filter.egc-memory.clean` configured by `egc init`, bound in `.git/info/attributes`, so `git add` stages zeroed blobs even with `--no-verify`; actions are printed and `--dry-run` is honored, with all config kept inside `.git`.

<sup>Written for commit 7251cdea656d0b42b2dd95ac29265e936f151c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

