### PR TITLE
docs(security): refresh THREAT-MODEL and SECURITY-ASSESSMENT through v1.1.16

### DIFF
--- a/docs/security/SECURITY-ASSESSMENT.md
+++ b/docs/security/SECURITY-ASSESSMENT.md
@@ -17,6 +17,7 @@ This assessment covers the EGC runtime and its primary components:
 | AI tool sockets | MCP servers communicate with AI tools via stdio or named sockets. No network exposure. |
 | External dependencies | npm packages. Pinned via `package-lock.json`, audited via Dependabot. |
 | GitHub Actions | CI/CD runs in ephemeral sandboxes with minimal permissions. |
+| Git history | State files carry distilled project decisions; they must never reach a public commit. Enforced by a git clean filter, a pre-commit hook, and a CI tree guard (v1.1.12-v1.1.13). |
 
 ## Threat Identification
 
@@ -24,31 +25,44 @@ This assessment covers the EGC runtime and its primary components:
 
 | Threat | Mitigation |
 |--------|-----------|
-| Malicious dependency supply chain | Pinned dependencies via package-lock.json; Dependabot alerts; npm audit in CI |
-| Command injection via MCP inputs | `egc-guardian` validates all tool calls via `validate_command` before execution |
-| Credential leakage in session logs | Session transcript sanitization removes sensitive env vars from log output |
+| Malicious dependency supply chain | Pinned dependencies via package-lock.json; Dependabot alerts; `dependency-review.yml` blocks high-severity additions; `npm audit` in CI |
+| Command injection via MCP inputs | `egc-guardian` validates all tool calls via `validate_command` before execution; `execSync` replaced with `spawnSync` plus argv tokenization, removing a shell-injection surface (v1.1.8, #690) |
+| Destructive CLI commands executed by the AI | `docker system prune`, `docker rm/rmi`, `docker run --privileged` or host mounts, `gh repo delete`, `gh api -X DELETE`, and `prisma migrate reset` / `--force-reset` / `db execute` return a hard DANGEROUS verdict instead of an advisory warning (v1.1.16, #1041). An absolute-path bypass (`/bin/rm`, `/usr/bin/mv`) was closed the same release (#1012). |
+| Validator itself failing silently | The bash hook dispatcher used to fail open on its own internal errors, silently disabling every guard (Guardian validate, GateGuard) for that command. It now fails closed instead (v1.1.16, #1019), the most critical finding of that release's security audit. |
+| Credential leakage in session logs | Session transcript sanitization removes sensitive env vars from log output; `egc-guardian` blocks writes to the specific credential files each AI tool stores rather than whole config directories (v1.1.8, #691, replacing an earlier whole-directory block that broke legitimate functionality without adding real security) |
 
 ### Medium Likelihood / Medium Impact
 
 | Threat | Mitigation |
 |--------|-----------|
 | Unauthorized filesystem access | MCP server runs in user context; no privilege escalation |
-| State file tampering | State files at `~/.egc/` are plain text; no security-sensitive data stored |
-| Prompt injection via transcript | AI tool is responsible for prompt handling; EGC provides raw session data only |
+| State file tampering or theft | State files under `~/.egc/state/` are encrypted at rest with AES-256-GCM (v1.1.6, #627) and carry a per-file HMAC-SHA256 integrity check that `get_state` verifies on read (v1.1.6, #625). They are not plain text and do contain security-sensitive project context, which is why encryption was added. |
+| Project memory leaking into a public commit | Enforced in three independent layers: a git clean filter configured by `egc init` that stages a zeroed blob even when hooks are bypassed (v1.1.13, #863), a tracked pre-commit hook, and a CI tree guard (v1.1.12, #856) |
+| Prompt injection via transcript | AI tool is responsible for prompt handling; EGC provides raw session data only. `session_events` payloads from other sessions on the session bus are explicitly documented as untrusted data, never instructions to execute blindly. |
+| TOCTOU races on files shared by concurrent EGC processes | Encryption key generation is now atomic (write-to-temp plus `fs.linkSync`), closing a race where a second process starting concurrently could read a partially-written key or silently generate a discarded one (v1.1.9, #696). A concurrent-access regression test is now a contribution requirement for any change touching a shared file under `~/.egc/` (v1.1.9, #697). |
+| `auto_learn` writing outside the project sandbox | `target_file` is validated against protected paths and must stay inside the project root (v1.1.16, #1009); `project_path` is resolved with `realpathSync` and checked before use (v1.1.8, #690) |
+| Guardian command-validator argument-parsing bypasses | Closed in v1.1.14 (#882); `core.hooksPath` no-verify bypass matched case-insensitively (v1.1.16, #1013) |
 
 ### Low Likelihood
 
 | Threat | Mitigation |
 |--------|-----------|
 | Denial of service via large transcript | 1MB stdin cap in session hooks |
+| Denial of service via oversized dashboard event payload | `POST /event` body capped at 256 KB (v1.1.6, #551) |
+| Denial of service via request flooding | `egc-guardian` scoped rate limiter per project path (v1.1.6, #544) |
+| Path traversal in dashboard static file server | Guard against `../` traversal (v1.1.6, #537) |
 | Malformed JSON crashing hook | Try/catch in all JSONL parsers; graceful exit on error |
+| CI/CD injection via untrusted PR content | `republish.yml`'s version input is validated instead of interpolated directly into a shell command (v1.1.16, #1027) |
+| Secrets leaking through provider SDK error messages | Redacted in mapped SDK errors, including Google API keys (v1.1.14, #883) |
+| Container escape / build-toolchain exposure in the shipped Docker image | Non-root user via multi-stage build; `.dockerignore` keeps `.git`, `.env`, and `node_modules` out of the build context (v1.1.16, #1036, #1028) |
 
 ## Known Limitations
 
 - EGC is a local-only tool; it has no server component, no authentication, and no network services.
 - The security posture depends on the security of the host machine and the AI tool integrations.
 - Prompt injection from external content (e.g., malicious files read by the AI) is an AI-tool-level concern, not addressable at the EGC layer.
+- Guardian validation depends on the harness actually invoking the registered hooks; a harness that does not support hook wiring (several Tier 1 discoverability-only adapters, e.g. Goose, OpenHands, Amazon Q, Roo Code, Qwen Code) gets memory and skills but not command-level enforcement.
 
 ## Assessment Date
 
-2026-06-04
+2026-06-04 (initial). Updated 2026-07-27 to reflect security work through v1.1.16: destructive-CLI hard blocks, the dispatcher fail-open-to-fail-closed fix, commit-privacy enforcement, state encryption and integrity, and the TOCTOU/concurrent-access fixes. This is a mitigation-tracking update against the same threat categories, not a new independent audit; a fresh third-party review remains a v2.0.0 goal (see `docs/spec/README.md`).

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -8,6 +8,7 @@ EGC is a local-first AI memory and orchestration runtime. It has no network serv
 2. The MCP servers running as local stdio processes
 3. The GitHub Actions CI/CD pipeline
 4. Session hooks that process transcript data
+5. The 23 supported AI harnesses' own config/instruction files, which EGC writes to (see `docs/spec/integration-tiers.md`)
 
 ## Actors
 
@@ -19,6 +20,7 @@ EGC is a local-first AI memory and orchestration runtime. It has no network serv
 | AI tool (Claude Code, etc.) | Trusted at runtime | Calls MCP tools; runs in same user context |
 | GitHub Actions runner | Trusted | Ephemeral sandboxed environment |
 | PR author (fork) | Untrusted | Code from forks does not access secrets |
+| Peer session on the session bus | Partially trusted | Can send events to other live sessions on the same project; payloads are treated as untrusted data by the receiver, never executed as instructions |
 
 ## Attack Surfaces and Mitigations
 
@@ -27,30 +29,45 @@ EGC is a local-first AI memory and orchestration runtime. It has no network serv
 **Threat:** A malicious or compromised npm package is introduced.
 
 **Mitigations:**
-- All dependencies are locked via `package-lock.json`
+- All dependencies are locked via `package-lock.json`, across the root and both MCP server subpackages
 - Dependabot monitors for vulnerability alerts
 - `dependency-review.yml` blocks PRs that introduce high-severity dependencies
 - CI runs `npm audit` on every push
+- OpenSSF Scorecard tracked publicly; pinned-dependency and branch-protection findings are treated as real work items, not just a badge (e.g. the `npm ci` / install-script finding that shaped #986)
 
-### 2. Command Injection via MCP Inputs
+### 2. Command Injection and Destructive Commands via MCP Inputs
 
-**Threat:** A malicious AI-generated MCP call attempts to execute arbitrary shell commands.
+**Threat:** A malicious or simply mistaken AI-generated tool call attempts to execute arbitrary or destructive shell commands.
 
 **Mitigations:**
 - `egc-guardian` validates all tool calls before execution via `validate_command`
-- Shell commands are constructed from whitelisted patterns, not raw string interpolation
+- Shell commands are constructed from whitelisted patterns, not raw string interpolation; `execSync` was replaced with `spawnSync` plus argv tokenization (v1.1.8, #690)
 - The guardian returns a block decision before any dangerous command runs
+- Destructive docker/gh/prisma variants (`docker system prune`, `docker rm/rmi`, `docker run --privileged` or host mounts, `gh repo delete`, `gh api -X DELETE`, `prisma migrate reset`/`--force-reset`/`db execute`) return a hard DANGEROUS verdict instead of an advisory warning (v1.1.16, #1041)
+- An absolute-path bypass (`/bin/rm`, `/usr/bin/mv` slipping through as an allowlist miss) was closed in the same release (#1012)
+- The bash hook dispatcher fails closed on its own internal errors instead of silently disabling every guard for that command, the most critical finding of the v1.1.16 security audit (#1019)
 
-### 3. Credential Leakage in Logs
+### 3. Credential Leakage in Logs and Writes
 
-**Threat:** Sensitive values (API keys, session tokens) appear in session transcript files.
+**Threat:** Sensitive values (API keys, session tokens) appear in session transcript files, or the AI writes to a credential file directly.
 
 **Mitigations:**
 - Session hook sanitizes transcript content before writing to disk
 - Environment variable names (`GEMINI_TRANSCRIPT_PATH`, `EGC_SESSION_ID`) are replaced with placeholders in log output
-- State files at `~/.egc/state/` contain only structured metadata, not raw transcripts
+- State files at `~/.egc/state/` contain only structured metadata, not raw transcripts, and are themselves encrypted at rest (AES-256-GCM, v1.1.6, #627) with an HMAC-SHA256 integrity check (#625)
+- `egc-guardian` blocks writes to the specific credential files each AI tool stores (OAuth tokens, session files, API keys) rather than whole config directories, a change made after the previous whole-directory block was found to break legitimate functionality without adding real security (v1.1.8, #691)
+- Secrets are redacted in mapped provider SDK errors, including Google API keys (v1.1.14, #883)
 
-### 4. CI/CD Pipeline Compromise
+### 4. Project Memory Leaking into Version Control
+
+**Threat:** The populated propagation files EGC writes to every AI tool's instruction file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Cursor rules, etc.) get committed with real project decisions in them.
+
+**Mitigations:**
+- A git clean filter, configured locally by `egc init`, stages a zeroed blob for the propagation files even when local hooks are bypassed (v1.1.13, #863)
+- A tracked pre-commit hook and a CI tree guard provide two independent layers on top of the filter (v1.1.12, #856)
+- The public baseline of every propagation file ships zeroed; the working tree keeps the populated memory locally only
+
+### 5. CI/CD Pipeline Compromise
 
 **Threat:** A malicious PR triggers a workflow that accesses secrets or modifies the release.
 
@@ -60,8 +77,9 @@ EGC is a local-first AI memory and orchestration runtime. It has no network serv
 - Workflows use minimal permissions (`permissions: contents: read` by default)
 - Release workflow only triggers on version tags pushed by the maintainer
 - All third-party actions are pinned to specific commit SHAs
+- CodeRabbit reviews contributor PRs automatically and skips the maintainer's own, retiring the older manual first-time-contributor gate workflows (v1.1.16, #997)
 
-### 5. Untrusted Input in CI Pipelines
+### 6. Untrusted Input in CI Pipelines
 
 **Threat:** Branch names, commit messages, or PR metadata are interpolated unsafely in shell commands.
 
@@ -69,20 +87,40 @@ EGC is a local-first AI memory and orchestration runtime. It has no network serv
 - All GitHub context variables that are used in `run:` steps are passed through `env:` and not directly interpolated in shell strings
 - The release workflow validates the tag format with a regex before using it
 - `workflow_dispatch` does not accept external user inputs
+- `republish.yml`'s version input is validated instead of interpolated directly into a shell command (v1.1.16, #1027)
+
+### 7. Concurrent-Process Races on Shared Local State
+
+**Threat:** Two EGC processes (e.g. two parallel AI sessions) read or write the same file under `~/.egc/` at the same time, producing a corrupted key, a lost write, or a silently discarded value.
+
+**Mitigations:**
+- Encryption key publication is atomic (write-to-temp plus `fs.linkSync`), closing a TOCTOU race where a racing reader used to be able to see a partial write or generate its own discarded key (v1.1.9, #696)
+- Multi-session SQLite write arbitration hardened with equal jitter and deeper retries (v1.1.12, #853)
+- The session bus uses fail-fast cooperative locks (`claim_path`/`release_path`): a refused claim means another live session holds it, and the caller is expected to coordinate rather than retry in a loop
+- Any change touching a file shared across concurrent EGC processes now requires a concurrent-access regression test before merge, a contribution requirement added directly because of the encryption-key race above (v1.1.9, #697)
+
+### 8. Container Image Attack Surface
+
+**Threat:** The published Docker image ships a larger attack surface than necessary (build toolchain, root user, extraneous files).
+
+**Mitigations:**
+- Images run as a non-root user via a multi-stage build that keeps the build toolchain out of the final image (v1.1.16, #1036)
+- `.dockerignore` keeps `.git`, `.env`, and `node_modules` out of the build context (v1.1.16, #1028)
 
 ## Critical Code Paths
 
 | Path | Risk | Protection |
 |------|------|-----------|
-| `scripts/egc-guardian/src/validate_command.ts` | High: gates all shell execution | Reviewed on every change; blocked by branch protection |
-| `install.sh` / `install.ps1` | Medium: modifies global AI tool configs | Verified in CI across Linux, macOS, Windows |
+| `mcp/servers/egc-guardian/src/validator.ts` | High: gates all shell execution and file writes | Reviewed on every change; blocked by branch protection; the destructive-CLI test suite alone is 64 cases |
+| `mcp/servers/egc-guardian/src/index.ts` (bash hook dispatcher entry) | High: an error here used to fail open for every guard | Fails closed since v1.1.16 (#1019); regression-tested |
+| `install.sh` / `install.ps1` | Medium: modifies global AI tool configs across 23 harnesses | Verified in CI across Linux, macOS, Windows (full matrix: Node 20/22 x npm/yarn/bun) |
 | `scripts/hooks/session-end.js` | Medium: reads transcript, writes to disk | Bounded stdin (1MB cap); structured error handling |
-| `mcp/servers/egc-memory/` | Low: reads/writes state files only | No shell execution; pure file I/O |
+| `mcp/servers/egc-memory/src/index.ts` | Medium: reads/writes encrypted state files, arbitrates concurrent writes | No shell execution; pure file I/O; concurrent-access regression tests required by policy |
 
 ## Residual Risk
 
-EGC is a developer tool that runs with full local-user permissions by design. A compromised host machine, compromised AI tool, or compromised npm package could affect EGC. These risks are outside EGC's control and mitigated by the host environment.
+EGC is a developer tool that runs with full local-user permissions by design. A compromised host machine, compromised AI tool, or compromised npm package could affect EGC. These risks are outside EGC's control and mitigated by the host environment. A harness that does not support hook wiring (several Tier 1 discoverability-only adapters: Goose, OpenHands, Amazon Q, Roo Code, Qwen Code) receives memory and skills but not command-level Guardian enforcement, since there is no hook API to attach to.
 
 ## Review Date
 
-2026-06-04: Felipe Marzochi
+2026-06-04: Felipe Marzochi (initial). 2026-07-27: updated to reflect the security work shipped in v1.1.8 through v1.1.16 (destructive-CLI hard blocks, fail-closed dispatcher, commit-privacy enforcement, encryption/integrity, concurrent-access hardening). A fresh independent third-party review remains a v2.0.0 goal (see `docs/spec/README.md`).


### PR DESCRIPTION
## Summary

Both formal security documents were dated 2026-06-04, which predates almost all of the project's actual security work (v1.1.0 shipped 2026-06-13, nine days later). Neither mentioned:

- Destructive-CLI hard blocks (#1041), the absolute-path bypass fix (#1012)
- The dispatcher fail-open -> fail-closed fix (#1019), the most critical finding of the v1.1.16 security audit
- Commit-privacy enforcement across three layers (#856, #863)
- State encryption (AES-256-GCM, #627) and integrity checks (HMAC-SHA256, #625) -- SECURITY-ASSESSMENT.md's "State file tampering" row actively claimed state files were "plain text; no security-sensitive data stored", which is no longer true
- The encryption-key TOCTOU fix and the resulting concurrent-access-test contribution requirement (#696, #697)
- `auto_learn` write-target validation (#1009), `core.hooksPath` bypass fix (#1013), `republish.yml` injection fix (#1027), Docker hardening (#1036, #1028), Guardian argument-parsing bypass fixes (#882)

Also fixed a wrong path in both documents' "Critical Code Paths" table: `scripts/egc-guardian/src/validate_command.ts` does not exist. The actual file is `mcp/servers/egc-guardian/src/validator.ts` (verified via `ls`), with `index.ts` as the MCP entry point that imports and dispatches to it.

Both documents keep their original section structure. New threat/mitigation rows are added where the existing category fit (e.g. "State file tampering" corrected in place); two new categories were added where nothing existing covered them (project-memory-into-git, container image attack surface).

This mirrors the same audit already applied to the GitHub Wiki's Security page in a prior commit today.

## Test plan

- [x] Every new claim traced to a real PR number in CHANGELOG.md before writing it (v1.1.0 through v1.1.17 read in full)
- [x] The "64 test cases" claim for the destructive-CLI suite verified directly: `grep -c "^run(" tests/egc-guardian-destructive-cli.test.js` = 64
- [x] The corrected file path verified via `ls mcp/servers/egc-guardian/src/` and `grep` for the `validateCommand` import in `index.ts`
- [x] Doc-only change, no code paths affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `THREAT-MODEL.md` and `SECURITY-ASSESSMENT.md` to reflect work through v1.1.16, adding key mitigations and fixing critical path references. Documents destructive-CLI blocks, fail-closed dispatcher, state encryption/integrity, commit-privacy guards, and concurrency fixes.

- **Updates**
  - Destructive command blocks (docker/gh/prisma) and absolute-path bypass closed; dispatcher now fails closed.
  - State encryption (AES-256-GCM) + HMAC integrity; commit-privacy enforced via clean filter, pre-commit hook, and CI guard.
  - TOCTOU/concurrent-access fixes for shared state; regression tests now required for shared files.
  - Validator bypass fixes and write-target checks (`auto_learn` protected paths, `core.hooksPath` case-insensitive).
  - CI/Docker hardening: dependency review, input validation (`republish.yml`), non-root multi-stage image, `.dockerignore`; size/rate caps and traversal guard; secrets redaction in SDK errors.
  - Corrects critical path to `mcp/servers/egc-guardian/src/validator.ts` (and `index.ts` entry); dates updated. Doc-only change.

<sup>Written for commit 05525d2f5c503dd633337e861303be018b8cf5d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

