### PR TITLE
chore(readme): drop the top badge row in all languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - Give Every AI Agent the Same Brain

--- a/translations/ar/README.md
+++ b/translations/ar/README.md
@@ -3,7 +3,7 @@
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+<img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
 <div align="center">

--- a/translations/ar/README.md
+++ b/translations/ar/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - امنح كل وكيل ذكاء اصطناعي الدماغ نفسه

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - Dale el Mismo Cerebro a Todos Tus Agentes de IA

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -3,7 +3,7 @@
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+<img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
 <div align="center">

--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - हर AI एजेंट को एक ही दिमाग़ दें

--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -3,7 +3,7 @@
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+<img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
 <div align="center">

--- a/translations/ja/README.md
+++ b/translations/ja/README.md
@@ -3,7 +3,7 @@
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+<img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
 <div align="center">

--- a/translations/ja/README.md
+++ b/translations/ja/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - すべてのAIエージェントに同じ脳を

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -3,7 +3,7 @@
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+<img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
 <div align="center">

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - 모든 AI 에이전트에게 같은 뇌를

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -3,7 +3,7 @@
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+<img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
 <div align="center">

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - Dê o Mesmo Cérebro a Todos os Seus Agentes de IA

--- a/translations/ru/README.md
+++ b/translations/ru/README.md
@@ -3,7 +3,7 @@
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
-<img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
+<img src="../../assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
 <div align="center">

--- a/translations/ru/README.md
+++ b/translations/ru/README.md
@@ -6,8 +6,6 @@
 <img src="assets/hero.png" alt="EGC - Extended Global Context" width="100%" />
 </div>
 
-[![npm downloads](https://img.shields.io/npm/dm/@egchq/egc?label=downloads&color=22c55e)](https://www.npmjs.com/package/@egchq/egc) [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/Fmarzochi/EGC?label=openssf+scorecard&style=flat)](https://securityscorecards.dev/viewer/?uri=github.com/Fmarzochi/EGC) [![Socket](https://socket.dev/api/badge/npm/package/@egchq/egc)](https://socket.dev/npm/package/@egchq/egc)
-
 <div align="center">
 
 # EGC - Дайте Каждому ИИ-Агенту Один Общий Мозг


### PR DESCRIPTION
Removes the npm downloads, OpenSSF Scorecard and Socket badge row from the top of the README and the 7 translations. At the project's current scale the row reads as noise between the banner and the headline. The OpenSSF footer block is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the top badge row (npm downloads for `@egchq/egc`, OpenSSF Scorecard, and Socket) from the main README and all seven translations to reduce visual noise between the banner and headline. Also fixed the hero banner path in translated READMEs to point to the repo root; the OpenSSF footer block and existing OpenSSF/Socket surfaces remain unchanged.

<sup>Written for commit a423fe31a6c179488727a92aa9349debda37a746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

