### PR TITLE
harden guardian command validation against path-qualified command names

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -444,7 +444,10 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   }
 
   const parts = command.trim().split(/\s+/);
-  const baseCommand = parts[0];
+  // Judge the command by its final path segment. Spelling out an absolute or
+  // relative path (/bin/rm, ./mv, /usr/bin/python3) must not sidestep the
+  // name-based destructive and inline-eval denials below.
+  const baseCommand = path.basename(parts[0]);
   const args = parts.slice(1);
 
   // 2. Dangerous commands: denied regardless of args
@@ -466,7 +469,10 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   // bypasses every other check in this file, so it must hard-block
   // regardless of allowlist status. Using DANGEROUS here (not BLOCKED) keeps
   // the reason string out of the hook's advisory-reason list.
-  const evalFlagsForBase = INLINE_EVAL_COMMANDS[baseCommand];
+  // A versioned interpreter binary (python3.11, perl5.36) carries the same
+  // eval power as its bare name; fall back to the version-stripped name.
+  const evalFlagsForBase = INLINE_EVAL_COMMANDS[baseCommand]
+    ?? INLINE_EVAL_COMMANDS[baseCommand.replace(/[0-9.]+$/, '')];
   if (evalFlagsForBase && args.some(a => matchesEvalFlag(a, evalFlagsForBase))) {
     return {
       allowed: false,

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -38,6 +38,17 @@ function matchesEvalFlag(arg: string, flags: string[]): boolean {
   return false;
 }
 
+// Strip a trailing version suffix (python3.11 -> python) so a versioned
+// interpreter binary resolves to the same inline-eval rule as its bare name.
+// Linear scan rather than a regex to keep this off any backtracking path.
+function bareInterpreterName(name: string): string {
+  let end = name.length;
+  while (end > 0 && (name[end - 1] === '.' || (name[end - 1] >= '0' && name[end - 1] <= '9'))) {
+    end -= 1;
+  }
+  return name.slice(0, end);
+}
+
 // A flag like --file=/path carries a real filesystem target even though the
 // argument starts with '-'; loops that skip dashed args entirely would let
 // protected paths through inside the value.
@@ -472,7 +483,7 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   // A versioned interpreter binary (python3.11, perl5.36) carries the same
   // eval power as its bare name; fall back to the version-stripped name.
   const evalFlagsForBase = INLINE_EVAL_COMMANDS[baseCommand]
-    ?? INLINE_EVAL_COMMANDS[baseCommand.replace(/[0-9.]+$/, '')];
+    ?? INLINE_EVAL_COMMANDS[bareInterpreterName(baseCommand)];
   if (evalFlagsForBase && args.some(a => matchesEvalFlag(a, evalFlagsForBase))) {
     return {
       allowed: false,

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -104,6 +104,7 @@ async function runTests() {
   console.log('\n=== validate_command: ALLOWED ===');
 
   run('ls -la',                  () => assertAllowed('ls -la'));
+  run('/bin/ls -la',             () => assertAllowed('/bin/ls -la'));
   run('cat README.md',           () => assertAllowed('cat README.md'));
   run('grep -r "foo" ./src',     () => assertAllowed('grep -r "foo" ./src'));
   run('git status',              () => assertAllowed('git status'));
@@ -127,6 +128,12 @@ async function runTests() {
   run('mv src dest',             () => assertDenied('mv src dest'));
   run('git push --force',        () => assertDenied('git push --force'));
   run('git push -f',             () => assertDenied('git push -f'));
+  // absolute/relative/versioned paths must not sidestep the name-based checks
+  run('/bin/rm -rf .',           () => assertDenied('/bin/rm -rf .'));
+  run('/usr/bin/mv src dest',    () => assertDenied('/usr/bin/mv src dest'));
+  run('/usr/bin/python3 -c ...', () => assertDenied('/usr/bin/python3 -c "import os"'));
+  run('python3.11 -c ...',       () => assertDenied('python3.11 -c "x"'));
+  run('/usr/bin/git push --force',() => assertDenied('/usr/bin/git push --force'));
   run(`cat ~/.aws/credentials`,  () => assertDenied(`cat ${home}/.aws/credentials`));
   run(`cat ~/.ssh/id_rsa`,       () => assertDenied(`cat ${home}/.ssh/id_rsa`));
   run('grep -r "" /',            () => assertDenied('grep -r "" /'));


### PR DESCRIPTION
Hardens `validateCommand` so a command given with a leading directory prefix is judged by the same name-based rules as its bare form.

The final path segment of the first token is taken before the destructive-command, inline-eval, allowlist, and per-command argument checks, so an absolute or relative path is not waved through. The inline-eval lookup also falls back to a version-stripped name so a versioned interpreter binary is covered by the same rule.

Tests: adds validator cases in `tests/scripts/egc-guardian.test.js` for path-qualified and versioned forms (denied) plus a path-qualified read-only command (allowed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened command validation so path-qualified commands are judged by their base name and cannot bypass dangerous or inline-eval checks. Also covers versioned interpreter binaries during inline-eval detection.

- **Bug Fixes**
  - Use the final path segment of the first token, so `/bin/rm`, `./mv`, and `/usr/bin/git` are treated like `rm`, `mv`, and `git`.
  - Inline-eval lookup falls back to a version-stripped name (e.g., `python3.11` → `python`), using a linear scan to strip the suffix and avoid regex backtracking.
  - Added tests for allowed path-qualified read-only commands and denied destructive/versioned forms.

<sup>Written for commit 158f5213e6af61b106df6baa29a508b38ee02d5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

