### PR TITLE
fix(i18n): teach the selector sync the zh-CN and zh-TW native labels

### DIFF
--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -18,6 +18,8 @@ const LANGUAGE_NAMES = {
   ar: "العربية",
   hi: "हिन्दी",
   zh: "中文",
+  "zh-CN": "简体中文",
+  "zh-TW": "繁體中文",
   ja: "日本語",
   ko: "한국어",
   vi: "Tiếng Việt",


### PR DESCRIPTION
The update-readme-languages workflow opened #877 trying to relabel the new zh-CN selector entry as "ZH-CN" because LANGUAGE_NAMES only knows bare "zh" and falls back to the uppercased code for regional variants. Adds the native-language labels for zh-CN (and zh-TW preemptively) so the sync matches the convention used by every other selector entry. #877 was closed in favor of the label added in #870.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native labels for `zh-CN` and `zh-TW` in the language selector sync script. This prevents uppercased regional codes and ensures the README shows "简体中文" and "繁體中文".

- **Bug Fixes**
  - Update `LANGUAGE_NAMES` in `scripts/update-readme-languages.js` with `zh-CN: 简体中文` and `zh-TW: 繁體中文`.
  - Keeps selector labels consistent and avoids unwanted relabels.

<sup>Written for commit 747585f4169bcf5a3ef1d06417fc3d15f5a84707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

