### PR TITLE
feat(install): launch the dashboard right after egc install

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -24,8 +24,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const http = require('node:http');
-const { spawnSync, spawn } = require('node:child_process');
+const { spawnSync } = require('node:child_process');
 const os = require('node:os');
 
 const { version: PKG_VERSION } = require('../package.json');
@@ -263,40 +262,6 @@ console.log(`  ${c.green}Memory loaded (project + global)${c.reset} ${c.dim}|${c
 console.log(`  ${c.dim}Route heavy commands through \`egc run <cmd>\`; see savings anytime with \`egc saved\`. Run \`egc doctor\` to verify.${c.reset}`);
 
 if (!flags.dryRun) {
-  const dashboardScript = path.join(ROOT_DIR, 'scripts', 'dashboard.js');
-  if (fs.existsSync(dashboardScript)) {
-    const dashPing = new Promise(resolve => {
-      const req = http.get('http://localhost:7890/ping', res => { res.resume(); resolve(res.statusCode === 200); });
-      req.on('error', () => resolve(false));
-      req.setTimeout(500, () => { req.destroy(); resolve(false); });
-    });
-    const openBrowser = () => {
-      const url = 'http://localhost:7890';
-      let cmd;
-      if (process.platform === 'win32') {
-        cmd = 'start';
-      } else if (process.platform === 'darwin') {
-        cmd = 'open';
-      } else {
-        cmd = 'xdg-open';
-      }
-      try { require('node:child_process').spawnSync(cmd, [url], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) { /* ignore: best-effort browser open, failure is non-fatal */ } // NOSONAR
-    };
-    dashPing.then(already => {
-      if (already) {
-        console.log(`\n  ${c.cyan}Dashboard already running at http://localhost:7890${c.reset}`);
-        openBrowser();
-        return;
-      }
-      const child = spawn(process.execPath, [dashboardScript], {
-        detached: true,
-        stdio: 'ignore',
-        ...(process.platform === 'win32' && { shell: true }),
-      });
-      child.unref();
-      console.log(`\n  ${c.cyan}EGC Dashboard starting at http://localhost:7890${c.reset}`);
-      console.log(`  ${c.dim}Minimize it to keep working. Run \`egc dashboard stop\` to close.${c.reset}`);
-      setTimeout(openBrowser, 1500);
-    });
-  }
+  const { launchDashboard } = require('./lib/dashboard-launch');
+  launchDashboard({ rootDir: ROOT_DIR, log: msg => console.log(`\n  ${c.cyan}${msg}${c.reset}`) });
 }

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -169,6 +169,10 @@ function main() {
       console.log(JSON.stringify({ dryRun: false, result }, null, 2)); // NOSONAR jssecurity:S8689
     } else {
       printHumanPlan(result, false);
+      const { launchDashboard, shouldAutoLaunch } = require('./lib/dashboard-launch');
+      if (shouldAutoLaunch()) {
+        launchDashboard({ rootDir: require('node:path').join(__dirname, '..'), log: msg => console.log(`  ${msg}`) });
+      }
     }
   } catch (error) {
     process.stderr.write(`Error: ${error.message}${getHelpText()}`);

--- a/scripts/lib/dashboard-launch.js
+++ b/scripts/lib/dashboard-launch.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// Shared dashboard launcher for `egc init` and `egc install`: pings the
+// local dashboard, starts it detached when absent, and opens the browser.
+// Never throws; installation must not fail because a browser could not open.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const { spawn, spawnSync } = require('node:child_process');
+
+const DASHBOARD_URL = 'http://localhost:7890';
+
+function pingDashboard() {
+  return new Promise(resolve => {
+    const req = http.get(`${DASHBOARD_URL}/ping`, res => { res.resume(); resolve(res.statusCode === 200); });
+    req.on('error', () => resolve(false));
+    req.setTimeout(500, () => { req.destroy(); resolve(false); });
+  });
+}
+
+function openBrowser() {
+  let cmd;
+  if (process.platform === 'win32') {
+    cmd = 'start';
+  } else if (process.platform === 'darwin') {
+    cmd = 'open';
+  } else {
+    cmd = 'xdg-open';
+  }
+  try { spawnSync(cmd, [DASHBOARD_URL], { shell: process.platform === 'win32', stdio: 'ignore' }); } catch (_) { /* ignore: best-effort browser open, failure is non-fatal */ } // NOSONAR
+}
+
+// log(msg) receives already-formatted lines so each caller keeps its own
+// styling. Resolves once the launch decision is made, never rejects.
+function launchDashboard({ rootDir, log = () => {} }) {
+  const dashboardScript = path.join(rootDir, 'scripts', 'dashboard.js');
+  if (!fs.existsSync(dashboardScript)) return Promise.resolve(false);
+
+  return pingDashboard().then(already => {
+    if (already) {
+      log(`Dashboard already running at ${DASHBOARD_URL}`);
+      openBrowser();
+      return true;
+    }
+    const child = spawn(process.execPath, [dashboardScript], {
+      detached: true,
+      stdio: 'ignore',
+      ...(process.platform === 'win32' && { shell: true }),
+    });
+    child.unref();
+    log(`EGC Dashboard starting at ${DASHBOARD_URL}`);
+    log('Minimize it to keep working. Run `egc dashboard stop` to close.');
+    setTimeout(openBrowser, 1500);
+    return true;
+  }).catch(err => {
+    log(`Dashboard startup skipped: ${err.message}`);
+    return false;
+  });
+}
+
+// The dashboard is only worth spawning for a human at an interactive
+// terminal; CI runs and scripted installs stay headless.
+function shouldAutoLaunch() {
+  return Boolean(process.stdout.isTTY) && !process.env.CI;
+}
+
+module.exports = { launchDashboard, shouldAutoLaunch, DASHBOARD_URL };


### PR DESCRIPTION
Pre-1.1.14 audit follow-up (EGC-342 claim alignment). The README promises the live dashboard spins up right after installation, but only egc init started it. The launcher is now a shared module (scripts/lib/dashboard-launch.js) used by both init and install: after a non-JSON, non-dry-run install on an interactive terminal (TTY, not CI), the dashboard is pinged, started detached when absent, and the browser opened. Never fails the install: launch errors are logged and swallowed. Suite 52/52 green, init dry-run unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically launch the dashboard after `egc install` in interactive terminals. Aligns with EGC-342 and the README claim; failures are swallowed and never break install.

- **New Features**
  - Runs only for non-JSON, non-dry-run installs on TTY; skipped in CI.
  - Pings the dashboard first; starts it detached if absent; opens the browser.

- **Refactors**
  - Shared launcher module `scripts/lib/dashboard-launch.js` used by `egc init` and `egc install`.
  - `egc init` dry-run behavior unchanged.

<sup>Written for commit 30fb9079e708e6f42c0a5c5852ed39742d2293e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

