### PR TITLE
fix(i18n): map Chinese Simplified to zh-CN and seed existing translations in Crowdin

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -28,7 +28,7 @@ jobs:
         uses: crowdin/github-action@e0c8f73cdc0fafde9396e056c5038217000a32d1 # v2
         with:
           upload_sources: true
-          upload_translations: false
+          upload_translations: true
           download_translations: false
           create_pull_request: false
         env:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,3 +7,6 @@ base_path: "."
 files:
   - source: /README.md
     translation: /translations/%two_letters_code%/README.md
+    languages_mapping:
+      two_letters_code:
+        zh-CN: zh-CN


### PR DESCRIPTION
## Problem (#483)

The Simplified Chinese README shows 0% (484 untranslated strings) in Crowdin even though `translations/zh-CN/README.md` already exists in the repo.

Root cause: `crowdin.yml` maps translations with `%two_letters_code%`, which resolves to `zh` for Chinese. Crowdin looks for `translations/zh/README.md` and never sees the existing `translations/zh-CN/README.md`. On top of that, the sync ran with `upload_translations: false`, so existing repo translations were never seeded into Crowdin.

## Fix

- `crowdin.yml`: add a `languages_mapping` so Chinese Simplified (`zh-CN`) maps to the `zh-CN` path segment instead of `zh`, matching the repo layout.
- `crowdin-sync.yml`: set `upload_translations: true` in the upload step, so existing repo translations are seeded into Crowdin. Contributors then only translate the new or changed strings, exactly as requested in #483.

The Crowdin action seeds translations without auto-approving or overwriting approved Crowdin work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Crowdin for Simplified Chinese by mapping `zh-CN` to the correct folder and uploading existing translations. zh-CN now matches the repo and shows accurate progress.

- **Bug Fixes**
  - Map `%two_letters_code%` to `zh-CN` in `crowdin.yml` so Crowdin uses `translations/zh-CN/README.md`.
  - Set `upload_translations: true` in `.github/workflows/crowdin-sync.yml` to seed existing translations without auto-approving or overwriting.

<sup>Written for commit c65778268dc17e981db4d556a20debc177a7af7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

