### PR TITLE
fix(dashboard): cap WebSocket reconnect attempts

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -658,6 +658,8 @@ const S={
   telemetryFailStreak:0,
   pingFailStreak:0,
   wsFailStreak:0,
+  wsReconnectAttempts:0,
+  wsReconnectMax:20,
   isOffline:false,
   telemetryReqId:0,
   pingReqId:0,
@@ -1148,8 +1150,30 @@ pollTelemetry();
 function connect(){
   try{
     S.ws=new WebSocket('ws://localhost:7890');
-    S.ws.onopen=()=>{setWs(true);S.rc=1000;S.wsFailStreak=0;updateOfflineState();};
-    S.ws.onclose=()=>{setWs(false);S.wsFailStreak++;updateOfflineState();setTimeout(connect,S.rc);S.rc=Math.min(S.rc*2,10000);};
+
+    S.ws.onopen=()=>{
+      setWs(true);
+      S.rc=1000;
+      S.wsFailStreak=0;
+      S.wsReconnectAttempts=0;
+      updateOfflineState();
+    };
+
+    S.ws.onclose=()=>{
+      S.wsFailStreak++;
+      S.wsReconnectAttempts++;
+      updateOfflineState();
+
+      if(S.wsReconnectAttempts>=S.wsReconnectMax){
+        setWs(false,'disconnected');
+        return;
+      }
+
+      setWs(false);
+      setTimeout(connect,S.rc);
+      S.rc=Math.min(S.rc*2,10000);
+    };
+
     S.ws.onmessage=m=>{
       try{
         const t0=performance.now();
@@ -1161,9 +1185,10 @@ function connect(){
     };
   }catch(e){}
 }
-function setWs(on){
+
+function setWs(on,label){
   document.getElementById('wsDot').className='ws-dot'+(on?' on':'');
-  document.getElementById('wsLbl').textContent=on?'live':'offline';
+  document.getElementById('wsLbl').textContent=on?'live':(label||'offline');
   document.getElementById('activeBadge').style.display=on?'':'none';
 }
 function pingLatency(){

--- a/tests/dashboard-ping-polling.test.js
+++ b/tests/dashboard-ping-polling.test.js
@@ -152,3 +152,60 @@ test('ping polling starts independently during dashboard initialization', () => 
     'dashboard initialization should start ping polling independently'
   );
 });
+
+test('WebSocket reconnect stops at the cap and shows disconnected state', () => {
+  const functionBody = extractFunctionBody(dashboardSource, 'connect');
+
+  const S = {
+    ws: null,
+    rc: 1000,
+    wsFailStreak: 0,
+    wsReconnectAttempts: 19,
+    wsReconnectMax: 20
+  };
+
+  const scheduledDelays = [];
+  const wsStates = [];
+
+  class WebSocketStub {
+    constructor(url) {
+      this.url = url;
+    }
+  }
+
+  function setTimeoutStub(_callback, delay) {
+    scheduledDelays.push(delay);
+  }
+
+  function setWsStub(on, label) {
+    wsStates.push([on, label]);
+  }
+
+  function updateOfflineStateStub() {}
+
+  const createConnect = new Function(
+    'S',
+    'WebSocket',
+    'setTimeout',
+    'setWs',
+    'updateOfflineState',
+    `return function connect() {
+      ${functionBody}
+    };`
+  );
+
+  const connect = createConnect(
+    S,
+    WebSocketStub,
+    setTimeoutStub,
+    setWsStub,
+    updateOfflineStateStub
+  );
+
+  connect();
+  S.ws.onclose();
+
+  assert.equal(S.wsReconnectAttempts, 20);
+  assert.deepEqual(scheduledDelays, []);
+  assert.deepEqual(wsStates, [[false, 'disconnected']]);
+});


### PR DESCRIPTION
## What Changed

- Added a WebSocket reconnect attempt counter with a maximum of 20 attempts.
- Reset the reconnect counter after a successful connection.
- Stop scheduling reconnect timers after the maximum is reached.
- Show a visible `disconnected` state when reconnect attempts are exhausted.
- Added a regression test covering the reconnect cap behavior.

## Why This Change

The dashboard previously retried WebSocket connections indefinitely after the connection closed. An abandoned browser tab could therefore keep reconnecting forever.

This change caps the reconnect cycle while allowing a page reload or successful connection to begin a fresh cycle.

Fixes #901

## Testing Done

- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

Test results:

- `node --test tests/dashboard-ping-polling.test.js`: 3 passed, 0 failed
- `node tests/run-all.js`: passed
- `git diff --check`: passed

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps dashboard WebSocket reconnects to 20 to prevent infinite retries in abandoned tabs. After hitting the cap, we stop reconnects and show "disconnected"; a successful connection resets the counter.

- **Bug Fixes**
  - Added reconnect attempt counter with a max of 20 and reset on successful connect.
  - Stop scheduling reconnect timers after the cap is reached.
  - Show a visible "disconnected" state when attempts are exhausted.
  - Added a regression test to verify the cap and no further retries.

<sup>Written for commit 7d98eea2afc064186715a1dc592315f882f8797e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

