### PR TITLE
docs(roadmap): sync unreleased with the late-night merges

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,6 +96,9 @@ Closes the commit-privacy scope started in v1.1.12:
 - CLA workflow runs are named after the PR they check instead of the base branch (#930)
 - Italian README translation, the 10th language, wired into all language selectors (#933, @LuckysHorizon)
 - Bare `egc install` runs the shipped onboarding installers instead of erroring in a clean environment (#937, @Aki-new via #935)
+- `egc catalog search <terms>`: ranked keyword search across skills, agents, rules, components and profiles (#939)
+- Lean root phase 3: the VERSION file dropped, package.json is the single version source (#940)
+- Official Hugging Face Space launched: https://huggingface.co/spaces/fmarzochi/EGC
 
 ## v1.2.0: Teams
 


### PR DESCRIPTION
Adds the merges and launches missing from the Unreleased section:

- #939 `egc catalog search` with ranked results
- #940 lean root phase 3, VERSION file dropped
- The official Hugging Face Space launch

Docs-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates docs/ROADMAP.md to sync the Unreleased section with recent merges: adds `egc catalog search <terms>` (ranked results, #939), lean root phase 3 (VERSION file removed, #940), and the official Hugging Face Space link.

<sup>Written for commit f6e6940f2d532afd3b5d022faf4b3373dcb6f91a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

