### PR TITLE
fix(deps): override brace-expansion to 5.0.8 in fuzz (last Dependabot advisory)

### DIFF
--- a/fuzz/package-lock.json
+++ b/fuzz/package-lock.json
@@ -239,19 +239,24 @@
       "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/caching-transform": {
@@ -355,12 +360,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/convert-source-map": {

--- a/fuzz/package.json
+++ b/fuzz/package.json
@@ -9,6 +9,7 @@
   "overrides": {
     "cross-spawn": "^7.0.6",
     "uuid": "^11.1.1",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "brace-expansion": "5.0.8"
   }
 }


### PR DESCRIPTION
Clears the last open Dependabot advisory: brace-expansion 1.1.16 (GHSA-mh99-v99m-4gvg, high) in fuzz/package-lock.json, transitive via jsfuzz to nyc to glob to minimatch with no fix on the normal tree. Adds a brace-expansion override forcing 5.0.8 (same pattern as the existing cross-spawn/uuid/js-yaml overrides). npm audit --package-lock-only now reports 0 vulnerabilities. This should also close the Scorecard Vulnerabilities code-scanning alert #215 on the next scan, since that check is derived from dependency vulns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `brace-expansion` to 5.0.8 in the `fuzz` project to resolve the high-severity advisory (GHSA-mh99-v99m-4gvg) and clear the last dependency vulnerability. `npm audit --package-lock-only` now reports 0 vulnerabilities, which should close Scorecard Vulnerabilities alert #215.

- **Dependencies**
  - Added `brace-expansion: 5.0.8` override in `fuzz/package.json` (same pattern as `cross-spawn`, `uuid`, `js-yaml`).
  - Updated lockfile: `brace-expansion` to 5.0.8, `balanced-match` to 4.0.4; removed `concat-map`.

<sup>Written for commit 495497f1fb80d2ca86c4f1c77089aa9e0feec845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

