### PR TITLE
perf(guardian): memoize catalog token sets in the keyword router

### DIFF
--- a/mcp/servers/egc-guardian/src/llm-router.ts
+++ b/mcp/servers/egc-guardian/src/llm-router.ts
@@ -22,11 +22,25 @@ export function tokenize(text: string): Set<string> {
   );
 }
 
+// The catalog is immutable at runtime, so an entry's token set never changes.
+// Memoize it per entry object (weakly keyed so ad-hoc entries stay GC-able)
+// instead of re-tokenizing all ~370 catalog entries on every routing query.
+const entryTokenCache = new WeakMap<object, Set<string>>();
+
+function entryTokensFor(entry: { name: string; description: string }): Set<string> {
+  let tokens = entryTokenCache.get(entry);
+  if (!tokens) {
+    tokens = tokenize(`${entry.name} ${entry.description}`);
+    entryTokenCache.set(entry, tokens);
+  }
+  return tokens;
+}
+
 export function keywordScore(
   promptTokens: Set<string>,
   entry: { name: string; description: string },
 ): number {
-  const entryTokens = tokenize(`${entry.name} ${entry.description}`);
+  const entryTokens = entryTokensFor(entry);
   let matches = 0;
   for (const t of promptTokens) if (entryTokens.has(t)) matches++;
   return matches === 0 ? 0 : Math.round((matches / Math.sqrt(entryTokens.size)) * 100) / 100;


### PR DESCRIPTION
## What

`keywordScore` re-tokenized an entry's `name + description` on every call, so `pickCandidates` re-tokenized the entire (~370-entry) catalog on every routing query. The catalog is immutable at runtime, so each entry's token set is now cached in a `WeakMap` keyed by the entry object (weakly, so ad-hoc entries stay GC-able). Behavior is identical; only the redundant per-query tokenization is removed.

## Not included (EGC-436 remainder, deliberately)

- **`isProtectedPath` `realpathSync`** (validator.ts): not cached on purpose. This is a security check that resolves symlinks fresh to prevent a TOCTOU bypass (the symlink-hardening from #1011). Caching the resolved path could reintroduce that bypass, so the per-call cost is the price of correctness.
- **`callGuardian` node spawn per command** (guardian-bin.js) and **session-activity-tracker git subprocesses**: real overhead, but reducing them is an architectural change (a resident helper / batched git) that risks behavior changes and belongs in its own dedicated PR, not a low-risk perf pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoizes each catalog entry’s name+description token set in a WeakMap keyed by the entry object, instead of tokenizing on every call. Speeds up keyword routing for the ~370-entry catalog with no behavior changes (EGC-436).

<sup>Written for commit cce840209bab69042d621e32f5aa720fcbc7ada6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

