### PR TITLE
fix(dashboard): buffer raw bytes across POST /event chunks before UTF-8 decode

### DIFF
--- a/dashboard/event-body.js
+++ b/dashboard/event-body.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Accumulates raw request-body Buffer chunks and decodes them as UTF-8 only
+ * once, at the end.
+ *
+ * Concatenating with `body += chunk` implicitly calls `chunk.toString('utf8')`
+ * on each chunk in isolation. When a multi-byte character (accented paths,
+ * CJK usernames, emoji) is split across two chunks, each half decodes on its
+ * own and turns into replacement-character garbage. Buffering the raw bytes
+ * and decoding once, after every chunk has arrived, avoids that. See
+ * Fmarzochi/EGC#916.
+ */
+function createBodyCollector() {
+  const chunks = [];
+  let size = 0;
+
+  return {
+    push(chunk) {
+      chunks.push(chunk);
+      size += chunk.length;
+      return size;
+    },
+    size() {
+      return size;
+    },
+    toString() {
+      return Buffer.concat(chunks).toString('utf8');
+    },
+  };
+}
+
+module.exports = { createBodyCollector };

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -7,6 +7,7 @@ const fs      = require('fs');
 const os      = require('os');
 const { execSync, execFileSync } = require('child_process');
 const { createAccumulator } = require('./accumulator');
+const { createBodyCollector } = require('./event-body');
 
 const PORT   = 7890;
 const PUBLIC = path.join(__dirname, 'public');
@@ -158,16 +159,14 @@ const server = http.createServer((req, res) => {
 
   // ── POST /event ─────────────────────────────────────────
   if (req.method === 'POST' && req.url === '/event') {
-    let body = '';
-    let currentSize = 0;
+    const collector = createBodyCollector();
     const MAX_SIZE = 256 * 1024; // 256 KB cap
     let exceeded = false;
 
     req.on('data', d => {
       if (exceeded) return;
-      
-      currentSize += d.length;
-      if (currentSize > MAX_SIZE) {
+
+      if (collector.push(d) > MAX_SIZE) {
         exceeded = true;
         res.writeHead(413, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Payload too large' }), () => {
@@ -175,8 +174,6 @@ const server = http.createServer((req, res) => {
         });
         return;
       }
-      
-      body += d;
     });
 
     req.on('end', () => {
@@ -184,7 +181,7 @@ const server = http.createServer((req, res) => {
 
       let ev;
       try {
-        ev = JSON.parse(body);
+        ev = JSON.parse(collector.toString());
       } catch (_) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Invalid JSON' }));

--- a/tests/dashboard-event-body.test.js
+++ b/tests/dashboard-event-body.test.js
@@ -1,0 +1,77 @@
+'use strict';
+/**
+ * Regression tests for Fmarzochi/EGC#916
+ *
+ * Exercises the real createBodyCollector() factory shared with
+ * dashboard/server.js's POST /event handler.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createBodyCollector } = require('../dashboard/event-body');
+
+// Returns a byte index that lands inside a multi-byte UTF-8 character
+// (i.e. on a continuation byte, 10xxxxxx), so splitting the buffer there
+// simulates a chunk boundary landing mid-character.
+function findMidCharacterSplit(buf) {
+  for (let i = 1; i < buf.length; i++) {
+    if ((buf[i] & 0xc0) === 0x80) return i;
+  }
+  throw new Error('payload has no multi-byte character to split');
+}
+
+test('multi-byte UTF-8 character split across chunks decodes correctly', () => {
+  const payload = JSON.stringify({
+    ide: 'claude',
+    event: 'pre_tool',
+    note: '日本語 パス名 🎉 done',
+  });
+  const buf = Buffer.from(payload, 'utf8');
+  const splitIndex = findMidCharacterSplit(buf);
+
+  const collector = createBodyCollector();
+  collector.push(buf.subarray(0, splitIndex));
+  collector.push(buf.subarray(splitIndex));
+
+  assert.equal(collector.toString(), payload);
+  assert.deepEqual(JSON.parse(collector.toString()), JSON.parse(payload));
+});
+
+test('character split across three chunks still decodes correctly', () => {
+  const payload = JSON.stringify({ ide: 'claude', note: '🎉' });
+  const buf = Buffer.from(payload, 'utf8');
+  const splitIndex = findMidCharacterSplit(buf);
+
+  const collector = createBodyCollector();
+  // Split the multi-byte character's bytes into two separate pushes too.
+  collector.push(buf.subarray(0, splitIndex));
+  collector.push(buf.subarray(splitIndex, splitIndex + 1));
+  collector.push(buf.subarray(splitIndex + 1));
+
+  assert.equal(collector.toString(), payload);
+});
+
+test('size() counts bytes, not decoded characters', () => {
+  const collector = createBodyCollector();
+  const buf = Buffer.from('日本語', 'utf8'); // 3 chars, 9 bytes
+  const returned = collector.push(buf);
+
+  assert.equal(buf.length, 9);
+  assert.equal(returned, 9);
+  assert.equal(collector.size(), 9);
+});
+
+test('size accumulates across multiple pushes', () => {
+  const collector = createBodyCollector();
+  collector.push(Buffer.from('abc'));
+  const total = collector.push(Buffer.from('defgh'));
+  assert.equal(total, 8);
+  assert.equal(collector.size(), 8);
+});
+
+test('ASCII-only payload delivered in a single chunk still works', () => {
+  const payload = JSON.stringify({ ide: 'claude', event: 'pre_tool' });
+  const collector = createBodyCollector();
+  collector.push(Buffer.from(payload, 'utf8'));
+  assert.equal(collector.toString(), payload);
+});

--- a/tests/dashboard-event-body.test.js
+++ b/tests/dashboard-event-body.test.js
@@ -10,43 +10,64 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { createBodyCollector } = require('../dashboard/event-body');
 
-// Returns a byte index that lands inside a multi-byte UTF-8 character
-// (i.e. on a continuation byte, 10xxxxxx), so splitting the buffer there
-// simulates a chunk boundary landing mid-character.
-function findMidCharacterSplit(buf) {
-  for (let i = 1; i < buf.length; i++) {
-    if ((buf[i] & 0xc0) === 0x80) return i;
-  }
-  throw new Error('payload has no multi-byte character to split');
+// U+1F389 PARTY POPPER, as raw UTF-8 bytes rather than a literal emoji
+// character. This file must stay free of Extended_Pictographic code points
+// (see scripts/ci/check-unicode-safety.js) — writing the emoji as a string
+// literal would trip that gate.
+const PARTY_POPPER_BYTES = Buffer.from([0xF0, 0x9F, 0x8E, 0x89]);
+const EMOJI_PLACEHOLDER = '@EMOJI@';
+
+// Serializes `obj` to JSON, then splices PARTY_POPPER_BYTES in at the byte
+// offset where EMOJI_PLACEHOLDER appears in the resulting text. This gives
+// an exact, known byte offset for the emoji's 4-byte UTF-8 sequence, so
+// tests can split precisely inside it instead of scanning for "some"
+// multi-byte character boundary.
+function payloadBufferWithEmoji(obj) {
+  const json = JSON.stringify(obj);
+  const markerIndex = json.indexOf(EMOJI_PLACEHOLDER);
+  if (markerIndex === -1) throw new Error('EMOJI_PLACEHOLDER not found in payload');
+
+  const before = Buffer.from(json.slice(0, markerIndex), 'utf8');
+  const after = Buffer.from(json.slice(markerIndex + EMOJI_PLACEHOLDER.length), 'utf8');
+
+  return {
+    buf: Buffer.concat([before, PARTY_POPPER_BYTES, after]),
+    emojiStart: before.length,
+  };
 }
 
 test('multi-byte UTF-8 character split across chunks decodes correctly', () => {
-  const payload = JSON.stringify({
+  const { buf: payloadBuf, emojiStart } = payloadBufferWithEmoji({
     ide: 'claude',
     event: 'pre_tool',
-    note: '日本語 パス名 🎉 done',
+    note: `日本語 パス名 ${EMOJI_PLACEHOLDER} done`,
   });
-  const buf = Buffer.from(payload, 'utf8');
-  const splitIndex = findMidCharacterSplit(buf);
+  const payload = payloadBuf.toString('utf8');
+
+  // Split 2 bytes into the emoji's 4-byte UTF-8 sequence.
+  const splitIndex = emojiStart + 2;
 
   const collector = createBodyCollector();
-  collector.push(buf.subarray(0, splitIndex));
-  collector.push(buf.subarray(splitIndex));
+  collector.push(payloadBuf.subarray(0, splitIndex));
+  collector.push(payloadBuf.subarray(splitIndex));
 
   assert.equal(collector.toString(), payload);
   assert.deepEqual(JSON.parse(collector.toString()), JSON.parse(payload));
 });
 
 test('character split across three chunks still decodes correctly', () => {
-  const payload = JSON.stringify({ ide: 'claude', note: '🎉' });
-  const buf = Buffer.from(payload, 'utf8');
-  const splitIndex = findMidCharacterSplit(buf);
+  const { buf: payloadBuf, emojiStart } = payloadBufferWithEmoji({
+    ide: 'claude',
+    note: EMOJI_PLACEHOLDER,
+  });
+  const payload = payloadBuf.toString('utf8');
 
   const collector = createBodyCollector();
-  // Split the multi-byte character's bytes into two separate pushes too.
-  collector.push(buf.subarray(0, splitIndex));
-  collector.push(buf.subarray(splitIndex, splitIndex + 1));
-  collector.push(buf.subarray(splitIndex + 1));
+  // Split the emoji's 4 raw bytes into three separate pushes: byte 0, byte 1,
+  // then bytes 2-3.
+  collector.push(payloadBuf.subarray(0, emojiStart + 1));
+  collector.push(payloadBuf.subarray(emojiStart + 1, emojiStart + 2));
+  collector.push(payloadBuf.subarray(emojiStart + 2));
 
   assert.equal(collector.toString(), payload);
 });


### PR DESCRIPTION
## Mission
Stops multi-byte UTF-8 payloads from being corrupted at chunk boundaries in `POST /event`, per #916.

## The fix
`server.js` accumulated the request body with `body += chunk`, which implicitly calls `chunk.toString('utf8')` on each Buffer chunk in isolation. A multi-byte UTF-8 character (accented paths, CJK usernames, emoji) split across two TCP chunks decoded each half independently, corrupting the character or breaking JSON parsing.

Extracted a `createBodyCollector()` helper (`dashboard/event-body.js`, mirroring the existing `accumulator.js` extraction pattern already used in this codebase) that buffers raw Buffer chunks and decodes once via `Buffer.concat(...).toString('utf8')` at request end. The 256 KB size cap still counts `Buffer.length` (bytes), unchanged.

## Regression test
`tests/dashboard-event-body.test.js` splits a payload at a byte offset landing mid-character and asserts the collector reassembles it byte-for-byte. I also empirically confirmed the *old* `body += chunk` approach corrupts this exact payload (`JSON.parse` succeeds, but the decoded string differs from the original) before verifying the new code makes them equal — so this is a real regression test, not a tautology.

## Acceptance criteria
- [x] An event whose multi-byte character is split across two chunks parses correctly end to end
- [x] A regression test simulates the split-chunk delivery
- [x] The 256 KB payload cap still counts bytes and still returns 413 (unchanged logic, only the accumulation storage changed)
- [x] `node --test tests/dashboard-event-body.test.js` passes (5/5); `node -c dashboard/server.js` and `node -c dashboard/event-body.js` both syntax-check clean

Commits are DCO-signed (`git commit -s`).

## Related issue
Closes #916

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UTF-8 corruption in `POST /event` when multi-byte characters span chunks by buffering raw bytes and decoding once at the end. Keeps the 256 KB cap and adds deterministic tests; fixes #916.

- **Bug Fixes**
  - Replace `body += chunk` with `createBodyCollector()` (`dashboard/server.js`, `dashboard/event-body.js`) to buffer `Buffer`s and decode once via `Buffer.concat(...).toString('utf8')`; 256 KB byte cap preserved (413 on overflow).
  - Update `tests/dashboard-event-body.test.js` to build the emoji from raw UTF-8 bytes at a known byte offset to satisfy the unicode-safety gate and make the split deterministic; covers mid-character splits and size counting.

<sup>Written for commit fa84b177eb442d695bd394a38670d81d4c743a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

