### PR TITLE
sec(guardian): hard-block destructive docker, gh, and prisma variants

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -59,6 +59,69 @@ function embeddedPathCandidate(arg: string): string | null {
   return null;
 }
 
+// True if `token` appears as a standalone arg or as a `--flag=token` value,
+// case-insensitively, so `-X DELETE`, `--method DELETE` and `--method=delete`
+// all match. Used to catch destructive verbs passed as option values.
+function hasArgToken(args: string[], token: string): boolean {
+  const t = token.toLowerCase();
+  return args.some(a => {
+    const lower = a.toLowerCase();
+    return lower === t || lower.endsWith('=' + t);
+  });
+}
+
+// Destructive variants of CLIs that are otherwise advisory-only at the
+// enforcement hook (see the allowlist-miss comment in validateCommand):
+// plain `docker build` / `gh pr list` / `prisma migrate dev` keep today's
+// advisory behavior, but the data-destroying forms below hard-block the
+// same way inline eval does. Returning null means "nothing destructive
+// here" and the command falls through to the ordinary allowlist handling.
+function checkDockerDestructive(args: string[]): ValidationResult | null {
+  const positional = args.filter(a => !a.startsWith('-'));
+  const destructiveSub = positional.some(a => a === 'prune' || a === 'rm' || a === 'rmi');
+  const downWithVolumes = positional.includes('down') && (args.includes('-v') || args.includes('--volumes'));
+  if (destructiveSub || downWithVolumes) {
+    return { allowed: false, reason: 'destructive docker operation is forbidden', trust_level: 'DANGEROUS' };
+  }
+  // run/create with a host mount or elevated privileges escapes the
+  // container boundary, taking every path-based check in this file with it.
+  const startsContainer = positional.includes('run') || positional.includes('create');
+  const mountsOrPrivileged = args.some(a =>
+    a === '-v' || a === '--volume' || a === '--mount' || a === '--privileged' || a === '--cap-add' ||
+    a.startsWith('--volume=') || a.startsWith('--mount=') || a.startsWith('--cap-add='),
+  );
+  if (startsContainer && mountsOrPrivileged) {
+    return { allowed: false, reason: 'docker run with host mounts or elevated privileges is forbidden', trust_level: 'DANGEROUS' };
+  }
+  return null;
+}
+
+function checkGhDestructive(args: string[]): ValidationResult | null {
+  // Covers `gh <resource> delete`, `gh api -X DELETE` and `--method=delete`.
+  if (hasArgToken(args, 'delete')) {
+    return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
+  }
+  return null;
+}
+
+function checkPrismaDestructive(args: string[]): ValidationResult | null {
+  if (hasArgToken(args, 'reset') || hasArgToken(args, '--force-reset') || hasArgToken(args, '--accept-data-loss')) {
+    return { allowed: false, reason: 'prisma data-loss operation is forbidden', trust_level: 'DANGEROUS' };
+  }
+  const lower = args.map(a => a.toLowerCase());
+  if (lower.includes('db') && lower.includes('execute')) {
+    return { allowed: false, reason: 'prisma db execute runs arbitrary SQL and is forbidden', trust_level: 'DANGEROUS' };
+  }
+  return null;
+}
+
+const DESTRUCTIVE_CLI_CHECKS: Record<string, (args: string[]) => ValidationResult | null> = {
+  docker: checkDockerDestructive,
+  'docker-compose': checkDockerDestructive,
+  gh: checkGhDestructive,
+  prisma: checkPrismaDestructive,
+};
+
 const INLINE_EVAL_COMMANDS: Record<string, string[]> = {
   node: ['-e', '--eval', '-p', '--print'],
   nodejs: ['-e', '--eval', '-p', '--print'],
@@ -492,7 +555,18 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
     };
   }
 
-  // 4. Not in any allowlist: blocked
+  // 4. Destructive variants of common CLIs (docker prune/rm, gh delete,
+  // prisma reset...) hard-block for the same reason inline eval does: the
+  // allowlist miss below is advisory-only at the hook layer, so without this
+  // check `docker system prune -af` would execute with nothing but a
+  // warning. Non-destructive forms of these CLIs keep the advisory path.
+  const destructiveCheck = DESTRUCTIVE_CLI_CHECKS[baseCommand];
+  if (destructiveCheck) {
+    const denial = destructiveCheck(args);
+    if (denial) return denial;
+  }
+
+  // 5. Not in any allowlist: blocked
   if (!SAFE_READONLY.includes(baseCommand) && !SAFE_DEV.includes(baseCommand)) {
     return {
       allowed: false,
@@ -501,7 +575,7 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
     };
   }
 
-  // 5. In allowlist: validate args
+  // 6. In allowlist: validate args
   return validateCommandArgs(baseCommand, args, cwd);
 }
 

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -62,10 +62,14 @@ function embeddedPathCandidate(arg: string): string | null {
 // Bare comparison token for the destructive-CLI checks: shell quotes and
 // backslash escapes stripped, lowercased, so `"prune"`, \reset and DELETE
 // all compare equal to their plain spellings (the shell strips those before
-// the real CLI sees them, so the validator must too). Path checks elsewhere
-// keep the raw argument.
+// the real CLI sees them, so the validator must too). Quotes are stripped
+// wherever they appear in the token, not just at the edges — a real shell
+// removes a quote character from a word regardless of position (pru"ne"
+// is shell-equivalent to prune), so an anchored-only strip leaves embedded
+// quotes able to defeat every exact-match keyword check below. Path checks
+// elsewhere keep the raw argument.
 function bareToken(a: string): string {
-  return a.replace(/\\/g, '').replace(/^["']+/, '').replace(/["']+$/, '').toLowerCase();
+  return a.replace(/\\/g, '').replace(/["']/g, '').toLowerCase();
 }
 
 function positionalsOf(tokens: string[]): string[] {
@@ -83,35 +87,112 @@ function positionalsOf(tokens: string[]): string[] {
 // (`docker system prune`, `docker volume rm`, `docker compose down`).
 const DOCKER_MGMT_GROUPS = new Set(['container', 'image', 'volume', 'network', 'system', 'builder', 'buildx', 'compose']);
 
+// Global docker flags that take a value and can appear BEFORE the subcommand
+// (`docker -H tcp://x system prune`, `docker --log-level debug rm c1`) — a
+// small, stable, fully-documented set (unlike run's much larger per-
+// subcommand flag surface below), so it can be enumerated completely.
+// Stripping these, and their values, before computing positionals is what
+// keeps a global value-flag from shifting the real subcommand out of the
+// position checkDockerDestructive looks at.
+const DOCKER_GLOBAL_VALUE_FLAGS = new Set([
+  '-h', '--host', '-l', '--log-level', '-c', '--context', '--config',
+  '--tlscacert', '--tlscert', '--tlskey',
+]);
+
+function stripDockerGlobalFlags(tokens: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    const eq = t.indexOf('=');
+    if (eq > 0 && DOCKER_GLOBAL_VALUE_FLAGS.has(t.slice(0, eq))) continue;
+    if (DOCKER_GLOBAL_VALUE_FLAGS.has(t)) {
+      // Only consume the next token as this flag's value if it doesn't
+      // itself look like a flag — mirrors how real getopt-style parsers
+      // never let one flag silently swallow the next flag as a value.
+      if (tokens[i + 1] !== undefined && !tokens[i + 1].startsWith('-')) i++;
+      continue;
+    }
+    out.push(t);
+  }
+  return out;
+}
+
 // run/create flags that consume the following token as a value; skipping the
 // value keeps the option-window scan below from mistaking it for the image.
+// Cannot be exhaustive against docker's full run-flag surface — that is why
+// runWindowMountsOrPrivileges never treats "unrecognized flag" as proof the
+// window has ended (see its own comment); this set only needs to cover the
+// common cases so their values are not misread as the image.
 const DOCKER_RUN_VALUE_FLAGS = new Set([
   '-e', '--env', '-p', '--publish', '-w', '--workdir', '--name', '-u', '--user',
   '--network', '-l', '--label', '--entrypoint', '--platform', '--pull', '--add-host',
+  '-m', '--memory', '--memory-swap', '-h', '--hostname', '--gpus', '--device',
+  '--dns', '--dns-search', '--restart', '--tmpfs', '--ip', '--ip6', '--mac-address',
+  '--health-cmd', '--health-interval', '--health-retries', '--health-timeout',
+  '--health-start-period', '--security-opt', '--log-driver', '--log-opt',
+  '--stop-signal', '--stop-timeout', '--shm-size', '--ulimit', '--pid', '--ipc',
+  '--uts', '--cgroup-parent', '--blkio-weight', '--cpus', '--cpuset-cpus', '--cpu-shares',
 ]);
+
+// A docker volume/mount SOURCE is a real host-escape risk only if it looks
+// like a path — absolute, relative, home-relative, or a Windows drive
+// letter. A bare identifier (docker's named-volume naming rule is
+// [a-zA-Z0-9][a-zA-Z0-9_.-]*) is a Docker-managed named volume with no host
+// filesystem access, and is the common form for stateful dev containers
+// (postgres/redis/mongo data volumes). Anything that fails to parse as a
+// clean identifier is treated as a path — fail closed on ambiguity.
+function isHostMountSource(source: string): boolean {
+  if (source.length === 0) return true;
+  if (source.startsWith('/') || source.startsWith('.') || source.startsWith('~')) return true;
+  if (/^[a-zA-Z]:[\\/]/.test(source)) return true;
+  return !/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(source);
+}
+
+function volumeValueIsHostMount(value: string): boolean {
+  return isHostMountSource(value.split(':')[0]);
+}
 
 // In docker syntax every option of run/create precedes the image name, and
 // everything after the image is the command executed INSIDE the container.
 // Scanning only that option window is what lets `docker run alpine rm -rf
 // /tmp/x` or `docker run img tar -xvf a.tar` pass while a host mount or
 // privilege escalation before the image still blocks. The bundled/glued
-// short-flag test (-itv, -v/:/host) is why exact `-v` membership is not enough.
+// short-flag test (-itv, -v/:/host) is why exact `-v` membership is not
+// enough. -v/--volume get their value checked (isHostMountSource) so a
+// named volume — the common stateful-dev-container pattern — does not
+// hard-block; every other spelling of a mount/privilege flag stays an
+// unconditional block, same as before.
 function runWindowMountsOrPrivileges(tokens: string[], startIdx: number): boolean {
   for (let i = startIdx + 1; i < tokens.length; i++) {
     const t = tokens[i];
     if (!t.startsWith('-')) return false;
     if (
-      t === '--privileged' || t === '--mount' || t === '--volume' || t === '--cap-add' ||
-      t.startsWith('--mount=') || t.startsWith('--volume=') || t.startsWith('--cap-add=')
+      t === '--privileged' || t === '--mount' || t === '--cap-add' ||
+      t.startsWith('--mount=') || t.startsWith('--cap-add=')
     ) return true;
-    if (!t.startsWith('--') && /^-[a-z]*v/.test(t)) return true;
+    if (t === '-v' || t === '--volume') {
+      const value = tokens[i + 1];
+      if (value === undefined || value.startsWith('-') || volumeValueIsHostMount(value)) return true;
+      i++;
+      continue;
+    }
+    if (t.startsWith('--volume=')) {
+      if (volumeValueIsHostMount(t.slice('--volume='.length))) return true;
+    } else if (t.startsWith('-v') && t.length > 2) {
+      if (volumeValueIsHostMount(t.slice(2))) return true;
+    } else if (!t.startsWith('--') && /^-[a-z]*v/.test(t)) {
+      // Bundled short flags (-itv, -dv...): the value's position inside the
+      // bundle is ambiguous, so this stays unconditionally dangerous rather
+      // than risk mis-parsing a host mount as a safe named volume.
+      return true;
+    }
     if (DOCKER_RUN_VALUE_FLAGS.has(t)) i++;
   }
   return false;
 }
 
 function checkDockerDestructive(args: string[]): ValidationResult | null {
-  const tokens = args.map(bareToken);
+  const tokens = stripDockerGlobalFlags(args.map(bareToken));
   const positionals = positionalsOf(tokens);
   // The destructive subcommand is the first positional, or the second when
   // the first is a management group. A later `rm`/`prune` (e.g. the command
@@ -136,15 +217,18 @@ function checkGhDestructive(args: string[]): ValidationResult | null {
   const positionals = positionalsOf(tokens);
   // `gh <resource> delete` always puts the verb in the second positional;
   // a later token spelled delete (an issue title word, a repo actually
-  // named delete in `gh repo view delete`) is data, not a subcommand.
-  if (positionals[1] === 'delete') {
+  // named delete in `gh repo view delete`) is data, not a subcommand. gh
+  // also has compound noun-verb subcommand names for the same action
+  // (`item-delete`, `field-delete` on `gh project`), so the suffix is
+  // checked too, not just an exact match.
+  if (positionals[1] === 'delete' || (positionals[1] ?? '').endsWith('-delete')) {
     return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
   }
   // gh api with an explicit DELETE method, in every spelling getopt
-  // accepts: -X DELETE, -XDELETE, --method DELETE, --method=delete.
+  // accepts: -X DELETE, -XDELETE, -X=DELETE, --method DELETE, --method=delete.
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
-    if (t === '-xdelete' || t === '--method=delete') {
+    if (t === '-xdelete' || t === '--method=delete' || t === '-x=delete') {
       return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
     }
     if ((t === '-x' || t === '--method') && tokens[i + 1] === 'delete') {
@@ -185,7 +269,14 @@ const DESTRUCTIVE_CLI_CHECKS: Record<string, (args: string[]) => ValidationResul
 // migrate reset` must be judged as prisma, not as npx (which is SAFE_DEV) —
 // and `yarn prisma ...` must not slide through as a plain allowlist miss.
 const RUNNER_CLIS = new Set(['npx', 'pnpx', 'bunx', 'yarn', 'pnpm', 'bun']);
-const RUNNER_SUBCOMMANDS = new Set(['dlx', 'x', 'exec']);
+// 'run' included alongside dlx/x/exec: `yarn run <bin>`/`bun run <bin>`
+// re-execute a node_modules/.bin binary the same way dlx/x/exec do.
+const RUNNER_SUBCOMMANDS = new Set(['dlx', 'x', 'exec', 'run']);
+// Runner flags that consume the following token as a value (the package to
+// install/run, a cwd, a registry). Without skipping the value too, the
+// unwrap loop below mistakes it for the inner command and judges the wrong
+// (misaligned) argument slice, e.g. `npx -p prisma prisma migrate reset`.
+const RUNNER_VALUE_FLAGS = new Set(['-p', '--package', '-c', '--call', '--cwd', '--registry']);
 
 function destructiveVerdict(baseCommand: string, args: string[]): ValidationResult | null {
   const check = DESTRUCTIVE_CLI_CHECKS[baseCommand];
@@ -194,6 +285,7 @@ function destructiveVerdict(baseCommand: string, args: string[]): ValidationResu
   let i = 0;
   while (i < args.length) {
     const t = bareToken(args[i]);
+    if (RUNNER_VALUE_FLAGS.has(t)) { i += 2; continue; }
     if (!t.startsWith('-') && !RUNNER_SUBCOMMANDS.has(t)) break;
     i += 1;
   }

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -59,15 +59,17 @@ function embeddedPathCandidate(arg: string): string | null {
   return null;
 }
 
-// True if `token` appears as a standalone arg or as a `--flag=token` value,
-// case-insensitively, so `-X DELETE`, `--method DELETE` and `--method=delete`
-// all match. Used to catch destructive verbs passed as option values.
-function hasArgToken(args: string[], token: string): boolean {
-  const t = token.toLowerCase();
-  return args.some(a => {
-    const lower = a.toLowerCase();
-    return lower === t || lower.endsWith('=' + t);
-  });
+// Bare comparison token for the destructive-CLI checks: shell quotes and
+// backslash escapes stripped, lowercased, so `"prune"`, \reset and DELETE
+// all compare equal to their plain spellings (the shell strips those before
+// the real CLI sees them, so the validator must too). Path checks elsewhere
+// keep the raw argument.
+function bareToken(a: string): string {
+  return a.replace(/\\/g, '').replace(/^["']+/, '').replace(/["']+$/, '').toLowerCase();
+}
+
+function positionalsOf(tokens: string[]): string[] {
+  return tokens.filter(t => t.length > 0 && !t.startsWith('-'));
 }
 
 // Destructive variants of CLIs that are otherwise advisory-only at the
@@ -76,40 +78,97 @@ function hasArgToken(args: string[], token: string): boolean {
 // advisory behavior, but the data-destroying forms below hard-block the
 // same way inline eval does. Returning null means "nothing destructive
 // here" and the command falls through to the ordinary allowlist handling.
+
+// docker management groups whose next positional is the real subcommand
+// (`docker system prune`, `docker volume rm`, `docker compose down`).
+const DOCKER_MGMT_GROUPS = new Set(['container', 'image', 'volume', 'network', 'system', 'builder', 'buildx', 'compose']);
+
+// run/create flags that consume the following token as a value; skipping the
+// value keeps the option-window scan below from mistaking it for the image.
+const DOCKER_RUN_VALUE_FLAGS = new Set([
+  '-e', '--env', '-p', '--publish', '-w', '--workdir', '--name', '-u', '--user',
+  '--network', '-l', '--label', '--entrypoint', '--platform', '--pull', '--add-host',
+]);
+
+// In docker syntax every option of run/create precedes the image name, and
+// everything after the image is the command executed INSIDE the container.
+// Scanning only that option window is what lets `docker run alpine rm -rf
+// /tmp/x` or `docker run img tar -xvf a.tar` pass while a host mount or
+// privilege escalation before the image still blocks. The bundled/glued
+// short-flag test (-itv, -v/:/host) is why exact `-v` membership is not enough.
+function runWindowMountsOrPrivileges(tokens: string[], startIdx: number): boolean {
+  for (let i = startIdx + 1; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (!t.startsWith('-')) return false;
+    if (
+      t === '--privileged' || t === '--mount' || t === '--volume' || t === '--cap-add' ||
+      t.startsWith('--mount=') || t.startsWith('--volume=') || t.startsWith('--cap-add=')
+    ) return true;
+    if (!t.startsWith('--') && /^-[a-z]*v/.test(t)) return true;
+    if (DOCKER_RUN_VALUE_FLAGS.has(t)) i++;
+  }
+  return false;
+}
+
 function checkDockerDestructive(args: string[]): ValidationResult | null {
-  const positional = args.filter(a => !a.startsWith('-'));
-  const destructiveSub = positional.some(a => a === 'prune' || a === 'rm' || a === 'rmi');
-  const downWithVolumes = positional.includes('down') && (args.includes('-v') || args.includes('--volumes'));
-  if (destructiveSub || downWithVolumes) {
+  const tokens = args.map(bareToken);
+  const positionals = positionalsOf(tokens);
+  // The destructive subcommand is the first positional, or the second when
+  // the first is a management group. A later `rm`/`prune` (e.g. the command
+  // run inside a container) is not a docker subcommand and must not match.
+  const sub = DOCKER_MGMT_GROUPS.has(positionals[0] ?? '') ? positionals[1] : positionals[0];
+  if (sub === 'rm' || sub === 'rmi' || sub === 'prune') {
     return { allowed: false, reason: 'destructive docker operation is forbidden', trust_level: 'DANGEROUS' };
   }
-  // run/create with a host mount or elevated privileges escapes the
-  // container boundary, taking every path-based check in this file with it.
-  const startsContainer = positional.includes('run') || positional.includes('create');
-  const mountsOrPrivileged = args.some(a =>
-    a === '-v' || a === '--volume' || a === '--mount' || a === '--privileged' || a === '--cap-add' ||
-    a.startsWith('--volume=') || a.startsWith('--mount=') || a.startsWith('--cap-add='),
-  );
-  if (startsContainer && mountsOrPrivileged) {
+  const volumesFlag = tokens.some(t => t === '-v' || t === '--volumes' || t.startsWith('--volumes='));
+  if (sub === 'down' && volumesFlag) {
+    return { allowed: false, reason: 'destructive docker operation is forbidden', trust_level: 'DANGEROUS' };
+  }
+  const startIdx = tokens.findIndex(t => t === 'run' || t === 'create');
+  if (startIdx >= 0 && runWindowMountsOrPrivileges(tokens, startIdx)) {
     return { allowed: false, reason: 'docker run with host mounts or elevated privileges is forbidden', trust_level: 'DANGEROUS' };
   }
   return null;
 }
 
 function checkGhDestructive(args: string[]): ValidationResult | null {
-  // Covers `gh <resource> delete`, `gh api -X DELETE` and `--method=delete`.
-  if (hasArgToken(args, 'delete')) {
+  const tokens = args.map(bareToken);
+  const positionals = positionalsOf(tokens);
+  // `gh <resource> delete` always puts the verb in the second positional;
+  // a later token spelled delete (an issue title word, a repo actually
+  // named delete in `gh repo view delete`) is data, not a subcommand.
+  if (positionals[1] === 'delete') {
     return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
+  }
+  // gh api with an explicit DELETE method, in every spelling getopt
+  // accepts: -X DELETE, -XDELETE, --method DELETE, --method=delete.
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === '-xdelete' || t === '--method=delete') {
+      return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
+    }
+    if ((t === '-x' || t === '--method') && tokens[i + 1] === 'delete') {
+      return { allowed: false, reason: 'gh delete operations are forbidden', trust_level: 'DANGEROUS' };
+    }
   }
   return null;
 }
 
 function checkPrismaDestructive(args: string[]): ValidationResult | null {
-  if (hasArgToken(args, 'reset') || hasArgToken(args, '--force-reset') || hasArgToken(args, '--accept-data-loss')) {
+  const tokens = args.map(bareToken);
+  const positionals = positionalsOf(tokens);
+  // Subcommand context, not token presence: `prisma migrate dev --name
+  // reset` names a migration and must pass; `prisma migrate reset` wipes.
+  if (positionals[0] === 'migrate' && positionals[1] === 'reset') {
     return { allowed: false, reason: 'prisma data-loss operation is forbidden', trust_level: 'DANGEROUS' };
   }
-  const lower = args.map(a => a.toLowerCase());
-  if (lower.includes('db') && lower.includes('execute')) {
+  if (tokens.some(t =>
+    t === '--force-reset' || t.startsWith('--force-reset=') ||
+    t === '--accept-data-loss' || t.startsWith('--accept-data-loss='),
+  )) {
+    return { allowed: false, reason: 'prisma data-loss operation is forbidden', trust_level: 'DANGEROUS' };
+  }
+  if (positionals[0] === 'db' && positionals[1] === 'execute') {
     return { allowed: false, reason: 'prisma db execute runs arbitrary SQL and is forbidden', trust_level: 'DANGEROUS' };
   }
   return null;
@@ -121,6 +180,30 @@ const DESTRUCTIVE_CLI_CHECKS: Record<string, (args: string[]) => ValidationResul
   gh: checkGhDestructive,
   prisma: checkPrismaDestructive,
 };
+
+// Package runners re-execute their first non-flag argument, so `npx prisma
+// migrate reset` must be judged as prisma, not as npx (which is SAFE_DEV) —
+// and `yarn prisma ...` must not slide through as a plain allowlist miss.
+const RUNNER_CLIS = new Set(['npx', 'pnpx', 'bunx', 'yarn', 'pnpm', 'bun']);
+const RUNNER_SUBCOMMANDS = new Set(['dlx', 'x', 'exec']);
+
+function destructiveVerdict(baseCommand: string, args: string[]): ValidationResult | null {
+  const check = DESTRUCTIVE_CLI_CHECKS[baseCommand];
+  if (check) return check(args);
+  if (!RUNNER_CLIS.has(baseCommand)) return null;
+  let i = 0;
+  while (i < args.length) {
+    const t = bareToken(args[i]);
+    if (!t.startsWith('-') && !RUNNER_SUBCOMMANDS.has(t)) break;
+    i += 1;
+  }
+  if (i >= args.length) return null;
+  // prisma@5.x and ./node_modules/.bin/prisma both resolve to prisma.
+  let inner = path.basename(bareToken(args[i]));
+  if (!inner.startsWith('@')) inner = inner.split('@')[0];
+  const innerCheck = DESTRUCTIVE_CLI_CHECKS[inner];
+  return innerCheck ? innerCheck(args.slice(i + 1)) : null;
+}
 
 const INLINE_EVAL_COMMANDS: Record<string, string[]> = {
   node: ['-e', '--eval', '-p', '--print'],
@@ -559,12 +642,10 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   // prisma reset...) hard-block for the same reason inline eval does: the
   // allowlist miss below is advisory-only at the hook layer, so without this
   // check `docker system prune -af` would execute with nothing but a
-  // warning. Non-destructive forms of these CLIs keep the advisory path.
-  const destructiveCheck = DESTRUCTIVE_CLI_CHECKS[baseCommand];
-  if (destructiveCheck) {
-    const denial = destructiveCheck(args);
-    if (denial) return denial;
-  }
+  // warning. Non-destructive forms of these CLIs keep the advisory path,
+  // and package runners (npx, yarn...) are unwrapped to the inner command.
+  const destructiveDenial = destructiveVerdict(baseCommand, args);
+  if (destructiveDenial) return destructiveDenial;
 
   // 5. Not in any allowlist: blocked
   if (!SAFE_READONLY.includes(baseCommand) && !SAFE_DEV.includes(baseCommand)) {

--- a/tests/egc-guardian-destructive-cli.test.js
+++ b/tests/egc-guardian-destructive-cli.test.js
@@ -105,6 +105,32 @@ run('pnpm dlx prisma migrate reset is hard-blocked', () => assertHardBlocked('pn
 // the DANGEROUS verdict, not the advisory allowlist miss.
 run('yarn prisma migrate reset is hard-blocked', () => assertHardBlocked('yarn prisma migrate reset'));
 
+// Second-round adversarial audit: bypasses that survived the first fix
+// round (commit d60df57c) — an unrecognized value-taking flag terminating
+// the docker run option-window scan early, a global docker flag shifting
+// the subcommand out of position, gh's =-glued method flag and compound
+// noun-delete subcommands, runner value-flags misaligning the inner-command
+// argument slice, and an embedded quote the anchored bareToken strip missed.
+run('docker run -m 512m --privileged (unrecognized value flag) is hard-blocked', () => assertHardBlocked('docker run -m 512m --privileged img'));
+run('docker -H tcp://x system prune -af (global flag before subcommand) is hard-blocked', () => assertHardBlocked('docker -H tcp://x system prune -af'));
+run('docker --log-level debug system prune -af (global flag before subcommand) is hard-blocked', () => assertHardBlocked('docker --log-level debug system prune -af'));
+run('gh api -X=DELETE (glued equals) is hard-blocked', () => assertHardBlocked('gh api -X=DELETE repos/owner/repo'));
+run('gh project item-delete (compound noun-delete subcommand) is hard-blocked', () => assertHardBlocked('gh project item-delete 3 --owner some-owner'));
+run('npx -p prisma prisma migrate reset (runner value flag) is hard-blocked', () => assertHardBlocked('npx -p prisma prisma migrate reset'));
+run('npx -p ./tool prisma migrate reset (runner value flag, path value) is hard-blocked', () => assertHardBlocked('npx -p ./tool prisma migrate reset'));
+run('yarn run prisma migrate reset (run subcommand) is hard-blocked', () => assertHardBlocked('yarn run prisma migrate reset'));
+run('docker system pru"ne" (embedded quote) is hard-blocked', () => assertHardBlocked('docker system pru"ne"'));
+
+// Second-round false positives: a docker named volume is not a host mount.
+run('docker run -v pgdata:/var/lib/postgresql/data (named volume) stays advisory', () => assertAdvisoryOnly('docker run -v pgdata:/var/lib/postgresql/data postgres'));
+run('docker run --volume myvol:/data (named volume, long flag) stays advisory', () => assertAdvisoryOnly('docker run --volume myvol:/data img'));
+
+// Regression guards: the expanded flag sets must not create new false
+// positives on ordinary daily commands.
+run('docker -H tcp://x ps (global flag, benign subcommand) stays advisory', () => assertAdvisoryOnly('docker -H tcp://x ps'));
+run('docker run -h myhost -m 512m img (run-scoped value flags) stays advisory', () => assertAdvisoryOnly('docker run -h myhost -m 512m img'));
+run('yarn run build (non-destructive inner command) stays advisory', () => assertAdvisoryOnly('yarn run build'));
+
 // False positives from the adversarial audit: all must keep today's
 // advisory (or allowed) behavior.
 run('docker run alpine rm -rf /tmp/foo stays advisory (rm runs inside the container)', () => assertAdvisoryOnly('docker run alpine rm -rf /tmp/foo'));

--- a/tests/egc-guardian-destructive-cli.test.js
+++ b/tests/egc-guardian-destructive-cli.test.js
@@ -85,6 +85,38 @@ run('prisma db push --force-reset is hard-blocked', () => assertHardBlocked('pri
 run('prisma db push --accept-data-loss is hard-blocked', () => assertHardBlocked('prisma db push --accept-data-loss'));
 run('prisma db execute is hard-blocked', () => assertHardBlocked('prisma db execute --file drop.sql'));
 
+// Bypass spellings from the adversarial audit: quoting, escapes, bundled
+// and glued short flags, method gluing, value suffixes, package runners.
+run('docker system "prune" (quoted) is hard-blocked', () => assertHardBlocked('docker system "prune"'));
+run("gh repo 'delete' o/r (quoted) is hard-blocked", () => assertHardBlocked("gh repo 'delete' owner/repo"));
+run('prisma migrate \\reset (escaped) is hard-blocked', () => assertHardBlocked('prisma migrate \\reset'));
+run('docker run -itv /:/host (bundled) is hard-blocked', () => assertHardBlocked('docker run -itv /:/host img'));
+run('docker run -v/:/host (glued) is hard-blocked', () => assertHardBlocked('docker run -v/:/host img'));
+run('docker run -e FOO -v /:/host (value flag) is hard-blocked', () => assertHardBlocked('docker run -e FOO -v /:/host img'));
+run('gh api -XDELETE (glued) is hard-blocked', () => assertHardBlocked('gh api -XDELETE repos/o/r'));
+run('gh api --method DELETE is hard-blocked', () => assertHardBlocked('gh api --method DELETE repos/o/r'));
+run('prisma db push --force-reset=true is hard-blocked', () => assertHardBlocked('prisma db push --force-reset=true'));
+run('docker compose down --volumes=true is hard-blocked', () => assertHardBlocked('docker compose down --volumes=true'));
+run('npx prisma migrate reset is hard-blocked', () => assertHardBlocked('npx prisma migrate reset'));
+run('npx -y prisma@5 db execute unwraps and is hard-blocked', () => assertHardBlocked('npx -y prisma@5 db execute --file x.sql'));
+run('pnpm dlx prisma migrate reset is hard-blocked', () => assertHardBlocked('pnpm dlx prisma migrate reset'));
+
+// yarn is outside the allowlist, so the wrapped destructive form must be
+// the DANGEROUS verdict, not the advisory allowlist miss.
+run('yarn prisma migrate reset is hard-blocked', () => assertHardBlocked('yarn prisma migrate reset'));
+
+// False positives from the adversarial audit: all must keep today's
+// advisory (or allowed) behavior.
+run('docker run alpine rm -rf /tmp/foo stays advisory (rm runs inside the container)', () => assertAdvisoryOnly('docker run alpine rm -rf /tmp/foo'));
+run('docker compose run web rm -rf cache stays advisory', () => assertAdvisoryOnly('docker compose run web rm -rf cache'));
+run('docker build -t prune . stays advisory', () => assertAdvisoryOnly('docker build -t prune .'));
+run('docker tag my-image rm stays advisory', () => assertAdvisoryOnly('docker tag my-image rm'));
+run('docker run img tar -xvf a.tar stays advisory (flags after the image)', () => assertAdvisoryOnly('docker run img tar -xvf a.tar'));
+run('gh issue list --search delete stays advisory', () => assertAdvisoryOnly('gh issue list --search delete'));
+run('gh issue create --title "delete old keys" stays advisory', () => assertAdvisoryOnly('gh issue create --title "delete old keys"'));
+run('gh repo view delete stays advisory (repo named delete)', () => assertAdvisoryOnly('gh repo view delete'));
+run('prisma migrate dev --name reset stays advisory (migration named reset)', () => assertAdvisoryOnly('prisma migrate dev --name reset'));
+
 // Benign forms stay advisory: the hook keeps letting them run.
 run('docker ps stays advisory', () => assertAdvisoryOnly('docker ps'));
 run('docker build stays advisory', () => assertAdvisoryOnly('docker build -t img .'));

--- a/tests/egc-guardian-destructive-cli.test.js
+++ b/tests/egc-guardian-destructive-cli.test.js
@@ -1,0 +1,99 @@
+'use strict';
+/**
+ * Tests the destructive-CLI hard blocks in validateCommand: docker/gh/prisma
+ * data-destroying variants must return a DANGEROUS (blocking) verdict, while
+ * their benign forms keep the advisory allowlist-miss verdict so the
+ * enforcement hook does not block them.
+ *
+ * Run with: node tests/egc-guardian-destructive-cli.test.js
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const buildPath = path.join(
+  __dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'validator.js',
+);
+
+if (!fs.existsSync(buildPath)) {
+  console.log('[SKIP] build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  process.exit(0);
+}
+
+const { validateCommand } = require(buildPath);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+// The hook only blocks verdicts whose reason is outside its advisory list,
+// so a hard block must be allowed:false, DANGEROUS, and not an
+// allowlist-miss reason.
+function assertHardBlocked(command) {
+  const v = validateCommand(command);
+  assert.strictEqual(v.allowed, false, `${command} should be denied`);
+  assert.strictEqual(v.trust_level, 'DANGEROUS', `${command} should be DANGEROUS, got ${v.trust_level}`);
+  assert.ok(!v.reason.includes('is not in the allowlist'), `${command} must not fall through to the advisory allowlist miss`);
+}
+
+// Benign forms keep today's behavior: denied only by the advisory
+// allowlist miss, which the enforcement hook never blocks on.
+function assertAdvisoryOnly(command) {
+  const v = validateCommand(command);
+  assert.strictEqual(v.allowed, false, `${command} stays outside the allowlist`);
+  assert.ok(v.reason.includes('is not in the allowlist'), `${command} should be an advisory allowlist miss, got: ${v.reason}`);
+}
+
+console.log('\n=== Testing egc-guardian destructive CLI hard blocks ===\n');
+
+// docker: data destruction
+run('docker system prune -af is hard-blocked', () => assertHardBlocked('docker system prune -af'));
+run('docker rm container is hard-blocked', () => assertHardBlocked('docker rm my-container'));
+run('docker rmi image is hard-blocked', () => assertHardBlocked('docker rmi my-image'));
+run('docker volume prune is hard-blocked', () => assertHardBlocked('docker volume prune'));
+run('docker compose down -v is hard-blocked', () => assertHardBlocked('docker compose down -v'));
+run('docker-compose down --volumes is hard-blocked', () => assertHardBlocked('docker-compose down --volumes'));
+
+// docker: sandbox escape
+run('docker run --privileged is hard-blocked', () => assertHardBlocked('docker run --privileged img'));
+run('docker run with host mount is hard-blocked', () => assertHardBlocked('docker run -v /:/host img'));
+run('docker run --mount= is hard-blocked', () => assertHardBlocked('docker run --mount=type=bind,src=/,dst=/host img'));
+run('docker create --cap-add is hard-blocked', () => assertHardBlocked('docker create --cap-add SYS_ADMIN img'));
+run('/usr/bin/docker rm resolves by basename and is hard-blocked', () => assertHardBlocked('/usr/bin/docker rm c1'));
+
+// gh: deletions in any spelling
+run('gh repo delete is hard-blocked', () => assertHardBlocked('gh repo delete owner/repo --yes'));
+run('gh api -X DELETE is hard-blocked', () => assertHardBlocked('gh api -X DELETE repos/o/r'));
+run('gh api --method=delete is hard-blocked', () => assertHardBlocked('gh api --method=delete repos/o/r'));
+run('gh release delete is hard-blocked', () => assertHardBlocked('gh release delete v1.0.0'));
+
+// prisma: data loss
+run('prisma migrate reset is hard-blocked', () => assertHardBlocked('prisma migrate reset'));
+run('prisma db push --force-reset is hard-blocked', () => assertHardBlocked('prisma db push --force-reset'));
+run('prisma db push --accept-data-loss is hard-blocked', () => assertHardBlocked('prisma db push --accept-data-loss'));
+run('prisma db execute is hard-blocked', () => assertHardBlocked('prisma db execute --file drop.sql'));
+
+// Benign forms stay advisory: the hook keeps letting them run.
+run('docker ps stays advisory', () => assertAdvisoryOnly('docker ps'));
+run('docker build stays advisory', () => assertAdvisoryOnly('docker build -t img .'));
+run('docker compose up stays advisory', () => assertAdvisoryOnly('docker compose up -d'));
+run('docker run without mounts stays advisory', () => assertAdvisoryOnly('docker run img'));
+run('gh pr list stays advisory', () => assertAdvisoryOnly('gh pr list'));
+run('gh api GET stays advisory', () => assertAdvisoryOnly('gh api repos/o/r'));
+run('prisma migrate dev stays advisory', () => assertAdvisoryOnly('prisma migrate dev'));
+run('prisma generate stays advisory', () => assertAdvisoryOnly('prisma generate'));
+
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## What

Hard-blocks for the destructive variants of three common CLIs in the guardian validator, extracted from the security half of #1001 (credit to @fuentes71). The allowlist expansion and multica changes from that PR stay out.

## Why

The enforcement hook treats allowlist misses as advisory by design, so these commands executed with nothing but a warning:

- `docker system prune -af`, `docker rm/rmi`, `docker compose down -v`, `docker run --privileged` / host mounts
- `gh repo delete`, `gh api -X DELETE`, `gh api --method=delete`
- `prisma migrate reset`, `--force-reset`, `--accept-data-loss`, `prisma db execute`

## How

A destructive-CLI check runs before the allowlist miss and returns a DANGEROUS verdict, the same mechanism inline eval uses to hard-block. Benign forms (`docker build`, `gh pr list`, `prisma migrate dev`...) keep the advisory path unchanged, so no daily workflow breaks.

Field-tested during development: the freshly built hook blocked this PR's own first commit because the message body contained a destructive command string.

## Tests

`tests/egc-guardian-destructive-cli.test.js`: 27 cases, 19 destructive forms hard-blocked (including basename resolution of path-qualified docker) and 8 benign forms asserted to stay advisory. Guardian regression suites pass (symlink 3/3, pre-bash hook 10/10, pre-write hook 7/7) and the MCP server boots.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an early destructive-CLI check to hard-block dangerous `docker`, `gh`, and `prisma` commands before allowlist handling. Second-round hardening closes audit bypasses and reduces false positives; benign commands stay advisory-only.

- **Bug Fixes**
  - Normalize tokens (strip embedded quotes/backslashes, lowercase) and use positional subcommand detection to avoid quoted/escaped bypasses and inside-container false positives.
  - `docker`: strip global value flags before subcommand detection; expand `run`/`create` value-flag set; scan only options before the image; handle bundled/glued short flags; treat named volumes as safe; keep `compose down` with volumes blocked.
  - `gh`: detect deletions via `delete` verbs and compound `*-delete` subcommands; cover `api` DELETE method flags including glued/equals forms (`-XDELETE`, `-X=DELETE`, `--method DELETE/=`).
  - `prisma` and runners: block `migrate reset`, `db execute`, and data-loss flags (incl. `=true`); unwrap `npx`/`pnpx`/`bunx`/`yarn`/`pnpm`/`bun`, skip runner value flags (`-p/--package`, etc.), support `run`, and resolve inner CLI by basename/scope/version.
  - Tests expanded to 64 cases covering all new bypasses and regression guards.

<sup>Written for commit 48407c247f2315637e6136a88cae68f178ba4a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

