### PR TITLE
docs(roadmap): note the auto_learn target_file security fix

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,6 +132,7 @@ Landed on main since v1.1.15, not yet released:
 - `get_state` no longer time-travels on feature branches: the default-branch fallback prefers the hashed main state file over the legacy plain `main.md` left behind by pre-hash versions, with a new test covering the full resolution order (#1005)
 - Crowdin sync hardened end to end: root-relative asset and doc links are normalized in downloaded translations (#1004) and the sync commit is signed so the DCO check passes on translations PRs (#1006); the first fully green sync PR landed the Turkish and Chinese Simplified updates (#1003)
 - Docs: the MCP server build is invoked with `bash`, matching the install script's shebang (#1007)
+- Guardian hardening: `auto_learn` now validates `target_file` against protected paths and requires it to stay inside the project root, closing a write-outside-sandbox path found in an internal security audit (#1009)
 - Three runtime bugs from the #987 deep audit fixed: the `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani)
 - All Dependabot and Scorecard advisories cleared to zero: `brace-expansion` and `tar` in the root lockfile (#992), `tar` in the two mcp server lockfiles (#994), and `brace-expansion` in `fuzz` via an override (#995); the Scorecard Vulnerabilities code-scanning alert closed with them
 - Supported-harness count kept in sync across the docs (#984)


### PR DESCRIPTION
Adds #1009 to the unreleased section: auto_learn now validates target_file against protected paths and project containment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `docs/ROADMAP.md` to note the `auto_learn` security fix from #1009. `auto_learn` now validates `target_file` against protected paths and blocks writes outside the project root.

<sup>Written for commit 630acd47035c882b59a10015d9e20858c0cf8552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

