### PR TITLE
docs(mirrors): sync dogfood context files with the propagation template

### DIFF
--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -1,6 +1,40 @@
 ---
-description: EGC project memory (auto-updated by update_state)
+description: EGC project memory (auto-updated)
 alwaysApply: true
 ---
 
 ## EGC Project Memory
+
+## EGC Natural Language Interface
+
+Detect user intent in any language and call the matching EGC tool — no keywords required:
+
+**Session**
+- User resumes work (any language) → `get_state`
+- User ends session (any language) → `update_state`
+
+**Diagnosis — when AI seems confused or hallucinating**
+- User questions whether things are working → `get_project_state`
+- User asks what mistakes keep repeating → `detect_patterns`
+- User asks what was learned in past sessions → `lesson_recall`
+
+**Memory — user forces a save**
+- User asks to record a decision → `store_decision`
+- User asks AI not to repeat a mistake → `lesson_save`
+- User confirms a past lesson happened again → `lesson_reinforce`
+- User wants to store something temporarily → `working_memory_set`
+- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
+
+**Search — when AI forgot something**
+- User asks about past decisions on a topic → `search_history`
+- User asks for recent decisions chronologically → `query_history`
+
+**Context — when heavy**
+- User says context is full or heavy → `reduce_context`
+- User asks to compress session observations → `compress_observations`
+
+**Safety — when user is suspicious**
+- User asks if a shell command is safe → `validate_command`
+- User asks if a file path is safe to write → `validate_write`
+- User asks to organize a complex task → `orchestrate_task`
+- User asks AI to learn from session errors → `auto_learn`

--- a/.trae/rules/egc-context.md
+++ b/.trae/rules/egc-context.md
@@ -24,4 +24,37 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
+## EGC Natural Language Interface
+
+Detect user intent in any language and call the matching EGC tool — no keywords required:
+
+**Session**
+- User resumes work (any language) → `get_state`
+- User ends session (any language) → `update_state`
+
+**Diagnosis — when AI seems confused or hallucinating**
+- User questions whether things are working → `get_project_state`
+- User asks what mistakes keep repeating → `detect_patterns`
+- User asks what was learned in past sessions → `lesson_recall`
+
+**Memory — user forces a save**
+- User asks to record a decision → `store_decision`
+- User asks AI not to repeat a mistake → `lesson_save`
+- User confirms a past lesson happened again → `lesson_reinforce`
+- User wants to store something temporarily → `working_memory_set`
+- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
+
+**Search — when AI forgot something**
+- User asks about past decisions on a topic → `search_history`
+- User asks for recent decisions chronologically → `query_history`
+
+**Context — when heavy**
+- User says context is full or heavy → `reduce_context`
+- User asks to compress session observations → `compress_observations`
+
+**Safety — when user is suspicious**
+- User asks if a shell command is safe → `validate_command`
+- User asks if a file path is safe to write → `validate_write`
+- User asks to organize a complex task → `orchestrate_task`
+- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,4 +62,37 @@ Skipping any of these breaks the EGC contract. There are no exceptions for "simp
 <!-- egc:start -->
 ## EGC Project Memory
 
+## EGC Natural Language Interface
+
+Detect user intent in any language and call the matching EGC tool — no keywords required:
+
+**Session**
+- User resumes work (any language) → `get_state`
+- User ends session (any language) → `update_state`
+
+**Diagnosis — when AI seems confused or hallucinating**
+- User questions whether things are working → `get_project_state`
+- User asks what mistakes keep repeating → `detect_patterns`
+- User asks what was learned in past sessions → `lesson_recall`
+
+**Memory — user forces a save**
+- User asks to record a decision → `store_decision`
+- User asks AI not to repeat a mistake → `lesson_save`
+- User confirms a past lesson happened again → `lesson_reinforce`
+- User wants to store something temporarily → `working_memory_set`
+- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
+
+**Search — when AI forgot something**
+- User asks about past decisions on a topic → `search_history`
+- User asks for recent decisions chronologically → `query_history`
+
+**Context — when heavy**
+- User says context is full or heavy → `reduce_context`
+- User asks to compress session observations → `compress_observations`
+
+**Safety — when user is suspicious**
+- User asks if a shell command is safe → `validate_command`
+- User asks if a file path is safe to write → `validate_write`
+- User asks to organize a complex task → `orchestrate_task`
+- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -93,4 +93,37 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
+## EGC Natural Language Interface
+
+Detect user intent in any language and call the matching EGC tool — no keywords required:
+
+**Session**
+- User resumes work (any language) → `get_state`
+- User ends session (any language) → `update_state`
+
+**Diagnosis — when AI seems confused or hallucinating**
+- User questions whether things are working → `get_project_state`
+- User asks what mistakes keep repeating → `detect_patterns`
+- User asks what was learned in past sessions → `lesson_recall`
+
+**Memory — user forces a save**
+- User asks to record a decision → `store_decision`
+- User asks AI not to repeat a mistake → `lesson_save`
+- User confirms a past lesson happened again → `lesson_reinforce`
+- User wants to store something temporarily → `working_memory_set`
+- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
+
+**Search — when AI forgot something**
+- User asks about past decisions on a topic → `search_history`
+- User asks for recent decisions chronologically → `query_history`
+
+**Context — when heavy**
+- User says context is full or heavy → `reduce_context`
+- User asks to compress session observations → `compress_observations`
+
+**Safety — when user is suspicious**
+- User asks if a shell command is safe → `validate_command`
+- User asks if a file path is safe to write → `validate_write`
+- User asks to organize a complex task → `orchestrate_task`
+- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->


### PR DESCRIPTION
## Summary

scripts/lib/propagate-state.js ships an EGC Natural Language Interface block (EGC_TRIGGERS) that egc install propagates into every user project's context mirrors. The EGC repo's own dogfood mirrors were missing that block.

This syncs AGENTS.md, GEMINI.md, .cursor/rules/egc-context.mdc and .trae/rules/egc-context.md with the template. The blocks are byte-identical to what the propagation engine renders, verified line by line against EGC_TRIGGERS. All 13 tool names referenced in the block exist in the egc-memory/egc-guardian servers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs AGENTS.md, GEMINI.md, `.cursor/rules/egc-context.mdc`, and `.trae/rules/egc-context.md` with the `EGC_TRIGGERS` template by adding the EGC Natural Language Interface block. This keeps our dogfood mirrors identical to what `propagate-state.js` renders for user projects.

<sup>Written for commit f987350a20a621c86c1d8b3ce96fa26fe14b809c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

