### PR TITLE
docs(roadmap): note the memory fallback fix and the hardened Crowdin sync

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,9 @@ Landed on main since v1.1.15, not yet released:
 - Chinese Simplified mapped to `zh-CN` in Crowdin with the existing repo translations seeded (#988, closes #483)
 - Crowdin sync now writes Chinese Simplified to the canonical `translations/zh-CN/` path: the workflow renames `zh` to `zh-CN` after download, since the Crowdin action exposes no download language mapping (#1000; the `crowdin.yml` mapping tried in #992 was invalid and was reverted in #998)
 - CodeRabbit reviews contributor PRs automatically and skips the maintainer's own to save review credits; the first-time-contributor gate workflows were retired (#997)
+- `get_state` no longer time-travels on feature branches: the default-branch fallback prefers the hashed main state file over the legacy plain `main.md` left behind by pre-hash versions, with a new test covering the full resolution order (#1005)
+- Crowdin sync hardened end to end: root-relative asset and doc links are normalized in downloaded translations (#1004) and the sync commit is signed so the DCO check passes on translations PRs (#1006); the first fully green sync PR landed the Turkish and Chinese Simplified updates (#1003)
+- Docs: the MCP server build is invoked with `bash`, matching the install script's shebang (#1007)
 - Three runtime bugs from the #987 deep audit fixed: the `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani)
 - All Dependabot and Scorecard advisories cleared to zero: `brace-expansion` and `tar` in the root lockfile (#992), `tar` in the two mcp server lockfiles (#994), and `brace-expansion` in `fuzz` via an override (#995); the Scorecard Vulnerabilities code-scanning alert closed with them
 - Supported-harness count kept in sync across the docs (#984)


### PR DESCRIPTION
Adds the afternoon's landed work to the unreleased section: the get_state default-branch fallback fix (#1005), the Crowdin link normalization (#1004), the signed sync commit closing DCO on translations PRs (#1006) with the first fully green sync PR (#1003), and the bash invocation doc fix (#1007).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ROADMAP to include recent unreleased work. Notes the `get_state` default-branch fallback fix, a hardened Crowdin sync (normalized root-relative links and signed sync commits for DCO with the first fully green sync), and invoking the MCP server build with bash.

<sup>Written for commit 28e1fe10c733d870e1dd38d011b066e4388c38ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

