### PR TITLE
fix(hooks): fail closed when the bash dispatcher's own plumbing errors

### DIFF
--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -147,12 +147,20 @@ function runHooks(rawInput, hooks) {
   let stderr = '';
 
   for (const hook of hooks) {
-    if (!isHookEnabled(hook.id, { profiles: hook.profiles })) {
-      trace('hook:dispatch:skipped', { id: hook.id });
-      continue;
-    }
-
     try {
+      // A failure while reading hook flags must never silently skip a
+      // security hook: treat an unreadable flag as enabled so the guard runs.
+      let enabled = true;
+      try {
+        enabled = isHookEnabled(hook.id, { profiles: hook.profiles });
+      } catch (flagError) {
+        trace('hook:dispatch:flag-error', { id: hook.id, error: flagError.message });
+      }
+      if (!enabled) {
+        trace('hook:dispatch:skipped', { id: hook.id });
+        continue;
+      }
+
       trace('hook:dispatch:running', { id: hook.id });
       const result = normalizeHookResult(currentRaw, hook.run(currentRaw));
       currentRaw = result.raw;
@@ -182,6 +190,43 @@ function runPostBash(rawInput) {
   return runHooks(rawInput, POST_BASH_HOOKS);
 }
 
+function denyEnvelope(reason) {
+  // PreToolUse deny envelope honored by Claude Code, Codex and CodeBuddy: the
+  // host blocks the command when this JSON is on stdout AND the process exits 0
+  // (a non-zero exit without valid JSON reads as a crashed hook and falls back
+  // to the host default, which can allow).
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: `[EGC] Blocked for safety: ${reason}`,
+    },
+  });
+}
+
+// Formats the pre-mode stdout for a chain result while preserving the chain's
+// decision: if envelope formatting itself throws, a deny stays a deny and an
+// allow still passes the command through unchanged.
+function resolvePreOutput(raw, result) {
+  try {
+    return toPreToolUseOutput(raw, result.output);
+  } catch (formatError) {
+    process.stderr.write(`[Hook] output formatting failed: ${formatError.message}\n`);
+    return result.exitCode !== 0
+      ? denyEnvelope('a security hook denied the command but its response could not be formatted')
+      : result.output;
+  }
+}
+
+// The stdout a dispatcher emits when its own infrastructure crashes before the
+// chain can decide. Pre mode gates security, so it fails closed (deny); post
+// mode is observational and fails open (emit nothing).
+function failClosedOutput(mode) {
+  return mode === 'post'
+    ? ''
+    : denyEnvelope('the security dispatcher crashed before the guards could run');
+}
+
 async function main() {
   const mode = process.argv[2];
   const raw = await readStdinRaw();
@@ -193,9 +238,7 @@ async function main() {
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
-  const output = mode === 'post'
-    ? result.output
-    : toPreToolUseOutput(raw, result.output);
+  const output = mode === 'post' ? result.output : resolvePreOutput(raw, result);
   process.stdout.write(output);
   process.exit(result.exitCode);
 }
@@ -203,6 +246,13 @@ async function main() {
 if (require.main === module) {
   main().catch(error => {
     process.stderr.write(`[Hook] bash-hook-dispatcher failed: ${error.message}\n`);
+    // Pre mode gates security: a dispatcher-infrastructure crash before the
+    // guards run must fail closed (deny), never silently allow. Post mode is
+    // observational, so a crash there is safe to swallow.
+    const out = failClosedOutput(process.argv[2]);
+    if (out) {
+      process.stdout.write(out);
+    }
     process.exit(0);
   });
 }
@@ -213,4 +263,7 @@ module.exports = {
   runPreBash,
   runPostBash,
   toPreToolUseOutput,
+  denyEnvelope,
+  resolvePreOutput,
+  failClosedOutput,
 };

--- a/scripts/hooks/post-bash-dispatcher.js
+++ b/scripts/hooks/post-bash-dispatcher.js
@@ -15,10 +15,17 @@ process.stdin.on('data', chunk => {
 });
 
 process.stdin.on('end', () => {
-  const result = runPostBash(raw);
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
+  try {
+    const result = runPostBash(raw);
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+    process.stdout.write(result.output);
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    // Post hooks are observational and cannot gate a command, so a crash is
+    // safe to swallow (fail open) rather than surface a spurious failure.
+    process.stderr.write(`[Hook] post-bash-dispatcher failed: ${error.message}\n`);
+    process.exitCode = 0;
   }
-  process.stdout.write(result.output);
-  process.exitCode = result.exitCode;
 });

--- a/scripts/hooks/pre-bash-dispatcher.js
+++ b/scripts/hooks/pre-bash-dispatcher.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const { runPreBash, toPreToolUseOutput } = require('./bash-hook-dispatcher');
+const { runPreBash, resolvePreOutput, failClosedOutput } = require('./bash-hook-dispatcher');
 
 let raw = '';
 const MAX_STDIN = 1024 * 1024;
@@ -15,10 +15,18 @@ process.stdin.on('data', chunk => {
 });
 
 process.stdin.on('end', () => {
-  const result = runPreBash(raw);
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
+  try {
+    const result = runPreBash(raw);
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+    process.stdout.write(resolvePreOutput(raw, result));
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    // Pre mode gates security: a dispatcher crash must fail closed (deny),
+    // never silently allow the command.
+    process.stderr.write(`[Hook] pre-bash-dispatcher failed: ${error.message}\n`);
+    process.stdout.write(failClosedOutput('pre'));
+    process.exitCode = 0;
   }
-  process.stdout.write(toPreToolUseOutput(raw, result.output));
-  process.exitCode = result.exitCode;
 });

--- a/tests/hooks/bash-hook-dispatcher.test.js
+++ b/tests/hooks/bash-hook-dispatcher.test.js
@@ -117,6 +117,37 @@ function runTests() {
     assert.ok(result.stderr.includes('gh pr review 42 --repo owner/repo'));
   })) passed++; else failed++;
 
+  // ── fail-closed contract for dispatcher-infrastructure crashes ──
+  // A crash in the dispatcher's own plumbing (before or around the hook chain)
+  // must not silently allow a command in pre mode. These lock the exact output
+  // the pre/post dispatchers emit on that path.
+
+  const dispatcher = require('../../scripts/hooks/bash-hook-dispatcher');
+
+  if (test('denyEnvelope emits the host-honored PreToolUse deny schema', () => {
+    const parsed = JSON.parse(dispatcher.denyEnvelope('something broke'));
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PreToolUse');
+    assert.strictEqual(parsed.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(parsed.hookSpecificOutput.permissionDecisionReason.includes('something broke'));
+  })) passed++; else failed++;
+
+  if (test('failClosedOutput denies in pre mode and fails open (silent) in post mode', () => {
+    const pre = JSON.parse(dispatcher.failClosedOutput('pre'));
+    assert.strictEqual(pre.hookSpecificOutput.permissionDecision, 'deny',
+      'a dispatcher crash in pre mode must fail closed (deny), never silently allow');
+    assert.strictEqual(dispatcher.failClosedOutput('post'), '',
+      'post hooks are observational, so a crash fails open with no output');
+  })) passed++; else failed++;
+
+  if (test('resolvePreOutput preserves the chain decision if envelope formatting throws', () => {
+    const raw = JSON.stringify({ tool_input: { command: 'ls' } });
+    // Allow with an unchanged command passes straight through.
+    assert.strictEqual(dispatcher.resolvePreOutput(raw, { output: raw, exitCode: 0 }), raw);
+    // A deny signalled by a non-zero exit code (empty stdout) stays empty so the
+    // host still reads the block from the exit code, never a stale allow.
+    assert.strictEqual(dispatcher.resolvePreOutput(raw, { output: '', exitCode: 2 }), '');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What

The pre-bash dispatcher runs the security guards (`guardian-validate`, `gateguard`), but an error in the dispatcher's own infrastructure fell through to a catch that exited 0, which a PreToolUse host reads as "allow". Two concrete gaps, both surfaced by the squad review:

- `isHookEnabled` was called **outside** the per-hook `try`, so a flag-read error aborted the whole chain before the guards ran.
- A crash in the output-envelope formatting **after** a hook had already denied lost that decision.

## Change

- Shield the flag lookup inside each hook's isolation: an unreadable flag now counts as **enabled**, so a security hook is never silently skipped.
- Preserve the chain's decision if envelope formatting throws (a deny stays a deny, an allow passes through).
- The pre-mode infrastructure-crash path now emits an explicit **deny** (`hookSpecificOutput.permissionDecision: "deny"` + exit 0, the schema the hosts honor). Post mode stays fail-open, since it is observational and cannot gate.
- Shared helpers (`denyEnvelope`, `resolvePreOutput`, `failClosedOutput`) cover the consolidated dispatcher and both thin entry points (`pre-bash-dispatcher.js`, `post-bash-dispatcher.js`), so no entry point is left behind.

## Tests

`tests/hooks/bash-hook-dispatcher.test.js` gains the fail-closed contract (deny schema, pre=deny / post=silent, decision preservation). Suites green: dispatcher 8/8, `hooks.test.js` 226/226. Normal operation is unchanged (allow passes through, `--no-verify` still blocks).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed in the pre-bash hook dispatcher when its own plumbing errors, so security hooks can’t be bypassed. Preserves hook decisions even if output formatting fails; post dispatcher stays fail‑open.

- **Bug Fixes**
  - Guard flag lookup per hook; an unreadable flag now counts as enabled so a security hook is never skipped.
  - Preserve the chain’s decision if PreToolUse envelope formatting throws (deny stays deny; allow passes through).
  - On pre-mode infrastructure crashes, emit a PreToolUse deny envelope to stdout and exit 0; post mode swallows errors and exits 0 with no output.
  - Added shared helpers `denyEnvelope`, `resolvePreOutput`, and `failClosedOutput`, used by the consolidated dispatcher and both entry points.
  - Tests cover the fail-closed contract and decision preservation; normal behavior unchanged.

<sup>Written for commit 185068117df8e0476b40720e73290933b4e19cf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

