### PR TITLE
fix(opencode): realign drifted plugin versions and bump them on release

### DIFF
--- a/.opencode/index.ts
+++ b/.opencode/index.ts
@@ -41,7 +41,7 @@ export { EGCHooksPlugin, default } from "./plugins/index.js"
 export * from "./plugins/index.js"
 
 // Version export
-export const VERSION = "1.0.0"
+export const VERSION = "1.1.13"
 
 // Plugin metadata
 export const metadata = {

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -513,7 +513,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
      */
     "shell.env": async () => {
       const env: Record<string, string> = {
-        EGC_VERSION: "1.1.6",
+        EGC_VERSION: "1.1.13",
         EGC_PLUGIN: "true",
         EGC_HOOK_PROFILE: currentProfile,
         EGC_DISABLED_HOOKS: process.env.EGC_DISABLED_HOOKS || "",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -61,6 +61,7 @@ update_version ".agents/plugins/marketplace.json"
 sed -i "s/${CURRENT}/${VERSION}/g" VERSION agent.yaml
 sed -i "s/EGC_VERSION: \"${CURRENT}\"/EGC_VERSION: \"${VERSION}\"/g" .opencode/plugins/egc-hooks.ts
 sed -i "s/Extended Global Context v${CURRENT}/Extended Global Context v${VERSION}/g" .opencode/plugins/egc-hooks.ts
+sed -i "s/export const VERSION = \"${CURRENT}\"/export const VERSION = \"${VERSION}\"/" .opencode/index.ts
 
 update_latest_release_heading "$ROOT_ZH_CN_README_FILE"
 


### PR DESCRIPTION
Pre-1.1.14 audit findings (plugins). The OpenCode plugin reported VERSION 1.0.0 and injected EGC_VERSION 1.1.6 into shell env: once those constants drifted from the package version, the release script's sed patterns (which substitute the current version) could never match again, so the drift was permanent. Realigns both to 1.1.13 and adds the index.ts VERSION constant to release.sh so future bumps keep all three in lockstep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes version drift in the OpenCode plugin by aligning `VERSION` and `EGC_VERSION` to 1.1.13 and updating the release script to bump them automatically. Keeps the package version, exported `VERSION`, and `EGC_VERSION` in sync.

- **Bug Fixes**
  - Set `.opencode/index.ts` `VERSION` to 1.1.13.
  - Set `.opencode/plugins/egc-hooks.ts` `EGC_VERSION` to 1.1.13.
  - Update `scripts/release.sh` to bump `export const VERSION` on release.

<sup>Written for commit 75c52831b93d5ebb3b1a1f50cf9b87e2c3756f23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

