### PR TITLE
feat(catalog): ranked keyword search for the component and skill catalog

### DIFF
--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -30,11 +30,13 @@ Usage:
   egc catalog profiles [--json]
   egc catalog components [--family <family>] [--target <target>] [--json]
   egc catalog show <component-id> [--json]
+  egc catalog search <term> [<term> ...] [--json]
 
 Examples:
   egc catalog profiles
   egc catalog components --family language
   egc catalog show framework:nextjs
+  egc catalog search memory session
 `);
 
   process.exit(exitCode);
@@ -56,6 +58,7 @@ function parseArgs(argv) {
     componentId: null,
     family: null,
     target: null,
+    terms: [],
     json: false,
     help: false,
   };
@@ -102,6 +105,10 @@ function processArg(args, index, parsed) {
   }
   if (parsed.command === 'show' && !parsed.componentId) {
     parsed.componentId = arg;
+    return index;
+  }
+  if (parsed.command === 'search' && !arg.startsWith('--')) {
+    parsed.terms.push(arg);
     return index;
   }
   throw new Error(`Unknown argument: ${arg}`);
@@ -174,6 +181,11 @@ function executeCommand(options) {
     return;
   }
 
+  if (options.command === 'search') {
+    handleSearch(options);
+    return;
+  }
+
   throw new Error(`Unknown catalog command: ${options.command}`);
 }
 
@@ -195,6 +207,46 @@ function handleComponents(options) {
     console.log(JSON.stringify({ components }, null, 2));
   } else {
     printComponents(components);
+  }
+}
+
+function handleSearch(options) {
+  if (options.terms.length === 0) {
+    throw new Error('Catalog search requires at least one term');
+  }
+
+  const { loadIndexEntries, searchEntries } = require('./lib/catalog-search');
+
+  const componentEntries = listInstallComponents({}).map(component => ({
+    kind: 'component',
+    name: component.id,
+    description: component.description,
+  }));
+  const profileEntries = listInstallProfiles().map(profile => ({
+    kind: 'profile',
+    name: profile.id,
+    description: profile.description,
+  }));
+
+  const results = searchEntries(
+    [...loadIndexEntries(), ...componentEntries, ...profileEntries],
+    options.terms
+  );
+
+  if (options.json) {
+    console.log(JSON.stringify({ results }, null, 2));
+    return;
+  }
+
+  if (results.length === 0) {
+    console.log(`No catalog entries match: ${options.terms.join(' ')}`);
+    return;
+  }
+
+  console.log(`Catalog matches for "${options.terms.join(' ')}":\n`);
+  for (const result of results) {
+    console.log(`- ${result.name} [${result.kind}]`);
+    console.log(`  ${result.description}`);
   }
 }
 

--- a/scripts/lib/catalog-search.js
+++ b/scripts/lib/catalog-search.js
@@ -42,7 +42,7 @@ function scoreEntry(entry, terms) {
 function searchEntries(entries, rawTerms, limit = 20) {
   const terms = (Array.isArray(rawTerms) ? rawTerms : [])
     .map(term => String(term).trim().toLowerCase())
-    .filter(Boolean);
+    .filter(term => term.length >= 2);
 
   if (terms.length === 0) {
     return [];

--- a/scripts/lib/catalog-search.js
+++ b/scripts/lib/catalog-search.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INDEX_PATH = path.join(__dirname, 'skill-index.json');
+
+function loadIndexEntries(indexPath = INDEX_PATH) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+    return Array.isArray(raw.entries) ? raw.entries : [];
+  } catch (_) {
+    // Missing or corrupt index degrades to manifest-only search results.
+    return [];
+  }
+}
+
+function scoreEntry(entry, terms) {
+  const name = String(entry.name || '').toLowerCase();
+  const description = String(entry.description || '').toLowerCase();
+  let total = 0;
+
+  for (const term of terms) {
+    let score = 0;
+    if (name === term) {
+      score = 5;
+    } else if (name.includes(term)) {
+      score = 3;
+    }
+    if (description.includes(term)) {
+      score += 1;
+    }
+    if (score === 0) {
+      return 0;
+    }
+    total += score;
+  }
+
+  return total;
+}
+
+function searchEntries(entries, rawTerms, limit = 20) {
+  const terms = (Array.isArray(rawTerms) ? rawTerms : [])
+    .map(term => String(term).trim().toLowerCase())
+    .filter(Boolean);
+
+  if (terms.length === 0) {
+    return [];
+  }
+
+  const scored = [];
+  for (const entry of entries) {
+    const score = scoreEntry(entry, terms);
+    if (score > 0) {
+      scored.push({ kind: entry.kind, name: entry.name, description: entry.description, score });
+    }
+  }
+
+  scored.sort(
+    (a, b) => b.score - a.score || String(a.name).localeCompare(String(b.name))
+  );
+
+  return scored.slice(0, limit);
+}
+
+module.exports = {
+  loadIndexEntries,
+  searchEntries,
+};

--- a/tests/scripts/catalog-search.test.js
+++ b/tests/scripts/catalog-search.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for scripts/lib/catalog-search.js and the `egc catalog search` command.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { searchEntries, loadIndexEntries } = require('../../scripts/lib/catalog-search');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'catalog.js');
+
+function run(args = []) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT, ...args], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (error) {
+    return {
+      code: error.status || 1,
+      stdout: error.stdout || '',
+      stderr: error.stderr || error.message || '',
+    };
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+const FIXTURE = [
+  { kind: 'skill', name: 'memory-keeper', description: 'Persists project memory across sessions' },
+  { kind: 'agent', name: 'reviewer', description: 'Reviews pull requests for quality' },
+  { kind: 'rule', name: 'memory', description: 'Session memory conventions' },
+  { kind: 'skill', name: 'dashboards', description: 'Builds dashboards from metrics' },
+];
+
+function runTests() {
+  console.log('\n=== Testing catalog search ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('exact name match outranks partial and description matches', () => {
+    const results = searchEntries(FIXTURE, ['memory']);
+    assert.strictEqual(results[0].name, 'memory');
+    assert.strictEqual(results.length, 2);
+    assert.ok(results[0].score > results[1].score);
+  })) passed++; else failed++;
+
+  if (test('multiple terms require every term to match', () => {
+    const results = searchEntries(FIXTURE, ['memory', 'sessions']);
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].name, 'memory-keeper');
+  })) passed++; else failed++;
+
+  if (test('empty or blank terms return no results', () => {
+    assert.deepStrictEqual(searchEntries(FIXTURE, []), []);
+    assert.deepStrictEqual(searchEntries(FIXTURE, ['  ']), []);
+    assert.deepStrictEqual(searchEntries(FIXTURE, null), []);
+  })) passed++; else failed++;
+
+  if (test('limit caps the result list', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({
+      kind: 'skill',
+      name: `tool-${i}`,
+      description: 'common description',
+    }));
+    assert.strictEqual(searchEntries(many, ['common'], 5).length, 5);
+  })) passed++; else failed++;
+
+  if (test('missing index file degrades to an empty list', () => {
+    assert.deepStrictEqual(loadIndexEntries('/nonexistent/skill-index.json'), []);
+  })) passed++; else failed++;
+
+  if (test('shipped index loads with entries', () => {
+    const entries = loadIndexEntries();
+    assert.ok(entries.length > 0, 'expected the committed skill-index.json to have entries');
+    assert.ok(entries[0].name && entries[0].description && entries[0].kind);
+  })) passed++; else failed++;
+
+  if (test('CLI search returns ranked JSON results', () => {
+    const result = run(['search', 'memory', '--json']);
+    assert.strictEqual(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.ok(Array.isArray(payload.results));
+    assert.ok(payload.results.length > 0);
+    assert.ok(payload.results[0].score >= payload.results[payload.results.length - 1].score);
+  })) passed++; else failed++;
+
+  if (test('CLI search without terms fails with guidance', () => {
+    const result = run(['search']);
+    assert.strictEqual(result.code, 1);
+    assert.ok(result.stderr.includes('requires at least one term'));
+  })) passed++; else failed++;
+
+  if (test('CLI search reports when nothing matches', () => {
+    const result = run(['search', 'zzzznomatchzzz']);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(result.stdout.includes('No catalog entries match'));
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/catalog-search.test.js
+++ b/tests/scripts/catalog-search.test.js
@@ -70,6 +70,35 @@ function runTests() {
     assert.deepStrictEqual(searchEntries(FIXTURE, null), []);
   })) passed++; else failed++;
 
+  if (test('single-character terms are ignored as noise', () => {
+    assert.deepStrictEqual(searchEntries(FIXTURE, ['e']), []);
+    const results = searchEntries(FIXTURE, ['e', 'memory']);
+    assert.ok(results.length > 0, 'longer term should still match after noise is dropped');
+  })) passed++; else failed++;
+
+  if (test('matching is case-insensitive', () => {
+    const results = searchEntries(FIXTURE, ['MeMoRy']);
+    assert.strictEqual(results.length, 2);
+    assert.strictEqual(results[0].name, 'memory');
+  })) passed++; else failed++;
+
+  if (test('description-only matches score and rank below name matches', () => {
+    const results = searchEntries(FIXTURE, ['metrics']);
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].name, 'dashboards');
+    assert.strictEqual(results[0].score, 1);
+  })) passed++; else failed++;
+
+  if (test('equal scores tie-break alphabetically', () => {
+    const tied = [
+      { kind: 'skill', name: 'zeta-tool', description: 'shared keyword here' },
+      { kind: 'skill', name: 'alpha-tool', description: 'shared keyword here' },
+    ];
+    const results = searchEntries(tied, ['keyword']);
+    assert.strictEqual(results[0].name, 'alpha-tool');
+    assert.strictEqual(results[1].name, 'zeta-tool');
+  })) passed++; else failed++;
+
   if (test('limit caps the result list', () => {
     const many = Array.from({ length: 30 }, (_, i) => ({
       kind: 'skill',


### PR DESCRIPTION
First approved adaptation from the harness/harness study (tracked internally as EGC-385).

## What

`egc catalog search <term> [<term> ...] [--json]` searches the whole catalog surface with one command:

- the shipped skill index (skills, agents, rules: 435 entries) via a new `scripts/lib/catalog-search.js`
- install components and profiles from the manifests

Ranking: exact name match > partial name match > description match; multiple terms are ANDed; ties break alphabetically; top 20 returned. `--json` emits machine-readable results. A missing or corrupt index degrades gracefully to manifest-only results.

## Why

The catalog has grown past browsing size (228 skills, 62 agents, 74 commands). Discovery today is listing plus eyeballing; this makes `egc catalog` answer "what do we have for X" directly, reusing the index that `build-skill-index.js` already ships for in-session routing.

## Tests

New suite `tests/scripts/catalog-search.test.js`: 9 cases covering ranking, AND semantics, blank input, result limit, index fallback, the committed index, and the CLI paths (JSON, no-terms error, no-match message). All green locally; existing catalog commands untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ranked keyword search to the catalog via `egc catalog search`, covering shipped skills/agents/rules plus install components and profiles. Improves discovery and aligns with Linear EGC-385.

- New Features
  - New CLI: `egc catalog search <term> [<term> ...] [--json]`.
  - Ranking: exact name > partial name > description; terms are ANDed; single-character terms are ignored; ties break alphabetically; top 20.
  - Sources: shipped skill index + install components and profiles; graceful fallback to manifest-only if the index is missing or corrupt.
  - Output: human-readable list or `--json` payload.
  - Tests: cover ranking, AND semantics, case-insensitive matching, single-char drop, limits, index fallback, and CLI paths.

<sup>Written for commit ef1600ce40f58e6199d23f658c2e7845e6583097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

