### PR TITLE
fix(hooks): Windows portability for the typecheck and Zed registration hooks

### DIFF
--- a/scripts/hooks/post-edit-typecheck.js
+++ b/scripts/hooks/post-edit-typecheck.js
@@ -43,35 +43,61 @@ function findTsConfig(startDir) {
   return null;
 }
 
+function reportTscErrors(output, dir, filePath, resolvedPath) {
+  const relPath = path.relative(dir, resolvedPath);
+  const candidates = new Set([filePath, resolvedPath, relPath]);
+  const relevantLines = output
+    .split("\n")
+    .filter((line) => {
+      for (const candidate of candidates) {
+        if (line.includes(candidate)) return true;
+      }
+      return false;
+    })
+    .slice(0, 10);
+
+  if (relevantLines.length > 0) {
+    console.error(
+      "[Hook] TypeScript errors in " + path.basename(filePath) + ":",
+    );
+    relevantLines.forEach((line) => console.error(line));
+  }
+}
+
+// Resolve the project's own tsc compiler by walking up from startDir for
+// node_modules/typescript/bin/tsc, a plain Node script we run through
+// process.execPath. This deliberately avoids npx: since Node 20.12 (the
+// CVE-2024-27980 mitigation) spawning the npx.cmd shim without a shell throws
+// EINVAL, so the previous execFileSync of npx silently never ran the check on
+// Windows, and adding shell:true would reopen a command-injection surface.
+function resolveTscBin(startDir) {
+  let dir = startDir;
+  const root = path.parse(dir).root;
+  let depth = 0;
+
+  while (depth < 20) {
+    const candidate = path.join(dir, "node_modules", "typescript", "bin", "tsc");
+    if (fs.existsSync(candidate)) return candidate;
+    if (dir === root) break;
+    dir = path.dirname(dir);
+    depth++;
+  }
+  return null;
+}
+
 function runTypeCheck(dir, filePath, resolvedPath) {
+  const tscBin = resolveTscBin(dir);
+  if (!tscBin) return;
+
   try {
-    const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
-    execFileSync(npxBin, ["tsc", "--noEmit", "--pretty", "false"], {
+    execFileSync(process.execPath, [tscBin, "--noEmit", "--pretty", "false"], {
       cwd: dir,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 30000,
     });
   } catch (err) {
-    const output = (err.stdout || "") + (err.stderr || "");
-    const relPath = path.relative(dir, resolvedPath);
-    const candidates = new Set([filePath, resolvedPath, relPath]);
-    const relevantLines = output
-      .split("\n")
-      .filter((line) => {
-        for (const candidate of candidates) {
-          if (line.includes(candidate)) return true;
-        }
-        return false;
-      })
-      .slice(0, 10);
-
-    if (relevantLines.length > 0) {
-      console.error(
-        "[Hook] TypeScript errors in " + path.basename(filePath) + ":",
-      );
-      relevantLines.forEach((line) => console.error(line));
-    }
+    reportTscErrors((err.stdout || "") + (err.stderr || ""), dir, filePath, resolvedPath);
   }
 }
 

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -287,9 +287,14 @@ function registerContinueYaml(targetDir, bins) {
 function registerZedContextServers(targetPath, bins) {
   const { guardianBin, memoryBin } = bins;
   const templatePath = path.join(__dirname, '..', '..', 'mcp-configs', 'zed-context-servers.json');
+  // The placeholders sit inside JSON string literals, so a Windows bin path's
+  // backslashes (C:\Users\...) must be escaped before substitution or the
+  // JSON.parse below throws on the invalid "\U" escape. jsonStringBody yields
+  // the escaped body of a JSON string without its surrounding quotes.
+  const jsonStringBody = (p) => JSON.stringify(p).slice(1, -1);
   const template = fs.readFileSync(templatePath, 'utf8')
-    .replaceAll('__GUARDIAN_BIN__', guardianBin)
-    .replaceAll('__MEMORY_BIN__', memoryBin);
+    .replaceAll('__GUARDIAN_BIN__', jsonStringBody(guardianBin))
+    .replaceAll('__MEMORY_BIN__', jsonStringBody(memoryBin));
   const incoming = JSON.parse(template);
 
   let settings = {};

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2714,7 +2714,7 @@ async function runTests() {
       // Strip comments to avoid matching "shell: true" in comment text
       const codeOnly = typecheckSource.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
       assert.ok(!codeOnly.includes('shell:'), 'post-edit-typecheck.js should not pass shell option in code');
-      assert.ok(typecheckSource.includes('npx.cmd'), 'Should use npx.cmd for Windows cross-platform safety');
+      assert.ok(codeOnly.includes('process.execPath'), 'Should run the resolved tsc through node (process.execPath): spawning the npx.cmd shim without a shell throws EINVAL on Node >= 20.12 (CVE-2024-27980 mitigation), so the old npx path never ran on Windows, and shell:true would reopen an injection surface');
     })
   )
     passed++;
@@ -5461,6 +5461,41 @@ Some random content without the expected ### Context to Load section
         assert.ok(result.stderr.includes('broken.ts'), `Should reference the edited file basename. Got: ${result.stderr}`);
       }
       // Either way, no crash and data passes through (verified above)
+      cleanupTestDir(testDir);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('runs the resolved tsc through node without a shell (Windows EINVAL-safe execution)', async () => {
+      const testDir = createTestDir();
+      // A fake local typescript compiler that only records how it was invoked.
+      const tscBinDir = path.join(testDir, 'node_modules', 'typescript', 'bin');
+      fs.mkdirSync(tscBinDir, { recursive: true });
+      const logFile = path.join(testDir, 'tsc-invocation.log');
+      fs.writeFileSync(
+        path.join(tscBinDir, 'tsc'),
+        [
+          "const fs = require('fs');",
+          `fs.appendFileSync(${JSON.stringify(logFile)}, JSON.stringify({ args: process.argv.slice(2) }) + '\\n');`,
+          'process.exit(0);'
+        ].join('\n')
+      );
+      fs.writeFileSync(path.join(testDir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { noEmit: true } }));
+      const testFile = path.join(testDir, 'sample.ts');
+      fs.writeFileSync(testFile, 'export const value = 1;\n');
+
+      const stdinJson = JSON.stringify({ tool_input: { file_path: testFile } });
+      const result = await runScript(path.join(scriptsDir, 'post-edit-typecheck.js'), stdinJson);
+
+      assert.strictEqual(result.code, 0, 'Should exit 0');
+      // The compiler is run via node on every platform, proving the old Windows
+      // path (execFileSync of npx.cmd without a shell -> EINVAL) is gone.
+      const log = fs.existsSync(logFile) ? fs.readFileSync(logFile, 'utf8').trim() : '';
+      assert.ok(log.length > 0, 'Should have invoked the resolved tsc compiler through node');
+      const entry = JSON.parse(log.split('\n')[0]);
+      assert.deepStrictEqual(entry.args, ['--noEmit', '--pretty', 'false'], 'Should pass the expected tsc flags');
       cleanupTestDir(testDir);
     })
   )

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -19,6 +19,7 @@ const {
   registerJson,
   registerToml,
   registerContinueYaml,
+  registerZedContextServers,
   registerMcpServers,
 } = require('../../scripts/lib/mcp-register');
 
@@ -414,6 +415,44 @@ function runTests() {
     const memoryParsed = parseBlock(memoryContent);
     assert.strictEqual(guardianParsed.mcpServers[0].name, 'egc-guardian');
     assert.strictEqual(memoryParsed.mcpServers[0].name, 'egc-memory');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // ── registerZedContextServers ───────────────────────────────────
+
+  (test('registerZedContextServers keeps a Windows bin path valid JSON (backslash escape)', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.config', 'zed', 'settings.json');
+    const winPath = 'C:\\Users\\person\\egc\\mcp\\servers\\egc-guardian\\build\\index.js';
+
+    // Substituting the raw Windows path into the JSON template unescaped makes
+    // "\U" an invalid JSON escape, so JSON.parse would throw before the file
+    // could ever be written.
+    const changed = registerZedContextServers(target, { guardianBin: winPath, memoryBin: bins.memoryBin });
+    assert.strictEqual(changed, true, 'should register on a fresh settings file');
+
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.strictEqual(
+      parsed.context_servers['egc-guardian'].command.args[0],
+      winPath,
+      'the Windows path should round-trip exactly through JSON.parse'
+    );
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerZedContextServers keeps a POSIX path with a double quote valid JSON', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.config', 'zed', 'settings.json');
+    // A double quote is legal in a POSIX directory name; unescaped it would
+    // terminate the JSON string early and corrupt the template.
+    const quotedPath = '/home/person/we"rd/egc-guardian/index.js';
+
+    registerZedContextServers(target, { guardianBin: quotedPath, memoryBin: bins.memoryBin });
+
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.strictEqual(parsed.context_servers['egc-guardian'].command.args[0], quotedPath, 'a path with a double quote should round-trip exactly');
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);


### PR DESCRIPTION
## What

Two Windows-only portability bugs in the runtime hooks, found while auditing cross-platform behavior:

- **post-edit-typecheck** resolved `tsc` through `npx.cmd`, which Node 20.12+ refuses to spawn without a shell (it throws `EINVAL`, the CVE-2024-27980 mitigation). The typecheck silently never ran on Windows. It now resolves the project's local `typescript` compiler and runs it through `node` (`process.execPath`): no shell, no `.cmd` shim, works on every platform, and keeps the existing no-shell safety guarantee intact.
- **Zed registration** (`mcp-register.js`) substituted the resolved bin path into a JSON template without escaping, so a Windows path's backslashes made `JSON.parse` throw on the invalid `\U` escape and the Zed settings file was never written. The path is now escaped to a JSON string body before substitution, matching the existing TOML handling.

## Tests

- `tests/hooks/hooks.test.js`: a new test runs the resolved compiler through a fake local `tsc` and asserts it is invoked via node on every platform (the old `npx.cmd` path threw `EINVAL` on Windows). The security test now asserts `process.execPath` execution with no shell. 227/227 pass.
- `tests/lib/mcp-register.test.js`: two new tests assert a Windows backslash path and a POSIX double-quote path both round-trip exactly through `JSON.parse`. 27/27 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows-only failures in the typecheck hook and Zed context-server registration. The hook now runs the local `typescript` compiler via `node`, and Zed JSON now escapes Windows paths so settings are written correctly.

- **Bug Fixes**
  - Typecheck hook: resolve `node_modules/typescript/bin/tsc` and execute with `process.execPath` (no shell). Avoids `npx.cmd` failures on Node ≥ 20.12 and improves error output with relevant lines only.
  - Zed registration: escape bin paths to a JSON string body before substituting into the template, so backslashes and quotes parse correctly and mirror existing TOML handling.

<sup>Written for commit a80178181fa28520641174258be5341c9ac3c58d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

