### PR TITLE
fix(dashboard): avoid watcher stat-open race

### DIFF
--- a/dashboard/aider-watcher.js
+++ b/dashboard/aider-watcher.js
@@ -5,6 +5,7 @@ const fs   = require('fs');
 const path = require('path');
 const http = require('http');
 const os   = require('os');
+const { readFileDelta } = require('./read-file-delta');
 
 const WATCH_PATHS = [
   path.join(os.homedir(), '.aider.chat.history.md'),
@@ -35,17 +36,11 @@ function watchFile(filePath) {
   fs.watch(filePath, { persistent:false }, (evt) => {
     if (evt !== 'change') return;
     try {
-      const stat = fs.statSync(filePath);
-      if (stat.size < lastSizes[filePath]) lastSizes[filePath] = 0;
-      if (stat.size <= lastSizes[filePath]) return;
+      const result = readFileDelta(filePath, lastSizes[filePath]);
+      lastSizes[filePath] = result.newSize;
+      if (result.chunk === null) return;
 
-      const fd = fs.openSync(filePath, 'r');
-      const buf = Buffer.alloc(stat.size - lastSizes[filePath]);
-      fs.readSync(fd, buf, 0, buf.length, lastSizes[filePath]);
-      fs.closeSync(fd);
-      lastSizes[filePath] = stat.size;
-
-      const chunk = buf.toString('utf8');
+      const chunk = result.chunk;
       const toolMatch = chunk.match(/\b(read|edit|write|bash|run)\b/i);
       const tool = toolMatch ? toolMatch[1].charAt(0).toUpperCase() + toolMatch[1].slice(1) : 'Aider';
 

--- a/dashboard/read-file-delta.js
+++ b/dashboard/read-file-delta.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const fs = require('fs');
+
+function readFileDelta(filePath, lastSize) {
+  const fd = fs.openSync(filePath, 'r');
+
+  try {
+    const stat = fs.fstatSync(fd);
+
+    if (stat.size < lastSize) lastSize = 0;
+    if (stat.size <= lastSize) {
+      return { chunk: null, newSize: lastSize };
+    }
+
+    const buffer = Buffer.alloc(stat.size - lastSize);
+    const bytesRead = fs.readSync(
+      fd,
+      buffer,
+      0,
+      buffer.length,
+      lastSize
+    );
+
+    return {
+      chunk: buffer.subarray(0, bytesRead).toString('utf8'),
+      newSize: lastSize + bytesRead,
+    };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+module.exports = { readFileDelta };

--- a/dashboard/vscode-adapter.js
+++ b/dashboard/vscode-adapter.js
@@ -5,6 +5,7 @@ const http = require('http');
 const fs   = require('fs');
 const path = require('path');
 const os   = require('os');
+const { readFileDelta } = require('./read-file-delta');
 
 const PORT = 7890;
 
@@ -65,16 +66,11 @@ function watch() {
 
     fs.watch(logFile, { persistent:false }, () => {
       try {
-        const stat = fs.statSync(logFile);
-        if (stat.size < lastSize) lastSize = 0;
-        if (stat.size <= lastSize) return;
-        const buf = Buffer.alloc(stat.size - lastSize);
-        const fd = fs.openSync(logFile, 'r');
-        fs.readSync(fd, buf, 0, buf.length, lastSize);
-        fs.closeSync(fd);
-        lastSize = stat.size;
+        const result = readFileDelta(logFile, lastSize);
+        lastSize = result.newSize;
+        if (result.chunk === null) return;
 
-        const chunk = buf.toString('utf8');
+        const chunk = result.chunk;
         if (chunk.includes('request') || chunk.includes('completion') || chunk.includes('edit')) {
           post({ ide:'vscode', event:'pre_tool', tool:'Copilot', agent:'main', detail:chunk.slice(0,60).trim(), status:'running' });
           setTimeout(()=>{ post({ ide:'vscode', event:'post_tool', tool:'Copilot', agent:'main', status:'success' }); }, 400);

--- a/tests/dashboard-watcher-rotation.test.js
+++ b/tests/dashboard-watcher-rotation.test.js
@@ -28,26 +28,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-// ---------------------------------------------------------------------------
-// Helper: the exact post-fix logic from aider-watcher.js / vscode-adapter.js,
-// extracted as a pure function of (filePath, lastSize) -> { chunk, newSize }.
-// This is the same four lines as dashboard/aider-watcher.js:38-46 (and the
-// equivalent in vscode-adapter.js:57-64), just wrapped so it's testable
-// without spinning up fs.watch(), setInterval(), or the HTTP POST side
-// effects that the real watcher scripts perform on require().
-// ---------------------------------------------------------------------------
-function readDelta(filePath, lastSize) {
-  const stat = fs.statSync(filePath);
-  if (stat.size < lastSize) lastSize = 0; // truncated/rotated: reset and re-read from start
-  if (stat.size <= lastSize) return { chunk: null, newSize: lastSize };
-
-  const fd = fs.openSync(filePath, 'r');
-  const buf = Buffer.alloc(stat.size - lastSize);
-  fs.readSync(fd, buf, 0, buf.length, lastSize);
-  fs.closeSync(fd);
-
-  return { chunk: buf.toString('utf8'), newSize: stat.size };
-}
+const { readFileDelta: readDelta } = require('../dashboard/read-file-delta');
 
 function withTempFile(initialContent, fn) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-watcher-test-'));
@@ -177,5 +158,28 @@ test('multiple shrink/grow cycles: watcher keeps emitting correctly across repea
     r = readDelta(filePath, lastSize);
     assert.equal(r.chunk, 'fourth-rotation',
       'second rotation: the fix must keep working across repeated truncations, not just once');
+  });
+});
+
+test('TOCTOU: rotation between stat and open uses the opened file size', () => {
+  withTempFile('old content that is much longer', (filePath) => {
+    const originalOpenSync = fs.openSync;
+    let rotated = false;
+
+    fs.openSync = function patchedOpenSync(target, ...args) {
+      if (!rotated && target === filePath) {
+        rotated = true;
+        fs.writeFileSync(filePath, 'new', 'utf8');
+      }
+      return originalOpenSync.call(fs, target, ...args);
+    };
+
+    try {
+      const result = readDelta(filePath, 0);
+      assert.equal(result.chunk, 'new');
+      assert.equal(result.newSize, 3);
+    } finally {
+      fs.openSync = originalOpenSync;
+    }
   });
 });


### PR DESCRIPTION
## What Changed

- Added a shared `readFileDelta` helper for dashboard log watchers.
- Opened the watched file before reading its size, then used `fstatSync()` on the same file descriptor.
- Updated both the Aider watcher and VS Code adapter to use the shared helper.
- Ensured file descriptors are always closed with `finally`.
- Added a regression test that replaces the file between the old `statSync()` and `openSync()` timing window.

## Why This Change

The watchers previously called `statSync(path)` before `openSync(path)`. If a log was truncated or rotated between those operations, the recorded size and the opened file could refer to different file versions.

This could produce incorrect offsets, null bytes, or failed reads. Reading the size from the already-open file descriptor keeps the size and content consistent.

Closes #898.

## Testing Done

- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Targeted watcher regression tests pass (`node --test tests/dashboard-watcher-rotation.test.js`)
- [x] `git diff --check` passes
- [x] Edge cases considered and tested

## Type of Change

- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [x] `refactor`: Code refactoring
- [ ] `docs`: Documentation
- [x] `test`: Tests
- [ ] `chore`: Maintenance/tooling
- [ ] `ci`: CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Existing default behavior remains unchanged
- [x] Shared file descriptors are closed even when reading throws

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TOCTOU race in dashboard log watchers by reading deltas from the opened file descriptor via a shared `readFileDelta` helper. Both `aider-watcher` and `vscode-adapter` now use it to avoid mismatched offsets on truncation/rotation.

- **Bug Fixes**
  - Open the file first, then call `fstatSync()` on the same fd; read only new bytes and always close in `finally`.
  - Reset offset when the file shrinks; no-op when size is unchanged.
  - Added a TOCTOU regression test that rotates the file between `stat` and `open`, and updated tests to use the shared helper.

<sup>Written for commit e466f514a92fbff79a1590edd85e8891e4f3aa40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

