### PR TITLE
fix(memory): close three cross-process races in session bus and update_state

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -254,6 +254,21 @@ async function acquireMigrationLock(lockFile: string): Promise<void> {
   if (!locked) throw new Error('Timeout acquiring migration lock');
 }
 
+// Cross-process mutex for state-file merges: update_state does a
+// read-merge-write on the encrypted file, so two server processes writing
+// concurrently would silently drop the loser's merge without this.
+async function withStateMergeLock<T>(stateFile: string, fn: () => Promise<T>): Promise<T> {
+  const lockFile = `${stateFile}.merge.lock`;
+  fs.mkdirSync(path.dirname(lockFile), { recursive: true });
+  clearStaleMigrationLock(lockFile);
+  await acquireMigrationLock(lockFile);
+  try {
+    return await fn();
+  } finally {
+    try { fs.unlinkSync(lockFile); } catch (_) { /* NOSONAR: already cleared by a stale sweep */ }
+  }
+}
+
 async function runMigrations(db: Database, dbDir: string) {
   const lockFile = path.join(dbDir, 'migration.lock');
 
@@ -1178,47 +1193,54 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
 
   if (args.scope === 'global') {
     const globalFile = getGlobalStateFile();
-    let existingGlobal: Record<string, string[]|string> = {};
-    try {
-      existingGlobal = readStateDoc(globalFile);
-    } catch (err) {
-      if (args.force && fs.existsSync(globalFile)) {
-        const backupPath = quarantineUndecryptableStateFile(globalFile);
-        log('WARN', 'update_state: force=true, undecryptable global state backed up and replaced', { file: globalFile, backup: backupPath, error: String(err) });
-      } else {
-        log('ERROR', '[EGC encryption] Cannot read existing global state, aborting update to prevent data loss', { file: globalFile, error: String(err) });
-        throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing global state file. The encryption key may have changed. Path: ${globalFile}. Retry with force: true to back up the unreadable file and start fresh.`);
+    return withStateMergeLock(globalFile, async () => {
+      let existingGlobal: Record<string, string[]|string> = {};
+      try {
+        existingGlobal = readStateDoc(globalFile);
+      } catch (err) {
+        if (args.force && fs.existsSync(globalFile)) {
+          const backupPath = quarantineUndecryptableStateFile(globalFile);
+          log('WARN', 'update_state: force=true, undecryptable global state backed up and replaced', { file: globalFile, backup: backupPath, error: String(err) });
+        } else {
+          log('ERROR', '[EGC encryption] Cannot read existing global state, aborting update to prevent data loss', { file: globalFile, error: String(err) });
+          throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing global state file. The encryption key may have changed. Path: ${globalFile}. Retry with force: true to back up the unreadable file and start fresh.`);
+        }
       }
-    }
-    writeStateDoc(globalFile, 'global', args, existingGlobal, null);
-    const writtenGlobal = readStateFile(globalFile, _encKey);
-    writeHmac(globalFile, writtenGlobal, _integrityKey);
-    log('INFO', 'Global state updated', { decisions: args.decisions?.length || 0 });
-    return { content: [{ type: "text", text: `Global memory updated (shared across all projects).\nFile: ${globalFile}\nDecisions saved: ${args.decisions?.length || 0}` }] };
+      writeStateDoc(globalFile, 'global', args, existingGlobal, null);
+      const writtenGlobal = readStateFile(globalFile, _encKey);
+      writeHmac(globalFile, writtenGlobal, _integrityKey);
+      log('INFO', 'Global state updated', { decisions: args.decisions?.length || 0 });
+      return { content: [{ type: "text", text: `Global memory updated (shared across all projects).\nFile: ${globalFile}\nDecisions saved: ${args.decisions?.length || 0}` }] };
+    });
   }
 
-  // Merge from the same file get_state would read, so the first
-  // branch-scoped write inherits the pre-existing flat state
-  const resolved = resolveStateRead(getStateDir(), projPath, branch);
-  let existing: Record<string, string[]|string>;
-  try {
-    existing = readStateDoc(resolved.filePath);
-  } catch (err) {
-    if (args.force && fs.existsSync(resolved.filePath)) {
-      const backupPath = quarantineUndecryptableStateFile(resolved.filePath);
-      log('WARN', 'update_state: force=true, undecryptable state file backed up and replaced', { file: resolved.filePath, backup: backupPath, error: String(err) });
-      existing = {};
-    } else {
-      log('ERROR', '[EGC encryption] Cannot read existing state — aborting update to prevent data loss', { file: resolved.filePath, error: String(err) });
-      throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing state file. The encryption key may have changed. Path: ${resolved.filePath}. Retry with force: true to back up the unreadable file and start fresh — only do this after confirming the failure is persistent, not a transient lock from another process.`);
-    }
-  }
   const filePath = resolveStateWrite(getStateDir(), projPath, branch);
 
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  writeStateDoc(filePath, projPath, args, existing, branch);
-  const writtenContent = readStateFile(filePath, _encKey);
-  writeHmac(filePath, writtenContent, _integrityKey);
+  // Merge from the same file get_state would read, so the first
+  // branch-scoped write inherits the pre-existing flat state. The read
+  // happens inside the merge lock: reading before acquiring it would
+  // reintroduce the lost-update race between concurrent sessions.
+  await withStateMergeLock(filePath, async () => {
+    const resolved = resolveStateRead(getStateDir(), projPath, branch);
+    let existing: Record<string, string[]|string>;
+    try {
+      existing = readStateDoc(resolved.filePath);
+    } catch (err) {
+      if (args.force && fs.existsSync(resolved.filePath)) {
+        const backupPath = quarantineUndecryptableStateFile(resolved.filePath);
+        log('WARN', 'update_state: force=true, undecryptable state file backed up and replaced', { file: resolved.filePath, backup: backupPath, error: String(err) });
+        existing = {};
+      } else {
+        log('ERROR', '[EGC encryption] Cannot read existing state — aborting update to prevent data loss', { file: resolved.filePath, error: String(err) });
+        throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing state file. The encryption key may have changed. Path: ${resolved.filePath}. Retry with force: true to back up the unreadable file and start fresh — only do this after confirming the failure is persistent, not a transient lock from another process.`);
+      }
+    }
+
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    writeStateDoc(filePath, projPath, args, existing, branch);
+    const writtenContent = readStateFile(filePath, _encKey);
+    writeHmac(filePath, writtenContent, _integrityKey);
+  });
   const propagated = propagateStateToTools({
     projectPath: projPath,
     context: args.context,
@@ -1235,16 +1257,17 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
   return { content: [{ type: "text", text: `Project memory updated.\n${branchLine}${toolsLine}File: ${filePath}\nDecisions saved: ${args.decisions?.length || 0}\nNext session items: ${args.next?.length || 0}` }] };
 }
 
-async function resolveBusSessionId(db: Database, provided?: string): Promise<string> {
-  if (provided) return provided;
-  const current = await getMaintenanceState(db, 'current_session_id');
-  return current || `bus-${process.pid}`;
+// Stable per process. Reading the shared current_session_id here would let
+// another session's id leak in between claim and release (breaking the
+// claim/release symmetry) or make parallel sessions collide on one identity.
+function resolveBusSessionId(provided?: string): string {
+  return provided || `bus-${process.pid}`;
 }
 
 async function handleSessionAnnounce(db: Database, toolArgs: unknown) {
   const args = SessionAnnounceSchema.parse(toolArgs || {});
   const projPath = resolveProjectPath(args.project_path);
-  const sessionId = await resolveBusSessionId(db, args.session_id);
+  const sessionId = resolveBusSessionId(args.session_id);
   await writeArbitrator.enqueue(async () => {
     await busSweepDead(db);
     await busAnnounce(db, { sessionId, projectPath: projPath, territory: args.territory });
@@ -1259,7 +1282,7 @@ async function handleSessionAnnounce(db: Database, toolArgs: unknown) {
 
 async function handleClaimPath(db: Database, toolArgs: unknown) {
   const args = ClaimPathSchema.parse(toolArgs || {});
-  const sessionId = await resolveBusSessionId(db, args.session_id);
+  const sessionId = resolveBusSessionId(args.session_id);
   const result = await writeArbitrator.enqueue(async () => {
     await busSweepDead(db);
     return busClaimPath(db, { sessionId, path: args.path, ttlSeconds: args.ttl_seconds });
@@ -1272,7 +1295,7 @@ async function handleClaimPath(db: Database, toolArgs: unknown) {
 
 async function handleReleasePath(db: Database, toolArgs: unknown) {
   const args = ReleasePathSchema.parse(toolArgs || {});
-  const sessionId = await resolveBusSessionId(db, args.session_id);
+  const sessionId = resolveBusSessionId(args.session_id);
   const released = await writeArbitrator.enqueue(async () => busReleasePath(db, { sessionId, path: args.path }));
   return { content: [{ type: "text", text: released ? `Lock released: ${args.path}` : `No lock held by ${sessionId} on ${args.path}; nothing released.` }] };
 }

--- a/mcp/servers/egc-memory/src/session-bus.ts
+++ b/mcp/servers/egc-memory/src/session-bus.ts
@@ -73,30 +73,52 @@ export interface ClaimResult {
 }
 
 // Fail-fast claim: a conflicting live lock is reported, never queued.
+// Every acquisition path is a conditional write (INSERT OR IGNORE or a
+// session-guarded UPDATE/DELETE), so two concurrent claimers can never both
+// win: whoever lands the row first owns it and the loser sees changes === 0.
 export async function claimPath(
   db: BusDb,
   input: { sessionId: string; path: string; ttlSeconds?: number },
   nowMs: number = Date.now()
 ): Promise<ClaimResult> {
   const ttl = Math.min(Math.max(input.ttlSeconds || DEFAULT_LOCK_TTL_SECONDS, 1), MAX_LOCK_TTL_SECONDS);
-  const existing = await db.get('SELECT session_id FROM bus_locks WHERE path = ?', input.path);
-  if (existing && existing.session_id !== input.sessionId) {
-    const holder = await db.get('SELECT id, territory FROM bus_sessions WHERE id = ?', existing.session_id);
-    if (holder) {
-      return { ok: false, holder: String(holder.id), holderTerritory: holder.territory ? String(holder.territory) : undefined };
-    }
-    await db.run('DELETE FROM bus_locks WHERE path = ?', input.path);
-  }
-  await db.run(
-    `INSERT INTO bus_locks (path, session_id, acquired_at, ttl_seconds)
-     VALUES (?, ?, ?, ?)
-     ON CONFLICT(path) DO UPDATE SET
-       session_id = excluded.session_id,
-       acquired_at = excluded.acquired_at,
-       ttl_seconds = excluded.ttl_seconds`,
-    input.path, input.sessionId, new Date(nowMs).toISOString(), ttl
+  const now = new Date(nowMs).toISOString();
+
+  const changed = (result: unknown): boolean =>
+    typeof (result as { changes?: number })?.changes === 'number'
+    && (result as { changes: number }).changes > 0;
+
+  const refresh = await db.run(
+    'UPDATE bus_locks SET acquired_at = ?, ttl_seconds = ? WHERE path = ? AND session_id = ?',
+    now, ttl, input.path, input.sessionId
   );
-  return { ok: true };
+  if (changed(refresh)) return { ok: true };
+
+  const tryInsert = () => db.run(
+    'INSERT OR IGNORE INTO bus_locks (path, session_id, acquired_at, ttl_seconds) VALUES (?, ?, ?, ?)',
+    input.path, input.sessionId, now, ttl
+  );
+  if (changed(await tryInsert())) return { ok: true };
+
+  const existing = await db.get('SELECT session_id FROM bus_locks WHERE path = ?', input.path);
+  if (!existing) {
+    return changed(await tryInsert())
+      ? { ok: true }
+      : { ok: false };
+  }
+
+  const holder = await db.get('SELECT id, territory FROM bus_sessions WHERE id = ?', existing.session_id);
+  if (!holder) {
+    await db.run(
+      'DELETE FROM bus_locks WHERE path = ? AND session_id = ?',
+      input.path, existing.session_id
+    );
+    if (changed(await tryInsert())) return { ok: true };
+    const winner = await db.get('SELECT session_id FROM bus_locks WHERE path = ?', input.path);
+    return { ok: false, holder: winner ? String(winner.session_id) : undefined };
+  }
+
+  return { ok: false, holder: String(holder.id), holderTerritory: holder.territory ? String(holder.territory) : undefined };
 }
 
 export async function releasePath(db: BusDb, input: { sessionId: string; path: string }): Promise<boolean> {

--- a/tests/egc-memory-multi-session.e2e.test.js
+++ b/tests/egc-memory-multi-session.e2e.test.js
@@ -1,0 +1,174 @@
+'use strict';
+// Multi-session coordination E2E: spawns N concurrent egc-memory server
+// instances sharing one isolated HOME, driving each over MCP stdio like a
+// real harness would. Proves: mutual visibility (session_peers), fail-fast
+// path locks with no steal under a concurrent claim (claim_path), stable
+// claim/release identity, and concurrent update_state without lost writes.
+//
+// Requires the built server; CI does not build the MCP servers, so the test
+// skips itself when the build output is absent. Run locally with:
+//   sh install.sh && node tests/egc-memory-multi-session.e2e.test.js
+// EGC_MSTEST_SESSIONS overrides the session count (default 4).
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SERVER = path.join(__dirname, '..', 'mcp', 'servers', 'egc-memory', 'build', 'index.js');
+if (!fs.existsSync(SERVER)) {
+  console.log('SKIP: egc-memory build output absent (CI does not build MCP servers)');
+  process.exit(0);
+}
+
+const FAKE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-mstest-home-'));
+const PROJECT = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-mstest-proj-'));
+const N = Math.max(2, Number.parseInt(process.env.EGC_MSTEST_SESSIONS || '4', 10) || 4);
+
+class Session {
+  constructor(name) {
+    this.name = name;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.buf = '';
+    this.proc = spawn('node', [SERVER], {
+      env: { ...process.env, HOME: FAKE_HOME },
+      cwd: PROJECT,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.proc.stdout.on('data', chunk => {
+      this.buf += chunk.toString();
+      let idx;
+      while ((idx = this.buf.indexOf('\n')) >= 0) {
+        const line = this.buf.slice(0, idx).trim();
+        this.buf = this.buf.slice(idx + 1);
+        if (!line) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id !== undefined && this.pending.has(msg.id)) {
+            this.pending.get(msg.id)(msg);
+            this.pending.delete(msg.id);
+          }
+        } catch { /* non-JSON noise on stdout is ignored */ }
+      }
+    });
+  }
+
+  rpc(method, params) {
+    const id = this.nextId++;
+    const p = new Promise((resolve, reject) => {
+      this.pending.set(id, resolve);
+      setTimeout(() => reject(new Error(`${this.name}: timeout on ${method}`)), 20000);
+    });
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    return p;
+  }
+
+  notify(method, params) {
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+  }
+
+  async init() {
+    await this.rpc('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: this.name, version: '1.0.0' },
+    });
+    this.notify('notifications/initialized', {});
+  }
+
+  async tool(name, args) {
+    const res = await this.rpc('tools/call', { name, arguments: args });
+    const text = res.result?.content?.[0]?.text ?? JSON.stringify(res.result ?? res.error);
+    return text;
+  }
+
+  kill() { this.proc.kill(); }
+}
+
+const results = [];
+function check(label, ok, detail) {
+  results.push({ label, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? `  [${detail}]` : ''}`);
+}
+
+async function main() {
+  console.log(`HOME isolado: ${FAKE_HOME}`);
+  console.log(`Projeto de teste: ${PROJECT}\n`);
+
+  const sessions = [];
+  for (let i = 1; i <= N; i++) {
+    const s = new Session(`harness-${i}`);
+    await s.init();
+    sessions.push(s);
+  }
+  console.log(`${N} servidores egc-memory de pé (1 por sessao, HOME compartilhado)\n`);
+
+  // 1. Announce all sessions concurrently, each with its own territory.
+  const announces = await Promise.all(sessions.map((s, i) =>
+    s.tool('session_announce', {
+      project_path: PROJECT,
+      session_name: s.name,
+      territory: `area-${i + 1}`,
+    })
+  ));
+  check(`announce concorrente das ${N} sessoes`, announces.every(a => !/error/i.test(a)));
+
+  // 2. Every session must see all four territories on the bus.
+  const peersRaw = await Promise.all(sessions.map(s => s.tool('session_peers', { project_path: PROJECT })));
+  const everyoneSeesAll = peersRaw.every(p =>
+    new RegExp(`Live sessions: ${N}`).test(p) && Array.from({ length: N }, (_, i) => i + 1).every(n => p.includes(`area-${n}`))
+  );
+  check(`cada sessao ve as ${N} presencas no session_peers`, everyoneSeesAll, everyoneSeesAll ? `${N}x${N} visibilidade` : peersRaw[0].slice(0, 120));
+
+  // 3. Fail-fast lock: sessions 1 and 2 claim the SAME path concurrently.
+  const [claimA, claimB] = await Promise.all([
+    sessions[0].tool('claim_path', { project_path: PROJECT, path: 'src/shared.js' }),
+    sessions[1].tool('claim_path', { project_path: PROJECT, path: 'src/shared.js' }),
+  ]);
+  const granted = [claimA, claimB].filter(c => !/refused|held|denied|conflict/i.test(c)).length;
+  check('claim simultaneo do mesmo path: exatamente 1 vence', granted === 1, `granted=${granted}`);
+  const refusal = [claimA, claimB].find(c => /refused|held|denied|conflict/i.test(c)) || '';
+  check('recusa identifica quem segura o lock', /locked by live session \S+ \(territory: area-[12]\)/.test(refusal), refusal.slice(0, 100));
+
+  // 4. Disjoint claims all succeed.
+  const disjoint = await Promise.all(sessions.map((s, i) =>
+    s.tool('claim_path', { project_path: PROJECT, path: `src/only-${i}.js` })
+  ));
+  check('claims de paths disjuntos: todos passam', disjoint.every(c => !/refused|held|denied|conflict/i.test(c)));
+
+  // 5a. Control case: sequential update_state from all four sessions.
+  for (const [i, s] of sessions.entries()) {
+    await s.tool('update_state', {
+      project_path: PROJECT,
+      decisions: [{ what: `seq da ${s.name}`, why: `escrita sequencial ${i}` }],
+    });
+  }
+  const seqState = await sessions[sessions.length - 1].tool('get_state', { project_path: PROJECT });
+  const seqAll = sessions.every(s => seqState.includes(`seq da ${s.name}`));
+  check(`${N} update_state SEQUENCIAIS, zero perda`, seqAll, seqAll ? `${N}/${N}` : seqState.slice(0, 200));
+
+  // 5b. Stress case: concurrent update_state from all four sessions.
+  await Promise.all(sessions.map((s, i) =>
+    s.tool('update_state', {
+      project_path: PROJECT,
+      decisions: [{ what: `conc da ${s.name}`, why: `escrita concorrente ${i}` }],
+    })
+  ));
+  const state = await sessions[sessions.length - 1].tool('get_state', { project_path: PROJECT });
+  const present = sessions.filter(s => state.includes(`conc da ${s.name}`)).length;
+  check(`${N} update_state CONCORRENTES, zero perda no get_state`, present === N, `${present}/${N} decisoes presentes`);
+
+  // 6. Release and confirm the freed path can be claimed by someone else.
+  const holderIdx = /area-1\)/.test(refusal) ? 0 : 1;
+  const released = await sessions[holderIdx].tool('release_path', { project_path: PROJECT, path: 'src/shared.js' });
+  const reclaim = await sessions[2].tool('claim_path', { project_path: PROJECT, path: 'src/shared.js' });
+  check('apos release, outra sessao consegue o lock', !/refused|held|denied|conflict/i.test(reclaim), `release: ${released.slice(0, 80)} | reclaim: ${reclaim.slice(0, 80)}`);
+
+  sessions.forEach(s => s.kill());
+  const failed = results.filter(r => !r.ok).length;
+  console.log(`\n${results.length - failed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => { console.error(err.message); process.exit(1); });


### PR DESCRIPTION
## Summary

A real multi-process E2E (N concurrent egc-memory servers over MCP stdio sharing one HOME) exposed three races that would hit anyone running parallel sessions:

1. **`claim_path` steal**: two concurrent claimers both passed the existence check; the upsert let the second overwrite the first and both reported success. Every acquisition path is now a conditional write (`INSERT OR IGNORE` or a session-guarded `UPDATE`), so exactly one claimer wins and the loser receives the holder identity.
2. **`update_state` lost writes**: the read-merge-write on the encrypted state file had no cross-process mutex; in a 4-session concurrent run only 3/4 merges survived. Project and global paths now serialize the merge through a pid-checked lockfile next to the state file.
3. **Bus identity drift**: `resolveBusSessionId` read the shared `current_session_id`, so the id at `release_path` time could differ from the id that claimed, leaving locks unreleasable. The id is now stable per process.

## Tests

- New `tests/egc-memory-multi-session.e2e.test.js` (8 checks): mutual visibility, single-winner concurrent claim, holder identified in refusals, disjoint claims, sequential and concurrent `update_state` with zero loss, release/reclaim. Skips itself when the server build is absent (CI does not build MCP servers). Verified locally with 4 and 10 sessions.
- `tests/egc-memory-session-bus.test.js` regression: 5/5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three cross-process races in the `egc-memory` session bus and state I/O so parallel sessions behave correctly. Locks are single-winner, state merges are lossless, and session IDs are stable per process.

- Bug Fixes
  - `claim_path`: now single-winner via conditional writes; losers get the current holder (no steals).
  - `update_state`: read-merge-write is serialized with a per-file lockfile; no lost writes across processes (global and project).
  - Bus identity: session ID is fixed per process, so `claim_path`/`release_path` always match; covered by a new multi-session E2E.

<sup>Written for commit 54bc69bb64f528cab78a6488f146bca141a151b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

