### PR TITLE
fix(crusher): emit hookSpecificOutput.updatedInput so rewrites actually apply

### DIFF
--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -181,6 +181,47 @@ function runPostBash(rawInput) {
   return runHooks(rawInput, POST_BASH_HOOKS);
 }
 
+// The pre-bash hooks chain input JSON to input JSON, so a rewrite leaves the
+// command changed inside a bare `{tool_name, tool_input}` object. Hosts
+// (Claude Code, Codex, CodeBuddy) ignore that shape and run the original
+// command; a rewrite only takes effect when returned as
+// `hookSpecificOutput.updatedInput`. This wraps a genuine rewrite in that
+// envelope while forwarding deny/ask/context outputs and unchanged commands
+// untouched. Fail-open: any parse failure emits the chain output verbatim.
+function toPreToolUseOutput(originalRaw, finalRaw) {
+  let original;
+  let final;
+  try {
+    original = JSON.parse(originalRaw);
+    final = JSON.parse(finalRaw);
+  } catch {
+    return finalRaw;
+  }
+
+  // A hook that denied, asked, or added context already speaks the host's
+  // hook-output schema; forward it verbatim.
+  if (final && typeof final === 'object'
+    && (final.hookSpecificOutput || final.decision || final.continue === false)) {
+    return finalRaw;
+  }
+
+  const originalCommand = original && original.tool_input && original.tool_input.command;
+  const finalCommand = final && final.tool_input && final.tool_input.command;
+
+  if (typeof finalCommand === 'string'
+    && typeof originalCommand === 'string'
+    && finalCommand !== originalCommand) {
+    return JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        updatedInput: final.tool_input,
+      },
+    });
+  }
+
+  return finalRaw;
+}
+
 async function main() {
   const mode = process.argv[2];
   const raw = await readStdinRaw();
@@ -192,7 +233,10 @@ async function main() {
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
-  process.stdout.write(result.output);
+  const output = mode === 'post'
+    ? result.output
+    : toPreToolUseOutput(raw, result.output);
+  process.stdout.write(output);
   process.exit(result.exitCode);
 }
 
@@ -208,4 +252,5 @@ module.exports = {
   POST_BASH_HOOKS,
   runPreBash,
   runPostBash,
+  toPreToolUseOutput,
 };

--- a/scripts/hooks/pre-bash-dispatcher.js
+++ b/scripts/hooks/pre-bash-dispatcher.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const { runPreBash } = require('./bash-hook-dispatcher');
+const { runPreBash, toPreToolUseOutput } = require('./bash-hook-dispatcher');
 
 let raw = '';
 const MAX_STDIN = 1024 * 1024;
@@ -19,6 +19,6 @@ process.stdin.on('end', () => {
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
-  process.stdout.write(result.output);
+  process.stdout.write(toPreToolUseOutput(raw, result.output));
   process.exitCode = result.exitCode;
 });

--- a/tests/hooks/bash-dispatcher-rewrite-output.test.js
+++ b/tests/hooks/bash-dispatcher-rewrite-output.test.js
@@ -1,0 +1,106 @@
+'use strict';
+/**
+ * Tests for the PreToolUse output envelope in scripts/hooks/bash-hook-dispatcher.js.
+ *
+ * The pre-bash hook chain rewrites a command inside a bare `{tool_name,
+ * tool_input}` object, but hosts (Claude Code, Codex, CodeBuddy) only apply a
+ * rewrite delivered as `hookSpecificOutput.updatedInput`. toPreToolUseOutput
+ * wraps a genuine rewrite in that envelope and forwards everything else
+ * untouched. An integration case spawns the dispatcher end to end to prove a
+ * real `git log` comes back as an updatedInput rewrite to `egc run`.
+ *
+ * Run with: node tests/hooks/bash-dispatcher-rewrite-output.test.js
+ */
+const assert = require('node:assert');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const DISPATCHER = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'bash-hook-dispatcher.js');
+const { toPreToolUseOutput } = require(DISPATCHER);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const runCase = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+const bashInput = command => JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+
+console.log('\n=== Testing bash-hook-dispatcher PreToolUse output ===\n');
+
+runCase('a rewritten command is wrapped as hookSpecificOutput.updatedInput', () => {
+  const original = bashInput('git log --oneline -50');
+  const final = bashInput('egc run git log --oneline -50');
+  const out = JSON.parse(toPreToolUseOutput(original, final));
+  assert.strictEqual(out.hookSpecificOutput.hookEventName, 'PreToolUse');
+  assert.strictEqual(out.hookSpecificOutput.updatedInput.command, 'egc run git log --oneline -50');
+});
+
+runCase('updatedInput preserves other tool_input fields', () => {
+  const original = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'git log', description: 'x' } });
+  const final = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'egc run git log', description: 'x' } });
+  const out = JSON.parse(toPreToolUseOutput(original, final));
+  assert.strictEqual(out.hookSpecificOutput.updatedInput.description, 'x');
+});
+
+runCase('an unchanged command passes through untouched', () => {
+  const raw = bashInput('ls -la');
+  assert.strictEqual(toPreToolUseOutput(raw, raw), raw);
+});
+
+runCase('a deny output is forwarded verbatim, not re-wrapped', () => {
+  const original = bashInput('rm -rf /');
+  const deny = JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: 'no' } });
+  assert.strictEqual(toPreToolUseOutput(original, deny), deny);
+});
+
+runCase('a legacy decision:block output is forwarded verbatim', () => {
+  const original = bashInput('git push');
+  const block = JSON.stringify({ decision: 'block', reason: 'nope' });
+  assert.strictEqual(toPreToolUseOutput(original, block), block);
+});
+
+runCase('malformed final JSON fails open (returned verbatim)', () => {
+  assert.strictEqual(toPreToolUseOutput(bashInput('git log'), 'not json'), 'not json');
+});
+
+runCase('malformed original JSON fails open', () => {
+  const final = bashInput('egc run git log');
+  assert.strictEqual(toPreToolUseOutput('not json', final), final);
+});
+
+runCase('non-bash input without a command is passed through', () => {
+  const original = JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/a' } });
+  const final = original;
+  assert.strictEqual(toPreToolUseOutput(original, final), final);
+});
+
+// Integration: spawn the dispatcher end to end with the gates disabled so the
+// crusher runs, and confirm a real git log comes back as an updatedInput rewrite.
+runCase('dispatcher end-to-end wraps a crushed command as updatedInput', () => {
+  const r = spawnSync('node', [DISPATCHER, 'pre'], {
+    input: bashInput('git log --oneline -50'),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      EGC_ASSUME_EGC_CLI: '1',
+      EGC_HOOK_PROFILE: 'standard',
+      EGC_DISABLED_HOOKS: 'pre:bash:gateguard-fact-force,pre:bash:guardian-validate,pre:bash:verification-gate,pre:bash:block-no-verify,pre:bash:commit-quality',
+    },
+  });
+  const out = JSON.parse(r.stdout);
+  assert.strictEqual(out.hookSpecificOutput.updatedInput.command, 'egc run git log --oneline -50');
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/integration/hooks.test.js
+++ b/tests/integration/hooks.test.js
@@ -359,7 +359,11 @@ async function runTests() {
     const output = result.stdout.trim();
     if (output) {
       const parsed = JSON.parse(output);
-      assert.ok(parsed.tool_input, 'Should output valid JSON with tool_input');
+      // A transformed command now comes back as hookSpecificOutput.updatedInput
+      // (the schema hosts actually apply); an untouched command stays a bare
+      // tool_input echo. Either is valid output.
+      const command = parsed.hookSpecificOutput?.updatedInput?.command ?? parsed.tool_input?.command;
+      assert.ok(command, 'Should output a command via updatedInput or tool_input');
     }
   })) passed++; else failed++;
 
@@ -543,8 +547,10 @@ async function runTests() {
     const output = result.stdout.trim();
     if (output) {
       const parsed = JSON.parse(output);
-      assert.ok(parsed.tool_input, 'Should output valid JSON with tool_input');
-      assert.ok(parsed.tool_input.command, 'Should have a command in output');
+      // A transform now returns hookSpecificOutput.updatedInput; a passthrough
+      // stays a bare tool_input echo. Accept either and require a command.
+      const command = parsed.hookSpecificOutput?.updatedInput?.command ?? parsed.tool_input?.command;
+      assert.ok(command, 'Should output a command via updatedInput or tool_input');
     }
   })) passed++; else failed++;
 


### PR DESCRIPTION
## The bug: the crusher never actually rewrote anything

The Token Crusher's rewrite is delivered by the pre-bash hook chain, which transforms input JSON to input JSON. A rewrite ended up as a bare `{"tool_name":"Bash","tool_input":{"command":"egc run ..."}}` object written to stdout.

But hosts do **not** apply a rewrite in that shape. Claude Code, Codex and CodeBuddy only honor a rewrite returned as:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":{"command":"egc run ..."}}}
```

So the bare echo was silently ignored and the **original** command ran. The crusher only ever compressed output when a command was typed with an explicit `egc run` prefix. Evidence: the local ledger (`egc gain`) showed **a single crushed run, ever**, despite the hook being installed. An end-to-end probe confirmed the dispatcher emitted the bare echo, never `hookSpecificOutput`.

## The fix

`toPreToolUseOutput(originalRaw, finalRaw)` in the dispatcher wraps a **genuine** rewrite (final command differs from the original) in the `hookSpecificOutput.updatedInput` envelope the hosts read. Everything else is forwarded untouched:

- deny / ask / context outputs (already in host schema) pass through verbatim
- unchanged commands pass through
- any JSON parse failure is fail-open (chain output emitted verbatim)

Both PreToolUse entry points (`bash-hook-dispatcher.js` and `pre-bash-dispatcher.js`) share the wrapper. Deny (GateGuard) already emitted the correct schema and is unaffected.

## Why it matters beyond Claude

`updatedInput.command` is the **same** rewrite schema Codex and CodeBuddy use. This fix makes the crusher actually fire on Claude Code today and unifies the output format for the multi-host propagation (Phase B) that follows.

## Tests

- `tests/hooks/bash-dispatcher-rewrite-output.test.js`: rewrite is wrapped; other tool_input fields preserved; unchanged/deny/`decision:block`/non-bash/malformed all pass through; **end-to-end** spawn of the dispatcher proves a real `git log` returns as `updatedInput` -> `egc run git log`.
- Full suite green, lint clean. **No version bump.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Token Crusher so rewritten bash commands are returned as PreToolUse `hookSpecificOutput.updatedInput`, making hosts apply rewrites instead of running the original command. Deny/ask/context outputs and unchanged commands pass through; parse errors fail open.

- **Bug Fixes**
  - Added `toPreToolUseOutput` to wrap genuine rewrites into the PreToolUse `updatedInput` envelope; all other outputs pass through and parsing is fail-open.
  - Shared the wrapper across `scripts/hooks/bash-hook-dispatcher.js` and `scripts/hooks/pre-bash-dispatcher.js`; updated dev-server integration tests to read `updatedInput` (including auto-tmux-dev) with fallback to bare `tool_input`, and added an end-to-end dispatcher test.

<sup>Written for commit 900726545ff5115e3a52d0941a673f7fd403215b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

