### PR TITLE
docs(roadmap): note all Dependabot and Scorecard advisories cleared to zero

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,7 +129,7 @@ Landed on main since v1.1.15, not yet released:
 - Chinese Simplified mapped to `zh-CN` in Crowdin with the existing repo translations seeded (#988, closes #483)
 - Crowdin sync now writes to the canonical `translations/zh-CN/` path instead of recreating `translations/zh/` (#992)
 - Three runtime bugs from the #987 deep audit fixed: the `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani)
-- High-severity root lockfile advisories cleared: `brace-expansion` and `tar` (#992)
+- All Dependabot and Scorecard advisories cleared to zero: `brace-expansion` and `tar` in the root lockfile (#992), `tar` in the two mcp server lockfiles (#994), and `brace-expansion` in `fuzz` via an override (#995); the Scorecard Vulnerabilities code-scanning alert closed with them
 - Supported-harness count kept in sync across the docs (#984)
 
 ## v1.2.0: Teams


### PR DESCRIPTION
Consolidates the Unreleased security line: root lockfile (#992), the two mcp server lockfiles (#994) and fuzz via a brace-expansion override (#995) advisories are all cleared, and the Scorecard Vulnerabilities code-scanning alert closed with them. Dependabot and code scanning are both at 0 open alerts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ROADMAP to note that all Dependabot and Scorecard advisories are cleared to zero and the Scorecard Vulnerabilities alert is closed.

<sup>Written for commit bbb60e719dd7576655b907b4fc2526e4a365721c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

