### PR TITLE
docs: complete the v1.1.16 changelog and fix roadmap chronology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,35 @@ All notable changes to EGC are documented here.
 ### Security
 
 - **Destructive-CLI hard blocks in the Guardian validator**: `docker system prune`, `docker rm/rmi`, `docker run --privileged` or host mounts, `gh repo delete`, `gh api -X DELETE`, and `prisma migrate reset` / `--force-reset` / `db execute` now return a hard DANGEROUS verdict instead of an advisory warning, closing a gap where the enforcement hook let these commands run with nothing but a warning (#1041, @fuentes71).
+- **Guardian validator hardened against an absolute-path bypass**: `/bin/rm`, `/usr/bin/mv` and similar path-qualified forms are now matched against the destructive command list instead of slipping through as an allowlist miss (#1012); path resolution and log file permissions were hardened at the same time (#1011).
+- **Bash hook dispatcher fails closed**: an error in the dispatcher's own plumbing used to fail open, silently disabling every guard (Guardian validate, GateGuard) for that command. It now fails closed, the most critical finding of the latest security audit (#1019).
+- **`auto_learn` validates its write target**: `target_file` is now checked against protected paths and must stay inside the project root, closing a write-outside-sandbox path (#1009). Two more destructive filesystem paths were guarded in the plugin and orchestration lib (#1016).
+- **`core.hooksPath` no-verify bypass closed**: git hook-path overrides are now matched case-insensitively (#1013).
+- **`republish.yml` command injection closed**: the version input is now validated instead of interpolated directly into a shell command (#1027).
+- **Docker hardened**: images run as a non-root user via a multi-stage build that keeps the build toolchain out of the final image (#1036), and a `.dockerignore` keeps `.git`, `.env` and `node_modules` out of the build context (#1028).
+- **All remaining Dependabot and Scorecard advisories cleared**: `tar` and `brace-expansion` across the root and both mcp-server lockfiles (#992, #994, #995).
 
 ### Bug Fixes
 
 - **Crowdin translation sync corruption fixed at the root**: `upload_translations` re-uploaded the post-processed export back to Crowdin, and Crowdin does not sentence-segment Chinese, so a whole paragraph collapsed onto the first segment. Sync is now one-way (Crowdin to repo only); the poisoned zh-CN strings were cleaned up via the Crowdin API (#1038, #1039, #1040).
+- **Chinese Simplified Crowdin path fixed end to end**: mapped to the canonical `zh-CN` path with existing repo translations seeded (#988, closes #483), root-relative asset and doc links rewritten in downloaded translations (#1004), and sync commits signed so the DCO check passes (#1006).
+- **Three runtime bugs from the #987 deep audit fixed**: an `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani).
+- **`get_state` no longer time-travels on feature branches**: the default-branch fallback now prefers the hashed main state file over the legacy plain `main.md` left behind by pre-hash versions (#1005).
+- **Bare `egc install` fixed on the published npm package**: `install.sh` falls back to `npm install` when the published tarball ships no root lockfile, and only builds when `src/` is present (#985, #986, closes #643).
+- **Team sync no longer deletes local state files** absent from the remote (#1015); the state store falls back to the jsonl store on a `state.db` error (#1014).
+- **`egc` CLI subcommand forwarding fixed** for `plugin`, `budget` and `team`, and `gain` / `install-apply` output corrected (#1024).
+- **Telemetry ping is time-bound** so it never delays CLI exit (#1023).
+- **Fuzz harness actually fuzzes**: the validator is bundled to CommonJS so `jsfuzz` can instrument it instead of running blind (#1029); CI now builds the MCP servers before the test suite, closing a false-green gap where roughly 20 defense tests were silently skipped (#1030).
+- **Catalog indexer fixed**: only `SKILL.md` files are indexed, and YAML block scalars in frontmatter parse correctly (#1025).
+- **Windows fixes**: the TypeScript check hook runs via `node`, and Zed JSON bin paths are escaped correctly (#1021); `install.sh` aligns the Node version floor, keeps dev dependencies, and hardens config writes (#1017).
+- **OpenAI provider fallback redacts unmapped SDK errors** instead of leaking them (#1022).
+
+### Maintenance
+
+- **CodeRabbit reviews contributor PRs automatically** and skips the maintainer's own to save review credits; the manual first-time-contributor gate workflows were retired (#997).
+- **Supported AI coding tool count synced** across docs, translations and plugin manifests (#984, #1018, #1020, #1031).
+- **Test coverage added** for the dispatcher, tool executor and prompt builder (#1037).
+- **Catalog keyword router memoizes token sets** for faster search (#1026).
 
 ## [1.1.15] - 2026-07-21
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,11 +82,6 @@ Closes the commit-privacy scope started in v1.1.12:
 - Lean repository root: tool configuration files moved to their conventional homes (#891)
 - `egc install` launches the dashboard right after installing (#893)
 
-## v1.1.16: Crowdin Root Fix and Destructive-CLI Hard Blocks (Released 2026-07-26)
-
-- Crowdin sync corruption fixed at the root: one-way sync (Crowdin to repo only), poisoned zh-CN strings cleaned via API (#1038, #1039, #1040)
-- Guardian validator hard-blocks destructive docker/gh/prisma variants instead of just warning (#1041, @fuentes71)
-
 ## v1.1.15: Universal Crusher and Clean Security (Released 2026-07-21)
 
 - Relicensed from MIT to Apache License 2.0 (#906)
@@ -126,21 +121,16 @@ Closes the commit-privacy scope started in v1.1.12:
 - High-severity advisories cleared: fast-uri and linkify-it across the root and mcp-server lockfiles (#967), and `@hono/node-server` forced to 2.x via npm override to close the last Dependabot and Scorecard findings (#968)
 - ClusterFuzzLite weekly schedule disabled while upstream is dead-locked for JavaScript, keeping manual `workflow_dispatch` (EGC#910)
 
-## Unreleased (on main)
+## v1.1.16: Security Hardening and Crowdin Root Fix (Released 2026-07-26)
 
-Landed on main since v1.1.15, not yet released:
-
-- Bare `egc install` from the published npm package fixed: `install.sh` falls back to `npm install` when the published tarball ships no root lockfile, and only builds when `src/` is present (#985, #986, closes #643)
-- Chinese Simplified mapped to `zh-CN` in Crowdin with the existing repo translations seeded (#988, closes #483)
-- Crowdin sync now writes Chinese Simplified to the canonical `translations/zh-CN/` path: the workflow renames `zh` to `zh-CN` after download, since the Crowdin action exposes no download language mapping (#1000; the `crowdin.yml` mapping tried in #992 was invalid and was reverted in #998)
-- CodeRabbit reviews contributor PRs automatically and skips the maintainer's own to save review credits; the first-time-contributor gate workflows were retired (#997)
-- `get_state` no longer time-travels on feature branches: the default-branch fallback prefers the hashed main state file over the legacy plain `main.md` left behind by pre-hash versions, with a new test covering the full resolution order (#1005)
-- Crowdin sync hardened end to end: root-relative asset and doc links are normalized in downloaded translations (#1004) and the sync commit is signed so the DCO check passes on translations PRs (#1006); the first fully green sync PR landed the Turkish and Chinese Simplified updates (#1003)
-- Docs: the MCP server build is invoked with `bash`, matching the install script's shebang (#1007)
-- Guardian hardening: `auto_learn` now validates `target_file` against protected paths and requires it to stay inside the project root, closing a write-outside-sandbox path found in an internal security audit (#1009)
-- Three runtime bugs from the #987 deep audit fixed: the `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani)
-- All Dependabot and Scorecard advisories cleared to zero: `brace-expansion` and `tar` in the root lockfile (#992), `tar` in the two mcp server lockfiles (#994), and `brace-expansion` in `fuzz` via an override (#995); the Scorecard Vulnerabilities code-scanning alert closed with them
-- Supported-harness count kept in sync across the docs (#984)
+- Guardian validator hardened: the absolute-path bypass on destructive commands closed (#1012), path resolution and log permissions hardened (#1011), `core.hooksPath` no-verify bypass closed (#1013), the bash hook dispatcher fails closed instead of fail-open on its own errors (#1019), `auto_learn` validates its write target against protected paths (#1009), and destructive docker/gh/prisma variants now hard-block instead of just warning (#1041, @fuentes71)
+- Crowdin translation sync fixed at the root: upload was re-poisoning Chinese Simplified because Crowdin does not sentence-segment Chinese; sync is now one-way, Crowdin to repo only, with the zh-CN path mapped correctly end to end (#988, #1000, #1003, #1004, #1005, #1006, #1038, #1039, #1040, closes #483)
+- Three runtime bugs from the #987 deep audit fixed: an `orchestrate_task` TOCTOU gap, lesson decay reading the wrong timestamp, and the integrity key loader silently regenerating on a malformed key (#989, @aryamirani)
+- Bare `egc install` fixed on the published npm package: falls back to `npm install` when the tarball ships no root lockfile (#985, #986, closes #643)
+- Docker hardened: non-root user, multi-stage build, `.dockerignore` (#1036, #1028); `republish.yml` command injection closed (#1027); all remaining Dependabot/Scorecard advisories cleared (#992, #994, #995)
+- Fuzz harness actually fuzzes now: validator bundled to CommonJS for `jsfuzz` instrumentation (#1029), and CI builds the MCP servers before running the defense test suite, closing a false-green gap (#1030)
+- CodeRabbit reviews contributor PRs automatically, retiring the manual first-time-contributor gate workflows (#997)
+- CLI, catalog indexer, and Windows install/hook fixes rounding out the squad audit cleanup (#1014, #1015, #1017, #1021, #1022, #1023, #1024, #1025, #1026, #1037)
 
 ## v1.2.0: Teams
 


### PR DESCRIPTION
Follow-up to #1042. The initial v1.1.16 entries only covered 2 of roughly 25 PRs already merged since v1.1.15. Also fixes the roadmap entry's chronological position, flagged by cubic's review on #1042.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the v1.1.16 changelog with all changes merged since v1.1.15 (security hardening, Crowdin root fix, Docker hardening, audit/runtime fixes, dependency advisories, CI/fuzz improvements). Fixes the roadmap chronology by placing the v1.1.16 release after v1.1.15.

<sup>Written for commit 68d164eea98356aefdf645629cb4e60e5dc37736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

