### PR TITLE
docs(roadmap): bring the roadmap current through v1.1.14 and unreleased work

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,6 +69,26 @@ Closes the commit-privacy scope started in v1.1.12:
 - Git clean filter as the third privacy layer: `egc init` configures `filter.egc-memory.clean` locally and binds the four propagation files in `.git/info/attributes`, so `git add` stages a zeroed blob even when local hooks are bypassed; the working tree keeps the populated memory (#863)
 - The installer prints the filter action plan before applying it and honors `--dry-run`; outside a git repository the step is skipped with a reason (#863)
 
+## v1.1.14: Community Wave (Released 2026-07-18)
+
+- README repositioned around the shared brain across all 8 languages (#869), with Chinese Simplified landing as the 9th community translation (#870, @jackmcwin)
+- `egc gain`: the full token savings panel, with `egc saved` as the short report (#874)
+- Session bus v2: event queue and implicit presence for parallel sessions (#875); three cross-process races closed (#867)
+- Secrets redacted in mapped SDK errors, Google API keys covered (#883)
+- Guardian command validator: argument-parsing bypasses closed (#882)
+- Commit privacy guard extended to all 11 memory propagation targets (#881)
+- `claw` and `harness-audit` registered as first-class `egc` commands (#889)
+- Team sync degrades to offline errors instead of crashing (#890)
+- Lean repository root: tool configuration files moved to their conventional homes (#891)
+- `egc install` launches the dashboard right after installing (#893)
+
+## Unreleased (on main)
+
+- Relicensed from MIT to Apache License 2.0 (#906)
+- Dashboard session shim no longer leaves a zombie process after every event (#907, @developmentwithparth1311)
+- Lean repository root phase 2: examples, lint, and test configs relocated, redundant files dropped (#908)
+- Dashboard offline badge after consecutive poll failures, with per-endpoint failure streaks (#911, @harshjainnn)
+
 ## v1.2.0: Teams
 
 Multi-developer workflows and shared context:
@@ -81,7 +101,7 @@ Multi-developer workflows and shared context:
 
 ## v1.3.0: Growth
 
-- Community translations: German, French, Chinese Simplified, Italian, Turkish, Ukrainian, Malay
+- Community translations: German, French, Italian, Turkish, Ukrainian, Malay
 - Per-project skill profiles and overrides
 - OSS-Fuzz integration for continuous fuzz testing
 


### PR DESCRIPTION
## Summary

docs/ROADMAP.md stopped at v1.1.13. This brings it current:

- New v1.1.14 section (released 2026-07-18): README repositioning, zh-CN translation, egc gain, session bus v2, secrets redaction, Guardian validator hardening, privacy guard for all 11 propagation targets, claw/harness-audit commands, team sync degradation, lean root, dashboard after install.
- New "Unreleased (on main)" section: Apache 2.0 relicense (#906), zombie shim fix (#907), lean root phase 2 (#908), dashboard offline badge (#911).
- v1.3.0 plan: Chinese Simplified removed from the pending translation list, it shipped in #870.

Docs only, no code changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bring docs/ROADMAP.md current through v1.1.14 and add an Unreleased section. v1.1.14 highlights: README repositioning, `egc gain`, session bus v2, secrets redaction, and broader commit privacy guard; Unreleased adds Apache 2.0 relicense and a dashboard offline badge, and v1.3.0 drops Chinese Simplified (already shipped).

<sup>Written for commit 120d40cd4a396f51712c5f55f34cab4ae50bf10c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

