### PR TITLE
fix(llm): redact unmapped SDK errors in the OpenAI provider fallback

### DIFF
--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -110,7 +110,14 @@ class OpenAIProvider(LLMProvider):
             raise RateLimitError(safe_msg, provider=self.provider_type) from e
         if "context" in msg.lower() and "length" in msg.lower():
             raise ContextLengthError(safe_msg, provider=self.provider_type) from e
-        raise e
+        if isinstance(e, LLMError):
+            # Our own contract errors carry fixed, secret-free messages and an
+            # already-tagged provider, so they are safe to re-raise verbatim.
+            raise e
+        # Unclassified raw SDK exception: its message can echo request headers
+        # or payloads (and thus the API key), so never re-raise it verbatim.
+        # Wrap it in a redacted LLMError, matching _wrap_generate_errors.
+        raise LLMError(safe_msg, provider=self.provider_type) from e
 
     def _wrap_generate_errors(self, fn):
         """Shared error-mapping wrapper for ``generate()``.

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -118,6 +118,23 @@ def test_stream_flag_raises_not_implemented(provider: OpenAIProvider) -> None:
 
 
 @pytest.mark.unit
+def test_unmapped_sdk_error_is_redacted_not_reraised_verbatim(provider: OpenAIProvider) -> None:
+    """A raw SDK exception that misses the 401/429/context classification must
+    not surface verbatim: its message can echo request headers/payloads (and
+    thus the API key). The fallback wraps it in a redacted LLMError instead of
+    re-raising the original."""
+    leak = "Bad request; sent Authorization: Bearer sk-live-abcdefghijklmnop"
+    provider.client.chat.completions.create.side_effect = RuntimeError(leak)
+
+    with pytest.raises(LLMError) as exc:
+        provider.generate(_simple_input())
+
+    assert exc.value.provider == ProviderType.OPENAI
+    assert "sk-live-abcdefghijklmnop" not in str(exc.value)
+    assert "<REDACTED>" in str(exc.value)
+
+
+@pytest.mark.unit
 def test_non_streaming_call_unchanged(provider: OpenAIProvider) -> None:
     """Regression test for issue #903: the non-streaming path (stream=False,
     the default) must continue to work exactly as before."""


### PR DESCRIPTION
## What

`OpenAIProvider._map_error` redacts the message for the classified `401`/`429`/context-length cases, but the fallback for an unclassified error re-raised the original exception verbatim. When `OpenAIProvider` is used directly (not through a subclass's `_wrap_generate_errors`), a raw SDK error message could reach the caller unredacted, and SDK error text can echo request headers or payloads.

The fallback now wraps an unclassified non-`LLMError` exception in a redacted `LLMError` (matching the shared `_wrap_generate_errors` behavior). Our own contract errors (`LLMError` subclasses, fixed secret-free messages) keep re-raising verbatim, so the existing classification and provider tagging are unchanged.

## Tests

`tests/test_openai_provider.py`: new test drives an unclassified SDK error whose message carries a bearer token and asserts the surfaced `LLMError` is redacted (`<REDACTED>`, token absent). Existing empty-choices / provider-tag behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts unmapped SDK error messages in the OpenAI provider fallback by wrapping unclassified exceptions in a redacted LLMError to avoid leaking headers or payloads. Classified errors and existing LLMError subclasses behave as before.

- **Bug Fixes**
  - Unclassified non-LLMError exceptions are now wrapped in a redacted LLMError (provider tagged) instead of re-raised verbatim.
  - Keeps 401/429/context-length mapping and verbatim re-raise for our LLMError subclasses; matches _wrap_generate_errors behavior.

<sup>Written for commit 10d327e2afd8228022603d76f19ff3bbd3bba97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

