### PR TITLE
add German README translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 **English** · [العربية](translations/ar/README.md) · [Español](translations/es/README.md) · [Français](translations/fr/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
+🌐 **English** · [العربية](translations/ar/README.md) · [Deutsch](translations/de/README.md) · [Español](translations/es/README.md) · [Français](translations/fr/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -79,7 +79,7 @@ There is no step two. Open any of your AI tools and just talk: "hi", "let's cont
 A live dashboard displaying agent activity, tokens, and costs spins up automatically right after installation. Prefer manual control? Every command is documented in the [installation guide](docs/installation.md): you will probably never need to type one.
 
 ---
-🌐 **English** · [العربية](translations/ar/README.md) · [Español](translations/es/README.md) · [Français](translations/fr/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
+🌐 **English** · [العربية](translations/ar/README.md) · [Deutsch](translations/de/README.md) · [Español](translations/es/README.md) · [Français](translations/fr/README.md) · [हिन्दी](translations/hi/README.md) · [Italiano](translations/it/README.md) · [日本語](translations/ja/README.md) · [한국어](translations/ko/README.md) · [Português (Brasil)](translations/pt/README.md) · [Русский](translations/ru/README.md) · [简体中文](translations/zh-CN/README.md)
 
 ---
 

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -106,7 +106,7 @@ function updateReadme() {
   
   // Also update bottom selector in root README if present (matching line starting with 🌐)
   const bottomSelectorEn = buildSelectorForLang("en", langs);
-  updatedEn = updatedEn.replace(/^🌐 .*$/m, bottomSelectorEn);
+  updatedEn = updatedEn.replace(/^🌐 .*$/gm, bottomSelectorEn);
 
   if (updatedEn !== enReadme) {
     fs.writeFileSync(README_PATH, updatedEn, "utf8");

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -1,85 +1,85 @@
 #!/usr/bin/env node
-"use strict";
+'use strict';
 
-const fs   = require("node:fs");
-const path = require("node:path");
+const fs = require('node:fs');
+const path = require('node:path');
 
 const LANGUAGE_NAMES = {
-  pt: "Português (Brasil)",
-  es: "Español",
-  fr: "Français",
-  de: "Deutsch",
-  it: "Italiano",
-  nl: "Nederlands",
-  pl: "Polski",
-  ru: "Русский",
-  uk: "Українська",
-  tr: "Türkçe",
-  ar: "العربية",
-  hi: "हिन्दी",
-  zh: "中文",
-  "zh-CN": "简体中文",
-  "zh-TW": "繁體中文",
-  ja: "日本語",
-  ko: "한국어",
-  vi: "Tiếng Việt",
-  th: "ภาษาไทย",
-  id: "Bahasa Indonesia",
-  sv: "Svenska",
-  da: "Dansk",
-  no: "Norsk",
-  fi: "Suomi",
-  cs: "Čeština",
-  sk: "Slovenčina",
-  ro: "Română",
-  hu: "Magyar",
-  bg: "Български",
-  hr: "Hrvatski",
-  el: "Ελληνικά",
-  he: "עברית",
-  fa: "فارسی",
-  bn: "বাংলা",
-  ms: "Bahasa Melayu",
-  ca: "Català",
+  pt: 'Português (Brasil)',
+  es: 'Español',
+  fr: 'Français',
+  de: 'Deutsch',
+  it: 'Italiano',
+  nl: 'Nederlands',
+  pl: 'Polski',
+  ru: 'Русский',
+  uk: 'Українська',
+  tr: 'Türkçe',
+  ar: 'العربية',
+  hi: 'हिन्दी',
+  zh: '中文',
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
+  ja: '日本語',
+  ko: '한국어',
+  vi: 'Tiếng Việt',
+  th: 'ภาษาไทย',
+  id: 'Bahasa Indonesia',
+  sv: 'Svenska',
+  da: 'Dansk',
+  no: 'Norsk',
+  fi: 'Suomi',
+  cs: 'Čeština',
+  sk: 'Slovenčina',
+  ro: 'Română',
+  hu: 'Magyar',
+  bg: 'Български',
+  hr: 'Hrvatski',
+  el: 'Ελληνικά',
+  he: 'עברית',
+  fa: 'فارسی',
+  bn: 'বাংলা',
+  ms: 'Bahasa Melayu',
+  ca: 'Català'
 };
 
-const ROOT         = path.join(__dirname, "..");
-const TRANSLATIONS = path.join(ROOT, "translations");
-const README_PATH  = path.join(ROOT, "README.md");
-const TOP_START    = "<!-- LANGUAGE-SELECTOR-START -->";
-const TOP_END      = "<!-- LANGUAGE-SELECTOR-END -->";
+const ROOT = path.join(__dirname, '..');
+const TRANSLATIONS = path.join(ROOT, 'translations');
+const README_PATH = path.join(ROOT, 'README.md');
+const TOP_START = '<!-- LANGUAGE-SELECTOR-START -->';
+const TOP_END = '<!-- LANGUAGE-SELECTOR-END -->';
 
 // Markers for blocks that should be identical across all translations
 // Format: [startMarker, endMarker]
 const SYNC_BLOCKS = [
-  ["<!-- BADGES-START -->", "<!-- BADGES-END -->"],
-  ["<!-- BOTTOM-BADGES-START -->", "<!-- BOTTOM-BADGES-END -->"],
+  ['<!-- BADGES-START -->', '<!-- BADGES-END -->'],
+  ['<!-- BOTTOM-BADGES-START -->', '<!-- BOTTOM-BADGES-END -->']
 ];
 
 function getAvailableLanguages() {
   if (!fs.existsSync(TRANSLATIONS)) return [];
   return fs
     .readdirSync(TRANSLATIONS)
-    .filter((code) => {
-      const stat   = fs.statSync(path.join(TRANSLATIONS, code));
-      const readme = path.join(TRANSLATIONS, code, "README.md");
+    .filter(code => {
+      const stat = fs.statSync(path.join(TRANSLATIONS, code));
+      const readme = path.join(TRANSLATIONS, code, 'README.md');
       return stat.isDirectory() && fs.existsSync(readme);
     })
     .sort();
 }
 
 function buildSelectorForLang(currentLang, langs) {
-  const links = langs.map((code) => {
+  const links = langs.map(code => {
     const name = LANGUAGE_NAMES[code] || code.toUpperCase();
     if (code === currentLang) {
       return `**${name}**`;
     }
-    const relPath = currentLang === "en" ? `translations/${code}/README.md` : `../${code}/README.md`;
+    const relPath = currentLang === 'en' ? `translations/${code}/README.md` : `../${code}/README.md`;
     return `[${name}](${relPath})`;
   });
 
-  const enName = currentLang === "en" ? "**English**" : "[English](../../README.md)";
-  return `\u{1F310} ${enName} · ${links.join(" · ")}`;
+  const enName = currentLang === 'en' ? '**English**' : '[English](../../README.md)';
+  return `\u{1F310} ${enName} · ${links.join(' · ')}`;
 }
 
 function replaceBlock(content, start, end, block) {
@@ -100,25 +100,25 @@ function updateReadme() {
   const langs = getAvailableLanguages();
 
   // 1. Update Root README
-  const enReadme = fs.readFileSync(README_PATH, "utf8");
-  const enSelector = `${TOP_START}\n${buildSelectorForLang("en", langs)}\n${TOP_END}`;
+  const enReadme = fs.readFileSync(README_PATH, 'utf8');
+  const enSelector = `${TOP_START}\n${buildSelectorForLang('en', langs)}\n${TOP_END}`;
   let updatedEn = replaceBlock(enReadme, TOP_START, TOP_END, enSelector);
-  
-  // Also update bottom selector in root README if present (matching line starting with 🌐)
-  const bottomSelectorEn = buildSelectorForLang("en", langs);
-  updatedEn = updatedEn.replace(/^🌐 .*$/gm, bottomSelectorEn);
+
+  // Also update bottom selector in root README if present (matching line starting with /u{1F310})
+  const bottomSelectorEn = buildSelectorForLang('en', langs);
+  updatedEn = updatedEn.replace(/^\u{1F310} .*$/gm, bottomSelectorEn);
 
   if (updatedEn !== enReadme) {
-    fs.writeFileSync(README_PATH, updatedEn, "utf8");
+    fs.writeFileSync(README_PATH, updatedEn, 'utf8');
     console.log(`Root README language selector updated with ${langs.length} language(s).`);
   }
 
   // 2. Update All Translation READMEs
   for (const lang of langs) {
-    const filePath = path.join(TRANSLATIONS, lang, "README.md");
+    const filePath = path.join(TRANSLATIONS, lang, 'README.md');
     if (!fs.existsSync(filePath)) continue;
 
-    const content = fs.readFileSync(filePath, "utf8");
+    const content = fs.readFileSync(filePath, 'utf8');
     const langSelector = buildSelectorForLang(lang, langs);
     const topBlock = `${TOP_START}\n${langSelector}\n${TOP_END}`;
 
@@ -126,20 +126,20 @@ function updateReadme() {
     if (content.includes(TOP_START) && content.includes(TOP_END)) {
       updated = replaceBlock(updated, TOP_START, TOP_END, topBlock);
     }
-    // Update bottom selector (all lines starting with 🌐)
-    updated = updated.replace(/^🌐 .*$/gm, langSelector);
+    // Update bottom selector (all lines starting with /u{1F310})
+    updated = updated.replace(/^\u{1F310} .*$/gm, langSelector);
 
     if (updated !== content) {
-      fs.writeFileSync(filePath, updated, "utf8");
+      fs.writeFileSync(filePath, updated, 'utf8');
       console.log(`Updated language selectors (top and bottom) in translations/${lang}/README.md`);
     }
   }
 }
 
 function syncBlocks() {
-  const enContent = fs.readFileSync(README_PATH, "utf8");
-  const langs     = getAvailableLanguages();
-  let   synced    = 0;
+  const enContent = fs.readFileSync(README_PATH, 'utf8');
+  const langs = getAvailableLanguages();
+  let synced = 0;
 
   for (const [start, end] of SYNC_BLOCKS) {
     const enBlock = extractBlock(enContent, start, end);
@@ -149,56 +149,56 @@ function syncBlocks() {
     }
 
     for (const lang of langs) {
-      const filePath = path.join(TRANSLATIONS, lang, "README.md");
-      const content  = fs.readFileSync(filePath, "utf8");
+      const filePath = path.join(TRANSLATIONS, lang, 'README.md');
+      const content = fs.readFileSync(filePath, 'utf8');
       if (!content.includes(start) || !content.includes(end)) {
         console.warn(`  Warning: sync marker missing in translations/${lang}/README.md: ${start}`);
         continue;
       }
       const updated = replaceBlock(content, start, end, enBlock);
       if (updated !== content) {
-        fs.writeFileSync(filePath, updated, "utf8");
+        fs.writeFileSync(filePath, updated, 'utf8');
         console.log(`  Synced block [${start}] in translations/${lang}/README.md`);
         synced++;
       }
     }
   }
 
-  if (synced === 0) console.log("Sync blocks: all translations up to date.");
+  if (synced === 0) console.log('Sync blocks: all translations up to date.');
 }
 
 function checkDrift() {
-  const enContent = fs.readFileSync(README_PATH, "utf8");
-  const langs     = getAvailableLanguages();
-  const warnings  = [];
+  const enContent = fs.readFileSync(README_PATH, 'utf8');
+  const langs = getAvailableLanguages();
+  const warnings = [];
 
   // Extract key fingerprints from the English README
-  const enToolCount  = (enContent.match(/^\| `\w/gm) || []).length;
-  const enHasSocket  = enContent.includes("socket.dev/npm/package");
-  const enHasOpenRouter = enContent.includes("OpenRouter");
+  const enToolCount = (enContent.match(/^\| `\w/gm) || []).length;
+  const enHasSocket = enContent.includes('socket.dev/npm/package');
+  const enHasOpenRouter = enContent.includes('OpenRouter');
 
   for (const lang of langs) {
-    const filePath = path.join(TRANSLATIONS, lang, "README.md");
-    const content  = fs.readFileSync(filePath, "utf8");
+    const filePath = path.join(TRANSLATIONS, lang, 'README.md');
+    const content = fs.readFileSync(filePath, 'utf8');
     const toolCount = (content.match(/^\| `\w/gm) || []).length;
 
     if (toolCount !== enToolCount) {
       warnings.push(`[${lang}] tool count mismatch: has ${toolCount}, EN has ${enToolCount}`);
     }
-    if (enHasSocket && !content.includes("socket.dev/npm/package")) {
+    if (enHasSocket && !content.includes('socket.dev/npm/package')) {
       warnings.push(`[${lang}] missing Socket.dev badge`);
     }
-    if (enHasOpenRouter && !content.includes("OpenRouter")) {
+    if (enHasOpenRouter && !content.includes('OpenRouter')) {
       warnings.push(`[${lang}] missing OpenRouter mention`);
     }
   }
 
   if (warnings.length === 0) {
-    console.log("Drift check: all translations appear in sync.");
+    console.log('Drift check: all translations appear in sync.');
   } else {
-    console.warn("Drift check warnings:");
-    warnings.forEach((w) => console.warn("  " + w));
-    if (process.argv.includes("--strict")) process.exit(1);
+    console.warn('Drift check warnings:');
+    warnings.forEach(w => console.warn('  ' + w));
+    if (process.argv.includes('--strict')) process.exit(1);
   }
 }
 

--- a/scripts/update-readme-languages.js
+++ b/scripts/update-readme-languages.js
@@ -68,12 +68,18 @@ function getAvailableLanguages() {
     .sort();
 }
 
-function buildTopSelector(langs) {
+function buildSelectorForLang(currentLang, langs) {
   const links = langs.map((code) => {
     const name = LANGUAGE_NAMES[code] || code.toUpperCase();
-    return `[${name}](translations/${code}/README.md)`;
+    if (code === currentLang) {
+      return `**${name}**`;
+    }
+    const relPath = currentLang === "en" ? `translations/${code}/README.md` : `../${code}/README.md`;
+    return `[${name}](${relPath})`;
   });
-  return `${TOP_START}\n\u{1F310} **English** · ${links.join(" · ")}\n${TOP_END}`;
+
+  const enName = currentLang === "en" ? "**English**" : "[English](../../README.md)";
+  return `\u{1F310} ${enName} · ${links.join(" · ")}`;
 }
 
 function replaceBlock(content, start, end, block) {
@@ -91,16 +97,42 @@ function extractBlock(content, start, end) {
 }
 
 function updateReadme() {
-  const readme = fs.readFileSync(README_PATH, "utf8");
-  const langs  = getAvailableLanguages();
+  const langs = getAvailableLanguages();
 
-  const updated = replaceBlock(readme, TOP_START, TOP_END, buildTopSelector(langs));
+  // 1. Update Root README
+  const enReadme = fs.readFileSync(README_PATH, "utf8");
+  const enSelector = `${TOP_START}\n${buildSelectorForLang("en", langs)}\n${TOP_END}`;
+  let updatedEn = replaceBlock(enReadme, TOP_START, TOP_END, enSelector);
+  
+  // Also update bottom selector in root README if present (matching line starting with 🌐)
+  const bottomSelectorEn = buildSelectorForLang("en", langs);
+  updatedEn = updatedEn.replace(/^🌐 .*$/m, bottomSelectorEn);
 
-  if (updated !== readme) {
-    fs.writeFileSync(README_PATH, updated, "utf8");
-    console.log(`Language selectors updated with ${langs.length} language(s): ${langs.join(", ")}`);
-  } else {
-    console.log("Language selectors already up to date.");
+  if (updatedEn !== enReadme) {
+    fs.writeFileSync(README_PATH, updatedEn, "utf8");
+    console.log(`Root README language selector updated with ${langs.length} language(s).`);
+  }
+
+  // 2. Update All Translation READMEs
+  for (const lang of langs) {
+    const filePath = path.join(TRANSLATIONS, lang, "README.md");
+    if (!fs.existsSync(filePath)) continue;
+
+    const content = fs.readFileSync(filePath, "utf8");
+    const langSelector = buildSelectorForLang(lang, langs);
+    const topBlock = `${TOP_START}\n${langSelector}\n${TOP_END}`;
+
+    let updated = content;
+    if (content.includes(TOP_START) && content.includes(TOP_END)) {
+      updated = replaceBlock(updated, TOP_START, TOP_END, topBlock);
+    }
+    // Update bottom selector (all lines starting with 🌐)
+    updated = updated.replace(/^🌐 .*$/gm, langSelector);
+
+    if (updated !== content) {
+      fs.writeFileSync(filePath, updated, "utf8");
+      console.log(`Updated language selectors (top and bottom) in translations/${lang}/README.md`);
+    }
   }
 }
 

--- a/translations/ar/README.md
+++ b/translations/ar/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · **العربية** · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · **العربية** · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC ليس قائمة أدوات؛ إنه دماغ واحد بعدة ملكات.
 
 ---
 
-🌐 [English](../../README.md) · **العربية** · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · **العربية** · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/de/README.md
+++ b/translations/de/README.md
@@ -1,0 +1,131 @@
+<!-- LANGUAGE-SELECTOR-START -->
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Deutsch** · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+<!-- LANGUAGE-SELECTOR-END -->
+
+<div align="center">
+<img src="../../assets/images/hero.png" alt="EGC - Extended Global Context" width="100%" />
+</div>
+
+<div align="center">
+
+# EGC - Gib jedem KI-Agenten dasselbe Gehirn
+
+**Persistenter Speicher, den jeder KI-Agent, jede IDE, jedes Terminal und jede Session automatisch teilt. Keine Prompts zum Auswendiglernen. Kein Kontext zum Wiederaufbauen. Einfach sprechen.**
+
+</div>
+
+---
+
+EGC ist nicht bloß ein weiteres Speicher-Tool. Es ist die Intelligenzschicht, die jede KI so arbeiten lässt, als wäre sie vom ersten Tag an in deinem Projekt dabei gewesen: in Cursor, Copilot, Claude Code, Codex, Aider und jedem Terminal-Agenten (insgesamt 20 KI-Coding-Tools). Funktioniert nativ mit Claude, GPT-4o, Gemini, DeepSeek, Mistral, Groq, Cohere und Vertex AI, plus OpenRouter für Qwen3, Llama 4 und mehr.
+
+Jedes Gespräch baut die kollektive Intelligenz deines Projekts auf. Jeder Agent erbt sie. Jede Session wird intelligenter.
+
+---
+
+## Installation
+
+```bash
+npm install -g @egchq/egc && egc install
+```
+
+- **Reduziere Kontext-Verschwendung um bis zu 90 %, senke Token-Kosten und halte jede KI über Sessions hinweg perfekt synchronisiert.**
+- **Guardian: Validiere jeden Befehl vor der Ausführung, blockiere gefährliche Schreibzugriffe und erkenne Prompt-Injection. Jedes geteilte Gehirn wird mit einer integrierten Sicherheitsschicht geliefert.**
+- **Ein Befehl, null Konfiguration: Der Speicher bleibt lokal sowie verschlüsselt auf deinem Rechner und wird niemals in Git committed.**
+
+<div align="center">
+  <img src="../../assets/gifs/install.gif" alt="Ein einziger Befehl installiert EGC über 20 KI-Coding-Tools hinweg" width="800" />
+</div>
+
+[Vollständige Installationsanleitung](../../docs/installation.md)
+
+---
+
+## Im Inneren des Gehirns: Wie EGC funktioniert
+
+EGC ist keine bloße Liste von Tools; es ist ein einzelnes Gehirn mit mehreren Fähigkeiten. Es erinnert sich, versteht, schützt, filtert und koordiniert über jeden KI-Agenten auf deinem Rechner hinweg.
+
+<div align="center">
+  <img src="../../assets/gifs/sharedbrain.gif" alt="Eine Entscheidung in Cursor ist in Claude Code bereits bekannt" width="900" />
+</div>
+
+### Keine Befehle auswendig lernen, einfach natürlich sprechen
+
+Sprich in jeder beliebigen Sprache mit dem Gehirn: "Speichere diese Session", "Was haben wir bezüglich Auth entschieden?", "Merke dir diese Entscheidung". EGC versteht die Absicht, speichert den Kontext und ruft ihn sofort in jedem anderen Tab, Terminal oder Tool auf deinem Rechner ab. Ein Gehirn. Jeder Agent. Null Befehle zum Auswendiglernen.
+
+### Persistenter Projekt-Speicher
+
+EGC verleiht jedem KI-Agenten ein persistentes, geteiltes Gehirn. Es erfasst Entscheidungen, Session-Kontext, Arbeitsspeicher sowie gelernte Muster und stellt diese sofort in jedem anderen Terminal, in jeder IDE oder in jedem neu geöffneten Agenten zur Verfügung. Session-Status, Projektverlauf und gesammelte Lektionen fließen nahtlos zwischen Tabs, Tools und Teammitgliedern: keine manuelle Synchronisation, kein Kontextverlust. Der gesamte Speicher liegt in `~/.egc` auf deinem Rechner, verschlüsselt mit AES-256-GCM, getrennt nach Projekt-Branch, und wird niemals in dein Repository committed.
+
+### Guardian: Integrierte Sicherheits-Schutzplanken
+
+Die zweite Hälfte des Gehirns führt Sicherheits-Schutzplanken im Hintergrund aus. Sie validiert Befehle vor ihrer Ausführung, blockiert risikoreiche Schreibzugriffe, komprimiert den Kontext, bevor er überläuft, orchestriert mehrstufige Aufgaben über Agenten hinweg und lernt aus jeder Korrektur, ganz ohne dass du ein einziges Tool aufrufen musst. Ein unsichtbares Sicherheitsnetz, das den Kontext schlank, Aktionen sicher und Workflows autonom hält.
+
+### Token Crusher: Das Gehirn filtert Rauschen, bevor es speichert
+
+Das Gehirn erinnert sich nicht nur: Es filtert. Bevor eine Shell-Ausgabe das Modell erreicht, komprimiert der Token Crusher von EGC Git-Logs, Test-Spam, Installations-Rauschen und riesige JSONs um bis zu 90 %, wobei jeder Fehler und jede Warnung erhalten bleibt. Frage einfach in einer beliebigen Sprache "Wie viel habe ich gespart?", und die Antwort kommt direkt aus deinem lokalen Ledger ohne jegliche Kosten: günstigere Sessions, länger anhaltender Kontext.
+
+---
+
+## Prompt-Bibliothek
+
+Als Bonus gewährt EGC dir Zugriff auf 63 Agenten, 230 Skills und 77 Befehle sowie 111 Regeln: Spezialisten, die deinen Code eigenständig überprüfen, Best-Practice-Leitfäden für jede Sprache und Situation, Shortcuts, die eine ganze Reihe von Aufgaben für dich ausführen, und Stilregeln, die deinen Code konsistent halten. Alles geschrieben aus realen Engineering-Sessions, nicht aus der Theorie. Du möchtest nichts davon nutzen? Kein Problem: Der permanente Speicher von EGC funktioniert genauso.
+
+---
+
+## Schnellstart
+
+Es gibt keinen zweiten Schritt. Öffne ein beliebiges deiner KI-Tools und sprich einfach los: "Hallo", "Lass uns weitermachen", "Merke dir diese Entscheidung", in jeder Sprache. Sessions verbinden sich sofort, der Speicher lädt automatisch und jeder offene Tab weiß bereits, was die anderen tun: Zwei Cursor-Tabs, ein Claude Code Terminal und eine Antigravity-Session teilen sich alle gleichzeitig denselben lebendigen Kontext.
+
+Ein Live-Dashboard, das Agenten-Aktivitäten, Tokens und Kosten anzeigt, startet direkt nach der Installation automatisch. Bevorzugst du manuelle Kontrolle? Jeder Befehl ist in der [Installationsanleitung](../../docs/installation.md) dokumentiert: Wahrscheinlich wirst du nie einen eingeben müssen.
+
+---
+
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Deutsch** · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+
+---
+
+## EGC unterstützen
+
+EGC wird von einem einzelnen Entwickler gebaut, öffentlich gepflegt und ist kostenlos.
+
+- **[Website](https://fmarzochi.github.io/EGCSite)**: Vollständige Dokumentation, Funktionsübersicht und Live-Demo
+- **[Discord beitreten](https://discord.gg/TxppsGb52)**: Fragen stellen, Feedback teilen
+- **[Sponsor auf GitHub werden](https://github.com/sponsors/Fmarzochi)**: Jeder Betrag hilft
+- **[Spenden über PayPal](https://www.paypal.com/donate/?business=fmarzochi%40gmail.com&currency_code=USD)**: Kein GitHub-Konto erforderlich
+- **Gib dem Repository einen Stern**: Hilft anderen Entwicklern, es zu finden
+- **[Mitwirken](../../.github/CONTRIBUTING.md)**: Agenten, Skills, Befehle, Bugfixes, Dokumentation
+- **Teilen**: Wenn EGC deine Arbeitsweise verändert hat, erzähle es weiter
+
+### Sponsoren
+
+Die Unterstützung aus der Community hält dieses Projekt am Leben und unabhängig.
+
+#### Tool-Partner
+
+KI-Coding-Tools, die sich nativ mit EGC integrieren. Partner erhalten Logo-Platzierungen auf allen READMEs und auf EGCSite.
+
+<a href="https://www.pincushion.io/"><img src="https://www.pincushion.io/logo-icon.png" width="52" height="52" alt="Pincushion" title="Pincushion" /></a>
+
+#### Jährliche Sponsoren · _Sei der erste jährliche Sponsor._
+
+---
+
+#### Unterstützer
+
+<a href="https://github.com/chizormaangel-commits"><img src="https://avatars.githubusercontent.com/u/291871326?v=4" width="52" height="52" alt="@chizormaangel-commits" title="@chizormaangel-commits" /></a>
+
+#### Monatliche Sponsoren · _sei der Erste_
+
+---
+
+<div align="center">
+
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13099/badge)](https://www.bestpractices.dev/projects/13099) [![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/13099/badge?level=baseline-1)](https://www.bestpractices.dev/projects/13099?level=baseline-1) [![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/13099/badge?level=baseline-2)](https://www.bestpractices.dev/projects/13099?level=baseline-2) [![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/13099/badge?level=baseline-3)](https://www.bestpractices.dev/projects/13099?level=baseline-3)
+
+<br>
+
+<a href="https://bestpractices.dev/projects/13099"><img src="../../assets/images/openssf-best-practices-badge.svg" alt="OpenSSF Best Practices" width="110" /></a>
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
+<a href="https://www.linkedin.com/in/felipemarzochi"><img src="../../assets/images/egc-logo.png" alt="EGC" width="110" /></a>
+
+</div>

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · **Español** · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ Un panel en vivo con la actividad, los tokens y los costos de tus agentes arranc
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · **Español** · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · **Español** · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/fr/README.md
+++ b/translations/fr/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · **Français** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · **Français** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ Un tableau de bord en direct affichant l'activité des agents, les tokens et les
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · **Français** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · **Français** · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/hi/README.md
+++ b/translations/hi/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC हर AI एजेंट को एक स्थायी, साझा द
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · **हिन्दी** · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/it/README.md
+++ b/translations/it/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ Una dashboard live che mostra attività degli agenti, token e costi si avvia aut
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · **Italiano** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/ja/README.md
+++ b/translations/ja/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGCはすべてのAIエージェントに永続的な共有脳を与えます。
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · **日本語** · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC는 모든 AI 에이전트에게 영속적인 공유 뇌를 줍니다. 결정
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · **한국어** · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/pt/README.md
+++ b/translations/pt/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ Um painel ao vivo com a atividade, os tokens e os custos dos seus agentes inicia
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Português (Brasil)** · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/ru/README.md
+++ b/translations/ru/README.md
@@ -1,5 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -80,7 +80,7 @@ EGC даёт каждому ИИ-агенту постоянный общий м
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · **Русский** · [简体中文](../zh-CN/README.md)
 
 ---
 

--- a/translations/zh-CN/README.md
+++ b/translations/zh-CN/README.md
@@ -1,7 +1,5 @@
 <!-- LANGUAGE-SELECTOR-START -->
-
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
-
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
 <!-- LANGUAGE-SELECTOR-END -->
 
 <div align="center">
@@ -91,7 +89,7 @@ egc dashboard
 
 ---
 
-🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
+🌐 [English](../../README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Español](../es/README.md) · [Français](../fr/README.md) · [हिन्दी](../hi/README.md) · [Italiano](../it/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Português (Brasil)](../pt/README.md) · [Русский](../ru/README.md) · **简体中文**
 
 ---
 


### PR DESCRIPTION
## What Changed
Added a German translation of the main README at translations/tr/README.md
Translated the documentation into natural and technically accurate German
Preserved the original Markdown structure
Kept code blocks, commands, file paths, product names, and links unchanged

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation
- [ ] Added comments for complex logic
- [x] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a German README translation and improves the language selector generator to render correct per-language selectors at the top and bottom across the root and all translations, with robust Unicode matching.

- **New Features**
  - Added German translation at `translations/de/README.md`.
  - Added “Deutsch” to language selectors in the root and all translated READMEs (top and bottom).

- **Refactors**
  - Reworked `scripts/update-readme-languages.js` with `buildSelectorForLang` to bold the current language, build correct relative links (English from translations uses `../../README.md`), and update bottom selectors by matching the globe via its Unicode escape (`\u{1F310}`) for consistent replacements.

<sup>Written for commit d7527bf5c9035c197f7c70a03e32c65d2e649c98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

