### PR TITLE
fix(sync): degrade team sync to offline errors instead of crashing

### DIFF
--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -66,7 +66,14 @@ export async function teamSync(): Promise<SyncResult> {
 
   const instance = new BackendClass();
   try {
-    await instance.init(config);
+    // A missing or unreachable remote must degrade to an offline no-op with
+    // a reported error, never an exception that takes the MCP server down.
+    try {
+      await instance.init(config);
+    } catch (err) {
+      result.errors.push(`Sync backend init failed (offline?): ${String(err)}`);
+      return result;
+    }
 
     // Step 1: Pull remote changes.
     try {

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -50,7 +50,7 @@ function printHuman(result) {
 
   console.log('Uninstall summary:\n');
   for (const entry of result.results) {
-    console.log(`- ${entry.adapter.id}`);
+    console.log(`- ${(entry.adapter && entry.adapter.id) || 'unknown adapter'}`);
     console.log(`  Status: ${entry.status.toUpperCase()}`);
     console.log(`  Install-state: ${entry.installStatePath}`);
 


### PR DESCRIPTION
Pre-1.1.14 audit follow-up (EGC-341 QA findings). teamSync wrapped pull and push individually but a backend init failure (missing or unreachable remote) still threw out of the function and could take the MCP server down mid-session; init errors now land in result.errors as an offline no-op. The uninstall human printer also stops assuming entry.adapter exists so a legacy install-state cannot crash the summary. Other QA findings verified already mitigated: mcp-register isolates each harness in try/catch with onWarn, and uninstall only removes files EGC itself copied (recorded in install-state), never shared configs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Team sync init failures now degrade to an offline error instead of crashing the MCP server. Also hardens the uninstall summary to handle missing adapter info in legacy install states. Addresses Linear EGC-341 QA findings.

- **Bug Fixes**
  - TeamSync: catch backend init errors; add to `result.errors` and return early (treat missing/unreachable remote as offline).
  - Uninstall: avoid assuming `entry.adapter` exists; show "unknown adapter" when absent.

<sup>Written for commit fc407374b48e362d0c00db0b62d96da1945f521b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

