### PR TITLE
fix(install): run the shipped onboarding installers on bare egc install

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -160,6 +160,9 @@ function main() {
         stdio: 'inherit',
         env: { ...process.env, EGC_INSTALL_DELEGATED: '1' },
       });
+      if (spawned.error) {
+        process.stderr.write(`Error: failed to launch ${wrapper.cmd}: ${spawned.error.message}\n`);
+      }
       process.exit(spawned.status === null ? 1 : spawned.status);
     }
     const request = normalizeInstallRequest({

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -136,6 +136,32 @@ function main() {
     } else {
       config = null;
     }
+    const hasSelection = Boolean(
+      config ||
+      options.profileId ||
+      options.moduleIds.length > 0 ||
+      options.includeComponentIds.length > 0 ||
+      options.excludeComponentIds.length > 0 ||
+      options.languages.length > 0
+    );
+    if (!hasSelection && !options.dryRun && !options.json && !process.env.EGC_INSTALL_DELEGATED) {
+      // A bare "egc install" is the README Quick Start path. The no-argument
+      // flow is already defined by the shipped onboarding installers, so run
+      // them instead of failing; the env guard stops the wrappers from
+      // recursing back into this script.
+      const path = require('node:path');
+      const { spawnSync } = require('node:child_process');
+      const rootDir = path.join(__dirname, '..');
+      const wrapper = process.platform === 'win32'
+        ? { cmd: 'powershell', args: ['-ExecutionPolicy', 'Bypass', '-File', path.join(rootDir, 'scripts', 'install.ps1')] }
+        : { cmd: 'bash', args: [path.join(rootDir, 'scripts', 'install.sh')] };
+      const spawned = spawnSync(wrapper.cmd, wrapper.args, {
+        cwd: rootDir,
+        stdio: 'inherit',
+        env: { ...process.env, EGC_INSTALL_DELEGATED: '1' },
+      });
+      process.exit(spawned.status === null ? 1 : spawned.status);
+    }
     const request = normalizeInstallRequest({
       ...options,
       config,

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -112,6 +112,25 @@ function runTests() {
     })) passed++; else failed++;
   }
 
+  if (process.platform !== 'win32') {
+    if (test('bare install surfaces a wrapper launch failure instead of swallowing it', () => {
+      const homeDir = createTempDir('install-apply-home-');
+      const projectDir = createTempDir('install-apply-project-');
+      const binDir = createTempDir('install-apply-bin-');
+
+      try {
+        fs.symlinkSync(process.execPath, path.join(binDir, 'node'));
+        const result = run([], { cwd: projectDir, homeDir, env: { PATH: binDir } });
+        assert.strictEqual(result.code, 1);
+        assert.ok(result.stderr.includes('failed to launch bash'));
+      } finally {
+        cleanup(homeDir);
+        cleanup(projectDir);
+        cleanup(binDir);
+      }
+    })) passed++; else failed++;
+  }
+
   if (test('delegated bare install keeps the explicit selection contract', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -85,6 +85,51 @@ function runTests() {
     assert.ok(result.stderr.includes('cannot be combined'));
   })) passed++; else failed++;
 
+  if (process.platform !== 'win32') {
+    if (test('bare install delegates to the shipped install.sh wrapper', () => {
+      const homeDir = createTempDir('install-apply-home-');
+      const projectDir = createTempDir('install-apply-project-');
+      const binDir = createTempDir('install-apply-bin-');
+
+      try {
+        const fakeBash = path.join(binDir, 'bash');
+        fs.writeFileSync(fakeBash, '#!/bin/sh\necho "WRAPPER CALLED: $1"\nexit 0\n');
+        fs.chmodSync(fakeBash, 0o755);
+
+        const result = run([], {
+          cwd: projectDir,
+          homeDir,
+          env: { PATH: `${binDir}${path.delimiter}${process.env.PATH}` },
+        });
+        assert.strictEqual(result.code, 0, result.stderr);
+        assert.ok(result.stdout.includes('WRAPPER CALLED'));
+        assert.ok(result.stdout.includes(path.join('scripts', 'install.sh')));
+      } finally {
+        cleanup(homeDir);
+        cleanup(projectDir);
+        cleanup(binDir);
+      }
+    })) passed++; else failed++;
+  }
+
+  if (test('delegated bare install keeps the explicit selection contract', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const result = run([], {
+        cwd: projectDir,
+        homeDir,
+        env: { EGC_INSTALL_DELEGATED: '1' },
+      });
+      assert.strictEqual(result.code, 1);
+      assert.ok(result.stderr.includes('No install profile'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('installs Gemini rules and writes install-state', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');


### PR DESCRIPTION
Fixes #935.

## Credit

Root cause surfaced by @Aki-new's report on the Windows testing mission #642.

## The fix, within the current design

EGC already defines the no-argument install: the onboarding flow in `scripts/install.sh` (`scripts/install.ps1` on Windows), shipped in the npm package. This PR makes bare `egc install` run that existing flow instead of erroring:

- `scripts/install-apply.js`: when no profile, modules, components, languages, or `egc-install.json` are provided (and neither `--dry-run` nor `--json` is set), delegate to the platform's installer script with inherited stdio and propagate its exit code. An `EGC_INSTALL_DELEGATED` env guard prevents the wrappers from recursing back into this script.
- No new install behavior: the wrapper scripts remain the single definition of the no-argument flow, and every explicit selection path is byte-for-byte untouched.

## Tests

- bare install spawns `scripts/install.sh` (verified via a PATH-shimmed `bash`, POSIX-only test)
- with the delegation guard set, the explicit-selection contract (error) is preserved
- full suites green locally: 30/30 `install-apply.test.js`, 7/7 `install-request.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bare `egc install` now runs the shipped onboarding installers (`scripts/install.sh` on POSIX, `scripts/install.ps1` on Windows) instead of erroring, and surfaces wrapper launch failures with a clear message. Fixes #935.

- **Bug Fixes**
  - When no selection is provided and not `--dry-run`/`--json`, delegate to the platform installer with inherited stdio and propagate its exit code.
  - Added `EGC_INSTALL_DELEGATED` to prevent recursion; explicit-selection behavior and errors remain unchanged.

<sup>Written for commit 1643a8b64c0fb2618fe920ae56eacb681e092ee2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

