### PR TITLE
fix(deps): patch tar, js-yaml and brace-expansion advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@egchq/egc",
       "version": "1.1.14",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
         "argparse": "^3.0.0",
@@ -876,9 +876,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1871,9 +1871,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## What

`npm audit fix` bumps three dependencies flagged by the Security Scan workflow:

- **tar** 7.5.16 to 7.5.20 (critical: PAX path confusion, unbounded decompression, infinite loop, NUL-byte DoS)
- **js-yaml** 4.2.0 to 4.3.0 (high: quadratic CPU via merge-key chains)
- **brace-expansion** 5.0.6 to 5.0.7 (high: exponential-time expansion DoS)

## Why

These advisories were published upstream and picked up by the audit on the next PR run. All three are dev/transitive; the fix is semver-compatible (`npm audit fix`, no `--force`), `package.json` is unchanged, and `npm audit --audit-level=high` now reports 0 vulnerabilities. Root lock `license` field also synced to Apache-2.0 (leftover from the license migration).

## Test

- `npm audit --audit-level=high`: 0 vulnerabilities
- CI runs the full suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches security advisories by bumping `tar`, `js-yaml`, and `brace-expansion`; semver-compatible with no `package.json` changes. `npm audit --audit-level=high` now reports 0 vulnerabilities.

- **Dependencies**
  - `tar`: 7.5.16 → 7.5.20
  - `js-yaml`: 4.2.0 → 4.3.0
  - `brace-expansion`: 5.0.6 → 5.0.7
  - Synced lockfile `license` to Apache-2.0

<sup>Written for commit 28859707ed066355bcece539c63924498b4cdbc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

