### PR TITLE
fix(dashboard): keep ping polling alive while WebSocket is down

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -661,6 +661,7 @@ const S={
   isOffline:false,
   telemetryReqId:0,
   pingReqId:0,
+  pingTimerId:null,
 };
 
 /* ── GREETING ───────────────────────────────────────────── */
@@ -1166,7 +1167,8 @@ function setWs(on){
   document.getElementById('activeBadge').style.display=on?'':'none';
 }
 function pingLatency(){
-  if(!S.ws||S.ws.readyState!==1)return;
+  clearTimeout(S.pingTimerId);
+  S.pingTimerId=setTimeout(pingLatency,5000);
   S.pingReqId++;
   const reqId = S.pingReqId;
   fetch('/ping').then(r=>{
@@ -1185,7 +1187,7 @@ function pingLatency(){
       reportPollResult('ping', false);
     }
   });
-  setTimeout(pingLatency,5000);
+
 }
 
 /* ── EVENT HANDLER ──────────────────────────────────────── */

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1148,7 +1148,7 @@ pollTelemetry();
 function connect(){
   try{
     S.ws=new WebSocket('ws://localhost:7890');
-    S.ws.onopen=()=>{setWs(true);S.rc=1000;S.wsFailStreak=0;updateOfflineState();pingLatency();};
+    S.ws.onopen=()=>{setWs(true);S.rc=1000;S.wsFailStreak=0;updateOfflineState();};
     S.ws.onclose=()=>{setWs(false);S.wsFailStreak++;updateOfflineState();setTimeout(connect,S.rc);S.rc=Math.min(S.rc*2,10000);};
     S.ws.onmessage=m=>{
       try{
@@ -1443,6 +1443,7 @@ setInterval(loadCostSummary, 10000);
 
 
 connect();
+pingLatency();
 
 loadSessionHistory();
 

--- a/tests/dashboard-ping-polling.test.js
+++ b/tests/dashboard-ping-polling.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const dashboardPath = path.join(
+  __dirname,
+  '..',
+  'dashboard',
+  'public',
+  'index.html'
+);
+
+const dashboardSource = fs.readFileSync(dashboardPath, 'utf8');
+
+function extractFunctionBody(source, functionName) {
+  const marker = `function ${functionName}(`;
+  const functionStart = source.indexOf(marker);
+
+  assert.notEqual(
+    functionStart,
+    -1,
+    `${functionName} should exist in dashboard/public/index.html`
+  );
+
+  const bodyStart = source.indexOf('{', functionStart);
+  let depth = 0;
+
+  for (let index = bodyStart; index < source.length; index++) {
+    if (source[index] === '{') {
+      depth++;
+    } else if (source[index] === '}') {
+      depth--;
+
+      if (depth === 0) {
+        return source.slice(bodyStart + 1, index);
+      }
+    }
+  }
+
+  throw new Error(`Could not extract ${functionName} body`);
+}
+
+test('ping polling continues with one timer while WebSocket is down', async () => {
+  const functionBody = extractFunctionBody(
+    dashboardSource,
+    'pingLatency'
+  );
+
+  const S = {
+    ws: null,
+    pingReqId: 0,
+    pingTimerId: 41
+  };
+
+  const activeTimers = new Set([41]);
+  const clearedTimers = [];
+  const scheduledDelays = [];
+  const requestedUrls = [];
+  const pollResults = [];
+
+  let nextTimerId = 100;
+
+  function clearTimeoutStub(timerId) {
+    clearedTimers.push(timerId);
+    activeTimers.delete(timerId);
+  }
+
+  function setTimeoutStub(_callback, delay) {
+    const timerId = nextTimerId++;
+    scheduledDelays.push(delay);
+    activeTimers.add(timerId);
+    return timerId;
+  }
+
+  async function fetchStub(url) {
+    requestedUrls.push(url);
+    throw new Error('server unavailable');
+  }
+
+  function reportPollResultStub(name, result) {
+    pollResults.push([name, result]);
+  }
+
+  const documentStub = {
+    getElementById() {
+      return { textContent: '' };
+    }
+  };
+
+  const createPingLatency = new Function(
+    'S',
+    'fetch',
+    'clearTimeout',
+    'setTimeout',
+    'reportPollResult',
+    'document',
+    `return function pingLatency() {
+      ${functionBody}
+    };`
+  );
+
+  const pingLatency = createPingLatency(
+    S,
+    fetchStub,
+    clearTimeoutStub,
+    setTimeoutStub,
+    reportPollResultStub,
+    documentStub
+  );
+
+  pingLatency();
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.deepEqual(requestedUrls, ['/ping']);
+  assert.deepEqual(pollResults, [['ping', false]]);
+  assert.deepEqual(clearedTimers, [41]);
+  assert.deepEqual(scheduledDelays, [5000]);
+  assert.equal(activeTimers.size, 1);
+  assert.ok(activeTimers.has(100));
+  assert.equal(S.pingTimerId, 100);
+
+  pingLatency();
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.deepEqual(requestedUrls, ['/ping', '/ping']);
+  assert.deepEqual(pollResults, [
+    ['ping', false],
+    ['ping', false]
+  ]);
+  assert.deepEqual(clearedTimers, [41, 100]);
+  assert.deepEqual(scheduledDelays, [5000, 5000]);
+  assert.equal(activeTimers.size, 1);
+  assert.ok(activeTimers.has(101));
+  assert.equal(S.pingTimerId, 101);
+});

--- a/tests/dashboard-ping-polling.test.js
+++ b/tests/dashboard-ping-polling.test.js
@@ -136,3 +136,19 @@ test('ping polling continues with one timer while WebSocket is down', async () =
   assert.ok(activeTimers.has(101));
   assert.equal(S.pingTimerId, 101);
 });
+
+test('ping polling starts independently during dashboard initialization', () => {
+  const connectBody = extractFunctionBody(dashboardSource, 'connect');
+
+  assert.doesNotMatch(
+    connectBody,
+    /\bpingLatency\(\)/,
+    'WebSocket onopen should not be responsible for starting ping polling'
+  );
+
+  assert.match(
+    dashboardSource,
+    /\nconnect\(\);\s*\npingLatency\(\);/,
+    'dashboard initialization should start ping polling independently'
+  );
+});


### PR DESCRIPTION
## What Changed

- Keep `/ping` polling active even when the WebSocket is disconnected.
- Store the ping timer ID and clear the previous timer before scheduling the next poll.
- Add a regression test that verifies polling continues and duplicate timer chains are not created.

## Why This Change

`pingLatency()` previously returned immediately when the WebSocket was not open. Because the next `setTimeout()` was placed after that return, the polling chain stopped permanently while the WebSocket was down.

The HTTP `/ping` poll should continue independently so failure streaks remain updated and the dashboard can detect offline conditions correctly.

Fixes #920

## Testing Done

- [ ] Manual testing completed
- [x] Automated tests pass locally (`npm test`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes, a concurrent-access test was added or updated

Additional verification:

- `node tests/dashboard-ping-polling.test.js` — 1 passed, 0 failed
- `npm test` — completed successfully, 2643 passed, 0 failed
- `npm run lint` — 0 errors
- `npx eslint tests/dashboard-ping-polling.test.js` — passed

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] No new dependencies introduced
- [x] The change is limited to the dashboard polling logic and its regression test
- [x] Commit includes the required `Signed-off-by`

## Documentation

No documentation update is required because this change does not modify the public API or configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `/ping` polling alive when the WebSocket is down and start it independently at dashboard init, so polling never stalls. Fixes #920.

- **Bug Fixes**
  - Start ping polling during initialization; remove `pingLatency()` from WebSocket `onopen` so polling runs regardless of socket state.
  - Schedule the next poll before the request and track it via `S.pingTimerId`; clear the previous timer to keep a single active chain. Added regression test `tests/dashboard-ping-polling.test.js`.

<sup>Written for commit 754099d285a66bb8ce72472c5ceafa4e16bafcce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

