### PR TITLE
fix(dashboard): offline badge now reacts to a dead WebSocket

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -657,6 +657,7 @@ const S={
   latencyMs:0,hooksOk:false,
   telemetryFailStreak:0,
   pingFailStreak:0,
+  wsFailStreak:0,
   isOffline:false,
   telemetryReqId:0,
   pingReqId:0,
@@ -1098,20 +1099,19 @@ function setOffline(offline){
     }
   });
 }
+function updateOfflineState(){
+  const offline = S.telemetryFailStreak>=3 || S.pingFailStreak>=3 || S.wsFailStreak>=3;
+  setOffline(offline);
+}
 function reportPollResult(type, ok){
   if(ok){
     if(type==='telemetry') S.telemetryFailStreak=0;
     if(type==='ping') S.pingFailStreak=0;
-    if(S.telemetryFailStreak===0 && S.pingFailStreak===0){
-      setOffline(false);
-    }
   }else{
     if(type==='telemetry') S.telemetryFailStreak++;
     if(type==='ping') S.pingFailStreak++;
-    if(S.telemetryFailStreak>=3 || S.pingFailStreak>=3){
-      setOffline(true);
-    }
   }
+  updateOfflineState();
 }
 
 function pollTelemetry(){
@@ -1147,8 +1147,8 @@ pollTelemetry();
 function connect(){
   try{
     S.ws=new WebSocket('ws://localhost:7890');
-    S.ws.onopen=()=>{setWs(true);S.rc=1000;pingLatency();};
-    S.ws.onclose=()=>{setWs(false);setTimeout(connect,S.rc);S.rc=Math.min(S.rc*2,10000);};
+    S.ws.onopen=()=>{setWs(true);S.rc=1000;S.wsFailStreak=0;updateOfflineState();pingLatency();};
+    S.ws.onclose=()=>{setWs(false);S.wsFailStreak++;updateOfflineState();setTimeout(connect,S.rc);S.rc=Math.min(S.rc*2,10000);};
     S.ws.onmessage=m=>{
       try{
         const t0=performance.now();
@@ -1164,12 +1164,6 @@ function setWs(on){
   document.getElementById('wsDot').className='ws-dot'+(on?' on':'');
   document.getElementById('wsLbl').textContent=on?'live':'offline';
   document.getElementById('activeBadge').style.display=on?'':'none';
-  if(!on){
-    S.pingFailStreak=0;
-    if(S.telemetryFailStreak===0){
-      setOffline(false);
-    }
-  }
 }
 function pingLatency(){
   if(!S.ws||S.ws.readyState!==1)return;


### PR DESCRIPTION
The offline badge introduced in #911 was driven exclusively by the /telemetry and /ping poll failure streaks. Worse, setWs(false) (fired on every WebSocket close) actively reset pingFailStreak and forced setOffline(false) whenever telemetryFailStreak was 0 — so a dead socket with healthy HTTP polls was invisible by design, not just by omission. pingLatency() also stops rescheduling entirely once the socket is down, so it couldn't pick up the slack either.

Adds a wsFailStreak counter driven by the reconnect loop (increments on each onclose, resets on onopen), folds it into a shared updateOfflineState() alongside the existing poll streaks, and removes the force-clear in setWs. Existing poll-streak behavior from #911 is unchanged.

Fixes #914

## What Changed
- `dashboard/public/index.html`: added `S.wsFailStreak` to the state object, alongside the existing `telemetryFailStreak` / `pingFailStreak` / `isOffline` fields.
- Added `updateOfflineState()`, a shared decision function that flips the badge when any of `telemetryFailStreak`, `pingFailStreak`, or `wsFailStreak` reaches 3 consecutive failures.
- `reportPollResult()` now delegates to `updateOfflineState()` instead of duplicating the threshold check inline.
- `connect()`'s `onopen`/`onclose` handlers now increment/reset `wsFailStreak` and call `updateOfflineState()`, so a dying WebSocket feeds into the same offline decision as the HTTP polls.
- Removed the `if(!on){...}` block from `setWs()`, which previously reset `pingFailStreak` and force-cleared the offline badge on every WebSocket close — this was the actual root cause of #914: a dead socket was actively prevented from ever triggering the badge, not merely unaccounted for.

## Why This Change
The offline badge from #911 only watched the two HTTP poll loops. If the WebSocket died while `/telemetry` and `/ping` stayed healthy, the dashboard looked fully alive while the live event feed was silently frozen. Worse, `setWs(false)` was actively clearing any offline state on every socket close, so this wasn't just a coverage gap — it was working against detection.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

Manual verification:
- Killed only the WebSocket (backend HTTP endpoints left running) — offline badge appeared after 3 consecutive failed reconnects, panels dimmed.
- Let the socket reconnect — badge cleared on the next successful `onopen`.
- Killed the full backend (HTTP + WS) — confirmed the original #911 poll-streak behavior still triggers the badge unchanged.
- Watched the console through all transitions — no new errors or warnings.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable) — N/A, no shell scripts touched
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation — N/A, no public API/config surface changed
- [x] Added comments for complex logic — N/A, function names (`updateOfflineState`, `wsFailStreak`) are self-descriptive; no new comments needed
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard offline badge so it triggers when the WebSocket dies, not just when HTTP polls fail. Prevents false “online” state when the live feed is down (fixes #914).

- **Bug Fixes**
  - Added `wsFailStreak` (increments on `onclose`, resets on `onopen`) and triggers the badge after 3 failures.
  - Introduced `updateOfflineState()` to unify offline checks; used by poll handlers and the WS reconnect loop.
  - Removed the force-clear in `setWs(false)` that reset ping streaks and hid WS failures.

<sup>Written for commit 0b63bff841e0d93ebf9905b1167bb0694926cea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

