### PR TITLE
fix(install): bare egc install defaults to the developer profile

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -150,7 +150,9 @@ function main() {
     );
     if (!hasSelection) {
       options.profileId = DEFAULT_INSTALL_PROFILE;
-      console.log(`No profile or modules specified; installing the default profile "${DEFAULT_INSTALL_PROFILE}". Run egc install --help to see every profile and option.`);
+      if (!options.json) {
+        console.log(`No profile or modules specified; installing the default profile "${DEFAULT_INSTALL_PROFILE}". Run egc install --help to see every profile and option.`);
+      }
     }
     const request = normalizeInstallRequest({
       ...options,

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -19,6 +19,10 @@ const {
   parseInstallArgs,
 } = require('./lib/install/request');
 
+// Bare "egc install" is the documented Quick Start path and must work in a
+// clean environment, so it falls back to the default engineering profile.
+const DEFAULT_INSTALL_PROFILE = 'developer';
+
 function getHelpText() {
   const languages = listLegacyCompatibilityLanguages();
 
@@ -135,6 +139,18 @@ function main() {
       config = loadInstallConfig(defaultConfigPath, { cwd: process.cwd() });
     } else {
       config = null;
+    }
+    const hasSelection = Boolean(
+      config ||
+      options.profileId ||
+      options.moduleIds.length > 0 ||
+      options.includeComponentIds.length > 0 ||
+      options.excludeComponentIds.length > 0 ||
+      options.languages.length > 0
+    );
+    if (!hasSelection) {
+      options.profileId = DEFAULT_INSTALL_PROFILE;
+      console.log(`No profile or modules specified; installing the default profile "${DEFAULT_INSTALL_PROFILE}". Run egc install --help to see every profile and option.`);
     }
     const request = normalizeInstallRequest({
       ...options,

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -85,6 +85,21 @@ function runTests() {
     assert.ok(result.stderr.includes('cannot be combined'));
   })) passed++; else failed++;
 
+  if (test('bare install defaults to the developer profile', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const result = run(['--dry-run'], { cwd: projectDir, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('default profile "developer"'));
+      assert.ok(result.stdout.includes('Profile: developer'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('installs Gemini rules and writes install-state', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -100,6 +100,22 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('bare install with --json keeps the output machine-readable', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const result = run(['--dry-run', '--json'], { cwd: projectDir, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      const payload = JSON.parse(result.stdout);
+      assert.strictEqual(payload.dryRun, true);
+      assert.strictEqual(payload.plan.profileId, 'developer');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('installs Gemini rules and writes install-state', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');


### PR DESCRIPTION
Fixes #935.

## Credit

Root cause surfaced by @Aki-new's report on the Windows testing mission #642: bare `egc install`, exactly what the README Quick Start promises, failed in any clean environment on every platform because there was no default profile fallback.

## What changed

- `scripts/install-apply.js`: when no profile, modules, components, languages, or `egc-install.json` are provided, the installer now falls back to the `developer` profile (the manifest's default engineering profile) and prints which profile was chosen and how to pick another.
- `tests/scripts/install-apply.test.js`: regression test running the bare `--dry-run` path in a clean home and project dir, asserting the fallback note and the resolved `Profile: developer` plan.

## Behavior preserved

Every explicit selection path (`--profile`, `--modules`, `--with`, `--without`, legacy languages, `--config`, auto-detected `egc-install.json`) is untouched, including error cases: covered by the existing 28 tests in `install-apply.test.js` and 7 in `install-request.test.js`, all green locally with the new test (36 total).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bare `egc install` now works in clean environments by defaulting to the `developer` profile when no options are provided. It prints which profile was chosen and how to pick another, and keeps `--json` output machine-readable.

- **Bug Fixes**
  - Fallback to `developer` when no profile/modules/components/languages/config are given; log a clear note unless `--json` is used.
  - Added regression tests for the bare `--dry-run` and `--json` paths; explicit selection paths remain unchanged.

<sup>Written for commit 3c7b6b1db5c7a9ba265a58a33d763beb9ce544d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

