### PR TITLE
test(llm): cover the dispatcher, tool executor, and prompt builder (EGC-440)

### DIFF
--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,81 @@
+"""Tests for llm.dispatcher -- hook command execution and event matching.
+
+Fills the src/llm coverage gap flagged by the squad audit (EGC-440): the
+dispatcher runs configured hook commands through a shell and sanitizes the
+session id before exporting it to the hook environment, yet had no test. The
+command comes from trusted hooks config (not user input), so shell=True is by
+design; these tests lock in the session-id sanitization and result handling.
+"""
+from __future__ import annotations
+
+import pytest
+
+from llm.core.types import ToolCall
+from llm.dispatcher import Dispatcher
+from llm.session_recorder import SessionRecorder
+
+
+@pytest.fixture
+def dispatcher(tmp_path):
+    recorder = SessionRecorder("test-session", base_dir=str(tmp_path))
+    disp = Dispatcher(recorder)
+    disp.project_root = str(tmp_path)
+    return disp
+
+
+@pytest.mark.unit
+class TestExecuteHookCommand:
+    def test_empty_or_missing_command_is_noop(self, dispatcher):
+        assert dispatcher._execute_hook_command("", {}, None).success is True
+        assert dispatcher._execute_hook_command(None, {}, None).success is True
+
+    def test_command_receives_json_payload_on_stdin(self, dispatcher):
+        # `cat` echoes the JSON payload straight back; the dispatcher parses it.
+        result = dispatcher._execute_hook_command("cat", {"foo": "bar"}, "s1")
+        assert result.success is True
+        assert result.data == {"foo": "bar"}
+
+    def test_nonzero_exit_is_failure(self, dispatcher):
+        result = dispatcher._execute_hook_command("exit 3", {}, None)
+        assert result.success is False
+        assert "3" in (result.error or "")
+
+    def test_non_json_stdout_still_succeeds_without_data(self, dispatcher):
+        result = dispatcher._execute_hook_command("echo not-json", {}, None)
+        assert result.success is True
+        assert result.data is None
+
+    def test_session_id_shell_metacharacters_are_sanitized(self, dispatcher):
+        # A session id carrying shell metacharacters must be scrubbed to
+        # [A-Za-z0-9._-] before it reaches the hook environment, so it can
+        # never break out of the exported SESSION_ID value.
+        malicious = "s1; rm -rf / `whoami` $(id)"
+        command = r'''printf '{"sid":"%s"}' "$SESSION_ID"'''
+        result = dispatcher._execute_hook_command(command, {}, malicious)
+        assert result.success is True
+        sid = (result.data or {}).get("sid", "")
+        for ch in [";", "/", " ", "`", "$", "(", ")"]:
+            assert ch not in sid
+        assert sid.startswith("s1")
+
+
+@pytest.mark.unit
+class TestMatch:
+    def test_wildcard_matches_any_tool(self, dispatcher):
+        assert dispatcher._match("*", "Bash") is True
+        assert dispatcher._match("*", "AnythingElse") is True
+
+    def test_pipe_list_matches_only_listed_tools(self, dispatcher):
+        assert dispatcher._match("Bash|Write", "Bash") is True
+        assert dispatcher._match("Bash|Write", "Write") is True
+        assert dispatcher._match("Bash|Write", "Read") is False
+
+
+@pytest.mark.unit
+class TestDispatch:
+    def test_dispatch_with_no_hooks_returns_tool_call_unchanged(self, dispatcher):
+        dispatcher.hooks_config = {"hooks": {}}
+        tc = ToolCall(id="1", name="Bash", arguments={"command": "ls"})
+        result = dispatcher.dispatch("PreToolUse", tool_call=tc)
+        assert result.vetoed is False
+        assert result.tool_call is tc

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,70 @@
+"""Tests for llm.tools.executor -- tool registry and tool executor.
+
+Part of the src/llm coverage gap flagged by the squad audit (EGC-440): the
+registry and executor turn provider tool calls into results but had no test.
+Covers registration/lookup and the execute paths (success, missing tool, and
+an exception inside a tool becoming an error result instead of propagating).
+"""
+from __future__ import annotations
+
+import pytest
+
+from llm.core.types import ToolCall, ToolDefinition
+from llm.tools.executor import ToolExecutor, ToolRegistry
+
+
+def _definition(name: str) -> ToolDefinition:
+    return ToolDefinition(name=name, description="d", parameters={})
+
+
+@pytest.mark.unit
+class TestToolRegistry:
+    def test_register_and_lookup(self):
+        reg = ToolRegistry()
+        reg.register(_definition("echo"), lambda **kw: kw)
+        assert reg.has("echo") is True
+        assert reg.get("echo") is not None
+        assert reg.get_definition("echo").name == "echo"
+        assert [d.name for d in reg.list_tools()] == ["echo"]
+
+    def test_missing_tool_lookup_returns_none(self):
+        reg = ToolRegistry()
+        assert reg.has("nope") is False
+        assert reg.get("nope") is None
+        assert reg.get_definition("nope") is None
+
+
+@pytest.mark.unit
+class TestToolExecutor:
+    def test_executes_registered_tool(self):
+        reg = ToolRegistry()
+        reg.register(_definition("add"), lambda a, b: a + b)
+        result = ToolExecutor(reg).execute(ToolCall(id="1", name="add", arguments={"a": 2, "b": 3}))
+        assert result.is_error is False
+        assert result.content == "5"
+        assert result.tool_call_id == "1"
+
+    def test_unknown_tool_is_error(self):
+        result = ToolExecutor(ToolRegistry()).execute(ToolCall(id="9", name="ghost", arguments={}))
+        assert result.is_error is True
+        assert "not found" in result.content
+
+    def test_tool_exception_becomes_error_result(self):
+        reg = ToolRegistry()
+
+        def boom(**kw):
+            raise ValueError("kaboom")
+
+        reg.register(_definition("boom"), boom)
+        result = ToolExecutor(reg).execute(ToolCall(id="7", name="boom", arguments={}))
+        assert result.is_error is True
+        assert "kaboom" in result.content
+
+    def test_execute_all_runs_each_call(self):
+        reg = ToolRegistry()
+        reg.register(_definition("up"), lambda s: s.upper())
+        results = ToolExecutor(reg).execute_all([
+            ToolCall(id="1", name="up", arguments={"s": "a"}),
+            ToolCall(id="2", name="up", arguments={"s": "b"}),
+        ])
+        assert [r.content for r in results] == ["A", "B"]

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,42 @@
+"""Tests for llm.prompt.builder -- provider-agnostic message assembly.
+
+Part of the src/llm coverage gap flagged by the squad audit (EGC-440). Covers
+empty input, prepending the system template, merging with an existing system
+message into a single system message, and injecting tool descriptions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from llm.core.types import Message, Role, ToolDefinition
+from llm.prompt.builder import PromptBuilder, PromptConfig
+
+
+@pytest.mark.unit
+class TestPromptBuilder:
+    def test_empty_messages_return_empty(self):
+        assert PromptBuilder().build([]) == []
+
+    def test_system_template_prepended_when_no_system_message(self):
+        builder = PromptBuilder(PromptConfig(system_template="You are EGC."))
+        out = builder.build([Message(role=Role.USER, content="hi")])
+        assert out[0].role == Role.SYSTEM
+        assert "You are EGC." in out[0].content
+        assert out[-1].content == "hi"
+
+    def test_existing_system_message_is_merged_into_one(self):
+        builder = PromptBuilder(PromptConfig(system_template="Extra."))
+        out = builder.build([
+            Message(role=Role.SYSTEM, content="Base."),
+            Message(role=Role.USER, content="hi"),
+        ])
+        assert out[0].role == Role.SYSTEM
+        assert "Base." in out[0].content and "Extra." in out[0].content
+        assert sum(1 for m in out if m.role == Role.SYSTEM) == 1
+
+    def test_tool_definitions_injected_into_system(self):
+        builder = PromptBuilder(PromptConfig(include_tools_in_system=True))
+        tools = [ToolDefinition(name="search", description="find things", parameters={})]
+        out = builder.build([Message(role=Role.USER, content="hi")], tools=tools)
+        assert out[0].role == Role.SYSTEM
+        assert "search" in out[0].content


### PR DESCRIPTION
Part of finishing Lote 12 (squad audit EGC-440): the `src/llm` layer had tests only for the HTTP provider wrappers, nothing for the **dispatcher** -- the component that runs configured hook commands through a shell and sanitizes the session id before exporting it.

## What is covered
- `_execute_hook_command`: empty/missing command is a no-op; JSON payload round-trips through stdin; non-zero exit becomes a failure; non-JSON stdout still succeeds without data.
- **Session-id sanitization**: a session id carrying shell metacharacters (`; / \` $ ( )`) is scrubbed to `[A-Za-z0-9._-]` before it reaches the hook environment.
- `_match`: wildcard and pipe-list matching.
- `dispatch`: a no-hook config returns the tool call unchanged.

Note: `shell=True` in the dispatcher is by design -- the command comes from trusted hooks config, not user input. These tests lock in the sanitization and result handling. Validated locally (pytest, 8 passed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `llm.dispatcher`, `llm.tools.executor`, and `llm.prompt.builder` to close the EGC-440 coverage gap.
Coverage includes hook command execution (empty/missing is no-op, JSON stdin round-trip, non-zero exit, non-JSON stdout), session-id sanitization, wildcard/pipe matching and no-hook passthrough, tool registry/execute flows (success, unknown tool, exception becomes error), and prompt assembly (empty input, system-template prepend/merge, tool injection).

<sup>Written for commit c5b5ee3ffce87b1319ed91e65d0a6c585354181d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

