### PR TITLE
fix(docker): add a .dockerignore so build context excludes secrets and node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Keep the Docker build context lean and, more importantly, keep local secrets
+# and version-control metadata out of the image layers. `docker/Dockerfile`
+# ends with `COPY . .`, which would otherwise bake .git/.env and the local
+# node_modules (overwriting the one `npm ci` just installed) into the image.
+.git
+.github
+.gitignore
+/node_modules
+*.log
+.env
+.env.*
+.egc
+coverage
+.nyc_output
+.DS_Store
+.vscode
+.idea


### PR DESCRIPTION
## What

`docker/Dockerfile` ends with `COPY . .` and there was no `.dockerignore`, so `docker build` copied `.git`, any local `.env`, and the host `node_modules` into the image layers. The last is also a correctness bug: it overwrites the `node_modules` that `npm ci` just installed in the image with whatever is on the build host.

Adds a conservative `.dockerignore` (`.git`, `.env*`, `.egc`, root `node_modules`, logs, editor dirs) — nothing the build needs (`docker/`, `package*.json`, `scripts/`, `src/`, `mcp/`) is excluded.

## Not included (EGC-441 Docker remainder)

Non-root `USER` and multi-stage build are the right next hardening steps, but no CI job builds the image, so they can't be validated here without a runtime test — kept for a follow-up that can actually run the container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a .dockerignore to exclude .git, .env*, local node_modules, logs, and editor dirs from the Docker build context (EGC-441). This prevents secrets from being baked into the image, avoids clobbering node_modules installed via npm ci, and reduces build size.

<sup>Written for commit eaaa77d1651e149ca86079c2759fc1d7bf3b024f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

