### PR TITLE
chore: sync plugin manifests and subsystem map to current catalog counts

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "egc",
   "version": "1.1.15",
-  "description": "Battle-tested Codex workflows \u2014 228 shared EGC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
+  "description": "Battle-tested Codex workflows \u2014 230 shared EGC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
   "author": {
     "name": "Felipe Marzochi",
     "email": "fmarzochi@gmail.com",
@@ -24,7 +24,7 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "EGC - Extended Global Context",
-    "shortDescription": "228 battle-tested EGC skills plus MCP configs for TDD, security, code review, and autonomous development.",
+    "shortDescription": "230 battle-tested EGC skills plus MCP configs for TDD, security, code review, and autonomous development.",
     "longDescription": "Extended Global Context (EGC) is a community-maintained collection of Codex-ready skills and MCP configs evolved over 10+ months of intensive daily use. It covers TDD workflows, security scanning, code review, architecture decisions, operator workflows, and more \u2014 all in one installable plugin.",
     "developerName": "Felipe Marzochi",
     "category": "Productivity",

--- a/.gemini-plugin/marketplace.json
+++ b/.gemini-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "egc",
       "source": "./",
-      "description": "EGC - Extended Global Context: 62 agents, 228 skills, 74 commands, persistent memory across sessions, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
+      "description": "EGC - Extended Global Context: 63 agents, 230 skills, 77 commands, persistent memory across sessions, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
       "version": "1.1.15",
       "author": {
         "name": "Felipe Marzochi",

--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "egc",
   "version": "1.1.15",
-  "description": "EGC - Extended Global Context: persistent memory and shared context for AI coding tools. 62 agents, 228 skills, 74 commands, production-ready hooks, and selective install workflows evolved through continuous real-world use",
+  "description": "EGC - Extended Global Context: persistent memory and shared context for AI coding tools. 63 agents, 230 skills, 77 commands, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {
     "name": "Felipe Marzochi",
     "url": "https://www.linkedin.com/in/felipemarzochi/"

--- a/docs/governance/SUBSYSTEM-MAP.md
+++ b/docs/governance/SUBSYSTEM-MAP.md
@@ -20,9 +20,9 @@ dormant.
 
 | Path | Class | Notes |
 |---|---|---|
-| `agents/` | ACTIVE | 62 agent definitions, source of truth |
-| `commands/` | ACTIVE | 74 slash commands |
-| `skills/` | ACTIVE | 228 skills across 14 namespaces |
+| `agents/` | ACTIVE | 63 agent definitions, source of truth |
+| `commands/` | ACTIVE | 77 slash commands |
+| `skills/` | ACTIVE | 230 skills across 14 namespaces |
 | `rules/` | ACTIVE | Cross-language coding rules |
 | `hooks/` | ACTIVE | Manifest (`hooks.json`); implementations live in `scripts/hooks/` |
 | `scripts/hooks/` | ACTIVE | 25 hooks loaded directly by `hooks/hooks.json`; rest transitive |

--- a/translations/pt/docs/governance/SUBSYSTEM-MAP.md
+++ b/translations/pt/docs/governance/SUBSYSTEM-MAP.md
@@ -17,9 +17,9 @@ Esta pagina classifica os subsistemas de nivel superior e subarvores notaveis do
 
 | Caminho | Classe | Notas |
 |---|---|---|
-| `agents/` | ACTIVE | 62 definicoes de agentes, fonte da verdade |
-| `commands/` | ACTIVE | 74 comandos de barra |
-| `skills/` | ACTIVE | 228 skills em 14 namespaces |
+| `agents/` | ACTIVE | 63 definicoes de agentes, fonte da verdade |
+| `commands/` | ACTIVE | 77 comandos de barra |
+| `skills/` | ACTIVE | 230 skills em 14 namespaces |
 | `rules/` | ACTIVE | Regras de codificacao para varias linguagens |
 | `hooks/` | ACTIVE | Manifesto (`hooks.json`); implementacoes em `scripts/hooks/` |
 | `scripts/hooks/` | ACTIVE | 25 hooks carregados diretamente pelo `hooks/hooks.json`; restante transitivo |


### PR DESCRIPTION
The Gemini/Codex plugin manifests, the marketplace entry, and the subsystem map (EN + PT) still advertised **62 agents / 228 skills / 74 commands**. The real catalog is **63 / 230 / 77** (README and `scripts/ci/catalog.js` already match). These files are outside the catalog CI check, so they drifted.

Brings them in line so the plugin listings and the HuggingFace space show the real numbers. No code paths touched; `plugin-manifest` (40/0) and `catalog.js --text` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs plugin manifests, marketplace listing, and subsystem maps to the current catalog so public listings show the correct totals. Updated to 63 agents, 230 skills, and 77 commands; no runtime code changes.

- **Bug Fixes**
  - Updated descriptions in `.gemini-plugin/marketplace.json`, `.gemini-plugin/plugin.json`, and `.codex-plugin/plugin.json`.
  - Aligned counts in `docs/governance/SUBSYSTEM-MAP.md` and `translations/pt/docs/governance/SUBSYSTEM-MAP.md`.

<sup>Written for commit fc0cd75f2bf45cbd2d42926eaa31bff982a279da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

