### PR TITLE
chore(ci): name CLA runs after the PR they check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,5 @@
 name: CLA
+run-name: "CLA check: PR #${{ github.event.pull_request.number || github.event.issue.number }}"
 
 on:
   issue_comment:


### PR DESCRIPTION
## Summary

Every CLA run triggered by pull_request_target executes in the base context, so failure emails arrive as "Run failed: CLA - main (sha)" with a main commit SHA, which reads like the workflow is broken on main. Today's four first-timer PRs generated four of these and cost a debugging round.

This adds a run-name carrying the PR number (works for both pull_request_target and issue_comment events). Behavior, triggers, job name (branch protection) and the action call are untouched.

Diagnosis note: the failures themselves are correct, they are the CLA gate flagging unsigned first-time PRs; only the run label was misleading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Label CLA workflow runs with the PR number to avoid “CLA - main” mislabeling and make failures point to the correct PR. Works for `pull_request_target` and `issue_comment` events; no changes to triggers, job name, or action behavior.

<sup>Written for commit 013052794e5f3c5ecc7b53c4bdae66e0e3675d0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

