### PR TITLE
guard two destructive filesystem paths in the plugin and orchestration lib

### DIFF
--- a/scripts/lib/plugin-registry.js
+++ b/scripts/lib/plugin-registry.js
@@ -226,8 +226,18 @@ function reinstallAllPlugins() {
       results.push({ name, success: false, errors: ['plugin.json missing; cannot reinstall'] });
       continue;
     }
-    const result = installPluginFromDir(pluginDir, name);
-    results.push({ name, ...result });
+    // installPluginFromDir wipes the destination before copying, and here the
+    // destination is the plugin's own dir, so reinstalling in place would
+    // erase it. Stage a copy in tmp and install from there.
+    const stageDir = path.join(os.tmpdir(), `egc-plugin-reinstall-${name}-${Date.now()}`);
+    try {
+      fs.mkdirSync(stageDir, { recursive: true });
+      copyRecursive(pluginDir, stageDir);
+      const result = installPluginFromDir(stageDir, name);
+      results.push({ name, ...result });
+    } finally {
+      fs.rmSync(stageDir, { recursive: true, force: true }); // NOSONAR jssecurity:S8707
+    }
   }
 
   return results;

--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -66,10 +66,11 @@ function normalizeSeedPaths(seedPaths, repoRoot) {
     const relativePath = path.relative(resolvedRepoRoot, absolutePath);
 
     if (
+      relativePath === '' ||
       relativePath.startsWith('..') ||
       path.isAbsolute(relativePath)
     ) {
-      throw new Error(`seedPaths entries must stay inside repoRoot: ${entry}`);
+      throw new Error(`seedPaths entries must name a location inside repoRoot, not '' or the root itself: ${entry}`);
     }
 
     const normalizedPath = relativePath.split(path.sep).join('/');

--- a/tests/lib/tmux-worktree-orchestrator.test.js
+++ b/tests/lib/tmux-worktree-orchestrator.test.js
@@ -116,6 +116,17 @@ test('buildOrchestrationPlan requires at least one worker', () => {
   );
 });
 
+test('normalizeSeedPaths rejects a seed path that resolves to the repo root', () => {
+  assert.throws(
+    () => normalizeSeedPaths(['.'], '/tmp/egc'),
+    /not '' or the root itself/
+  );
+  assert.throws(
+    () => normalizeSeedPaths(['sub/..'], '/tmp/egc'),
+    /not '' or the root itself/
+  );
+});
+
 test('buildOrchestrationPlan normalizes global and worker seed paths', () => {
   const plan = buildOrchestrationPlan({
     repoRoot: '/tmp/egc',


### PR DESCRIPTION
Two destructive filesystem paths in `scripts/lib`.

- `reinstallAllPlugins` reinstalled each plugin from its own directory, but `installPluginFromDir` wipes the destination before copying and the destination was that same directory, so an in-place reinstall erased every plugin into an empty stub. It now stages a copy in a temp dir and installs from there.
- `normalizeSeedPaths` accepted a seed entry that resolves to the repo root (e.g. `.` or `sub/..`), which made `overlaySeedPaths` `rmSync` the entire worktree and copy the whole repo into it. Such entries are now rejected. (The empty-string case was already skipped upstream, so `.` was the real vector.)

Adds a regression test for the seed-path guard; the tmux-worktree suite stays green (15 cases).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented destructive deletes during plugin reinstalls and worktree seeding. Reinstalls now stage from a temp dir, and seed paths that resolve to the repo root are rejected.

- **Bug Fixes**
  - Plugin registry: `reinstallAllPlugins` now copies each plugin to a temp dir and installs from there, avoiding in-place wipes. Temp dir is removed after use.
  - Orchestrator: `normalizeSeedPaths` rejects entries that resolve to the repo root (e.g., '.' or 'sub/..'), preventing full worktree deletion.
  - Tests: added a regression test for the seed-path guard; tmux-worktree suite stays green.

<sup>Written for commit c7e617172b0bb1f5e7a2cc40af9c21594f6bafd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

