### PR TITLE
docs: run install.sh with bash, not sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Both servers must be registered in your MCP config (`.mcp.json`):
 - `egc-guardian`: `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task`
 - `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`, `session_announce`, `session_peers`, `claim_path`, `release_path`
 
-Run `sh scripts/install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.
+Run `bash scripts/install.sh` to build the servers. Run `egc doctor` to verify they are registered and running.
 
 ## EGC Guardian Protocol — MANDATORY
 


### PR DESCRIPTION
scripts/install.sh has a #!/bin/bash shebang and a bashism at line 313; the documented 'sh scripts/install.sh' breaks on dash-based systems (Ubuntu's sh) with a syntax error right after the MCP registration step, silently skipping the server builds. Reproduced today; running with bash completes. One-word doc fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to run the installer with bash instead of sh so builds complete on dash-based systems. This avoids the syntax error after the MCP registration step that was silently skipping server builds by changing `sh scripts/install.sh` to `bash scripts/install.sh`.

<sup>Written for commit 990821e670d0243a795dc22fa78167aece5af1ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

