### PR TITLE
refactor(providers): share the generate() error wrapper across OpenAI…

### DIFF
--- a/src/llm/providers/deepseek.py
+++ b/src/llm/providers/deepseek.py
@@ -17,9 +17,8 @@ try:
 except ImportError:  # pragma: no cover - SDK optional
     OpenAI = None  # type: ignore[assignment]
 
-from llm.core.interface import AuthenticationError, LLMError, LLMProvider
+from llm.core.interface import AuthenticationError, LLMProvider
 from llm.core.model_resolver import ModelResolver
-from llm.core.redact import redact_secrets
 from llm.core.types import ModelInfo, ProviderType
 from llm.providers.openai import OpenAIProvider
 
@@ -80,30 +79,11 @@ class DeepSeekProvider(OpenAIProvider):
                     stream=llm_input.stream,
                     metadata=llm_input.metadata,
                 )
-        try:
-            return super().generate(llm_input)
-        except LLMError as exc:
-            # Re-tag in place so telemetry attributes to DEEPSEEK, while
-            # preserving the original exception subclass (AuthenticationError,
-            # RateLimitError, ContextLengthError, ...) — constructing a new
-            # plain LLMError here would discard that subclass information.
-            exc.provider = ProviderType.DEEPSEEK
-            raise
-        except NotImplementedError:
-            # Contract-level errors (e.g. streaming not supported) are not
-            # provider-attributable wire failures - let them surface as-is.
-            raise
-        except Exception as exc:
-            # fix #2: native OpenAI SDK exceptions (RateLimitError,
-            # APIConnectionError, AuthenticationError, etc.) propagate here
-            # unwrapped when OpenAIProvider.generate() hits the bare `raise`.
-            # Wrap them so telemetry always attributes to DEEPSEEK, never OPENAI.
-            # Redacted: a raw SDK exception message can embed the HTTP
-            # response body, which may echo request headers/payloads back.
-            raise LLMError(
-                redact_secrets(str(exc)),
-                provider=ProviderType.DEEPSEEK,
-            ) from exc
+        # The try/except that maps LLMError/NotImplementedError/raw SDK
+        # exceptions to this provider lives once, on OpenAIProvider - see
+        # OpenAIProvider._wrap_generate_errors for the shared behavior.
+        base_generate = super().generate
+        return self._wrap_generate_errors(lambda: base_generate(llm_input))
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()

--- a/src/llm/providers/groq.py
+++ b/src/llm/providers/groq.py
@@ -17,9 +17,8 @@ try:
 except ImportError:  # pragma: no cover - SDK optional
     OpenAI = None  # type: ignore[assignment]
 
-from llm.core.interface import AuthenticationError, LLMError, LLMProvider
+from llm.core.interface import AuthenticationError, LLMProvider
 from llm.core.model_resolver import ModelResolver
-from llm.core.redact import redact_secrets
 from llm.core.types import ModelInfo, ProviderType
 from llm.providers.openai import OpenAIProvider
 
@@ -52,29 +51,11 @@ class GroqProvider(OpenAIProvider):
         ]
 
     def generate(self, llm_input: "LLMInput") -> "LLMOutput":  # type: ignore[override]
-        try:
-            return super().generate(llm_input)
-        except LLMError as exc:
-            # Re-tag in place so telemetry attributes to GROQ, while
-            # preserving the original exception subclass (AuthenticationError,
-            # RateLimitError, ContextLengthError, ...) — constructing a new
-            # plain LLMError here would discard that subclass information.
-            exc.provider = ProviderType.GROQ
-            raise
-        except NotImplementedError:
-            # Contract-level errors (e.g. streaming not supported) are not
-            # provider-attributable wire failures - let them surface as-is.
-            raise
-        except Exception as exc:
-            # Native OpenAI SDK exceptions (RateLimitError, APIConnectionError,
-            # AuthenticationError, etc.) propagate here unwrapped when
-            # OpenAIProvider.generate() hits the bare `raise`. Wrap them so
-            # telemetry always attributes to GROQ, never OPENAI. Redacted:
-            # a raw SDK exception message can embed the HTTP response body.
-            raise LLMError(
-                redact_secrets(str(exc)),
-                provider=ProviderType.GROQ,
-            ) from exc
+        # The try/except that maps LLMError/NotImplementedError/raw SDK
+        # exceptions to this provider lives once, on OpenAIProvider - see
+        # OpenAIProvider._wrap_generate_errors for the shared behavior.
+        base_generate = super().generate
+        return self._wrap_generate_errors(lambda: base_generate(llm_input))
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()

--- a/src/llm/providers/mistral.py
+++ b/src/llm/providers/mistral.py
@@ -10,9 +10,8 @@ try:
 except ImportError: 
     OpenAI = None 
 
-from llm.core.interface import AuthenticationError, LLMError
+from llm.core.interface import AuthenticationError
 from llm.core.model_resolver import ModelResolver
-from llm.core.redact import redact_secrets
 from llm.core.types import ModelInfo, ProviderType
 from llm.providers.openai import OpenAIProvider
 
@@ -49,29 +48,11 @@ class MistralProvider(OpenAIProvider):
         ]
 
     def generate(self, llm_input: "LLMInput") -> "LLMOutput":  # type: ignore[override]
-        try:
-            return super().generate(llm_input)
-        except LLMError as exc:
-            # Re-tag in place so telemetry attributes to MISTRAL, while
-            # preserving the original exception subclass (AuthenticationError,
-            # RateLimitError, ContextLengthError, ...) — constructing a new
-            # plain LLMError here would discard that subclass information.
-            exc.provider = ProviderType.MISTRAL
-            raise
-        except NotImplementedError:
-            # Contract-level errors (e.g. streaming not supported) are not
-            # provider-attributable wire failures - let them surface as-is.
-            raise
-        except Exception as exc:
-            # Native OpenAI SDK exceptions (RateLimitError, APIConnectionError,
-            # AuthenticationError, etc.) propagate here unwrapped when
-            # OpenAIProvider.generate() hits the bare `raise`. Wrap them so
-            # telemetry always attributes to MISTRAL, never OPENAI. Redacted:
-            # a raw SDK exception message can embed the HTTP response body.
-            raise LLMError(
-                redact_secrets(str(exc)),
-                provider=ProviderType.MISTRAL,
-            ) from exc
+        # The try/except that maps LLMError/NotImplementedError/raw SDK
+        # exceptions to this provider lives once, on OpenAIProvider - see
+        # OpenAIProvider._wrap_generate_errors for the shared behavior.
+        base_generate = super().generate
+        return self._wrap_generate_errors(lambda: base_generate(llm_input))
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -94,6 +94,31 @@ class OpenAIProvider(LLMProvider):
             raise ContextLengthError(safe_msg, provider=self.provider_type) from e
         raise e
 
+    def _wrap_generate_errors(self, fn):
+        """Shared error-mapping wrapper for ``generate()``.
+
+        Every OpenAI-compatible subclass (Groq, Mistral, DeepSeek, ...) needs
+        the exact same try/except around its call into the OpenAI transport:
+        re-raise ``LLMError`` with the provider re-tagged, let contract-level
+        ``NotImplementedError`` (e.g. unsupported streaming) pass through
+        untouched, and wrap any other raw SDK exception in a redacted
+        ``LLMError`` attributed to the subclass's provider. Centralizing it
+        here means that logic exists in exactly one place instead of being
+        copied into every subclass's ``generate()`` override.
+        """
+        try:
+            return fn()
+        except LLMError as exc:
+            exc.provider = self.provider_type
+            raise
+        except NotImplementedError:
+            raise
+        except Exception as exc:
+            raise LLMError(
+                redact_secrets(str(exc)),
+                provider=self.provider_type,
+            ) from exc
+
     def generate(self, input: LLMInput) -> LLMOutput:
         if input.stream:
             # Streaming is not implemented in this adapter. Fail loudly instead


### PR DESCRIPTION
refactor(providers): share the generate() error wrapper across OpenAI-compatible subclasses

Extract the try/except that maps LLMError/NotImplementedError/raw SDK exceptions into a single _wrap_generate_errors() hook on OpenAIProvider. Groq, Mistral, and DeepSeek providers now call this shared hook instead of each carrying an identical copy of the wrapper.
- The try/except wrapper now exists in exactly one place (OpenAIProvider).
- Error behavior is unchanged (same exception types, same provider re-tagging, same redaction) - full provider test suite passes unmodified.

Fixes #915

## What Changed
- Added `OpenAIProvider._wrap_generate_errors(fn)` in `src/llm/providers/openai.py`: a shared hook that re-tags `LLMError.provider`, lets `NotImplementedError` pass through untouched, and wraps any other exception in a redacted `LLMError`.
- `GroqProvider.generate()`, `MistralProvider.generate()`, and `DeepSeekProvider.generate()` (in `groq.py`, `mistral.py`, `deepseek.py`) now call `self._wrap_generate_errors(...)` instead of each repeating the same try/except block.
- Removed the now-unused `LLMError` / `redact_secrets` imports from those three files.
- `DeepSeekProvider`'s reasoner-specific input normalization (forcing `temperature=1.0`, dropping `tools` for `deepseek-reasoner`) is untouched — it still runs before the shared wrapper is invoked.
- `OpenRouterProvider` was left as-is; it already inherits `generate()` directly with no wrapper, so it doesn't duplicate any logic.

## Why This Change
Groq, Mistral, and DeepSeek each carried a byte-for-byte identical try/except in `generate()`. That's three copies of the same error-mapping logic to keep in sync — the exact drift the issue calls out (e.g. PR #912 having to patch each one separately for the `NotImplementedError` bypass). Centralizing it on `OpenAIProvider` means future error-handling changes are made once.

## Testing Done
- [x] Automated tests pass locally: `PYTHONPATH=src python3 -m pytest tests/ -q` → **120 passed**
- [x] Focused run on touched providers: `pytest tests/test_groq_provider.py tests/test_mistral_provider.py tests/test_deepseek_provider.py tests/test_openai_provider.py -q` → **62 passed**
- [x] Edge cases considered and tested: `NotImplementedError` (streaming) passthrough, `LLMError` re-tagging preserves subclass (`AuthenticationError`, `RateLimitError`, `ContextLengthError`), raw SDK exception redaction, DeepSeek reasoner temperature/tools normalization still applied before wrapping
- [ ] `node tests/run-all.js` — not applicable; this repo's Python provider tests run under pytest, `run-all.js` only discovers `tests/**/*.test.js`
- [ ] This PR does not touch any file shared across concurrent EGC processes (no encryption key, state file, install-state, or lockfile under `~/.egc/` involved)

## Type of Change
- [ ] `fix:` Bug fix
- [x] `feat:` New feature
- [x] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly (no JSON files touched)
- [ ] Shell scripts pass shellcheck (not applicable — no shell scripts touched)
- [ ] Pre-commit hooks pass locally (if configured — not run in this environment; please verify locally)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation (no user-facing behavior change; docstring added on `_wrap_generate_errors` explaining its purpose)
- [x] Added comments for complex logic
- [ ] README updated (if needed — not needed, internal refactor only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes generate() error handling for all OpenAI‑compatible providers by moving the try/except into `OpenAIProvider._wrap_generate_errors` and updating Groq, Mistral, and DeepSeek to use it (fixes #915). Behavior is unchanged; telemetry attribution and redaction remain consistent.

- **Refactors**
  - Added `OpenAIProvider._wrap_generate_errors(fn)` to retag `LLMError.provider`, pass through `NotImplementedError`, and wrap other exceptions with redacted messages.
  - Updated `GroqProvider.generate()`, `MistralProvider.generate()`, and `DeepSeekProvider.generate()` to call the shared wrapper; removed redundant imports.
  - Preserved DeepSeek reasoner input normalization; `OpenRouterProvider` unchanged.

<sup>Written for commit 4e97fb8255fd6383921dd7411e682fecd5085467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

