### PR TITLE
fix(deps): bump tar to 7.5.22 in the mcp server lockfiles (Dependabot)

### DIFF
--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -1763,9 +1763,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -2067,9 +2067,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
Clears the tar advisory (GHSA-r292-9mhp-454m, moderate) in mcp/servers/egc-guardian and mcp/servers/egc-memory. Patch bump 7.5.20 to 7.5.22, dev-only transitive, no other package changed, typescript untouched. Root lockfile was fixed in #992. Remaining: fuzz brace-expansion (high) needs a non-semver-safe fix and is tracked in EGC-418 for the squad.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch bump `tar` to 7.5.22 in `mcp/servers/egc-guardian` and `mcp/servers/egc-memory` lockfiles to clear Dependabot advisory GHSA-r292-9mhp-454m (moderate); dev-only transitive with no other changes. Remaining high-severity `brace-expansion` work is tracked in EGC-418.

<sup>Written for commit 0c5a0c8c4274bcd9383bdf3a03b792bbecbaf537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

