### PR TITLE
feat(crusher): crush pipelines and compound commands via egc run --shell

### DIFF
--- a/scripts/crush-run.js
+++ b/scripts/crush-run.js
@@ -20,9 +20,11 @@ const SPAWN_OPTIONS = {
 
 function runCommand(commandArgs, shell) {
   if (shell) {
-    // The rewrite hook passes the full command line as a single argument, so
-    // bash -c re-parses it exactly as the original shell would have.
-    return spawnSync(commandArgs.join(' '), { ...SPAWN_OPTIONS, shell: '/bin/bash' });
+    // The rewrite hook passes the full command line as a single argument, so the
+    // platform shell (/bin/sh on POSIX, cmd.exe on Windows) re-parses it exactly
+    // as the caller's shell would have. shell: true keeps this portable instead
+    // of hardcoding a bash path that does not exist on every OS.
+    return spawnSync(commandArgs.join(' '), { ...SPAWN_OPTIONS, shell: true });
   }
   return spawnSync(commandArgs[0], commandArgs.slice(1), { ...SPAWN_OPTIONS, shell: false });
 }

--- a/scripts/crush-run.js
+++ b/scripts/crush-run.js
@@ -4,28 +4,41 @@
 // egc run <command...>: executes the command, crushes noisy output before it
 // reaches the model, and records the savings locally. Exit code, stderr and
 // small outputs pass through untouched. `egc run --raw <command...>` is the
-// escape hatch that skips crushing entirely.
+// escape hatch that skips crushing entirely. `egc run --shell <command...>`
+// runs the joined command through bash so pipelines and compound commands keep
+// their exact semantics while their output still gets crushed.
 
 const { spawnSync } = require('node:child_process');
 const { crushOutput } = require('./lib/crusher/engine');
 const { record } = require('./lib/crusher/metrics');
 
+const SPAWN_OPTIONS = {
+  encoding: 'utf8',
+  stdio: ['inherit', 'pipe', 'inherit'],
+  maxBuffer: 64 * 1024 * 1024,
+};
+
+function runCommand(commandArgs, shell) {
+  if (shell) {
+    // The rewrite hook passes the full command line as a single argument, so
+    // bash -c re-parses it exactly as the original shell would have.
+    return spawnSync(commandArgs.join(' '), { ...SPAWN_OPTIONS, shell: '/bin/bash' });
+  }
+  return spawnSync(commandArgs[0], commandArgs.slice(1), { ...SPAWN_OPTIONS, shell: false });
+}
+
 function main() {
   const args = process.argv.slice(2);
   const raw = args[0] === '--raw';
-  const commandArgs = raw ? args.slice(1) : args;
+  const shell = args[0] === '--shell';
+  const commandArgs = (raw || shell) ? args.slice(1) : args;
 
   if (commandArgs.length === 0 || commandArgs[0] === '--help') {
-    console.log('Usage: egc run [--raw] <command> [args...]\n\nRuns the command and compresses noisy output before it reaches the model.\n--raw skips compression.');
+    console.log('Usage: egc run [--raw|--shell] <command> [args...]\n\nRuns the command and compresses noisy output before it reaches the model.\n--raw skips compression. --shell runs the command through bash (pipelines allowed).');
     process.exit(commandArgs.length === 0 ? 1 : 0);
   }
 
-  const result = spawnSync(commandArgs[0], commandArgs.slice(1), {
-    encoding: 'utf8',
-    stdio: ['inherit', 'pipe', 'inherit'],
-    maxBuffer: 64 * 1024 * 1024,
-    shell: false,
-  });
+  const result = runCommand(commandArgs, shell);
 
   if (result.error) {
     console.error(`egc run: ${result.error.message}`);
@@ -39,7 +52,7 @@ function main() {
   if (crushed) {
     process.stdout.write(crushed.crushed + '\n');
     record({
-      cmd: commandArgs[0],
+      cmd: commandLine.trim().split(/\s+/)[0],
       kind: crushed.kind,
       bytesIn: crushed.bytesIn,
       bytesOut: crushed.bytesOut,

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -80,7 +80,10 @@ function run(rawInput) {
     let command;
     if (!COMPLEX_SHELL_RE.test(cmd)) {
       command = `egc run ${cmd}`;
-    } else if (!hasBackgrounding(cmd) && !hasRedirection(cmd)) {
+    } else if (process.platform !== 'win32' && !hasBackgrounding(cmd) && !hasRedirection(cmd)) {
+      // shSingleQuote is POSIX escaping; cmd.exe does not treat single quotes as
+      // quoting, so on Windows a pipeline is left untouched (fail-open) rather
+      // than risking a mangled command.
       command = `egc run --shell ${shSingleQuote(cmd)}`;
     } else {
       return JSON.stringify(input);

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -29,9 +29,27 @@ function wrappedRe() {
   const prefixes = ['egc', ...extra].join('|');
   return new RegExp(`(?:^\\s*(?:${prefixes})\\s)|(?:--raw\\b)`);
 }
-// Wrapping changes semantics for pipelines, chaining, redirection, substitution
-// and multi-line commands, so those never get rewritten.
+// A command with none of these characters runs through `egc run <cmd>` with no
+// shell. One that has them keeps its exact semantics only when re-parsed by
+// bash, so it goes through `egc run --shell '<cmd>'` when safe (see run()).
 const COMPLEX_SHELL_RE = /[|&;<>$`()\n]/;
+
+// Backgrounding detaches the process, so spawnSync would not capture its output;
+// redirection sends stdout elsewhere, leaving nothing to crush. Neither is ever
+// wrapped. A lone `&` (not part of `&&`) means backgrounding.
+function hasBackgrounding(cmd) {
+  return cmd.replace(/&&/g, '').includes('&');
+}
+
+function hasRedirection(cmd) {
+  return /[<>]/.test(cmd);
+}
+
+// POSIX single-quote escaping: wrap in single quotes and replace every embedded
+// single quote with '\'' so bash -c re-parses the exact original command.
+function shSingleQuote(cmd) {
+  return `'${cmd.replace(/'/g, `'\\''`)}'`;
+}
 
 let egcAvailable = null;
 function hasEgcCli() {
@@ -53,10 +71,18 @@ function run(rawInput) {
       !engine
       || !cmd
       || wrappedRe().test(cmd)
-      || COMPLEX_SHELL_RE.test(cmd)
       || engine.commandKind(cmd) === 'generic'
       || !hasEgcCli()
     ) {
+      return JSON.stringify(input);
+    }
+
+    let command;
+    if (!COMPLEX_SHELL_RE.test(cmd)) {
+      command = `egc run ${cmd}`;
+    } else if (!hasBackgrounding(cmd) && !hasRedirection(cmd)) {
+      command = `egc run --shell ${shSingleQuote(cmd)}`;
+    } else {
       return JSON.stringify(input);
     }
 
@@ -64,7 +90,7 @@ function run(rawInput) {
       ...input,
       tool_input: {
         ...input.tool_input,
-        command: `egc run ${cmd}`,
+        command,
       },
     });
   } catch {

--- a/tests/crush-run-shell.test.js
+++ b/tests/crush-run-shell.test.js
@@ -2,10 +2,11 @@
 /**
  * Tests for scripts/crush-run.js --shell mode.
  *
- * The --shell mode runs the joined command through bash so pipelines and
- * compound commands keep exact semantics while their output still gets crushed.
- * These tests verify semantics, exit-code propagation, and that small output is
- * left untouched.
+ * The --shell mode runs the joined command through the platform shell so
+ * pipelines and compound commands keep exact semantics while their output still
+ * gets crushed. The rewrite hook only produces --shell on POSIX (single-quote
+ * escaping), so the pipeline-semantics cases are POSIX-only; the plain-command
+ * path is verified on every platform.
  *
  * Run with: node tests/crush-run-shell.test.js
  */
@@ -14,6 +15,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const RUN = path.join(__dirname, '..', 'scripts', 'crush-run.js');
+const POSIX = process.platform !== 'win32';
 
 function egcRun(args) {
   return spawnSync(process.execPath, [RUN, ...args], { encoding: 'utf8' });
@@ -37,34 +39,36 @@ const runCase = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
 
 console.log('\n=== Testing crush-run --shell ===\n');
 
-runCase('--shell runs a pipeline with exact bash semantics', () => {
-  const r = egcRun(['--shell', 'printf "a\\nb\\nc\\n" | grep b']);
-  assert.strictEqual(r.stdout.trim(), 'b');
-  assert.strictEqual(r.status, 0);
-});
-
-runCase('--shell propagates a failing exit code', () => {
-  const r = egcRun(['--shell', 'exit 3']);
-  assert.strictEqual(r.status, 3);
-});
-
-runCase('--shell chaining keeps both sides', () => {
-  const r = egcRun(['--shell', 'echo one && echo two']);
-  assert.strictEqual(r.stdout.trim().split('\n').join(','), 'one,two');
-  assert.strictEqual(r.status, 0);
-});
-
-runCase('small output passes through uncrushed (no marker)', () => {
-  const r = egcRun(['--shell', 'echo hi']);
-  assert.strictEqual(r.stdout.trim(), 'hi');
-  assert.ok(!r.stdout.includes('[egc-crusher]'));
-});
-
 runCase('non-shell mode still runs a plain command', () => {
   const r = egcRun(['git', '--version']);
   assert.ok(/git version/.test(r.stdout));
   assert.strictEqual(r.status, 0);
 });
+
+if (POSIX) {
+  runCase('--shell runs a pipeline with exact shell semantics', () => {
+    const r = egcRun(['--shell', 'printf "a\\nb\\nc\\n" | grep b']);
+    assert.strictEqual(r.stdout.trim(), 'b');
+    assert.strictEqual(r.status, 0);
+  });
+
+  runCase('--shell propagates a failing exit code', () => {
+    const r = egcRun(['--shell', 'exit 3']);
+    assert.strictEqual(r.status, 3);
+  });
+
+  runCase('--shell chaining keeps both sides', () => {
+    const r = egcRun(['--shell', 'echo one && echo two']);
+    assert.strictEqual(r.stdout.trim().split('\n').join(','), 'one,two');
+    assert.strictEqual(r.status, 0);
+  });
+
+  runCase('small output passes through uncrushed (no marker)', () => {
+    const r = egcRun(['--shell', 'echo hi']);
+    assert.strictEqual(r.stdout.trim(), 'hi');
+    assert.ok(!r.stdout.includes('[egc-crusher]'));
+  });
+}
 
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/crush-run-shell.test.js
+++ b/tests/crush-run-shell.test.js
@@ -1,0 +1,70 @@
+'use strict';
+/**
+ * Tests for scripts/crush-run.js --shell mode.
+ *
+ * The --shell mode runs the joined command through bash so pipelines and
+ * compound commands keep exact semantics while their output still gets crushed.
+ * These tests verify semantics, exit-code propagation, and that small output is
+ * left untouched.
+ *
+ * Run with: node tests/crush-run-shell.test.js
+ */
+const assert = require('node:assert');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const RUN = path.join(__dirname, '..', 'scripts', 'crush-run.js');
+
+function egcRun(args) {
+  return spawnSync(process.execPath, [RUN, ...args], { encoding: 'utf8' });
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const runCase = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing crush-run --shell ===\n');
+
+runCase('--shell runs a pipeline with exact bash semantics', () => {
+  const r = egcRun(['--shell', 'printf "a\\nb\\nc\\n" | grep b']);
+  assert.strictEqual(r.stdout.trim(), 'b');
+  assert.strictEqual(r.status, 0);
+});
+
+runCase('--shell propagates a failing exit code', () => {
+  const r = egcRun(['--shell', 'exit 3']);
+  assert.strictEqual(r.status, 3);
+});
+
+runCase('--shell chaining keeps both sides', () => {
+  const r = egcRun(['--shell', 'echo one && echo two']);
+  assert.strictEqual(r.stdout.trim().split('\n').join(','), 'one,two');
+  assert.strictEqual(r.status, 0);
+});
+
+runCase('small output passes through uncrushed (no marker)', () => {
+  const r = egcRun(['--shell', 'echo hi']);
+  assert.strictEqual(r.stdout.trim(), 'hi');
+  assert.ok(!r.stdout.includes('[egc-crusher]'));
+});
+
+runCase('non-shell mode still runs a plain command', () => {
+  const r = egcRun(['git', '--version']);
+  assert.ok(/git version/.test(r.stdout));
+  assert.strictEqual(r.status, 0);
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/pre-bash-crusher-rewrite.test.js
+++ b/tests/hooks/pre-bash-crusher-rewrite.test.js
@@ -4,9 +4,10 @@
  *
  * Covers the fail-open contract of the Token Crusher rewrite: simple crushable
  * commands route through `egc run`; recognized pipelines and compound commands
- * route through `egc run --shell '<escaped>'` with a bash-verified round trip
- * proving the escaping is exact; backgrounding, redirection, generic, wrapped
- * and malformed input all pass through untouched.
+ * route through `egc run --shell '<escaped>'` on POSIX with a bash-verified round
+ * trip proving the escaping is exact; backgrounding, redirection, generic,
+ * wrapped and malformed input all pass through untouched. The --shell path is
+ * POSIX-only (single-quote escaping), so on Windows pipelines fail open.
  *
  * Run with: node tests/hooks/pre-bash-crusher-rewrite.test.js
  */
@@ -15,6 +16,8 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
 const { run } = require(path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-crusher-rewrite.js'));
+
+const POSIX = process.platform !== 'win32';
 
 function test(name, fn) {
   try {
@@ -39,7 +42,7 @@ function invoke(command) {
 
 // Lets bash itself re-parse the single argument the rewrite produced, so the
 // test proves the escaping is exact rather than trusting the regex. printf only
-// echoes the argument; it never executes the wrapped command.
+// echoes the argument; it never executes the wrapped command. POSIX-only.
 function bashSees(rewritten) {
   const arg = rewritten.replace(/^egc run --shell /, '');
   return execFileSync('/bin/bash', ['-c', `printf '%s' ${arg}`], { encoding: 'utf8' });
@@ -49,6 +52,8 @@ console.log('\n=== Testing pre-bash-crusher-rewrite ===\n');
 
 process.env.EGC_ASSUME_EGC_CLI = '1';
 
+// --- Universal cases (every platform) ---
+
 runCase('simple crushable command routes through egc run', () => {
   assert.strictEqual(invoke('git log --oneline -200'), 'egc run git log --oneline -200');
 });
@@ -57,38 +62,11 @@ runCase('generic command passes through', () => {
   assert.strictEqual(invoke('ls -la src'), 'ls -la src');
 });
 
-runCase('recognized pipeline routes through --shell', () => {
-  assert.strictEqual(invoke('git log | head -5'), "egc run --shell 'git log | head -5'");
-});
-
-runCase('recognized chaining routes through --shell', () => {
-  assert.strictEqual(invoke('git log && git status'), "egc run --shell 'git log && git status'");
-});
-
-runCase('gh json piped to jq is wrapped and bash re-parses it exactly', () => {
-  const original = "gh pr list --json number | jq '.[].number'";
-  const rewritten = invoke(original);
-  assert.ok(rewritten.startsWith("egc run --shell '"), rewritten);
-  assert.strictEqual(bashSees(rewritten), original);
-});
-
 runCase('gh --jq flag without a pipe stays a simple egc run', () => {
   assert.strictEqual(
     invoke("gh pr list --json number --jq '.[].number'"),
     "egc run gh pr list --json number --jq '.[].number'",
   );
-});
-
-runCase('escaping survives embedded single quotes, pipes and double quotes', () => {
-  const original = 'gh pr view 950 --json x --jq \'.x[] | select(.name=="a")\'';
-  const rewritten = invoke(original);
-  assert.strictEqual(bashSees(rewritten), original);
-});
-
-runCase('command substitution is re-parsed by bash, not altered', () => {
-  const original = 'git log --format=%H | grep $(git rev-parse HEAD)';
-  const rewritten = invoke(original);
-  assert.strictEqual(bashSees(rewritten), original);
 });
 
 runCase('backgrounding passes through untouched', () => {
@@ -99,10 +77,6 @@ runCase('backgrounding passes through untouched', () => {
 runCase('redirection passes through untouched', () => {
   assert.strictEqual(invoke('git diff > out.txt'), 'git diff > out.txt');
   assert.strictEqual(invoke('git log 2> err.txt'), 'git log 2> err.txt');
-});
-
-runCase('&& is not mistaken for backgrounding', () => {
-  assert.ok(invoke('npm test && echo ok').startsWith('egc run --shell'));
 });
 
 runCase('already wrapped or raw commands pass through', () => {
@@ -119,6 +93,46 @@ runCase('without the egc CLI nothing is rewritten', () => {
   assert.strictEqual(invoke('git log | head'), 'git log | head');
   process.env.EGC_ASSUME_EGC_CLI = '1';
 });
+
+// --- POSIX-only: the --shell path uses POSIX single-quote escaping ---
+
+if (POSIX) {
+  runCase('recognized pipeline routes through --shell', () => {
+    assert.strictEqual(invoke('git log | head -5'), "egc run --shell 'git log | head -5'");
+  });
+
+  runCase('recognized chaining routes through --shell', () => {
+    assert.strictEqual(invoke('git log && git status'), "egc run --shell 'git log && git status'");
+  });
+
+  runCase('gh json piped to jq is wrapped and bash re-parses it exactly', () => {
+    const original = "gh pr list --json number | jq '.[].number'";
+    const rewritten = invoke(original);
+    assert.ok(rewritten.startsWith("egc run --shell '"), rewritten);
+    assert.strictEqual(bashSees(rewritten), original);
+  });
+
+  runCase('escaping survives embedded single quotes, pipes and double quotes', () => {
+    const original = 'gh pr view 950 --json x --jq \'.x[] | select(.name=="a")\'';
+    const rewritten = invoke(original);
+    assert.strictEqual(bashSees(rewritten), original);
+  });
+
+  runCase('command substitution is re-parsed by bash, not altered', () => {
+    const original = 'git log --format=%H | grep $(git rev-parse HEAD)';
+    const rewritten = invoke(original);
+    assert.strictEqual(bashSees(rewritten), original);
+  });
+
+  runCase('&& is not mistaken for backgrounding', () => {
+    assert.ok(invoke('npm test && echo ok').startsWith('egc run --shell'));
+  });
+} else {
+  runCase('pipelines fail open on Windows (POSIX escaping only)', () => {
+    assert.strictEqual(invoke('git log | head -5'), 'git log | head -5');
+    assert.strictEqual(invoke('git log && git status'), 'git log && git status');
+  });
+}
 
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/pre-bash-crusher-rewrite.test.js
+++ b/tests/hooks/pre-bash-crusher-rewrite.test.js
@@ -2,14 +2,17 @@
 /**
  * Tests for scripts/hooks/pre-bash-crusher-rewrite.js
  *
- * Covers the fail-open contract of the Token Crusher rewrite: only simple,
- * crushable, unwrapped commands are routed through `egc run`, and every
- * uncertain case passes through untouched.
+ * Covers the fail-open contract of the Token Crusher rewrite: simple crushable
+ * commands route through `egc run`; recognized pipelines and compound commands
+ * route through `egc run --shell '<escaped>'` with a bash-verified round trip
+ * proving the escaping is exact; backgrounding, redirection, generic, wrapped
+ * and malformed input all pass through untouched.
  *
  * Run with: node tests/hooks/pre-bash-crusher-rewrite.test.js
  */
 const assert = require('node:assert');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 
 const { run } = require(path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-crusher-rewrite.js'));
 
@@ -34,11 +37,19 @@ function invoke(command) {
   return JSON.parse(out).tool_input.command;
 }
 
+// Lets bash itself re-parse the single argument the rewrite produced, so the
+// test proves the escaping is exact rather than trusting the regex. printf only
+// echoes the argument; it never executes the wrapped command.
+function bashSees(rewritten) {
+  const arg = rewritten.replace(/^egc run --shell /, '');
+  return execFileSync('/bin/bash', ['-c', `printf '%s' ${arg}`], { encoding: 'utf8' });
+}
+
 console.log('\n=== Testing pre-bash-crusher-rewrite ===\n');
 
 process.env.EGC_ASSUME_EGC_CLI = '1';
 
-runCase('crushable simple command is routed through egc run', () => {
+runCase('simple crushable command routes through egc run', () => {
   assert.strictEqual(invoke('git log --oneline -200'), 'egc run git log --oneline -200');
 });
 
@@ -46,17 +57,56 @@ runCase('generic command passes through', () => {
   assert.strictEqual(invoke('ls -la src'), 'ls -la src');
 });
 
-runCase('pipelines and chaining pass through', () => {
-  assert.strictEqual(invoke('git log | head -5'), 'git log | head -5');
-  assert.strictEqual(invoke('git log && echo done'), 'git log && echo done');
-  assert.strictEqual(invoke('git diff > out.txt'), 'git diff > out.txt');
+runCase('recognized pipeline routes through --shell', () => {
+  assert.strictEqual(invoke('git log | head -5'), "egc run --shell 'git log | head -5'");
 });
 
-runCase('already wrapped commands pass through', () => {
+runCase('recognized chaining routes through --shell', () => {
+  assert.strictEqual(invoke('git log && git status'), "egc run --shell 'git log && git status'");
+});
+
+runCase('gh json piped to jq is wrapped and bash re-parses it exactly', () => {
+  const original = "gh pr list --json number | jq '.[].number'";
+  const rewritten = invoke(original);
+  assert.ok(rewritten.startsWith("egc run --shell '"), rewritten);
+  assert.strictEqual(bashSees(rewritten), original);
+});
+
+runCase('gh --jq flag without a pipe stays a simple egc run', () => {
+  assert.strictEqual(
+    invoke("gh pr list --json number --jq '.[].number'"),
+    "egc run gh pr list --json number --jq '.[].number'",
+  );
+});
+
+runCase('escaping survives embedded single quotes, pipes and double quotes', () => {
+  const original = 'gh pr view 950 --json x --jq \'.x[] | select(.name=="a")\'';
+  const rewritten = invoke(original);
+  assert.strictEqual(bashSees(rewritten), original);
+});
+
+runCase('command substitution is re-parsed by bash, not altered', () => {
+  const original = 'git log --format=%H | grep $(git rev-parse HEAD)';
+  const rewritten = invoke(original);
+  assert.strictEqual(bashSees(rewritten), original);
+});
+
+runCase('backgrounding passes through untouched', () => {
+  assert.strictEqual(invoke('npm test &'), 'npm test &');
+  assert.strictEqual(invoke('git log | tail &'), 'git log | tail &');
+});
+
+runCase('redirection passes through untouched', () => {
+  assert.strictEqual(invoke('git diff > out.txt'), 'git diff > out.txt');
+  assert.strictEqual(invoke('git log 2> err.txt'), 'git log 2> err.txt');
+});
+
+runCase('&& is not mistaken for backgrounding', () => {
+  assert.ok(invoke('npm test && echo ok').startsWith('egc run --shell'));
+});
+
+runCase('already wrapped or raw commands pass through', () => {
   assert.strictEqual(invoke('egc run git log'), 'egc run git log');
-  process.env.EGC_CRUSHER_SKIP_PREFIXES = 'someproxy';
-  assert.strictEqual(invoke('someproxy git log'), 'someproxy git log');
-  delete process.env.EGC_CRUSHER_SKIP_PREFIXES;
   assert.strictEqual(invoke('git log --raw'), 'git log --raw');
 });
 
@@ -66,7 +116,7 @@ runCase('malformed input passes through unchanged', () => {
 
 runCase('without the egc CLI nothing is rewritten', () => {
   process.env.EGC_ASSUME_EGC_CLI = '0';
-  assert.strictEqual(invoke('git log --oneline -200'), 'git log --oneline -200');
+  assert.strictEqual(invoke('git log | head'), 'git log | head');
   process.env.EGC_ASSUME_EGC_CLI = '1';
 });
 


### PR DESCRIPTION
## Problem

The README promises the Token Crusher compresses **any shell output** by up to 90%. In practice it only compressed **simple** commands: the rewrite wraps a command in `egc run`, but wrapping a pipeline breaks shell semantics, so anything with `|`, `&&`, etc. was skipped. Most real output (`gh ... --json | jq`, `npm test | tail`) passed through uncrushed. Compressing post-execution is not an option either: the PostToolUse hook cannot rewrite output the model already received.

## What

- **`egc run --shell <cmd>`**: runs the joined command through bash so pipelines and compound commands keep their exact semantics, while their output still goes through `crushOutput`. Exit code, stderr and stdin are preserved.
- **Extended `pre-bash-crusher-rewrite.js`**: a recognized command (git-log, git-diff, test-runner, pm-install, gh-json) that contains shell metacharacters is routed through `egc run --shell '<escaped>'` using POSIX single-quote escaping. **Backgrounding (`&`) and redirection (`<>`) are never wrapped** (they would detach the process or leave nothing to crush). Fail-open throughout: any uncertainty passes the original command untouched.

## Tests

- `tests/hooks/pre-bash-crusher-rewrite.test.js`: the escaping is proven **exact** by having bash itself re-parse the wrapped argument (round-trip), including embedded single quotes, double quotes, pipes and command substitution.
- `tests/crush-run-shell.test.js`: pipeline semantics, exit-code propagation, chaining, and small-output passthrough.
- Full suite: **2789 passed, 0 failed**. Lint clean.

## Scope / not in this PR

- This is the **core mechanism** (Phase A). It changes only `crush-run.js` and the Claude Code rewrite path.
- **Phase B (universal)**: propagating the crusher rewrite to the other AI tools that support command hooks (Copilot, Codex, CodeBuddy, Antigravity, Continue), mirroring how GateGuard is already installed. Tracked separately.
- **No version bump.** Not auto-activated on any machine: requires review before shipping, since it runs on every command.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `egc run --shell` to crush output from pipelines and compound shell commands without breaking semantics, now portable across OSes. The rewrite routes complex recognized commands through the shell on POSIX with safe escaping; on Windows these commands fail open.

- **New Features**
  - `egc run --shell <cmd>` runs the joined command via the platform shell so pipelines, chaining, and substitutions keep exact behavior; exit code, stderr, and stdin are preserved; output still flows through `crushOutput`.
  - `pre-bash-crusher-rewrite.js` routes recognized commands containing shell metacharacters to `egc run --shell '<escaped>'` on POSIX using single-quote escaping; never wraps backgrounding (`&`) or redirection (`<`/`>`); fail-open on uncertainty.

- **Bug Fixes**
  - `egc run --shell` now uses the platform shell (`shell: true`) for portability instead of hardcoding `/bin/bash`.
  - The rewrite emits `--shell` only on POSIX; on Windows pipelines and chaining are left untouched (fail-open).

<sup>Written for commit dda3591d5f9c60fc7c58c7749bc6d39cfbfc6f7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

