### PR TITLE
fix(install): Windows/Git Bash MCP path bug and install.ps1 drift

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,7 +74,7 @@ sh scripts/install.sh
 
 > **Note:** Gemini CLI free tier was discontinued on June 18, 2026 for individual users. The `~/.gemini/GEMINI.md` target still works for paid Google accounts. For free-tier users, [Antigravity CLI](https://antigravity.dev) is the recommended alternative: EGC supports it via `egc install --target antigravity`.
 4. Registers both MCP servers in every detected tool's config file
-5. Asks interactively whether to install the prompt library (63 agents, 229 skills, 76 commands): skipped automatically in CI
+5. Asks interactively whether to install the prompt library (63 agents, 230 skills, 77 commands): skipped automatically in CI
 
 ### Example output
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -6,6 +6,18 @@ $EgcInstall    = Join-Path (Join-Path $RootDir "scripts") "install-apply.js"
 $GuardianBin   = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $RootDir "mcp") "servers") "egc-guardian") "build") "index.js"
 $MemoryBin     = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $RootDir "mcp") "servers") "egc-memory") "build") "index.js"
 
+# npm strips the root package-lock.json from published tarballs, so a globally
+# installed package has no root lockfile (npm already resolved its deps during
+# `npm install -g`). The sub-package lockfiles travel via package.json "files",
+# so run a pinned `npm ci` wherever a lockfile is present and skip otherwise.
+function Install-Deps {
+    if (Test-Path "package-lock.json") {
+        npm ci --silent
+    } else {
+        npm install --silent
+    }
+}
+
 # Forward --help directly to the Node installer
 if ($args -contains '--help') {
     node $EgcInstall @args
@@ -14,11 +26,14 @@ if ($args -contains '--help') {
 
 Write-Host "EGC install"
 
-# Node.js version check
+# Node.js version check. Keep this floor in lockstep with package.json
+# "engines" and scripts/preinstall.js, which both require Node 20; a lower
+# gate here would let 18/19 reach the better-sqlite3 build and the
+# TypeScript build steps below.
 try {
     $nodeVersion = node -e "process.stdout.write(process.versions.node.split('.')[0])"
-    if ([int]$nodeVersion -lt 18) {
-        Write-Error "Node.js >= 18 is required (found: $(node --version))"
+    if ([int]$nodeVersion -lt 20) {
+        Write-Error "Node.js >= 20 is required (found: $(node --version))"
         exit 1
     }
     Write-Host "  node $(node --version)"
@@ -33,7 +48,7 @@ if (-not $DryRun) {
     # Root dependencies
     Write-Host "  installing root dependencies..."
     Set-Location -Path $RootDir
-    npm install --silent
+    Install-Deps
 
     # Verify native modules (better-sqlite3 requires Build Tools on Windows)
     $nativeOk = $true
@@ -60,8 +75,12 @@ if (-not $DryRun) {
         exit 1
     }
     Set-Location -Path $GuardianDir
-    npm install --silent
-    npm run build
+    Install-Deps
+    # The published package ships build/ but not src/, so only (re)build from
+    # a git checkout where the TypeScript sources are present.
+    if (Test-Path "src") {
+        npm run build
+    }
 
     # egc-memory
     Write-Host "  building egc-memory..."
@@ -71,8 +90,11 @@ if (-not $DryRun) {
         exit 1
     }
     Set-Location -Path $MemoryDir
-    npm install --silent
-    npm run build
+    Install-Deps
+    # Published package ships build/ but not src/; only build from a checkout.
+    if (Test-Path "src") {
+        npm run build
+    }
 
     # Initialize database
     Write-Host "  initializing database..."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,12 +9,12 @@ $MemoryBin     = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $RootDir 
 # npm strips the root package-lock.json from published tarballs, so a globally
 # installed package has no root lockfile (npm already resolved its deps during
 # `npm install -g`). The sub-package lockfiles travel via package.json "files",
-# so run a pinned `npm ci` wherever a lockfile is present and skip otherwise.
+# so run a pinned `npm ci` wherever a lockfile is present and skip entirely
+# otherwise -- mirrors install.sh's install_deps exactly, including the lack
+# of an npm install fallback (a global install has already resolved deps).
 function Install-Deps {
     if (Test-Path "package-lock.json") {
         npm ci --silent
-    } else {
-        npm install --silent
     }
 }
 
@@ -184,7 +184,17 @@ if (-not $DryRun) {
         if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
         $obj = @{ mcpServers = @{} }
         if (Test-Path $Target) {
-            try { $obj = Get-Content $Target -Raw | ConvertFrom-Json -AsHashtable } catch {}
+            try {
+                $obj = Get-Content $Target -Raw | ConvertFrom-Json -AsHashtable
+            } catch {
+                # Existing config is not valid JSON: leave it untouched and
+                # skip, matching install.sh's Node helper exactly. Falling
+                # through here would merge the new servers into a fresh empty
+                # hashtable and overwrite the file, destroying whatever the
+                # user already had in it.
+                Write-Host "  - skipped $Label ($Target): existing config is not valid JSON" -ForegroundColor Yellow
+                return
+            }
         }
         if (-not $obj.mcpServers) { $obj.mcpServers = @{} }
         $changed = $false
@@ -253,8 +263,14 @@ if (-not $DryRun) {
         Set-Content -Path $tmpCodexJs -Encoding UTF8 -Value @'
 const fs=require("fs"),path=require("path");
 const[,,t,g,m]=process.argv;
-const ge='\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["'+g+'"]\n';
-const me='\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["'+m+'"]\n';
+// Escape backslashes (Windows paths are the common case here) and double
+// quotes so the path stays a valid TOML basic string; mirrors tomlEscape in
+// scripts/install.sh and scripts/lib/mcp-register.js. Without this, a raw
+// Windows path like C:\Users\x\... corrupts the TOML (\U... reads as an
+// invalid/wrong Unicode escape).
+const tomlEscape=(p)=>p.split("\\").join("\\\\").split('"').join('\\"');
+const ge='\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["'+tomlEscape(g)+'"]\n';
+const me='\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["'+tomlEscape(m)+'"]\n';
 let c=fs.existsSync(t)?fs.readFileSync(t,"utf8"):"";
 let ch=false;
 if(!c.includes("egc-guardian")){c+=ge;ch=true;}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,23 @@ set -e
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+# On Windows via Git Bash/MSYS, $ROOT_DIR is a POSIX-style mount path (e.g.
+# /c/Users/x/EGC) that bash and node-run-from-bash understand, but any path
+# written into an MCP client's config JSON is read by that client's own
+# native Windows node.exe (Claude Desktop, Cursor, etc. are native Windows
+# programs, not Git Bash processes) and cannot resolve the /c/... mount
+# form. `pwd -W` is MSYS's coreutils extension that prints the Windows-
+# native equivalent (C:/Users/x/EGC); use it only for paths destined for a
+# written config, never for bash's own cd/test/node invocations below.
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*)
+    MCP_ROOT_DIR="$(cd "$ROOT_DIR" && pwd -W)"
+    ;;
+  *)
+    MCP_ROOT_DIR="$ROOT_DIR"
+    ;;
+esac
+
 # npm strips the root package-lock.json from published tarballs, so a globally
 # installed package has no root lockfile (npm already resolved its deps during
 # `npm install -g`). The sub-package lockfiles travel via package.json "files",
@@ -121,11 +138,11 @@ cat > "$ROOT_DIR/.mcp.egc.json" <<EOF
   "mcpServers": {
     "egc-guardian": {
       "command": "node",
-      "args": ["$ROOT_DIR/mcp/servers/egc-guardian/build/index.js"]
+      "args": ["$MCP_ROOT_DIR/mcp/servers/egc-guardian/build/index.js"]
     },
     "egc-memory": {
       "command": "node",
-      "args": ["$ROOT_DIR/mcp/servers/egc-memory/build/index.js"]
+      "args": ["$MCP_ROOT_DIR/mcp/servers/egc-memory/build/index.js"]
     }
   }
 }
@@ -184,8 +201,8 @@ fi
 
 # ── MCP auto-registration ─────────────────────────────────────────────────────
 
-GUARDIAN_BIN="$ROOT_DIR/mcp/servers/egc-guardian/build/index.js"
-MEMORY_BIN="$ROOT_DIR/mcp/servers/egc-memory/build/index.js"
+GUARDIAN_BIN="$MCP_ROOT_DIR/mcp/servers/egc-guardian/build/index.js"
+MEMORY_BIN="$MCP_ROOT_DIR/mcp/servers/egc-memory/build/index.js"
 
 register_mcp_json() {
   local target="$1"

--- a/tests/scripts/install-ps1.test.js
+++ b/tests/scripts/install-ps1.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const { execFileSync, spawnSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install.ps1');
+const BASH_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install.sh');
 const PACKAGE_JSON = path.join(__dirname, '..', '..', 'package.json');
 
 function createTempDir(prefix) {
@@ -87,6 +88,43 @@ function runTests() {
   if (test('publishes egc-install through the Node installer runtime for cross-platform npm usage', () => {
     const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
     assert.strictEqual(packageJson.bin['egc-install'], 'scripts/install-apply.js');
+  })) passed++; else failed++;
+
+  const scriptSource = fs.readFileSync(SCRIPT, 'utf8');
+  const bashSource = fs.readFileSync(BASH_SCRIPT, 'utf8');
+
+  // Parity checks, not fixed numbers: install.ps1 has drifted from install.sh
+  // before (stuck on a Node >= 18 floor and a bare npm install with no
+  // lockfile/src guards after install.sh got those fixes). Reading install.sh's
+  // actual current value here means the next drift fails CI on its own,
+  // instead of silently shipping until someone happens to compare the two
+  // files by hand again.
+  if (test('Node version floor matches install.sh, not a stale hardcoded value', () => {
+    const bashFloor = bashSource.match(/NODE_MAJOR"\s*-lt\s*(\d+)/);
+    assert.ok(bashFloor, 'could not read the Node floor out of install.sh');
+    const ps1Floor = scriptSource.match(/nodeVersion\s*-lt\s*(\d+)/);
+    assert.ok(ps1Floor, 'could not read the Node floor out of install.ps1');
+    assert.strictEqual(ps1Floor[1], bashFloor[1], 'install.ps1 Node floor must match install.sh');
+  })) passed++; else failed++;
+
+  if (test('installs dependencies via a lockfile-aware helper, not a bare npm install', () => {
+    assert.ok(scriptSource.includes('function Install-Deps'), 'should define the lockfile-aware helper');
+    assert.ok(scriptSource.includes('Test-Path "package-lock.json"'));
+    assert.ok(scriptSource.includes('npm ci --silent'));
+    // The helper's own fallback branch is the one legitimate "npm install
+    // --silent" in the file; every install site (root, guardian, memory)
+    // must call the helper instead of its own bare npm install.
+    const bareInstallCalls = scriptSource.match(/^\s*npm install --silent\s*$/gm) || [];
+    assert.strictEqual(bareInstallCalls.length, 1, 'only the Install-Deps fallback branch should call npm install --silent directly');
+    const helperCalls = scriptSource.match(/^\s*Install-Deps\s*$/gm) || [];
+    assert.strictEqual(helperCalls.length, 3, 'root, egc-guardian and egc-memory should each call Install-Deps');
+  })) passed++; else failed++;
+
+  if (test('only builds egc-guardian/egc-memory when src/ is present (published tarball has none)', () => {
+    const buildGuards = scriptSource.match(/if \(Test-Path "src"\)/g) || [];
+    assert.strictEqual(buildGuards.length, 2, 'both guardian and memory builds should be guarded');
+    const bashGuards = bashSource.match(/if \[ -d src \]/g) || [];
+    assert.strictEqual(buildGuards.length, bashGuards.length, 'install.ps1 and install.sh should guard the same number of builds');
   })) passed++; else failed++;
 
   if (!powerShellCommand) {

--- a/tests/scripts/install-ps1.test.js
+++ b/tests/scripts/install-ps1.test.js
@@ -107,17 +107,37 @@ function runTests() {
     assert.strictEqual(ps1Floor[1], bashFloor[1], 'install.ps1 Node floor must match install.sh');
   })) passed++; else failed++;
 
-  if (test('installs dependencies via a lockfile-aware helper, not a bare npm install', () => {
+  if (test('installs dependencies via a lockfile-aware helper matching install.sh exactly (no npm install fallback)', () => {
     assert.ok(scriptSource.includes('function Install-Deps'), 'should define the lockfile-aware helper');
     assert.ok(scriptSource.includes('Test-Path "package-lock.json"'));
     assert.ok(scriptSource.includes('npm ci --silent'));
-    // The helper's own fallback branch is the one legitimate "npm install
-    // --silent" in the file; every install site (root, guardian, memory)
-    // must call the helper instead of its own bare npm install.
-    const bareInstallCalls = scriptSource.match(/^\s*npm install --silent\s*$/gm) || [];
-    assert.strictEqual(bareInstallCalls.length, 1, 'only the Install-Deps fallback branch should call npm install --silent directly');
+    // install.sh's install_deps has no else branch: a global install has
+    // already resolved deps, so the no-lockfile case does nothing at all.
+    // A "npm install --silent" fallback here would be a real behavioral
+    // drift from install.sh, not a harmless equivalent.
+    const bareInstallCalls = scriptSource.match(/npm install --silent/g) || [];
+    assert.strictEqual(bareInstallCalls.length, 0, 'install.ps1 must not have any npm install fallback; install.sh has none either');
     const helperCalls = scriptSource.match(/^\s*Install-Deps\s*$/gm) || [];
     assert.strictEqual(helperCalls.length, 3, 'root, egc-guardian and egc-memory should each call Install-Deps');
+  })) passed++; else failed++;
+
+  if (test('skips (never overwrites) an existing MCP config that fails to parse as JSON', () => {
+    // A pre-existing config with invalid JSON must be left untouched: the
+    // default $obj = @{ mcpServers = @{} } falling through to the merge/
+    // write path below would overwrite the user's real config with just
+    // the two new servers, discarding everything else in the file.
+    assert.ok(
+      /catch\s*\{[^}]*is not valid JSON[^}]*return[^}]*\}/s.test(scriptSource),
+      'the ConvertFrom-Json catch block must warn and return, not fall through to a merge/overwrite'
+    );
+  })) passed++; else failed++;
+
+  if (test('escapes backslashes and quotes before writing a path into Codex CLI TOML', () => {
+    // A raw Windows path (C:\Users\x\...) concatenated into a TOML basic
+    // string is corrupted: TOML treats \U as the start of an 8-hex-digit
+    // Unicode escape. Must mirror install.sh's tomlEscape.
+    assert.ok(scriptSource.includes('tomlEscape'), 'Codex CLI TOML writer must escape paths via a tomlEscape helper');
+    assert.ok(scriptSource.includes('tomlEscape(g)') && scriptSource.includes('tomlEscape(m)'), 'both guardian and memory TOML entries must go through tomlEscape');
   })) passed++; else failed++;
 
   if (test('only builds egc-guardian/egc-memory when src/ is present (published tarball has none)', () => {

--- a/tests/scripts/install-sh.test.js
+++ b/tests/scripts/install-sh.test.js
@@ -155,6 +155,38 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('MCP config paths are Windows-native under Git Bash, not the POSIX mount form', () => {
+    const script = fs.readFileSync(SCRIPT, 'utf8');
+
+    // Under Git Bash/MSYS on Windows, $ROOT_DIR is a POSIX mount path
+    // (/c/Users/x/EGC) that bash understands but a native Windows MCP
+    // client's own node.exe (Claude Desktop, Cursor, etc. run outside Git
+    // Bash) cannot resolve. Any path written into an MCP config JSON must
+    // use the Windows-native form (`pwd -W`, MSYS's coreutils extension),
+    // detected via `uname -s` so Linux/macOS keep using $ROOT_DIR unchanged.
+    assert.ok(
+      /MINGW\*\|MSYS\*/.test(script),
+      'install.sh must detect Git Bash/MSYS via uname -s'
+    );
+    assert.ok(
+      /pwd -W/.test(script),
+      'install.sh must compute the Windows-native root via pwd -W on Git Bash'
+    );
+    assert.ok(
+      script.includes('GUARDIAN_BIN="$MCP_ROOT_DIR'),
+      'GUARDIAN_BIN must use the Windows-native root, not the POSIX $ROOT_DIR'
+    );
+    assert.ok(
+      script.includes('MEMORY_BIN="$MCP_ROOT_DIR'),
+      'MEMORY_BIN must use the Windows-native root, not the POSIX $ROOT_DIR'
+    );
+    assert.ok(
+      script.includes('"$MCP_ROOT_DIR/mcp/servers/egc-guardian/build/index.js"]') &&
+      script.includes('"$MCP_ROOT_DIR/mcp/servers/egc-memory/build/index.js"]'),
+      '.mcp.egc.json must write the Windows-native root, not the POSIX $ROOT_DIR'
+    );
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What

Two real cross-platform install bugs, both flagged in prior audits but never fixed:

1. **install.sh writes a Windows-unreadable path into MCP client configs.** Under Git Bash/MSYS, `$ROOT_DIR` is a POSIX mount path (`/c/Users/x/EGC`) that bash understands but the MCP client's own native Windows `node.exe` (Claude Desktop, Cursor, etc. are native Windows programs) cannot resolve, so MCP registration silently fails on Windows. Now detects Git Bash/MSYS via `uname -s` and uses `pwd -W` (Windows-native path) for anything written into a config.
2. **install.ps1 drifted from install.sh**: Node floor stuck at >=18 (should be >=20), no lockfile-aware install (bare `npm install` instead of `npm ci` when a lockfile exists), and `npm run build` not guarded by a `src/` check (breaks on the published npm package, which ships `build/` but not `src/`).

## Why this keeps happening

install.ps1's test suite only ran against a hardcoded expectation, so it couldn't catch drift from install.sh. Rewrote the relevant assertions to read install.sh's actual current values (Node floor, src/ guard count) and compare, so the next drift fails CI instead of shipping silently.

## Also

- `docs/installation.md` had a stale prompt-library count (229/76 instead of the real 230/77).

## Test plan

- [x] `node tests/scripts/install-sh.test.js` (5/5 pass, including new Windows-path case)
- [x] `node tests/scripts/install-ps1.test.js` (4/4 pass; PowerShell-execution cases still skip locally, no pwsh on this machine, but will run for real on windows-latest CI)
- [x] `node tests/run-all.js` (2937/2937 pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows/Git Bash MCP path resolution and tightens the PowerShell installer to prevent broken registrations and bad config writes. Adds TOML path escaping and protects existing configs from accidental overwrite.

- **Bug Fixes**
  - Windows/Git Bash: detect `MINGW/MSYS` and write Windows-native paths via `pwd -W` into MCP configs; use `MCP_ROOT_DIR` for `.mcp.egc.json`, `GUARDIAN_BIN`, and `MEMORY_BIN`.
  - PowerShell parity and safety: require Node >= 20; install deps via `Install-Deps` (uses `npm ci` when a lockfile exists, no `npm install` fallback); build only when `src/` exists; skip and warn on invalid JSON MCP configs (do not overwrite); escape backslashes and quotes when writing Codex CLI TOML paths.
  - Docs: update prompt library counts to 230 skills and 77 commands.

- **Refactors**
  - Tests now cross-check `install.ps1` against `install.sh` (Node floor, lockfile helper with no fallback, build guards) and verify the Windows-native path fix, invalid-JSON skip, and TOML escaping to prevent future drift.

<sup>Written for commit e2f15b0ec633063c29972a50a21f499d2fac0ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

