### PR TITLE
fix(i18n): drop invalid zh mapping key that broke Crowdin Sync

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -9,5 +9,4 @@ files:
     translation: /translations/%two_letters_code%/README.md
     languages_mapping:
       two_letters_code:
-        zh: zh-CN
         zh-CN: zh-CN


### PR DESCRIPTION
The Crowdin Sync has failed since 25/07 with 'Configuration file is invalid'. Cause: the zh: zh-CN entry added in #992 — a languages_mapping key must be a valid Crowdin language code (the CLI says: crowdin_language_code: code_you_use), and Chinese Simplified is zh-CN, not zh. The invalid zh key failed the whole config, so every sync errored at 'Upload sources to Crowdin'. Remove it, keeping the valid zh-CN: zh-CN entry, so the sync runs again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an invalid `zh: zh-CN` mapping in `crowdin.yml` that broke Crowdin Sync with “Configuration file is invalid.” Kept the valid `zh-CN: zh-CN` entry so uploads run again.

<sup>Written for commit 3529180c5c76e4ffa947eb96895910112ae43429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

