### PR TITLE
fix(crusher): keep ANSI-colored error lines; genericize x-api example handle

### DIFF
--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -29,9 +29,10 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 
 const KEEP_LINE_RE = /\b(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception)\b/i;
 
-// Terminal color codes glue onto words (\x1b[31merror) and break the \b
+// Terminal color codes glue onto words (ESC[31merror) and break the \b
 // word boundary, silently dropping colored error lines from the kept set.
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+// Built via the constructor because eslint forbids control chars in literals.
+const ANSI_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*[A-Za-z]`, 'g');
 function stripAnsi(line) {
   return line.replace(ANSI_RE, '');
 }

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -29,6 +29,13 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 
 const KEEP_LINE_RE = /\b(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception)\b/i;
 
+// Terminal color codes glue onto words (\x1b[31merror) and break the \b
+// word boundary, silently dropping colored error lines from the kept set.
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+function stripAnsi(line) {
+  return line.replace(ANSI_RE, '');
+}
+
 // EGC_CRUSHER_SKIP_PREFIXES names other local CLI proxies; their prefix is
 // stripped so the underlying command is still classified correctly.
 function stripProxyPrefix(command) {
@@ -82,11 +89,12 @@ function crushGitDiff(output) {
 
 function crushTestRunner(output) {
   const lines = output.split('\n');
-  const kept = lines.filter(l =>
-    KEEP_LINE_RE.test(l)
-    || /^\s*(Tests|Test Suites|Snapshots|Time|Ran all|passed|failed|\u2715|\u2717|\u2716|FAIL|PASS:?\s*$)/i.test(l.trim())
-    || /^\s*\d+ (passed|failed|skipped|pending)/i.test(l)
-  );
+  const kept = lines.filter(raw => {
+    const l = stripAnsi(raw);
+    return KEEP_LINE_RE.test(l)
+      || /^\s*(Tests|Test Suites|Snapshots|Time|Ran all|passed|failed|\u2715|\u2717|\u2716|FAIL|PASS:?\s*$)/i.test(l.trim())
+      || /^\s*\d+ (passed|failed|skipped|pending)/i.test(l);
+  });
   const summaryTail = lines.slice(-5).filter(l => l.trim());
   const merged = [...new Set([...kept, ...summaryTail])];
   if (merged.length >= lines.length) return null;
@@ -95,7 +103,7 @@ function crushTestRunner(output) {
 
 function crushPmInstall(output) {
   const lines = output.split('\n');
-  const kept = lines.filter(l => KEEP_LINE_RE.test(l));
+  const kept = lines.filter(l => KEEP_LINE_RE.test(stripAnsi(l)));
   const tail = lines.slice(-6).filter(l => l.trim());
   const merged = [...new Set([...kept, ...tail])];
   if (merged.length >= lines.length) return null;

--- a/skills/integrations/x-api/SKILL.md
+++ b/skills/integrations/x-api/SKILL.md
@@ -120,7 +120,7 @@ resp = requests.get(
     "https://api.x.com/2/tweets/search/recent",
     headers=headers,
     params={
-        "query": "from:MarzochiFelipe -is:retweet",
+        "query": "from:yourhandle -is:retweet",
         "max_results": 10,
         "tweet.fields": "public_metrics,created_at",
     }
@@ -134,7 +134,7 @@ resp = requests.get(
     "https://api.x.com/2/tweets/search/recent",
     headers=headers,
     params={
-        "query": "from:MarzochiFelipe -is:retweet -is:reply",
+        "query": "from:yourhandle -is:retweet -is:reply",
         "max_results": 25,
         "tweet.fields": "created_at,public_metrics",
     }
@@ -146,7 +146,7 @@ voice_samples = resp.json()
 
 ```python
 resp = requests.get(
-    "https://api.x.com/2/users/by/username/MarzochiFelipe",
+    "https://api.x.com/2/users/by/username/yourhandle",
     headers=headers,
     params={"user.fields": "public_metrics,description,created_at"}
 )


### PR DESCRIPTION
Two remaining pre-1.1.14 audit follow-ups. The crusher's keep-line regex relied on word boundaries that terminal color codes break (a colored error glues into the escape sequence), so colored error lines were silently dropped from compressed test-runner and package-manager output; lines are now matched against an ANSI-stripped copy, validated in practice (colored EACCES line preserved, ~3.3K tokens still saved on the fixture). The x-api skill examples used a real personal handle; replaced with a generic placeholder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep ANSI-colored error and warning lines in crushed test runner and package manager output by matching against an ANSI-stripped copy, using a lint-safe ANSI regex built via the constructor. Replace the real handle in `x-api` examples with the generic `yourhandle`.

<sup>Written for commit a47203895095fa9000919927c75806fc1c4a9794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

