### PR TITLE
fix(privacy): guard all 11 memory propagation targets, not just 4

### DIFF
--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -34,8 +34,21 @@ function git(args, options) {
   return execFileSync(GIT_BIN, args, { encoding: 'utf8', ...options });
 }
 
-function isMarkdownPath(p) {
-  return p.endsWith('.md') || p.endsWith('.mdc') || p.endsWith('.markdown');
+// Every propagation target of egc-memory (propagate.ts) is scanned, not just
+// markdown: several targets (.rules, .clinerules, .cursorrules, llms.txt)
+// have no .md extension and would otherwise slip past the guard.
+const NON_MARKDOWN_TARGETS = [
+  '.rules',
+  '.clinerules',
+  '.cursorrules',
+  'CONVENTIONS.md',
+  'llms.txt',
+];
+
+function isGuardedPath(p) {
+  if (p.endsWith('.md') || p.endsWith('.mdc') || p.endsWith('.markdown')) return true;
+  const base = p.split('/').pop();
+  return NON_MARKDOWN_TARGETS.includes(base);
 }
 
 function findLeak(content) {
@@ -68,7 +81,7 @@ function cleanContent(content) {
 
 function checkStaged() {
   const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACM'])
-    .split('\n').filter(Boolean).filter(isMarkdownPath);
+    .split('\n').filter(Boolean).filter(isGuardedPath);
   const leaks = [];
   for (const file of staged) {
     let content;
@@ -83,7 +96,7 @@ function checkStaged() {
 }
 
 function checkTree() {
-  const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(isMarkdownPath);
+  const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(isGuardedPath);
   const leaks = [];
   for (const file of tracked) {
     let content;

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -25,6 +25,13 @@ const PROPAGATION_FILES = [
   'GEMINI.md',
   '.cursor/rules/egc-context.mdc',
   '.trae/rules/egc-context.md',
+  '.github/copilot-instructions.md',
+  '.windsurf/rules/egc-context.md',
+  '.rules',
+  '.clinerules',
+  '.cursorrules',
+  'CONVENTIONS.md',
+  'llms.txt',
 ];
 
 function gitDir(projectDir) {


### PR DESCRIPTION
egc-memory propagates populated project memory into 11 files in the working tree, but the anti-leak defenses (pre-commit staged check, CI tree check, and the git clean filter bindings) only covered 4 of them (AGENTS.md, GEMINI.md, .cursor, .trae). Targets without a markdown extension (.rules, .clinerules, .cursorrules, llms.txt) and newer ones (.github/copilot-instructions.md, .windsurf, CONVENTIONS.md) slipped past the guard entirely; a near-leak through copilot-instructions.md was caught by hand.

- check-state-leak.js: isMarkdownPath becomes isGuardedPath, covering every propagation target including the non-markdown ones by basename
- memory-filters.js: PROPAGATION_FILES extended from 4 to the full 11 targets so the clean filter zeroes populated memory on stage for all of them

Squad-reviewed pre-commit (verdict: commit, with the dead llms.txt branch removed). Tests: 11/11 green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands privacy guards to cover all 11 `egc-memory` propagation targets, including non-markdown files, so populated memory can’t leak into the repo. Pre-commit, CI tree checks, and git clean filters now sanitize every target.

- **Bug Fixes**
  - Replaced isMarkdownPath with isGuardedPath to scan all targets by basename (covers `.rules`, `.clinerules`, `.cursorrules`, `CONVENTIONS.md`, `llms.txt`, etc.).
  - Extended PROPAGATION_FILES from 4 to 11 so the clean filter zeroes staged memory across all targets.

<sup>Written for commit b933c881c7ff4ca46e8e31b016ac0f83794b18c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

