### PR TITLE
feat(cli): register claw and harness-audit as first-class egc commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -250,6 +250,8 @@ You never need to type any of these. Talk to your AI naturally, in any language,
 | `egc saved` | Accumulated Token Crusher savings, short summary |
 | `egc gain` | Full savings panel (--history for the run-by-run log) |
 | `egc discover` | Scan recent session transcripts for crushable output that skipped the crusher |
+| `egc claw` | NanoClaw REPL: persistent session-aware agent loop with Markdown history |
+| `egc harness-audit` | Score the harness setup across tool coverage, quality gates, memory, and security |
 
 ---
 

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -137,6 +137,14 @@ const COMMANDS = {
     script: 'discover.js',
     description: 'Scan recent session transcripts for crushable output that skipped the Token Crusher',
   },
+  claw: {
+    script: 'claw.js',
+    description: 'NanoClaw REPL: persistent session-aware agent loop with Markdown history',
+  },
+  'harness-audit': {
+    script: 'harness-audit.js',
+    description: 'Score the harness setup across tool coverage, quality gates, memory, and security',
+  },
 };
 
 const PRIMARY_COMMANDS = [
@@ -168,6 +176,8 @@ const PRIMARY_COMMANDS = [
   'saved',
   'gain',
   'discover',
+  'claw',
+  'harness-audit',
 ];
 
 const TELEMETRY_COMMANDS = new Set(['install', 'doctor', 'init']);


### PR DESCRIPTION
Pre-1.1.14 audit follow-up (EGC-337 finding 4). scripts/claw.js (NanoClaw REPL, a persistent session-aware agent loop) and scripts/harness-audit.js (harness scoring across tool coverage, quality gates, memory, and security) existed and were user-facing but were never wired into the egc CLI router, so they could only be run by path. Both are now registered in COMMANDS and PRIMARY_COMMANDS and documented in the installation guide command reference. Validated: egc claw opens the REPL, egc harness-audit --format json emits the report.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `claw` and `harness-audit` as first-class `egc` CLI commands so they can be run directly. Addresses Linear EGC-337 (finding 4) by wiring the scripts into the CLI and documenting them.

- **New Features**
  - Added `claw` and `harness-audit` to `COMMANDS` and `PRIMARY_COMMANDS` in `scripts/egc.js`.
  - Updated `docs/installation.md` with command reference entries for both commands.

<sup>Written for commit 06244ce0429697f515d37e7bdd65cd08c6deee43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

