### PR TITLE
release: v1.1.17

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "egc",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "source": {
         "source": "local",
         "path": "../.."

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Battle-tested Codex workflows \u2014 230 shared EGC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
   "author": {
     "name": "Felipe Marzochi",

--- a/.gemini-plugin/marketplace.json
+++ b/.gemini-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "egc",
       "source": "./",
       "description": "EGC - Extended Global Context: 63 agents, 230 skills, 77 commands, persistent memory across sessions, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "author": {
         "name": "Felipe Marzochi",
         "email": "fmarzochi@gmail.com"

--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "EGC - Extended Global Context: persistent memory and shared context for AI coding tools. 63 agents, 230 skills, 77 commands, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {
     "name": "Felipe Marzochi",

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "egc-universal",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "egc-universal",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.4.3",

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egc-universal",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Extended Global Context (EGC) plugin for OpenCode - agents, commands, hooks, and skills",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -513,7 +513,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
      */
     "shell.env": async () => {
       const env: Record<string, string> = {
-        EGC_VERSION: "1.1.16",
+        EGC_VERSION: "1.1.17",
         EGC_PLUGIN: "true",
         EGC_HOOK_PROFILE: currentProfile,
         EGC_DISABLED_HOOKS: process.env.EGC_DISABLED_HOOKS || "",
@@ -567,7 +567,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
       const contextBlock = [
         "# EGC Context (preserve across compaction)",
         "",
-        "## Active Plugin: EGC - Extended Global Context v1.1.16",
+        "## Active Plugin: EGC - Extended Global Context v1.1.17",
         "- Hooks: file.edited, tool.execute.before/after, session.created/idle/deleted, shell.env, compacting, permission.ask",
         "- Tools: run-tests, check-coverage, security-audit, format-code, lint-check, git-summary, changed-files",
         "- Agents: 13 specialized (planner, architect, tdd-guide, code-reviewer, security-reviewer, build-error-resolver, e2e-runner, refactor-cleaner, doc-updater, go-reviewer, go-build-resolver, database-reviewer, python-reviewer)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to EGC are documented here.
 
+## [1.1.17] - 2026-07-27
+
+### Bug Fixes
+
+- **Windows install fixed at the actual root cause**: `install.sh` wrote MCP server paths in the POSIX form Git Bash exposes (`/c/Users/...`), which native Windows MCP clients such as Claude Desktop and Cursor cannot resolve. `install.sh` now detects `MINGW*`/`MSYS*` via `uname -s` and rewrites those paths through `pwd -W` before they reach the MCP config JSON, closing the item left open since the 2026-07-25 install audit and the real reason the project's "one script, one install" design was not holding on Windows (#1045).
+- **`install.ps1` brought back in line with `install.sh`** after drifting silently for weeks: the Node version floor was still 18 instead of 20; dependency installs had no lockfile-aware path (`npm ci` when a lockfile is present, nothing otherwise, exactly matching `install.sh`); an existing MCP config that failed to parse as JSON was silently overwritten instead of left untouched, which could have discarded a user's real configuration; Codex CLI TOML paths were not escaped, so a raw Windows backslash path could corrupt the TOML file through an accidental `\U` Unicode escape; and the guardian/memory builds were not guarded behind a `src/` check for the published tarball (#1045).
+- Installation guide skill/command counts corrected to 230 skills and 77 commands (#1045).
+
 ## [1.1.16] - 2026-07-26
 
 ### Security

--- a/agent.yaml
+++ b/agent.yaml
@@ -1,6 +1,6 @@
 spec_version: "0.1.0"
 name: egc
-version: 1.1.16
+version: 1.1.17
 description: "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools. Desenvolvido por Felipe Marzochi. @MarzochiFelipe. https://github.com/Fmarzochi/EGC"
 author: fmarzochi
 license: Apache-2.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,6 +132,11 @@ Closes the commit-privacy scope started in v1.1.12:
 - CodeRabbit reviews contributor PRs automatically, retiring the manual first-time-contributor gate workflows (#997)
 - CLI, catalog indexer, and Windows install/hook fixes rounding out the squad audit cleanup (#1014, #1015, #1017, #1021, #1022, #1023, #1024, #1025, #1026, #1037)
 
+## v1.1.17: Cross-Platform Install Fixed at the Root (Released 2026-07-27)
+
+- `install.sh` no longer writes unusable POSIX Git Bash paths into MCP config JSON on Windows: `MINGW*`/`MSYS*` is detected via `uname -s` and paths are rewritten through `pwd -W` first (#1045)
+- `install.ps1` resynced with `install.sh` after drifting for several releases: Node floor raised to 20, lockfile-aware dependency install with no fallback, a malformed existing MCP config is left untouched instead of being overwritten, Codex CLI TOML paths are escaped, and builds are guarded behind a `src/` check (#1045)
+
 ## v1.2.0: Teams
 
 Multi-developer workflows and shared context:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egchq/egc",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "EGC is a local-first MCP runtime that gives every AI agent the same brain: persistent shared memory, security guardrails, and up to 90% token savings across 23 AI coding tools.",
   "author": "Felipe Marzochi <fmarzochi@gmail.com> (https://github.com/Fmarzochi)",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Bump version 1.1.16 -> 1.1.17 across all manifests (`scripts/release.sh 1.1.17`)
- CHANGELOG.md and docs/ROADMAP.md entries for this release, included in this PR from the start (not as a follow-up)

## What shipped in this version

This release contains a single piece of work: #1045, the actual root-cause fix for the Windows/cross-platform install problems reported after v1.1.16.

- `install.sh`: Git Bash/MSYS wrote POSIX-style paths (`/c/Users/...`) into the MCP config JSON, which native Windows MCP clients cannot read. Now detected via `uname -s` and rewritten through `pwd -W`.
- `install.ps1`: resynced with `install.sh` after drifting silently -- Node floor, lockfile-aware dependency install, a data-loss bug where a malformed existing MCP config was silently overwritten, Codex TOML path escaping, and a `src/`-guard on builds.
- `docs/installation.md`: stale skill/command counts corrected.

## Test plan

- [x] PR #1045 CI green on all 32 checks, including the full Windows matrix (windows-latest x Node 20/22 x npm/yarn/bun) -- the first real PowerShell execution of the `install.ps1` fixes
- [x] `scripts/release.sh 1.1.17` version-sync tests: 40/40 passed
- [x] CHANGELOG.md and ROADMAP.md cross-checked against `git log v1.1.16..main` so this release's docs match what actually shipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.1.17 fixes Windows installs by converting Git Bash paths to native Windows and syncs `install.ps1` with `install.sh`. Versions are bumped across packages and docs are updated for this release.

- **Bug Fixes**
  - Windows: `install.sh` detects `MINGW*`/`MSYS*` via `uname -s` and rewrites POSIX paths using `pwd -W` before writing MCP config JSON.
  - PowerShell: `install.ps1` aligned with `install.sh`—Node >= 20, lockfile-aware installs (`npm ci` when present), malformed MCP config left untouched, TOML paths escaped, and builds guarded behind `src/`.
  - Docs: installation counts corrected to 230 skills and 77 commands.

- **Dependencies**
  - Bumped versions to `1.1.17` across `@egchq/egc`, `.codex-plugin`, `.gemini-plugin`, `.opencode`, and `agent.yaml`. Updated `CHANGELOG.md` and `docs/ROADMAP.md`.

<sup>Written for commit c10ceccfe669c608ff9405136c1633b3a887fe42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

