### PR TITLE
docs(roadmap): update unreleased section for #997, #998 and #1000

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,7 +127,8 @@ Landed on main since v1.1.15, not yet released:
 
 - Bare `egc install` from the published npm package fixed: `install.sh` falls back to `npm install` when the published tarball ships no root lockfile, and only builds when `src/` is present (#985, #986, closes #643)
 - Chinese Simplified mapped to `zh-CN` in Crowdin with the existing repo translations seeded (#988, closes #483)
-- Crowdin sync now writes to the canonical `translations/zh-CN/` path instead of recreating `translations/zh/` (#992)
+- Crowdin sync now writes Chinese Simplified to the canonical `translations/zh-CN/` path: the workflow renames `zh` to `zh-CN` after download, since the Crowdin action exposes no download language mapping (#1000; the `crowdin.yml` mapping tried in #992 was invalid and was reverted in #998)
+- CodeRabbit reviews contributor PRs automatically and skips the maintainer's own to save review credits; the first-time-contributor gate workflows were retired (#997)
 - Three runtime bugs from the #987 deep audit fixed: the `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani)
 - All Dependabot and Scorecard advisories cleared to zero: `brace-expansion` and `tar` in the root lockfile (#992), `tar` in the two mcp server lockfiles (#994), and `brace-expansion` in `fuzz` via an override (#995); the Scorecard Vulnerabilities code-scanning alert closed with them
 - Supported-harness count kept in sync across the docs (#984)


### PR DESCRIPTION
Corrects the unreleased section: the canonical zh-CN path is delivered by the workflow rename in #1000 (the crowdin.yml mapping tried in #992 was invalid and was reverted in #998), and adds the CodeRabbit auto-review change with the maintainer skip (#997, gate workflows retired).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ROADMAP “Unreleased” to reflect that Crowdin sync now writes Chinese Simplified to the canonical translations/zh-CN path via a post-download workflow rename (#1000), replacing the invalid `crowdin.yml` mapping reverted in #998. Also note that CodeRabbit now auto-reviews contributor PRs and skips maintainers, and the first-time-contributor gate workflows are retired (#997).

<sup>Written for commit 4e43d6c6571cd840637896e6ac648feecd4f1a60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

