### PR TITLE
fix(dashboard): preserve replay file paths from detail

### DIFF
--- a/dashboard/accumulator.js
+++ b/dashboard/accumulator.js
@@ -115,7 +115,7 @@ function createAccumulator(externalPrices) {
         t:     Date.now(),
         event: ev.event || 'unknown',
         tool:  ev.tool_name || ev.tool || null,
-        file:  ev.file_path || ev.file || null,
+        file:  ev.file_path || ev.file || ev.detail || null,
         cmd:   ev.command   || null,
         mem:   ev.memory_key || null,
         model: ev.model || null,

--- a/tests/dashboard-server.test.js
+++ b/tests/dashboard-server.test.js
@@ -90,6 +90,24 @@ test('invalid event returns false (broadcast guard)', () => {
   assert.equal(accumulateEvent({ ide: 42 }), false);
 });
 
+
+test('replay stores file path from detail-shaped file-edit event', () => {
+  const { accumulateEvent, getReplayEvents } = createAccumulator();
+
+  accumulateEvent({
+    ide: 'claude',
+    event: 'pre_tool',
+    tool: 'Edit',
+    detail: '/workspace/src/app.js',
+    session_id: 'detail-file-path-test',
+  });
+
+  const replay = getReplayEvents('detail-file-path-test');
+
+  assert.equal(replay.events.length, 1);
+  assert.equal(replay.events[0].file, '/workspace/src/app.js');
+});
+
 // ---------------------------------------------------------------------------
 // HTTP Server Payload Cap Regression Test Case (Live POST verification)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What Changed

- Added `ev.detail` to the replay file-path fallback chain.
- Added a regression test covering file-edit events whose path is provided through `detail`.

## Why This Change

The dashboard shim sends edited file paths in the `detail` field, while the accumulator previously only checked `file_path` and `file`. This caused replay entries for file-edit events to store a null file path.

Fixes #896

## Testing Done

- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

Test results:

- `node --test tests/dashboard-server.test.js`: 14 passed, 0 failed
- `node tests/run-all.js`: 2643 passed, 0 failed
- `git diff --check`: passed

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves file paths in dashboard replay for file-edit events by falling back to `detail` when `file_path` and `file` are missing. Adds a test to verify the path is captured from `detail` and not stored as null.

<sup>Written for commit f2b7241baee44165fd0ac242ab4b90221a1b827a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

