### PR TITLE
docs(spec): fix stale compatibility commitment (7 -> 24 stable targets)

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -57,7 +57,7 @@ This section is deliberately public. Honest gap-tracking beats aspirational omis
 
 ## Compatibility commitments
 
-- The 7 `SUPPORTED_INSTALL_TARGETS` identifiers (`egc`, `cursor`, `antigravity`, `codex`, `gemini`, `opencode`, `codebuddy`) are stable. They will not be renamed within `0.x`
+- All 24 `SUPPORTED_INSTALL_TARGETS` identifiers (`egc`, `claude`, `cursor`, `antigravity`, `codex`, `gemini`, `qwen`, `opencode`, `codebuddy`, `windsurf`, `amp`, `copilot`, `zed`, `continue`, `kiro`, `trae`, `junie`, `goose`, `amazonq`, `roocode`, `openhands`, `aider`, `cline`, `warp`) are stable. They will not be renamed within `0.x`
 - The Tier 2 install entry points (`.kiro/install.sh`, `.trae/install.sh`) are stable within `0.x`
 - The Tier 3 protocol injection target paths (`~/.claude/CLAUDE.md` for Claude Code) are stable within `0.x`
 - JSON Schema field names are stable within `MINOR` versions. Removals require a `MAJOR` bump


### PR DESCRIPTION
## Summary

- \`docs/spec/README.md\` claimed only 7 \`SUPPORTED_INSTALL_TARGETS\` identifiers were stable (\`egc\`, \`cursor\`, \`antigravity\`, \`codex\`, \`gemini\`, \`opencode\`, \`codebuddy\`), omitting \`claude\` and 17 other targets added since.
- Verified against the actual array in \`scripts/lib/install-manifests.js\`: 24 entries total. There is no plausible reason \`claude\` (Claude Code) would be excluded from the stability commitment while \`cursor\` is included -- this was stale, not a deliberate narrower scope.
- Updated the line to list all 24 current identifiers.

Found during a full spec-accuracy sweep (\`docs/spec/integration-tiers.md\` and \`docs/spec/agent-memory-interchange.md\` were both verified accurate against source; no changes needed there).

## Test plan

- [x] Cross-checked \`SUPPORTED_INSTALL_TARGETS\` in \`scripts/lib/install-manifests.js\` directly
- [x] Doc-only change, no code paths affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stale docs: `docs/spec/README.md` now states all 24 `SUPPORTED_INSTALL_TARGETS` are stable (was 7), matching `scripts/lib/install-manifests.js`.
Doc-only change; no code impact.

<sup>Written for commit c532626055b2e40a8224ba231d3f1b15b3b9f66d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

