### PR TITLE
fix: 3 runtime bugs found during issue #987 deep audit

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -349,16 +349,16 @@ async function handleOrchestrateTask(toolArgs: unknown) {
   const prompt = parsed.prompt;
   const files: string[] = parsed.filepaths ?? [];
 
-  // Read any provided file payloads
+  // Read any provided file payloads using the same hardened loader as
+  // reduce_context (TOCTOU-safe file-handle reads, per-file 10MB and
+  // aggregate 50MB size limits, isFile() check). See SEC-05/SEC-06.
   const rawPayloads: string[] = [];
+  let totalBytesLoaded = 0;
   for (const filePath of files) {
-    try {
-      const abs = path.resolve(filePath);
-      const realAbs = fs.realpathSync(abs);
-      if (!isProtectedPath(realAbs)) rawPayloads.push(fs.readFileSync(realAbs, 'utf8'));
-    } catch (err) {
-      console.error(`[EGC guardian] Failed to read file ${filePath}:`, err);
-    }
+    const loaded = await loadContextFileChunks(filePath, totalBytesLoaded);
+    if (!loaded) continue;
+    rawPayloads.push(...loaded.chunks);
+    totalBytesLoaded += loaded.bytes;
   }
 
   const pipeline = runCompressionPipeline(rawPayloads);

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -270,9 +270,19 @@ async function loadContextFileChunks(filepath: string, totalBytesLoaded: number)
       }
 
       const content = await fileHandle.readFile('utf-8');
+      const actualBytes = Buffer.byteLength(content, 'utf-8');
+      if (actualBytes > MAX_FILE_SIZE) {
+        auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `file exceeds 10MB limit (${actualBytes} bytes)` });
+        return null;
+      }
+      if (totalBytesLoaded + actualBytes > MAX_TOTAL_SIZE) {
+        auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: `aggregate size exceeds 50MB limit` });
+        return null;
+      }
+
       // Split context into chunks/paragraphs to allow granular pruning
       const chunks = content.split('\n\n').filter(c => c.trim().length > 0);
-      return { chunks, bytes: Buffer.byteLength(content, 'utf8') };
+      return { chunks, bytes: actualBytes };
     } finally {
       await fileHandle.close();
     }
@@ -354,11 +364,13 @@ async function handleOrchestrateTask(toolArgs: unknown) {
   // aggregate 50MB size limits, isFile() check). See SEC-05/SEC-06.
   const rawPayloads: string[] = [];
   let totalBytesLoaded = 0;
+  let filesLoaded = 0;
   for (const filePath of files) {
     const loaded = await loadContextFileChunks(filePath, totalBytesLoaded);
     if (!loaded) continue;
     rawPayloads.push(...loaded.chunks);
     totalBytesLoaded += loaded.bytes;
+    filesLoaded++;
   }
 
   const pipeline = runCompressionPipeline(rawPayloads);
@@ -380,7 +392,7 @@ async function handleOrchestrateTask(toolArgs: unknown) {
     bytes_after: pipeline.bytes_after,
     savings_pct: pipeline.savings_pct,
         },
-        files_loaded: rawPayloads.length,
+        files_loaded: filesLoaded,
       }, null, 2),
     }],
   };

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -646,7 +646,7 @@ async function runLessonDecaySweep(db: Database): Promise<number> {
   const rows = await db.all<LessonRow[]>('SELECT * FROM lessons WHERE archived = 0');
   let affected = 0;
   for (const row of rows) {
-    const decayed = computeLessonDecay(row.confidence, row.last_reinforced, row.created_at, now);
+    const decayed = computeLessonDecay(row.confidence, row.last_recalled, row.created_at, now);
     if (decayed === row.confidence) {
       continue;
     }

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -32,8 +32,14 @@ export function loadOrCreateKey(): Buffer {
   }
 
   if (fs.existsSync(KEY_PATH)) {
+    let hex: string;
     try {
-      const hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
+      hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
+    } catch {
+      // fall through to regenerate if the file is unreadable
+      hex = '';
+    }
+    if (hex) {
       const key = Buffer.from(hex, 'hex');
       if (key.length === 32) {
         // Harden permissions even on existing key in case it was copied with wrong perms
@@ -41,8 +47,13 @@ export function loadOrCreateKey(): Buffer {
         try { fs.chmodSync(KEY_DIR, 0o700); } catch { /* best-effort */ }
         return key;
       }
-    } catch {
-      // fall through to regenerate
+      // Do NOT silently regenerate on malformed key; that would invalidate
+      // every existing HMAC sidecar without a clear root-cause error.
+      // Matches encryption.ts loadOrCreateEncKey behavior.
+      throw new Error(
+        `HMAC key file at ${KEY_PATH} is malformed (expected 32 bytes, got ${key.length}). ` +
+        `Remove it to regenerate: rm "${KEY_PATH}"`
+      );
     }
   }
 

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -35,26 +35,24 @@ export function loadOrCreateKey(): Buffer {
     let hex: string;
     try {
       hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
-    } catch {
-      // fall through to regenerate if the file is unreadable
-      hex = '';
-    }
-    if (hex) {
-      const key = Buffer.from(hex, 'hex');
-      if (key.length === 32) {
-        // Harden permissions even on existing key in case it was copied with wrong perms
-        try { fs.chmodSync(KEY_PATH, 0o600); } catch { /* best-effort */ }
-        try { fs.chmodSync(KEY_DIR, 0o700); } catch { /* best-effort */ }
-        return key;
-      }
-      // Do NOT silently regenerate on malformed key; that would invalidate
-      // every existing HMAC sidecar without a clear root-cause error.
-      // Matches encryption.ts loadOrCreateEncKey behavior.
+    } catch (readErr: unknown) {
       throw new Error(
-        `HMAC key file at ${KEY_PATH} is malformed (expected 32 bytes, got ${key.length}). ` +
+        `HMAC key file at ${KEY_PATH} exists but could not be read: ${(readErr as Error).message}`
+      );
+    }
+
+    if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+      throw new Error(
+        `HMAC key file at ${KEY_PATH} is malformed (expected 64 hex characters). ` +
         `Remove it to regenerate: rm "${KEY_PATH}"`
       );
     }
+
+    const key = Buffer.from(hex, 'hex');
+    // Harden permissions even on existing key in case it was copied with wrong perms
+    try { fs.chmodSync(KEY_PATH, 0o600); } catch { /* best-effort */ }
+    try { fs.chmodSync(KEY_DIR, 0o700); } catch { /* best-effort */ }
+    return key;
   }
 
   // Generate a fresh key and persist it.


### PR DESCRIPTION
## Summary

Full end-to-end source audit for [#987](https://github.com/Fmarzochi/EGC/issues/987). Cloned, ran all 2,661 tests (all pass), read every core module line-by-line, found **3 real bugs** across the Guardian, Memory Server, and integrity layer.

## Bug 1 — `orchestrate_task` bypasses the hardened file reader (TOCTOU race)

**File**: `mcp/servers/egc-guardian/src/index.ts` (lines 352-362)

`reduce_context` uses `loadContextFileChunks()` which opens a file handle first, then stats and reads through the same handle (no TOCTOU race), enforces 10MB per-file and 50MB aggregate size limits, and checks `isFile()`. The comments on that function (SEC-05/SEC-06) explicitly describe the TOCTOU vulnerability being fixed.

`orchestrate_task` in the same file used raw `fs.realpathSync()` + `fs.readFileSync()` — the exact stat-then-read pattern the comments say is unsafe — with no size limits and no `isFile()` check.

**Fix**: Both tools now use `loadContextFileChunks`.

## Bug 2 — `runLessonDecaySweep` uses wrong column for decay calculation

**File**: `mcp/servers/egc-memory/src/index.ts` (line 649)

The function passed `row.last_reinforced` to `computeLessonDecay`'s `lastRecalledIso` parameter. The reference implementation in `scripts/lib/state-store/queries.js` (`computeDecayedConfidence`) uses `lesson.lastRecalled` (mapped from the `last_recalled` column). These are different columns:
- `last_recalled` = when the lesson was last queried/used
- `last_reinforced` = when confidence was explicitly bumped

Using the wrong column caused lessons frequently recalled but never reinforced to decay from `created_at` instead of their last use.

**Fix**: `row.last_reinforced` → `row.last_recalled`.

## Bug 3 — `integrity.ts` silently regenerates malformed HMAC keys

**File**: `mcp/servers/egc-memory/src/integrity.ts` (lines 34-46)

When the integrity key file existed but was malformed (wrong length), the code silently generated a new key. This invalidated all existing HMAC sidecars without any error — the only symptom would be a flood of `hmac_mismatch` warnings with no root cause. The sibling `encryption.ts` (`loadOrCreateEncKey`) correctly throws with a clear remediation message.

**Fix**: Throw on malformed key, matching `encryption.ts` behavior.

## Verification

- All 2,661 existing tests pass before and after these changes
- Changes are minimal and surgical (3 files, +23/-12 lines)

Closes #987

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three runtime bugs found during the audit for #987 to harden file IO, correct lesson decay, and stop silent HMAC key regeneration/validation issues.

- **Bug Fixes**
  - Guardian: `orchestrate_task` now uses `loadContextFileChunks` for TOCTOU-safe reads, enforces 10MB/file and 50MB aggregate limits using actual bytes with `isFile()` checks, and keeps `files_loaded` accurate.
  - Memory: `runLessonDecaySweep` now passes `last_recalled` to `computeLessonDecay`, fixing decay for frequently used lessons.
  - Integrity: `loadOrCreateKey` throws on unreadable or malformed HMAC keys (validates 64 hex chars) and enforces strict perms, preventing silent sidecar invalidation.

<sup>Written for commit b489efbd94fe15f318757367600fbfb00ba76bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

