### PR TITLE
feat(install): add native Qwen Code install target

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -12,7 +12,7 @@ EGC supports 20 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 20 harnesses
+## The 21 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -36,6 +36,7 @@ EGC supports 20 AI coding tools through 3 distinct integration mechanisms. This 
 | 18 | **OpenHands** | 1 | `openhands` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex/Goose) | Skills installed flat; no GateGuard hook wiring; discoverability-only adapter -- the issue asked for `.openhands/microagents/`, but current OpenHands docs recommend the AgentSkills-standard `.agents/skills/<name>/SKILL.md` path (legacy `.openhands/microagents/` still works but isn't the documented target), so this mirrors the Goose adapter instead |
 | 19 | **Aider** | 1 | `aider` | `.aider/skills/<name>.md` (project only, no home target) | Skills copied flat as single `.md` files (Aider does not scan a skill-folder convention); each file's path is merged into the `read:` list of `.aider.conf.yml` via a new `merge-yaml-read-list` operation kind, preserving any unrelated existing keys; install/repair/uninstall all wired |
 | 20 | **Warp** | 1 | `warp` | `.warp/skills/<name>.md` + index in project root `AGENTS.md` (project only, no home target) | Warp only discovers a single root `AGENTS.md`/`WARP.md` file as project rules, not a directory of skill files -- confirmed a plain `AGENTS.md` is sufficient (Warp's own docs call it the default project rules file; `WARP.md` is legacy and only takes priority if both exist). Full skill content is copied flat to `.warp/skills/<name>.md` (read on demand); a short index (name + one-line description + path) is merged into a marked block inside `AGENTS.md` via a new `merge-markdown-skill-index` operation kind, since concatenating all 230+ skills (~2MB) into the always-loaded rules file would blow the context budget. Install/repair/uninstall all wired; uninstall never deletes `AGENTS.md` itself, only the EGC block |
+| 21 | **Qwen Code** | 1 | `qwen` | `.qwen/skills/<name>/SKILL.md` (project only, no home target) | Skills installed flat with the source category stripped; Qwen Code discovers project skills natively from `.qwen/skills/`; no hook wiring |
 
 ## Why three tiers (history, not aspiration)
 

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -24,6 +24,7 @@
         "antigravity",
         "codex",
         "gemini",
+        "qwen",
         "opencode",
         "codebuddy",
         "windsurf",

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('node:path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'openhands', 'aider', 'warp'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'qwen', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'openhands', 'aider', 'warp'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/qwen-project.js
+++ b/scripts/lib/install-targets/qwen-project.js
@@ -1,0 +1,16 @@
+const {
+  createFlatSkillPlanOperations,
+  createInstallTargetAdapter,
+} = require('./helpers');
+
+// Qwen Code discovers project skills from
+// .qwen/skills/<skill-name>/SKILL.md.
+module.exports = createInstallTargetAdapter({
+  id: 'qwen-project',
+  target: 'qwen',
+  kind: 'project',
+  rootSegments: ['.qwen'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.qwen',
+  planOperations: createFlatSkillPlanOperations,
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -10,6 +10,7 @@ const geminiProject = require('./gemini-project');
 const gooseHome = require('./goose-home');
 const kiroHome = require('./kiro-home');
 const openhandsHome = require('./openhands-home');
+const qwenProject = require('./qwen-project');
 const kiroProject = require('./kiro-project');
 const opencodeHome = require('./opencode-home');
 const windsurfHome = require('./windsurf-home');
@@ -34,6 +35,7 @@ const ADAPTERS = Object.freeze([
   codexHome,
   gooseHome,
   openhandsHome,
+  qwenProject,
   geminiProject,
   opencodeHome,
   codebuddyProject,

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1988,6 +1988,77 @@ function runTests() {
     assert.ok(targets.includes('aider'), 'Should include aider target');
   })) passed++; else failed++;
 
+  if (test('resolves qwen adapter root and install-state path from project root', () => {
+    const adapter = getInstallTargetAdapter('qwen');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'qwen-project');
+    assert.strictEqual(adapter.target, 'qwen');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.qwen'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.qwen', 'egc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('qwen adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('qwen');
+    const byId = getInstallTargetAdapter('qwen-project');
+
+    assert.strictEqual(byTarget.id, 'qwen-project');
+    assert.strictEqual(byId.id, 'qwen-project');
+    assert.ok(byTarget.supports('qwen'));
+    assert.ok(byTarget.supports('qwen-project'));
+  })) passed++; else failed++;
+
+  if (test('qwen adapter installs skills into the native .qwen/skills directory', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'qwen',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'testing', paths: ['skills/testing/tdd-workflow'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'qwen-project');
+    assert.strictEqual(plan.operations.length, 1);
+
+    const operation = plan.operations[0];
+    assert.strictEqual(operation.kind, 'copy-path');
+    assert.strictEqual(
+      normalizedRelativePath(operation.sourceRelativePath),
+      'skills/testing/tdd-workflow'
+    );
+    assert.strictEqual(
+      operation.destinationPath,
+      path.join(projectRoot, '.qwen', 'skills', 'tdd-workflow')
+    );
+  })) passed++; else failed++;
+
+  if (test('qwen adapter passes non-skill paths through and appears in the adapter list', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'qwen',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'rules-core', paths: ['rules'] }],
+    });
+
+    assert.strictEqual(plan.operations.length, 1);
+    assert.strictEqual(
+      plan.operations[0].destinationPath,
+      path.join(projectRoot, '.qwen', 'rules')
+    );
+    assert.ok(
+      listInstallTargetAdapters().some(adapter => adapter.target === 'qwen'),
+      'Should include qwen target'
+    );
+  })) passed++; else failed++;
+
   if (test('resolves warp adapter root and install-state path from project root', () => {
     const adapter = getInstallTargetAdapter('warp');
     const projectRoot = '/workspace/app';

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -17,6 +17,7 @@ const EXPECTED_HARNESSES = [
   'Claude Code',
   'Antigravity',
   'Gemini CLI',
+  'Qwen Code',
   'Cursor',
   'Codex CLI',
   'OpenCode',
@@ -36,7 +37,7 @@ const EXPECTED_HARNESSES = [
   'Zed',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'openhands', 'aider', 'warp'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'qwen', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'openhands', 'aider', 'warp'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## What Changed

- Added a native `qwen-project` install target
- Install project skills under `.qwen/skills/<name>/SKILL.md`
- Registered `qwen` in the adapter registry, supported target list, and config schema
- Added install-target tests and updated the integration-tier contract

## Why This Change

Qwen Code natively discovers project Agent Skills from `.qwen/skills/<skill-name>/SKILL.md`, so EGC can install its skills directly into Qwen Code's documented discovery path.

Official documentation used to verify the path:

https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/

## Testing Done

- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes, a concurrent-access test was added or updated

## Type of Change

- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `refactor`: Code refactoring
- [x] `docs`: Documentation
- [x] `test`: Tests
- [ ] `chore`: Maintenance/tooling
- [ ] `ci`: CI/CD changes

Fixes #845

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native `qwen` install target so EGC installs project Agent Skills into Qwen Code’s discovery path. Qwen Code now picks up skills from `.qwen/skills/<name>/SKILL.md` without custom scripts.

- **New Features**
  - Added adapter `qwen-project` (project-only), root `.qwen`, install state `.qwen/egc-install-state.json`.
  - Registered in the adapter registry; added `qwen` to supported targets and `schemas/egc-install-config.schema.json`.
  - Updated integration tiers doc and tests: now 22 harnesses; Qwen Code listed; Tier 1 targets include `qwen`.
  - Added tests for adapter lookup, root/state paths, native copy-plan to `.qwen/skills/<name>`, pass-through for non-skill paths, and adapter listing.

<sup>Written for commit 40def64901245b048bab8999f62949c7785c3c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

