### PR TITLE
fix(dashboard): reject malformed JSON on POST /event with 400

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -182,13 +182,20 @@ const server = http.createServer((req, res) => {
     req.on('end', () => {
       if (exceeded) return;
 
+      let ev;
       try {
-        const ev = JSON.parse(body);
-        if (accumulateEvent(ev)) {
-          const msg = JSON.stringify(ev);
-          for (const ws of clients) { if (ws.readyState === 1) ws.send(msg); }
-        }
-      } catch (_) {}
+        ev = JSON.parse(body);
+      } catch (_) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+
+      if (accumulateEvent(ev)) {
+        const msg = JSON.stringify(ev);
+        for (const ws of clients) { if (ws.readyState === 1) ws.send(msg); }
+      }
+
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end('{"ok":true}');
     });

--- a/tests/dashboard-server.test.js
+++ b/tests/dashboard-server.test.js
@@ -94,7 +94,7 @@ test('invalid event returns false (broadcast guard)', () => {
 // HTTP Server Payload Cap Regression Test Case (Live POST verification)
 // ---------------------------------------------------------------------------
 
-test('POST /event rejects payloads larger than 256 KB with 413 status code', (t, done) => {
+function runWithDashboardServer(testFn, done) {
   const originalCreateServer = http.createServer;
   const originalSetInterval = global.setInterval;
   const originalWatchFile = fs.watchFile;
@@ -123,10 +123,14 @@ test('POST /event rejects payloads larger than 256 KB with 413 status code', (t,
     }
   };
 
-  // Safely evaluate the target module and guarantee cleanup via try/finally
   try {
     delete require.cache[require.resolve('../dashboard/server.js')];
     require('../dashboard/server.js');
+  } catch (err) {
+    http.createServer = originalCreateServer;
+    global.setInterval = originalSetInterval;
+    fs.watchFile = originalWatchFile;
+    return done(err);
   } finally {
     http.createServer = originalCreateServer;
     global.setInterval = originalSetInterval;
@@ -144,17 +148,33 @@ test('POST /event rejects payloads larger than 256 KB with 413 status code', (t,
   }
 
   const testServer = http.createServer(serverHandler);
-  let responseValidated = false;
+  let finished = false;
+
+  const cleanup = (err) => {
+    if (finished) return;
+    finished = true;
+    testServer.close(() => {
+      cleanupHandles();
+      done(err);
+    });
+  };
 
   testServer.on('error', (err) => {
-    cleanupHandles();
-    done(err);
+    cleanup(err);
   });
 
-  // Dynamic port assignment (Port 0) avoids cross-process network binding collisions
   testServer.listen(0, '127.0.0.1', () => {
     const DYNAMIC_PORT = testServer.address().port;
+    try {
+      testFn(DYNAMIC_PORT, cleanup);
+    } catch (err) {
+      cleanup(err);
+    }
+  });
+}
 
+test('POST /event rejects payloads larger than 256 KB with 413 status code', (t, done) => {
+  runWithDashboardServer((port, cleanup) => {
     const payloadSize = 300 * 1024;
     const largePayload = JSON.stringify({
       ide: 'claude',
@@ -164,7 +184,7 @@ test('POST /event rejects payloads larger than 256 KB with 413 status code', (t,
 
     const options = {
       hostname: '127.0.0.1',
-      port: DYNAMIC_PORT,
+      port: port,
       path: '/event',
       method: 'POST',
       headers: {
@@ -178,103 +198,37 @@ test('POST /event rejects payloads larger than 256 KB with 413 status code', (t,
       res.setEncoding('utf8');
       res.on('data', chunk => { responseData += chunk; });
       res.on('end', () => {
-        testServer.close(() => {
-          cleanupHandles();
-          try {
-            assert.equal(res.statusCode, 413, 'Server must reject large inputs with 413 Status');
-            const body = JSON.parse(responseData);
-            assert.equal(body.error, 'Payload too large', 'Error response should explicitly match design expectations');
-            responseValidated = true;
-            done();
-          } catch (err) {
-            done(err);
-          }
-        });
-      });
-    });
-
-    req.on('error', (err) => {
-      if (responseValidated) return; // Prevent double-callback invocations if already verified cleanly
-      
-      testServer.close(() => {
-        cleanupHandles();
-        if (err.code === 'ECONNRESET') {
-          done(new Error('Connection reset before 413 response was fully processed – server may not be sending the expected rejection'));
-        } else {
-          done(err);
+        try {
+          assert.equal(res.statusCode, 413, 'Server must reject large inputs with 413 Status');
+          const body = JSON.parse(responseData);
+          assert.equal(body.error, 'Payload too large', 'Error response should explicitly match design expectations');
+          cleanup();
+        } catch (err) {
+          cleanup(err);
         }
       });
     });
 
+    req.on('error', (err) => {
+      if (err.code === 'ECONNRESET') {
+        cleanup(new Error('Connection reset before 413 response was fully processed - server may not be sending the expected rejection'));
+      } else {
+        cleanup(err);
+      }
+    });
+
     req.write(largePayload);
     req.end();
-  });
+  }, done);
 });
 
 test('POST /event rejects malformed JSON with 400 status code', (t, done) => {
-  const originalCreateServer = http.createServer;
-  const originalSetInterval = global.setInterval;
-  const originalWatchFile = fs.watchFile;
-  
-  let serverHandler = null;
-  const activeIntervals = [];
-  const watchedFiles = [];
-
-  http.createServer = (handler) => {
-    serverHandler = handler;
-    return { listen: () => {}, on: () => {} };
-  };
-
-  global.setInterval = (cb, ms) => {
-    const timerId = originalSetInterval(cb, ms);
-    activeIntervals.push(timerId);
-    return timerId;
-  };
-
-  fs.watchFile = (filename, options, listener) => {
-    watchedFiles.push(filename);
-    if (typeof options === 'function') {
-      originalWatchFile(filename, {}, options);
-    } else {
-      originalWatchFile(filename, options, listener);
-    }
-  };
-
-  try {
-    delete require.cache[require.resolve('../dashboard/server.js')];
-    require('../dashboard/server.js');
-  } finally {
-    http.createServer = originalCreateServer;
-    global.setInterval = originalSetInterval;
-    fs.watchFile = originalWatchFile;
-  }
-
-  const cleanupHandles = () => {
-    activeIntervals.forEach(id => clearInterval(id));
-    watchedFiles.forEach(file => fs.unwatchFile(file));
-  };
-
-  if (typeof serverHandler !== 'function') {
-    cleanupHandles();
-    return done(new Error('Failed to intercept dashboard server route handler logic'));
-  }
-
-  const testServer = http.createServer(serverHandler);
-  let responseValidated = false;
-
-  testServer.on('error', (err) => {
-    cleanupHandles();
-    done(err);
-  });
-
-  testServer.listen(0, '127.0.0.1', () => {
-    const DYNAMIC_PORT = testServer.address().port;
-
+  runWithDashboardServer((port, cleanup) => {
     const malformedPayload = '{"ide":"claude","event":';
 
     const options = {
       hostname: '127.0.0.1',
-      port: DYNAMIC_PORT,
+      port: port,
       path: '/event',
       method: 'POST',
       headers: {
@@ -288,99 +242,34 @@ test('POST /event rejects malformed JSON with 400 status code', (t, done) => {
       res.setEncoding('utf8');
       res.on('data', chunk => { responseData += chunk; });
       res.on('end', () => {
-        testServer.close(() => {
-          cleanupHandles();
-          try {
-            assert.equal(res.statusCode, 400, 'Server must reject malformed JSON with 400 Status');
-            const body = JSON.parse(responseData);
-            assert.equal(typeof body.error, 'string', 'Error message must be a string');
-            assert.ok(body.error.length > 0, 'Error message must not be empty');
-            responseValidated = true;
-            done();
-          } catch (err) {
-            done(err);
-          }
-        });
+        try {
+          assert.equal(res.statusCode, 400, 'Server must reject malformed JSON with 400 Status');
+          const body = JSON.parse(responseData);
+          assert.equal(typeof body.error, 'string', 'Error message must be a string');
+          assert.ok(body.error.length > 0, 'Error message must not be empty');
+          cleanup();
+        } catch (err) {
+          cleanup(err);
+        }
       });
     });
 
     req.on('error', (err) => {
-      if (responseValidated) return;
-      testServer.close(() => {
-        cleanupHandles();
-        done(err);
-      });
+      cleanup(err);
     });
 
     req.write(malformedPayload);
     req.end();
-  });
+  }, done);
 });
 
 test('POST /event still accepts valid JSON with 200 status code', (t, done) => {
-  const originalCreateServer = http.createServer;
-  const originalSetInterval = global.setInterval;
-  const originalWatchFile = fs.watchFile;
-  
-  let serverHandler = null;
-  const activeIntervals = [];
-  const watchedFiles = [];
-
-  http.createServer = (handler) => {
-    serverHandler = handler;
-    return { listen: () => {}, on: () => {} };
-  };
-
-  global.setInterval = (cb, ms) => {
-    const timerId = originalSetInterval(cb, ms);
-    activeIntervals.push(timerId);
-    return timerId;
-  };
-
-  fs.watchFile = (filename, options, listener) => {
-    watchedFiles.push(filename);
-    if (typeof options === 'function') {
-      originalWatchFile(filename, {}, options);
-    } else {
-      originalWatchFile(filename, options, listener);
-    }
-  };
-
-  try {
-    delete require.cache[require.resolve('../dashboard/server.js')];
-    require('../dashboard/server.js');
-  } finally {
-    http.createServer = originalCreateServer;
-    global.setInterval = originalSetInterval;
-    fs.watchFile = originalWatchFile;
-  }
-
-  const cleanupHandles = () => {
-    activeIntervals.forEach(id => clearInterval(id));
-    watchedFiles.forEach(file => fs.unwatchFile(file));
-  };
-
-  if (typeof serverHandler !== 'function') {
-    cleanupHandles();
-    return done(new Error('Failed to intercept dashboard server route handler logic'));
-  }
-
-  const testServer = http.createServer(serverHandler);
-  let responseValidated = false;
-
-  testServer.on('error', (err) => {
-    cleanupHandles();
-    done(err);
-  });
-
-  testServer.listen(0, '127.0.0.1', () => {
-    const DYNAMIC_PORT = testServer.address().port;
-
+  runWithDashboardServer((port, cleanup) => {
     const validPayload = JSON.stringify({ ide: 'claude', event: 'pre_tool' });
 
     const options = {
       hostname: '127.0.0.1',
-      port: DYNAMIC_PORT,
+      port: port,
       path: '/event',
       method: 'POST',
       headers: {
@@ -394,30 +283,22 @@ test('POST /event still accepts valid JSON with 200 status code', (t, done) => {
       res.setEncoding('utf8');
       res.on('data', chunk => { responseData += chunk; });
       res.on('end', () => {
-        testServer.close(() => {
-          cleanupHandles();
-          try {
-            assert.equal(res.statusCode, 200, 'Server must accept valid JSON with 200 Status');
-            const body = JSON.parse(responseData);
-            assert.equal(body.ok, true, 'Response body must contain ok: true');
-            responseValidated = true;
-            done();
-          } catch (err) {
-            done(err);
-          }
-        });
+        try {
+          assert.equal(res.statusCode, 200, 'Server must accept valid JSON with 200 Status');
+          const body = JSON.parse(responseData);
+          assert.equal(body.ok, true, 'Response body must contain ok: true');
+          cleanup();
+        } catch (err) {
+          cleanup(err);
+        }
       });
     });
 
     req.on('error', (err) => {
-      if (responseValidated) return;
-      testServer.close(() => {
-        cleanupHandles();
-        done(err);
-      });
+      cleanup(err);
     });
 
     req.write(validPayload);
     req.end();
-  });
+  }, done);
 });

--- a/tests/dashboard-server.test.js
+++ b/tests/dashboard-server.test.js
@@ -210,3 +210,214 @@ test('POST /event rejects payloads larger than 256 KB with 413 status code', (t,
     req.end();
   });
 });
+
+test('POST /event rejects malformed JSON with 400 status code', (t, done) => {
+  const originalCreateServer = http.createServer;
+  const originalSetInterval = global.setInterval;
+  const originalWatchFile = fs.watchFile;
+  
+  let serverHandler = null;
+  const activeIntervals = [];
+  const watchedFiles = [];
+
+  http.createServer = (handler) => {
+    serverHandler = handler;
+    return { listen: () => {}, on: () => {} };
+  };
+
+  global.setInterval = (cb, ms) => {
+    const timerId = originalSetInterval(cb, ms);
+    activeIntervals.push(timerId);
+    return timerId;
+  };
+
+  fs.watchFile = (filename, options, listener) => {
+    watchedFiles.push(filename);
+    if (typeof options === 'function') {
+      originalWatchFile(filename, {}, options);
+    } else {
+      originalWatchFile(filename, options, listener);
+    }
+  };
+
+  try {
+    delete require.cache[require.resolve('../dashboard/server.js')];
+    require('../dashboard/server.js');
+  } finally {
+    http.createServer = originalCreateServer;
+    global.setInterval = originalSetInterval;
+    fs.watchFile = originalWatchFile;
+  }
+
+  const cleanupHandles = () => {
+    activeIntervals.forEach(id => clearInterval(id));
+    watchedFiles.forEach(file => fs.unwatchFile(file));
+  };
+
+  if (typeof serverHandler !== 'function') {
+    cleanupHandles();
+    return done(new Error('Failed to intercept dashboard server route handler logic'));
+  }
+
+  const testServer = http.createServer(serverHandler);
+  let responseValidated = false;
+
+  testServer.on('error', (err) => {
+    cleanupHandles();
+    done(err);
+  });
+
+  testServer.listen(0, '127.0.0.1', () => {
+    const DYNAMIC_PORT = testServer.address().port;
+
+    const malformedPayload = '{"ide":"claude","event":';
+
+    const options = {
+      hostname: '127.0.0.1',
+      port: DYNAMIC_PORT,
+      path: '/event',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(malformedPayload)
+      }
+    };
+
+    const req = http.request(options, (res) => {
+      let responseData = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => { responseData += chunk; });
+      res.on('end', () => {
+        testServer.close(() => {
+          cleanupHandles();
+          try {
+            assert.equal(res.statusCode, 400, 'Server must reject malformed JSON with 400 Status');
+            const body = JSON.parse(responseData);
+            assert.equal(typeof body.error, 'string', 'Error message must be a string');
+            assert.ok(body.error.length > 0, 'Error message must not be empty');
+            responseValidated = true;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
+      });
+    });
+
+    req.on('error', (err) => {
+      if (responseValidated) return;
+      testServer.close(() => {
+        cleanupHandles();
+        done(err);
+      });
+    });
+
+    req.write(malformedPayload);
+    req.end();
+  });
+});
+
+test('POST /event still accepts valid JSON with 200 status code', (t, done) => {
+  const originalCreateServer = http.createServer;
+  const originalSetInterval = global.setInterval;
+  const originalWatchFile = fs.watchFile;
+  
+  let serverHandler = null;
+  const activeIntervals = [];
+  const watchedFiles = [];
+
+  http.createServer = (handler) => {
+    serverHandler = handler;
+    return { listen: () => {}, on: () => {} };
+  };
+
+  global.setInterval = (cb, ms) => {
+    const timerId = originalSetInterval(cb, ms);
+    activeIntervals.push(timerId);
+    return timerId;
+  };
+
+  fs.watchFile = (filename, options, listener) => {
+    watchedFiles.push(filename);
+    if (typeof options === 'function') {
+      originalWatchFile(filename, {}, options);
+    } else {
+      originalWatchFile(filename, options, listener);
+    }
+  };
+
+  try {
+    delete require.cache[require.resolve('../dashboard/server.js')];
+    require('../dashboard/server.js');
+  } finally {
+    http.createServer = originalCreateServer;
+    global.setInterval = originalSetInterval;
+    fs.watchFile = originalWatchFile;
+  }
+
+  const cleanupHandles = () => {
+    activeIntervals.forEach(id => clearInterval(id));
+    watchedFiles.forEach(file => fs.unwatchFile(file));
+  };
+
+  if (typeof serverHandler !== 'function') {
+    cleanupHandles();
+    return done(new Error('Failed to intercept dashboard server route handler logic'));
+  }
+
+  const testServer = http.createServer(serverHandler);
+  let responseValidated = false;
+
+  testServer.on('error', (err) => {
+    cleanupHandles();
+    done(err);
+  });
+
+  testServer.listen(0, '127.0.0.1', () => {
+    const DYNAMIC_PORT = testServer.address().port;
+
+    const validPayload = JSON.stringify({ ide: 'claude', event: 'pre_tool' });
+
+    const options = {
+      hostname: '127.0.0.1',
+      port: DYNAMIC_PORT,
+      path: '/event',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(validPayload)
+      }
+    };
+
+    const req = http.request(options, (res) => {
+      let responseData = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => { responseData += chunk; });
+      res.on('end', () => {
+        testServer.close(() => {
+          cleanupHandles();
+          try {
+            assert.equal(res.statusCode, 200, 'Server must accept valid JSON with 200 Status');
+            const body = JSON.parse(responseData);
+            assert.equal(body.ok, true, 'Response body must contain ok: true');
+            responseValidated = true;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
+      });
+    });
+
+    req.on('error', (err) => {
+      if (responseValidated) return;
+      testServer.close(() => {
+        cleanupHandles();
+        done(err);
+      });
+    });
+
+    req.write(validPayload);
+    req.end();
+  });
+});


### PR DESCRIPTION
Fixes #899

JSON.parse failures in the /event handler were caught and silently discarded, and the unconditional 200 response below the try/catch still fired regardless. Senders never learned their payload was dropped. Now a parse failure returns 400 with a small JSON error body; the valid-event path is unchanged.

## What Changed
- `dashboard/server.js`: separated `JSON.parse(body)` from the `accumulateEvent(ev)` call in the POST `/event` handler. A parse failure now writes a `400` with a JSON error body (`{ "error": "Invalid JSON" }`) and returns immediately, instead of falling through to the unconditional `200` that previously ran regardless of whether parsing succeeded.
- `tests/dashboard-server.test.js`: added two regression tests alongside the existing 413 payload-cap test, reusing the same server-interception pattern (mocking `http.createServer`/`setInterval`/`fs.watchFile`, requiring `dashboard/server.js` fresh, listening on a dynamic port):
  - malformed JSON POSTed to `/event` → asserts `400` and a JSON body with a non-empty `error` field.
  - valid JSON POSTed to `/event` → asserts `200` and `{"ok":true}`, confirming the existing path is untouched.

## Why This Change
The `/event` endpoint silently accepted corrupted JSON with HTTP 200. Senders had no way to know their payload was dropped, so bad events just vanished with no error signal on either side.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

Manual verification:
- POSTed truncated/malformed JSON to `/event` → received `400` with a JSON error body.
- POSTed a valid event body to `/event` → received `200`, `{"ok":true}`, unchanged from before.
- Confirmed the pre-existing 413 payload-cap test still passes — that branch returns via `req.destroy()` before `JSON.parse` is ever reached, so it's unaffected by this change.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable) — N/A, no shell scripts touched
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation — N/A, no public API/config surface changed beyond the error response shape, which matches the issue's fix hint
- [x] Added comments for complex logic — N/A, the change is small and self-explanatory; no new comments were needed
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The dashboard POST `/event` endpoint now rejects malformed JSON with a 400 and a JSON error body, instead of silently returning 200. Valid requests are unchanged.

- **Bug Fixes**
  - Parse body before `accumulateEvent`; on failure, return 400 with `{"error":"Invalid JSON"}`.
  - Added tests for 400 malformed JSON and 200 `{"ok":true}`; extracted `runWithDashboardServer` to DRY server setup/mocking for 413/400/200.

<sup>Written for commit 1b1933fe25ba2679241a961fa69587cd531d4489. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

