### PR TITLE
docs(roadmap): sync unreleased with the morning merges

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -99,6 +99,8 @@ Closes the commit-privacy scope started in v1.1.12:
 - `egc catalog search <terms>`: ranked keyword search across skills, agents, rules, components and profiles (#939)
 - Lean root phase 3: the VERSION file dropped, package.json is the single version source (#940)
 - Official Hugging Face Space launched: https://huggingface.co/spaces/fmarzochi/EGC
+- Dashboard /ping polling survives WebSocket outages on a single self-healing timer chain (#943, @Tyr1onX)
+- The generate() error wrapper deduplicated into one shared hook across the OpenAI-compatible providers (#944, @harshjainnn)
 
 ## v1.2.0: Teams
 


### PR DESCRIPTION
Add the two merges of the morning to the Unreleased section:

- #943 (@Tyr1onX): dashboard /ping polling survives WebSocket outages
- #944 (@harshjainnn): generate() error wrapper deduplicated into one shared hook

Follows the same convention as #938 and #942.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Unreleased section in the roadmap to include two recently merged changes. Adds entries for dashboard /ping polling resilience during WebSocket outages (#943) and a shared generate() error wrapper across OpenAI-compatible providers (#944).

<sup>Written for commit 3a3b472af9f29b34a757bcb628497eb03e60a448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

