### PR TITLE
chore(copilot): teach the code reviewer the project rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Copilot instructions for EGC
+
+EGC is a local-first MCP runtime that gives every AI coding agent a shared
+persistent memory (egc-memory), a safety layer that validates commands and
+writes before they run (egc-guardian), and shell-output compression (Token
+Crusher). It installs into 20 AI coding tools from one npm package
+(@egchq/egc). Memory lives encrypted in ~/.egc on the user's machine and must
+never reach the repository.
+
+## Writing style (enforced project-wide)
+
+- Never use em dashes and never use a spaced hyphen (" - ") as a sentence
+  separator in prose. Rewrite with a comma, a colon, or two sentences.
+  Brand headings like "EGC - Give Every AI Agent the Same Brain" are the only
+  exception.
+- All repository content is written in English, except the files under
+  translations/.
+- Flag any populated memory content in AGENTS.md, GEMINI.md,
+  .cursor/rules/egc-context.mdc or .trae/rules/egc-context.md: those
+  propagation files must ship with an empty structure only.
+
+## README and translations
+
+- README.md must keep the exact catalog sentence matching "access to N
+  agents, N skills, and N commands" and the "Works natively with ..."
+  provider sentence: CI validates both.
+- The 7 translations (ar, es, hi, ja, ko, pt, ru) must mirror the heading
+  levels of README.md in the same order; adding or removing a section in one
+  language only is a defect.
+- The Support EGC section and everything below it (sponsors, backers,
+  OpenSSF footer) changes only when the maintainer edits it deliberately.
+
+## Code review priorities
+
+- Commits need a DCO Signed-off-by line and follow conventional commits.
+- New code never uses Math.random for anything security-adjacent: use
+  crypto.randomInt (SonarCloud S2245 gates the merge).
+- Binaries invoked from scripts are resolved from fixed paths with a PATH
+  fallback, not bare names (S4036 pattern used across scripts/).
+- Any change touching files shared across concurrent EGC processes
+  (~/.egc state, encryption key, install-state, lockfiles) requires a
+  concurrent-access regression test; check for read-merge-write races and
+  lock steal in upserts.
+- Shell-facing features must be fail-open: a broken hook or missing binary
+  must never block the user's command.
+- Version bumps happen only in dedicated release PRs that update the whole
+  release surface (11 files); flag any stray version change elsewhere.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,17 +7,14 @@ Crusher). It installs into 20 AI coding tools from one npm package
 (@egchq/egc). Memory lives encrypted in ~/.egc on the user's machine and must
 never reach the repository.
 
-## Writing style (enforced project-wide)
+## Repository conventions
 
-- Never use em dashes and never use a spaced hyphen (" - ") as a sentence
-  separator in prose. Rewrite with a comma, a colon, or two sentences.
-  Brand headings like "EGC - Give Every AI Agent the Same Brain" are the only
-  exception.
 - All repository content is written in English, except the files under
   translations/.
 - Flag any populated memory content in AGENTS.md, GEMINI.md,
   .cursor/rules/egc-context.mdc or .trae/rules/egc-context.md: those
-  propagation files must ship with an empty structure only.
+  propagation files must ship with an empty structure only, and CI enforces
+  it.
 
 ## README and translations
 


### PR DESCRIPTION
GitHub Copilot code review is now active on the repository (it reviewed #870 unprompted). This adds `.github/copilot-instructions.md` so its reviews enforce the project's real rules: writing style (no dash separators), README catalog and provider sentences, translation heading parity, DCO, the SonarCloud patterns that gate merges, concurrent-access test requirements for shared state, fail-open shell features, and release-surface discipline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.github/copilot-instructions.md` to guide Copilot reviews using only publicly verifiable, CI/Sonar-checked project rules. Focuses on docs parity, commit checks, security patterns, concurrency tests, shell behavior, and release version discipline.

- **New Features**
  - Repository/propagation: English-only outside `translations/`; propagation files ship empty (no memory data).
  - README/translations: enforce catalog/provider sentences; mirror headings across 7 locales; Support section unchanged.
  - Commits/merges: DCO + conventional commits; SonarCloud rules (use `crypto.randomInt`, fixed-path binaries).
  - Concurrency: require tests for shared `~/.egc` state and lock handling.
  - Shell/releases: fail-open shell; version bumps only via dedicated release PRs covering all 11 files.

<sup>Written for commit 3d413f877c166e5120e6f05cdca45314e7739727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

