### PR TITLE
feat(crusher): propagate the Token Crusher to Copilot, Antigravity and Continue

### DIFF
--- a/scripts/lib/antigravity-settings-hooks.js
+++ b/scripts/lib/antigravity-settings-hooks.js
@@ -22,6 +22,8 @@ const path = require('node:path');
 const {
   createGateGuardHookMergeOperationForDestination,
   resolveGateGuardHookScriptDestination,
+  createCrusherHookMergeOperationForDestination,
+  resolveCrusherHookScriptDestination,
 } = require('./claude-settings-hooks');
 
 function resolveAntigravityProjectHooksFilePath(projectRoot) {
@@ -48,9 +50,20 @@ function createGlobalGateGuardHookMergeOperation(targetRoot, homeDir, matcher) {
   );
 }
 
+// Token Crusher: same hooks.json shape, registered at the project hooks file
+// (.agents/hooks.json) pointing at the crusher hook under the adapter root.
+function createProjectCrusherHookMergeOperation(targetRoot, projectRoot, matcher) {
+  return createCrusherHookMergeOperationForDestination(
+    resolveAntigravityProjectHooksFilePath(projectRoot),
+    resolveCrusherHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
 module.exports = {
   createGlobalGateGuardHookMergeOperation,
   createProjectGateGuardHookMergeOperation,
+  createProjectCrusherHookMergeOperation,
   resolveAntigravityGlobalHooksFilePath,
   resolveAntigravityProjectHooksFilePath,
 };

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -700,6 +700,24 @@ function createGateGuardHookMergeOperationForDestination(destinationPath, hookSc
   };
 }
 
+// Crusher variant of the destination-driven merge op, for hosts whose
+// hooks.json path is not derivable from targetRoot (Copilot ~/.copilot/hooks,
+// Antigravity's project/global split). Same Claude hooks.json schema.
+function createCrusherHookMergeOperationForDestination(destinationPath, hookScriptPath, matcher) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: CRUSHER_HOOK_MODULE_ID,
+    sourceRelativePath: CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: matcher,
+    hookScriptPath,
+  };
+}
+
 module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -746,6 +764,7 @@ module.exports = {
   createPreToolUseGateGuardHookMergeOperation,
   createCrusherScriptCopyOperations,
   createPreToolUseCrusherHookMergeOperation,
+  createCrusherHookMergeOperationForDestination,
   resolveCrusherHookScriptDestination,
   createPreToolUseWriteValidatorHookMergeOperation,
   createSessionStartHookMergeOperation,

--- a/scripts/lib/continue-gateguard-hooks.js
+++ b/scripts/lib/continue-gateguard-hooks.js
@@ -15,21 +15,29 @@
 const {
   createGateGuardScriptCopyOperations,
   createPreToolUseGateGuardHookMergeOperation,
+  createCrusherScriptCopyOperations,
+  createPreToolUseCrusherHookMergeOperation,
 } = require('./claude-settings-hooks');
 
 function createContinueGateGuardOperations(adapter, targetRoot, createRemappedOperation) {
-  const copyOperations = createGateGuardScriptCopyOperations(
-    (moduleId, sourceRelativePath, destinationPath, options) => (
-      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-    ),
-    targetRoot
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
+  const copyOperations = createGateGuardScriptCopyOperations(remap, targetRoot);
 
   const mergeOperations = ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
     createPreToolUseGateGuardHookMergeOperation(targetRoot, matcher)
   ));
 
-  return [...copyOperations, ...mergeOperations];
+  // Token Crusher: Continue reads the same hooks.json schema as Claude Code, so
+  // scaffold the standalone hook + its deps and register it on Bash. Fail-open,
+  // so a Continue build that ignores updatedInput just runs the command as-is.
+  const crusherOperations = [
+    ...createCrusherScriptCopyOperations(remap, targetRoot),
+    createPreToolUseCrusherHookMergeOperation(targetRoot, 'Bash'),
+  ];
+
+  return [...copyOperations, ...mergeOperations, ...crusherOperations];
 }
 
 module.exports = { createContinueGateGuardOperations };

--- a/scripts/lib/copilot-settings-hooks.js
+++ b/scripts/lib/copilot-settings-hooks.js
@@ -21,6 +21,8 @@ const path = require('node:path');
 const {
   createGateGuardHookMergeOperationForDestination,
   resolveGateGuardHookScriptDestination,
+  createCrusherHookMergeOperationForDestination,
+  resolveCrusherHookScriptDestination,
 } = require('./claude-settings-hooks');
 
 function resolveCopilotHooksFilePath(homeDir) {
@@ -35,7 +37,19 @@ function createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, matche
   );
 }
 
+// Token Crusher: VS Code's Copilot hooks read the same hooks.json schema, so the
+// crusher hook (installed under the adapter's own ~/.github root) is registered
+// at ~/.copilot/hooks/hooks.json just like the gate.
+function createPreToolUseCrusherHookMergeOperation(targetRoot, homeDir, matcher) {
+  return createCrusherHookMergeOperationForDestination(
+    resolveCopilotHooksFilePath(homeDir),
+    resolveCrusherHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
 module.exports = {
   createPreToolUseGateGuardHookMergeOperation,
+  createPreToolUseCrusherHookMergeOperation,
   resolveCopilotHooksFilePath,
 };

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -12,9 +12,11 @@ const {
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   resolveGateGuardHookScriptDestination,
+  createCrusherScriptCopyOperations,
 } = require('../claude-settings-hooks');
 const {
   createProjectGateGuardHookMergeOperation,
+  createProjectCrusherHookMergeOperation,
 } = require('../antigravity-settings-hooks');
 
 const SUPPORTED_SOURCE_PREFIXES = ['rules', 'commands', 'agents', 'skills', '.agents', 'AGENTS.md'];
@@ -60,6 +62,15 @@ function createGateGuardOperations(adapter, targetRoot, projectRoot) {
     createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, 'Write'),
     createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, 'MultiEdit'),
     createProjectGateGuardHookMergeOperation(targetRoot, projectRoot, 'Bash'),
+    // Token Crusher: same hooks.json shape, scaffold the hook + deps under the
+    // adapter root and register it on Bash at .agents/hooks.json.
+    ...createCrusherScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) => (
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+      ),
+      targetRoot
+    ),
+    createProjectCrusherHookMergeOperation(targetRoot, projectRoot, 'Bash'),
   ];
 }
 

--- a/scripts/lib/install-targets/copilot-home.js
+++ b/scripts/lib/install-targets/copilot-home.js
@@ -10,9 +10,11 @@ const {
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   resolveGateGuardHookScriptDestination,
+  createCrusherScriptCopyOperations,
 } = require('../claude-settings-hooks');
 const {
   createPreToolUseGateGuardHookMergeOperation,
+  createPreToolUseCrusherHookMergeOperation,
 } = require('../copilot-settings-hooks');
 
 const UTILS_SOURCE_RELATIVE_PATH = 'scripts/lib/utils.js';
@@ -48,6 +50,15 @@ function createGateGuardOperations(adapter, targetRoot, homeDir) {
     createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, 'Write'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, 'MultiEdit'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, homeDir, 'Bash'),
+    // Token Crusher: same hooks.json schema, scaffold the hook + deps under the
+    // adapter root and register it on Bash at ~/.copilot/hooks/hooks.json.
+    ...createCrusherScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) => (
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+      ),
+      targetRoot
+    ),
+    createPreToolUseCrusherHookMergeOperation(targetRoot, homeDir, 'Bash'),
   ];
 }
 

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1521,6 +1521,47 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('crusher hook is registered on Bash and scaffolded for Copilot, Antigravity and Continue', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+    const projectRoot = '/workspace/app';
+
+    const cases = [
+      { target: 'copilot', input: { homeDir }, hooksFilePath: path.join(homeDir, '.copilot', 'hooks', 'hooks.json'), root: path.join(homeDir, '.github') },
+      { target: 'antigravity', input: { projectRoot }, hooksFilePath: path.join(projectRoot, '.agents', 'hooks.json'), root: path.join(projectRoot, '.agents') },
+      { target: 'continue', input: { homeDir }, hooksFilePath: path.join(homeDir, '.continue', 'settings.json'), root: path.join(homeDir, '.continue') },
+    ];
+
+    for (const { target, input, hooksFilePath, root } of cases) {
+      const plan = planInstallTargetScaffold({ target, repoRoot, modules: [], ...input });
+      const crusherScriptPath = path.join(root, 'scripts', 'hooks', 'crusher-hook.js');
+
+      const crusherOps = plan.operations.filter(operation => (
+        operation.kind === 'merge-claude-settings-hooks'
+        && operation.hookEvent === 'PreToolUse'
+        && operation.destinationPath === hooksFilePath
+        && operation.hookScriptPath === crusherScriptPath
+      ));
+      assert.strictEqual(crusherOps.length, 1, `${target}: crusher registered once`);
+      assert.strictEqual(crusherOps[0].hookMatcher, 'Bash', `${target}: crusher on Bash`);
+
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/crusher-hook.js'
+          && operation.destinationPath === crusherScriptPath
+        )),
+        `${target}: crusher hook script scaffolded`
+      );
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/crusher/engine.js'
+          && operation.destinationPath === path.join(root, 'scripts', 'lib', 'crusher', 'engine.js')
+        )),
+        `${target}: crusher engine dependency scaffolded`
+      );
+    }
+  })) passed++; else failed++;
+
   if (test('codebuddy adapter registers the GateGuard fact-force hook at .codebuddy/settings.json', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';


### PR DESCRIPTION
## Phase B, final: the Token Crusher reaches every hook-capable host

Completes the multi-host rollout started in #959 (Codex, CodeBuddy) by wiring the crusher into the last three: **Copilot** (VS Code agent hooks, `~/.copilot/hooks/hooks.json`), **Antigravity** (`.agents/hooks.json`), and **Continue** (`~/.continue/settings.json`).

## Why these are safe to wire

All three already document reading the **same Claude-style `hooks.json` schema**, and each already installs the `gateguard-fact-force.js` gate, which emits `hookSpecificOutput.permissionDecision:"deny"`. Since they apply that envelope, they understand `hookSpecificOutput`, so the crusher's `updatedInput` rewrite is in a schema they already parse. And the crusher hook is **fail-open**: if a host ignores `updatedInput`, it simply runs the original command, so wiring it can never break command execution, only add compression where supported.

## What

- **`createCrusherHookMergeOperationForDestination`** in `claude-settings-hooks.js`: the crusher counterpart of the existing gateguard destination-driven merge op, for hosts whose `hooks.json` path is not derivable from `targetRoot`.
- **Copilot / Antigravity / Continue** installers now scaffold `crusher-hook.js` + its dependency tree (`pre-bash-crusher-rewrite`, `pretooluse-output`, `lib/crusher/engine`) under their own root and register the hook on the **Bash** matcher (edits have nothing to crush).

## Tests

- `tests/lib/install-targets.test.js`: one case asserts all three hosts register the crusher exactly once on Bash and scaffold the hook script + engine dependency into the right root.
- Full suite green (reproduced the CI Ubuntu tmux path locally), lint clean. **No version bump.**

## Coverage after this PR

Claude Code (native chain) + Codex + CodeBuddy + Copilot + Antigravity + Continue. The crusher now runs on every EGC host that exposes a command-rewriting PreToolUse hook.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates the Token Crusher to Copilot, Antigravity, and Continue so Bash commands are compressed on all remaining hosts. Uses the shared Claude-style hooks.json schema and keeps behavior fail-open.

- **New Features**
  - Added `createCrusherHookMergeOperationForDestination` to wire the crusher where hooks paths aren’t derivable from `targetRoot`.
  - Scaffolds and registers the crusher on Bash for Copilot (`~/.copilot/hooks/hooks.json`), Antigravity (`.agents/hooks.json`), and Continue (`~/.continue/settings.json`), including `scripts/hooks/crusher-hook.js` and `scripts/lib/crusher/engine.js`.
  - Fail-open: if a host ignores `updatedInput`, it runs the original command.

<sup>Written for commit 38492c67d5c97577a126dc747e68d91cab73069a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

