### PR TITLE
docs(roadmap): add Turkish and German README translations to unreleased

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -116,6 +116,8 @@ Closes the commit-privacy scope started in v1.1.12:
 - `stream=True` now raises `NotImplementedError` across the five remaining native providers (Claude, Cohere, Gemini, Ollama, Vertex AI), completing stream-guard coverage (#924, @hanu-14)
 - Dashboard serves static files added after startup without a restart, with a symlink guard and a debounced manifest rebuild that preserves the traversal protection (#928, @hanu-14)
 - French README translation, the 11th language, wired into every language selector (#948, @ankit24417-sys)
+- Turkish README translation, the 12th language, wired into every language selector (#970, @Iahmacun)
+- German README translation, the 13th language, wired into every language selector (#972, @rathaur-ankit)
 - High-severity advisories cleared: fast-uri and linkify-it across the root and mcp-server lockfiles (#967), and `@hono/node-server` forced to 2.x via npm override to close the last Dependabot and Scorecard findings (#968)
 - ClusterFuzzLite weekly schedule disabled while upstream is dead-locked for JavaScript, keeping manual `workflow_dispatch` (EGC#910)
 


### PR DESCRIPTION
Record the two community translations merged today in the Unreleased section, next to the French entry: Turkish (#970, @Iahmacun, 12th language) and German (#972, @rathaur-ankit, 13th language).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Turkish (12th) and German (13th) README translations to the ROADMAP Unreleased section, noting both are wired into every language selector.

<sup>Written for commit e26961a187d792c41ccd774422b87b09e821fd95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

