### PR TITLE
added French README translation 

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -11,3 +11,5 @@ By contributing to EGC (Extended Global Context), you agree to the following ter
 4. **Patent Grant** - You grant a license under any patents you hold that are necessarily infringed by your contribution.
 
 This agreement covers all past and future contributions to the Fmarzochi/EGC repository.
+
+I have read the CLA Document and I hereby sign the CLA.

--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -11,5 +11,3 @@ By contributing to EGC (Extended Global Context), you agree to the following ter
 4. **Patent Grant** - You grant a license under any patents you hold that are necessarily infringed by your contribution.
 
 This agreement covers all past and future contributions to the Fmarzochi/EGC repository.
-
-I have read the CLA Document and I hereby sign the CLA.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 **English** · [العربية](translations/ar/README.md) · [Español](translations/es/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
+🌐 **English** · [العربية](translations/ar/README.md) · [Español](translations/es/README.md) · [Français](translations/fr/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -79,7 +79,7 @@ There is no step two. Open any of your AI tools and just talk: "hi", "let's cont
 A live dashboard displaying agent activity, tokens, and costs spins up automatically right after installation. Prefer manual control? Every command is documented in the [installation guide](docs/installation.md): you will probably never need to type one.
 
 ---
-🌐 **English** · [العربية](translations/ar/README.md) · [Español](translations/es/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
+🌐 **English** · [العربية](translations/ar/README.md) · [Español](translations/es/README.md) · [Français](translations/fr/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
 
 ---
 

--- a/translations/ar/README.md
+++ b/translations/ar/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · **العربية** · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · **العربية** · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC ليس قائمة أدوات؛ إنه دماغ واحد بعدة ملكات.
 
 ---
 
-🌐 [English](../../README.md) · **العربية** · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · **العربية** · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ Un panel en vivo con la actividad, los tokens y los costos de tus agentes arranc
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/fr/README.md
+++ b/translations/fr/README.md
@@ -1,0 +1,131 @@
+<!-- LANGUAGE-SELECTOR-START -->
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · **Français** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+<!-- LANGUAGE-SELECTOR-END -->
+
+<div align="center">
+<img src="../../assets/images/hero.png" alt="EGC - Extended Global Context" width="100%" />
+</div>
+
+<div align="center">
+
+# EGC - Donnez le même cerveau à tous vos agents IA
+
+**Une mémoire persistante partagée automatiquement par chaque agent IA, IDE, terminal et session. Aucun prompt à mémoriser. Aucun contexte à reconstruire. Parlez, tout simplement.**
+
+</div>
+
+---
+
+EGC n'est pas un outil de mémoire de plus. C'est la couche d'intelligence qui permet à chaque IA de travailler comme si elle était sur votre projet depuis le premier jour, dans Cursor, Copilot, Claude Code, Codex, Aider et n'importe quel agent de terminal (20 outils de codage IA au total). Fonctionne nativement avec Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere et Vertex AI, ainsi qu'avec OpenRouter pour Qwen3, Llama 4 et plus encore.
+
+Chaque conversation renforce l'intelligence collective de votre projet. Chaque agent en hérite. Chaque session devient plus intelligente.
+
+---
+
+## Installation
+
+```bash
+npm install -g @egchq/egc && egc install
+```
+
+- **Réduisez le gaspillage de contexte jusqu'à 90 %, réduisez le coût des tokens et gardez chaque IA parfaitement alignée d'une session à l'autre.**
+- **Guardian : validez chaque commande avant exécution, bloquez les écritures dangereuses et détectez les injections de prompts. Chaque cerveau partagé intègre une couche de sécurité native.**
+- **Une seule commande, zéro configuration : la mémoire reste locale et chiffrée sur votre machine, et n'est jamais commitée sur git.**
+
+<div align="center">
+  <img src="../../assets/gifs/install.gif" alt="Une seule commande installe EGC sur 20 outils de codage IA" width="800" />
+</div>
+
+[Guide d'installation complet](../../docs/installation.md)
+
+---
+
+## Au cœur du cerveau : comment fonctionne EGC
+
+EGC n'est pas une simple liste d'outils ; c'est un cerveau unique doté de plusieurs facultés. Il mémorise, comprend, protège, filtre et coordonne les actions de tous les agents IA de votre machine.
+
+<div align="center">
+  <img src="../../assets/gifs/sharedbrain.gif" alt="Une décision prise dans Cursor est déjà connue de Claude Code" width="900" />
+</div>
+
+### Ne mémorisez plus de commandes, parlez naturellement
+
+Adressez-vous au cerveau dans la langue de votre choix : "sauvegarde cette session", "qu'avons-nous décidé pour l'authentification ?", "mémorise cette décision". EGC comprend l'intention, stocke le contexte et le restitue instantanément dans n'importe quel autre onglet, terminal ou outil de votre machine. Un seul cerveau. Tous les agents. Zéro commande à retenir.
+
+### Mémoire de projet persistante
+
+EGC dote chaque agent IA d'un cerveau partagé et persistant. Il capture les décisions, le contexte de session, la mémoire de travail et les schémas appris, puis les rend instantanément disponibles dans tout autre terminal, IDE ou agent que vous ouvrez. L'état de la session, l'historique du projet et les leçons accumulées circulent de manière fluide entre les onglets, les outils et les membres de l'équipe : pas de synchronisation manuelle, pas de perte de contexte. Toute la mémoire réside dans `~/.egc` sur votre machine, chiffrée en AES-256-GCM, conservée par branche de projet, et n'est jamais commitée sur votre dépôt.
+
+### Guardian : garde-fous de sécurité intégrés
+
+L'autre moitié du cerveau exécute des garde-fous en arrière-plan. Elle valide les commandes avant leur exécution, contrôle les écritures risquées, compresse le contexte avant qu'il ne déborde, orchestre des tâches multi-étapes entre les agents et apprend de chaque correction, le tout sans que vous n'ayez à invoquer le moindre outil. Un filet de sécurité invisible qui maintient le contexte léger, les actions sûres et les flux de travail autonomes.
+
+### Token Crusher : le cerveau filtre le bruit avant de mémoriser
+
+Le cerveau ne fait pas que mémoriser : il filtre. Avant que la sortie d'un terminal n'atteigne le modèle, le Token Crusher d'EGC compresse les logs git, les rapports de tests verbeux, les messages d'installation et les fichiers JSON géants jusqu'à 90 %, tout en préservant chaque erreur et avertissement. Demandez simplement "combien ai-je économisé ?" dans n'importe quelle langue, et la réponse proviendra directement de votre registre local, sans aucun coût : des sessions plus économiques et un contexte qui dure.
+
+---
+
+## Bibliothèque de prompts
+
+En bonus, EGC vous donne accès à 63 agents, 230 skills et 77 commandes, ainsi que 111 règles : des spécialistes qui révisent votre code de manière autonome, des guides de bonnes pratiques pour chaque langage et situation, des raccourcis qui exécutent des séquences entières de tâches pour vous, et des règles de style qui maintiennent la cohérence de votre code. Tout a été rédigé à partir de véritables sessions d'ingénierie, et non de la théorie. Vous ne souhaitez rien utiliser de tout cela ? Aucun problème : la mémoire persistante d'EGC fonctionne exactement de la même manière.
+
+---
+
+## Démarrage rapide
+
+Il n'y a pas d'étape suivante. Ouvrez l'un de vos outils d'IA et parlez, tout simplement : "salut", "continuons", "mémorise cette décision", dans la langue de votre choix. Les sessions se connectent instantanément, la mémoire se charge automatiquement, et chaque onglet ouvert sait déjà ce que font les autres : deux onglets Cursor, un terminal Claude Code et une session Antigravity partagent tous simultanément le même contexte dynamique.
+
+Un tableau de bord en direct affichant l'activité des agents, les tokens et les coûts se lance automatiquement juste après l'installation. Vous préférez un contrôle manuel ? Chaque commande est documentée dans le [guide d'installation](../../docs/installation.md) : vous n'aurez probablement jamais besoin d'en saisir une.
+
+---
+
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · **Français** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+
+---
+
+## Soutenir EGC
+
+EGC est développé par une seule personne, maintenu de manière ouverte et gratuit.
+
+- **[Site web](https://fmarzochi.github.io/EGCSite)** : documentation complète, présentation des fonctionnalités et démo en direct
+- **[Rejoindre le Discord](https://discord.gg/TxppsGb52)** : posez des questions, partagez vos retours
+- **[Sponsoriser sur GitHub](https://github.com/sponsors/Fmarzochi)** : n'importe quel montant
+- **[Faire un don via PayPal](https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD)** : aucun compte GitHub n'est requis
+- **Ajouter une étoile au dépôt** : aide d'autres développeurs à le découvrir
+- **[Contribuer](../../.github/CONTRIBUTING.md)** : agents, skills, commandes, corrections de bugs et documentation
+- **Partager** : si EGC a changé votre façon de travailler, parlez-en autour de vous
+
+### Sponsors
+
+Le soutien de la communauté maintient ce projet vivant et indépendant.
+
+#### Outils partenaires
+
+Outils de codage IA qui s'intègrent nativement avec EGC. Les partenaires bénéficient d'un placement de logo sur tous les README et sur EGCSite.
+
+<a href="https://www.pincushion.io/"><img src="https://www.pincushion.io/logo-icon.png" width="52" height="52" alt="Pincushion" title="Pincushion" /></a>
+
+#### Sponsors annuels · _Soyez le premier sponsor annuel._
+
+---
+
+#### Contributeurs
+
+<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="52" height="52" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
+
+#### Sponsors mensuels · _soyez le premier_
+
+---
+
+<div align="center">
+
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3)
+
+<br>
+
+<a href="https://bestpractices.dev/projects/13099"><img src="../../assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices" width="110" /></a>
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
+<a href="https://www.linkedin.com/in/felipemarzochi"><img src="../../assets/images/egc-logo.png" alt="EGC" width="110" /></a>
+
+</div>

--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC हर AI एजेंट को एक स्थायी, साझा द
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/it/README.md
+++ b/translations/it/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ Una dashboard live che mostra attività degli agenti, token e costi si avvia aut
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/ja/README.md
+++ b/translations/ja/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGCはすべてのAIエージェントに永続的な共有脳を与えます。
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC는 모든 AI 에이전트에게 영속적인 공유 뇌를 줍니다. 결정
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ Um painel ao vivo com a atividade, os tokens e os custos dos seus agentes inicia
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/ru/README.md
+++ b/translations/ru/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC даёт каждому ИИ-агенту постоянный общий м
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/zh-CN/README.md
+++ b/translations/zh-CN/README.md
@@ -1,6 +1,6 @@
 <!-- LANGUAGE-SELECTOR-START -->
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
 
 <!-- LANGUAGE-SELECTOR-END -->
 
@@ -91,7 +91,7 @@ egc dashboard
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
 
 ---
 


### PR DESCRIPTION
## What Changed
 added French translation of README.md


## Type of Change
- [ ] `docs:` Documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full French README at translations/fr/README.md and updates language selectors across all READMEs to include “Français”, improving navigation for French-speaking users.

<sup>Written for commit 37d384f3443cddf0af12f520c3f902f686c1e79a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

