### PR TITLE
feat(dashboard): show offline badge after consecutive poll failures

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1164,6 +1164,12 @@ function setWs(on){
   document.getElementById('wsDot').className='ws-dot'+(on?' on':'');
   document.getElementById('wsLbl').textContent=on?'live':'offline';
   document.getElementById('activeBadge').style.display=on?'':'none';
+  if(!on){
+    S.pingFailStreak=0;
+    if(S.telemetryFailStreak===0){
+      setOffline(false);
+    }
+  }
 }
 function pingLatency(){
   if(!S.ws||S.ws.readyState!==1)return;

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -655,7 +655,8 @@ const S={
   eco:{tok:0,hitCt:0,lifetok:1482221},
   mission:{task:'Waiting...',file:'--',pct:0},
   latencyMs:0,hooksOk:false,
-  pollFailStreak:0,
+  telemetryFailStreak:0,
+  pingFailStreak:0,
   isOffline:false,
   telemetryReqId:0,
   pingReqId:0,
@@ -1097,13 +1098,17 @@ function setOffline(offline){
     }
   });
 }
-function reportPollResult(ok){
+function reportPollResult(type, ok){
   if(ok){
-    S.pollFailStreak=0;
-    setOffline(false);
+    if(type==='telemetry') S.telemetryFailStreak=0;
+    if(type==='ping') S.pingFailStreak=0;
+    if(S.telemetryFailStreak===0 && S.pingFailStreak===0){
+      setOffline(false);
+    }
   }else{
-    S.pollFailStreak++;
-    if(S.pollFailStreak>=3){
+    if(type==='telemetry') S.telemetryFailStreak++;
+    if(type==='ping') S.pingFailStreak++;
+    if(S.telemetryFailStreak>=3 || S.pingFailStreak>=3){
       setOffline(true);
     }
   }
@@ -1116,20 +1121,22 @@ function pollTelemetry(){
     if(!r.ok) throw new Error(`HTTP ${r.status}`);
     return r.json();
   }).then(t=>{
-    renderEconomy(t);
-    // Update pill alive state from server truth
-    Object.entries(t).forEach(([ide,p])=>{
-      const el=document.getElementById(`pill-${ide}`);
-      if(!el)return;
-      if(p.running)el.classList.add('alive');
-      else el.classList.remove('alive');
-    });
     if(reqId===S.telemetryReqId){
-      reportPollResult(true);
+      reportPollResult('telemetry', true);
     }
+    try{
+      renderEconomy(t);
+      // Update pill alive state from server truth
+      Object.entries(t).forEach(([ide,p])=>{
+        const el=document.getElementById(`pill-${ide}`);
+        if(!el)return;
+        if(p.running)el.classList.add('alive');
+        else el.classList.remove('alive');
+      });
+    }catch(e){}
   }).catch(()=>{
     if(reqId===S.telemetryReqId){
-      reportPollResult(false);
+      reportPollResult('telemetry', false);
     }
   });
 }
@@ -1166,14 +1173,16 @@ function pingLatency(){
     if(!r.ok) throw new Error(`HTTP ${r.status}`);
     return r.json();
   }).then(d=>{
-    const lat=Date.now()-d.ts;
-    document.getElementById('shLat').textContent=lat+'ms';
     if(reqId===S.pingReqId){
-      reportPollResult(true);
+      reportPollResult('ping', true);
     }
+    try{
+      const lat=Date.now()-d.ts;
+      document.getElementById('shLat').textContent=lat+'ms';
+    }catch(e){}
   }).catch(()=>{
     if(reqId===S.pingReqId){
-      reportPollResult(false);
+      reportPollResult('ping', false);
     }
   });
   setTimeout(pingLatency,5000);

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -67,6 +67,9 @@ body{
 .hd-val{font-size:13px;font-weight:500;color:var(--ink);white-space:nowrap;}
 .status-badge{display:flex;align-items:center;gap:6px;padding:4px 12px;border-radius:9999px;border:1px solid rgba(0,217,146,.3);background:rgba(0,217,146,.06);font-size:10px;font-weight:600;letter-spacing:1.5px;color:var(--primary);}
 .status-dot{width:6px;height:6px;border-radius:50%;background:var(--primary);animation:pip 1.4s ease-in-out infinite;}
+.status-badge.offline{border-color:rgba(248,113,113,.35);background:rgba(248,113,113,.08);color:var(--red);}
+.status-badge.offline .status-dot{background:var(--red);animation:none;}
+.stale{opacity:.45;filter:grayscale(.4);pointer-events:none;transition:opacity .3s ease,filter .3s ease;}
 .session-time{font-family:SFMono-Regular,Menlo,monospace;font-size:20px;font-weight:500;color:var(--ink-strong);letter-spacing:2px;}
 .hd-right{display:flex;align-items:center;gap:8px;}
 .sys-health{display:flex;align-items:center;gap:6px;padding:5px 12px;background:var(--canvas-soft);border:1px solid var(--hairline);border-radius:8px;}
@@ -406,6 +409,7 @@ body.minimized footer{display:none!important;}
     </div>
     <div class="vd hd-hide"></div>
     <div class="status-badge" id="activeBadge" style="display:none"><div class="status-dot"></div>ACTIVE</div>
+    <div class="status-badge offline" id="offlineBadge" style="display:none"><div class="status-dot"></div>OFFLINE</div>
     <div class="vd"></div>
     <div class="hd-block">
       <span class="hd-eye">Session</span>
@@ -651,6 +655,8 @@ const S={
   eco:{tok:0,hitCt:0,lifetok:1482221},
   mission:{task:'Waiting...',file:'--',pct:0},
   latencyMs:0,hooksOk:false,
+  pollFailStreak:0,
+  isOffline:false,
 };
 
 /* ── GREETING ───────────────────────────────────────────── */
@@ -1072,6 +1078,35 @@ ${value.toLocaleString()} tokens`;
     });
 }
 
+function setOffline(offline){
+  if(S.isOffline===offline)return;
+  S.isOffline=offline;
+  const badge=document.getElementById('offlineBadge');
+  if(badge)badge.style.display=offline?'':'none';
+  const els=[
+    document.querySelector('.panel-brain'),
+    document.getElementById('panelCenter'),
+    document.getElementById('panelRight')
+  ];
+  els.forEach(el=>{
+    if(el){
+      if(offline)el.classList.add('stale');
+      else el.classList.remove('stale');
+    }
+  });
+}
+function reportPollResult(ok){
+  if(ok){
+    S.pollFailStreak=0;
+    setOffline(false);
+  }else{
+    S.pollFailStreak++;
+    if(S.pollFailStreak>=3){
+      setOffline(true);
+    }
+  }
+}
+
 function pollTelemetry(){
   fetch('/telemetry').then(r=>r.json()).then(t=>{
     renderEconomy(t);
@@ -1082,7 +1117,10 @@ function pollTelemetry(){
       if(p.running)el.classList.add('alive');
       else el.classList.remove('alive');
     });
-  }).catch(()=>{});
+    reportPollResult(true);
+  }).catch(()=>{
+    reportPollResult(false);
+  });
 }
 setInterval(pollTelemetry,8000);
 pollTelemetry();
@@ -1114,7 +1152,10 @@ function pingLatency(){
   fetch('/ping').then(r=>r.json()).then(d=>{
     const lat=Date.now()-d.ts;
     document.getElementById('shLat').textContent=lat+'ms';
-  }).catch(()=>{});
+    reportPollResult(true);
+  }).catch(()=>{
+    reportPollResult(false);
+  });
   setTimeout(pingLatency,5000);
 }
 

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -657,6 +657,8 @@ const S={
   latencyMs:0,hooksOk:false,
   pollFailStreak:0,
   isOffline:false,
+  telemetryReqId:0,
+  pingReqId:0,
 };
 
 /* ── GREETING ───────────────────────────────────────────── */
@@ -1108,7 +1110,12 @@ function reportPollResult(ok){
 }
 
 function pollTelemetry(){
-  fetch('/telemetry').then(r=>r.json()).then(t=>{
+  S.telemetryReqId++;
+  const reqId = S.telemetryReqId;
+  fetch('/telemetry').then(r=>{
+    if(!r.ok) throw new Error(`HTTP ${r.status}`);
+    return r.json();
+  }).then(t=>{
     renderEconomy(t);
     // Update pill alive state from server truth
     Object.entries(t).forEach(([ide,p])=>{
@@ -1117,9 +1124,13 @@ function pollTelemetry(){
       if(p.running)el.classList.add('alive');
       else el.classList.remove('alive');
     });
-    reportPollResult(true);
+    if(reqId===S.telemetryReqId){
+      reportPollResult(true);
+    }
   }).catch(()=>{
-    reportPollResult(false);
+    if(reqId===S.telemetryReqId){
+      reportPollResult(false);
+    }
   });
 }
 setInterval(pollTelemetry,8000);
@@ -1149,12 +1160,21 @@ function setWs(on){
 }
 function pingLatency(){
   if(!S.ws||S.ws.readyState!==1)return;
-  fetch('/ping').then(r=>r.json()).then(d=>{
+  S.pingReqId++;
+  const reqId = S.pingReqId;
+  fetch('/ping').then(r=>{
+    if(!r.ok) throw new Error(`HTTP ${r.status}`);
+    return r.json();
+  }).then(d=>{
     const lat=Date.now()-d.ts;
     document.getElementById('shLat').textContent=lat+'ms';
-    reportPollResult(true);
+    if(reqId===S.pingReqId){
+      reportPollResult(true);
+    }
   }).catch(()=>{
-    reportPollResult(false);
+    if(reqId===S.pingReqId){
+      reportPollResult(false);
+    }
   });
   setTimeout(pingLatency,5000);
 }


### PR DESCRIPTION
Track consecutive failures across the /telemetry and /ping polling loops. After 3 consecutive failures, flip an OFFLINE badge in the header and dim the stale panels. Clears automatically on the first successful poll.

Fixes #900

## What Changed
- Added `S.pollFailStreak` and `S.isOffline` to the dashboard state object.
- Added `setOffline(offline)` helper: toggles `#offlineBadge` visibility and adds/removes a `.stale` class on `.panel-brain`, `#panelCenter`, and `#panelRight`. No-ops if state hasn't changed.
- Added `reportPollResult(ok)` helper: resets the fail streak and clears offline state on success; increments the streak on failure and flips offline once it hits 3 consecutive failures.
- Wired `reportPollResult` into the `.then()`/`.catch()` of both `pollTelemetry()` (`/telemetry`, 8s interval) and `pingLatency()` (`/ping`, 5s interval).
- Added `#offlineBadge` markup in the header, right after `#activeBadge`, reusing the existing `.status-badge`/`.status-dot` pattern.
- Added `.status-badge.offline`, `.status-badge.offline .status-dot`, and `.stale` CSS rules, reusing the existing `--red` token — no new design tokens introduced.

## Why This Change
Both polling loops previously swallowed fetch errors in empty `.catch(()=>{})` blocks. If the backend died, the dashboard kept rendering the last known numbers indefinitely with no indication anything was wrong. This makes backend outages visible in the UI instead of silently showing stale data as if it were live.

## Testing Done
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

Manual steps performed:
- Opened the dashboard, killed the backend process — OFFLINE badge appeared in the header within ~24s (3 consecutive telemetry failures), `.panel-brain`, `#panelCenter`, and `#panelRight` dimmed and became non-interactive.
- Restarted the backend — badge disappeared and panels returned to full opacity on the very next successful poll, no page reload needed.
- Watched the console throughout both transitions — no new errors, warnings, or log spam introduced.

Not applicable: this is a frontend-only change to `dashboard/public/index.html`; it doesn't touch any files under `~/.egc/` or shared/concurrent-access state.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable) — N/A, no shell scripts touched
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation — N/A, no public API or config surface changed
- [x] Added comments for complex logic — N/A, logic is small and self-explanatory (helper names describe behavior); no inline comments were added
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows an OFFLINE badge and dims panels after 3 consecutive /telemetry or /ping failures. Clears only when both polls recover; handles out-of-order replies and non-OK HTTP; fixes #900.

- **New Features**
  - Independent fail streaks for `/telemetry` and `/ping`; go offline when either >= 3; recover when both are 0.
  - Added `#offlineBadge` and styles (`.status-badge.offline`, `.stale`) to signal outages.
  - State and helpers: `S.telemetryFailStreak`, `S.pingFailStreak`, `S.isOffline`, `S.telemetryReqId`, `S.pingReqId`; `setOffline`, `reportPollResult`. Sequence responses, throw on non-OK, report success before UI, wrap UI in try/catch. Reset `pingFailStreak` and clear the badge on WebSocket disconnect to avoid a stuck OFFLINE state.

<sup>Written for commit 1f1c948f5d2cdb44cd478fce9e1a4058ecce73d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

