### PR TITLE
refactor(crusher): make proxy-prefix detection configurable via env

### DIFF
--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -19,7 +19,16 @@ function tryRequire(modulePath) {
 // Repo layout first, flattened install layout second.
 const engine = tryRequire('../lib/crusher/engine') || tryRequire('../lib/crusher-engine');
 
-const WRAPPED_RE = /(?:^\s*(?:egc|rtk)\s)|(?:--raw\b)/;
+// EGC_CRUSHER_SKIP_PREFIXES lists extra command prefixes (comma-separated)
+// that mean the command is already handled by another local CLI proxy.
+function wrappedRe() {
+  const extra = (process.env.EGC_CRUSHER_SKIP_PREFIXES || '')
+    .split(',')
+    .map(p => p.trim())
+    .filter(p => /^[\w.-]+$/.test(p));
+  const prefixes = ['egc', ...extra].join('|');
+  return new RegExp(`(?:^\\s*(?:${prefixes})\\s)|(?:--raw\\b)`);
+}
 // Wrapping changes semantics for pipelines, chaining, redirection, substitution
 // and multi-line commands, so those never get rewritten.
 const COMPLEX_SHELL_RE = /[|&;<>$`()\n]/;
@@ -43,7 +52,7 @@ function run(rawInput) {
     if (
       !engine
       || !cmd
-      || WRAPPED_RE.test(cmd)
+      || wrappedRe().test(cmd)
       || COMPLEX_SHELL_RE.test(cmd)
       || engine.commandKind(cmd) === 'generic'
       || !hasEgcCli()

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -29,8 +29,22 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 
 const KEEP_LINE_RE = /\b(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception)\b/i;
 
+// EGC_CRUSHER_SKIP_PREFIXES names other local CLI proxies; their prefix is
+// stripped so the underlying command is still classified correctly.
+function stripProxyPrefix(command) {
+  const trimmed = command.trim();
+  const prefixes = (process.env.EGC_CRUSHER_SKIP_PREFIXES || '')
+    .split(',')
+    .map(p => p.trim())
+    .filter(p => /^[\w.-]+$/.test(p));
+  for (const prefix of prefixes) {
+    if (trimmed.startsWith(`${prefix} `)) return trimmed.slice(prefix.length + 1);
+  }
+  return trimmed;
+}
+
 function commandKind(command) {
-  const normalized = command.trim().replace(/^rtk\s+/, '');
+  const normalized = stripProxyPrefix(command);
   if (/^git\s+log\b/.test(normalized)) return 'git-log';
   if (/^git\s+diff\b/.test(normalized)) return 'git-diff';
   if (/\b(jest|vitest|pytest|mocha)\b/.test(normalized) || /npm\s+(run\s+)?test\b/.test(normalized) || /node\s+\S*tests?\//.test(normalized)) return 'test-runner';

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -44,7 +44,9 @@ run('classifies commands into kinds', () => {
   assert.strictEqual(commandKind('yarn install'), 'pm-install');
   assert.strictEqual(commandKind('gh pr list --json number'), 'gh-json');
   assert.strictEqual(commandKind('ls -la'), 'generic');
-  assert.strictEqual(commandKind('rtk git log'), 'git-log');
+  process.env.EGC_CRUSHER_SKIP_PREFIXES = 'someproxy';
+  assert.strictEqual(commandKind('someproxy git log'), 'git-log');
+  delete process.env.EGC_CRUSHER_SKIP_PREFIXES;
 });
 
 run('small outputs pass through untouched', () => {

--- a/tests/hooks/pre-bash-crusher-rewrite.test.js
+++ b/tests/hooks/pre-bash-crusher-rewrite.test.js
@@ -54,7 +54,9 @@ runCase('pipelines and chaining pass through', () => {
 
 runCase('already wrapped commands pass through', () => {
   assert.strictEqual(invoke('egc run git log'), 'egc run git log');
-  assert.strictEqual(invoke('rtk git log'), 'rtk git log');
+  process.env.EGC_CRUSHER_SKIP_PREFIXES = 'someproxy';
+  assert.strictEqual(invoke('someproxy git log'), 'someproxy git log');
+  delete process.env.EGC_CRUSHER_SKIP_PREFIXES;
   assert.strictEqual(invoke('git log --raw'), 'git log --raw');
 });
 


### PR DESCRIPTION
## Summary

The wrapped-command detector in the bash-dispatcher adapter and the command classifier in the crusher engine hardcoded one specific local proxy prefix. Both now read `EGC_CRUSHER_SKIP_PREFIXES` (comma-separated command prefixes of other local CLI proxies), defaulting to none. Prefixes are validated against a safe charset before entering the regex.

## Tests

- tests/crusher-engine.test.js: 10/10
- tests/hooks/pre-bash-crusher-rewrite.test.js: 6/6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make proxy-prefix detection configurable via the `EGC_CRUSHER_SKIP_PREFIXES` env var to support any local CLI proxy. Removes hardcoded prefixes so wrapped commands pass through and underlying commands classify correctly.

- **New Features**
  - Bash rewrite hook reads `EGC_CRUSHER_SKIP_PREFIXES` (comma-separated) to detect already-proxied commands; prefixes validated with a safe charset.
  - Crusher engine strips configured prefixes before command classification; defaults to none.

<sup>Written for commit 74988fee9346ea602b03dc8d113566a04b773496. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

