### PR TITLE
fix(cli): time-bound the telemetry ping so it never delays CLI exit

### DIFF
--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -122,6 +122,11 @@ function ping(pagePath, title) {
     .then(() => fetch(url, {
       method: 'GET',
       headers: { 'User-Agent': userAgent },
+      // Bound the request: main() sets process.exitCode instead of calling
+      // process.exit, so a slow or unreachable GoatCounter would keep the event
+      // loop alive and stall the CLI's exit until the OS TCP timeout. Abort at
+      // 2s so telemetry stays fire-and-forget without delaying shutdown.
+      signal: AbortSignal.timeout(2000),
     }))
     .catch(() => {});
 }

--- a/tests/scripts/telemetry.test.js
+++ b/tests/scripts/telemetry.test.js
@@ -264,8 +264,9 @@ async function runTests() {
         JSON.stringify({ enabled: true, version: 1 }), 'utf8');
 
       let capturedUrl = null;
+      let capturedOpts = null;
       const origFetch = global.fetch;
-      global.fetch = (url) => { capturedUrl = url; return Promise.resolve({}); };
+      global.fetch = (url, opts) => { capturedUrl = url; capturedOpts = opts; return Promise.resolve({}); };
 
       const { ping } = loadTelemetry(dir);
       ping('/cli/install', 'EGC Install');
@@ -277,6 +278,9 @@ async function runTests() {
       assert.strictEqual(new URL(capturedUrl).hostname, 'egc.goatcounter.com', 'URL should target GoatCounter host');
       const params = new URL(capturedUrl).searchParams;
       assert.ok(params.get('p') !== null, 'URL should include page path param');
+      // The request must be time-bounded so a stalled GoatCounter can't keep
+      // the CLI process alive past its command (main uses process.exitCode).
+      assert.ok(capturedOpts && capturedOpts.signal instanceof AbortSignal, 'fetch should pass an AbortSignal to bound the request');
     } finally { cleanup(dir); }
   })) { passed++; } else { failed++; }
 


### PR DESCRIPTION
## What

`telemetry.ping()` fires a fire-and-forget `fetch` with no timeout. Because `main()` sets `process.exitCode` instead of calling `process.exit`, a pending request keeps the event loop alive, so a slow or unreachable GoatCounter stalls the CLI's exit until the OS TCP timeout (potentially tens of seconds) after the command has already finished and printed its output.

The request is now bounded with `AbortSignal.timeout(2000)`: telemetry stays fire-and-forget and swallows all errors, but can no longer delay shutdown.

## Tests

`tests/scripts/telemetry.test.js`: the existing ping test now also asserts `fetch` receives an `AbortSignal`, so the request stays time-bounded. 16/16 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Time-bound the CLI telemetry ping to 2s so it never delays process exit when GoatCounter is slow or unreachable. Uses `AbortSignal.timeout(2000)` on the fire-and-forget `fetch`; tests now assert the signal is passed.

<sup>Written for commit a8bf5a04d22ad34530776fb8736698b27493da00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

