### PR TITLE
fix(i18n): write Chinese Simplified to zh-CN in the Crowdin sync workflow

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -97,24 +97,47 @@ jobs:
             sleep 10
           done
 
-      - name: Download translations and create PR
+      - name: Download translations
         uses: crowdin/github-action@e0c8f73cdc0fafde9396e056c5038217000a32d1 # v2
         with:
           upload_sources: false
           upload_translations: false
           download_translations: true
-          create_pull_request: true
-          pull_request_title: "chore: sync translations from Crowdin"
-          pull_request_body: |
-            Translations synced automatically from [Crowdin](https://crowdin.com/project/egc).
-
-            Only fully translated files are included (`skip_untranslated_files: true`).
-
-            > This PR was created automatically. Do not merge unless all checks pass.
-          pull_request_base_branch_name: main
-          localization_branch_name: chore/crowdin-translations
+          create_pull_request: false
+          push_translations: false
           skip_untranslated_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      # Crowdin resolves %two_letters_code% for Chinese Simplified to "zh", but the
+      # canonical path in this repo is zh-CN. The action/CLI expose no download
+      # language mapping, so the folder is normalized here before opening the PR.
+      - name: Normalize Chinese Simplified path and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The crowdin action runs in Docker and writes files as root, so take
+          # ownership back before the rename and git operations.
+          sudo chown -R "$(id -u):$(id -g)" translations
+          if [ -d translations/zh ]; then
+            mkdir -p translations/zh-CN
+            cp -a translations/zh/. translations/zh-CN/
+            rm -rf translations/zh
+          fi
+          if [ -z "$(git status --porcelain -- translations)" ]; then
+            echo "No translation changes to sync."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C chore/crowdin-translations
+          git add -- translations
+          git commit -m "chore: sync translations from Crowdin"
+          git push -f origin chore/crowdin-translations
+          if [ -z "$(gh pr list --head chore/crowdin-translations --state open --json number --jq '.[0].number // empty')" ]; then
+            gh pr create --base main --head chore/crowdin-translations \
+              --title "chore: sync translations from Crowdin" \
+              --body "Translations synced automatically from Crowdin. Only fully translated files are included. Do not merge unless all checks pass."
+          fi


### PR DESCRIPTION
The crowdin/github-action and crowdin-cli expose no download language mapping (confirmed in their official docs), so the sync kept recreating translations/zh/ instead of the canonical translations/zh-CN/. This splits the download from PR creation and renames zh to zh-CN before opening the PR, taking ownership back from the Docker-created files with sudo chown. Validated end-to-end on this branch via workflow_dispatch: the run passes and the translations branch now has translations/zh-CN/ with no translations/zh/ (zh returns 404).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Chinese Simplified downloads from Crowdin to `translations/zh-CN` and creates the PR after the rename. Prevents duplicate locale folders and duplicate PRs while keeping the repo’s canonical path.

- **Bug Fixes**
  - Split download from PR creation in `crowdin/github-action`; disable `create_pull_request` and `push_translations`, handle PR with `gh`.
  - Rename `translations/zh` to `translations/zh-CN` and reclaim file ownership with `sudo chown` to avoid Docker root perms.
  - Only push and open a PR if there are changes; skip if an open PR already exists; keep `skip_untranslated_files: true`.

<sup>Written for commit b6d5156c20a95c85523d1edfab5e5a3e8e5ec08b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

