### PR TITLE
ci(coverage): build the MCP servers so guardian/memory defense tests run

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -27,6 +27,17 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # The guardian/memory suites skip when the compiled MCP servers are
+      # absent (build/ is gitignored). Build them here so those defense tests
+      # actually run under coverage instead of silently skipping to a false
+      # green. Ubuntu-only keeps the native sqlite3 build off the Windows matrix.
+      - name: Build MCP servers
+        run: |
+          npm --prefix mcp/servers/egc-guardian ci
+          npm --prefix mcp/servers/egc-guardian run build
+          npm --prefix mcp/servers/egc-memory ci
+          npm --prefix mcp/servers/egc-memory run build
 
       - name: Run tests with coverage
         run: npx c8 --reporter=lcov --reporter=text-summary node tests/run-all.js


### PR DESCRIPTION
## Problem

The Coverage job installed only the root dependencies, so the compiled guardian
and memory MCP servers were absent. Their suites (guardian validator/audit/
symlink, memory encryption/integrity/session-bus, etc.) hit the `[SKIP] build
not found` path and exit 0 without running. `run-all.js` scores a skipped file
as a pass, so those defense suites were a false green in CI.

## Fix

Build both MCP servers in the Coverage job before running the suite, so those
tests actually execute and enter coverage. Ubuntu-only, which keeps the native
sqlite3 build off the Windows matrix. Job timeout raised to absorb the build.

## Verification

Ran the guardian defense suites locally against a fresh build: all green
(egc-guardian 123/123, cache-aligner 12/0, smart-crusher 8/0, audit-log 10/0,
symlink 3/0). The symlink test only failed against a stale local build that
predated the realpath hardening in #1011; a fresh build passes, which is what
CI produces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the MCP servers in the Coverage workflow so guardian/memory defense tests run instead of skipping, fixing false green coverage. Increased job timeout to accommodate the build.

- **Bug Fixes**
  - Build `mcp/servers/egc-guardian` and `mcp/servers/egc-memory` before tests so defense suites run under coverage.
  - Limit to Ubuntu to avoid native `sqlite3` on Windows and raise timeout to 20 minutes.

<sup>Written for commit 4b368263a14ed3f0064dbbcaa9cf9c2062d7ccb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

