### PR TITLE
stop team sync from deleting local state files absent from the remote

### DIFF
--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -144,11 +144,8 @@ async function mergeTeamState(): Promise<void> {
   if (syncFiles.length === 0) {
     return; // No remote state yet; preserve local files.
   }
-  const syncedRelativePaths = new Set<string>();
-
   for (const syncFile of syncFiles) {
     const relativePath = path.relative(syncStateDir, syncFile);
-    syncedRelativePaths.add(relativePath);
     const localFile = path.join(localStateDir, relativePath);
 
     const syncContent = fs.readFileSync(syncFile, 'utf-8');
@@ -168,14 +165,10 @@ async function mergeTeamState(): Promise<void> {
     }
   }
 
-  // Propagate remote deletions: remove local files absent from sync repo.
-  const localFiles = getAllFiles(localStateDir);
-  for (const localFile of localFiles) {
-    const relativePath = path.relative(localStateDir, localFile);
-    if (!syncedRelativePaths.has(relativePath)) {
-      fs.unlinkSync(localFile);
-    }
-  }
+  // A team sync never removes local state files: a file absent from the sync
+  // repo may be one this machine created and has not pushed yet, and deleting
+  // it would be silent, unrecoverable memory loss. Remote deletions therefore
+  // do not propagate automatically.
 }
 
 function getAllFiles(dir: string): string[] {


### PR DESCRIPTION
`mergeTeamState` deleted every local state file that was absent from the team-sync repo, to "propagate remote deletions". A sync cannot distinguish a remotely-deleted file from one this machine created and has not pushed yet, so this silently and unrecoverably erased local memory the moment a new project or branch state was synced before its first push.

The sync now never removes local state files; remote deletions do not propagate automatically, which is the safe default for a persistent-memory store. Dedicated `sync/` regression coverage is tracked with the broader test-coverage work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Team sync no longer deletes local state files that are missing from the remote, preventing silent and unrecoverable memory loss when syncing before the first push. `mergeTeamState` now only adds or updates local files; remote deletions do not propagate automatically.

<sup>Written for commit 88b60eb71e9604755856bacb7ee2e4e1ed0f666a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

