### PR TITLE
match git hook-path overrides case-insensitively and cover all write-target fields

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -36,6 +36,9 @@ const GIT_COMMANDS_WITH_NO_VERIFY = [
 const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
 
 const GIT_CONFIG_KEY_PREFIX = 'core.hooksPath=';
+// git treats config section/key names case-insensitively, so core.hookspath=
+// and CORE.HOOKSPATH= reach the same setting; compare the prefix lowercased.
+const GIT_CONFIG_KEY_PREFIX_LC = GIT_CONFIG_KEY_PREFIX.toLowerCase();
 
 const GIT_GLOBAL_FLAGS_WITH_ARG = new Set(['-c', '-C', '--work-tree', '--git-dir', '--namespace', '--super-prefix']);
 
@@ -412,14 +415,14 @@ function hasHooksPathOverride(input, detected) {
 
     if (value === '-c') {
       const next = tokens[i + 1]?.value;
-      if (typeof next === 'string' && next.startsWith(GIT_CONFIG_KEY_PREFIX)) {
+      if (typeof next === 'string' && next.toLowerCase().startsWith(GIT_CONFIG_KEY_PREFIX_LC)) {
         return true;
       }
       i++;
       continue;
     }
 
-    if (value.startsWith(`-c${GIT_CONFIG_KEY_PREFIX}`)) {
+    if (value.toLowerCase().startsWith(`-c${GIT_CONFIG_KEY_PREFIX_LC}`)) {
       return true;
     }
   }

--- a/scripts/hooks/pre-write-guardian-validate.js
+++ b/scripts/hooks/pre-write-guardian-validate.js
@@ -34,7 +34,14 @@ function parseInput(inputOrRaw) {
 
 function run(inputOrRaw) {
   const input = parseInput(inputOrRaw);
-  const filePath = input?.tool_input?.file_path || input?.tool_input?.file || '';
+  // Harnesses name the write target differently: file_path (Claude Code),
+  // path (Gemini CLI), TargetFile (Antigravity). Cover them all so a protected
+  // path is validated regardless of which harness issued the write.
+  const filePath = input?.tool_input?.file_path
+    || input?.tool_input?.file
+    || input?.tool_input?.path
+    || input?.tool_input?.TargetFile
+    || '';
   if (!filePath || typeof filePath !== 'string') return { exitCode: 0 };
 
   const cli = resolveGuardianCli();

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -78,6 +78,18 @@ if (test('blocks quoted core.hooksPath override argument', () => {
   assert.ok(r.stderr.includes('core.hooksPath'), `stderr should mention core.hooksPath: ${r.stderr}`);
 })) passed++; else failed++;
 
+// git config section/key names are case-insensitive, so a lowercase or
+// upper-cased key reaches the same setting and must be blocked too.
+if (test('blocks a lowercase core.hookspath override key', () => {
+  const r = runHook({ tool_input: { command: 'git -c core.hookspath=/dev/null commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks an upper-cased CORE.HOOKSPATH override key', () => {
+  const r = runHook({ tool_input: { command: 'git -c CORE.HOOKSPATH=/dev/null commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
 // --- Chained command false positive prevention (Comment 2) ---
 
 if (test('does not false-positive on -n belonging to git log in a chain', () => {

--- a/tests/hooks/pre-write-guardian-validate.test.js
+++ b/tests/hooks/pre-write-guardian-validate.test.js
@@ -67,6 +67,31 @@ function runTests() {
     assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
   })) passed++; else failed++;
 
+  // Harnesses name the write target differently; a protected path must be
+  // caught whether it arrives as file_path, path (Gemini CLI) or TargetFile
+  // (Antigravity).
+  function runHookField(field, filePath) {
+    const rawInput = JSON.stringify({ tool_name: 'Write', tool_input: { [field]: filePath, content: 'x' } });
+    const result = spawnSync('node', [runner, 'pre:write-guardian-validate', 'scripts/hooks/pre-write-guardian-validate.js', 'minimal,standard,strict'], {
+      input: rawInput,
+      encoding: 'utf8',
+      env: { ...process.env, ECC_HOOK_PROFILE: 'standard', EGC_GUARDIAN_CLI: fakeCli },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    return Number.isInteger(result.status) ? result.status : 1;
+  }
+
+  if (test('blocks a protected write arriving via the path field', () => {
+    const code = runHookField('path', path.join(os.homedir(), '.ssh', 'id_rsa'));
+    assert.strictEqual(code, 2, 'Expected block when the target arrives as path');
+  })) passed++; else failed++;
+
+  if (test('blocks a protected write arriving via the TargetFile field', () => {
+    const code = runHookField('TargetFile', path.join(os.homedir(), '.aws', 'credentials'));
+    assert.strictEqual(code, 2, 'Expected block when the target arrives as TargetFile');
+  })) passed++; else failed++;
+
   if (test('fails open silently when the validator crashes', () => {
     const brokenCli = path.join(os.tmpdir(), `egc-broken-cli-${Date.now()}.js`);
     fs.writeFileSync(brokenCli, 'process.exit(1);\n');


### PR DESCRIPTION
Two hardening fixes in the hook layer.

- `block-no-verify` matched the `core.hooksPath` git-config key case-sensitively. git treats config section and key names case-insensitively, so a differently-cased key (`core.hookspath=`, `CORE.HOOKSPATH=`) reached the same setting without being caught. The comparison is now lowercased.
- `pre-write-guardian-validate` read the write target only from `file_path`/`file`. It now also reads `path` (Gemini CLI) and `TargetFile` (Antigravity) so a protected path is validated regardless of which harness issued the write.

Tests added for both; the existing hook suites stay green (24 and 7 cases).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks case-insensitive `core.hooksPath` overrides and validates protected writes across all write-target fields to close bypass gaps in the hook layer.

- **Bug Fixes**
  - `block-no-verify`: detect `-c core.hooksPath=...` overrides case-insensitively (also matches `core.hookspath`, `CORE.HOOKSPATH`).
  - `pre-write-guardian-validate`: read the write target from `file_path`, `file`, `path` (Gemini CLI), and `TargetFile` (Antigravity) so protected-path checks always run.

<sup>Written for commit f93a9b52f7c04f1676a12c1375f1513c7b4e2c18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

