### PR TITLE
fix(memory): default-branch fallback reads the hashed main state

### DIFF
--- a/mcp/servers/egc-memory/src/branch-state.ts
+++ b/mcp/servers/egc-memory/src/branch-state.ts
@@ -86,6 +86,13 @@ export function resolveStateRead(stateDir: string, projectPath: string, branch: 
     if (fs.existsSync(legacyBranchFile)) {
       return { filePath: legacyBranchFile, source: 'branch', branch };
     }
+    // Current versions write the default branch under its hashed key, so the
+    // fallback must look there first; the plain main.md name is only left
+    // behind by pre-hash versions and would otherwise shadow newer state.
+    const defaultHashedFile = branchStateFile(stateDir, projectPath, 'main');
+    if (fs.existsSync(defaultHashedFile)) {
+      return { filePath: defaultHashedFile, source: 'default-branch', branch };
+    }
     const defaultFile = path.join(stateDir, projectSlug(projectPath), DEFAULT_BRANCH_FILE);
     if (fs.existsSync(defaultFile)) {
       return { filePath: defaultFile, source: 'default-branch', branch };

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -104,6 +104,13 @@ function resolveStateRead(stateDir, projectPath, branch) {
     if (fs.existsSync(legacyBranchFile)) {
       return { filePath: legacyBranchFile, source: 'branch', branch };
     }
+    // Current versions write the default branch under its hashed key, so the
+    // fallback must look there first; the plain main.md name is only left
+    // behind by pre-hash versions and would otherwise shadow newer state.
+    const defaultHashedFile = branchStateFile(stateDir, projectPath, 'main');
+    if (fs.existsSync(defaultHashedFile)) {
+      return { filePath: defaultHashedFile, source: 'default-branch', branch };
+    }
     const defaultFile = path.join(stateDir, projectSlug(projectPath), DEFAULT_BRANCH_FILE);
     if (fs.existsSync(defaultFile)) {
       return { filePath: defaultFile, source: 'default-branch', branch };

--- a/tests/egc-memory-branch-state.test.js
+++ b/tests/egc-memory-branch-state.test.js
@@ -1,0 +1,96 @@
+'use strict';
+/**
+ * Tests for scripts/lib/branch-state.js (mirrored by
+ * mcp/servers/egc-memory/src/branch-state.ts).
+ *
+ * Covers resolveStateRead precedence: the branch's own hashed file first,
+ * then the branch's legacy sanitized name, then the default branch, where
+ * the hashed main file written by current versions must win over the plain
+ * main.md left behind by pre-hash versions. That legacy file otherwise
+ * shadows newer state forever on any feature branch without its own state.
+ *
+ * Run with: node tests/egc-memory-branch-state.test.js
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  branchStateFile,
+  legacyBranchStateFile,
+  projectSlug,
+  resolveStateRead,
+} = require(path.join(__dirname, '..', 'scripts', 'lib', 'branch-state.js'));
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing egc-memory branch state resolution ===\n');
+
+const projectPath = '/home/user/Projetos/EGC';
+const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-branch-state-'));
+const slugDir = path.join(stateDir, projectSlug(projectPath));
+fs.mkdirSync(slugDir, { recursive: true });
+
+const hashedMain = branchStateFile(stateDir, projectPath, 'main');
+const legacyMain = path.join(slugDir, 'main.md');
+const featureBranch = 'feature/new-thing';
+
+run('branch with its own hashed file wins over everything', () => {
+  const own = branchStateFile(stateDir, projectPath, featureBranch);
+  fs.writeFileSync(own, 'own');
+  fs.writeFileSync(hashedMain, 'hashed');
+  fs.writeFileSync(legacyMain, 'legacy');
+  const resolved = resolveStateRead(stateDir, projectPath, featureBranch);
+  assert.strictEqual(resolved.filePath, own);
+  assert.strictEqual(resolved.source, 'branch');
+  fs.rmSync(own);
+});
+
+run('branch legacy sanitized file wins over the default branch fallback', () => {
+  const legacyOwn = legacyBranchStateFile(stateDir, projectPath, featureBranch);
+  fs.writeFileSync(legacyOwn, 'legacy-own');
+  const resolved = resolveStateRead(stateDir, projectPath, featureBranch);
+  assert.strictEqual(resolved.filePath, legacyOwn);
+  assert.strictEqual(resolved.source, 'branch');
+  fs.rmSync(legacyOwn);
+});
+
+run('default fallback prefers the hashed main file over legacy main.md', () => {
+  const resolved = resolveStateRead(stateDir, projectPath, featureBranch);
+  assert.strictEqual(resolved.filePath, hashedMain);
+  assert.strictEqual(resolved.source, 'default-branch');
+});
+
+run('default fallback still reads legacy main.md when no hashed main exists', () => {
+  fs.rmSync(hashedMain);
+  const resolved = resolveStateRead(stateDir, projectPath, featureBranch);
+  assert.strictEqual(resolved.filePath, legacyMain);
+  assert.strictEqual(resolved.source, 'default-branch');
+});
+
+run('reading the main branch itself resolves to its hashed file', () => {
+  fs.writeFileSync(hashedMain, 'hashed');
+  const resolved = resolveStateRead(stateDir, projectPath, 'main');
+  assert.strictEqual(resolved.filePath, hashedMain);
+  assert.strictEqual(resolved.source, 'branch');
+});
+
+fs.rmSync(stateDir, { recursive: true, force: true });
+
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
get_state on a feature branch without its own state fell back to the plain main.md left behind by pre-hash versions, serving state frozen at the migration date while update_state kept writing to the hashed main file: memory appeared to travel back in time. Observed live on this machine: source=default-branch, integrity=hmac_mismatch, returning 2026-07-18 content while main--sha256(main).md held current state written the same day. The fallback now prefers the hashed main file and keeps plain main.md as last resort. Both the scripts/lib mirror and the TS server source updated identically; tests/egc-memory-branch-state.test.js covers the full resolution order (5 cases).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes default-branch fallback to read the hashed `main` state before legacy `main.md`, so feature branches without their own state no longer return stale memory. Keeps `main.md` as a last resort and adds tests for the resolution order.

- **Bug Fixes**
  - Update `resolveStateRead` to prefer the hashed `main` file; fall back to `main.md` only if needed.
  - Apply the same change in `mcp/servers/egc-memory/src/branch-state.ts` and `scripts/lib/branch-state.js`.
  - Add `tests/egc-memory-branch-state.test.js` to verify branch, legacy, and default-branch precedence.

<sup>Written for commit be4a2dac2186e61e38a2e4d4485c75112c33e485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

