### PR TITLE
fix(providers): raise NotImplementedError when stream=True

### DIFF
--- a/src/llm/providers/deepseek.py
+++ b/src/llm/providers/deepseek.py
@@ -91,7 +91,7 @@ class DeepSeekProvider(OpenAIProvider):
             raise
         except NotImplementedError:
             # Contract-level errors (e.g. streaming not supported) are not
-            # provider-attributable wire failures — let them surface as-is.
+            # provider-attributable wire failures - let them surface as-is.
             raise
         except Exception as exc:
             # fix #2: native OpenAI SDK exceptions (RateLimitError,

--- a/src/llm/providers/deepseek.py
+++ b/src/llm/providers/deepseek.py
@@ -89,6 +89,10 @@ class DeepSeekProvider(OpenAIProvider):
             # plain LLMError here would discard that subclass information.
             exc.provider = ProviderType.DEEPSEEK
             raise
+        except NotImplementedError:
+            # Contract-level errors (e.g. streaming not supported) are not
+            # provider-attributable wire failures — let them surface as-is.
+            raise
         except Exception as exc:
             # fix #2: native OpenAI SDK exceptions (RateLimitError,
             # APIConnectionError, AuthenticationError, etc.) propagate here

--- a/src/llm/providers/groq.py
+++ b/src/llm/providers/groq.py
@@ -61,6 +61,10 @@ class GroqProvider(OpenAIProvider):
             # plain LLMError here would discard that subclass information.
             exc.provider = ProviderType.GROQ
             raise
+        except NotImplementedError:
+            # Contract-level errors (e.g. streaming not supported) are not
+            # provider-attributable wire failures - let them surface as-is.
+            raise
         except Exception as exc:
             # Native OpenAI SDK exceptions (RateLimitError, APIConnectionError,
             # AuthenticationError, etc.) propagate here unwrapped when

--- a/src/llm/providers/mistral.py
+++ b/src/llm/providers/mistral.py
@@ -58,6 +58,10 @@ class MistralProvider(OpenAIProvider):
             # plain LLMError here would discard that subclass information.
             exc.provider = ProviderType.MISTRAL
             raise
+        except NotImplementedError:
+            # Contract-level errors (e.g. streaming not supported) are not
+            # provider-attributable wire failures - let them surface as-is.
+            raise
         except Exception as exc:
             # Native OpenAI SDK exceptions (RateLimitError, APIConnectionError,
             # AuthenticationError, etc.) propagate here unwrapped when

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -95,6 +95,11 @@ class OpenAIProvider(LLMProvider):
         raise e
 
     def generate(self, input: LLMInput) -> LLMOutput:
+        if input.stream:
+            # Streaming is not implemented in this adapter. Fail loudly instead
+            # of silently downgrading to a blocking call, which would mislead
+            # callers into thinking they are consuming a stream.
+            raise NotImplementedError("streaming not supported")
         try:
             params: dict[str, Any] = {
                 "model": input.model or self.get_default_model(),

--- a/tests/test_deepseek_provider.py
+++ b/tests/test_deepseek_provider.py
@@ -285,6 +285,24 @@ def test_resolve_deepseek_reasoner_is_not_replaced_by_default() -> None:
 
 
 @pytest.mark.unit
+def test_stream_flag_raises_not_implemented(provider: DeepSeekProvider) -> None:
+    """Regression test for issue #903: DeepSeekProvider forwards the stream
+    flag through the OpenAI-compatible flow. Because streaming is not
+    implemented, the request must fail loudly instead of silently
+    downgrading to a blocking call."""
+    stream_input = LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="deepseek-chat",
+        stream=True,
+    )
+
+    with pytest.raises(NotImplementedError, match="streaming not supported"):
+        provider.generate(stream_input)
+
+    provider.client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.unit
 def test_bare_deepseek_alias_does_not_claim_deepseek_provider() -> None:
     """P2 fix: the bare token 'deepseek' is an alias, not a model ID.
     _provider_for must not return 'deepseek' for it, so LLM_MODEL=deepseek

--- a/tests/test_deepseek_provider.py
+++ b/tests/test_deepseek_provider.py
@@ -285,6 +285,32 @@ def test_resolve_deepseek_reasoner_is_not_replaced_by_default() -> None:
 
 
 @pytest.mark.unit
+def test_non_streaming_call_unchanged(provider: DeepSeekProvider) -> None:
+    """Regression test for issue #903: the non-streaming path (stream=False,
+    the default) must continue to work exactly as before and must not forward
+    a `stream` kwarg to the SDK."""
+    response = MagicMock()
+    choice = MagicMock()
+    choice.message.content = "hi"
+    choice.message.tool_calls = None
+    choice.finish_reason = "stop"
+    response.choices = [choice]
+    response.model = "deepseek-chat"
+    usage = MagicMock()
+    usage.prompt_tokens = 1
+    usage.completion_tokens = 2
+    usage.total_tokens = 3
+    response.usage = usage
+    provider.client.chat.completions.create.return_value = response
+
+    result = provider.generate(_simple_input())
+
+    assert result.content == "hi"
+    _, kwargs = provider.client.chat.completions.create.call_args
+    assert "stream" not in kwargs
+
+
+@pytest.mark.unit
 def test_stream_flag_raises_not_implemented(provider: DeepSeekProvider) -> None:
     """Regression test for issue #903: DeepSeekProvider forwards the stream
     flag through the OpenAI-compatible flow. Because streaming is not

--- a/tests/test_groq_provider.py
+++ b/tests/test_groq_provider.py
@@ -169,6 +169,23 @@ def test_retagging_preserves_exception_subclass(provider: GroqProvider) -> None:
 
 
 @pytest.mark.unit
+def test_stream_flag_raises_not_implemented(provider: GroqProvider) -> None:
+    """Regression test for issue #903: GroqProvider inherits the OpenAI-compatible
+    flow, so LLMInput.stream=True must fail loudly instead of being swallowed
+    by the provider-retagging wrapper and re-raised as a generic LLMError."""
+    stream_input = LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="openai/gpt-oss-120b",
+        stream=True,
+    )
+
+    with pytest.raises(NotImplementedError, match="streaming not supported"):
+        provider.generate(stream_input)
+
+    provider.client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.unit
 def test_provider_for_groq_model_name() -> None:
     from llm.core.model_resolver import ModelResolver
     assert ModelResolver._provider_for("openai/gpt-oss-120b") == "groq"

--- a/tests/test_mistral_provider.py
+++ b/tests/test_mistral_provider.py
@@ -132,6 +132,23 @@ def test_unauthorized_exception_raises_authentication_error(provider):
     assert exc.value.provider == ProviderType.MISTRAL
 
 
+def test_stream_flag_raises_not_implemented(provider):
+    """Regression test for issue #903: MistralProvider inherits the OpenAI-compatible
+    flow, so LLMInput.stream=True must fail loudly instead of being swallowed
+    by the provider-retagging wrapper and re-raised as a generic LLMError."""
+    from llm.core.types import LLMInput, Message, Role
+    stream_input = LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="mistral-large-latest",
+        stream=True,
+    )
+
+    with pytest.raises(NotImplementedError, match="streaming not supported"):
+        provider.generate(stream_input)
+
+    provider.mock_create.assert_not_called()
+
+
 # --- Configuration Tests ---
 
 def test_validate_config_true(provider):

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -98,3 +98,34 @@ def test_missing_usage_degrades_to_zeros_instead_of_crashing(provider: OpenAIPro
 
     assert result.content == "hi"
     assert result.usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+@pytest.mark.unit
+def test_stream_flag_raises_not_implemented(provider: OpenAIProvider) -> None:
+    """Regression test for issue #903: LLMInput.stream=True was silently
+    dropped when building the request params, downgrading callers to a
+    blocking call. Streaming must either be implemented or fail loudly."""
+    stream_input = LLMInput(
+        messages=[Message(role=Role.USER, content="hi")],
+        model="gpt-4o-mini",
+        stream=True,
+    )
+
+    with pytest.raises(NotImplementedError, match="streaming not supported"):
+        provider.generate(stream_input)
+
+    provider.client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_non_streaming_call_unchanged(provider: OpenAIProvider) -> None:
+    """Regression test for issue #903: the non-streaming path (stream=False,
+    the default) must continue to work exactly as before."""
+    usage = MagicMock(prompt_tokens=1, completion_tokens=2, total_tokens=3)
+    provider.client.chat.completions.create.return_value = _make_response(_text_choice("hi"), usage)
+
+    result = provider.generate(_simple_input())
+
+    assert result.content == "hi"
+    _, kwargs = provider.client.chat.completions.create.call_args
+    assert "stream" not in kwargs


### PR DESCRIPTION
## Summary
Closes #903.
 `LLMInput.stream` was accepted and propagated through the OpenAI-compatible flow but never read when `OpenAIProvider.generate` built the request params, so `stream=True` silently downgraded to a blocking call. Per the issue's acceptance criteria, this fails loudly with `NotImplementedError("streaming not supported")` instead.

## Changes
- `src/llm/providers/openai.py`: raise `NotImplementedError("streaming not supported")` at the top of `generate()` when `input.stream` is truthy. Non-streaming path unchanged.
- `src/llm/providers/deepseek.py`: add a narrow `except NotImplementedError: raise` so the contract error surfaces as-is instead of being caught by the broad `except Exception` that re-wraps native SDK errors as provider-attributed `LLMError`.

## Validation
- `python -m pytest tests/test_openai_provider.py tests/test_deepseek_provider.py` — 30 passed (27 pre-existing + 3 new).
- `python -m pytest tests/` — 117 passed, no regressions.
- New tests cover: (1) OpenAI `stream=True` raises `NotImplementedError` and the client is never called; (2) DeepSeek `stream=True` raises `NotImplementedError` (not wrapped as `LLMError`); (3) OpenAI `stream=False` behavior unchanged and no `stream` kwarg is forwarded to the SDK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise NotImplementedError("streaming not supported") when LLMInput.stream is True across OpenAI-compatible providers to prevent silent downgrade to a blocking call. DeepSeek, Groq, and Mistral now surface this contract error unchanged.

- Bug Fixes
  - OpenAIProvider.generate: early NotImplementedError when stream=True; non-stream path unchanged and no `stream` kwarg forwarded.
  - DeepSeekProvider, GroqProvider, MistralProvider: let NotImplementedError bubble (not wrapped as `LLMError`); tests cover stream=True errors with clients not called and add non-streaming regressions for OpenAI and DeepSeek.

<sup>Written for commit 9f24f7c1f3a11264ecb907af770e66a42609d418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

