### PR TITLE
fix(dashboard): consume response stream and explicitly exit to prevent zombie shim processes

### DIFF
--- a/dashboard/shim-session.js
+++ b/dashboard/shim-session.js
@@ -18,6 +18,10 @@ function post(ev) {
       res.on('end', () => {
         process.exit(0);
       });
+
+      res.on('error', () => {
+        process.exit(0);
+      });
     }
   );
   

--- a/dashboard/shim-session.js
+++ b/dashboard/shim-session.js
@@ -12,10 +12,24 @@ function post(ev) {
     { hostname:'127.0.0.1', port:7890, path:'/event', method:'POST',
       headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
       timeout:300 },
-    ()=>{}
+    (res) => {
+      res.resume();
+      
+      res.on('end', () => {
+        process.exit(0);
+      });
+    }
   );
-  req.on('error', ()=>{});
-  req.on('timeout', ()=>req.destroy());
+  
+  req.on('error', () => {
+    process.exit(0);
+  });
+  
+  req.on('timeout', () => {
+    req.destroy();
+    process.exit(0);
+  });
+  
   req.end(body);
 }
 


### PR DESCRIPTION
### Description
Fixes the issue where the dashboard session shim process lingers as a zombie for ~5 seconds after every session event due to an unconsumed HTTP response stream and an unhandled process lifecycle.

### Changes Made
- Updated `dashboard/shim-session.js` to capture the `res` object in the HTTP request callback.
- Added `res.resume()` to explicitly consume the response data stream, freeing up the underlying keep-alive socket immediately.
- Implemented explicit `process.exit(0)` calls on the successful response stream `end` event.
- Added clean `process.exit(0)` handlings to the `error` and `timeout` event listeners to ensure the process exits cleanly even if the dashboard server is down or unresponsive.

### Verification Results
- [x] Verified that no lingering shim processes remain after events are posted using `ps`.
- [x] Confirmed that errors and timeouts exit cleanly without hanging.
- [x] Ran the local test suite successfully:
  ```bash
  node tests/run-all.js

###Result: 
Total Tests: 2628 | Passed: 2628 | Failed: 0

Closes #895

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents zombie dashboard shim processes by consuming the HTTP response stream and exiting immediately after each event. Adds response stream error handling to avoid mid-response hangs and free the keep-alive socket.

- **Bug Fixes**
  - Capture `res` in the HTTP callback and call `res.resume()` to consume the stream.
  - Exit on `res` `end` and `error`, and on request `error` and `timeout` (destroying the request first).

<sup>Written for commit a8544ee35dfd4af691c707993753eff4ea747a76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

