### PR TITLE
fix(i18n): rewrite root-relative links in downloaded translations

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -126,6 +126,17 @@ jobs:
             cp -a translations/zh/. translations/zh-CN/
             rm -rf translations/zh
           fi
+          # Crowdin exports translations of source strings whose links are
+          # root-relative (assets/..., docs/...), but translation files live
+          # two levels down, so those links 404 on GitHub. Rewrite them; the
+          # patterns only match links without a leading path, so already
+          # correct ../../ links are untouched.
+          find translations -name 'README.md' -exec sed -i -E \
+            -e 's|(src=")assets/|\1../../assets/|g' \
+            -e 's|(href=")assets/|\1../../assets/|g' \
+            -e 's|(\]\()assets/|\1../../assets/|g' \
+            -e 's|(href=")docs/|\1../../docs/|g' \
+            -e 's|(\]\()docs/|\1../../docs/|g' {} +
           if [ -z "$(git status --porcelain -- translations)" ]; then
             echo "No translation changes to sync."
             exit 0


### PR DESCRIPTION
The first production sync PR (#1003) came back with the zh-CN hero image and the installation guide link broken: Crowdin translates source strings whose links are root-relative, but translation files live two levels down. Add a link normalization pass to the sync workflow's normalize step (sed, idempotent: already correct ../../ links are untouched). Deterministic for every language and every future sync; no dependency on Crowdin-side string fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize root-relative asset and docs links in translated README files during the Crowdin sync workflow. Fixes broken hero image and installation guide links and ensures consistent link behavior across languages.

- **Bug Fixes**
  - Add a sed-based normalization that rewrites assets/ and docs/ links to ../../assets/ and ../../docs/ only when needed; already-correct ../../ links are untouched.

<sup>Written for commit 2582a98bbd834a21e1fed7300e7495f0be639780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

