### PR TITLE
fix(i18n): remap two_letters_code zh to zh-CN so Crowdin sync uses the canonical path

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -9,4 +9,5 @@ files:
     translation: /translations/%two_letters_code%/README.md
     languages_mapping:
       two_letters_code:
+        zh: zh-CN
         zh-CN: zh-CN

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,16 +876,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
Problem: the daily Crowdin sync reopened the old translations/zh/README.md path (closed in #991) instead of the canonical translations/zh-CN/README.md, even though #988 added a languages_mapping for Chinese Simplified.

Root cause: languages_mapping.two_letters_code was keyed on zh-CN, but the download step resolves the %two_letters_code% placeholder to zh for Chinese, so the mapping never matched and the path stayed zh.

Fix: add a zh mapping (zh to zh-CN) so the value produced on download is remapped to zh-CN, keeping the zh-CN entry as a fallback. Only Chinese is affected; every other language keeps its two-letter folder. Follow-up to #483 and #988.

Validation: not verifiable locally (needs the Crowdin secrets in CI). After merge, trigger Crowdin Sync via workflow_dispatch and confirm the next sync targets translations/zh-CN/README.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map `zh` to `zh-CN` in `crowdin.yml` so Crowdin sync writes to translations/zh-CN/README.md instead of translations/zh/README.md. Dev-only audit fix: bump `brace-expansion` and `tar` in `package-lock.json`.

<sup>Written for commit 69812a1837864ee752df6a814fc58801873149ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

