### PR TITLE
feat(crusher): propagate the Token Crusher to Codex and CodeBuddy

### DIFF
--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -3,6 +3,7 @@
 
 const { isHookEnabled } = require('../lib/hook-flags');
 const { trace } = require('../lib/utils');
+const { toPreToolUseOutput } = require('./pretooluse-output');
 
 const { run: runGuardianValidate } = require('./pre-bash-guardian-validate');
 const { run: runBlockNoVerify } = require('./block-no-verify');
@@ -179,47 +180,6 @@ function runPreBash(rawInput) {
 
 function runPostBash(rawInput) {
   return runHooks(rawInput, POST_BASH_HOOKS);
-}
-
-// The pre-bash hooks chain input JSON to input JSON, so a rewrite leaves the
-// command changed inside a bare `{tool_name, tool_input}` object. Hosts
-// (Claude Code, Codex, CodeBuddy) ignore that shape and run the original
-// command; a rewrite only takes effect when returned as
-// `hookSpecificOutput.updatedInput`. This wraps a genuine rewrite in that
-// envelope while forwarding deny/ask/context outputs and unchanged commands
-// untouched. Fail-open: any parse failure emits the chain output verbatim.
-function toPreToolUseOutput(originalRaw, finalRaw) {
-  let original;
-  let final;
-  try {
-    original = JSON.parse(originalRaw);
-    final = JSON.parse(finalRaw);
-  } catch {
-    return finalRaw;
-  }
-
-  // A hook that denied, asked, or added context already speaks the host's
-  // hook-output schema; forward it verbatim.
-  if (final && typeof final === 'object'
-    && (final.hookSpecificOutput || final.decision || final.continue === false)) {
-    return finalRaw;
-  }
-
-  const originalCommand = original && original.tool_input && original.tool_input.command;
-  const finalCommand = final && final.tool_input && final.tool_input.command;
-
-  if (typeof finalCommand === 'string'
-    && typeof originalCommand === 'string'
-    && finalCommand !== originalCommand) {
-    return JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        updatedInput: final.tool_input,
-      },
-    });
-  }
-
-  return finalRaw;
 }
 
 async function main() {

--- a/scripts/hooks/crusher-hook.js
+++ b/scripts/hooks/crusher-hook.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+'use strict';
+
+// Standalone Token Crusher hook for hosts other than Claude Code that support
+// PreToolUse command rewriting through hooks.json (Codex, CodeBuddy, ...).
+// Claude Code runs the crusher inside the full bash-hook-dispatcher chain; the
+// other hosts install only this single hook. It reuses the shared rewrite
+// decision (pre-bash-crusher-rewrite) and the hookSpecificOutput.updatedInput
+// envelope so a crushable command is routed through `egc run` before it runs.
+// Fail-open: anything not rewritten (or any error) passes through untouched, so
+// a host that ignores updatedInput simply runs the original command.
+
+const { run: runCrusherRewrite } = require('./pre-bash-crusher-rewrite');
+const { toPreToolUseOutput } = require('./pretooluse-output');
+
+function run(rawInput) {
+  try {
+    return toPreToolUseOutput(rawInput, runCrusherRewrite(rawInput));
+  } catch {
+    return typeof rawInput === 'string' ? rawInput : JSON.stringify(rawInput);
+  }
+}
+
+const MAX_STDIN = 1024 * 1024;
+
+function main() {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    process.stdout.write(run(raw));
+    process.exit(0);
+  });
+  process.stdin.on('error', () => {
+    process.stdout.write(raw);
+    process.exit(0);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { run };

--- a/scripts/hooks/pretooluse-output.js
+++ b/scripts/hooks/pretooluse-output.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Shared PreToolUse output envelope for command-rewriting hooks.
+//
+// The pre-bash hook chain transforms input JSON to input JSON, so a rewrite
+// leaves the command changed inside a bare `{tool_name, tool_input}` object.
+// Hosts (Claude Code, Codex, CodeBuddy) ignore that shape and run the original
+// command; a rewrite only takes effect when returned as
+// `hookSpecificOutput.updatedInput`. This wraps a genuine rewrite in that
+// envelope while forwarding deny/ask/context outputs and unchanged commands
+// untouched. Fail-open: any parse failure emits the chain output verbatim.
+function toPreToolUseOutput(originalRaw, finalRaw) {
+  let original;
+  let final;
+  try {
+    original = JSON.parse(originalRaw);
+    final = JSON.parse(finalRaw);
+  } catch {
+    return finalRaw;
+  }
+
+  // A hook that denied, asked, or added context already speaks the host's
+  // hook-output schema; forward it verbatim.
+  if (final && typeof final === 'object'
+    && (final.hookSpecificOutput || final.decision || final.continue === false)) {
+    return finalRaw;
+  }
+
+  const originalCommand = original && original.tool_input && original.tool_input.command;
+  const finalCommand = final && final.tool_input && final.tool_input.command;
+
+  if (typeof finalCommand === 'string'
+    && typeof originalCommand === 'string'
+    && finalCommand !== originalCommand) {
+    return JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        updatedInput: final.tool_input,
+      },
+    });
+  }
+
+  return finalRaw;
+}
+
+module.exports = { toPreToolUseOutput };

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -31,6 +31,8 @@ const ROUTER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/prompt-router.js'
 const ROUTER_HOOK_MODULE_ID = 'claude-prompt-router-hook';
 const GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/gateguard-fact-force.js';
 const GATEGUARD_HOOK_MODULE_ID = 'claude-gateguard-fact-force-hook';
+const CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/crusher-hook.js';
+const CRUSHER_HOOK_MODULE_ID = 'egc-crusher-hook';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -635,6 +637,49 @@ function createGateGuardScriptCopyOperations(createRemappedOperation, targetRoot
   ];
 }
 
+// Token Crusher hook (crusher-hook.js): standalone PreToolUse rewrite for hosts
+// other than Claude Code that read hooks.json with the same schema (Codex,
+// CodeBuddy). Its dependency tree is crusher-hook.js -> pre-bash-crusher-rewrite
+// -> lib/crusher/engine, plus the shared pretooluse-output envelope. All are
+// scaffolded together, preserving their relative paths so the requires resolve.
+const CRUSHER_HOOK_LIB_SOURCES = [
+  'scripts/hooks/pre-bash-crusher-rewrite.js',
+  'scripts/hooks/pretooluse-output.js',
+  'scripts/lib/crusher/engine.js',
+];
+
+function resolveCrusherHookScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'crusher-hook.js');
+}
+
+function createPreToolUseCrusherHookMergeOperation(targetRoot, matcher) {
+  const hookScriptPath = resolveCrusherHookScriptDestination(targetRoot);
+  return buildPreToolUseMergeOperation(
+    targetRoot,
+    CRUSHER_HOOK_MODULE_ID,
+    CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    hookScriptPath,
+    matcher
+  );
+}
+
+function createCrusherScriptCopyOperations(createRemappedOperation, targetRoot) {
+  return [
+    createRemappedOperation(
+      CRUSHER_HOOK_MODULE_ID,
+      CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveCrusherHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ),
+    ...CRUSHER_HOOK_LIB_SOURCES.map(src => createRemappedOperation(
+      CRUSHER_HOOK_MODULE_ID,
+      src,
+      path.join(targetRoot, ...src.split('/')),
+      { strategy: 'preserve-relative-path' }
+    )),
+  ];
+}
+
 // Same merge operation shape as above, but for targets whose hooks.json
 // location cannot be derived from resolveSettingsPath(targetRoot) the way
 // Claude Code's can (e.g. Copilot's ~/.copilot/hooks/hooks.json, or
@@ -661,6 +706,8 @@ module.exports = {
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
+  CRUSHER_HOOK_MODULE_ID,
+  CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -697,6 +744,9 @@ module.exports = {
   createPreToolUseBashDispatcherHookMergeOperation,
   createGateGuardScriptCopyOperations,
   createPreToolUseGateGuardHookMergeOperation,
+  createCrusherScriptCopyOperations,
+  createPreToolUseCrusherHookMergeOperation,
+  resolveCrusherHookScriptDestination,
   createPreToolUseWriteValidatorHookMergeOperation,
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -3,11 +3,14 @@ const path = require('node:path');
 const {
   createFlatRuleOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
   isForeignPlatformPath,
   planFlatSkillOperation,
 } = require('./helpers');
 const {
   createPreToolUseGateGuardHookMergeOperation,
+  createPreToolUseCrusherHookMergeOperation,
+  createCrusherScriptCopyOperations,
 } = require('../claude-settings-hooks');
 
 // CodeBuddy's PreToolUse hooks read from <project>/.codebuddy/settings.json
@@ -17,12 +20,23 @@ const {
 // same root the hooks-runtime module scaffolds scripts/hooks/
 // gateguard-fact-force.js and scripts/lib/utils.js into. So the generic
 // Claude merge helper is reusable here without modification.
-function createGateGuardOperations(targetRoot) {
+function createHookOperations(adapter, targetRoot) {
   return [
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'MultiEdit'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Bash'),
+    // Token Crusher: CodeBuddy reads the same hooks.json schema as Claude Code,
+    // so an updatedInput rewrite applies. Scaffold the standalone crusher hook
+    // and its dependency tree explicitly (no content module carries them) and
+    // register it on Bash only, where there is shell output to compress.
+    ...createCrusherScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) => (
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+      ),
+      targetRoot
+    ),
+    createPreToolUseCrusherHookMergeOperation(targetRoot, 'Bash'),
   ];
 }
 
@@ -80,7 +94,7 @@ module.exports = createInstallTargetAdapter({
     // mirroring Claude Code's always-on hook registration.
     return [
       ...moduleOperations,
-      ...createGateGuardOperations(targetRoot),
+      ...createHookOperations(adapter, targetRoot),
     ];
   },
 });

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -10,9 +10,12 @@ const {
 const {
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  CRUSHER_HOOK_MODULE_ID,
+  CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   HOOK_OPERATION_KIND,
   PRE_TOOL_USE_EVENT,
   createGateGuardScriptCopyOperations,
+  createCrusherScriptCopyOperations,
 } = require('../claude-settings-hooks');
 
 // Codex CLI's skills root (~/.agents, this adapter's own resolveRoot()) and
@@ -39,11 +42,11 @@ function resolveCodexHome(input) {
   return path.join(input.homeDir || os.homedir(), '.codex');
 }
 
-function buildCodexPreToolUseMergeOperation(codexHome, hookScriptPath, matcher) {
+function buildCodexPreToolUseMergeOperation(codexHome, moduleId, sourceRelativePath, hookScriptPath, matcher) {
   return {
     kind: HOOK_OPERATION_KIND,
-    moduleId: GATEGUARD_HOOK_MODULE_ID,
-    sourceRelativePath: GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    moduleId,
+    sourceRelativePath,
     destinationPath: path.join(codexHome, 'hooks.json'),
     strategy: HOOK_OPERATION_KIND,
     ownership: 'managed',
@@ -67,10 +70,41 @@ function createCodexGateGuardOperations(adapter, codexHome) {
   // are matcher aliases only, per codex-rs/core/src/tools/hook_names.rs);
   // "Bash" is used verbatim for both the legacy shell tool and unified_exec.
   const mergeOperations = ['apply_patch', 'Bash'].map(matcher => (
-    buildCodexPreToolUseMergeOperation(codexHome, hookScriptPath, matcher)
+    buildCodexPreToolUseMergeOperation(
+      codexHome,
+      GATEGUARD_HOOK_MODULE_ID,
+      GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      hookScriptPath,
+      matcher
+    )
   ));
 
   return [...copyOperations, ...mergeOperations];
+}
+
+// Token Crusher for Codex: Codex reads the same hooks.json schema as Claude
+// Code, so a crusher-hook.js rewrite returned as
+// hookSpecificOutput.updatedInput.command is applied before the command runs.
+// Only the Bash matcher: the crusher compresses shell output, and apply_patch
+// is a file edit with nothing to crush.
+function createCodexCrusherOperations(adapter, codexHome) {
+  const hookScriptPath = path.join(codexHome, 'scripts', 'hooks', 'crusher-hook.js');
+  const copyOperations = createCrusherScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    codexHome
+  );
+
+  const mergeOperation = buildCodexPreToolUseMergeOperation(
+    codexHome,
+    CRUSHER_HOOK_MODULE_ID,
+    CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    hookScriptPath,
+    'Bash'
+  );
+
+  return [...copyOperations, mergeOperation];
 }
 
 module.exports = createInstallTargetAdapter({
@@ -102,9 +136,11 @@ module.exports = createInstallTargetAdapter({
       return paths.map(sourceRelativePath => planFlatSkillOperation(adapter, module.id, sourceRelativePath, planningInput, targetRoot));
     });
 
+    const codexHome = resolveCodexHome(planningInput);
     return [
       ...moduleOperations,
-      ...createCodexGateGuardOperations(adapter, resolveCodexHome(planningInput)),
+      ...createCodexGateGuardOperations(adapter, codexHome),
+      ...createCodexCrusherOperations(adapter, codexHome),
     ];
   },
 });

--- a/tests/hooks/crusher-hook.test.js
+++ b/tests/hooks/crusher-hook.test.js
@@ -1,0 +1,74 @@
+'use strict';
+/**
+ * Tests for scripts/hooks/crusher-hook.js: the standalone Token Crusher hook
+ * installed on hosts other than Claude Code (Codex, CodeBuddy). It reuses the
+ * crusher rewrite decision and returns a genuine rewrite as
+ * hookSpecificOutput.updatedInput, so the host applies `egc run` before the
+ * command executes. Everything else passes through untouched (fail-open).
+ *
+ * Run with: node tests/hooks/crusher-hook.test.js
+ */
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { run } = require(path.join(__dirname, '..', '..', 'scripts', 'hooks', 'crusher-hook.js'));
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const runCase = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+const bashInput = command => JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+const POSIX = process.platform !== 'win32';
+
+console.log('\n=== Testing crusher-hook (standalone) ===\n');
+
+process.env.EGC_ASSUME_EGC_CLI = '1';
+
+runCase('a crushable command is returned as hookSpecificOutput.updatedInput', () => {
+  const out = JSON.parse(run(bashInput('git log --oneline -50')));
+  assert.strictEqual(out.hookSpecificOutput.hookEventName, 'PreToolUse');
+  assert.strictEqual(out.hookSpecificOutput.updatedInput.command, 'egc run git log --oneline -50');
+});
+
+runCase('a generic command passes through untouched', () => {
+  const raw = bashInput('ls -la src');
+  assert.strictEqual(run(raw), raw);
+});
+
+runCase('an already-wrapped egc run command passes through', () => {
+  const raw = bashInput('egc run git log');
+  assert.strictEqual(run(raw), raw);
+});
+
+runCase('malformed input fails open (returned verbatim)', () => {
+  assert.strictEqual(run('not json'), 'not json');
+});
+
+runCase('without the egc CLI nothing is rewritten', () => {
+  process.env.EGC_ASSUME_EGC_CLI = '0';
+  const raw = bashInput('git log --oneline -50');
+  assert.strictEqual(run(raw), raw);
+  process.env.EGC_ASSUME_EGC_CLI = '1';
+});
+
+if (POSIX) {
+  runCase('a recognized pipeline is wrapped via egc run --shell', () => {
+    const out = JSON.parse(run(bashInput("git log | head -5")));
+    assert.strictEqual(out.hookSpecificOutput.updatedInput.command, "egc run --shell 'git log | head -5'");
+  });
+}
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -720,6 +720,44 @@ function runTests() {
     assert.ok(libCopyOperation, 'Should copy gateguard-fact-force.js\'s only dependency alongside it');
   })) passed++; else failed++;
 
+  if (test('codex adapter also wires the Token Crusher into ~/.codex/hooks.json on the Bash matcher', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codex',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+
+    const codexHome = path.join(homeDir, '.codex');
+    const crusherScriptPath = path.join(codexHome, 'scripts', 'hooks', 'crusher-hook.js');
+
+    const crusherHookOps = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.hookScriptPath === crusherScriptPath
+    ));
+    assert.strictEqual(crusherHookOps.length, 1, 'Crusher is registered once, on Bash only (apply_patch has nothing to crush)');
+    assert.strictEqual(crusherHookOps[0].hookMatcher, 'Bash');
+    assert.strictEqual(crusherHookOps[0].destinationPath, path.join(codexHome, 'hooks.json'));
+
+    // The whole crusher dependency tree must be scaffolded so the requires resolve.
+    for (const src of [
+      'scripts/hooks/crusher-hook.js',
+      'scripts/hooks/pre-bash-crusher-rewrite.js',
+      'scripts/hooks/pretooluse-output.js',
+      'scripts/lib/crusher/engine.js',
+    ]) {
+      const op = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === src
+        && operation.destinationPath === path.join(codexHome, ...src.split('/'))
+      ));
+      assert.ok(op, `Should scaffold ${src} into ~/.codex`);
+    }
+  })) passed++; else failed++;
+
   for (const [target, expectedRootSegments] of [['continue', ['.continue']], ['continue-project', ['.continue']]]) {
     if (test(`${target} adapter wires GateGuard PreToolUse for Edit/Write/MultiEdit/Bash into settings.json`, () => {
       const repoRoot = path.join(__dirname, '..', '..');
@@ -1510,6 +1548,42 @@ function runTests() {
       ['Bash', 'Edit', 'MultiEdit', 'Write'],
       'GateGuard should be registered on Edit, Write, MultiEdit and Bash for CodeBuddy'
     );
+  })) passed++; else failed++;
+
+  if (test('codebuddy adapter also registers the Token Crusher on Bash at .codebuddy/settings.json', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codebuddy',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+    const settingsPath = path.join(projectRoot, '.codebuddy', 'settings.json');
+    const crusherScriptPath = path.join(projectRoot, '.codebuddy', 'scripts', 'hooks', 'crusher-hook.js');
+
+    const crusherOps = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === settingsPath
+      && operation.hookScriptPath === crusherScriptPath
+    ));
+    assert.strictEqual(crusherOps.length, 1, 'Crusher registered once, on Bash');
+    assert.strictEqual(crusherOps[0].hookMatcher, 'Bash');
+
+    for (const src of [
+      'scripts/hooks/crusher-hook.js',
+      'scripts/hooks/pre-bash-crusher-rewrite.js',
+      'scripts/hooks/pretooluse-output.js',
+      'scripts/lib/crusher/engine.js',
+    ]) {
+      const op = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === src
+        && operation.destinationPath === path.join(projectRoot, '.codebuddy', ...src.split('/'))
+      ));
+      assert.ok(op, `Should scaffold ${src} into .codebuddy`);
+    }
   })) passed++; else failed++;
 
   if (test('antigravity-project adapter registers the GateGuard fact-force hook at .agents/hooks.json', () => {


### PR DESCRIPTION
## Phase B: the Token Crusher goes multi-host

Now that the rewrite is emitted as `hookSpecificOutput.updatedInput` (#958), the same envelope works on every host that reads the Claude-style hooks.json schema. This wires the crusher into the two hosts whose rewrite support is verified: **Codex** (`~/.codex/hooks.json`) and **CodeBuddy** (`.codebuddy/settings.json`).

## What

- **`scripts/hooks/crusher-hook.js`**: a standalone PreToolUse hook for non-Claude hosts. It reuses the crusher rewrite decision (`pre-bash-crusher-rewrite`) and the shared `pretooluse-output` envelope, returning a crushable command as `updatedInput.command = "egc run ..."`. **Fail-open**: anything not rewritten (or any error) passes through untouched, so a host that ignores `updatedInput` simply runs the original command, no harm.
- **`scripts/hooks/pretooluse-output.js`**: `toPreToolUseOutput` extracted from the dispatcher into a shared module, so the standalone hook does not pull the whole hook chain. The dispatcher now imports and re-exports it (no behavior change).
- **Installers**: Codex and CodeBuddy scaffold `crusher-hook.js` + its dependency tree (`pre-bash-crusher-rewrite`, `pretooluse-output`, `lib/crusher/engine`) and register the hook on the **Bash** matcher only (apply_patch/edits have nothing to crush).

## Why only Bash and only these two hosts

- Bash: the crusher compresses shell output; file-edit tools produce none.
- Codex is verified against the OpenAI hooks docs (`updatedInput.command`); CodeBuddy documents the same hooks.json schema as Claude Code. **Copilot, Antigravity and Continue** use different hook settings formats (`copilot-settings-hooks`, `antigravity-settings-hooks`, `continue-gateguard-hooks`) and need per-host verification before wiring, so they are deliberately left for a follow-up rather than wired blindly.

## Tests

- `tests/hooks/crusher-hook.test.js`: rewrite -> `updatedInput`, pipeline -> `egc run --shell`, generic/wrapped/malformed/no-egc-CLI all pass through.
- `tests/lib/install-targets.test.js`: Codex and CodeBuddy each register the crusher once on Bash and scaffold the whole dependency tree.
- Full suite green (reproduced the CI Ubuntu tmux path locally), lint clean. **No version bump.**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone Token Crusher hook for Codex and CodeBuddy that rewrites Bash commands via `hookSpecificOutput.updatedInput` so they run through `egc run`. This brings crusher support to both hosts with fail-open behavior, Bash-only.

- **New Features**
  - Added `scripts/hooks/crusher-hook.js` that reuses `pre-bash-crusher-rewrite` and wraps rewrites with `toPreToolUseOutput` (fail-open passthrough on no-change/errors).
  - Updated installers:
    - Codex (`~/.codex/hooks.json`): scaffolds `crusher-hook.js` + deps (`pre-bash-crusher-rewrite`, `pretooluse-output`, `lib/crusher/engine`) and registers on `Bash`.
    - CodeBuddy (`.codebuddy/settings.json`): scaffolds the same tree and registers on `Bash`.
  - Extended `scripts/lib/claude-settings-hooks.js` with Crusher constants and helper ops to copy/register the hook.
  - Intentional exclusions: Copilot, Antigravity, Continue use different hook formats and will be handled separately.

- **Refactors**
  - Extracted `toPreToolUseOutput` into `scripts/hooks/pretooluse-output.js`; `bash-hook-dispatcher` now imports it (no behavior change).

<sup>Written for commit 59272c79dea3bef5311c9a86c8d09274287f4902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

