### PR TITLE
fix(ci): sign off the Crowdin sync commit so the DCO check passes

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -134,7 +134,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -C chore/crowdin-translations
           git add -- translations
-          git commit -m "chore: sync translations from Crowdin"
+          git commit -s -m "chore: sync translations from Crowdin"
           git push -f origin chore/crowdin-translations
           if [ -z "$(gh pr list --head chore/crowdin-translations --state open --json number --jq '.[0].number // empty')" ]; then
             gh pr create --base main --head chore/crowdin-translations \


### PR DESCRIPTION
The translations PR opened by the sync workflow (#1003) fails the DCO check because the bot commit has no Signed-off-by trailer. Add -s to the workflow's git commit; the trailer matches the configured github-actions bot identity, so every future sync PR passes DCO cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add -s to the Crowdin sync workflow’s git commit to include a Signed-off-by trailer. This makes translation PRs pass the DCO check automatically.

<sup>Written for commit 933ae96d67c028d5292014b835cc7866a801d74a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

