### PR TITLE
fix(install): install deps without a lockfile and skip build when src is absent

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,18 @@ set -e
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+# npm strips the root package-lock.json from the published tarball, and the
+# guardian/memory lockfiles are not in package.json "files", so `npm ci` has no
+# lockfile during a clean `npm install -g @egchq/egc` + `egc install`. Use npm ci
+# only when a lockfile is present (git checkout) and fall back to npm install.
+install_deps() {
+  if [ -f package-lock.json ]; then
+    npm ci --silent
+  else
+    npm install --no-audit --no-fund --silent
+  fi
+}
+
 # Forward --help directly to the Node installer
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   node "$ROOT_DIR/scripts/install-apply.js" "$@"
@@ -48,7 +60,7 @@ if [ "$DRY_RUN" = false ]; then
   # Root dependencies (better-sqlite3 etc.)
   echo "  installing root dependencies..."
   cd "$ROOT_DIR"
-  npm ci --silent
+  install_deps
 
   # egc-guardian
   echo "  building egc-guardian..."
@@ -58,8 +70,12 @@ if [ "$DRY_RUN" = false ]; then
     exit 1
   fi
   cd "$GUARDIAN_DIR"
-  npm ci --silent
-  npm run build
+  install_deps
+  # The published package ships build/ but not src/, so only (re)build from a
+  # git checkout where the TypeScript sources are present.
+  if [ -d src ]; then
+    npm run build
+  fi
 
   # egc-memory
   echo "  building egc-memory..."
@@ -69,8 +85,11 @@ if [ "$DRY_RUN" = false ]; then
     exit 1
   fi
   cd "$MEMORY_DIR"
-  npm ci --silent
-  npm run build
+  install_deps
+  # Published package ships build/ but not src/; only build from a checkout.
+  if [ -d src ]; then
+    npm run build
+  fi
 
   # Initialize database and local directories
   echo "  initializing database..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,10 @@ install_deps() {
   if [ -f package-lock.json ]; then
     npm ci --silent
   else
-    npm install --no-audit --no-fund --silent
+    # No lockfile: install without running untrusted lifecycle scripts, then
+    # rebuild only the already-resolved native modules (e.g. better-sqlite3).
+    npm install --ignore-scripts --no-audit --no-fund --silent
+    npm rebuild --silent
   fi
 }
 

--- a/tests/scripts/install-sh.test.js
+++ b/tests/scripts/install-sh.test.js
@@ -95,6 +95,40 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('installs deps without a lockfile and skips build when src/ is absent (regression #643)', () => {
+    const script = fs.readFileSync(SCRIPT, 'utf8');
+
+    // A clean `npm install -g @egchq/egc` + `egc install` unpacks a tarball with
+    // no root/guardian/memory package-lock.json (npm strips the root lockfile and
+    // the sub-package lockfiles are not in package.json "files"), so a bare
+    // `npm ci` aborts before Guardian and Memory are ever installed.
+    assert.ok(
+      /install_deps\s*\(\)\s*\{/.test(script),
+      'install.sh must define an install_deps helper'
+    );
+    assert.ok(
+      /-f\s+package-lock\.json/.test(script) && /npm install/.test(script),
+      'install_deps must fall back to npm install when no lockfile is present'
+    );
+
+    // npm ci may appear only inside install_deps, never as a bare install step.
+    const bareNpmCi = script
+      .split('\n')
+      .filter(line => /^\s*npm ci\b/.test(line));
+    assert.strictEqual(
+      bareNpmCi.length,
+      1,
+      `npm ci must live only inside install_deps (found ${bareNpmCi.length} occurrences)`
+    );
+
+    // The published package ships build/ but not src/, so the TypeScript build
+    // must be guarded by a src/ presence check.
+    assert.ok(
+      /if\s+\[\s+-d\s+src\s+\]/.test(script),
+      'npm run build must be guarded by an "if [ -d src ]" check'
+    );
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What

`egc install` from the published npm package failed on a clean machine. Two packaging bugs, one hidden behind the other:

1. `scripts/install.sh` ran `npm ci` in the root, guardian, and memory dirs, but npm strips the root `package-lock.json` from the published tarball and the sub-package lockfiles are not in `files`, so `npm ci` aborted at the first step, before Guardian and Memory were ever installed.
2. Once the root step was unblocked, `npm run build` failed because the published package ships `build/` but not `src/`, so `tsc` and `build-skill-index.js` had no sources to compile.

## Fix

- `install_deps()` helper: use `npm ci` when a lockfile is present (git checkout, deterministic) and fall back to `npm install` when it is not (published package). Applied to root, guardian, and memory, and matches what `install.ps1` already did on Windows.
- Only run `npm run build` from a checkout that ships `src/`; the published package already includes a built `build/`.
- Regression test in `install-sh.test.js` that fails if a bare `npm ci` returns to a dependency step or the `src/` build guard is dropped.

## Verification

Packed the tarball with `npm pack`, extracted it (all three lockfiles absent, reproducing the report), confirmed `npm ci` fails there, then ran `egc install` end to end with an isolated HOME: it now completes with `Installation complete.` and both MCP builds verified.

Reported by @Tyr1onX in #643.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `egc install` from the published package by safely installing deps when no lockfile is present and skipping builds when `src/` is missing. This makes `npm install -g @egchq/egc` + `egc install` work on clean machines.

- **Bug Fixes**
  - Added `install_deps()` to run `npm ci` when a `package-lock.json` exists, else `npm install --ignore-scripts` + `npm rebuild` (root, guardian, memory).
  - Only run `npm run build` when `src/` is present; the published package already ships `build/`.
  - Added a regression test to block bare `npm ci` calls and enforce the `src/` build guard.

<sup>Written for commit 82ecb4fd74759569b306cf3c4958cb789c6a5e7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

