### PR TITLE
docs(roadmap): refresh unreleased section and translation status after v1.1.15

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,7 +123,14 @@ Closes the commit-privacy scope started in v1.1.12:
 
 ## Unreleased (on main)
 
-_Nothing yet since v1.1.15._
+Landed on main since v1.1.15, not yet released:
+
+- Bare `egc install` from the published npm package fixed: `install.sh` falls back to `npm install` when the published tarball ships no root lockfile, and only builds when `src/` is present (#985, #986, closes #643)
+- Chinese Simplified mapped to `zh-CN` in Crowdin with the existing repo translations seeded (#988, closes #483)
+- Crowdin sync now writes to the canonical `translations/zh-CN/` path instead of recreating `translations/zh/` (#992)
+- Three runtime bugs from the #987 deep audit fixed: the `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani)
+- High-severity root lockfile advisories cleared: `brace-expansion` and `tar` (#992)
+- Supported-harness count kept in sync across the docs (#984)
 
 ## v1.2.0: Teams
 
@@ -137,7 +144,7 @@ Multi-developer workflows and shared context:
 
 ## v1.3.0: Growth
 
-- Community translations: German, French, Italian, Turkish, Ukrainian, Malay
+- Community translations: Ukrainian, Malay (German, French, Italian, and Turkish shipped across v1.1.14 and v1.1.15)
 - Per-project skill profiles and overrides
 - OSS-Fuzz integration for continuous fuzz testing
 


### PR DESCRIPTION
The Unreleased-on-main section said nothing had landed since v1.1.15 while six PRs already had; list them (#984, #985, #986, #988, #989, #992). Also move German, French, Italian and Turkish out of the v1.3.0 translation wishlist since they shipped in v1.1.14 and v1.1.15, leaving Ukrainian and Malay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh ROADMAP after v1.1.15: populate “Unreleased (on main)” with six landed changes and update the v1.3.0 translations to reflect shipped languages.
Highlights include the install flow fix, zh-CN mapping and path correction in Crowdin, three runtime bug fixes, cleared advisories in `brace-expansion` and `tar`, and docs harness count sync; only Ukrainian and Malay remain on the translation list.

<sup>Written for commit 2df2fda0c74cef9bbd29ddbcd895a4a163d4675f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

