### PR TITLE
docs(roadmap): sync unreleased with the evening merges

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -95,7 +95,7 @@ Closes the commit-privacy scope started in v1.1.12:
 - Last em dash removed from the docs per repo writing convention (#929, @aryamirani)
 - CLA workflow runs are named after the PR they check instead of the base branch (#930)
 - Italian README translation, the 10th language, wired into all language selectors (#933, @LuckysHorizon)
-- Bare `egc install` runs the shipped onboarding installers instead of erroring in a clean environment (#937, reported by @Aki-new in #935)
+- Bare `egc install` runs the shipped onboarding installers instead of erroring in a clean environment (#937, @Aki-new via #935)
 
 ## v1.2.0: Teams
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,6 +92,10 @@ Closes the commit-privacy scope started in v1.1.12:
 - Dashboard POST /event rejects malformed JSON with a 400 instead of a silent 200 (#917, @harshjainnn)
 - Dashboard offline badge reacts to a dead WebSocket, not only to poll failures (#919, @harshjainnn)
 - zh-CN README rendering fixed after the closing div (#922, @Aki-new)
+- Last em dash removed from the docs per repo writing convention (#929, @aryamirani)
+- CLA workflow runs are named after the PR they check instead of the base branch (#930)
+- Italian README translation, the 10th language, wired into all language selectors (#933, @LuckysHorizon)
+- Bare `egc install` runs the shipped onboarding installers instead of erroring in a clean environment (#937, reported by @Aki-new in #935)
 
 ## v1.2.0: Teams
 


### PR DESCRIPTION
Adds the four merges missing from the Unreleased section:

- #929 last em dash removed from docs (@aryamirani)
- #930 CLA workflow runs named after the PR they check
- #933 Italian README translation, the 10th language (@LuckysHorizon)
- #937 bare `egc install` runs the shipped onboarding installers (reported by @Aki-new in #935)

Docs-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the Unreleased section of `docs/ROADMAP.md` with recent merges. Adds entries for last em dash removal, CLA run naming, Italian README translation in selectors, and `egc install` running onboarding installers in clean environments.

<sup>Written for commit c4a6a00593c9fc8d6911e52cf99a83d655c897b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

