### PR TITLE
fix(crowdin): stop re-uploading exported translations to Crowdin

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -24,11 +24,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # upload_translations must stay false: re-uploading the exported files
+      # feeds post-processed content back into Crowdin, and for languages
+      # Crowdin cannot sentence-split (zh-CN) the whole paragraph lands on the
+      # first segment, so the next export duplicates every sentence after it.
       - name: Upload sources to Crowdin
         uses: crowdin/github-action@e0c8f73cdc0fafde9396e056c5038217000a32d1 # v2
         with:
           upload_sources: true
-          upload_translations: true
+          upload_translations: false
           download_translations: false
           create_pull_request: false
         env:
@@ -127,16 +131,18 @@ jobs:
             rm -rf translations/zh
           fi
           # Crowdin exports translations of source strings whose links are
-          # root-relative (assets/..., docs/...), but translation files live
-          # two levels down, so those links 404 on GitHub. Rewrite them; the
-          # patterns only match links without a leading path, so already
-          # correct ../../ links are untouched.
+          # root-relative (assets/..., docs/..., .github/..., translations/...),
+          # but translation files live two levels down, so those links 404 on
+          # GitHub. Rewrite them; the patterns only match links without a
+          # leading path, so already correct ../../ links are untouched.
           find translations -name 'README.md' -exec sed -i -E \
             -e 's|(src=")assets/|\1../../assets/|g' \
             -e 's|(href=")assets/|\1../../assets/|g' \
             -e 's|(\]\()assets/|\1../../assets/|g' \
             -e 's|(href=")docs/|\1../../docs/|g' \
-            -e 's|(\]\()docs/|\1../../docs/|g' {} +
+            -e 's|(\]\()docs/|\1../../docs/|g' \
+            -e 's|(\]\()\.github/|\1../../.github/|g' \
+            -e 's|(\]\()translations/|\1../|g' {} +
           if [ -z "$(git status --porcelain -- translations)" ]; then
             echo "No translation changes to sync."
             exit 0


### PR DESCRIPTION
## Root cause of the corrupted zh-CN sync (#1038)

The sync workflow ran with `upload_translations: true`, re-uploading the post-processed files from `translations/` back to Crowdin on every run. Two failure modes, both confirmed via the Crowdin API:

1. **Paragraph duplication (zh-CN only).** Crowdin cannot sentence-split Chinese text, so the uploaded `translations/zh-CN/README.md` paragraph was aligned whole against the first source segment (translation created 2026-07-26T08:34Z by the sync token, verified in the translation history for string 996). On export, the full paragraph is emitted for segment 1 and every following sentence is emitted again for segments 2..N, producing the duplicated paragraphs and the literal `\*\*` in #1038. Latin-script languages align 1:1, which is why only zh-CN corrupts.
2. **Link feedback loop.** The `../../` links rewritten by the post-processing step were uploaded back as translations (e.g. `[完整安装指南](../../docs/installation.md)` for string 278), polluting the TM.

## Fix

- `upload_translations: false`: translations flow one way, Crowdin -> repo.
- The link rewrite now also covers `.github/` and `translations/` root-relative links, so fresh machine translations export with working links instead of depending on previously fed-back rewritten links.

The corrupted translations in Crowdin are being removed separately via the API; #1038 will be refreshed by re-running the sync afterwards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Crowdin sync one-way to stop re-uploading post-processed translations, fixing zh-CN paragraph duplication and preventing TM pollution. Update link rewrites so exported README links to assets/docs/.github/translations work from translation folders.

- **Bug Fixes**
  - Set `upload_translations: false` in the Crowdin workflow using `crowdin/github-action` to prevent feedback loops.
  - Extend the sed rewrite to cover root-relative `.github/` and `translations/` links, leaving existing `../../` links unchanged.

<sup>Written for commit 493dc467c813425bc7c7e7c4f0930a100bc8d54a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

