### PR TITLE
fix(guardian): validate auto_learn target_file against protected paths

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -417,7 +417,30 @@ async function handleAutoLearn(toolArgs: Record<string, unknown> | undefined) {
     throw new McpError(ErrorCode.InvalidParams, 'project_path must not be a protected path');
   }
 
-  const result = await autoLearn({ project_path: projectPath, target_file: targetFile, limit });
+  // target_file is written to directly by autoLearn, so an unchecked value
+  // could plant content in ~/.ssh, ~/.bashrc, etc. Resolve it (following
+  // symlinks on the parent dir) and require it to be a non-protected path
+  // inside the project root. The absolute resolved path is passed downstream
+  // so a relative target_file cannot resolve against the process CWD instead.
+  let resolvedTarget = targetFile;
+  if (targetFile !== undefined) {
+    const absTarget = path.resolve(realProjectPath, targetFile);
+    let realTargetDir: string;
+    try {
+      realTargetDir = fs.realpathSync(path.dirname(absTarget));
+    } catch {
+      throw new McpError(ErrorCode.InvalidParams, 'target_file directory does not exist');
+    }
+    resolvedTarget = path.join(realTargetDir, path.basename(absTarget));
+    if (isProtectedPath(resolvedTarget)) {
+      throw new McpError(ErrorCode.InvalidParams, 'target_file must not be a protected path');
+    }
+    if (realTargetDir !== realProjectPath && !realTargetDir.startsWith(realProjectPath + path.sep)) {
+      throw new McpError(ErrorCode.InvalidParams, 'target_file must be inside project_path');
+    }
+  }
+
+  const result = await autoLearn({ project_path: projectPath, target_file: resolvedTarget, limit });
 
   auditLog('AUTO_LEARN', 'MUTATED', {
     project_path: projectPath,


### PR DESCRIPTION
Security fix. handleAutoLearn validated project_path but passed target_file to autoLearn unchecked, and learn-writer writes to it directly with fs.writeFileSync. A caller could pass a permitted project_path and a target_file pointing at ~/.ssh/authorized_keys, ~/.bashrc or another protected path, planting content outside the sandbox.

The handler now resolves target_file (realpath on the parent dir, so a symlink cannot redirect the write past the check), rejects protected paths, and requires the target to stay inside the project root. The absolute resolved path is passed downstream so a relative target_file cannot resolve against the process CWD instead of the project.

Found during an internal security audit of the guardian/memory runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened guardian `auto_learn` by validating `target_file` and enforcing containment inside `project_path`. This prevents writes to protected paths or outside the project, including via symlinks or relative paths.

- **Bug Fixes**
  - Resolve `target_file` against the real project root; realpath the parent directory and error if it doesn’t exist.
  - Reject protected paths via `isProtectedPath`.
  - Require the resolved directory to be inside `project_path`.
  - Pass the absolute resolved `target_file` to `autoLearn` to avoid CWD-based resolution.

<sup>Written for commit 3ae7ce81f00cb4850b3ee0da61f55a94d7c59efc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

