### PR TITLE
release: v1.1.16

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "egc",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "source": {
         "source": "local",
         "path": "../.."

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Battle-tested Codex workflows \u2014 230 shared EGC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
   "author": {
     "name": "Felipe Marzochi",

--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -1,40 +1,6 @@
 ---
-description: EGC project memory (auto-updated)
+description: EGC project memory (auto-updated by update_state)
 alwaysApply: true
 ---
 
 ## EGC Project Memory
-
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`

--- a/.gemini-plugin/marketplace.json
+++ b/.gemini-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "egc",
       "source": "./",
       "description": "EGC - Extended Global Context: 63 agents, 230 skills, 77 commands, persistent memory across sessions, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "author": {
         "name": "Felipe Marzochi",
         "email": "fmarzochi@gmail.com"

--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "EGC - Extended Global Context: persistent memory and shared context for AI coding tools. 63 agents, 230 skills, 77 commands, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {
     "name": "Felipe Marzochi",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,3 +42,8 @@ never reach the repository.
   must never block the user's command.
 - Version bumps happen only in dedicated release PRs that update the whole
   release surface (11 files); flag any stray version change elsewhere.
+
+<!-- egc:start -->
+## EGC Project Memory
+
+<!-- egc:end -->

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "egc-universal",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "egc-universal",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.4.3",

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egc-universal",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Extended Global Context (EGC) plugin for OpenCode - agents, commands, hooks, and skills",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -513,7 +513,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
      */
     "shell.env": async () => {
       const env: Record<string, string> = {
-        EGC_VERSION: "1.1.15",
+        EGC_VERSION: "1.1.16",
         EGC_PLUGIN: "true",
         EGC_HOOK_PROFILE: currentProfile,
         EGC_DISABLED_HOOKS: process.env.EGC_DISABLED_HOOKS || "",
@@ -567,7 +567,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
       const contextBlock = [
         "# EGC Context (preserve across compaction)",
         "",
-        "## Active Plugin: EGC - Extended Global Context v1.1.15",
+        "## Active Plugin: EGC - Extended Global Context v1.1.16",
         "- Hooks: file.edited, tool.execute.before/after, session.created/idle/deleted, shell.env, compacting, permission.ask",
         "- Tools: run-tests, check-coverage, security-audit, format-code, lint-check, git-summary, changed-files",
         "- Agents: 13 specialized (planner, architect, tdd-guide, code-reviewer, security-reviewer, build-error-resolver, e2e-runner, refactor-cleaner, doc-updater, go-reviewer, go-build-resolver, database-reviewer, python-reviewer)",

--- a/.trae/rules/egc-context.md
+++ b/.trae/rules/egc-context.md
@@ -24,37 +24,4 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,37 +62,4 @@ Skipping any of these breaks the EGC contract. There are no exceptions for "simp
 <!-- egc:start -->
 ## EGC Project Memory
 
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to EGC are documented here.
 
+## [1.1.16] - 2026-07-26
+
+### Security
+
+- **Destructive-CLI hard blocks in the Guardian validator**: `docker system prune`, `docker rm/rmi`, `docker run --privileged` or host mounts, `gh repo delete`, `gh api -X DELETE`, and `prisma migrate reset` / `--force-reset` / `db execute` now return a hard DANGEROUS verdict instead of an advisory warning, closing a gap where the enforcement hook let these commands run with nothing but a warning (#1041, @fuentes71).
+
+### Bug Fixes
+
+- **Crowdin translation sync corruption fixed at the root**: `upload_translations` re-uploaded the post-processed export back to Crowdin, and Crowdin does not sentence-segment Chinese, so a whole paragraph collapsed onto the first segment. Sync is now one-way (Crowdin to repo only); the poisoned zh-CN strings were cleaned up via the Crowdin API (#1038, #1039, #1040).
+
 ## [1.1.15] - 2026-07-21
 
 ### New Features

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -93,37 +93,4 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/agent.yaml
+++ b/agent.yaml
@@ -1,6 +1,6 @@
 spec_version: "0.1.0"
 name: egc
-version: 1.1.15
+version: 1.1.16
 description: "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools. Desenvolvido por Felipe Marzochi. @MarzochiFelipe. https://github.com/Fmarzochi/EGC"
 author: fmarzochi
 license: Apache-2.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,6 +82,11 @@ Closes the commit-privacy scope started in v1.1.12:
 - Lean repository root: tool configuration files moved to their conventional homes (#891)
 - `egc install` launches the dashboard right after installing (#893)
 
+## v1.1.16: Crowdin Root Fix and Destructive-CLI Hard Blocks (Released 2026-07-26)
+
+- Crowdin sync corruption fixed at the root: one-way sync (Crowdin to repo only), poisoned zh-CN strings cleaned via API (#1038, #1039, #1040)
+- Guardian validator hard-blocks destructive docker/gh/prisma variants instead of just warning (#1041, @fuentes71)
+
 ## v1.1.15: Universal Crusher and Clean Security (Released 2026-07-21)
 
 - Relicensed from MIT to Apache License 2.0 (#906)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egchq/egc",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "EGC is a local-first MCP runtime that gives every AI agent the same brain: persistent shared memory, security guardrails, and up to 90% token savings across 23 AI coding tools.",
   "author": "Felipe Marzochi <fmarzochi@gmail.com> (https://github.com/Fmarzochi)",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What

Version bump 1.1.15 to 1.1.16, covering:

- Crowdin translation sync corruption fixed at the root (one-way sync, poisoned zh-CN strings cleaned via API): #1038, #1039, #1040
- Guardian validator hard-blocks destructive docker/gh/prisma variants instead of just warning: #1041 (@fuentes71)

## Changes

- Version manifests bumped via `scripts/release.sh 1.1.16`
- CHANGELOG.md and docs/ROADMAP.md updated with the 1.1.16 entry
- EGC project memory synced to the tool config mirror files (AGENTS.md, GEMINI.md, IDE rules)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.1.16 adds hard blocks for destructive CLI commands and fixes the Crowdin translation sync corruption. It also updates version manifests and syncs the EGC project memory across tool config files.

- **Security**
  - Guardian validator now hard-blocks destructive `docker`, `gh`, and `prisma` commands (e.g., `docker system prune`, `gh repo delete`, `prisma migrate reset`) instead of only warning.

- **Bug Fixes**
  - Crowdin sync is now one-way (Crowdin → repo) to prevent collapsed zh-CN segments; corrupted strings cleaned via the Crowdin API.

<sup>Written for commit a53830247aacaaf1e875e0a3d287e88cb4674d99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

