### PR TITLE
harden guardian path resolution and log file permissions

### DIFF
--- a/mcp/servers/egc-guardian/src/index.ts
+++ b/mcp/servers/egc-guardian/src/index.ts
@@ -85,7 +85,7 @@ class PersistentLogger {
 
   constructor(serviceName: string) {
     const logDir = path.join(os.homedir(), '.egc', 'logs');
-    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
     hideEgcRootOnWindows();
     this.logPath = path.join(logDir, `${serviceName}.log`);
   }
@@ -102,7 +102,7 @@ class PersistentLogger {
       } catch (_e) { // NOSONAR: rotating a missing log file is a no-op
         // file might not exist
       }
-      await fs.promises.appendFile(this.logPath, payload + '\n', 'utf-8');
+      await fs.promises.appendFile(this.logPath, payload + '\n', { encoding: 'utf-8', mode: 0o600 });
     } catch(err) {
       console.error('[EGC Guardian] PersistentLogger failed to write:', err);
     }

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import os from 'node:os';
+import fs from 'node:fs';
 
 // Trust level tiers
 export const SAFE_READONLY = ['ls', 'cat', 'grep', 'find', 'stat', 'head', 'git'];
@@ -179,7 +180,17 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
     ? path.join(os.homedir(), p.slice(1))
     : p;
 
-  const normalizedP = path.resolve(baseDir, expanded);
+  let normalizedP = path.resolve(baseDir, expanded);
+  // Resolve symlinks so a link inside an allowed directory cannot point past
+  // this check into a denied path. Fall back to the lexical path (then the
+  // parent) when the target does not exist yet, e.g. a write being created.
+  try {
+    normalizedP = fs.realpathSync(normalizedP);
+  } catch {
+    try {
+      normalizedP = path.join(fs.realpathSync(path.dirname(normalizedP)), path.basename(normalizedP));
+    } catch { /* keep the lexical resolution */ }
+  }
 
   for (const denied of DENIED_PATHS) {
     if (normalizedP === denied || normalizedP.startsWith(denied + path.sep)) {

--- a/tests/egc-guardian-symlink.test.js
+++ b/tests/egc-guardian-symlink.test.js
@@ -1,0 +1,63 @@
+'use strict';
+/**
+ * Tests that isProtectedPath resolves symlinks, so a link created inside an
+ * allowed directory cannot point past the check into a denied path.
+ *
+ * Run with: node tests/egc-guardian-symlink.test.js
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const buildPath = path.join(
+  __dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'validator.js',
+);
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  process.exit(0);
+}
+if (process.platform === 'win32') {
+  console.log('[SKIP] symlink creation needs elevation on Windows.');
+  process.exit(0);
+}
+
+const { isProtectedPath } = require(buildPath);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing egc-guardian symlink resolution ===\n');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-sym-'));
+const linkToEtc = path.join(tmp, 'link-to-etc');
+fs.symlinkSync('/etc', linkToEtc);
+
+run('a symlink pointing at a denied dir resolves and is protected', () => {
+  assert.strictEqual(isProtectedPath(linkToEtc), true);
+});
+run('a plain path in a temp dir is not protected', () => {
+  assert.strictEqual(isProtectedPath(path.join(tmp, 'notes.txt')), false);
+});
+run('a not-yet-created file resolves via its parent and stays allowed', () => {
+  assert.strictEqual(isProtectedPath(path.join(tmp, 'new-file.md')), false);
+});
+
+fs.rmSync(tmp, { recursive: true, force: true });
+
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Two small hardening changes to `egc-guardian`, bringing it in line with the privacy posture `egc-memory` already has.

## Changes

- **Path resolution in `isProtectedPath`.** The denied-path check now resolves the real path before comparing, so a symlink sitting inside an allowed directory is judged by where it actually points rather than by its lexical location. When the target does not exist yet (for example a file about to be created), it falls back to the lexical path, then to the resolved parent directory, so ordinary writes are unaffected.
- **Log file permissions.** The guardian log directory and its files are now created with `0700`/`0600` instead of inheriting the default umask. `egc-memory` already does this via `ensurePrivateDir`; the guardian was the one place still writing world-readable logs.

## Tests

Adds `tests/egc-guardian-symlink.test.js`, which builds a symlink into a denied directory and asserts it resolves and is treated as protected, while a plain temp path and a not-yet-created file stay allowed. The test skips cleanly on Windows and when the build output is absent.

Verified against the source directly: symlink into a denied path is protected, a plain path is not, a not-yet-created file resolves via its parent and stays allowed, and existing absolute and `~`-relative denied paths keep matching. No behavior change for normal paths.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened path checks in `egc-guardian` to block symlink bypasses and tightened log permissions to private defaults, matching `egc-memory`. No behavior change for normal paths.

- **Bug Fixes**
  - `isProtectedPath`: resolves real paths (follows symlinks) before deny checks; falls back to parent for not-yet-existing targets so ordinary writes remain allowed.
  - Logging: creates `~/.egc/logs` with 0700 and log files with 0600 (no umask inheritance).

<sup>Written for commit abd0dbe435a2bbe51cc68e93b1eef00dcc21eb6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

