### PR TITLE
sec: guardian security limits and command allowlist expansion

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -343,8 +343,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "orchestrate_task": {
         const prompt = request.params.arguments?.prompt as string;
-        const agents: string[] = (request.params.arguments?.agents ?? []) as string[];
-        const skills: string[] = (request.params.arguments?.skills ?? []) as string[];
         const files: string[] = (request.params.arguments?.filepaths ?? []) as string[];
 
         // Read any provided file payloads

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -13,8 +13,8 @@ function hideEgcRootOnWindows(): void {
   const egcRoot = path.join(os.homedir(), '.egc');
   try {
     execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
-  } catch (_) {
-    // non-critical: folder works even if attribute fails
+  } catch (error) {
+    console.error('non-critical: folder works even if attribute fails', error);
   }
 }
 import { z } from 'zod';

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -106,7 +106,9 @@ class PersistentLogger {
         // file might not exist
       }
       await fs.promises.appendFile(this.logPath, payload + '\n', 'utf-8');
-    } catch(e) {}
+    } catch (e) {
+      console.error('[EGC guardian] Log write failed (disk full?):', String(e));
+    }
   }
 }
 

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -267,6 +267,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'protected path' });
                continue;
              }
+             const stats = fs.statSync(realResolved);
+             if (!stats.isFile()) {
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'not a regular file' });
+               continue;
+             }
+             if (stats.size > 10 * 1024 * 1024) { // 10MB per file max
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'exceeds per-file 10MB limit' });
+               continue;
+             }
+             if (totalBytesLoaded + stats.size > 50 * 1024 * 1024) { // 50MB aggregate max
+               auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'exceeds aggregate 50MB limit' });
+               continue;
+             }
              const content = await fs.promises.readFile(realResolved, 'utf-8');
              // Split context into chunks/paragraphs to allow granular pruning
              const chunks = content.split('\n\n').filter(c => c.trim().length > 0);
@@ -374,6 +387,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         if (!projectPath) {
           throw new McpError(ErrorCode.InvalidParams, 'project_path is required');
+        }
+        let realProjectPath: string;
+        try {
+          realProjectPath = fs.realpathSync(path.resolve(projectPath));
+        } catch {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path resolution failed');
+        }
+        if (isProtectedPath(realProjectPath)) {
+          throw new McpError(ErrorCode.InvalidParams, 'project_path must not be a protected path');
         }
 
         const result = await autoLearn({ project_path: projectPath, target_file: targetFile, limit });

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -14,7 +14,7 @@ function hideEgcRootOnWindows(): void {
   try {
     execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
   } catch (error) {
-    console.error('non-critical: folder works even if attribute fails', error);
+    console.error('non-critical: folder works even if attribute fails');
   }
 }
 import { z } from 'zod';

--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -269,7 +269,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'protected path' });
                continue;
              }
-             const stats = fs.statSync(realResolved);
+             const stats = await fs.promises.stat(realResolved);
              if (!stats.isFile()) {
                auditLog('CONTEXT_LOAD', 'DENIED', { filepath, reason: 'not a regular file' });
                continue;

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -31,6 +31,7 @@ export function buildDeniedPaths(): string[] {
     path.join(home, '.cursor'),
     path.join(home, '.claude'),
     path.join(home, '.gemini'),
+    path.join(home, '.egc'), // MCP internal data dir — protected from user/LLM access
     '/etc',
   ];
 

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -216,7 +216,7 @@ export function validateCommandArgs(
     }
 
     case 'gh': {
-      if (args.includes('delete')) {
+      if (args.some(a => a.toLowerCase() === 'delete')) {
         return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
       }
       return { allowed: true, trust_level: 'SAFE_DEV' };

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -2,8 +2,8 @@ import path from 'path';
 import os from 'os';
 
 // Trust level tiers
-export const SAFE_READONLY = ['ls', 'cat', 'grep', 'find', 'stat', 'head', 'git'];
-export const SAFE_DEV = ['npm', 'npx', 'node', 'tsc'];
+export const SAFE_READONLY = ['ls', 'cat', 'grep', 'find', 'stat', 'head', 'git', 'dir', 'where', 'where.exe'];
+export const SAFE_DEV = ['npm', 'npx', 'node', 'tsc', 'egc', 'multica', 'gh', 'docker', 'prisma', 'php', 'pnpm', 'turbo'];
 export const DANGEROUS = ['rm', 'mv'];
 
 export const SHELL_META_REGEX = /[&|;<>$`\n\r]/;
@@ -203,10 +203,41 @@ export function validateCommandArgs(
       return { allowed: true, trust_level: 'SAFE_READONLY' };
     }
 
+    case 'docker': {
+      // Block data-destroying operations; plain build/up/down stay allowed.
+      const positional = args.filter(a => !a.startsWith('-'));
+      if (
+        positional.some(a => a === 'prune' || a === 'rm' || a === 'rmi') ||
+        (positional.includes('down') && (args.includes('-v') || args.includes('--volumes')))
+      ) {
+        return { allowed: false, reason: 'destructive docker operation is forbidden', trust_level: 'DANGEROUS' };
+      }
+      return { allowed: true, trust_level: 'SAFE_DEV' };
+    }
+
+    case 'gh': {
+      if (args.includes('delete')) {
+        return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
+      }
+      return { allowed: true, trust_level: 'SAFE_DEV' };
+    }
+
+    case 'prisma': {
+      if (args.includes('reset') || args.includes('--force-reset')) {
+        return { allowed: false, reason: 'prisma reset drops data and is forbidden', trust_level: 'DANGEROUS' };
+      }
+      return { allowed: true, trust_level: 'SAFE_DEV' };
+    }
+
     case 'npm':
     case 'npx':
     case 'node':
-    case 'tsc': {
+    case 'tsc':
+    case 'egc':
+    case 'multica':
+    case 'php':
+    case 'pnpm':
+    case 'turbo': {
       return { allowed: true, trust_level: 'SAFE_DEV' };
     }
 

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -3,7 +3,7 @@ import os from 'os';
 
 // Trust level tiers
 export const SAFE_READONLY = ['ls', 'cat', 'grep', 'find', 'stat', 'head', 'git', 'dir', 'where', 'where.exe'];
-export const SAFE_DEV = ['npm', 'npx', 'node', 'tsc', 'egc', 'multica', 'gh', 'docker', 'prisma', 'php', 'pnpm', 'turbo'];
+export const SAFE_DEV = ['npm', 'npx', 'node', 'tsc', 'egc', 'gh', 'docker', 'prisma', 'php', 'pnpm', 'turbo'];
 export const DANGEROUS = ['rm', 'mv'];
 
 export const SHELL_META_REGEX = /[&|;<>$`\n\r]/;
@@ -79,171 +79,157 @@ export interface ValidationResult {
   trust_level?: 'SAFE_READONLY' | 'SAFE_DEV' | 'DANGEROUS' | 'BLOCKED';
 }
 
+const READONLY_OK: ValidationResult = { allowed: true, trust_level: 'SAFE_READONLY' };
+const DEV_OK: ValidationResult = { allowed: true, trust_level: 'SAFE_DEV' };
+
+type ArgValidator = (args: string[], baseCommand: string) => ValidationResult;
+
+// First non-flag argument that resolves to a protected path, if any.
+function firstProtectedPositional(args: string[]): string | undefined {
+  return args.find(a => !a.startsWith('-') && isProtectedPath(a));
+}
+
+// True if `token` appears as a standalone arg or in a `--flag=token` form,
+// case-insensitively, so `-X DELETE`, `--method DELETE` and `--method=delete`
+// all match. Used to catch destructive verbs passed as option values.
+function hasArgToken(args: string[], token: string): boolean {
+  const t = token.toLowerCase();
+  return args.some(a => {
+    const lower = a.toLowerCase();
+    return lower === t || lower.endsWith('=' + t);
+  });
+}
+
+function validateGit(args: string[]): ValidationResult {
+  if (
+    args.includes('--force') ||
+    args.includes('-f') ||
+    (args.includes('push') && (args.includes('--force') || args.includes('-f')))
+  ) {
+    return { allowed: false, reason: 'git force-push is forbidden', trust_level: 'SAFE_READONLY' };
+  }
+  // Combined short flags like -fu, and --force-with-lease, used with push.
+  if (args.includes('push') && args.some(a => /^-[a-zA-Z]*f/.test(a) || a === '--force-with-lease')) {
+    return { allowed: false, reason: 'git push with force flag is forbidden', trust_level: 'SAFE_READONLY' };
+  }
+  return READONLY_OK;
+}
+
+function validateGrep(args: string[]): ValidationResult {
+  const home = os.homedir();
+  const isRecursive = args.some(
+    a => a === '-r' || a === '-R' || a === '--recursive' || /^-[a-zA-Z]*[rR]/.test(a),
+  );
+  // grep [options] PATTERN [FILE...]: first positional is the pattern.
+  const positionalArgs = args.filter(a => a.length > 0 && !a.startsWith('-'));
+  const pathArgs = positionalArgs.slice(1);
+
+  if (isRecursive) {
+    for (const p of pathArgs) {
+      if (p === '/' || p === home || isProtectedPath(p)) {
+        return { allowed: false, reason: `grep recursive over protected path '${p}' is forbidden`, trust_level: 'SAFE_READONLY' };
+      }
+    }
+    if (positionalArgs.length === 1 && (positionalArgs[0] === '/' || isProtectedPath(positionalArgs[0]))) {
+      return { allowed: false, reason: `grep over protected path '${positionalArgs[0]}' is forbidden`, trust_level: 'SAFE_READONLY' };
+    }
+  }
+  for (const p of pathArgs) {
+    if (isProtectedPath(p)) {
+      return { allowed: false, reason: `grep over protected path '${p}' is forbidden`, trust_level: 'SAFE_READONLY' };
+    }
+  }
+  return READONLY_OK;
+}
+
+// cat, find, ls, head, stat, and the Windows equivalents dir/where: read-only,
+// but never over a protected path (the previous switch left dir/where without
+// this check, so `dir ~/.ssh` slipped through the default branch).
+function validateReadonlyPaths(args: string[], baseCommand: string): ValidationResult {
+  const hit = firstProtectedPositional(args);
+  if (hit) {
+    return { allowed: false, reason: `${baseCommand} on protected path '${hit}' is forbidden`, trust_level: 'SAFE_READONLY' };
+  }
+  return READONLY_OK;
+}
+
+function validateDocker(args: string[]): ValidationResult {
+  const positional = args.filter(a => !a.startsWith('-'));
+  const destructiveSub = positional.some(a => a === 'prune' || a === 'rm' || a === 'rmi');
+  const downWithVolumes = positional.includes('down') && (args.includes('-v') || args.includes('--volumes'));
+  if (destructiveSub || downWithVolumes) {
+    return { allowed: false, reason: 'destructive docker operation is forbidden', trust_level: 'DANGEROUS' };
+  }
+  // run/create with a host mount or elevated privileges can escape the sandbox.
+  const startsContainer = positional.includes('run') || positional.includes('create');
+  const mountsOrPrivileged = args.some(a =>
+    a === '-v' || a === '--volume' || a === '--mount' || a === '--privileged' || a === '--cap-add' ||
+    a.startsWith('--volume=') || a.startsWith('--mount=') || a.startsWith('--cap-add='),
+  );
+  if (startsContainer && mountsOrPrivileged) {
+    return { allowed: false, reason: 'docker run with host mounts or elevated privileges is forbidden', trust_level: 'DANGEROUS' };
+  }
+  return DEV_OK;
+}
+
+function validateGh(args: string[]): ValidationResult {
+  // Covers `gh <resource> delete`, `gh api -X DELETE`, `gh api --method DELETE`.
+  if (hasArgToken(args, 'delete')) {
+    return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
+  }
+  return DEV_OK;
+}
+
+function validatePrisma(args: string[]): ValidationResult {
+  if (hasArgToken(args, 'reset') || hasArgToken(args, '--force-reset') || hasArgToken(args, '--accept-data-loss')) {
+    return { allowed: false, reason: 'prisma data-loss operation is forbidden', trust_level: 'DANGEROUS' };
+  }
+  const lower = args.map(a => a.toLowerCase());
+  if (lower.includes('db') && lower.includes('execute')) {
+    return { allowed: false, reason: 'prisma db execute runs arbitrary SQL and is forbidden', trust_level: 'DANGEROUS' };
+  }
+  return DEV_OK;
+}
+
+const devOk: ArgValidator = () => DEV_OK;
+
+// Each allowlisted command maps to its argument validator. Commands present in
+// SAFE_READONLY/SAFE_DEV with no entry fall through to a read-only pass. Node,
+// npm, php, pnpm and turbo are trusted dev tools by design, like `node -e`.
+const ARG_VALIDATORS: Record<string, ArgValidator> = {
+  git: validateGit,
+  grep: validateGrep,
+  cat: validateReadonlyPaths,
+  find: validateReadonlyPaths,
+  ls: validateReadonlyPaths,
+  head: validateReadonlyPaths,
+  stat: validateReadonlyPaths,
+  dir: validateReadonlyPaths,
+  where: validateReadonlyPaths,
+  'where.exe': validateReadonlyPaths,
+  docker: validateDocker,
+  gh: validateGh,
+  prisma: validatePrisma,
+  npm: devOk,
+  npx: devOk,
+  node: devOk,
+  tsc: devOk,
+  egc: devOk,
+  php: devOk,
+  pnpm: devOk,
+  turbo: devOk,
+};
+
 /**
  * Validate arguments for a specific allowed command.
  * Returns { allowed: false, reason } if the args are unsafe.
  */
-export function validateCommandArgs(
-  baseCommand: string,
-  args: string[],
-): ValidationResult {
-  const allArgs = args.join(' ');
-
-  switch (baseCommand) {
-    case 'git': {
-      // Block force pushes
-      if (
-        args.includes('--force') ||
-        args.includes('-f') ||
-        (args.includes('push') && (args.includes('--force') || args.includes('-f')))
-      ) {
-        return { allowed: false, reason: 'git force-push is forbidden', trust_level: 'SAFE_READONLY' };
-      }
-      // Additional check for combined flags like -fu, --force-with-lease used destructively
-      if (args.includes('push') && args.some(a => /^-[a-zA-Z]*f/.test(a))) {
-        return { allowed: false, reason: 'git push with force flag is forbidden', trust_level: 'SAFE_READONLY' };
-      }
-      return { allowed: true, trust_level: 'SAFE_READONLY' };
-    }
-
-    case 'grep': {
-      const home = os.homedir();
-
-      // Detect if any recursive flag is present
-      const isRecursive = args.some(
-        a => a === '-r' || a === '-R' || a === '--recursive' ||
-             // combined short flags: -rn, -Rn, -rl, etc.
-             /^-[a-zA-Z]*[rR]/.test(a),
-      );
-
-      // Non-flag, non-empty args are candidates for pattern or path.
-      // In grep: grep [options] PATTERN [FILE…]
-      // The first non-flag arg is the pattern; the rest are paths.
-      const positionalArgs = args.filter(a => a.length > 0 && !a.startsWith('-'));
-
-      // Paths are all positional args after the first one (the pattern).
-      const pathArgs = positionalArgs.slice(1);
-
-      if (isRecursive) {
-        for (const p of pathArgs) {
-          if (p === '/' || p === home || isProtectedPath(p)) {
-            return {
-              allowed: false,
-              reason: `grep recursive over protected path '${p}' is forbidden`,
-              trust_level: 'SAFE_READONLY',
-            };
-          }
-        }
-        // If no explicit path args, grep defaults to '.', which is fine.
-        // But if the only non-flag positional IS '/' (i.e., pattern was empty), still block.
-        if (positionalArgs.length === 1 && (positionalArgs[0] === '/' || isProtectedPath(positionalArgs[0]))) {
-          return {
-            allowed: false,
-            reason: `grep over protected path '${positionalArgs[0]}' is forbidden`,
-            trust_level: 'SAFE_READONLY',
-          };
-        }
-      }
-
-      // Even without -r, block explicit protected paths
-      for (const p of pathArgs) {
-        if (isProtectedPath(p)) {
-          return {
-            allowed: false,
-            reason: `grep over protected path '${p}' is forbidden`,
-            trust_level: 'SAFE_READONLY',
-          };
-        }
-      }
-
-      return { allowed: true, trust_level: 'SAFE_READONLY' };
-    }
-
-    case 'cat': {
-      for (const arg of args) {
-        if (!arg.startsWith('-') && isProtectedPath(arg)) {
-          return {
-            allowed: false,
-            reason: `cat of protected path '${arg}' is forbidden`,
-            trust_level: 'SAFE_READONLY',
-          };
-        }
-      }
-      return { allowed: true, trust_level: 'SAFE_READONLY' };
-    }
-
-    case 'find': {
-      // First non-flag arg is typically the search root
-      const pathArgs = args.filter(a => !a.startsWith('-'));
-      for (const p of pathArgs) {
-        if (isProtectedPath(p)) {
-          return {
-            allowed: false,
-            reason: `find over protected path '${p}' is forbidden`,
-            trust_level: 'SAFE_READONLY',
-          };
-        }
-      }
-      return { allowed: true, trust_level: 'SAFE_READONLY' };
-    }
-
-    case 'head':
-    case 'stat':
-    case 'ls': {
-      // These are read-only but we still block protected paths
-      for (const arg of args) {
-        if (!arg.startsWith('-') && isProtectedPath(arg)) {
-          return {
-            allowed: false,
-            reason: `${baseCommand} on protected path '${arg}' is forbidden`,
-            trust_level: 'SAFE_READONLY',
-          };
-        }
-      }
-      return { allowed: true, trust_level: 'SAFE_READONLY' };
-    }
-
-    case 'docker': {
-      // Block data-destroying operations; plain build/up/down stay allowed.
-      const positional = args.filter(a => !a.startsWith('-'));
-      if (
-        positional.some(a => a === 'prune' || a === 'rm' || a === 'rmi') ||
-        (positional.includes('down') && (args.includes('-v') || args.includes('--volumes')))
-      ) {
-        return { allowed: false, reason: 'destructive docker operation is forbidden', trust_level: 'DANGEROUS' };
-      }
-      return { allowed: true, trust_level: 'SAFE_DEV' };
-    }
-
-    case 'gh': {
-      if (args.some(a => a.toLowerCase() === 'delete')) {
-        return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
-      }
-      return { allowed: true, trust_level: 'SAFE_DEV' };
-    }
-
-    case 'prisma': {
-      if (args.includes('reset') || args.includes('--force-reset')) {
-        return { allowed: false, reason: 'prisma reset drops data and is forbidden', trust_level: 'DANGEROUS' };
-      }
-      return { allowed: true, trust_level: 'SAFE_DEV' };
-    }
-
-    case 'npm':
-    case 'npx':
-    case 'node':
-    case 'tsc':
-    case 'egc':
-    case 'multica':
-    case 'php':
-    case 'pnpm':
-    case 'turbo': {
-      return { allowed: true, trust_level: 'SAFE_DEV' };
-    }
-
-    default:
-      return { allowed: true, trust_level: 'SAFE_READONLY' };
+export function validateCommandArgs(baseCommand: string, args: string[]): ValidationResult {
+  const validator = ARG_VALIDATORS[baseCommand];
+  if (!validator) {
+    return READONLY_OK;
   }
+  return validator(args, baseCommand);
 }
 
 export function validateCommand(command: string): ValidationResult {

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -74,8 +74,8 @@ function hideEgcRootOnWindows(): void {
   const egcRoot = path.join(os.homedir(), '.egc');
   try {
     execSync(`attrib +h "${egcRoot}"`, { stdio: 'ignore' });
-  } catch (_) {
-    // non-critical: folder works even if attribute fails
+  } catch (error) {
+    console.error('non-critical: folder works even if attribute fails', error);
   }
 }
 

--- a/tests/egc-guardian-validator.test.js
+++ b/tests/egc-guardian-validator.test.js
@@ -1,0 +1,86 @@
+'use strict';
+/**
+ * Tests for mcp/servers/egc-guardian/src/validator.ts (via the compiled build).
+ *
+ * Covers the dispatch-map allowlist introduced when the command validator was
+ * refactored out of a single long switch: multica is not allowlisted, the
+ * Windows read commands dir/where honor protected paths (the old switch let
+ * them fall through unchecked), and the docker/gh/prisma guards block host
+ * escapes, deletes and data-loss while leaving plain dev use alone.
+ *
+ * Run with: node tests/egc-guardian-validator.test.js
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const buildPath = path.join(
+  __dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'validator.js',
+);
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  process.exit(0);
+}
+
+const { validateCommand } = require(buildPath);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing egc-guardian command validator ===\n');
+
+const denied = [
+  'multica issue list',                 // not in any allowlist
+  'dir ~/.ssh',                          // Windows read command over protected path
+  'docker run -v /:/host alpine',        // host mount escapes the sandbox
+  'docker run --privileged x',           // privilege escalation
+  'gh api -X DELETE /repos/x',           // destructive verb as option value
+  'gh api --method DELETE',
+  'prisma db execute --file x.sql',      // arbitrary SQL
+  'prisma migrate reset',                // data loss
+  'git push --force',
+  'git push --force-with-lease',
+  'rm -rf x',                            // always-denied destructive command
+  'cat ~/.ssh/id_rsa',                   // protected file
+];
+
+const allowed = [
+  'docker build .',
+  'docker compose up',
+  'gh pr list',
+  'prisma generate',
+  'npm install',
+  'node -e code',
+  'php -r code',
+  'git status',
+  'ls /tmp',
+  'where mytool',
+];
+
+for (const cmd of denied) {
+  run(`denies: ${cmd}`, () => {
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} should be denied`);
+  });
+}
+for (const cmd of allowed) {
+  run(`allows: ${cmd}`, () => {
+    assert.strictEqual(validateCommand(cmd).allowed, true, `${cmd} should be allowed`);
+  });
+}
+
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+if (failed > 0) process.exit(1);

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -101,7 +101,7 @@ for (const testFile of testFiles) {
   if (result.status !== 0) {
     console.log(`✗ ${displayPath} exited with status ${result.status}`);
     if (!combined.trim()) {
-      console.log(`  ⚠ Script crashed with no output. Counted as 1 unknown failure.`);
+      console.log(`  [!] Script crashed with no output. Counted as 1 unknown failure.`);
     }
     totalFailed += failedMatch ? 0 : 1;
   }

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -100,6 +100,9 @@ for (const testFile of testFiles) {
 
   if (result.status !== 0) {
     console.log(`✗ ${displayPath} exited with status ${result.status}`);
+    if (!combined.trim()) {
+      console.log(`  ⚠ Script crashed with no output. Counted as 1 unknown failure.`);
+    }
     totalFailed += failedMatch ? 0 : 1;
   }
 }


### PR DESCRIPTION
Expands the guardian command allowlist to match the real daily workflow and ships the pending security-limit work on this branch.

Allowlist (new commit):
1. SAFE_DEV gains egc, multica, gh, docker, prisma, php, pnpm, turbo. SAFE_READONLY gains dir, where, where.exe. These were all hitting a blanket deny (see ~/.egc/audit.log full of DENIED since 2026-07-24), which made validate_command useless in practice.
2. New CLIs are not blanket-trusted: docker blocks prune/rm/rmi and down with volumes, gh blocks delete, prisma blocks reset and --force-reset.
3. powershell, wsl and Remove-Item stay denied: the first two are wrappers that would smuggle arbitrary commands past validation, the last is rm.

Pre-existing commits on this branch, included here for review: SEC-04/05/06 and REL-06 path validation and limits, two SonarQube fixes, one CI unicode fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the guardian allowlist to support daily tooling while blocking destructive flags, refactors validation into a per-command dispatch map, and enforces strict path and size limits for context and `project_path`. Implements SEC-04/05/06 and REL-06 path validation and limits.

- **New Features**
  - Expanded allowlist: added `egc`, `gh`, `docker`, `prisma`, `php`, `pnpm`, `turbo`; read-only adds `dir`, `where`, `where.exe`. Removed `multica`.
  - Destructive-arg guards: block `docker prune/rm/rmi`, `compose down -v/--volumes`, `docker run/create` with host mounts or `--privileged`; block `gh` deletes (including `-X/--method DELETE`); block Prisma `reset`/`--force-reset`, `db execute`, and `--accept-data-loss`. `powershell`, `wsl`, and `Remove-Item` remain denied.
  - Path and size limits: protect `~/.egc`; context files must be regular files, ≤10MB each and ≤50MB total; realpath and validate `project_path`, reject protected paths.

- **Refactors**
  - Validator reworked to a per-command dispatch map; added a validator test covering allow/deny sets. Also improved error logging for Windows hidden-attr setup and persistent logger writes, and made CI treat crash-with-no-output as one unknown failure.

<sup>Written for commit f045ab25906a6517d8ef1e6ce36584e0a1e4e420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened filesystem protections by verifying resolved paths are regular files, enforcing per-file and total size limits, and recording denials for oversized or invalid inputs.
  - Expanded command allowlists and tightened protections against destructive actions (e.g., Docker, GitHub, Prisma), including additional protected locations.
  - Improved validation for learning operations by resolving and validating real project paths before proceeding.
- **Reliability**
  - Added explicit non-critical error logging for Windows root-hiding and improved visibility when audit logging fails.
  - Improved test runner messaging for crashes with no output.
- **Behavior Changes**
  - Task routing now relies on the request prompt and provided file paths only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->