### PR TITLE
docs(roadmap): sync the unreleased section with today's community merges

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,6 +88,10 @@ Closes the commit-privacy scope started in v1.1.12:
 - Dashboard session shim no longer leaves a zombie process after every event (#907, @developmentwithparth1311)
 - Lean repository root phase 2: examples, lint, and test configs relocated, redundant files dropped (#908)
 - Dashboard offline badge after consecutive poll failures, with per-endpoint failure streaks (#911, @harshjainnn)
+- `LLMInput.stream=True` now raises `NotImplementedError` across the OpenAI-compatible providers instead of silently downgrading to a blocking call (#912, @Sufiyan-MSA)
+- Dashboard POST /event rejects malformed JSON with a 400 instead of a silent 200 (#917, @harshjainnn)
+- Dashboard offline badge reacts to a dead WebSocket, not only to poll failures (#919, @harshjainnn)
+- zh-CN README rendering fixed after the closing div (#922, @Aki-new)
 
 ## v1.2.0: Teams
 


### PR DESCRIPTION
## Summary

Adds the four merges that landed after PR #913 to the Unreleased section: #912 (stream guard, @Sufiyan-MSA), #917 (400 on malformed JSON), #919 (offline badge reacts to dead WebSocket) and #922 (zh-CN rendering, @Aki-new).

Docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the Unreleased section of docs/ROADMAP.md with recent community merges. Adds entries for: `LLMInput.stream=True` now raises `NotImplementedError` on OpenAI-compatible providers; dashboard `POST /event` returns 400 for malformed JSON; offline badge updates on dead WebSocket; zh-CN README rendering fix.

<sup>Written for commit 8982d969d4115ad78cca52f5b7268fd6509f294c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

