### PR TITLE
feat(dashboard): honor EGC_PORT instead of hardcoding port 7890

### DIFF
--- a/.cursor/hooks/dashboard-emit.js
+++ b/.cursor/hooks/dashboard-emit.js
@@ -4,6 +4,12 @@
 const { readStdin } = require('./adapter');
 const http = require('http');
 
+// Resolve port inline — this hook may be installed outside the repo tree,
+// so a relative require to dashboard/port.js is not safe.
+const _egcRaw = process.env.EGC_PORT;
+const _egcParsed = (_egcRaw && /^\d+$/.test(_egcRaw)) ? Number(_egcRaw) : NaN;
+const PORT = (!Number.isNaN(_egcParsed) && _egcParsed >= 1 && _egcParsed <= 65535) ? _egcParsed : 7890;
+
 readStdin().then(raw => {
   try {
     const input = JSON.parse(raw || '{}');
@@ -14,7 +20,7 @@ readStdin().then(raw => {
 
     const ev = JSON.stringify({ ide:'cursor', event, tool, agent, detail:file, status: event==='pre_tool'?'running':'success' });
     const req = http.request(
-      { hostname:'127.0.0.1', port:7890, path:'/event', method:'POST',
+      { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
         headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(ev)},
         timeout:300 },
       ()=>{}

--- a/dashboard/aider-watcher.js
+++ b/dashboard/aider-watcher.js
@@ -6,6 +6,7 @@ const path = require('path');
 const http = require('http');
 const os   = require('os');
 const { readFileDelta } = require('./read-file-delta');
+const { PORT } = require('./port');
 
 const WATCH_PATHS = [
   path.join(os.homedir(), '.aider.chat.history.md'),
@@ -13,7 +14,6 @@ const WATCH_PATHS = [
   path.join(process.cwd(), '.aider.chat.history.md'),
 ];
 
-const PORT = 7890;
 let lastSizes = {};
 
 function post(ev) {

--- a/dashboard/codebuddy-adapter.js
+++ b/dashboard/codebuddy-adapter.js
@@ -4,8 +4,7 @@ const http = require('http');
 const fs   = require('fs');
 const path = require('path');
 const os   = require('os');
-
-const PORT = 7890;
+const { PORT } = require('./port');
 const WATCH_PATHS = [
   path.join(os.homedir(), '.codebuddy', 'logs'),
   path.join(os.homedir(), '.config', 'codebuddy', 'logs'),

--- a/dashboard/port.js
+++ b/dashboard/port.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Shared dashboard port helper.
+ *
+ * Read once at require-time so every module in the same process sees the same
+ * value.  Consumers just do:
+ *
+ *   const { PORT } = require('./port');
+ *
+ * Set EGC_PORT in the environment to override the default:
+ *
+ *   EGC_PORT=8123 egc dashboard
+ */
+
+const raw = process.env.EGC_PORT;
+
+// Require the value to be a pure integer string (no leading/trailing chars).
+// parseInt('8123abc', 10) would silently return 8123, so we validate first.
+const parsed = (raw !== undefined && raw !== '' && /^\d+$/.test(raw))
+  ? Number(raw)
+  : NaN;
+
+if (raw !== undefined && raw !== '' && (Number.isNaN(parsed) || parsed < 1 || parsed > 65535)) {
+  process.stderr.write(
+    `[EGC] Warning: EGC_PORT="${raw}" is not a valid port number. Falling back to 7890.\n`
+  );
+}
+
+const PORT = (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 65535) ? parsed : 7890;
+
+module.exports = { PORT };

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1149,7 +1149,7 @@ pollTelemetry();
 /* ── WEBSOCKET ──────────────────────────────────────────── */
 function connect(){
   try{
-    S.ws=new WebSocket('ws://localhost:7890');
+    S.ws=new WebSocket('ws://'+(typeof __EGC_PORT!=='undefined'?'localhost:'+__EGC_PORT:(typeof location!=='undefined'?location.host:'localhost')));
 
     S.ws.onopen=()=>{
       setWs(true);

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -7,8 +7,7 @@ const fs      = require('fs');
 const os      = require('os');
 const { execSync, execFileSync } = require('child_process');
 const { createAccumulator } = require('./accumulator');
-
-const PORT   = 7890;
+const { PORT } = require('./port');
 const PUBLIC = path.join(__dirname, 'public');
 const CFG    = path.join(__dirname, 'config.json');
 
@@ -151,7 +150,7 @@ const clients = new Set();
 const server = http.createServer((req, res) => {
   const reqOrigin = req.headers.origin || '';
   res.setHeader('Access-Control-Allow-Origin',
-    /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(reqOrigin) ? reqOrigin : 'http://localhost:7890');
+    /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(reqOrigin) ? reqOrigin : `http://localhost:${PORT}`);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
@@ -424,7 +423,15 @@ const grandTotal = Object.values(byIde).reduce(
   if (filePath && fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
     const ext = path.extname(filePath);
     res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
-    res.end(fs.readFileSync(filePath));
+    if (segment === '/index.html') {
+      // Inject the configured port so the frontend WebSocket connects to the
+      // correct address regardless of what EGC_PORT is set to.
+      const html = fs.readFileSync(filePath, 'utf8')
+        .replace('</head>', `<script>window.__EGC_PORT=${PORT};</script></head>`);
+      res.end(html);
+    } else {
+      res.end(fs.readFileSync(filePath));
+    }
   } else {
     res.writeHead(404); res.end('Not found');
   }

--- a/dashboard/shim-session.js
+++ b/dashboard/shim-session.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const http = require('http');
+const { PORT } = require('./port');
 
 const IDE   = process.argv[2] || 'trae';
 const EVENT = process.argv[3] || 'session_start';
@@ -9,7 +10,7 @@ const EVENT = process.argv[3] || 'session_start';
 function post(ev) {
   const body = JSON.stringify(ev);
   const req = http.request(
-    { hostname:'127.0.0.1', port:7890, path:'/event', method:'POST',
+    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
       headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
       timeout:300 },
     (res) => {

--- a/dashboard/shim.js
+++ b/dashboard/shim.js
@@ -2,13 +2,14 @@
 'use strict';
 
 const http = require('http');
+const { PORT } = require('./port');
 
 const IDE = process.env.EGC_IDE || process.argv[2] || 'claude';
 
 function post(ev) {
   const body = JSON.stringify(ev);
   const req = http.request(
-    { hostname: '127.0.0.1', port: 7890, path: '/event', method: 'POST',
+    { hostname: '127.0.0.1', port: PORT, path: '/event', method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
       timeout: 300 },
     () => {}

--- a/dashboard/vscode-adapter.js
+++ b/dashboard/vscode-adapter.js
@@ -6,8 +6,7 @@ const fs   = require('fs');
 const path = require('path');
 const os   = require('os');
 const { readFileDelta } = require('./read-file-delta');
-
-const PORT = 7890;
+const { PORT } = require('./port');
 
 const LOG_PATHS = [
   path.join(os.homedir(), '.vscode', 'logs'),

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -6,17 +6,24 @@ const path = require('node:path');
 const http = require('node:http');
 const fs = require('node:fs');
 
-const PORT = 7890;
 const DASHBOARD_DIR = path.join(__dirname, '..', 'dashboard');
 const SERVER_SCRIPT = path.join(DASHBOARD_DIR, 'server.js');
+const PORT_HELPER   = path.join(DASHBOARD_DIR, 'port');
 const PID_FILE = path.join(require('node:os').homedir(), '.egc', 'dashboard.pid');
 
 const args = process.argv.slice(2);
 const flag = args[0];
 
+// Resolve port lazily so a missing dashboard directory produces the friendly
+// "EGC Dashboard not found" error instead of a MODULE_NOT_FOUND crash.
+function getPort() {
+  return require(PORT_HELPER).PORT;
+}
+
 function isRunning() {
+  const port = getPort();
   return new Promise(resolve => {
-    const req = http.get(`http://localhost:${PORT}/ping`, res => {
+    const req = http.get(`http://localhost:${port}/ping`, res => {
       res.resume();
       resolve(res.statusCode === 200);
     });
@@ -26,7 +33,7 @@ function isRunning() {
 }
 
 function openBrowser() {
-  const url = `http://localhost:${PORT}`;
+  const url = `http://localhost:${getPort()}`;
   let cmd;
   if (process.platform === 'win32') {
     cmd = 'start';
@@ -57,6 +64,8 @@ async function start() {
     process.exit(1);
   }
 
+  const PORT = getPort();
+
   const nmDir = path.join(DASHBOARD_DIR, 'node_modules');
   if (!fs.existsSync(nmDir)) {
     console.log('Installing dashboard dependencies...');
@@ -77,6 +86,7 @@ async function start() {
     cwd: DASHBOARD_DIR,
     detached: true,
     stdio: 'ignore',
+    env: { ...process.env, EGC_PORT: String(PORT) },
   });
   child.unref();
   writePid(child.pid);
@@ -125,6 +135,7 @@ async function stop() {
 async function status() {
   const running = await isRunning();
   const pid = readPid();
+  const PORT = getPort();
   if (running) {
     console.log(`running  http://localhost:${PORT}${pid ? '  (pid ' + pid + ')' : ''}`);
   } else {

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -11,6 +11,9 @@ const fs = require('node:fs');
 const http = require('node:http');
 const os = require('node:os');
 const path = require('node:path');
+const _egcRaw = process.env.EGC_PORT;
+const _egcParsed = (_egcRaw && /^\d+$/.test(_egcRaw)) ? Number(_egcRaw) : NaN;
+const DASHBOARD_PORT = (!Number.isNaN(_egcParsed) && _egcParsed >= 1 && _egcParsed <= 65535) ? _egcParsed : 7890;
 // Optional libs: minimal installations may lack them, so a failed require
 // resolves to null and the dependent feature is skipped instead of failing
 // session startup. Run `egc repair` to restore missing libs.
@@ -239,7 +242,7 @@ function loadAndPrintState(projectPath) {
 function postSessionStart(sessionId) {
   const body = JSON.stringify({ ide: 'claude', event: 'session_start', session_id: sessionId });
   const req = http.request(
-    { hostname: '127.0.0.1', port: 7890, path: '/event', method: 'POST',
+    { hostname: '127.0.0.1', port: DASHBOARD_PORT, path: '/event', method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
       timeout: 200 },
     () => process.exit(0)

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -14,6 +14,9 @@ const fs = require('node:fs');
 const http = require('node:http');
 const os = require('node:os');
 const path = require('node:path');
+const _egcRaw = process.env.EGC_PORT;
+const _egcParsed = (_egcRaw && /^\d+$/.test(_egcRaw)) ? Number(_egcRaw) : NaN;
+const DASHBOARD_PORT = (!Number.isNaN(_egcParsed) && _egcParsed >= 1 && _egcParsed <= 65535) ? _egcParsed : 7890;
 
 const DEFAULT_INTERVAL_MINUTES = 30;
 
@@ -61,7 +64,7 @@ function shouldPromptSave(input, nowMs) {
 function post(ev, done) {
   const body = JSON.stringify(ev);
   const req = http.request(
-    { hostname: '127.0.0.1', port: 7890, path: '/event', method: 'POST',
+    { hostname: '127.0.0.1', port: DASHBOARD_PORT, path: '/event', method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
       timeout: 300 },
     () => done()

--- a/scripts/lib/dashboard-launch.js
+++ b/scripts/lib/dashboard-launch.js
@@ -8,8 +8,9 @@ const fs = require('node:fs');
 const path = require('node:path');
 const http = require('node:http');
 const { spawn, spawnSync } = require('node:child_process');
+const { PORT } = require(path.join(__dirname, '..', '..', 'dashboard', 'port'));
 
-const DASHBOARD_URL = 'http://localhost:7890';
+const DASHBOARD_URL = `http://localhost:${PORT}`;
 
 function pingDashboard() {
   return new Promise(resolve => {
@@ -46,6 +47,7 @@ function launchDashboard({ rootDir, log = () => {} }) {
     const child = spawn(process.execPath, [dashboardScript], {
       detached: true,
       stdio: 'ignore',
+      env: { ...process.env, EGC_PORT: String(PORT) },
       ...(process.platform === 'win32' && { shell: true }),
     });
     child.unref();

--- a/scripts/replay.js
+++ b/scripts/replay.js
@@ -2,9 +2,11 @@
 'use strict';
 
 const http = require('node:http');
+const path = require('node:path');
 const { execSync } = require('node:child_process');
+const { PORT } = require(path.join(__dirname, '..', 'dashboard', 'port'));
 
-const DASHBOARD_URL = 'http://localhost:7890';
+const DASHBOARD_URL = `http://localhost:${PORT}`;
 
 function showHelp() {
   console.log(`

--- a/tests/dashboard-port.test.js
+++ b/tests/dashboard-port.test.js
@@ -1,0 +1,72 @@
+'use strict';
+/**
+ * Tests for dashboard/port.js — Fmarzochi/EGC#897
+ *
+ * port.js is require-cached after the first load, so each scenario is run in
+ * a child process that inherits only the env vars we set explicitly.
+ */
+
+const { test } = require('node:test');
+const assert  = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const NODE     = process.execPath;
+const PORT_MOD = path.join(__dirname, '..', 'dashboard', 'port.js');
+
+/**
+ * Evaluate `require('./port').PORT` in a fresh child process with the given env,
+ * returning the numeric PORT value.
+ */
+function loadPort(env = {}) {
+  const script = `process.stdout.write(String(require(${JSON.stringify(PORT_MOD)}).PORT))`;
+  const out = execFileSync(NODE, ['-e', script], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return Number(out.trim());
+}
+
+// ---------------------------------------------------------------------------
+
+test('defaults to 7890 when EGC_PORT is not set', () => {
+  const env = { ...process.env };
+  delete env.EGC_PORT;
+  const script = `process.stdout.write(String(require(${JSON.stringify(PORT_MOD)}).PORT))`;
+  const out = execFileSync(NODE, ['-e', script], { env, encoding: 'utf8' });
+  assert.equal(Number(out.trim()), 7890);
+});
+
+test('honours EGC_PORT when set to a valid number', () => {
+  assert.equal(loadPort({ EGC_PORT: '8123' }), 8123);
+});
+
+test('honours EGC_PORT=1 (minimum valid port)', () => {
+  assert.equal(loadPort({ EGC_PORT: '1' }), 1);
+});
+
+test('honours EGC_PORT=65535 (maximum valid port)', () => {
+  assert.equal(loadPort({ EGC_PORT: '65535' }), 65535);
+});
+
+test('falls back to 7890 when EGC_PORT is not a number', () => {
+  assert.equal(loadPort({ EGC_PORT: 'banana' }), 7890);
+});
+
+test('falls back to 7890 when EGC_PORT is 0 (out of range)', () => {
+  assert.equal(loadPort({ EGC_PORT: '0' }), 7890);
+});
+
+test('falls back to 7890 when EGC_PORT is 65536 (out of range)', () => {
+  assert.equal(loadPort({ EGC_PORT: '65536' }), 7890);
+});
+
+test('falls back to 7890 when EGC_PORT is empty string', () => {
+  assert.equal(loadPort({ EGC_PORT: '' }), 7890);
+});
+
+test('PORT export is a number, not a string', () => {
+  const script = `process.stdout.write(typeof require(${JSON.stringify(PORT_MOD)}).PORT)`;
+  const out = execFileSync(NODE, ['-e', script], { encoding: 'utf8' });
+  assert.equal(out.trim(), 'number');
+});


### PR DESCRIPTION
## Summary
 
Closes #897
 
Port `7890` was hardcoded as a raw literal in **12 source files** across the dashboard, scripts, and hooks. Anyone whose system already had port 7890 occupied could not use the dashboard at all, and there was no way to configure it without editing source files directly.
 
This PR introduces a single shared helper (`dashboard/port.js`) that reads `process.env.EGC_PORT || 7890` once at require-time, and updates every consumer to import from it instead of repeating the literal.
 
---
 
## What changed
 
### New file: `dashboard/port.js`
 
Single source of truth for the dashboard port. Reads `EGC_PORT` from the environment, validates the value (integer, 1–65535), warns to stderr on invalid input, and falls back to `7890` silently when the variable is unset.
 
```js
const PORT = (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 65535) ? parsed : 7890;
module.exports = { PORT };
```
 
### Files updated (hardcoded `7890` removed)
 
| File | Change |
|---|---|
| `dashboard/shim.js` | `require('./port')` |
| `dashboard/shim-session.js` | `require('./port')` |
| `dashboard/aider-watcher.js` | `require('./port')`, removed local `const PORT = 7890` |
| `dashboard/codebuddy-adapter.js` | `require('./port')`, removed local `const PORT = 7890` |
| `dashboard/vscode-adapter.js` | `require('./port')`, removed local `const PORT = 7890` |
| `dashboard/server.js` | `require('./port')`, CORS fallback now uses `PORT` variable |
| `scripts/dashboard.js` | loads port from `dashboard/port.js`; passes `EGC_PORT` explicitly in `spawn` env so detached server child always inherits the correct port |
| `scripts/replay.js` | builds `DASHBOARD_URL` dynamically from `PORT` |
| `scripts/lib/dashboard-launch.js` | builds `DASHBOARD_URL` dynamically; passes `EGC_PORT` in `spawn` env |
| `scripts/hooks/claude-session-start.js` | `require('../../dashboard/port')` |
| `scripts/hooks/claude-session-stop.js` | `require('../../dashboard/port')` |
| `.cursor/hooks/dashboard-emit.js` | `require('../../dashboard/port')` |
| `scripts/egc.js` | updated CLI description string to mention `EGC_PORT` |
 
### New test file: `tests/dashboard-port.test.js`
 
9 tests covering:
- Default fallback to `7890` when `EGC_PORT` is unset
- Valid override (`8123`, `1`, `65535`)
- Invalid inputs: non-numeric string, `0`, `65536`, empty string → all fall back to `7890`
- `PORT` export is a `number`, not a string
---
 
## Acceptance criteria (from issue)
 
- [x] `EGC_PORT=8123 egc dashboard` works end to end — server, shims, watchers, UI all bind to `8123`
- [x] Default behaviour unchanged when `EGC_PORT` is unset — falls back to `7890`
- [x] `node tests/run-all.js` passes locally (9 new tests pass; no regressions introduced)
---
 
## How to test
 
```bash
# 1. Install deps and link local repo globally
npm install
npm install -g .
 
# 2. Test custom port
egc dashboard stop
EGC_PORT=8123 egc dashboard
# → EGC Dashboard running at http://localhost:8123
 
# 3. Test default unchanged
egc dashboard stop
egc dashboard
# → EGC Dashboard running at http://localhost:7890
 
# 4. Run new unit tests
node tests/dashboard-port.test.js
# → 9 pass, 0 fail
```
 
---
 
## Notes
 
- No breaking changes. Default behaviour (`7890`) is identical to before.
- The `spawn` call in `scripts/dashboard.js` and `scripts/lib/dashboard-launch.js` now explicitly passes `env: { ...process.env, EGC_PORT: String(PORT) }` to the detached server child. This ensures the resolved port is inherited correctly regardless of shell environment stripping in detached processes.
- Invalid `EGC_PORT` values produce a warning to stderr and fall back gracefully — the dashboard never fails to start due to a misconfigured env var.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the dashboard port configurable via `EGC_PORT` instead of hardcoding 7890. All server, UI, adapters, hooks, and scripts now honor the selected port; default stays 7890.

- **New Features**
  - Added `dashboard/port.js` as the single source of truth; validates `EGC_PORT` (1–65535), warns on invalid, falls back to 7890.
  - Updated all callers: server CORS fallback uses the resolved port; child processes inherit `EGC_PORT`; external hooks that can run outside the repo (`.cursor/hooks/dashboard-emit.js`, `scripts/hooks/claude-*`) now resolve the port from `process.env` with validation.
  - Frontend now gets `window.__EGC_PORT` injected in `index.html`, and the WebSocket connects using that port (or `location.host` as a fallback).
  - Meets #897: end-to-end `EGC_PORT` override works; default unchanged; 9 tests added.

<sup>Written for commit edd8db36aa2e153b53a73c809bc62bab37cac3ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

