### PR TITLE
chore: release v1.1.15

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "egc",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "source": {
         "source": "local",
         "path": "../.."

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Battle-tested Codex workflows \u2014 228 shared EGC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
   "author": {
     "name": "Felipe Marzochi",

--- a/.gemini-plugin/marketplace.json
+++ b/.gemini-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "egc",
       "source": "./",
       "description": "EGC - Extended Global Context: 62 agents, 228 skills, 74 commands, persistent memory across sessions, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "author": {
         "name": "Felipe Marzochi",
         "email": "fmarzochi@gmail.com"

--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "EGC - Extended Global Context: persistent memory and shared context for AI coding tools. 62 agents, 228 skills, 74 commands, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {
     "name": "Felipe Marzochi",

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -2,8 +2,12 @@ name: ClusterFuzzLite batch fuzzing
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * 0'
+  # schedule disabled (EGC#910): ClusterFuzzLite is dead-locked upstream for
+  # JavaScript (config_utils.py rejects `none` while compile requires it), so the
+  # weekly batch never goes green and only masks real failures. Manual runs via
+  # workflow_dispatch remain; re-enable once the upstream contradiction is fixed.
+  # schedule:
+  #   - cron: '0 6 * * 0'
 
 permissions: {}
 

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -2,8 +2,12 @@ name: ClusterFuzzLite cron tasks
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 7 * * 0'
+  # schedule disabled (EGC#910): ClusterFuzzLite is dead-locked upstream for
+  # JavaScript (config_utils.py rejects `none` while compile requires it), so the
+  # weekly cron never goes green and only masks real failures. Manual runs via
+  # workflow_dispatch remain; re-enable once the upstream contradiction is fixed.
+  # schedule:
+  #   - cron: '0 7 * * 0'
 
 permissions: {}
 

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "egc-universal",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "egc-universal",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.4.3",

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egc-universal",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Extended Global Context (EGC) plugin for OpenCode - agents, commands, hooks, and skills",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -513,7 +513,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
      */
     "shell.env": async () => {
       const env: Record<string, string> = {
-        EGC_VERSION: "1.1.14",
+        EGC_VERSION: "1.1.15",
         EGC_PLUGIN: "true",
         EGC_HOOK_PROFILE: currentProfile,
         EGC_DISABLED_HOOKS: process.env.EGC_DISABLED_HOOKS || "",
@@ -567,7 +567,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
       const contextBlock = [
         "# EGC Context (preserve across compaction)",
         "",
-        "## Active Plugin: EGC - Extended Global Context v1.1.14",
+        "## Active Plugin: EGC - Extended Global Context v1.1.15",
         "- Hooks: file.edited, tool.execute.before/after, session.created/idle/deleted, shell.env, compacting, permission.ask",
         "- Tools: run-tests, check-coverage, security-audit, format-code, lint-check, git-summary, changed-files",
         "- Agents: 13 specialized (planner, architect, tdd-guide, code-reviewer, security-reviewer, build-error-resolver, e2e-runner, refactor-cleaner, doc-updater, go-reviewer, go-build-resolver, database-reviewer, python-reviewer)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to EGC are documented here.
 
+## [1.1.15] - 2026-07-21
+
+### New Features
+
+- **Token Crusher on every hook-capable host**: the compression hook now reaches all six harnesses. Codex and CodeBuddy (#959), Copilot, Antigravity and Continue (#964), plus pipelines and compound commands crushed through `egc run --shell` (#956). The core bug that silently dropped every rewrite is fixed: the dispatcher now emits `hookSpecificOutput.updatedInput`, so the host actually applies the compressed command (#958).
+- **Three new install targets**: Roo Code (#957), Qwen Code (#962) and Cline (#965), bringing EGC to 23 supported AI coding harnesses.
+- **Ranked keyword search for the catalog**: `egc` scores skills and components by relevance instead of listing them flat (#939).
+- **Two new README translations**: Italian (#933) and French (#948), wired into every language selector, bring EGC to 11 languages.
+- **Agent Memory Interchange draft specification**: a first draft of the cross-tool memory interchange format (#947).
+- **Configurable dashboard port**: the dashboard honors `EGC_PORT` instead of hardcoding 7890 (#963).
+- **Explicit HTTP timeouts on every provider**: all native LLM provider clients set a connect/read timeout (#961), and the remaining native providers gained a `stream=True` guard that raises `NotImplementedError` instead of silently returning a blocking response (#912, #924).
+
+### Security
+
+- **Two high-severity advisories patched**: `fast-uri` (GHSA-4c8g-83qw-93j6, host confusion via failed IDN canonicalization) and `linkify-it` (GHSA-v245-v573-v5vm, quadratic DoS in the `mailto:` validator) bumped across the root and both mcp-server lockfiles (#967).
+- **`@hono/node-server` serve-static advisory cleared** (GHSA-frvp-7c67-39w9): a transitive pin under `@modelcontextprotocol/sdk` with no patched 1.x release is forced to 2.x via an npm override, clearing the Dependabot alerts and the Scorecard finding. Both mcp servers use stdio transport, so the HTTP adapter never loads.
+- **Earlier advisory rounds**: `tar`, `js-yaml` and `brace-expansion` (#952), the mcp and fuzz lockfiles (#955), and `body-parser` (#954).
+
+### Bug Fixes
+
+- **Dashboard serves late-added static files without a restart**: files dropped into `public/` after an in-place upgrade are served immediately, with a symlink guard and a debounced manifest rebuild that keeps the path-traversal protection intact (#928).
+- **Multi-byte UTF-8 preserved across TCP chunks** on `POST /event` (#960); malformed JSON now returns 400 instead of crashing the handler (#917).
+- **Dashboard resilience**: ping polling survives a dead WebSocket (#943), the offline badge reacts to a dead socket and to consecutive poll failures (#911, #919), reconnect attempts are capped (#951), replay file paths are preserved (#950), a watcher stat-open race is closed (#953), and zombie shim processes can no longer linger (#907).
+- **Providers share a single `generate()` error wrapper** across the OpenAI-compatible subclasses, removing duplicated redaction paths (#944).
+
+### Maintenance
+
+- **License migrated from MIT to Apache License 2.0** (#906).
+- **Leaner repository root**: configs relocated and the redundant `VERSION` file dropped in favor of `package.json` as the single version source (#908, #940, #946).
+- **Bare `egc install` runs the shipped onboarding installers** (#937).
+
 ## [1.1.14] - 2026-07-19
 
 ### New Features

--- a/agent.yaml
+++ b/agent.yaml
@@ -1,6 +1,6 @@
 spec_version: "0.1.0"
 name: egc
-version: 1.1.14
+version: 1.1.15
 description: "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools. Desenvolvido por Felipe Marzochi. @MarzochiFelipe. https://github.com/Fmarzochi/EGC"
 author: fmarzochi
 license: Apache-2.0

--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -19,10 +19,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -19,6 +19,7 @@
     "typescript": "^7.0.2"
   },
   "overrides": {
-    "undici": "^6.27.0"
+    "undici": "^6.27.0",
+    "@hono/node-server": "^2.0.5"
   }
 }

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -23,12 +23,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -22,6 +22,7 @@
     "node": ">=18"
   },
   "overrides": {
-    "undici": "^6.27.0"
+    "undici": "^6.27.0",
+    "@hono/node-server": "^2.0.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egchq/egc",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "EGC is a local-first MCP runtime that gives every AI agent the same brain: persistent shared memory, security guardrails, and up to 90% token savings across 20 AI coding tools.",
   "author": "Felipe Marzochi <fmarzochi@gmail.com> (https://github.com/Fmarzochi)",
   "license": "Apache-2.0",

--- a/translations/fr/README.md
+++ b/translations/fr/README.md
@@ -113,6 +113,7 @@ Outils de codage IA qui s'intègrent nativement avec EGC. Les partenaires béné
 #### Contributeurs
 
 <a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="52" height="52" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
+<a href="https://github.com/ankit24417-sys"><img src="https://avatars.githubusercontent.com/u/259909839?v=4" width="52" height="52" alt="@ankit24417-sys" title="@ankit24417-sys" /></a>
 
 #### Sponsors mensuels · _soyez le premier_
 


### PR DESCRIPTION
Release v1.1.15. Bumps all manifests in lockstep and ships the CHANGELOG section.

Two pre-release fixes are folded in so the release lands with zero open advisories:
- Security: forces @hono/node-server to 2.x via npm override, clearing the last two Dependabot alerts and the Scorecard #215 finding (GHSA-frvp-7c67-39w9). All high and medium advisories are now zero across every lockfile.
- Credits the French translator (@ankit24417-sys) in the fr README, per the translator-credit convention.

Highlights since v1.1.14: Token Crusher wired into all six hook-capable hosts, three new install targets (23 harnesses total), French and Italian READMEs (11 languages), explicit provider HTTP timeouts, and the MIT to Apache-2.0 migration. Full details in CHANGELOG.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.1.15 with lockstep version bumps and the updated CHANGELOG. Adds a security override, disables flaky fuzzing schedules, and ships with zero open advisories.

- **Dependencies**
  - Override `@hono/node-server` to 2.x in both MCP servers to clear the `serve-static` advisory; lockfiles updated.

- **Bug Fixes**
  - Disable weekly ClusterFuzzLite schedules to avoid upstream JS config deadlock; keep manual `workflow_dispatch`.
  - Credit the French translator `@ankit24417-sys` in `translations/fr/README.md` per convention.

<sup>Written for commit 6a9c1f8192cd6d9267fc88109f665549d2467d19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

