### PR TITLE
fall back to the jsonl store on a state.db error and stabilize synthetic observation ids

### DIFF
--- a/mcp/servers/egc-memory/src/compress.ts
+++ b/mcp/servers/egc-memory/src/compress.ts
@@ -201,7 +201,14 @@ export async function loadRawObservations(
   limit: number = 50,
   since?: string
 ): Promise<RawObservation[]> {
-  const sqliteObservations = await loadRawObservationsFromStateDb(projectPath, limit, since);
+  let sqliteObservations: RawObservation[] = [];
+  try {
+    sqliteObservations = await loadRawObservationsFromStateDb(projectPath, limit, since);
+  } catch (err) {
+    // A locked, busy or corrupt state.db must not sink compression: fall
+    // through to the observations.jsonl reader below instead of throwing.
+    console.error("[EGC compress] state.db read failed, using observations.jsonl fallback:", String(err));
+  }
 
   if (sqliteObservations.length > 0) {
     return sqliteObservations;
@@ -237,8 +244,10 @@ function readObsFile(filePath: string, limit: number, since?: string): RawObserv
           if (time < sinceTime) continue;
         }
 
-        // non-security hash: used for dedup/identity only
-        const id = parsed.id || `obs-${i}-${crypto.createHash("sha256").update(lines[i]).digest("hex").slice(0, 8)}`;
+        // Content-only hash, deliberately position-independent: the same
+        // observation must resolve to the same id here and in
+        // replaceObservation, whose line array is not blank-line filtered.
+        const id = parsed.id || `obs-${crypto.createHash("sha256").update(lines[i]).digest("hex").slice(0, 8)}`;
         observations.push({
           id,
           tool: parsed.tool,
@@ -306,8 +315,9 @@ export async function replaceObservation(projectPath: string, id: string, compre
     if (!lines[i]) continue;
     try {
       const parsed = JSON.parse(lines[i]);
-      // non-security hash: used for dedup/identity only
-      const lineId = parsed.id || `obs-${i}-${crypto.createHash("sha256").update(lines[i]).digest("hex").slice(0, 8)}`;
+      // Position-independent content hash, matching readObsFile so the id
+      // resolves the same despite the differing blank-line handling.
+      const lineId = parsed.id || `obs-${crypto.createHash("sha256").update(lines[i]).digest("hex").slice(0, 8)}`;
       if (lineId === id) {
         lines[i] = JSON.stringify({
           ...compressed,


### PR DESCRIPTION
Two reliability fixes in the observation-compression path.

- `loadRawObservations` threw out of the whole compression pass when the SQLite `state.db` was locked, busy or corrupt, so the `observations.jsonl` fallback right below it was skipped. It now catches that and falls through to the file store.
- The synthetic observation id (used only for a line that carries no explicit id) embedded the array index. That index differs between the blank-line-filtered read (`readObsFile`) and the unfiltered replace (`replaceObservation`), so a replacement silently missed whenever the file had blank lines. The id is now a position-independent content hash, identical on both paths.

The existing `ruleBasedCompress` tests are unaffected; dedicated coverage for the jsonl fallback path is tracked with the broader memory test-coverage work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve reliability of observation compression. Falls back to `observations.jsonl` when `state.db` read fails, and stabilizes synthetic observation IDs so replacements work even with blank lines.

- **Bug Fixes**
  - Catch SQLite errors (locked, busy, corrupt) in `loadRawObservations` and use the file-store fallback instead of throwing.
  - Replace index-based synthetic IDs with a position-independent content hash so `readObsFile` and `replaceObservation` resolve the same ID.

<sup>Written for commit 9791ddf03cc899e64dd2fd1ae067fe260d32aeee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

