### PR TITLE
fix(scripts): harden harness-audit, consolidate, and init against crash paths

### DIFF
--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -147,12 +147,16 @@ function main() {
       backup: null,
     };
 
-    if (!fs.existsSync(stateFile)) {
-      handleMissingState(report, options);
-      return;
+    let content;
+    try {
+      content = fs.readFileSync(stateFile, 'utf8');
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        handleMissingState(report, options);
+        return;
+      }
+      throw err;
     }
-
-    const content = fs.readFileSync(stateFile, 'utf8');
     const result = consolidateState(content, { threshold });
 
     report.linesBefore = result.linesBefore;

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -205,7 +205,7 @@ function findPluginInstall(rootDir) {
 }
 
 function getRepoChecks(rootDir) {
-  const packageJson = JSON.parse(readText(rootDir, 'package.json'));
+  const packageJson = safeParseJson(safeRead(rootDir, 'package.json')) || {};
   const commandPrimary = safeRead(rootDir, 'commands/harness-audit.md').trim();
   const commandParity = safeRead(rootDir, '.opencode/commands/harness-audit.md').trim();
   const hooksJson = safeRead(rootDir, 'hooks/hooks.json');

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -297,6 +297,8 @@ if (!flags.dryRun) {
       console.log(`\n  ${c.cyan}EGC Dashboard starting at http://localhost:7890${c.reset}`);
       console.log(`  ${c.dim}Minimize it to keep working. Run \`egc dashboard stop\` to close.${c.reset}`);
       setTimeout(openBrowser, 1500);
+    }).catch(err => {
+      console.error(`  ${c.dim}Dashboard startup skipped: ${err.message}${c.reset}`);
     });
   }
 }


### PR DESCRIPTION
Pre-1.1.14 audit findings (scripts). harness-audit getRepoChecks now uses the existing safeParseJson/safeRead helpers instead of a bare JSON.parse that crashed the whole audit on a missing or corrupt package.json; consolidate reads the state file inside try/catch so a file deleted between check and read (concurrent sessions) routes to the missing-state path instead of an unhandled exception; init chains a catch onto the dashboard startup promise so a synchronous spawn/openBrowser failure cannot become an unhandled rejection that kills the bootstrap on Node 20+. Tests: 201/201 green on the touched suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed crash paths in `harness-audit`, `consolidate`, and `init` to prevent audit failures, handle missing state during concurrent runs, and avoid unhandled rejections on dashboard startup.

- **Bug Fixes**
  - `harness-audit`: Use `safeParseJson(safeRead('package.json'))` to avoid crashing on missing or corrupt `package.json`.
  - `consolidate`: Wrap `readFileSync` in try/catch; route `ENOENT` to the missing-state handler instead of throwing.
  - `init`: Add `.catch` to the dashboard startup promise; log and continue if spawn/openBrowser fails (Node 20+).

<sup>Written for commit 75352263b1ff5beabeca69dc87b763db60feb913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

