### PR TITLE
fix(cli): forward subcommands to plugin/budget/team and fix gain/install-apply output

### DIFF
--- a/scripts/budget.js
+++ b/scripts/budget.js
@@ -134,7 +134,9 @@ function handleReset() {
 }
 
 async function main() {
-  const args = process.argv.slice(3);
+  // egc.js strips the "budget" command word before spawning this script, so
+  // argv is ["node", "budget.js", ...subcommandArgs]; slice(2) keeps them.
+  const args = process.argv.slice(2);
   const firstArg = args[0];
 
   if (!firstArg || firstArg === '--help' || firstArg === '-h') {

--- a/scripts/gain.js
+++ b/scripts/gain.js
@@ -86,8 +86,8 @@ function main() {
   console.log(`  Output size:      ${formatBytes(totals.bytesIn)} -> ${formatBytes(totals.bytesOut)}`);
   console.log(`  Tokens saved:     ~${formatTokens(totals.tokensSaved)}`);
   console.log(`  Avg per run:      ~${formatTokens(avg)} tokens`);
-  if (biggest && biggest.command) {
-    console.log(`  Biggest crush:    ~${formatTokens(biggest.tokensSaved || 0)} tokens (${biggest.command})`);
+  if (biggest && biggest.cmd) {
+    console.log(`  Biggest crush:    ~${formatTokens(biggest.tokensSaved || 0)} tokens (${biggest.cmd})`);
   }
   console.log(`  Efficiency:       ${bar(pct)} ${(pct * 100).toFixed(1)}%`);
   console.log('');

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -204,7 +204,7 @@ function main() {
       }
     }
   } catch (error) {
-    process.stderr.write(`Error: ${error.message}${getHelpText()}`);
+    process.stderr.write(`Error: ${error.message}\n${getHelpText()}`);
     process.exit(1);
   }
 }

--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -164,7 +164,9 @@ function handleUpdate(args) {
 }
 
 async function main() {
-  const args = process.argv.slice(3);
+  // egc.js strips the "plugin" command word before spawning this script, so
+  // argv is ["node", "plugin.js", ...subcommandArgs]; slice(2) keeps them.
+  const args = process.argv.slice(2);
   const firstArg = args[0];
 
   if (!firstArg || firstArg === '--help' || firstArg === '-h') {

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -245,7 +245,9 @@ function handleStatus() {
 }
 
 async function main() {
-  const args = process.argv.slice(3); // skip "node team.js" or "egc team"
+  // egc.js already strips the "team" command word before spawning this script,
+  // so argv is ["node", "team.js", ...subcommandArgs]; slice(2) keeps them.
+  const args = process.argv.slice(2);
   const firstArg = args[0];
 
   if (!firstArg || firstArg === '--help' || firstArg === '-h') {

--- a/tests/crusher-gain-discover.test.js
+++ b/tests/crusher-gain-discover.test.js
@@ -39,6 +39,23 @@ run('gain --history --json returns the raw ledger entries', () => {
   assert.ok(Array.isArray(entries), 'history is an array');
 });
 
+run('gain summary prints the biggest crush with its command', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-gain-home-'));
+  const ledgerDir = path.join(home, '.egc', 'metrics');
+  fs.mkdirSync(ledgerDir, { recursive: true });
+  const entry = { ts: '2026-07-26T04:00:00Z', kind: 'git-log', cmd: 'git log --stat', tokensSaved: 5000, bytesIn: 100000, bytesOut: 2000 };
+  fs.writeFileSync(path.join(ledgerDir, 'crusher.jsonl'), `${JSON.stringify(entry)}\n`);
+
+  const res = spawnSync('node', [GAIN], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+  });
+  assert.strictEqual(res.status, 0, res.stderr);
+  // Regression for the .command/.cmd mismatch: the ledger stores `cmd`, so the
+  // Biggest crush line must surface the command instead of never printing.
+  assert.match(res.stdout, /Biggest crush:.*git log --stat/);
+});
+
 run('discover finds a crushable run in a fixture transcript', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-discover-'));
   const bigLog = 'commit abc123 something\n'.repeat(200);

--- a/tests/scripts/egc.test.js
+++ b/tests/scripts/egc.test.js
@@ -98,6 +98,14 @@ function main() {
       assert.deepStrictEqual(payload.plan.legacyLanguages, ['typescript']);
       assert.ok(payload.plan.selectedModuleIds.includes('framework-language'));
     }],
+    ['egc budget forwards the subcommand to budget.js (argv slice regression)', () => {
+      const result = runCli(['budget', 'definitely-not-a-subcommand']);
+      // With the old slice(3), budget/plugin/team dropped the subcommand word
+      // and fell through to help with exit 0; slice(2) forwards it, so an
+      // unknown subcommand is reported and exits non-zero.
+      assert.strictEqual(result.status, 1, result.stdout + result.stderr);
+      assert.match(result.stderr + result.stdout, /Unknown budget subcommand/);
+    }],
     ['routes implicit top-level args to install', () => {
       const result = runCli(['--dry-run', '--json', 'typescript']);
       assert.strictEqual(result.status, 0, result.stderr);


### PR DESCRIPTION
## What

Three CLI defects:

- **`egc plugin` / `egc budget` / `egc team` were fully broken.** Their `main()` read `process.argv.slice(3)`, but `egc.js` already strips the command word before spawning the script, so `argv` is `["node", "plugin.js", ...subArgs]`. `slice(3)` dropped the subcommand, so every invocation fell through to help with exit 0. Now `slice(2)`.
- **`gain.js` never printed the "Biggest crush" line.** It checked `biggest.command`, but the crush ledger stores each entry under `cmd` (as the summary loop already uses). Now `biggest.cmd`.
- **`install-apply.js` ran the error message into the help text** with no newline. Added one.

## Tests

`tests/scripts/egc.test.js`: new regression test asserts `egc budget <sub>` forwards the subcommand (unknown sub exits 1 with "Unknown budget subcommand" instead of falling through to help). 19/19 pass. `doctor` 2/2, gain 3/3.

## Not included (EGC-437 remainder)

- `egc prompt "msg"` requiring `-p` is an argparse/UX decision, not a defect fix.
- `doctor` exit code on missing `state.db`: the existing "healthy install exits 0" test treats a missing `state.db` as healthy, which conflicts with flagging it as an error. This is a product call.
- `runCommand` `stdio` (`maxBuffer`/TTY) and `db-adapter` last-writer-wins are larger behavioral/architectural changes; kept separate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI subcommand forwarding for `egc plugin`, `egc budget`, and `egc team`; restores the "Biggest crush" line in `egc gain`; and fixes error formatting in `install-apply`. Adds regression tests for subcommand forwarding and gain output; part of EGC-437 (CLI parsing).

- **Bug Fixes**
  - Forward subcommands by slicing `argv` correctly in `plugin.js`, `budget.js`, and `team.js`; unknown subs now exit 1 with a clear message instead of falling through to help.
  - Show "Biggest crush" in `gain.js` by reading `biggest.cmd` (not `biggest.command`).
  - Separate error and help text in `install-apply.js` with a newline.

<sup>Written for commit 71ac190929836ddacd406f5a7299a7692cdeef9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

