### PR TITLE
feat(install): add native Cline install target

### DIFF
--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -2,7 +2,7 @@
 
 > The honest map of how each supported AI coding tool integrates with EGC.
 
-EGC supports 22 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
+EGC supports 23 AI coding tools through 3 distinct integration mechanisms. This document is the source of truth for what is and is not integrated, and at what depth.
 
 ## Tier definitions
 
@@ -12,7 +12,7 @@ EGC supports 22 AI coding tools through 3 distinct integration mechanisms. This 
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
-## The 22 harnesses
+## The 23 harnesses
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
@@ -36,8 +36,9 @@ EGC supports 22 AI coding tools through 3 distinct integration mechanisms. This 
 | 18 | **Roo Code** | 1 | `roocode` | `.roo/rules/` (project only, no home target) | Default scaffold with category structure preserved; Roo Code recursively discovers project rules from `.roo/rules/`; no hook wiring |
 | 19 | **OpenHands** | 1 | `openhands` | `~/.agents/skills/<name>/SKILL.md` (shared with Codex/Goose) | Skills installed flat; no GateGuard hook wiring; discoverability-only adapter -- the issue asked for `.openhands/microagents/`, but current OpenHands docs recommend the AgentSkills-standard `.agents/skills/<name>/SKILL.md` path (legacy `.openhands/microagents/` still works but isn't the documented target), so this mirrors the Goose adapter instead |
 | 20 | **Aider** | 1 | `aider` | `.aider/skills/<name>.md` (project only, no home target) | Skills copied flat as single `.md` files (Aider does not scan a skill-folder convention); each file's path is merged into the `read:` list of `.aider.conf.yml` via a new `merge-yaml-read-list` operation kind, preserving any unrelated existing keys; install/repair/uninstall all wired |
-| 21 | **Warp** | 1 | `warp` | `.warp/skills/<name>.md` + index in project root `AGENTS.md` (project only, no home target) | Warp only discovers a single root `AGENTS.md`/`WARP.md` file as project rules, not a directory of skill files -- confirmed a plain `AGENTS.md` is sufficient (Warp's own docs call it the default project rules file; `WARP.md` is legacy and only takes priority if both exist). Full skill content is copied flat to `.warp/skills/<name>.md` (read on demand); a short index (name + one-line description + path) is merged into a marked block inside `AGENTS.md` via a new `merge-markdown-skill-index` operation kind, since concatenating all 230+ skills (~2MB) into the always-loaded rules file would blow the context budget. Install/repair/uninstall all wired; uninstall never deletes `AGENTS.md` itself, only the EGC block |
-| 22 | **Qwen Code** | 1 | `qwen` | `.qwen/skills/<name>/SKILL.md` (project only, no home target) | Skills installed flat with the source category stripped; Qwen Code discovers project skills natively from `.qwen/skills/`; no hook wiring |
+| 21 | **Cline** | 1 | `cline` | `.clinerules/` (project only, no home target) | Rules are flattened into Cline's project-level rules directory using collision-safe namespaced filenames |
+| 22 | **Warp** | 1 | `warp` | `.warp/skills/<name>.md` + index in project root `AGENTS.md` (project only, no home target) | Warp only discovers a single root `AGENTS.md`/`WARP.md` file as project rules, not a directory of skill files -- confirmed a plain `AGENTS.md` is sufficient (Warp's own docs call it the default project rules file; `WARP.md` is legacy and only takes priority if both exist). Full skill content is copied flat to `.warp/skills/<name>.md` (read on demand); a short index (name + one-line description + path) is merged into a marked block inside `AGENTS.md` via a new `merge-markdown-skill-index` operation kind, since concatenating all 230+ skills (~2MB) into the always-loaded rules file would blow the context budget. Install/repair/uninstall all wired; uninstall never deletes `AGENTS.md` itself, only the EGC block |
+| 23 | **Qwen Code** | 1 | `qwen` | `.qwen/skills/<name>/SKILL.md` (project only, no home target) | Skills installed flat with the source category stripped; Qwen Code discovers project skills natively from `.qwen/skills/`; no hook wiring |
 
 ## Why three tiers (history, not aspiration)
 
@@ -49,7 +50,7 @@ Tier 3 (protocol-only) is the entry point for any tool that supports MCP. Claude
 
 ## What "supported" guarantees
 
-For all 22 harnesses, EGC guarantees:
+For all 23 harnesses, EGC guarantees:
 
 - The install path is documented above
 - MCP server registration (if the tool supports MCP)

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -12,7 +12,8 @@
         "egc",
         "cursor",
         "antigravity",
-        "codebuddy"
+        "codebuddy",
+        "cline"
       ],
       "dependencies": [],
       "defaultInstall": true,

--- a/schemas/egc-install-config.schema.json
+++ b/schemas/egc-install-config.schema.json
@@ -40,6 +40,7 @@
         "roocode",
         "openhands",
         "aider",
+        "cline",
         "warp"
       ]
     },

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -66,6 +66,7 @@
                 "amazonq",
                 "openhands",
                 "aider",
+                "cline",
                 "warp"
               ]
             }

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('node:path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'qwen', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'roocode', 'openhands', 'aider', 'warp'];
+const SUPPORTED_INSTALL_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'qwen', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'roocode', 'openhands', 'aider', 'cline', 'warp'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',

--- a/scripts/lib/install-targets/cline-project.js
+++ b/scripts/lib/install-targets/cline-project.js
@@ -1,0 +1,63 @@
+const {
+  createFlatRuleOperations,
+  createInstallTargetAdapter,
+  isForeignPlatformPath,
+} = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'cline-project',
+  target: 'cline',
+  kind: 'project',
+  rootSegments: ['.clinerules'],
+  installStatePathSegments: ['egc-install-state.json'],
+  nativeRootRelativePath: '.clinerules',
+  planOperations(input, adapter) {
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
+
+    const {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    } = input;
+
+    const planningInput = {
+      repoRoot,
+      projectRoot,
+      homeDir,
+    };
+
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+
+      return paths
+        .filter(sourcePath => !isForeignPlatformPath(sourcePath, adapter.target))
+        .flatMap(sourceRelativePath => {
+          if (sourceRelativePath === 'rules') {
+            return createFlatRuleOperations({
+              moduleId: module.id,
+              repoRoot,
+              sourceRelativePath,
+              destinationDir: targetRoot,
+            });
+          }
+
+          return [
+            adapter.createScaffoldOperation(
+              module.id,
+              sourceRelativePath,
+              planningInput
+            ),
+          ];
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -5,6 +5,7 @@ const antigravityProject = require('./antigravity-project');
 const claudeCodeHome = require('./claude-home');
 const egcHome = require('./gemini-home');
 const codebuddyProject = require('./codebuddy-project');
+const clineProject = require('./cline-project');
 const codexHome = require('./codex-home');
 const cursorProject = require('./cursor-project');
 const geminiProject = require('./gemini-project');
@@ -41,6 +42,7 @@ const ADAPTERS = Object.freeze([
   geminiProject,
   opencodeHome,
   codebuddyProject,
+  clineProject,
   kiroHome,
   kiroProject,
   windsurfHome,

--- a/tests/lib/install-manifests.test.js
+++ b/tests/lib/install-manifests.test.js
@@ -198,6 +198,39 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('resolves Cline profile to project-level flat rules only', () => {
+    const projectRoot = '/workspace/app';
+    const plan = resolveInstallPlan({
+      profileId: 'core',
+      target: 'cline',
+      projectRoot,
+    });
+
+    assert.deepStrictEqual(plan.selectedModuleIds, ['rules-core']);
+    assert.ok(plan.skippedModuleIds.includes('agents-core'));
+    assert.ok(plan.skippedModuleIds.includes('commands-core'));
+    assert.ok(plan.skippedModuleIds.includes('hooks-runtime'));
+    assert.strictEqual(plan.targetAdapterId, 'cline-project');
+    assert.strictEqual(plan.targetRoot, path.join(projectRoot, '.clinerules'));
+    assert.strictEqual(
+      plan.installStatePath,
+      path.join(projectRoot, '.clinerules', 'egc-install-state.json')
+    );
+
+    assert.ok(
+      plan.operations.some(operation => (
+        operation.sourceRelativePath === 'rules/common/coding-style.md'
+        && operation.destinationPath === path.join(
+          projectRoot,
+          '.clinerules',
+          'common-coding-style.md'
+        )
+        && operation.strategy === 'flatten-copy'
+      )),
+      'Should materialize Cline rules as flat namespaced files'
+    );
+  })) passed++; else failed++;
+
   if (test('resolves antigravity profiles while skipping only unsupported modules', () => {
     const projectRoot = '/workspace/app';
     const plan = resolveInstallPlan({ profileId: 'core', target: 'antigravity', projectRoot });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -502,6 +502,87 @@ function runTests() {
     assert.strictEqual(statePath, path.join(projectRoot, '.gemini', 'egc-install-state.json'));
   })) passed++; else failed++;
 
+  if (test('resolves cline adapter root and install-state path from project root', () => {
+    const adapter = getInstallTargetAdapter('cline');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'cline-project');
+    assert.strictEqual(adapter.target, 'cline');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.clinerules'));
+    assert.strictEqual(
+      statePath,
+      path.join(projectRoot, '.clinerules', 'egc-install-state.json')
+    );
+  })) passed++; else failed++;
+
+  if (test('cline adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('cline');
+    const byId = getInstallTargetAdapter('cline-project');
+
+    assert.strictEqual(byTarget.id, 'cline-project');
+    assert.strictEqual(byId.id, 'cline-project');
+    assert.ok(byTarget.supports('cline'));
+    assert.ok(byTarget.supports('cline-project'));
+  })) passed++; else failed++;
+
+  if (test('plans cline rules as flat namespaced files under .clinerules', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'cline',
+      repoRoot,
+      projectRoot,
+      modules: [
+        {
+          id: 'rules-core',
+          paths: ['rules'],
+        },
+      ],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'cline-project');
+    assert.strictEqual(plan.targetRoot, path.join(projectRoot, '.clinerules'));
+    assert.strictEqual(
+      plan.installStatePath,
+      path.join(projectRoot, '.clinerules', 'egc-install-state.json')
+    );
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'rules/common/coding-style.md'
+        && operation.destinationPath === path.join(
+          projectRoot,
+          '.clinerules',
+          'common-coding-style.md'
+        )
+      )),
+      'Should flatten common rules into namespaced files for Cline'
+    );
+
+    assert.ok(
+      !plan.operations.some(operation => (
+        operation.destinationPath === path.join(
+          projectRoot,
+          '.clinerules',
+          'common',
+          'coding-style.md'
+        )
+      )),
+      'Should not preserve nested rule directories for Cline installs'
+    );
+  })) passed++; else failed++;
+
+  if (test('cline adapter is included in the full adapter list', () => {
+    const adapters = listInstallTargetAdapters();
+    const targets = adapters.map(adapter => adapter.target);
+
+    assert.ok(targets.includes('cline'), 'Should include cline target');
+  })) passed++; else failed++;
+
   if (test('codebuddy adapter supports lookup by target and adapter id', () => {
     const byTarget = getInstallTargetAdapter('codebuddy');
     const byId = getInstallTargetAdapter('codebuddy-project');

--- a/tests/spec/integration-tiers.test.js
+++ b/tests/spec/integration-tiers.test.js
@@ -30,6 +30,7 @@ const EXPECTED_HARNESSES = [
   'Roo Code',
   'OpenHands',
   'Aider',
+  'Cline',
   'Warp',
   'Windsurf',
   'Amp',
@@ -38,7 +39,7 @@ const EXPECTED_HARNESSES = [
   'Zed',
 ];
 
-const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'qwen', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'roocode', 'openhands', 'aider', 'warp'];
+const EXPECTED_TIER1_TARGETS = ['egc', 'claude', 'cursor', 'antigravity', 'codex', 'gemini', 'qwen', 'opencode', 'codebuddy', 'windsurf', 'amp', 'copilot', 'zed', 'continue', 'kiro', 'trae', 'junie', 'goose', 'amazonq', 'roocode', 'openhands', 'aider', 'cline', 'warp'];
 const EXPECTED_TIER2_INSTALLERS = ['.kiro/install.sh', '.trae/install.sh'];
 
 function loadDoc() {


### PR DESCRIPTION
## What Changed

- Added a native `cline-project` install target
- Installed EGC rules into Cline's project-level `.clinerules/` directory
- Flattened nested rule files into collision-safe namespaced filenames
- Registered `cline` in the adapter registry, supported target list, schemas, and install manifest
- Added adapter and real manifest regression tests
- Updated the integration-tier documentation and contract tests

## Why This Change

Cline natively discovers project rules from the `.clinerules/` directory. This adapter allows EGC to install its rule modules directly into Cline's documented discovery path without requiring manual setup.

Official documentation used to verify the path:

https://docs.cline.bot/customization/cline-rules

## Testing Done

- [x] `node tests/lib/install-targets.test.js`
- [x] `node tests/lib/install-manifests.test.js`
- [x] `node tests/spec/integration-tiers.test.js`
- [x] `node tests/run-all.js`
- [x] `git diff --check`
- [x] Existing default behavior remains unchanged

## Type of Change

- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [x] `docs`: Documentation
- [x] `test`: Tests
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance/tooling
- [ ] `ci`: CI/CD changes

Fixes #846

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a native `cline` install target that installs EGC rules into the project’s `.clinerules/` directory as flat, collision-safe files. This enables zero-setup rule discovery in Cline.

- **New Features**
  - Added `cline-project` adapter (project-only) with install state at `.clinerules/egc-install-state.json`.
  - Flattens nested rule files into namespaced files under `.clinerules/`.
  - Registered `cline` in the adapter registry, supported targets, manifests, and schemas.
  - Added adapter and manifest regression tests; updated integration-tier docs and contract tests to include Cline (now 23 harnesses).

<sup>Written for commit b28bd31d659630e799a48088c1cd48ae385c3131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

