### PR TITLE
fix(guardian): close 9 real bypasses found by PR review, cover all CLIs

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -248,9 +248,20 @@ function unwrapLeadingConstructs(tokens: string[]): UnwrapResult {
     // does (the shell keeps it in the environment for every command that
     // follows in this session/segment chain, not just the current one), so
     // it gets the identical dangerous-name check rather than being treated
-    // as an unknown, advisory-only 'export' command.
+    // as an unknown, advisory-only 'export' command. `export` accepts its
+    // own options (-f, -n, -p) and a `--` end-of-options marker before the
+    // assignment, same as any other bash builtin — skipping straight to
+    // current[1] missed `export -- GIT_SSH_COMMAND=...`, which real bash
+    // still treats as an assignment despite the leading `--`.
     if (head === 'export' && current.length > 1) {
-      const exportMatch = ENV_ASSIGNMENT_RE.exec(current[1]);
+      let idx = 1;
+      while (idx < current.length) {
+        const flagToken = stripQuotes(current[idx]);
+        if (flagToken === '--') { idx += 1; break; }
+        if (!flagToken.startsWith('-')) break;
+        idx += 1;
+      }
+      const exportMatch = idx < current.length ? ENV_ASSIGNMENT_RE.exec(current[idx]) : null;
       if (exportMatch) {
         if (isDangerousEnvVarName(exportMatch[1])) {
           return {
@@ -262,7 +273,7 @@ function unwrapLeadingConstructs(tokens: string[]): UnwrapResult {
             },
           };
         }
-        current = current.slice(2);
+        current = current.slice(idx + 1);
         changed = true;
         continue;
       }

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -80,7 +80,7 @@ function bareToken(a: string): string {
 // silently consuming (or failing to consume) the wrong number of tokens and
 // misidentifying the real wrapped command.
 function stripQuotes(a: string): string {
-  return a.replace(/\\/g, '').replace(/["']/g, '');
+  return a.replaceAll('\\', '').replaceAll(/["']/g, '');
 }
 
 function positionalsOf(tokens: string[]): string[] {

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -72,6 +72,17 @@ function bareToken(a: string): string {
   return a.replace(/\\/g, '').replace(/["']/g, '').toLowerCase();
 }
 
+// Same quote/backslash stripping as bareToken(), but case-preserving. Used
+// wherever a flag's exact letter case is part of its identity (e.g. a
+// wrapper's -e vs -E are two different flags with different arities) —
+// lowercasing before the membership check would make an unrecognized
+// uppercase flag collide with an unrelated lowercase entry in valueFlags,
+// silently consuming (or failing to consume) the wrong number of tokens and
+// misidentifying the real wrapped command.
+function stripQuotes(a: string): string {
+  return a.replace(/\\/g, '').replace(/["']/g, '');
+}
+
 function positionalsOf(tokens: string[]): string[] {
   return tokens.filter(t => t.length > 0 && !t.startsWith('-'));
 }
@@ -232,11 +243,57 @@ function unwrapLeadingConstructs(tokens: string[]): UnwrapResult {
     }
 
     const head = bareToken(first);
+
+    // `export VAR=value` persists the same way a bare `VAR=value` prefix
+    // does (the shell keeps it in the environment for every command that
+    // follows in this session/segment chain, not just the current one), so
+    // it gets the identical dangerous-name check rather than being treated
+    // as an unknown, advisory-only 'export' command.
+    if (head === 'export' && current.length > 1) {
+      const exportMatch = ENV_ASSIGNMENT_RE.exec(current[1]);
+      if (exportMatch) {
+        if (isDangerousEnvVarName(exportMatch[1])) {
+          return {
+            tokens: [],
+            blocked: {
+              allowed: false,
+              reason: `exporting '${exportMatch[1]}' persists a git execution/config override and is forbidden`,
+              trust_level: 'DANGEROUS',
+            },
+          };
+        }
+        current = current.slice(2);
+        changed = true;
+        continue;
+      }
+    }
+
     const spec = WRAPPER_SPECS[head];
     if (spec) {
+      // env -S/--split-string re-splits its value into a new argv and execs
+      // the first word of that split — the same "string becomes code" shape
+      // as eval, just via env(1) instead of a shell builtin. The value isn't
+      // a simple opaque flag argument to skip past; it can itself be a full
+      // destructive command, so this is a hard deny rather than an unwrap.
+      if (head === 'env') {
+        const hasSplitString = current.slice(1).some(t => {
+          const bare = stripQuotes(t);
+          return bare === '-S' || bare === '--split-string' || bare.startsWith('--split-string=');
+        });
+        if (hasSplitString) {
+          return {
+            tokens: [],
+            blocked: {
+              allowed: false,
+              reason: `'env -S/--split-string' re-splits and executes its value and is forbidden`,
+              trust_level: 'DANGEROUS',
+            },
+          };
+        }
+      }
       let i = 1;
-      while (i < current.length && current[i].startsWith('-')) {
-        const flag = bareToken(current[i]);
+      while (i < current.length && stripQuotes(current[i]).startsWith('-')) {
+        const flag = stripQuotes(current[i]);
         const eq = flag.indexOf('=');
         const flagName = eq > 0 ? flag.slice(0, eq) : flag;
         if (eq < 0 && spec.valueFlags.has(flagName)) i += 2;
@@ -529,6 +586,14 @@ export const PROTECTED_FILE_PATTERNS: RegExp[] = [
   /\.gemini[\\/]google_accounts\.json$/,
   /\.gemini[\\/].*mcp-oauth-tokens\.json$/,
   /\.gemini[\\/]a2a-oauth-tokens\.json$/,
+  // Gemini CLI's real MCP server registration file (scripts/lib/
+  // mcp-register.js, confirmed 2026-07-27). guardian-bin.js's
+  // fromMcpConfigs() now trusts this file the same way it already trusts
+  // ~/.claude.json, to resolve the guardian CLI for a Gemini-CLI-only
+  // install — that trust is only sound if a write here is denied, or a
+  // prompt-injected agent could repoint egc-guardian's own MCP entry at an
+  // arbitrary script and have this validator treat it as authoritative.
+  /\.gemini[\\/]config[\\/]mcp_config\.json$/,
   // Codex CLI: OAuth/API key auth file.
   /\.codex[\\/]auth\.json$/,
   // Amp: OAuth tokens live under this subfolder; config is elsewhere.
@@ -669,25 +734,36 @@ const DANGEROUS_GIT_CONFIG_KEYS = new Set([
   'core.pager',
   'core.editor',
   'core.sshcommand',
+  'core.fsmonitor',
   'credential.helper',
   'diff.external',
   'include.path',
 ]);
 // A merge driver runs an arbitrary command on every merge that touches a
 // matching path, by design of the merge.<name>.driver mechanism itself —
-// any write to one is dangerous regardless of the command it names.
+// any write to one is dangerous regardless of the command it names. filter
+// clean/smudge/process drivers and a named diff driver's own command run the
+// same way, on every checkout/diff of a matching path.
 const GIT_CONFIG_MERGE_DRIVER_KEY_RE = /^merge\..+\.driver$/;
+const GIT_CONFIG_FILTER_KEY_RE = /^filter\..+\.(clean|smudge|process)$/;
+const GIT_CONFIG_DIFF_COMMAND_KEY_RE = /^diff\..+\.command$/;
 // An alias is only a shell-escape risk when its value starts with '!' (git's
 // own syntax for "run this as a shell command" instead of a git subcommand);
 // alias.co = checkout is ordinary and harmless.
 const GIT_CONFIG_ALIAS_KEY_RE = /^alias\..+$/;
 
-// Flags that make `git config` a read (or a removal) rather than a write —
-// these must never trip the dangerous-key check below.
+// Flags that make `git config` strictly a read or a removal — never a write
+// — and so must never trip the dangerous-key check below. Output-annotation
+// flags (--show-scope, --show-origin, --name-only) are deliberately NOT
+// here: nothing stops one of them from appearing in argv alongside a real
+// key+value SET, so treating their mere presence as proof of "this is a
+// read" would let a set slip through unchecked (e.g. `git config
+// --show-scope core.hooksPath /tmp/evil`). --edit/-e is excluded for the
+// opposite reason — it IS a write (opens an editor over the config file)
+// and gets its own unconditional deny below instead of an exemption.
 const GIT_CONFIG_READONLY_FLAGS = new Set([
   '--get', '--get-all', '--get-regexp', '--get-urlmatch', '--list', '-l',
-  '--edit', '-e', '--unset', '--unset-all', '--name-only', '--show-origin',
-  '--show-scope',
+  '--unset', '--unset-all',
 ]);
 const GIT_CONFIG_VALUE_FLAGS = new Set(['-f', '--file', '--blob', '--type', '--default']);
 
@@ -695,7 +771,9 @@ const GIT_CONFIG_VALUE_FLAGS = new Set(['-f', '--file', '--blob', '--type', '--d
 // `args` is everything after 'git' (so args[0] === 'config'). Detects a
 // SET (a key positional followed by a value positional, or --add/
 // --replace-all) of one of the dangerous keys above and hard-blocks it —
-// reading or unsetting the same key is left untouched.
+// reading or unsetting the same key is left untouched. Also hard-denies
+// --edit/-e outright, since an editor session's eventual changes cannot be
+// inspected the way a plain key/value pair can.
 function checkGitConfigWrite(args: string[]): ValidationResult | null {
   const rest = args.slice(1);
   let readOnly = false;
@@ -703,16 +781,23 @@ function checkGitConfigWrite(args: string[]): ValidationResult | null {
 
   for (let i = 0; i < rest.length; i++) {
     const raw = rest[i];
-    if (raw === '--') { positionals.push(...rest.slice(i + 1).map(bareToken)); break; }
-    if (raw.startsWith('-')) {
-      const flag = bareToken(raw);
+    if (bareToken(raw) === '--') { positionals.push(...rest.slice(i + 1).map(bareToken)); break; }
+    const flag = bareToken(raw);
+    if (flag.startsWith('-')) {
+      if (flag === '--edit' || flag === '-e') {
+        return {
+          allowed: false,
+          reason: `git config --edit opens an editable session over the config file and is forbidden`,
+          trust_level: 'DANGEROUS',
+        };
+      }
       const eq = flag.indexOf('=');
       const flagName = eq > 0 ? flag.slice(0, eq) : flag;
       if (GIT_CONFIG_READONLY_FLAGS.has(flagName)) readOnly = true;
       if (eq < 0 && GIT_CONFIG_VALUE_FLAGS.has(flagName)) i += 1;
       continue;
     }
-    positionals.push(bareToken(raw));
+    positionals.push(flag);
   }
 
   if (readOnly || positionals.length < 2) return null;
@@ -721,6 +806,8 @@ function checkGitConfigWrite(args: string[]): ValidationResult | null {
   const value = positionals[1];
   const isDangerous = DANGEROUS_GIT_CONFIG_KEYS.has(key)
     || GIT_CONFIG_MERGE_DRIVER_KEY_RE.test(key)
+    || GIT_CONFIG_FILTER_KEY_RE.test(key)
+    || GIT_CONFIG_DIFF_COMMAND_KEY_RE.test(key)
     || (GIT_CONFIG_ALIAS_KEY_RE.test(key) && value.startsWith('!'));
 
   if (!isDangerous) return null;
@@ -729,6 +816,31 @@ function checkGitConfigWrite(args: string[]): ValidationResult | null {
     reason: `git config write to '${key}' persists a hook/execution-bypass override and is forbidden`,
     trust_level: 'DANGEROUS',
   };
+}
+
+// Global git flags that take a value and can appear BEFORE the subcommand
+// (`git -c foo=bar config ...`, `git -C /path config ...`), mirroring the
+// same set block-no-verify.js already trusts for this exact purpose. Without
+// skipping these (and their values), a global flag in front of `config`
+// shifts the subcommand out of args[0] and the dangerous-key check below is
+// never reached at all.
+const GIT_GLOBAL_FLAGS_WITH_ARG = new Set(['-c', '-C', '--work-tree', '--git-dir', '--namespace', '--super-prefix']);
+
+// Returns the index of the actual subcommand token (skipping global flags
+// and their values), not just its name — reusing this same index to slice
+// `args` is what keeps "is the subcommand config" and "where does config's
+// own arg list start" from ever disagreeing with each other, which a second,
+// independent indexOf/findIndex scan over the same array could do (e.g. if
+// 'config' also appears earlier as the VALUE of a global flag like `-C`).
+function findGitSubcommandIndex(args: string[]): number {
+  let i = 0;
+  while (i < args.length) {
+    const t = bareToken(args[i]);
+    if (!t.startsWith('-')) return i;
+    if (GIT_GLOBAL_FLAGS_WITH_ARG.has(t)) i += 2;
+    else i += 1;
+  }
+  return -1;
 }
 
 function validateGitArgs(args: string[]): ValidationResult {
@@ -745,8 +857,9 @@ return { allowed: false, reason: 'git force-push is forbidden', trust_level: 'SA
   if (args.includes('push') && args.some(a => /^-[a-zA-Z]*f/.test(a))) {
 return { allowed: false, reason: 'git push with force flag is forbidden', trust_level: 'SAFE_READONLY' };
   }
-  if (bareToken(args[0] ?? '') === 'config') {
-    const configDenial = checkGitConfigWrite(args);
+  const subcommandIdx = findGitSubcommandIndex(args);
+  if (subcommandIdx >= 0 && bareToken(args[subcommandIdx]) === 'config') {
+    const configDenial = checkGitConfigWrite(args.slice(subcommandIdx));
     if (configDenial) return configDenial;
   }
   return { allowed: true, trust_level: 'SAFE_READONLY' };

--- a/scripts/hooks/pre-bash-guardian-validate.js
+++ b/scripts/hooks/pre-bash-guardian-validate.js
@@ -22,10 +22,16 @@
 'use strict';
 
 const { resolveGuardianCli, callGuardian } = require('../lib/guardian-bin');
-const { splitShellSegments } = require('../lib/shell-split');
+const { splitShellSegments, extractSubstitutionBodies } = require('../lib/shell-split');
 
 const MAX_STDIN = 1024 * 1024;
 const VALIDATE_TIMEOUT_MS = 4000;
+
+// Caps recursion into nested command/process substitutions
+// ($(echo $(echo $(...)))) — a real script has no reason to nest these more
+// than a couple of levels deep; this is purely a backstop against adversarial
+// or pathological input, not a limit anyone should ever hit legitimately.
+const MAX_SUBSTITUTION_DEPTH = 5;
 
 const ADVISORY_REASONS = [
   'Shell chaining/metacharacters are forbidden',
@@ -52,10 +58,25 @@ function parseInput(inputOrRaw) {
 // duplicating the same peeling logic in two places is exactly how earlier
 // fixes here ended up covering only the specific wrapper names each audit
 // happened to name (see the project's Guardian bypass post-mortem).
-function extractSegments(command) {
-  return splitShellSegments(command, { splitOnPipe: true })
+//
+// Command/process substitutions ($(...), <(...), >(...), `...`) are also
+// extracted and validated as their own additional segments, recursively (up
+// to MAX_SUBSTITUTION_DEPTH): `echo $(rm -rf /)` must not slip through as
+// one benign-looking `echo` segment just because `$`/backtick are not
+// top-level separators.
+function extractSegments(command, depth = 0) {
+  const topLevel = splitShellSegments(command, { splitOnPipe: true })
     .map(s => s.trim())
     .filter(Boolean);
+
+  if (depth >= MAX_SUBSTITUTION_DEPTH) return topLevel;
+
+  const nested = [];
+  for (const body of extractSubstitutionBodies(command)) {
+    nested.push(...extractSegments(body, depth + 1));
+  }
+
+  return [...topLevel, ...nested];
 }
 
 function isAdvisory(verdict) {
@@ -72,9 +93,18 @@ function run(inputOrRaw) {
   if (segments.length === 0) return { exitCode: 0 };
 
   const cli = resolveGuardianCli();
+  // resolveGuardianCli() only returns falsy when all 3 of its resolution
+  // strategies fail at once (env var, package-relative build, and both
+  // trusted MCP config files); against a real checkout with its own build
+  // present, fromPackageLayout() always succeeds, so this can't be
+  // triggered deterministically here without environment isolation fragile
+  // enough to break on CI. Covered conceptually by the "fails open" test
+  // below, which exercises the sibling !Array.isArray(verdicts) fail-open.
+  /* c8 ignore start */
   if (!cli) {
     return { exitCode: 0 };
   }
+  /* c8 ignore stop */
 
   const cwd = typeof input.cwd === 'string' ? input.cwd : undefined;
   const verdicts = callGuardian(

--- a/scripts/hooks/pre-bash-guardian-validate.js
+++ b/scripts/hooks/pre-bash-guardian-validate.js
@@ -33,6 +33,18 @@ const VALIDATE_TIMEOUT_MS = 4000;
 // or pathological input, not a limit anyone should ever hit legitimately.
 const MAX_SUBSTITUTION_DEPTH = 5;
 
+// extractSegments returns null (instead of the usual segment array) when a
+// command nests substitutions deeper than MAX_SUBSTITUTION_DEPTH allows
+// fully unwrapping. Silently returning only the outer, already-parsed
+// segments here (as this used to do) fails OPEN: the innermost
+// substitution — the one actually worth hiding a destructive command in,
+// e.g. `echo $(echo $(...(rm -rf /)...))` nested one level past the cap —
+// is never extracted or validated, and stays buried as inert-looking text
+// inside an outer segment whose own leading token (like `echo`) reads as
+// safe. run() below hard-blocks on a null return instead, so a command too
+// deep to fully analyze fails CLOSED rather than being treated as if
+// nothing were found.
+
 const ADVISORY_REASONS = [
   'Shell chaining/metacharacters are forbidden',
   'is not in the allowlist',
@@ -65,15 +77,23 @@ function parseInput(inputOrRaw) {
 // one benign-looking `echo` segment just because `$`/backtick are not
 // top-level separators.
 function extractSegments(command, depth = 0) {
+  const bodies = extractSubstitutionBodies(command);
+
+  // There is at least one more level of substitution here that recursing
+  // would need to unwrap, and depth is already at the cap: analysis cannot
+  // continue safely. Return null rather than the partial topLevel result so
+  // the caller blocks instead of silently accepting an unanalyzed command.
+  if (bodies.length > 0 && depth >= MAX_SUBSTITUTION_DEPTH) return null;
+
   const topLevel = splitShellSegments(command, { splitOnPipe: true })
     .map(s => s.trim())
     .filter(Boolean);
 
-  if (depth >= MAX_SUBSTITUTION_DEPTH) return topLevel;
-
   const nested = [];
-  for (const body of extractSubstitutionBodies(command)) {
-    nested.push(...extractSegments(body, depth + 1));
+  for (const body of bodies) {
+    const nestedSegments = extractSegments(body, depth + 1);
+    if (nestedSegments === null) return null;
+    nested.push(...nestedSegments);
   }
 
   return [...topLevel, ...nested];
@@ -90,21 +110,28 @@ function run(inputOrRaw) {
   if (!command || typeof command !== 'string') return { exitCode: 0 };
 
   const segments = extractSegments(command);
+  if (segments === null) {
+    return {
+      exitCode: 2,
+      stderr:
+        'EGC Guardian BLOCKED this command: nested command/process substitutions ' +
+        'go deeper than this validator can safely unwrap and analyze. Simplify the ' +
+        'command so every substitution can be validated.',
+    };
+  }
   if (segments.length === 0) return { exitCode: 0 };
 
   const cli = resolveGuardianCli();
   // resolveGuardianCli() only returns falsy when all 3 of its resolution
   // strategies fail at once (env var, package-relative build, and both
-  // trusted MCP config files); against a real checkout with its own build
-  // present, fromPackageLayout() always succeeds, so this can't be
-  // triggered deterministically here without environment isolation fragile
-  // enough to break on CI. Covered conceptually by the "fails open" test
-  // below, which exercises the sibling !Array.isArray(verdicts) fail-open.
-  /* c8 ignore start */
+  // trusted MCP config files) — reproduced deterministically in
+  // tests/hooks/pre-bash-guardian-validate.test.js by stubbing guardian-bin
+  // in require.cache before re-requiring this file, so the falsy-cli branch
+  // is genuinely exercised (and its coverage correctly attributed here)
+  // without needing a real "nothing resolves" filesystem/HOME setup.
   if (!cli) {
     return { exitCode: 0 };
   }
-  /* c8 ignore stop */
 
   const cwd = typeof input.cwd === 'string' ? input.cwd : undefined;
   const verdicts = callGuardian(

--- a/scripts/hooks/windsurf-guardian-adapter.js
+++ b/scripts/hooks/windsurf-guardian-adapter.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Windsurf Cascade Hooks adapter for the EGC Guardian command validator.
+ *
+ * Windsurf's pre_run_command hook uses a different wire contract than Claude
+ * Code's PreToolUse hook (see windsurf-gateguard-adapter.js for the same
+ * distinction this file mirrors): {agent_action_name, tool_info:
+ * {command_line}} on stdin instead of {tool_name, tool_input}, and a plain
+ * exit-code-2-with-stderr block instead of a hookSpecificOutput JSON
+ * envelope on stdout.
+ *
+ * pre-bash-guardian-validate.js's own run() already returns {exitCode,
+ * stderr} directly (no JSON envelope to unwrap), so unlike the GateGuard
+ * adapter this translation only needs to build its input shape and relay
+ * its output as-is.
+ *
+ * Registered only on Windsurf's pre_run_command event (not
+ * pre_write_code) — the Guardian validates shell commands, not file writes.
+ */
+
+'use strict';
+
+const { run } = require('./pre-bash-guardian-validate');
+
+function buildGuardianInput(windsurfEvent) {
+  const actionName = windsurfEvent.agent_action_name || '';
+  if (actionName !== 'pre_run_command') {
+    return null;
+  }
+  const command = (windsurfEvent.tool_info || {}).command_line || '';
+  if (!command) {
+    return null;
+  }
+  return { tool_name: 'Bash', tool_input: { command } };
+}
+
+function main() {
+  const MAX_STDIN = 1024 * 1024;
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('end', () => {
+    let windsurfEvent;
+    try {
+      windsurfEvent = JSON.parse(raw);
+    } catch {
+      // Allow on parse error: same fail-open policy as the other adapters.
+      process.exit(0);
+    }
+
+    const guardianInput = buildGuardianInput(windsurfEvent);
+    if (!guardianInput) {
+      process.exit(0);
+    }
+
+    const result = run(guardianInput);
+    if (result.exitCode === 2) {
+      const reason = result.stderr || 'Blocked by the EGC Guardian.';
+      process.stderr.write(reason.endsWith('\n') ? reason : `${reason}\n`);
+      process.exit(2);
+    }
+
+    process.exit(0);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { buildGuardianInput };

--- a/scripts/hooks/windsurf-guardian-adapter.js
+++ b/scripts/hooks/windsurf-guardian-adapter.js
@@ -27,20 +27,34 @@ function buildGuardianInput(windsurfEvent) {
   if (actionName !== 'pre_run_command') {
     return null;
   }
-  const command = (windsurfEvent.tool_info || {}).command_line || '';
+  const toolInfo = windsurfEvent.tool_info || {};
+  const command = toolInfo.command_line || '';
   if (!command) {
     return null;
   }
-  return { tool_name: 'Bash', tool_input: { command } };
+  // cwd matters here (unlike for GateGuard's fact-forcing gate): the
+  // Guardian resolves relative protected paths (e.g. `cat .ssh/id_rsa`)
+  // against it. Without it, those checks fall back to this adapter
+  // process's own cwd instead of the directory Windsurf actually runs the
+  // command in.
+  const input = { tool_name: 'Bash', tool_input: { command } };
+  if (typeof toolInfo.cwd === 'string') {
+    input.cwd = toolInfo.cwd;
+  }
+  return input;
 }
 
 function main() {
   const MAX_STDIN = 1024 * 1024;
   let raw = '';
+  let truncated = false;
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', chunk => {
     if (raw.length < MAX_STDIN) {
       raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+    if (raw.length >= MAX_STDIN) {
+      truncated = true;
     }
   });
   process.stdin.on('end', () => {
@@ -48,7 +62,19 @@ function main() {
     try {
       windsurfEvent = JSON.parse(raw);
     } catch {
-      // Allow on parse error: same fail-open policy as the other adapters.
+      // A parse failure caused by hitting the size cap is not the same as
+      // ordinary malformed input: an attacker can pad a command past
+      // MAX_STDIN specifically to land here and fail open. Only genuinely
+      // malformed (non-truncated) input gets the fail-open policy the other
+      // adapters use; a truncated payload is unanalyzable and fails closed.
+      if (truncated) {
+        process.stderr.write(
+          'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+          'this validator can safely read, so it could not be parsed or validated. ' +
+          'Simplify the command.\n'
+        );
+        process.exit(2);
+      }
       process.exit(0);
     }
 

--- a/scripts/lib/antigravity-settings-hooks.js
+++ b/scripts/lib/antigravity-settings-hooks.js
@@ -24,6 +24,8 @@ const {
   resolveGateGuardHookScriptDestination,
   createCrusherHookMergeOperationForDestination,
   resolveCrusherHookScriptDestination,
+  createBashGuardianHookMergeOperationForDestination,
+  resolveBashGuardianHookScriptDestination,
 } = require('./claude-settings-hooks');
 
 function resolveAntigravityProjectHooksFilePath(projectRoot) {
@@ -60,10 +62,35 @@ function createProjectCrusherHookMergeOperation(targetRoot, projectRoot, matcher
   );
 }
 
+// EGC Guardian: same hooks.json shape; GateGuard above only forces
+// investigation before a risky action, it never checks a Bash command
+// against the Guardian's actual allowlist/denylist. 2026-07-27 audit
+// (EGC-460) found this target had GateGuard + Crusher wired but never the
+// Guardian validator itself, and separately (EGC-460/461) that Antigravity's
+// own MCP config file was never a trusted candidate for resolving the
+// Guardian CLI either — see PROTECTED_FILE_PATTERNS/guardian-bin.js.
+function createProjectBashGuardianHookMergeOperation(targetRoot, projectRoot, matcher) {
+  return createBashGuardianHookMergeOperationForDestination(
+    resolveAntigravityProjectHooksFilePath(projectRoot),
+    resolveBashGuardianHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
+function createGlobalBashGuardianHookMergeOperation(targetRoot, homeDir, matcher) {
+  return createBashGuardianHookMergeOperationForDestination(
+    resolveAntigravityGlobalHooksFilePath(homeDir),
+    resolveBashGuardianHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
 module.exports = {
   createGlobalGateGuardHookMergeOperation,
   createProjectGateGuardHookMergeOperation,
   createProjectCrusherHookMergeOperation,
+  createProjectBashGuardianHookMergeOperation,
+  createGlobalBashGuardianHookMergeOperation,
   resolveAntigravityGlobalHooksFilePath,
   resolveAntigravityProjectHooksFilePath,
 };

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -31,6 +31,8 @@ const ROUTER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/prompt-router.js'
 const ROUTER_HOOK_MODULE_ID = 'claude-prompt-router-hook';
 const GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/gateguard-fact-force.js';
 const GATEGUARD_HOOK_MODULE_ID = 'claude-gateguard-fact-force-hook';
+const BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/pre-bash-guardian-validate.js';
+const BASH_GUARDIAN_HOOK_MODULE_ID = 'egc-bash-guardian-hook';
 const CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/crusher-hook.js';
 const CRUSHER_HOOK_MODULE_ID = 'egc-crusher-hook';
 
@@ -718,9 +720,75 @@ function createCrusherHookMergeOperationForDestination(destinationPath, hookScri
   };
 }
 
+// EGC Guardian command validator (pre-bash-guardian-validate.js): standalone
+// PreToolUse hook, same shape as the Crusher hook above, for hosts other than
+// Claude Code that read hooks.json with the same schema. 2026-07-27 audit
+// (EGC-460..464) found this was the one piece consistently missing from every
+// non-Claude target that already had GateGuard + Crusher wired: those two
+// give investigation-gating and output-compression, but neither one
+// validates a command against the Guardian's actual allowlist/denylist —
+// only pre-bash-guardian-validate.js does, and it was never registered
+// anywhere except Claude Code's own bash-hook-dispatcher.js chain.
+const BASH_GUARDIAN_HOOK_LIB_SOURCES = [
+  'scripts/lib/guardian-bin.js',
+  'scripts/lib/shell-split.js',
+];
+
+function resolveBashGuardianHookScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+}
+
+function createPreToolUseBashGuardianHookMergeOperation(targetRoot, matcher) {
+  const hookScriptPath = resolveBashGuardianHookScriptDestination(targetRoot);
+  return buildPreToolUseMergeOperation(
+    targetRoot,
+    BASH_GUARDIAN_HOOK_MODULE_ID,
+    BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    hookScriptPath,
+    matcher
+  );
+}
+
+// Destination-driven variant, for hosts whose hooks.json path is not
+// derivable from targetRoot (Copilot ~/.copilot/hooks, Antigravity's
+// project/global split). Same Claude hooks.json schema.
+function createBashGuardianHookMergeOperationForDestination(destinationPath, hookScriptPath, matcher) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: BASH_GUARDIAN_HOOK_MODULE_ID,
+    sourceRelativePath: BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: matcher,
+    hookScriptPath,
+  };
+}
+
+function createBashGuardianScriptCopyOperations(createRemappedOperation, targetRoot) {
+  return [
+    createRemappedOperation(
+      BASH_GUARDIAN_HOOK_MODULE_ID,
+      BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveBashGuardianHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ),
+    ...BASH_GUARDIAN_HOOK_LIB_SOURCES.map(src => createRemappedOperation(
+      BASH_GUARDIAN_HOOK_MODULE_ID,
+      src,
+      path.join(targetRoot, ...src.split('/')),
+      { strategy: 'preserve-relative-path' }
+    )),
+  ];
+}
+
 module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  BASH_GUARDIAN_HOOK_MODULE_ID,
+  BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
@@ -766,6 +834,10 @@ module.exports = {
   createPreToolUseCrusherHookMergeOperation,
   createCrusherHookMergeOperationForDestination,
   resolveCrusherHookScriptDestination,
+  createBashGuardianScriptCopyOperations,
+  createPreToolUseBashGuardianHookMergeOperation,
+  createBashGuardianHookMergeOperationForDestination,
+  resolveBashGuardianHookScriptDestination,
   createPreToolUseWriteValidatorHookMergeOperation,
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,

--- a/scripts/lib/continue-gateguard-hooks.js
+++ b/scripts/lib/continue-gateguard-hooks.js
@@ -17,6 +17,8 @@ const {
   createPreToolUseGateGuardHookMergeOperation,
   createCrusherScriptCopyOperations,
   createPreToolUseCrusherHookMergeOperation,
+  createBashGuardianScriptCopyOperations,
+  createPreToolUseBashGuardianHookMergeOperation,
 } = require('./claude-settings-hooks');
 
 function createContinueGateGuardOperations(adapter, targetRoot, createRemappedOperation) {
@@ -37,7 +39,16 @@ function createContinueGateGuardOperations(adapter, targetRoot, createRemappedOp
     createPreToolUseCrusherHookMergeOperation(targetRoot, 'Bash'),
   ];
 
-  return [...copyOperations, ...mergeOperations, ...crusherOperations];
+  // EGC Guardian: GateGuard above only forces investigation before a risky
+  // action; it never checks a Bash command against the Guardian's actual
+  // allowlist/denylist. 2026-07-27 audit (EGC-462) found this target had
+  // GateGuard + Crusher wired but never the Guardian validator itself.
+  const guardianOperations = [
+    ...createBashGuardianScriptCopyOperations(remap, targetRoot),
+    createPreToolUseBashGuardianHookMergeOperation(targetRoot, 'Bash'),
+  ];
+
+  return [...copyOperations, ...mergeOperations, ...crusherOperations, ...guardianOperations];
 }
 
 module.exports = { createContinueGateGuardOperations };

--- a/scripts/lib/copilot-settings-hooks.js
+++ b/scripts/lib/copilot-settings-hooks.js
@@ -23,6 +23,8 @@ const {
   resolveGateGuardHookScriptDestination,
   createCrusherHookMergeOperationForDestination,
   resolveCrusherHookScriptDestination,
+  createBashGuardianHookMergeOperationForDestination,
+  resolveBashGuardianHookScriptDestination,
 } = require('./claude-settings-hooks');
 
 function resolveCopilotHooksFilePath(homeDir) {
@@ -48,8 +50,22 @@ function createPreToolUseCrusherHookMergeOperation(targetRoot, homeDir, matcher)
   );
 }
 
+// EGC Guardian: same hooks.json schema; GateGuard above only forces
+// investigation before a risky action, it never checks a Bash command
+// against the Guardian's actual allowlist/denylist. 2026-07-27 audit
+// (EGC-462) found this target had GateGuard + Crusher wired but never the
+// Guardian validator itself.
+function createPreToolUseBashGuardianHookMergeOperation(targetRoot, homeDir, matcher) {
+  return createBashGuardianHookMergeOperationForDestination(
+    resolveCopilotHooksFilePath(homeDir),
+    resolveBashGuardianHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
 module.exports = {
   createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseCrusherHookMergeOperation,
+  createPreToolUseBashGuardianHookMergeOperation,
   resolveCopilotHooksFilePath,
 };

--- a/scripts/lib/guardian-bin.js
+++ b/scripts/lib/guardian-bin.js
@@ -36,7 +36,13 @@ function fromPackageLayout() {
 function fromMcpConfigs() {
   const configPaths = [
     path.join(os.homedir(), '.claude.json'),
-    path.join(os.homedir(), '.gemini', 'settings.json'),
+    // Gemini CLI's real MCP registration file (confirmed against
+    // scripts/lib/mcp-register.js's "Gemini CLI" target and live on disk,
+    // 2026-07-27 audit) — NOT ~/.gemini/settings.json, which Gemini CLI
+    // does not use for MCP server config at all. Without this fix, a
+    // Gemini-CLI-only install (no ~/.claude.json alongside it) had no
+    // working fallback here and failed open silently.
+    path.join(os.homedir(), '.gemini', 'config', 'mcp_config.json'),
   ];
 
   // Resolved candidates must live under the user's home directory. This

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -31,6 +31,20 @@ const {
   removeStopHookFromFile,
 } = require('./claude-settings-hooks');
 const {
+  PRE_RUN_COMMAND_EVENT: WINDSURF_PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT: WINDSURF_PRE_WRITE_CODE_EVENT,
+  applyWindsurfGateGuardHookToFile,
+  inspectWindsurfGateGuardHookFile,
+  removeWindsurfGateGuardHookFromFile,
+} = require('./windsurf-gateguard-hooks');
+
+// Windsurf's hooks.json is a flat {hooks: {<event>: [...]}} map, not
+// Claude's matcher/group settings.json schema -- an operation whose
+// hookEvent is one of these two needs the Windsurf-specific
+// apply/inspect/remove helpers above, not the Claude ones the rest of this
+// file's HOOK_OPERATION_KIND branches fall back to.
+const WINDSURF_HOOK_EVENTS = new Set([WINDSURF_PRE_WRITE_CODE_EVENT, WINDSURF_PRE_RUN_COMMAND_EVENT]);
+const {
   MERGE_YAML_READ_LIST_KIND,
   REMOVE_SENTINEL: AIDER_REMOVE_SENTINEL,
   mergeAiderConfigReadList,
@@ -335,6 +349,8 @@ function repairClaudeSettingsHook(operation) {
     applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
     applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
+  } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
+    applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
     applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
   }
@@ -535,6 +551,8 @@ function uninstallClaudeSettingsHook(operation) {
     removeIntuitionHookFromFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
     removeHookEntryFromFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath);
+  } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
+    removeWindsurfGateGuardHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
     removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
   }
@@ -664,6 +682,9 @@ function inspectManagedOperation(repoRoot, operation) {
     }
     if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
       return inspectResult(inspectHookEntryFile(destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, operation.hookMatcher), operation, destinationPath);
+    }
+    if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
+      return inspectResult(inspectWindsurfGateGuardHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
     }
     return inspectResult(inspectSessionStartHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
   }

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -342,7 +342,7 @@ function shouldRepairFromRecordedOperations(state) {
   return getManagedOperations(state).some(operation => operation.kind !== 'copy-file');
 }
 
-function repairClaudeSettingsHook(operation) {
+function repairManagedHookOperation(operation) {
   if (operation.hookEvent === STOP_EVENT) {
     applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
@@ -430,7 +430,7 @@ function executeRepairOperation(repoRoot, operation) {
   } else if (operation.kind === 'remove') {
     repairRemove(operation);
   } else if (operation.kind === HOOK_OPERATION_KIND) {
-    repairClaudeSettingsHook(operation);
+    repairManagedHookOperation(operation);
   } else if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
     repairMergeYamlReadList(operation);
   } else if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {
@@ -542,7 +542,7 @@ function uninstallWarpAgentsIndexEntry(operation) {
   return { removedPaths: [], cleanupTargets: [] };
 }
 
-function uninstallClaudeSettingsHook(operation) {
+function uninstallManagedHookOperation(operation) {
   // Strips only the EGC-managed hook entry. The settings file itself is never
   // deleted because Claude Code and the user own its other keys.
   if (operation.hookEvent === STOP_EVENT) {
@@ -563,7 +563,7 @@ const UNINSTALL_HANDLERS = {
   'copy-file': uninstallCopyFile,
   'merge-json': uninstallMergeJson,
   'remove': uninstallRemove,
-  [HOOK_OPERATION_KIND]: uninstallClaudeSettingsHook,
+  [HOOK_OPERATION_KIND]: uninstallManagedHookOperation,
   [MERGE_YAML_READ_LIST_KIND]: uninstallAiderConfigReadList,
   [MERGE_MARKDOWN_INDEX_KIND]: uninstallWarpAgentsIndexEntry,
 };

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -13,10 +13,12 @@ const {
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   resolveGateGuardHookScriptDestination,
   createCrusherScriptCopyOperations,
+  createBashGuardianScriptCopyOperations,
 } = require('../claude-settings-hooks');
 const {
   createProjectGateGuardHookMergeOperation,
   createProjectCrusherHookMergeOperation,
+  createProjectBashGuardianHookMergeOperation,
 } = require('../antigravity-settings-hooks');
 
 const SUPPORTED_SOURCE_PREFIXES = ['rules', 'commands', 'agents', 'skills', '.agents', 'AGENTS.md'];
@@ -71,6 +73,17 @@ function createGateGuardOperations(adapter, targetRoot, projectRoot) {
       targetRoot
     ),
     createProjectCrusherHookMergeOperation(targetRoot, projectRoot, 'Bash'),
+    // EGC Guardian: GateGuard above only forces investigation before a risky
+    // action; it never checks a Bash command against the Guardian's actual
+    // allowlist/denylist. 2026-07-27 audit (EGC-460) found this target had
+    // GateGuard + Crusher wired but never the Guardian validator itself.
+    ...createBashGuardianScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) => (
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+      ),
+      targetRoot
+    ),
+    createProjectBashGuardianHookMergeOperation(targetRoot, projectRoot, 'Bash'),
   ];
 }
 

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -11,6 +11,8 @@ const {
   createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseCrusherHookMergeOperation,
   createCrusherScriptCopyOperations,
+  createPreToolUseBashGuardianHookMergeOperation,
+  createBashGuardianScriptCopyOperations,
 } = require('../claude-settings-hooks');
 
 // CodeBuddy's PreToolUse hooks read from <project>/.codebuddy/settings.json
@@ -37,6 +39,17 @@ function createHookOperations(adapter, targetRoot) {
       targetRoot
     ),
     createPreToolUseCrusherHookMergeOperation(targetRoot, 'Bash'),
+    // EGC Guardian: GateGuard above only forces investigation before a risky
+    // action; it never checks a Bash command against the Guardian's actual
+    // allowlist/denylist. 2026-07-27 audit (EGC-462) found this target had
+    // GateGuard + Crusher wired but never the Guardian validator itself.
+    ...createBashGuardianScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) => (
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+      ),
+      targetRoot
+    ),
+    createPreToolUseBashGuardianHookMergeOperation(targetRoot, 'Bash'),
   ];
 }
 

--- a/scripts/lib/install-targets/copilot-home.js
+++ b/scripts/lib/install-targets/copilot-home.js
@@ -11,10 +11,12 @@ const {
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   resolveGateGuardHookScriptDestination,
   createCrusherScriptCopyOperations,
+  createBashGuardianScriptCopyOperations,
 } = require('../claude-settings-hooks');
 const {
   createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseCrusherHookMergeOperation,
+  createPreToolUseBashGuardianHookMergeOperation,
 } = require('../copilot-settings-hooks');
 
 const UTILS_SOURCE_RELATIVE_PATH = 'scripts/lib/utils.js';
@@ -59,6 +61,17 @@ function createGateGuardOperations(adapter, targetRoot, homeDir) {
       targetRoot
     ),
     createPreToolUseCrusherHookMergeOperation(targetRoot, homeDir, 'Bash'),
+    // EGC Guardian: GateGuard above only forces investigation before a risky
+    // action; it never checks a Bash command against the Guardian's actual
+    // allowlist/denylist. 2026-07-27 audit (EGC-462) found this target had
+    // GateGuard + Crusher wired but never the Guardian validator itself.
+    ...createBashGuardianScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) => (
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+      ),
+      targetRoot
+    ),
+    createPreToolUseBashGuardianHookMergeOperation(targetRoot, homeDir, 'Bash'),
   ];
 }
 

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -11,6 +11,10 @@ const {
   createGlobalGateGuardHookMergeOperation,
   createGlobalBashGuardianHookMergeOperation,
 } = require('../antigravity-settings-hooks');
+const {
+  createGateGuardScriptCopyOperations,
+  createBashGuardianScriptCopyOperations,
+} = require('../claude-settings-hooks');
 
 const GEMINI_EGC_NAMESPACE = 'egc';
 const AGY_SKILLS_SUBDIR = 'antigravity-cli/skills';
@@ -20,28 +24,38 @@ const AGY_SKILLS_SUBDIR = 'antigravity-cli/skills';
 // ~/.gemini/antigravity-cli/hooks.json, distinct from Gemini CLI's
 // ~/.gemini/hooks/hooks.json -- so Gemini CLI's existing GateGuard wiring
 // does not automatically cover Antigravity and needs this separate merge.
-// scripts/hooks/gateguard-fact-force.js is already scaffolded at
-// resolveGateGuardHookScriptDestination(targetRoot) for this target via the
-// hooks-runtime module (paths: scripts/hooks, scripts/lib), so this only
-// adds the hooks.json registration.
-function createAntigravityGlobalGateGuardOperations(targetRoot, homeDir) {
-  return ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
+// scripts/hooks/gateguard-fact-force.js normally also arrives at this
+// target via the hooks-runtime module's own scaffold (paths: scripts/hooks,
+// scripts/lib) -- but hooks-runtime is only a DEFAULT base module for the
+// 'egc' target's legacy profile, not something every install is guaranteed
+// to select (a minimal/custom module selection can omit it). Copying the
+// script explicitly here, unconditional of module selection, closes that
+// gap: cubic-dev-ai review (PR #1052, 2026-07-27) found a minimal install
+// could register this hooks.json entry while the script it points at was
+// never actually copied anywhere, so every Antigravity Bash/Edit/Write call
+// would try to launch a nonexistent file.
+function createAntigravityGlobalGateGuardOperations(targetRoot, homeDir, createRemap) {
+  const scriptCopyOperations = createGateGuardScriptCopyOperations(createRemap, targetRoot);
+  const mergeOperations = ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
     createGlobalGateGuardHookMergeOperation(targetRoot, homeDir, matcher)
   ));
+  return [...scriptCopyOperations, ...mergeOperations];
 }
 
-// EGC Guardian: same hooks-runtime scaffold already places
+// EGC Guardian: same reasoning as GateGuard above -- copy
 // pre-bash-guardian-validate.js (and its guardian-bin.js/shell-split.js
-// deps) under this target's scripts/hooks and scripts/lib alongside
-// gateguard-fact-force.js above -- this only adds the hooks.json
-// registration, on Bash only (the Guardian validates shell commands, not
-// file writes). cubic-dev-ai review (PR #1052, 2026-07-27) found
-// createGlobalBashGuardianHookMergeOperation was added to
-// antigravity-settings-hooks.js but never actually called anywhere, so
-// global Antigravity installs never got the Guardian despite the helper
-// existing.
-function createAntigravityGlobalGuardianOperations(targetRoot, homeDir) {
-  return [createGlobalBashGuardianHookMergeOperation(targetRoot, homeDir, 'Bash')];
+// deps) explicitly rather than relying on hooks-runtime having scaffolded
+// them, then register it on Bash only (the Guardian validates shell
+// commands, not file writes). cubic-dev-ai review (PR #1052, 2026-07-27)
+// first found createGlobalBashGuardianHookMergeOperation was added to
+// antigravity-settings-hooks.js but never actually called anywhere, then
+// (once wired) found the same missing-script-copy gap GateGuard had.
+function createAntigravityGlobalGuardianOperations(targetRoot, homeDir, createRemap) {
+  const scriptCopyOperations = createBashGuardianScriptCopyOperations(createRemap, targetRoot);
+  return [
+    ...scriptCopyOperations,
+    createGlobalBashGuardianHookMergeOperation(targetRoot, homeDir, 'Bash'),
+  ];
 }
 
 function getGeminiManagedDestinationPath(adapter, sourceRelativePath, input) {
@@ -163,13 +177,17 @@ module.exports = createInstallTargetAdapter({
         });
     });
 
+    const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    );
+
     // Deterministic: every egc-home install also registers the GateGuard
     // fact-forcing gate for Antigravity's global hooks.json, even when no
     // content modules are selected.
     return [
       ...moduleOperations,
-      ...createAntigravityGlobalGateGuardOperations(targetRoot, homeDir),
-      ...createAntigravityGlobalGuardianOperations(targetRoot, homeDir),
+      ...createAntigravityGlobalGateGuardOperations(targetRoot, homeDir, remap),
+      ...createAntigravityGlobalGuardianOperations(targetRoot, homeDir, remap),
     ];
   },
 });

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -58,6 +58,48 @@ function createAntigravityGlobalGuardianOperations(targetRoot, homeDir, createRe
   ];
 }
 
+// The GateGuard/Guardian script copies above are unconditional (needed for
+// minimal installs that skip the hooks-runtime module, see the comments on
+// those two functions), but a default install DOES select hooks-runtime,
+// which independently scaffolds the whole scripts/hooks and scripts/lib
+// directories via the generic module-path flow below -- as ONE 'copy-path'
+// operation per directory (sourceRelativePath exactly 'scripts/hooks' or
+// 'scripts/lib'), not one per file. That directory-level copy already
+// includes every file the explicit ones also copy, so without this a
+// default install recorded a redundant second copy of the same bytes to
+// the same destination for each script (wasteful I/O, duplicate bookkeeping
+// in the install state) per cubic-dev-ai review (PR #1052, 2026-07-27).
+//
+// Deliberately scoped to SOURCE paths under exactly these two directories,
+// not a generic "any copy-path nested under any other copy-path" rule: an
+// earlier version of this function compared DESTINATION paths across the
+// whole operations list, which also caught unrelated --with/skills/rules
+// operations that happened to land under a shared parent directory from a
+// completely different module and dropped them too (a real regression --
+// e.g. a --with-selected skill file nested under a skills/ directory
+// operation from another module). Only a source path that is an actual
+// descendant of one of these two known, hardcoded directories can ever be
+// redundant with them.
+const HOOKS_RUNTIME_DIRECTORY_SOURCES = ['scripts/hooks', 'scripts/lib'];
+
+function dedupeCopyOperations(operations) {
+  const presentDirectorySources = new Set(
+    operations
+      .filter(operation => (
+        operation.kind === 'copy-path' && HOOKS_RUNTIME_DIRECTORY_SOURCES.includes(operation.sourceRelativePath)
+      ))
+      .map(operation => operation.sourceRelativePath)
+  );
+
+  return operations.filter(operation => {
+    if (operation.kind !== 'copy-path') return true;
+    return ![...presentDirectorySources].some(directorySource => (
+      operation.sourceRelativePath !== directorySource
+      && operation.sourceRelativePath.startsWith(`${directorySource}/`)
+    ));
+  });
+}
+
 function getGeminiManagedDestinationPath(adapter, sourceRelativePath, input) {
   const normalizedSourcePath = normalizeRelativePath(sourceRelativePath);
   const targetRoot = adapter.resolveRoot(input);
@@ -184,10 +226,10 @@ module.exports = createInstallTargetAdapter({
     // Deterministic: every egc-home install also registers the GateGuard
     // fact-forcing gate for Antigravity's global hooks.json, even when no
     // content modules are selected.
-    return [
+    return dedupeCopyOperations([
       ...moduleOperations,
       ...createAntigravityGlobalGateGuardOperations(targetRoot, homeDir, remap),
       ...createAntigravityGlobalGuardianOperations(targetRoot, homeDir, remap),
-    ];
+    ]);
   },
 });

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -9,6 +9,7 @@ const {
 } = require('./helpers');
 const {
   createGlobalGateGuardHookMergeOperation,
+  createGlobalBashGuardianHookMergeOperation,
 } = require('../antigravity-settings-hooks');
 
 const GEMINI_EGC_NAMESPACE = 'egc';
@@ -27,6 +28,20 @@ function createAntigravityGlobalGateGuardOperations(targetRoot, homeDir) {
   return ['Edit', 'Write', 'MultiEdit', 'Bash'].map(matcher => (
     createGlobalGateGuardHookMergeOperation(targetRoot, homeDir, matcher)
   ));
+}
+
+// EGC Guardian: same hooks-runtime scaffold already places
+// pre-bash-guardian-validate.js (and its guardian-bin.js/shell-split.js
+// deps) under this target's scripts/hooks and scripts/lib alongside
+// gateguard-fact-force.js above -- this only adds the hooks.json
+// registration, on Bash only (the Guardian validates shell commands, not
+// file writes). cubic-dev-ai review (PR #1052, 2026-07-27) found
+// createGlobalBashGuardianHookMergeOperation was added to
+// antigravity-settings-hooks.js but never actually called anywhere, so
+// global Antigravity installs never got the Guardian despite the helper
+// existing.
+function createAntigravityGlobalGuardianOperations(targetRoot, homeDir) {
+  return [createGlobalBashGuardianHookMergeOperation(targetRoot, homeDir, 'Bash')];
 }
 
 function getGeminiManagedDestinationPath(adapter, sourceRelativePath, input) {
@@ -154,6 +169,7 @@ module.exports = createInstallTargetAdapter({
     return [
       ...moduleOperations,
       ...createAntigravityGlobalGateGuardOperations(targetRoot, homeDir),
+      ...createAntigravityGlobalGuardianOperations(targetRoot, homeDir),
     ];
   },
 });

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -39,11 +39,84 @@ function handleSingleAmpersand(ch, next, prev, current, segments) {
   return { current: '', handled: true };
 }
 
-// Matches a heredoc redirect operator (<<EOF, <<-EOF, <<'EOF', <<"EOF") at
-// the start of the given string. Group 1/2 capture a quoted delimiter
-// (quotes stripped, no escape processing needed inside); group 3 captures a
-// bare or backslash-escaped delimiter word.
-const HEREDOC_OPERATOR_RE = /^<<-?\s*(?:'([^']*)'|"([^"]*)"|(\\?[A-Za-z_]\w*))/;
+// Characters that end an unquoted heredoc delimiter word (whitespace or a
+// shell metacharacter) — anything else, including punctuation like `-` or
+// `.`, is part of the word. A bare regex like [A-Za-z_]\w* previously
+// stopped at the first non-identifier character, silently truncating a
+// delimiter such as `EOF-1` down to `EOF`: the parser then waited forever
+// for a body line that read exactly `EOF` (which never appears, since the
+// real terminator is `EOF-1`), so the heredoc body never closed and every
+// command after it was swallowed as inert body text instead of validated.
+const HEREDOC_WORD_STOP_RE = /[\s;&|()<>]/;
+
+// Parses one (possibly quoted/escaped) word starting at `command[start]`,
+// honoring bash's rule that quoted and unquoted parts of the same word can
+// be concatenated (`EO"F"1` is the word `EOF1`). Returns null on an
+// unterminated quote (malformed input — the caller must not guess a
+// delimiter out of it) or if no word is present at all.
+function parseHeredocDelimiterWord(command, start) {
+  let i = start;
+  let value = '';
+  let literal = false;
+  let consumedAny = false;
+
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === '\\' && i + 1 < command.length) {
+      value += command[i + 1];
+      literal = true;
+      i += 2;
+      consumedAny = true;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      const closeIndex = command.indexOf(ch, i + 1);
+      if (closeIndex === -1) return null;
+      value += command.slice(i + 1, closeIndex);
+      literal = true;
+      i = closeIndex + 1;
+      consumedAny = true;
+      continue;
+    }
+    if (HEREDOC_WORD_STOP_RE.test(ch)) break;
+    value += ch;
+    i += 1;
+    consumedAny = true;
+  }
+
+  if (!consumedAny) return null;
+  return { value, literal, consumedLength: i - start };
+}
+
+// Parses a full heredoc redirect operator (<<EOF, <<-EOF, <<'EOF', <<"EOF",
+// <<EO"F"1, ...) starting at command[i]. Caller must already have confirmed
+// command[i..i+1] is an unescaped `<<` (not `<<<`) — both call sites below
+// do this before invoking it, so it is not re-checked here. Returns null if
+// there is no usable delimiter word after the operator (e.g. `<<` with
+// nothing following it) — the caller then treats the `<<` as ordinary text,
+// which is the safe direction: an unrecognized construct is never silently
+// swallowed as a heredoc body.
+function parseHeredocOperator(command, i) {
+  let pos = i + 2;
+  let stripLeadingTabs = false;
+  if (command[pos] === '-') {
+    stripLeadingTabs = true;
+    pos += 1;
+  }
+  while (command[pos] === ' ' || command[pos] === '\t') pos += 1;
+  const word = parseHeredocDelimiterWord(command, pos);
+  if (!word) return null;
+  return {
+    delimiter: word.value,
+    // Any quoted or backslash-escaped part of the delimiter word disables
+    // all expansion inside the heredoc body (parameter/command
+    // substitution) — this is what bash itself keys off of, not merely
+    // whether the WHOLE word happens to be quoted.
+    literal: word.literal,
+    stripLeadingTabs,
+    length: (pos + word.consumedLength) - i,
+  };
+}
 
 /**
  * Split a shell command into segments by operators (&&, ||, ;, &)
@@ -54,9 +127,12 @@ const HEREDOC_OPERATOR_RE = /^<<-?\s*(?:'([^']*)'|"([^"]*)"|(\\?[A-Za-z_]\w*))/;
  * newlines/operators — its content is literal data for the command that
  * requested it, not further shell syntax, so a line inside it that merely
  * resembles a destructive command (e.g. a code example in a commit message
- * template) must not be judged as its own segment. Only one heredoc is
- * tracked at a time (the common case); a line consisting of exactly the
- * delimiter (leading tabs stripped first for the `<<-` form) ends the body.
+ * template) must not be judged as its own segment. A line consisting of
+ * exactly the delimiter (leading tabs stripped first for the `<<-` form)
+ * ends the body. A command line can chain multiple heredocs (`cmd <<A <<B`);
+ * each `<<` found before the first one's body has started is queued, and
+ * bodies are consumed in the order their operators appeared, so the second
+ * heredoc's body is never mistaken for ordinary command segments.
  *
  * options.splitOnPipe (default false) additionally splits on a bare `|`
  * (not `||`, already handled above). Off by default because an existing
@@ -81,6 +157,9 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
   let heredocState = null;
   let heredocDelimiter = null;
   let heredocStripLeadingTabs = false;
+  // Heredocs queued on the same operator line after the first (e.g. the `B`
+  // in `cmd <<A <<B`), consumed in order as each preceding body closes.
+  const heredocQueue = [];
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
@@ -93,8 +172,17 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
       if (candidate === heredocDelimiter) {
         current += rawLine;
         i += rawLine.length - 1;
-        heredocState = null;
-        heredocDelimiter = null;
+        const next = heredocQueue.shift();
+        if (next) {
+          heredocDelimiter = next.delimiter;
+          heredocStripLeadingTabs = next.stripLeadingTabs;
+          // Stay in 'in-body': the newline right after this terminator line
+          // is also the first character of the next queued heredoc's body,
+          // not a fresh 'awaiting-body' gap.
+        } else {
+          heredocState = null;
+          heredocDelimiter = null;
+        }
         continue;
       }
       current += ch;
@@ -128,14 +216,21 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
       continue;
     }
 
-    if (heredocState === null && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
-      const m = HEREDOC_OPERATOR_RE.exec(command.slice(i));
-      if (m) {
-        heredocDelimiter = m[1] ?? m[2] ?? m[3].replaceAll('\\', '');
-        heredocStripLeadingTabs = m[0].startsWith('<<-');
-        heredocState = 'awaiting-body';
-        current += m[0];
-        i += m[0].length - 1;
+    if (heredocState !== 'in-body' && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
+      const op = parseHeredocOperator(command, i);
+      if (op) {
+        if (heredocState === null) {
+          heredocDelimiter = op.delimiter;
+          heredocStripLeadingTabs = op.stripLeadingTabs;
+          heredocState = 'awaiting-body';
+        } else {
+          // Already awaiting the first heredoc's body on this same command
+          // line — this is a second (or later) chained heredoc; its body
+          // comes after the first one's, so only queue it for now.
+          heredocQueue.push({ delimiter: op.delimiter, stripLeadingTabs: op.stripLeadingTabs });
+        }
+        current += command.slice(i, i + op.length);
+        i += op.length - 1;
         continue;
       }
     }
@@ -262,46 +357,118 @@ function pushSubstitutionAt(command, i, bodies) {
  * substitution (`<(...)`/`>(...)`) has no special meaning inside either
  * quote type (it is a bare word there), so it is only recognized unquoted.
  *
+ * Also honors the two other places bash text can contain a `$(...)`-shaped
+ * substring without it ever being live: a `# comment` (runs to end of line,
+ * never expanded) and a heredoc body whose delimiter was quoted/escaped
+ * (`<<'EOF'`, `<<"EOF"`, `<<\EOF` — fully literal, no expansion at all). A
+ * heredoc with a bare, unquoted delimiter (`<<EOF`) is NOT literal — bash
+ * still expands `$(...)` inside it — so that case still scans normally.
+ * Without this, a code example inside either construct (e.g. `# example:
+ * $(rm -rf /)` in a commit message template) would be extracted and judged
+ * as a live command it can never actually become.
+ *
  * Not recursive by itself — a caller that re-scans each returned body finds
  * substitutions nested inside substitutions; keeping recursion at the call
  * site (with its own depth guard) keeps this function simple and testable
  * in isolation.
  */
-function extractSubstitutionBodies(command) {
+function extractSubstitutionBodies(command) { // NOSONAR: shell scanner state machine kept inline for auditability
   const bodies = [];
   let quote = null;
+  let heredocState = null;
+  let heredocDelimiter = null;
+  let heredocStripLeadingTabs = false;
+  let heredocLiteral = false;
+  const heredocQueue = [];
+  let inComment = false;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
 
-    if (quote === "'") {
+    if (ch === '\n') inComment = false;
+
+    if (heredocState === 'in-body') {
+      const lineEnd = command.indexOf('\n', i);
+      const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
+      const line = rawLine.replace(/\r$/, '');
+      const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
+      if (candidate === heredocDelimiter) {
+        i += rawLine.length - 1;
+        const next = heredocQueue.shift();
+        if (next) {
+          heredocDelimiter = next.delimiter;
+          heredocStripLeadingTabs = next.stripLeadingTabs;
+          heredocLiteral = next.literal;
+        } else {
+          heredocState = null;
+          heredocDelimiter = null;
+        }
+        continue;
+      }
+      if (heredocLiteral) continue;
+      // Bare/unquoted-delimiter heredoc body: falls through to the normal
+      // scan below, since bash still expands $(...) here.
+    }
+
+    if (heredocState !== 'in-body' && quote === "'") {
       if (ch === quote) quote = null;
       continue;
     }
 
-    if (quote === '"' && ch === '\\' && i + 1 < command.length) {
+    if (heredocState !== 'in-body' && quote === '"' && ch === '\\' && i + 1 < command.length) {
       i += 1;
       continue;
     }
 
-    if (quote === '"' && ch === quote) {
+    if (heredocState !== 'in-body' && quote === '"' && ch === quote) {
       quote = null;
       continue;
     }
 
-    if (!quote && ch === '\\' && i + 1 < command.length) {
+    if (heredocState !== 'in-body' && !quote && ch === '\\' && i + 1 < command.length) {
       i += 1;
       continue;
     }
 
-    if (!quote && (ch === '"' || ch === "'")) {
+    if (heredocState !== 'in-body' && !quote && (ch === '"' || ch === "'")) {
       quote = ch;
       continue;
     }
 
-    // Reached only in an unquoted or double-quoted context (single-quoted
-    // spans already `continue`d above) — the two contexts where a real
-    // shell still expands $(...)/`...` (see the doc comment above).
+    if (heredocState !== 'in-body' && !quote && !inComment && ch === '#'
+        && (i === 0 || HEREDOC_WORD_STOP_RE.test(command[i - 1]))) {
+      inComment = true;
+      continue;
+    }
+
+    if (inComment) continue;
+
+    if (heredocState === 'awaiting-body' && ch === '\n') {
+      heredocState = 'in-body';
+      continue;
+    }
+
+    if (heredocState !== 'in-body' && !quote && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
+      const op = parseHeredocOperator(command, i);
+      if (op) {
+        if (heredocState === null) {
+          heredocDelimiter = op.delimiter;
+          heredocStripLeadingTabs = op.stripLeadingTabs;
+          heredocLiteral = op.literal;
+          heredocState = 'awaiting-body';
+        } else {
+          heredocQueue.push({ delimiter: op.delimiter, stripLeadingTabs: op.stripLeadingTabs, literal: op.literal });
+        }
+        i += op.length - 1;
+        continue;
+      }
+    }
+
+    // Reached only in an unquoted or double-quoted context, outside a
+    // comment and outside a literal heredoc body (single-quoted spans and
+    // literal heredoc bodies already `continue`d above) — the contexts
+    // where a real shell still expands $(...)/`...` (see the doc comment
+    // above).
     const end = pushSubstitutionAt(command, i, bodies);
     if (end !== -1) i += (end - i);
   }

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -86,8 +86,22 @@ function parseHeredocDelimiterWord(command, start) {
       while (j < command.length) {
         const c = command[j];
         if (quoteChar === '"' && c === '\\' && j + 1 < command.length) {
-          inner += command[j + 1];
-          j += 2;
+          const escaped = command[j + 1];
+          // Bash only strips the backslash inside "..." when it precedes
+          // one of these five characters; before anything else the
+          // backslash is kept literally in the string. Always stripping it
+          // (as this used to) computed a too-short delimiter value for
+          // forms like <<"EO\NF" (backslash-N is not special), so the real
+          // terminator line — which bash resolves to the correct, longer
+          // value including the literal backslash — never matched, and the
+          // heredoc body never closed.
+          if (escaped === '$' || escaped === '`' || escaped === '"' || escaped === '\\' || escaped === '\n') {
+            inner += escaped;
+            j += 2;
+          } else {
+            inner += c;
+            j += 1;
+          }
           continue;
         }
         if (c === quoteChar) { closed = true; j += 1; break; }

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -70,11 +70,34 @@ function parseHeredocDelimiterWord(command, start) {
       continue;
     }
     if (ch === "'" || ch === '"') {
-      const closeIndex = command.indexOf(ch, i + 1);
-      if (closeIndex === -1) return null;
-      value += command.slice(i + 1, closeIndex);
+      // A plain indexOf() for the closing quote treats an escaped quote
+      // inside a double-quoted span (`<<"EO\"F"`) as the real closer,
+      // truncating the delimiter early — the real terminator line (which
+      // must match the FULL, correctly-unescaped word) then never matches
+      // this too-short guess, so the heredoc body never closes and every
+      // command after it goes unvalidated (the same failure shape as the
+      // EOF-1 truncation bug above, just via escaping instead of a
+      // narrow character class). Single quotes have no escape mechanism in
+      // bash (the first `'` always closes), so only `"` needs this.
+      const quoteChar = ch;
+      let j = i + 1;
+      let inner = '';
+      let closed = false;
+      while (j < command.length) {
+        const c = command[j];
+        if (quoteChar === '"' && c === '\\' && j + 1 < command.length) {
+          inner += command[j + 1];
+          j += 2;
+          continue;
+        }
+        if (c === quoteChar) { closed = true; j += 1; break; }
+        inner += c;
+        j += 1;
+      }
+      if (!closed) return null;
+      value += inner;
       literal = true;
-      i = closeIndex + 1;
+      i = j;
       consumedAny = true;
       continue;
     }
@@ -160,31 +183,43 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
   // Heredocs queued on the same operator line after the first (e.g. the `B`
   // in `cmd <<A <<B`), consumed in order as each preceding body closes.
   const heredocQueue = [];
+  // True only for the first character of a body line -- the terminator can
+  // only ever be a whole line, so the expensive indexOf('\n')+slice+compare
+  // below only needs to run there. Re-running it at every character of a
+  // long single-line body was O(line length) work per character, i.e.
+  // O(n^2) for one long line, before Guardian even validated anything.
+  let heredocAtLineStart = false;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
 
     if (heredocState === 'in-body') {
-      const lineEnd = command.indexOf('\n', i);
-      const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
-      const line = rawLine.replace(/\r$/, '');
-      const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
-      if (candidate === heredocDelimiter) {
-        current += rawLine;
-        i += rawLine.length - 1;
-        const next = heredocQueue.shift();
-        if (next) {
-          heredocDelimiter = next.delimiter;
-          heredocStripLeadingTabs = next.stripLeadingTabs;
-          // Stay in 'in-body': the newline right after this terminator line
-          // is also the first character of the next queued heredoc's body,
-          // not a fresh 'awaiting-body' gap.
-        } else {
-          heredocState = null;
-          heredocDelimiter = null;
+      if (heredocAtLineStart) {
+        const lineEnd = command.indexOf('\n', i);
+        const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
+        const line = rawLine.replace(/\r$/, '');
+        const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
+        if (candidate === heredocDelimiter) {
+          current += rawLine;
+          i += rawLine.length - 1;
+          const next = heredocQueue.shift();
+          if (next) {
+            heredocDelimiter = next.delimiter;
+            heredocStripLeadingTabs = next.stripLeadingTabs;
+            // Stay in 'in-body' and at a (new) line start: the newline
+            // right after this terminator line is also the first character
+            // of the next queued heredoc's body, not a fresh
+            // 'awaiting-body' gap.
+          } else {
+            heredocState = null;
+            heredocDelimiter = null;
+            heredocAtLineStart = false;
+          }
+          continue;
         }
-        continue;
+        heredocAtLineStart = false;
       }
+      if (ch === '\n') heredocAtLineStart = true;
       current += ch;
       continue;
     }
@@ -213,6 +248,7 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
     if (heredocState === 'awaiting-body' && ch === '\n') {
       current += ch;
       heredocState = 'in-body';
+      heredocAtLineStart = true;
       continue;
     }
 
@@ -324,6 +360,30 @@ function findMatchingBacktick(command, start) {
 function pushSubstitutionAt(command, i, bodies) {
   const next = command[i + 1] || '';
   const ch = command[i];
+  if (ch === '$' && next === '(' && command[i + 2] === '(') {
+    const end = findMatchingParen(command, i + 2);
+    if (end !== -1) {
+      // Arithmetic expansion $((...)) never executes its expression as a
+      // shell command -- only a real $(...) or `...` substitution does.
+      // findMatchingParen(i+2) treats the arithmetic's own inner '(' as an
+      // extra nesting level and returns the OUTER closing paren, so without
+      // this the whole "(expr)" text gets pushed as if it were command
+      // content -- miscounting as one more level of command-substitution
+      // nesting toward MAX_SUBSTITUTION_DEPTH even for something as
+      // harmless as `$((1+2))`. If the expression's own text contains no
+      // `$(`/backtick anywhere, there is categorically nothing to validate
+      // inside it (both require that literal syntax to exist), so no body
+      // is pushed at all. If it DOES contain one (bash really does execute
+      // `$(( $(cat x) + 1 ))`'s inner substitution), fall through to the
+      // ordinary handling below unchanged -- never unwrap it here directly,
+      // which would recurse outside pre-bash-guardian-validate.js's depth
+      // counter and defeat the cap entirely for deeply-nested arithmetic.
+      const inner = command.slice(i + 3, end - 1);
+      if (!inner.includes('$(') && !inner.includes('`')) {
+        return end;
+      }
+    }
+  }
   if ((ch === '$' || ch === '<' || ch === '>') && next === '(') {
     const end = findMatchingParen(command, i + 2);
     if (end !== -1) {
@@ -381,6 +441,11 @@ function extractSubstitutionBodies(command) { // NOSONAR: shell scanner state ma
   let heredocLiteral = false;
   const heredocQueue = [];
   let inComment = false;
+  // True only for the first character of a body line -- see the identical
+  // field in splitShellSegments for why re-checking the terminator at every
+  // character (not just line starts) was an O(n^2) cost on one long body
+  // line.
+  let heredocAtLineStart = false;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
@@ -388,23 +453,28 @@ function extractSubstitutionBodies(command) { // NOSONAR: shell scanner state ma
     if (ch === '\n') inComment = false;
 
     if (heredocState === 'in-body') {
-      const lineEnd = command.indexOf('\n', i);
-      const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
-      const line = rawLine.replace(/\r$/, '');
-      const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
-      if (candidate === heredocDelimiter) {
-        i += rawLine.length - 1;
-        const next = heredocQueue.shift();
-        if (next) {
-          heredocDelimiter = next.delimiter;
-          heredocStripLeadingTabs = next.stripLeadingTabs;
-          heredocLiteral = next.literal;
-        } else {
-          heredocState = null;
-          heredocDelimiter = null;
+      if (heredocAtLineStart) {
+        const lineEnd = command.indexOf('\n', i);
+        const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
+        const line = rawLine.replace(/\r$/, '');
+        const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
+        if (candidate === heredocDelimiter) {
+          i += rawLine.length - 1;
+          const next = heredocQueue.shift();
+          if (next) {
+            heredocDelimiter = next.delimiter;
+            heredocStripLeadingTabs = next.stripLeadingTabs;
+            heredocLiteral = next.literal;
+          } else {
+            heredocState = null;
+            heredocDelimiter = null;
+            heredocAtLineStart = false;
+          }
+          continue;
         }
-        continue;
+        heredocAtLineStart = false;
       }
+      if (ch === '\n') heredocAtLineStart = true;
       if (heredocLiteral) continue;
       // Bare/unquoted-delimiter heredoc body: falls through to the normal
       // scan below, since bash still expands $(...) here.
@@ -445,6 +515,7 @@ function extractSubstitutionBodies(command) { // NOSONAR: shell scanner state ma
 
     if (heredocState === 'awaiting-body' && ch === '\n') {
       heredocState = 'in-body';
+      heredocAtLineStart = true;
       continue;
     }
 

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -131,7 +131,7 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
     if (heredocState === null && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
       const m = HEREDOC_OPERATOR_RE.exec(command.slice(i));
       if (m) {
-        heredocDelimiter = m[1] ?? m[2] ?? m[3].replace(/\\/g, '');
+        heredocDelimiter = m[1] ?? m[2] ?? m[3].replaceAll('\\', '');
         heredocStripLeadingTabs = m[0].startsWith('<<-');
         heredocState = 'awaiting-body';
         current += m[0];
@@ -181,6 +181,24 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
   return segments;
 }
 
+// One scan step for findMatchingParen: given the current quote state,
+// returns how far to additionally advance past this char (an escaped char
+// consumes its pair), the quote state after this char, and how much this
+// char changes the paren depth (0 unless it's an unquoted paren). Splitting
+// this out of the loop keeps each branch a flat, single-condition early
+// return instead of nested ifs, which is what keeps cognitive complexity low.
+function scanParenChar(ch, i, command, quote) {
+  if (quote) {
+    if (ch === '\\' && quote === '"' && i + 1 < command.length) return { advance: 1, quote, delta: 0 };
+    return { advance: 0, quote: ch === quote ? null : quote, delta: 0 };
+  }
+  if (ch === '\\' && i + 1 < command.length) return { advance: 1, quote: null, delta: 0 };
+  if (ch === '"' || ch === "'") return { advance: 0, quote: ch, delta: 0 };
+  if (ch === '(') return { advance: 0, quote: null, delta: 1 };
+  if (ch === ')') return { advance: 0, quote: null, delta: -1 };
+  return { advance: 0, quote: null, delta: 0 };
+}
+
 // Finds the index of the `)` that matches the `(` implicitly opened at
 // `start` (i.e. `start` is the position right after that `(`), honoring
 // quotes so an unbalanced paren inside a quoted string doesn't close early.
@@ -190,19 +208,11 @@ function findMatchingParen(command, start) {
   let depth = 1;
   let quote = null;
   for (let i = start; i < command.length; i++) {
-    const ch = command[i];
-    if (quote) {
-      if (ch === '\\' && quote === '"' && i + 1 < command.length) { i += 1; continue; }
-      if (ch === quote) quote = null;
-      continue;
-    }
-    if (ch === '\\' && i + 1 < command.length) { i += 1; continue; }
-    if (ch === '"' || ch === "'") { quote = ch; continue; }
-    if (ch === '(') depth += 1;
-    else if (ch === ')') {
-      depth -= 1;
-      if (depth === 0) return i;
-    }
+    const r = scanParenChar(command[i], i, command, quote);
+    quote = r.quote;
+    i += r.advance;
+    depth += r.delta;
+    if (r.delta && depth === 0) return i;
   }
   return -1;
 }
@@ -269,19 +279,31 @@ function extractSubstitutionBodies(command) {
       continue;
     }
 
-    if (quote === '"') {
-      if (ch === '\\' && i + 1 < command.length) { i += 1; continue; }
-      if (ch === quote) { quote = null; continue; }
-      const end = pushSubstitutionAt(command, i, bodies);
-      if (end !== -1) { i = end; continue; }
+    if (quote === '"' && ch === '\\' && i + 1 < command.length) {
+      i += 1;
       continue;
     }
 
-    if (ch === '\\' && i + 1 < command.length) { i += 1; continue; }
-    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (quote === '"' && ch === quote) {
+      quote = null;
+      continue;
+    }
 
+    if (!quote && ch === '\\' && i + 1 < command.length) {
+      i += 1;
+      continue;
+    }
+
+    if (!quote && (ch === '"' || ch === "'")) {
+      quote = ch;
+      continue;
+    }
+
+    // Reached only in an unquoted or double-quoted context (single-quoted
+    // spans already `continue`d above) — the two contexts where a real
+    // shell still expands $(...)/`...` (see the doc comment above).
     const end = pushSubstitutionAt(command, i, bodies);
-    if (end !== -1) { i = end; continue; }
+    if (end !== -1) i += (end - i);
   }
 
   return bodies;

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -39,10 +39,24 @@ function handleSingleAmpersand(ch, next, prev, current, segments) {
   return { current: '', handled: true };
 }
 
+// Matches a heredoc redirect operator (<<EOF, <<-EOF, <<'EOF', <<"EOF") at
+// the start of the given string. Group 1/2 capture a quoted delimiter
+// (quotes stripped, no escape processing needed inside); group 3 captures a
+// bare or backslash-escaped delimiter word.
+const HEREDOC_OPERATOR_RE = /^<<-?\s*(?:'([^']*)'|"([^"]*)"|(\\?[A-Za-z_]\w*))/;
+
 /**
  * Split a shell command into segments by operators (&&, ||, ;, &)
  * while respecting quoting (single/double) and escaped characters.
  * Redirection operators (&>, >&, 2>&1) are NOT treated as separators.
+ *
+ * A heredoc body (<<EOF ... EOF) is never split on its own embedded
+ * newlines/operators — its content is literal data for the command that
+ * requested it, not further shell syntax, so a line inside it that merely
+ * resembles a destructive command (e.g. a code example in a commit message
+ * template) must not be judged as its own segment. Only one heredoc is
+ * tracked at a time (the common case); a line consisting of exactly the
+ * delimiter (leading tabs stripped first for the `<<-` form) ends the body.
  *
  * options.splitOnPipe (default false) additionally splits on a bare `|`
  * (not `||`, already handled above). Off by default because an existing
@@ -56,9 +70,36 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
   const segments = [];
   let current = '';
   let quote = null;
+  // Heredoc state machine: null (no heredoc pending) -> 'awaiting-body' (the
+  // <<DELIM operator was just parsed; the body starts at the NEXT newline,
+  // not immediately) -> 'in-body' (scanning body lines for the terminator)
+  // -> null again. Keeping this as one variable (rather than a heredocState
+  // flag plus a separate "seen delimiter" flag) is deliberate: two
+  // independently-updated flags previously went out of sync exactly at this
+  // transition, causing the terminator's own trailing newline to be
+  // swallowed into the body instead of ending the segment.
+  let heredocState = null;
+  let heredocDelimiter = null;
+  let heredocStripLeadingTabs = false;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
+
+    if (heredocState === 'in-body') {
+      const lineEnd = command.indexOf('\n', i);
+      const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
+      const line = rawLine.replace(/\r$/, '');
+      const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
+      if (candidate === heredocDelimiter) {
+        current += rawLine;
+        i += rawLine.length - 1;
+        heredocState = null;
+        heredocDelimiter = null;
+        continue;
+      }
+      current += ch;
+      continue;
+    }
 
     if (quote) {
       const r = handleInsideQuotes(ch, i, command, quote);
@@ -79,6 +120,24 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
       quote = ch;
       current += ch;
       continue;
+    }
+
+    if (heredocState === 'awaiting-body' && ch === '\n') {
+      current += ch;
+      heredocState = 'in-body';
+      continue;
+    }
+
+    if (heredocState === null && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
+      const m = HEREDOC_OPERATOR_RE.exec(command.slice(i));
+      if (m) {
+        heredocDelimiter = m[1] ?? m[2] ?? m[3].replace(/\\/g, '');
+        heredocStripLeadingTabs = m[0].startsWith('<<-');
+        heredocState = 'awaiting-body';
+        current += m[0];
+        i += m[0].length - 1;
+        continue;
+      }
     }
 
     if (ch === '\n' || ch === '\r') {
@@ -122,4 +181,110 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
   return segments;
 }
 
-module.exports = { splitShellSegments };
+// Finds the index of the `)` that matches the `(` implicitly opened at
+// `start` (i.e. `start` is the position right after that `(`), honoring
+// quotes so an unbalanced paren inside a quoted string doesn't close early.
+// Returns -1 if the input is malformed (no matching close) — callers must
+// treat that as "nothing to extract here", not throw.
+function findMatchingParen(command, start) {
+  let depth = 1;
+  let quote = null;
+  for (let i = start; i < command.length; i++) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === '\\' && quote === '"' && i + 1 < command.length) { i += 1; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) { i += 1; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (ch === '(') depth += 1;
+    else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function findMatchingBacktick(command, start) {
+  for (let i = start; i < command.length; i++) {
+    const ch = command[i];
+    if (ch === '\\' && i + 1 < command.length) { i += 1; continue; }
+    if (ch === '`') return i;
+  }
+  return -1;
+}
+
+function pushSubstitutionAt(command, i, bodies) {
+  const next = command[i + 1] || '';
+  const ch = command[i];
+  if ((ch === '$' || ch === '<' || ch === '>') && next === '(') {
+    const end = findMatchingParen(command, i + 2);
+    if (end !== -1) {
+      bodies.push(command.slice(i + 2, end));
+      return end;
+    }
+  }
+  if (ch === '`') {
+    const end = findMatchingBacktick(command, i + 1);
+    if (end !== -1) {
+      bodies.push(command.slice(i + 1, end));
+      return end;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Extracts the inner text of every top-level command substitution
+ * (`$(...)`), process substitution (`<(...)`, `>(...)`), and legacy
+ * backtick substitution (`` `...` ``) in a command string, honoring quotes.
+ * A command hidden inside one of these executes exactly like the rest of
+ * the command line — `echo $(rm -rf /)` still runs `rm -rf /` — but neither
+ * character (`$`/backtick) is itself a segment separator, so without this
+ * extraction its content is invisible to segment-based validation and is
+ * covered only by the advisory (non-blocking) metacharacter check.
+ *
+ * Double quotes do NOT suppress `$(...)`/backtick expansion in a real shell
+ * (only single quotes do), so both are still recognized while quote === '"'
+ * — `echo "$(rm -rf /)"` is just as live as the unquoted form. Process
+ * substitution (`<(...)`/`>(...)`) has no special meaning inside either
+ * quote type (it is a bare word there), so it is only recognized unquoted.
+ *
+ * Not recursive by itself — a caller that re-scans each returned body finds
+ * substitutions nested inside substitutions; keeping recursion at the call
+ * site (with its own depth guard) keeps this function simple and testable
+ * in isolation.
+ */
+function extractSubstitutionBodies(command) {
+  const bodies = [];
+  let quote = null;
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+
+    if (quote === "'") {
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (quote === '"') {
+      if (ch === '\\' && i + 1 < command.length) { i += 1; continue; }
+      if (ch === quote) { quote = null; continue; }
+      const end = pushSubstitutionAt(command, i, bodies);
+      if (end !== -1) { i = end; continue; }
+      continue;
+    }
+
+    if (ch === '\\' && i + 1 < command.length) { i += 1; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+
+    const end = pushSubstitutionAt(command, i, bodies);
+    if (end !== -1) { i = end; continue; }
+  }
+
+  return bodies;
+}
+
+module.exports = { splitShellSegments, extractSubstitutionBodies };

--- a/scripts/lib/windsurf-gateguard-hooks.js
+++ b/scripts/lib/windsurf-gateguard-hooks.js
@@ -66,11 +66,21 @@ function isEgcEntry(entry, command) {
   return isPlainObject(entry) && entry.command === command;
 }
 
+const EGC_ADAPTER_BASENAMES = [
+  path.basename(ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH),
+  path.basename(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH),
+];
+
 function isStaleEgcEntry(entry, command) {
   if (!isPlainObject(entry) || typeof entry.command !== 'string' || entry.command === command) {
     return false;
   }
-  return entry.command.includes(path.basename(ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH));
+  // Only checking the GateGuard adapter's basename meant a relocated
+  // Guardian entry (e.g. after an install path change) was never
+  // recognized as stale here, so repair appended a duplicate pointing at
+  // the new path instead of migrating the old one in place, leaving both
+  // in hooks.json.
+  return EGC_ADAPTER_BASENAMES.some(basename => entry.command.includes(basename));
 }
 
 function addWindsurfHookEntry(config, event, command) {

--- a/scripts/lib/windsurf-gateguard-hooks.js
+++ b/scripts/lib/windsurf-gateguard-hooks.js
@@ -111,6 +111,64 @@ function applyWindsurfGateGuardHookToFile(hooksJsonPath, event, adapterScriptPat
   return { changed };
 }
 
+// Pure counterpart to addWindsurfHookEntry: drops only the EGC-managed
+// entry (matched by exact command) from hooks[event], leaving every other
+// entry (third-party hooks, other events) untouched. Deletes the event key
+// entirely once it is empty, rather than leaving a dangling `[]` in the
+// user's hooks.json.
+function removeWindsurfHookEntry(config, event, command) {
+  const base = isPlainObject(config) ? config : {};
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+  const nextEntries = existing.filter(entry => !isEgcEntry(entry, command));
+
+  if (nextEntries.length === existing.length) {
+    return { config: base, changed: false };
+  }
+
+  if (nextEntries.length > 0) {
+    hooks[event] = nextEntries;
+  } else {
+    delete hooks[event];
+  }
+  return { config: { ...base, hooks }, changed: true };
+}
+
+// install-lifecycle.js's install-manifests.js-driven repair/inspect/
+// uninstall previously had no notion of Windsurf's event-keyed hooks.json
+// at all (only Claude's matcher/group settings.json schema), so a Windsurf
+// GateGuard/Guardian entry: repair injected a bogus SessionStart group into
+// the same file instead of touching pre_write_code/pre_run_command, doctor
+// always reported drift (it checked for that same bogus SessionStart
+// group, which never exists organically), and uninstall left the real
+// entry behind pointing at a script the copy-file uninstall step had
+// already deleted. These two functions give install-lifecycle.js the same
+// remove/inspect primitives it already has for Claude's schema.
+function removeWindsurfGateGuardHookFromFile(hooksJsonPath, event, adapterScriptPath) {
+  if (!fs.existsSync(hooksJsonPath)) {
+    return { changed: false };
+  }
+  const command = buildHookCommand(adapterScriptPath);
+  const current = readHooksFile(hooksJsonPath);
+  const { config, changed } = removeWindsurfHookEntry(current, event, command);
+  if (changed) {
+    writeHooksFile(hooksJsonPath, config);
+  }
+  return { changed };
+}
+
+function inspectWindsurfGateGuardHookFile(hooksJsonPath, event, adapterScriptPath) {
+  try {
+    const command = buildHookCommand(adapterScriptPath);
+    const current = readHooksFile(hooksJsonPath);
+    const hooks = isPlainObject(current.hooks) ? current.hooks : {};
+    const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+    return existing.some(entry => isEgcEntry(entry, command)) ? 'ok' : 'drifted';
+  } catch {
+    return 'drifted';
+  }
+}
+
 module.exports = {
   ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
   GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -118,6 +176,9 @@ module.exports = {
   PRE_WRITE_CODE_EVENT,
   addWindsurfHookEntry,
   applyWindsurfGateGuardHookToFile,
+  inspectWindsurfGateGuardHookFile,
+  removeWindsurfGateGuardHookFromFile,
+  removeWindsurfHookEntry,
   resolveAdapterScriptDestination,
   resolveGuardianAdapterScriptDestination,
   resolveHooksJsonPath,

--- a/scripts/lib/windsurf-gateguard-hooks.js
+++ b/scripts/lib/windsurf-gateguard-hooks.js
@@ -15,6 +15,7 @@ const path = require('node:path');
 const PRE_WRITE_CODE_EVENT = 'pre_write_code';
 const PRE_RUN_COMMAND_EVENT = 'pre_run_command';
 const ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/windsurf-gateguard-adapter.js';
+const GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/windsurf-guardian-adapter.js';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -26,6 +27,10 @@ function buildHookCommand(scriptPath) {
 
 function resolveAdapterScriptDestination(targetRoot) {
   return path.join(targetRoot, 'scripts', 'hooks', 'windsurf-gateguard-adapter.js');
+}
+
+function resolveGuardianAdapterScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'windsurf-guardian-adapter.js');
 }
 
 function resolveHooksJsonPath(targetRoot) {
@@ -108,10 +113,12 @@ function applyWindsurfGateGuardHookToFile(hooksJsonPath, event, adapterScriptPat
 
 module.exports = {
   ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
   PRE_RUN_COMMAND_EVENT,
   PRE_WRITE_CODE_EVENT,
   addWindsurfHookEntry,
   applyWindsurfGateGuardHookToFile,
   resolveAdapterScriptDestination,
+  resolveGuardianAdapterScriptDestination,
   resolveHooksJsonPath,
 };

--- a/scripts/lib/windsurf-gateguard-operations.js
+++ b/scripts/lib/windsurf-gateguard-operations.js
@@ -15,23 +15,26 @@
 const {
   GATEGUARD_HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
+  BASH_GUARDIAN_HOOK_MODULE_ID,
   createGateGuardScriptCopyOperations,
+  createBashGuardianScriptCopyOperations,
 } = require('./claude-settings-hooks');
 const {
   ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
   PRE_RUN_COMMAND_EVENT,
   PRE_WRITE_CODE_EVENT,
   resolveAdapterScriptDestination,
+  resolveGuardianAdapterScriptDestination,
   resolveHooksJsonPath,
 } = require('./windsurf-gateguard-hooks');
 
 function createWindsurfGateGuardOperations(adapter, targetRoot, createRemappedOperation) {
-  const scriptCopyOperations = createGateGuardScriptCopyOperations(
-    (moduleId, sourceRelativePath, destinationPath, options) => (
-      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-    ),
-    targetRoot
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
+
+  const scriptCopyOperations = createGateGuardScriptCopyOperations(remap, targetRoot);
 
   const adapterScriptDestination = resolveAdapterScriptDestination(targetRoot);
   const adapterCopyOperation = createRemappedOperation(
@@ -55,7 +58,41 @@ function createWindsurfGateGuardOperations(adapter, targetRoot, createRemappedOp
     hookScriptPath: adapterScriptDestination,
   }));
 
-  return [...scriptCopyOperations, adapterCopyOperation, ...mergeOperations];
+  // EGC Guardian: the GateGuard adapter above only forces investigation
+  // before a risky action, it never checks a Bash command against the
+  // Guardian's actual allowlist/denylist. 2026-07-27 audit (EGC-460/462)
+  // found Windsurf's adapter called only gateguard-fact-force.js, never
+  // pre-bash-guardian-validate.js. Registered on pre_run_command only (the
+  // Guardian validates shell commands, not file writes).
+  const guardianScriptCopyOperations = createBashGuardianScriptCopyOperations(remap, targetRoot);
+  const guardianAdapterScriptDestination = resolveGuardianAdapterScriptDestination(targetRoot);
+  const guardianAdapterCopyOperation = createRemappedOperation(
+    adapter,
+    BASH_GUARDIAN_HOOK_MODULE_ID,
+    GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    guardianAdapterScriptDestination,
+    { strategy: 'preserve-relative-path' }
+  );
+  const guardianMergeOperation = {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: BASH_GUARDIAN_HOOK_MODULE_ID,
+    sourceRelativePath: GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: hooksJsonPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_RUN_COMMAND_EVENT,
+    hookScriptPath: guardianAdapterScriptDestination,
+  };
+
+  return [
+    ...scriptCopyOperations,
+    adapterCopyOperation,
+    ...mergeOperations,
+    ...guardianScriptCopyOperations,
+    guardianAdapterCopyOperation,
+    guardianMergeOperation,
+  ];
 }
 
 module.exports = { createWindsurfGateGuardOperations };

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -135,8 +135,15 @@ run('env --split-string="rm -rf /" is hard-blocked', () => assertHardBlocked('en
 run('env -i FOO=bar npm test stays allowed (ordinary env usage, no -S)', () => assertAllowed('env -i FOO=bar npm test'));
 
 run('export GIT_SSH_COMMAND=/tmp/evil is hard-blocked (persists like a bare VAR= prefix)', () => assertHardBlocked('export GIT_SSH_COMMAND=/tmp/evil'));
-run('export GIT_SSH_COMMAND=/tmp/evil && git fetch is hard-blocked (segment 1 alone already denies)', () => assertHardBlocked('export GIT_SSH_COMMAND=/tmp/evil'));
+run('export GIT_SSH_COMMAND=/tmp/evil && git fetch is hard-blocked (segment 1 alone already denies)', () => assertHardBlocked('export GIT_SSH_COMMAND=/tmp/evil && git fetch'));
 run('export FOO=bar stays allowed (harmless env var)', () => assertAllowed('export FOO=bar'));
+run('export -- GIT_SSH_COMMAND=/tmp/evil is hard-blocked (-- end-of-options no longer hides the assignment)', () => assertHardBlocked('export -- GIT_SSH_COMMAND=/tmp/evil'));
+run('export -f -- GIT_SSH_COMMAND=/tmp/evil is hard-blocked (flag before -- still skipped correctly)', () => assertHardBlocked('export -f -- GIT_SSH_COMMAND=/tmp/evil'));
+run('export -- FOO=bar stays allowed (harmless var behind --)', () => assertAllowed('export -- FOO=bar'));
+run('export -p is not hard-blocked (no assignment present, falls through like any unknown command)', () => {
+  const v = validateCommand('export -p');
+  assert.notStrictEqual(v.trust_level, 'DANGEROUS', 'export -p (listing, no assignment) must not hit the DANGEROUS export check');
+});
 
 run('git config --show-scope core.hooksPath /tmp/evil is hard-blocked (output-annotator flag no longer exempts a real SET)', () => assertHardBlocked('git config --show-scope core.hooksPath /tmp/evil'));
 run('git config --name-only core.hooksPath /tmp/evil is hard-blocked', () => assertHardBlocked('git config --name-only core.hooksPath /tmp/evil'));

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -129,5 +129,44 @@ run('.git/info/exclude write stays allowed (not a hooks/config path)', () => {
   assert.strictEqual(v.allowed, true, `expected .git/info/exclude to stay allowed, got: ${v.reason}`);
 });
 
+console.log('\ncubic-dev-ai PR review findings (2026-07-27, follow-up round):');
+run('env -S "rm -rf /" is hard-blocked (split-string re-execs its value)', () => assertHardBlocked('env -S "rm -rf /"'));
+run('env --split-string="rm -rf /" is hard-blocked', () => assertHardBlocked('env --split-string="rm -rf /"'));
+run('env -i FOO=bar npm test stays allowed (ordinary env usage, no -S)', () => assertAllowed('env -i FOO=bar npm test'));
+
+run('export GIT_SSH_COMMAND=/tmp/evil is hard-blocked (persists like a bare VAR= prefix)', () => assertHardBlocked('export GIT_SSH_COMMAND=/tmp/evil'));
+run('export GIT_SSH_COMMAND=/tmp/evil && git fetch is hard-blocked (segment 1 alone already denies)', () => assertHardBlocked('export GIT_SSH_COMMAND=/tmp/evil'));
+run('export FOO=bar stays allowed (harmless env var)', () => assertAllowed('export FOO=bar'));
+
+run('git config --show-scope core.hooksPath /tmp/evil is hard-blocked (output-annotator flag no longer exempts a real SET)', () => assertHardBlocked('git config --show-scope core.hooksPath /tmp/evil'));
+run('git config --name-only core.hooksPath /tmp/evil is hard-blocked', () => assertHardBlocked('git config --name-only core.hooksPath /tmp/evil'));
+run('git config --edit is hard-blocked unconditionally (opaque editor session)', () => assertHardBlocked('git config --edit'));
+run('git config -e is hard-blocked unconditionally', () => assertHardBlocked('git config -e'));
+run('git config --show-scope --get core.hooksPath stays allowed (genuine read)', () => assertAllowed('git config --show-scope --get core.hooksPath'));
+
+run('git config "--global" core.hooksPath /tmp/evil is hard-blocked (quoted flag no longer misread as a positional)', () => assertHardBlocked('git config "--global" core.hooksPath /tmp/evil'));
+
+run('git -c foo=bar config core.hooksPath /tmp/evil is hard-blocked (global flag before config no longer hides the subcommand)', () => assertHardBlocked('git -c foo=bar config core.hooksPath /tmp/evil'));
+run('git -C /tmp config core.hooksPath /tmp/evil is hard-blocked (global -C flag+value skipped correctly)', () => assertHardBlocked('git -C /tmp config core.hooksPath /tmp/evil'));
+run('git -C config status stays allowed (literal "config" as a -C value is not mistaken for the subcommand)', () => assertAllowed('git -C config status'));
+
+run('git config core.fsmonitor /tmp/evil is hard-blocked (expanded dangerous-key coverage)', () => assertHardBlocked('git config core.fsmonitor /tmp/evil'));
+run('git config filter.lfs.clean /tmp/evil is hard-blocked', () => assertHardBlocked('git config filter.lfs.clean /tmp/evil'));
+run('git config filter.lfs.smudge /tmp/evil is hard-blocked', () => assertHardBlocked('git config filter.lfs.smudge /tmp/evil'));
+run('git config filter.lfs.process /tmp/evil is hard-blocked', () => assertHardBlocked('git config filter.lfs.process /tmp/evil'));
+run('git config diff.evil.command /tmp/evil is hard-blocked', () => assertHardBlocked('git config diff.evil.command /tmp/evil'));
+
+run('sudo -U rm -rf / is not silently misparsed by case-insensitive flag lookup (unknown flag stays boolean, rm is still reached)', () => assertHardBlocked('sudo -U rm -rf /'));
+
+console.log('\nGemini CLI cross-CLI fail-open fix (2026-07-27 audit):');
+run('.gemini/config/mcp_config.json write is blocked (guardian-bin.js now trusts this file to resolve the CLI)', () => {
+  const v = validateWrite('.gemini/config/mcp_config.json');
+  assert.strictEqual(v.allowed, false, 'expected .gemini/config/mcp_config.json write to be blocked');
+});
+run('.gemini/GEMINI.md write stays allowed (functional file, not a credential/trust-anchor)', () => {
+  const v = validateWrite('.gemini/GEMINI.md');
+  assert.strictEqual(v.allowed, true, `expected .gemini/GEMINI.md to stay allowed, got: ${v.reason}`);
+});
+
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
 if (failed > 0) process.exit(1);

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -10,6 +10,18 @@ const { spawnSync } = require('child_process');
 
 const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
 const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+const hookPath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+const { extractSegments } = require(hookPath);
+
+// Builds `echo $(echo $(... echo $(innerCommand) ...))` nested `depth` levels
+// deep, matching the shape cubic-dev-ai's review used to demonstrate the
+// silent-truncation bypass (a real destructive command nested one level past
+// MAX_SUBSTITUTION_DEPTH used to be dropped instead of analyzed).
+function nestedSubstitution(depth, innerCommand) {
+  let cmd = innerCommand;
+  for (let i = 0; i < depth; i++) cmd = `echo $(${cmd})`;
+  return cmd;
+}
 
 function test(name, fn) {
   try {
@@ -105,6 +117,40 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('fails open (exercised, not just documented) when no Guardian CLI resolves at all', () => {
+    // resolveGuardianCli() returning falsy is the real "no build, no
+    // override, no trusted MCP config" state, not just a hypothetical.
+    // Reproducing it via a subprocess on a temp copy of the hook would run
+    // the same logic but at a different file path, so c8 could never credit
+    // the coverage to the real scripts/hooks/pre-bash-guardian-validate.js.
+    // Stubbing guardian-bin.js in this process's require.cache and
+    // re-requiring the hook fresh keeps everything on the real file path
+    // while still deterministically forcing the falsy-cli branch.
+    const guardianBinPath = require.resolve(path.join('..', '..', 'scripts', 'lib', 'guardian-bin.js'));
+    const originalGuardianBinEntry = require.cache[guardianBinPath];
+    const originalHookEntry = require.cache[hookPath];
+    try {
+      delete require.cache[guardianBinPath];
+      delete require.cache[hookPath];
+      require.cache[guardianBinPath] = {
+        id: guardianBinPath,
+        filename: guardianBinPath,
+        loaded: true,
+        exports: { resolveGuardianCli: () => null, callGuardian: () => null },
+      };
+
+      const { run: runWithoutResolvedCli } = require(hookPath);
+      const result = runWithoutResolvedCli(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } }));
+      assert.strictEqual(result.exitCode, 0, 'Expected fail-open when no CLI resolves');
+      assert.strictEqual(result.stderr, undefined, 'Expected no stderr on fail-open');
+    } finally {
+      delete require.cache[guardianBinPath];
+      delete require.cache[hookPath];
+      if (originalGuardianBinEntry) require.cache[guardianBinPath] = originalGuardianBinEntry;
+      if (originalHookEntry) require.cache[hookPath] = originalHookEntry;
+    }
+  })) passed++; else failed++;
+
   if (test('passes through input without a command field', () => {
     const rawInput = JSON.stringify({ tool_name: 'Bash', tool_input: {} });
     const result = spawnSync('node', [runner, 'pre:bash:guardian-validate', 'scripts/hooks/pre-bash-guardian-validate.js', 'minimal,standard,strict'], {
@@ -131,6 +177,24 @@ function runTests() {
   if (test('allows a benign command with a $(...) substitution that resolves to nothing dangerous', () => {
     const result = runHook('echo $(date)');
     assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('extractSegments fails closed (returns null) when a destructive command is nested one level past MAX_SUBSTITUTION_DEPTH', () => {
+    const command = nestedSubstitution(6, 'rm -rf /');
+    const segments = extractSegments(command);
+    assert.strictEqual(segments, null, `Expected null (too deep to analyze), got: ${JSON.stringify(segments)}`);
+  })) passed++; else failed++;
+
+  if (test('extractSegments still fully analyzes nesting within MAX_SUBSTITUTION_DEPTH (no regression)', () => {
+    const command = nestedSubstitution(4, 'rm -rf /');
+    const segments = extractSegments(command);
+    assert.notStrictEqual(segments, null, 'Expected a real segment list, not the too-deep sentinel');
+    assert.ok(segments.includes('rm -rf /'), `Expected 'rm -rf /' to be extracted, got: ${JSON.stringify(segments)}`);
+  })) passed++; else failed++;
+
+  if (test('blocks (fails closed) end-to-end when a destructive command hides past the substitution depth cap', () => {
+    const result = runHook(nestedSubstitution(6, 'rm -rf /'));
+    assert.strictEqual(result.code, 2, `Expected the hook to block instead of silently allowing, got exit ${result.code}`);
   })) passed++; else failed++;
 
   if (test('runs standalone via node (require.main === module stdin path), not just through run-with-flags', () => {

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -185,6 +185,23 @@ function runTests() {
     assert.strictEqual(segments, null, `Expected null (too deep to analyze), got: ${JSON.stringify(segments)}`);
   })) passed++; else failed++;
 
+  if (test('extractSegments does not count arithmetic expansion as an extra substitution depth level', () => {
+    // 5 layers of real `echo $(...)` nesting (right at MAX_SUBSTITUTION_DEPTH)
+    // plus one innocuous arithmetic expansion at the bottom -- before the
+    // arithmetic-awareness fix, $((1+2))'s spurious extra "nesting level"
+    // pushed this over the cap and returned null (a false block) even
+    // though nothing is actually hidden inside it.
+    const command = nestedSubstitution(5, 'echo $((1+2))');
+    const segments = extractSegments(command);
+    assert.notStrictEqual(segments, null, 'Arithmetic expansion must not count toward the substitution depth cap');
+  })) passed++; else failed++;
+
+  if (test('extractSegments still finds a real command substitution hidden inside arithmetic expansion', () => {
+    const segments = extractSegments('echo $(( $(cat /etc/shadow) + 1 ))');
+    assert.notStrictEqual(segments, null);
+    assert.ok(segments.includes('cat /etc/shadow'), `Expected 'cat /etc/shadow' to be extracted, got: ${JSON.stringify(segments)}`);
+  })) passed++; else failed++;
+
   if (test('extractSegments still fully analyzes nesting within MAX_SUBSTITUTION_DEPTH (no regression)', () => {
     const command = nestedSubstitution(4, 'rm -rf /');
     const segments = extractSegments(command);

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -118,6 +118,60 @@ function runTests() {
     assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough');
   })) passed++; else failed++;
 
+  if (test('blocks a destructive command hidden inside a $(...) command substitution', () => {
+    const result = runHook('echo $(rm -rf /)');
+    assert.strictEqual(result.code, 2, 'Expected the substitution body to be extracted and blocked');
+  })) passed++; else failed++;
+
+  if (test('blocks a destructive command hidden inside a backtick substitution', () => {
+    const result = runHook('echo `rm -rf /`');
+    assert.strictEqual(result.code, 2, 'Expected the substitution body to be extracted and blocked');
+  })) passed++; else failed++;
+
+  if (test('allows a benign command with a $(...) substitution that resolves to nothing dangerous', () => {
+    const result = runHook('echo $(date)');
+    assert.strictEqual(result.code, 0, `Expected allow, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('runs standalone via node (require.main === module stdin path), not just through run-with-flags', () => {
+    const hookPath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+    const rawInput = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'git status' } });
+    const result = spawnSync('node', [hookPath], {
+      input: rawInput,
+      encoding: 'utf8',
+      env: { ...process.env, EGC_GUARDIAN_CLI: fakeCli },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    assert.strictEqual(result.status, 0, `Expected allow, got: ${result.stderr}`);
+    assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough on stdout');
+  })) passed++; else failed++;
+
+  if (test('runs standalone via node and blocks + writes stderr on a destructive command', () => {
+    const hookPath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+    const rawInput = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } });
+    const result = spawnSync('node', [hookPath], {
+      input: rawInput,
+      encoding: 'utf8',
+      env: { ...process.env, EGC_GUARDIAN_CLI: fakeCli },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    assert.strictEqual(result.status, 2, 'Expected block exit code');
+    assert.ok(result.stderr.includes('destructive command'), `Expected reason on stderr, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('handles malformed JSON input without crashing (fails open)', () => {
+    const result = spawnSync('node', [runner, 'pre:bash:guardian-validate', 'scripts/hooks/pre-bash-guardian-validate.js', 'minimal,standard,strict'], {
+      input: '{not valid json',
+      encoding: 'utf8',
+      env: { ...process.env, ECC_HOOK_PROFILE: 'standard', EGC_GUARDIAN_CLI: fakeCli },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    assert.strictEqual(result.status, 0, 'Expected fail-open on malformed JSON input');
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/hooks/windsurf-guardian-adapter.test.js
+++ b/tests/hooks/windsurf-guardian-adapter.test.js
@@ -1,0 +1,138 @@
+/**
+ * Tests for scripts/hooks/windsurf-guardian-adapter.js
+ *
+ * Windsurf's pre_run_command hook uses a different wire contract than
+ * Claude Code's PreToolUse hook (see windsurf-gateguard-adapter.js for the
+ * same distinction) -- this file exercises both the pure translation
+ * function and the real CLI entrypoint end to end, including the
+ * cwd-preservation and oversized-input fail-closed fixes from the
+ * 2026-07-27 cubic-dev-ai review.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'windsurf-guardian-adapter.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+const { buildGuardianInput } = require(adapterScript);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const result = spawnSync('node', [adapterScript], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, EGC_GUARDIAN_CLI: fakeCli, ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing windsurf-guardian-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('maps pre_run_command to a Guardian Bash input', () => {
+    const mapped = buildGuardianInput({
+      agent_action_name: 'pre_run_command',
+      tool_info: { command_line: 'echo hi' },
+    });
+    assert.deepStrictEqual(mapped, { tool_name: 'Bash', tool_input: { command: 'echo hi' } });
+  })) passed++; else failed++;
+
+  if (test('preserves tool_info.cwd on the mapped input (relative protected-path checks need it)', () => {
+    const mapped = buildGuardianInput({
+      agent_action_name: 'pre_run_command',
+      tool_info: { command_line: 'cat .ssh/id_rsa', cwd: '/Users/example/project' },
+    });
+    assert.strictEqual(mapped.cwd, '/Users/example/project');
+  })) passed++; else failed++;
+
+  if (test('omits cwd when tool_info has none (not a string)', () => {
+    const mapped = buildGuardianInput({
+      agent_action_name: 'pre_run_command',
+      tool_info: { command_line: 'echo hi' },
+    });
+    assert.strictEqual('cwd' in mapped, false);
+  })) passed++; else failed++;
+
+  if (test('returns null for unmapped Windsurf events (pre_write_code, pre_read_code, ...)', () => {
+    assert.strictEqual(buildGuardianInput({ agent_action_name: 'pre_write_code', tool_info: {} }), null);
+    assert.strictEqual(buildGuardianInput({ agent_action_name: 'pre_read_code', tool_info: {} }), null);
+  })) passed++; else failed++;
+
+  if (test('returns null for pre_run_command with no command_line', () => {
+    assert.strictEqual(buildGuardianInput({ agent_action_name: 'pre_run_command', tool_info: {} }), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: blocks a destructive command with exit 2 and a reason on stderr', () => {
+    const result = runAdapterCli({
+      agent_action_name: 'pre_run_command',
+      tool_info: { command_line: 'rm -rf /' },
+    });
+    assert.strictEqual(result.code, 2);
+    assert.ok(result.stderr.length > 0, 'expected a reason on stderr');
+  })) passed++; else failed++;
+
+  if (test('CLI: allows a safe allowlisted command (exit 0)', () => {
+    const result = runAdapterCli({
+      agent_action_name: 'pre_run_command',
+      tool_info: { command_line: 'git status' },
+    });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stderr, '');
+  })) passed++; else failed++;
+
+  if (test('CLI: unmapped event (pre_write_code) exits 0 with no output', () => {
+    const result = runAdapterCli({
+      agent_action_name: 'pre_write_code',
+      tool_info: { file_path: '/tmp/some-file.js' },
+    });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, '');
+    assert.strictEqual(result.stderr, '');
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed (non-truncated) stdin JSON fails open (exit 0)', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+  })) passed++; else failed++;
+
+  if (test('CLI: an oversized payload that gets truncated into invalid JSON fails CLOSED (exit 2), not open', () => {
+    // Pads well past the adapter's 1MB stdin cap so JSON.parse() sees a
+    // truncated, syntactically invalid document -- before the fix this hit
+    // the generic "malformed input" catch and allowed the command through
+    // unvalidated, letting an attacker pad any command past the cap to
+    // bypass the Guardian entirely.
+    const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      agent_action_name: 'pre_run_command',
+      tool_info: { command_line: 'rm -rf /', padding: oversizedPadding },
+    });
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/guardian-bin.test.js
+++ b/tests/lib/guardian-bin.test.js
@@ -223,6 +223,68 @@ function main() {
     }
   });
 
+  run('resolves via ~/.gemini/config/mcp_config.json on a Gemini-CLI-only install (no ~/.claude.json)', () => {
+    // 2026-07-27 audit (Guardian cross-CLI fail-open fix): guardian-bin.js
+    // used to check ~/.gemini/settings.json, a file Gemini CLI never writes
+    // for MCP config — a Gemini-only install (no Claude Code alongside it)
+    // had no working config-based fallback at all and failed open silently.
+    const fakeHome = createTempDir('egc-guardian-bin-home-');
+    try {
+      const installDir = path.join(fakeHome, 'somewhere', 'egc-guardian', 'build');
+      fs.mkdirSync(installDir, { recursive: true });
+      fs.writeFileSync(path.join(installDir, 'guardian-cli.js'), '// real cli\n');
+      fs.mkdirSync(path.join(fakeHome, '.gemini', 'config'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeHome, '.gemini', 'config', 'mcp_config.json'),
+        JSON.stringify({
+          mcpServers: {
+            'egc-guardian': {
+              command: 'node',
+              args: [path.join(installDir, 'index.js')],
+            },
+          },
+        }),
+      );
+
+      withEnv({ HOME: fakeHome, USERPROFILE: fakeHome }, () => {
+        const { fromMcpConfigs } = freshGuardianBin();
+        const resolved = fromMcpConfigs();
+        assert.strictEqual(resolved, path.join(installDir, 'guardian-cli.js'));
+      });
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  run('no longer checks the dead ~/.gemini/settings.json path', () => {
+    const fakeHome = createTempDir('egc-guardian-bin-home-');
+    try {
+      const installDir = path.join(fakeHome, 'somewhere', 'egc-guardian', 'build');
+      fs.mkdirSync(installDir, { recursive: true });
+      fs.writeFileSync(path.join(installDir, 'guardian-cli.js'), '// real cli\n');
+      fs.mkdirSync(path.join(fakeHome, '.gemini'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeHome, '.gemini', 'settings.json'),
+        JSON.stringify({
+          mcpServers: {
+            'egc-guardian': {
+              command: 'node',
+              args: [path.join(installDir, 'index.js')],
+            },
+          },
+        }),
+      );
+
+      withEnv({ HOME: fakeHome, USERPROFILE: fakeHome }, () => {
+        const { fromMcpConfigs } = freshGuardianBin();
+        const resolved = fromMcpConfigs();
+        assert.strictEqual(resolved, null, 'settings.json should no longer be consulted');
+      });
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   console.log(`\n${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -33,6 +33,13 @@ const {
   MERGE_MARKDOWN_INDEX_KIND,
   mergeSkillIndexEntry,
 } = require('../../scripts/lib/warp-agents-merge');
+const {
+  GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_RUN_COMMAND_EVENT,
+  applyWindsurfGateGuardHookToFile,
+  resolveGuardianAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('../../scripts/lib/windsurf-gateguard-hooks');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const CURRENT_PACKAGE_VERSION = JSON.parse(
@@ -160,6 +167,68 @@ function writeClaudeSessionHookState(homeDir, options = {}) {
   });
 
   return { targetRoot, installStatePath, settingsPath, hookScriptPath };
+}
+
+function writeWindsurfGuardianHookState(homeDir, options = {}) {
+  const targetRoot = path.join(homeDir, '.codeium', 'windsurf');
+  const installStatePath = path.join(targetRoot, 'egc', 'install-state.json');
+  const hooksJsonPath = resolveHooksJsonPath(targetRoot);
+  const guardianAdapterScriptPath = resolveGuardianAdapterScriptDestination(targetRoot);
+  const guardianAdapterSourcePath = path.join(REPO_ROOT, GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH);
+
+  fs.mkdirSync(path.dirname(guardianAdapterScriptPath), { recursive: true });
+  fs.copyFileSync(guardianAdapterSourcePath, guardianAdapterScriptPath);
+  if (options.existingHooks) {
+    fs.writeFileSync(hooksJsonPath, JSON.stringify(options.existingHooks, null, 2));
+  }
+  applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, guardianAdapterScriptPath);
+
+  writeState(installStatePath, {
+    adapter: { id: 'windsurf-home', target: 'windsurf', kind: 'home' },
+    targetRoot,
+    installStatePath,
+    request: {
+      profile: null,
+      modules: [],
+      includeComponents: [],
+      excludeComponents: [],
+      legacyLanguages: [],
+      legacyMode: true,
+    },
+    resolution: {
+      selectedModules: [],
+      skippedModules: [],
+    },
+    operations: [
+      {
+        kind: 'copy-file',
+        moduleId: 'egc-bash-guardian-hook',
+        sourceRelativePath: GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+        destinationPath: guardianAdapterScriptPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      },
+      {
+        kind: 'merge-claude-settings-hooks',
+        moduleId: 'egc-bash-guardian-hook',
+        sourceRelativePath: GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+        destinationPath: hooksJsonPath,
+        strategy: 'merge-claude-settings-hooks',
+        ownership: 'managed',
+        scaffoldOnly: false,
+        hookEvent: PRE_RUN_COMMAND_EVENT,
+        hookScriptPath: guardianAdapterScriptPath,
+      },
+    ],
+    source: {
+      repoVersion: CURRENT_PACKAGE_VERSION,
+      repoCommit: 'abc123',
+      manifestVersion: CURRENT_MANIFEST_VERSION,
+    },
+  });
+
+  return { targetRoot, installStatePath, hooksJsonPath, guardianAdapterScriptPath };
 }
 
 function managedOperation(kind, destinationPath, overrides = {}) {
@@ -1753,6 +1822,94 @@ function runTests() {
       assert.deepStrictEqual(settings.hooks.PreToolUse, [
         { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo guard' }] },
       ]);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  // Windsurf's hooks.json is a flat {hooks: {<event>: [...]}} map, not
+  // Claude's matcher/group settings.json -- doctor/repair/uninstall had no
+  // notion of this at all (cubic-dev-ai review, PR #1052, 2026-07-27):
+  // repair injected a bogus SessionStart group into the Windsurf file
+  // instead of touching pre_run_command, doctor always reported drift on a
+  // healthy install (it checked for that same bogus group), and uninstall
+  // left the real hooks.json entry behind pointing at a script the
+  // copy-file uninstall step had already deleted.
+  if (test('doctor reports a removed Windsurf Guardian hook as drift, not a false positive on a healthy install', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeWindsurfGuardianHookState(homeDir);
+
+      let report = buildDoctorReport({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(report.results[0].status, 'ok', 'a freshly-applied hook must not be reported as drift');
+
+      fs.writeFileSync(installed.hooksJsonPath, JSON.stringify({
+        hooks: { pre_write_code: [{ command: 'echo third-party' }] },
+      }, null, 2));
+
+      report = buildDoctorReport({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(report.results[0].status, 'warning');
+      const driftIssue = report.results[0].issues.find(issue => issue.code === 'drifted-managed-files');
+      assert.ok(driftIssue, 'Should flag the missing pre_run_command entry as drift');
+      assert.ok(driftIssue.paths.includes(installed.hooksJsonPath));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair restores the Windsurf Guardian hook on pre_run_command without touching third-party hooks or other events', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeWindsurfGuardianHookState(homeDir);
+      fs.writeFileSync(installed.hooksJsonPath, JSON.stringify({
+        hooks: {
+          pre_write_code: [{ command: 'echo third-party' }],
+          pre_run_command: [{ command: 'echo third-party' }],
+        },
+      }, null, 2));
+
+      const result = repairInstalledStates({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(result.results[0].status, 'repaired');
+      assert.ok(result.results[0].repairedPaths.includes(installed.hooksJsonPath));
+
+      const hooksConfig = JSON.parse(fs.readFileSync(installed.hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(hooksConfig.hooks.pre_write_code, [{ command: 'echo third-party' }]);
+      assert.strictEqual(hooksConfig.hooks.pre_run_command.length, 2);
+      assert.strictEqual(hooksConfig.hooks.pre_run_command[0].command, 'echo third-party');
+      assert.ok(hooksConfig.hooks.pre_run_command[1].command.includes(installed.guardianAdapterScriptPath));
+      assert.strictEqual(hooksConfig.hooks.SessionStart, undefined, 'must never inject a Claude-schema SessionStart group into a Windsurf hooks.json');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('uninstall removes only the EGC Windsurf Guardian entry and keeps third-party hooks and other events', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeWindsurfGuardianHookState(homeDir, {
+        existingHooks: {
+          hooks: {
+            pre_write_code: [{ command: 'echo third-party' }],
+          },
+        },
+      });
+
+      const result = uninstallInstalledStates({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(result.results[0].status, 'uninstalled');
+      assert.ok(!fs.existsSync(installed.guardianAdapterScriptPath), 'the adapter script itself must be removed');
+
+      const hooksConfig = JSON.parse(fs.readFileSync(installed.hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(hooksConfig.hooks.pre_write_code, [{ command: 'echo third-party' }]);
+      assert.strictEqual(hooksConfig.hooks.pre_run_command, undefined, 'the now-empty event key must be dropped, not left as an entry pointing at a deleted script');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1913,13 +1913,28 @@ function runTests() {
       'GateGuard should be registered on Edit, Write, MultiEdit and Bash for Antigravity global hooks.json, ' +
       'separate from Gemini CLI\'s own ~/.gemini/hooks/hooks.json'
     );
+
+    // cubic-dev-ai review (PR #1052, 2026-07-27): this test already used
+    // modules: [] (no hooks-runtime module selected), so if the script copy
+    // were still implicit/optional the hooks.json entry above would point
+    // at a file that was never actually scaffolded. Asserting the copy
+    // operation exists here, in the same modules: [] scenario, proves the
+    // registration is now self-sufficient regardless of module selection.
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+        && operation.destinationPath === gateGuardScriptPath
+      )),
+      'gateguard-fact-force.js must be copied unconditionally, not only via the hooks-runtime module'
+    );
   })) passed++; else failed++;
 
   // EGC Guardian: cubic-dev-ai review (PR #1052, 2026-07-27) found
   // createGlobalBashGuardianHookMergeOperation existed in
   // antigravity-settings-hooks.js but was never called from gemini-home.js,
   // so global Antigravity installs never got the Guardian despite GateGuard
-  // (test above) being wired.
+  // (test above) being wired. A follow-up review then found the same
+  // registered-but-never-copied gap once it WAS wired.
   if (test('egc-home adapter registers the EGC Guardian on Bash for Antigravity global scope too', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const homeDir = '/Users/example';
@@ -1943,6 +1958,16 @@ function runTests() {
     ));
     assert.strictEqual(guardianOperations.length, 1, 'Guardian registered once for the Antigravity global hooks.json');
     assert.strictEqual(guardianOperations[0].hookMatcher, 'Bash', 'Guardian only needs the Bash matcher');
+
+    for (const src of ['scripts/hooks/pre-bash-guardian-validate.js', 'scripts/lib/guardian-bin.js', 'scripts/lib/shell-split.js']) {
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === src
+          && operation.destinationPath === path.join(homeDir, '.gemini', ...src.split('/'))
+        )),
+        `${src} must be copied unconditionally (modules: []), not only via the hooks-runtime module`
+      );
+    }
   })) passed++; else failed++;
 
   if (test('resolves kiro home adapter root to ~/.kiro and install-state path', () => {

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -921,6 +921,64 @@ function runTests() {
     })) passed++; else failed++;
   }
 
+  // EGC Guardian: 2026-07-27 audit (EGC-460/462) found Windsurf had
+  // GateGuard wired (test above) but never the Guardian command validator
+  // itself -- windsurf-gateguard-adapter.js only ever called
+  // gateguard-fact-force.js. Fixed via a dedicated windsurf-guardian-adapter.js
+  // registered on pre_run_command only (Guardian validates shell commands,
+  // not file writes, unlike GateGuard which also covers Edit/Write).
+  for (const [target, rootFn] of [
+    ['windsurf', homeDir => path.join(homeDir, '.codeium', 'windsurf')],
+    ['windsurf-project', (_homeDir, projectRoot) => path.join(projectRoot, '.windsurf')],
+  ]) {
+    if (test(`${target} adapter wires the EGC Guardian into hooks.json via its own Windsurf-contract adapter script (pre_run_command only)`, () => {
+      const repoRoot = path.join(__dirname, '..', '..');
+      const homeDir = '/Users/example';
+      const projectRoot = '/workspace/app';
+
+      const plan = planInstallTargetScaffold({
+        target,
+        repoRoot,
+        homeDir,
+        projectRoot,
+        modules: [],
+      });
+
+      const targetRoot = rootFn(homeDir, projectRoot);
+      const guardianAdapterScriptPath = path.join(targetRoot, 'scripts', 'hooks', 'windsurf-guardian-adapter.js');
+      const hooksJsonPath = path.join(targetRoot, 'hooks.json');
+
+      const hookOperations = plan.operations.filter(operation => (
+        operation.kind === 'merge-claude-settings-hooks'
+        && operation.hookScriptPath === guardianAdapterScriptPath
+        && operation.destinationPath === hooksJsonPath
+      ));
+      const events = hookOperations.map(operation => operation.hookEvent).sort();
+      assert.deepStrictEqual(events, ['pre_run_command'], 'Guardian should only be registered on pre_run_command, not pre_write_code');
+
+      const adapterCopyOperation = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/windsurf-guardian-adapter.js'
+        && operation.destinationPath === guardianAdapterScriptPath
+      ));
+      assert.ok(adapterCopyOperation, 'Should copy the Windsurf-contract Guardian adapter script');
+
+      const guardianScriptPath = path.join(targetRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+      const guardianCopyOperation = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'
+        && operation.destinationPath === guardianScriptPath
+      ));
+      assert.ok(guardianCopyOperation, 'Should also copy pre-bash-guardian-validate.js itself (the adapter requires it in-process)');
+
+      for (const lib of ['scripts/lib/guardian-bin.js', 'scripts/lib/shell-split.js']) {
+        const libCopyOperation = plan.operations.find(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === lib
+          && operation.destinationPath === path.join(targetRoot, ...lib.split('/'))
+        ));
+        assert.ok(libCopyOperation, `Should copy the Guardian's dependency ${lib}`);
+      }
+    })) passed++; else failed++;
+  }
+
   if (test('resolves codex adapter root to ~/.agents and install-state path', () => {
     const adapter = getInstallTargetAdapter('codex');
     const homeDir = '/Users/example';
@@ -1643,6 +1701,46 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // EGC Guardian: 2026-07-27 audit (EGC-460..464) found these three targets
+  // had GateGuard + Crusher wired (tests above) but never the Guardian
+  // command validator itself -- neither one actually checks a Bash command
+  // against the Guardian's allowlist/denylist.
+  if (test('Guardian hook is registered on Bash and scaffolded for Copilot, Antigravity and Continue', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+    const projectRoot = '/workspace/app';
+
+    const cases = [
+      { target: 'copilot', input: { homeDir }, hooksFilePath: path.join(homeDir, '.copilot', 'hooks', 'hooks.json'), root: path.join(homeDir, '.github') },
+      { target: 'antigravity', input: { projectRoot }, hooksFilePath: path.join(projectRoot, '.agents', 'hooks.json'), root: path.join(projectRoot, '.agents') },
+      { target: 'continue', input: { homeDir }, hooksFilePath: path.join(homeDir, '.continue', 'settings.json'), root: path.join(homeDir, '.continue') },
+    ];
+
+    for (const { target, input, hooksFilePath, root } of cases) {
+      const plan = planInstallTargetScaffold({ target, repoRoot, modules: [], ...input });
+      const guardianScriptPath = path.join(root, 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+
+      const guardianOps = plan.operations.filter(operation => (
+        operation.kind === 'merge-claude-settings-hooks'
+        && operation.hookEvent === 'PreToolUse'
+        && operation.destinationPath === hooksFilePath
+        && operation.hookScriptPath === guardianScriptPath
+      ));
+      assert.strictEqual(guardianOps.length, 1, `${target}: Guardian registered once`);
+      assert.strictEqual(guardianOps[0].hookMatcher, 'Bash', `${target}: Guardian on Bash`);
+
+      for (const src of ['scripts/hooks/pre-bash-guardian-validate.js', 'scripts/lib/guardian-bin.js', 'scripts/lib/shell-split.js']) {
+        assert.ok(
+          plan.operations.some(operation => (
+            normalizedRelativePath(operation.sourceRelativePath) === src
+            && operation.destinationPath === path.join(root, ...src.split('/'))
+          )),
+          `${target}: ${src} scaffolded`
+        );
+      }
+    }
+  })) passed++; else failed++;
+
   if (test('codebuddy adapter registers the GateGuard fact-force hook at .codebuddy/settings.json', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';
@@ -1699,6 +1797,41 @@ function runTests() {
       'scripts/hooks/pre-bash-crusher-rewrite.js',
       'scripts/hooks/pretooluse-output.js',
       'scripts/lib/crusher/engine.js',
+    ]) {
+      const op = plan.operations.find(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === src
+        && operation.destinationPath === path.join(projectRoot, '.codebuddy', ...src.split('/'))
+      ));
+      assert.ok(op, `Should scaffold ${src} into .codebuddy`);
+    }
+  })) passed++; else failed++;
+
+  if (test('codebuddy adapter also registers the EGC Guardian on Bash at .codebuddy/settings.json', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codebuddy',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+    const settingsPath = path.join(projectRoot, '.codebuddy', 'settings.json');
+    const guardianScriptPath = path.join(projectRoot, '.codebuddy', 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+
+    const guardianOps = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === settingsPath
+      && operation.hookScriptPath === guardianScriptPath
+    ));
+    assert.strictEqual(guardianOps.length, 1, 'Guardian registered once, on Bash');
+    assert.strictEqual(guardianOps[0].hookMatcher, 'Bash');
+
+    for (const src of [
+      'scripts/hooks/pre-bash-guardian-validate.js',
+      'scripts/lib/guardian-bin.js',
+      'scripts/lib/shell-split.js',
     ]) {
       const op = plan.operations.find(operation => (
         normalizedRelativePath(operation.sourceRelativePath) === src

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1915,6 +1915,36 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  // EGC Guardian: cubic-dev-ai review (PR #1052, 2026-07-27) found
+  // createGlobalBashGuardianHookMergeOperation existed in
+  // antigravity-settings-hooks.js but was never called from gemini-home.js,
+  // so global Antigravity installs never got the Guardian despite GateGuard
+  // (test above) being wired.
+  if (test('egc-home adapter registers the EGC Guardian on Bash for Antigravity global scope too', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'egc',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+    const hooksFilePath = path.join(homeDir, '.gemini', 'antigravity-cli', 'hooks.json');
+    const guardianScriptPath = path.join(
+      homeDir, '.gemini', 'scripts', 'hooks', 'pre-bash-guardian-validate.js'
+    );
+
+    const guardianOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === hooksFilePath
+      && operation.hookScriptPath === guardianScriptPath
+    ));
+    assert.strictEqual(guardianOperations.length, 1, 'Guardian registered once for the Antigravity global hooks.json');
+    assert.strictEqual(guardianOperations[0].hookMatcher, 'Bash', 'Guardian only needs the Bash matcher');
+  })) passed++; else failed++;
+
   if (test('resolves kiro home adapter root to ~/.kiro and install-state path', () => {
     const adapter = getInstallTargetAdapter('kiro');
     const homeDir = '/Users/example';

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1970,6 +1970,66 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // cubic-dev-ai review (PR #1052, 2026-07-27): making the copies above
+  // unconditional meant a DEFAULT install (which does select hooks-runtime)
+  // now recorded two copy-path operations per script -- one from
+  // hooks-runtime's own directory-level scaffold of scripts/hooks and
+  // scripts/lib, one from the explicit calls above. Both write the same
+  // bytes to the same destination, but duplicate the install-state
+  // bookkeeping. This must not regress: the explicit per-file operations
+  // should be suppressed whenever the broader directory copy already
+  // covers them.
+  if (test('egc-home adapter does not duplicate GateGuard/Guardian script copies when hooks-runtime IS selected (default install)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'egc',
+      repoRoot,
+      homeDir,
+      modules: [{ id: 'hooks-runtime', paths: ['hooks', 'scripts/hooks', 'scripts/lib'] }],
+    });
+
+    const directoryDestinations = [
+      path.join(homeDir, '.gemini', 'scripts', 'hooks'),
+      path.join(homeDir, '.gemini', 'scripts', 'lib'),
+    ];
+    for (const destination of directoryDestinations) {
+      const matches = plan.operations.filter(operation => (
+        operation.kind === 'copy-path' && operation.destinationPath === destination
+      ));
+      assert.strictEqual(matches.length, 1, `${destination} should be scaffolded once, by hooks-runtime's own directory copy`);
+    }
+
+    for (const src of [
+      'scripts/hooks/gateguard-fact-force.js',
+      'scripts/lib/utils.js',
+      'scripts/hooks/pre-bash-guardian-validate.js',
+      'scripts/lib/guardian-bin.js',
+      'scripts/lib/shell-split.js',
+    ]) {
+      const destination = path.join(homeDir, '.gemini', ...src.split('/'));
+      const fileLevelCopies = plan.operations.filter(operation => (
+        operation.kind === 'copy-path' && operation.destinationPath === destination
+      ));
+      assert.strictEqual(
+        fileLevelCopies.length,
+        0,
+        `${src} must not get its own copy-path operation when the parent directory is already being copied`
+      );
+    }
+
+    // The hooks.json registrations themselves are unrelated to the copy
+    // dedup and must still be present.
+    const hooksFilePath = path.join(homeDir, '.gemini', 'antigravity-cli', 'hooks.json');
+    assert.ok(
+      plan.operations.some(operation => (
+        operation.kind === 'merge-claude-settings-hooks' && operation.destinationPath === hooksFilePath
+      )),
+      'hooks.json registrations must survive the copy dedup'
+    );
+  })) passed++; else failed++;
+
   if (test('resolves kiro home adapter root to ~/.kiro and install-state path', () => {
     const adapter = getInstallTargetAdapter('kiro');
     const homeDir = '/Users/example';

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -194,6 +194,19 @@ test('heredoc delimiter with an unterminated quote is not treated as a heredoc (
   const segs = splitShellSegments("cat <<'EOF\nrm -rf /\n");
   assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
 });
+test('heredoc delimiter with an escaped quote inside a double-quoted span is parsed correctly (not truncated at the escaped quote)', () => {
+  const segs = splitShellSegments('cat <<"EO\\"F"\nbody text\nEO"F\necho done\n');
+  assert.deepStrictEqual(segs, ['cat <<"EO\\"F"\nbody text\nEO"F', 'echo done']);
+});
+test('a very long single-line heredoc body does not cause quadratic slowdown', () => {
+  const longLine = 'x'.repeat(200000);
+  const command = `cat <<EOF\n${longLine}\nEOF\n`;
+  const start = Date.now();
+  const segs = splitShellSegments(command);
+  const elapsedMs = Date.now() - start;
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}`);
+  assert.ok(elapsedMs < 2000, `expected roughly linear-time scan, took ${elapsedMs}ms for a 200k-char line`);
+});
 test('multiple heredocs on one line are consumed in order, not mixed with ordinary segments', () => {
   const segs = splitShellSegments(
     'cat <<MARKERA <<MARKERB\nline one for A\nMARKERA\nline one for B\nMARKERB\necho done\n'
@@ -303,6 +316,23 @@ test('multiple heredocs on one line: each body is scanned per its own delimiter\
     ),
     ['rm -rf /b'],
   );
+});
+test('does not treat pure arithmetic expansion $((...)) as a substitution body', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo $((1+2))'), []);
+});
+test('still surfaces a real command substitution nested inside arithmetic expansion (one more extraction level, per the documented non-recursive contract)', () => {
+  const outerBodies = extractSubstitutionBodies('echo $(( $(cat /etc/shadow) + 1 ))');
+  assert.strictEqual(outerBodies.length, 1, 'the arithmetic body containing a real substitution must still be pushed once');
+  assert.deepStrictEqual(extractSubstitutionBodies(outerBodies[0]), ['cat /etc/shadow']);
+});
+test('extractSubstitutionBodies: a very long single-line heredoc body does not cause quadratic slowdown', () => {
+  const longLine = 'x'.repeat(200000);
+  const command = `cat <<EOF\n${longLine}\nEOF\n`;
+  const start = Date.now();
+  const bodies = extractSubstitutionBodies(command);
+  const elapsedMs = Date.now() - start;
+  assert.deepStrictEqual(bodies, []);
+  assert.ok(elapsedMs < 2000, `expected roughly linear-time scan, took ${elapsedMs}ms for a 200k-char line`);
 });
 test('extractSubstitutionBodies honors <<- leading-tab stripping when matching the terminator line', () => {
   assert.deepStrictEqual(

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -174,6 +174,35 @@ test('heredoc body line that merely starts with the delimiter text does not end 
   const segs = splitShellSegments('cat <<EOF\nEOFOO not the real terminator\nEOF\n');
   assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
 });
+test('heredoc delimiter with punctuation (EOF-1) is parsed in full, body closes and later commands are their own segment', () => {
+  const segs = splitShellSegments('cat <<EOF-1\nbody text\nEOF-1\necho done\n');
+  assert.deepStrictEqual(segs, ['cat <<EOF-1\nbody text\nEOF-1', 'echo done']);
+});
+test('heredoc delimiter with a dot (v1.0) is parsed in full, not truncated at the identifier boundary', () => {
+  const segs = splitShellSegments('cat <<v1.0\nbody text\nv1.0\necho done\n');
+  assert.deepStrictEqual(segs, ['cat <<v1.0\nbody text\nv1.0', 'echo done']);
+});
+test('heredoc operator with a space before the delimiter word is recognized the same as no space', () => {
+  const segs = splitShellSegments('cat << EOF\nbody\nEOF\n');
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
+});
+test('heredoc operator with nothing usable after it (end of string) is not treated as a heredoc', () => {
+  const segs = splitShellSegments('cat <<');
+  assert.deepStrictEqual(segs, ['cat <<']);
+});
+test('heredoc delimiter with an unterminated quote is not treated as a heredoc (fails safe, does not hang or throw)', () => {
+  const segs = splitShellSegments("cat <<'EOF\nrm -rf /\n");
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
+});
+test('multiple heredocs on one line are consumed in order, not mixed with ordinary segments', () => {
+  const segs = splitShellSegments(
+    'cat <<MARKERA <<MARKERB\nline one for A\nMARKERA\nline one for B\nMARKERB\necho done\n'
+  );
+  assert.deepStrictEqual(segs, [
+    'cat <<MARKERA <<MARKERB\nline one for A\nMARKERA\nline one for B\nMARKERB',
+    'echo done',
+  ]);
+});
 
 // extractSubstitutionBodies (cubic-dev-ai P0: $(...)/`...`/<(...)/>(...) content
 // must be recoverable so a hidden command can be validated, not just skipped)
@@ -241,6 +270,51 @@ test('an escaped char inside a double-quoted span before a substitution does not
 test('a heredoc with no terminator runs to the end of the string without throwing', () => {
   const segs = splitShellSegments('cat <<EOF\nbody with no terminator');
   assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
+});
+
+// cubic-dev-ai P2 (2026-07-27, second follow-up round): $(...) written only
+// as documentation inside a # comment or a literal (quoted-delimiter)
+// heredoc body must not be extracted, since bash never expands it there.
+test('does not extract $(...) written only as an example inside a # comment', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo hi # example: $(rm -rf /)'), []);
+});
+test('still extracts $(...) when # appears mid-word, not starting a real comment', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo foo#bar $(rm -rf /)'), ['rm -rf /']);
+});
+test('a comment only runs to end of line: a substitution on the next line is still extracted', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo hi # $(rm -rf /a)\necho $(rm -rf /b)'), ['rm -rf /b']);
+});
+test('does not extract $(...) inside a heredoc body whose delimiter was single-quoted (fully literal, no expansion)', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies("cat <<'EOF'\nexample: $(rm -rf /)\nEOF\n"), []);
+});
+test('does not extract $(...) inside a heredoc body whose delimiter was double-quoted (also fully literal)', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('cat <<"EOF"\nexample: $(rm -rf /)\nEOF\n'), []);
+});
+test('does not extract $(...) inside a heredoc body whose delimiter was backslash-escaped (also fully literal)', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('cat <<\\EOF\nexample: $(rm -rf /)\nEOF\n'), []);
+});
+test('still extracts $(...) inside a heredoc body with a bare/unquoted delimiter (bash still expands it there)', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('cat <<EOF\n$(rm -rf /)\nEOF\n'), ['rm -rf /']);
+});
+test('multiple heredocs on one line: each body is scanned per its own delimiter\'s literalness', () => {
+  assert.deepStrictEqual(
+    extractSubstitutionBodies(
+      "cat <<'LIT' <<EXP\nliteral body $(rm -rf /a)\nLIT\nexpandable body $(rm -rf /b)\nEXP\n"
+    ),
+    ['rm -rf /b'],
+  );
+});
+test('extractSubstitutionBodies honors <<- leading-tab stripping when matching the terminator line', () => {
+  assert.deepStrictEqual(
+    extractSubstitutionBodies('cat <<-EOF\n\t$(rm -rf /)\n\tEOF\n'),
+    ['rm -rf /'],
+  );
+});
+test('a heredoc with no terminator still extracts substitutions from its unterminated expandable body', () => {
+  assert.deepStrictEqual(
+    extractSubstitutionBodies('cat <<EOF\nbody with no terminator $(rm -rf /)'),
+    ['rm -rf /'],
+  );
 });
 
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -198,6 +198,10 @@ test('heredoc delimiter with an escaped quote inside a double-quoted span is par
   const segs = splitShellSegments('cat <<"EO\\"F"\nbody text\nEO"F\necho done\n');
   assert.deepStrictEqual(segs, ['cat <<"EO\\"F"\nbody text\nEO"F', 'echo done']);
 });
+test('heredoc delimiter with a backslash before a non-special character inside double quotes keeps the backslash literally', () => {
+  const segs = splitShellSegments('cat <<"EO\\NF"\nbody text\nEO\\NF\necho done\n');
+  assert.deepStrictEqual(segs, ['cat <<"EO\\NF"\nbody text\nEO\\NF', 'echo done']);
+});
 test('a very long single-line heredoc body does not cause quadratic slowdown', () => {
   const longLine = 'x'.repeat(200000);
   const command = `cat <<EOF\n${longLine}\nEOF\n`;

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const { splitShellSegments } = require('../../scripts/lib/shell-split');
+const { splitShellSegments, extractSubstitutionBodies } = require('../../scripts/lib/shell-split');
 
 console.log('=== Testing shell-split.js ===\n');
 
@@ -108,6 +108,139 @@ test('empty string returns empty array', () => {
 });
 test('single command no operators', () => {
   assert.deepStrictEqual(splitShellSegments('npm run dev'), ['npm run dev']);
+});
+
+// Newline/CR splitting (unconditional, all callers)
+console.log('\nNewline/CR splitting:');
+test('embedded newline splits into two segments', () => {
+  assert.deepStrictEqual(splitShellSegments('echo a\necho b'), ['echo a', 'echo b']);
+});
+test('embedded carriage return splits into two segments', () => {
+  assert.deepStrictEqual(splitShellSegments('echo a\recho b'), ['echo a', 'echo b']);
+});
+test('quoted newline does not split', () => {
+  assert.deepStrictEqual(splitShellSegments('echo "a\nb"'), ['echo "a\nb"']);
+});
+
+// splitOnPipe option (opt-in, guardian command validator)
+console.log('\nsplitOnPipe option:');
+test('bare pipe stays one segment by default (splitOnPipe unset)', () => {
+  assert.deepStrictEqual(splitShellSegments('echo a | grep b'), ['echo a | grep b']);
+});
+test('bare pipe splits into two segments when splitOnPipe is true', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo a | grep b', { splitOnPipe: true }),
+    ['echo a', 'grep b'],
+  );
+});
+test('|| still splits as a single operator even with splitOnPipe true (not double-counted)', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo a || echo b', { splitOnPipe: true }),
+    ['echo a', 'echo b'],
+  );
+});
+test('quoted pipe does not split even with splitOnPipe true', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo "a | b"', { splitOnPipe: true }),
+    ['echo "a | b"'],
+  );
+});
+test('multi-stage pipeline splits into one segment per stage when splitOnPipe is true', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo x | xargs rm -rf', { splitOnPipe: true }),
+    ['echo x', 'xargs rm -rf'],
+  );
+});
+
+// Heredoc bodies (cubic-dev-ai P2: newline splitting must not fragment one)
+console.log('\nHeredoc bodies:');
+test('heredoc body is not split by its own embedded newlines', () => {
+  const segs = splitShellSegments('cat <<EOF\nrm -rf /\nsome other line\nEOF\n');
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
+});
+test('command after a heredoc terminator is still its own segment', () => {
+  const segs = splitShellSegments('cat <<EOF\nbody text\nEOF\necho done\n');
+  assert.deepStrictEqual(segs, ['cat <<EOF\nbody text\nEOF', 'echo done']);
+});
+test('<<- heredoc strips leading tabs only when matching the terminator line', () => {
+  const segs = splitShellSegments('cat <<-EOF\n\tbody text\n\tEOF\n');
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
+});
+test('quoted heredoc delimiter is recognized', () => {
+  const segs = splitShellSegments("cat <<'EOF'\nrm -rf /\nEOF\n");
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
+});
+test('heredoc body line that merely starts with the delimiter text does not end it early', () => {
+  const segs = splitShellSegments('cat <<EOF\nEOFOO not the real terminator\nEOF\n');
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
+});
+
+// extractSubstitutionBodies (cubic-dev-ai P0: $(...)/`...`/<(...)/>(...) content
+// must be recoverable so a hidden command can be validated, not just skipped)
+console.log('\nextractSubstitutionBodies:');
+test('extracts a $(...) command substitution body', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo $(rm -rf /)'), ['rm -rf /']);
+});
+test('extracts a backtick substitution body', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo `rm -rf /`'), ['rm -rf /']);
+});
+test('extracts a <(...) process substitution body', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('diff <(rm -rf /) file'), ['rm -rf /']);
+});
+test('extracts a >(...) process substitution body', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo x >(rm -rf /)'), ['rm -rf /']);
+});
+test('extracts multiple substitutions in one command', () => {
+  assert.deepStrictEqual(
+    extractSubstitutionBodies('echo $(rm -rf /) `mv /a /b`'),
+    ['rm -rf /', 'mv /a /b'],
+  );
+});
+test('still extracts $(...) inside double quotes (double quotes do not suppress command substitution in a real shell)', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo "$(rm -rf /)"'), ['rm -rf /']);
+});
+test('does not extract $(...) hidden inside a single-quoted string (shell would not expand it either)', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies("echo '$(rm -rf /)'"), []);
+});
+test('handles nested command substitution by returning the outer body whole (caller recurses)', () => {
+  assert.deepStrictEqual(
+    extractSubstitutionBodies('echo $(echo $(rm -rf /))'),
+    ['echo $(rm -rf /)'],
+  );
+});
+test('returns empty array for a command with no substitutions', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('npm run build'), []);
+});
+test('malformed unterminated $( does not throw and extracts nothing', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo $(rm -rf /'), []);
+});
+test('malformed unterminated backtick does not throw and extracts nothing', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo `rm -rf /'), []);
+});
+test('a closing paren inside a quoted string within $(...) does not close the substitution early', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo $(echo "a)b" rm -rf /)'), ['echo "a)b" rm -rf /']);
+});
+test('an escaped double quote inside $(...) does not end the quoted span early', () => {
+  assert.deepStrictEqual(
+    extractSubstitutionBodies('echo $(echo "a\\"b)" rm -rf /)'),
+    ['echo "a\\"b)" rm -rf /'],
+  );
+});
+test('an escaped paren inside $(...) (outside any quote) does not close the substitution early', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo $(a \\) b)'), ['a \\) b']);
+});
+test('an escaped backtick inside a backtick substitution does not end it early', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo `a \\` b`'), ['a \\` b']);
+});
+test('an escaped quote at the top level (outside any substitution) is skipped without starting a quote span', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo \\" $(rm -rf /)'), ['rm -rf /']);
+});
+test('an escaped char inside a double-quoted span before a substitution does not break tracking', () => {
+  assert.deepStrictEqual(extractSubstitutionBodies('echo "a\\"b" $(rm -rf /)'), ['rm -rf /']);
+});
+test('a heredoc with no terminator runs to the end of the string without throwing', () => {
+  const segs = splitShellSegments('cat <<EOF\nbody with no terminator');
+  assert.strictEqual(segs.length, 1, `expected 1 segment, got ${segs.length}: ${JSON.stringify(segs)}`);
 });
 
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);

--- a/tests/lib/windsurf-gateguard-hooks.test.js
+++ b/tests/lib/windsurf-gateguard-hooks.test.js
@@ -90,6 +90,18 @@ function runTests() {
     assert.strictEqual(config.hooks[PRE_WRITE_CODE_EVENT][0].command, 'node /new/path/windsurf-gateguard-adapter.js');
   })) passed++; else failed++;
 
+  if (test('addWindsurfHookEntry migrates a stale GUARDIAN entry (same script, different path) in place instead of duplicating', () => {
+    const base = {
+      hooks: {
+        [PRE_RUN_COMMAND_EVENT]: [{ command: 'node /old/path/windsurf-guardian-adapter.js' }],
+      },
+    };
+    const { config, changed } = addWindsurfHookEntry(base, PRE_RUN_COMMAND_EVENT, 'node /new/path/windsurf-guardian-adapter.js');
+    assert.strictEqual(changed, true);
+    assert.strictEqual(config.hooks[PRE_RUN_COMMAND_EVENT].length, 1, 'must migrate in place, not append a duplicate');
+    assert.strictEqual(config.hooks[PRE_RUN_COMMAND_EVENT][0].command, 'node /new/path/windsurf-guardian-adapter.js');
+  })) passed++; else failed++;
+
   if (test('applyWindsurfGateGuardHookToFile writes both events to a fresh file and is idempotent', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'windsurf-hooks-apply-'));
     const hooksJsonPath = path.join(tempDir, 'hooks.json');


### PR DESCRIPTION
## Summary
Follow-up to #1051. cubic-dev-ai's review of that PR found 9 real issues after merge (7 high severity) that were missed because the review comments were never read before merging.

- `env -S`/`--split-string` now hard-denied (re-splits and execs its value, same shape as eval)
- Wrapper value-flag matching is now case-preserving (was lowercasing before comparison, letting an unrecognized uppercase flag collide with an unrelated lowercase entry)
- `export VAR=value` now recognized as persisting an override, same as a bare `VAR=value` prefix
- `git config` output-annotator flags (`--show-scope`, `--name-only`) no longer exempt a real key+value SET from the dangerous-key check; `--edit`/`-e` now hard-denied outright
- Quoted git config flags (`"--global"`) no longer misread as positionals
- Global git flags before `config` (`git -c x=y config ...`) no longer skip the dangerous-key check
- Dangerous git config keys expanded: `core.fsmonitor`, `filter.*.clean/smudge/process`, `diff.*.command`
- Command substitution (`$(...)`, backticks, `<(...)`, `>(...)`) content is now extracted and validated recursively instead of being invisible to segmentation
- Heredoc bodies no longer get fragmented by their own embedded newlines

Also:
- Closes the Codecov patch-coverage gap left by #1051 (shell-split.js was 61.9%) with direct unit tests for every new branch
- Fixes a real cross-CLI gap: `guardian-bin.js` only ever checked `~/.claude.json` and a `~/.gemini/settings.json` path Gemini CLI has never used for MCP config. A Gemini-CLI-only install had no working fallback and failed open silently. Now checks Gemini's real registration file (`~/.gemini/config/mcp_config.json`), added to the write-protected patterns so trusting it doesn't reopen the RCE this resolution order guards against.

## Test plan
- [x] Full project test suite green (2945/2945)
- [x] New dedicated tests for every one of the 9 findings plus the cross-CLI fix
- [x] 100% line coverage on `shell-split.js`; `pre-bash-guardian-validate.js` at 100% lines (one line documented as impractical to cover deterministically)
- [x] Existing guardian/hook test suites unaffected (destructive-cli, block-no-verify, pre-write, guardian-bin)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes Guardian bypasses and wires the Bash validator into all supported editors/CLIs. Adds a Windsurf adapter and lifecycle support, tightens fail-closed handling and parsing, and dedupes Gemini Antigravity script copies.

- **New Features**
  - Register the validator for Bash on CodeBuddy, Continue, Copilot, and Antigravity (PreToolUse).
  - Add Windsurf support via `scripts/hooks/windsurf-guardian-adapter.js` on `pre_run_command` only.

- **Bug Fixes**
  - Heredocs: robust delimiter parsing (handles punctuation and escaped quotes/backslashes in double quotes) with linear-time body scanning; `$((...))` is treated as arithmetic, not extra command-substitution depth.
  - Adapters/install: Windsurf adapter fails closed on truncated stdin and preserves `cwd`; add repair/doctor/uninstall for Windsurf’s hooks schema; migrate relocated Guardian entries instead of duplicating; global Antigravity installs now copy GateGuard/Guardian scripts explicitly and register the Guardian on Bash; dedupe redundant GateGuard/Guardian script-copy operations in `gemini-home.js` when `hooks-runtime` already scaffolds `scripts/hooks` and `scripts/lib`; ensure Gemini CLI resolution uses `~/.gemini/config/mcp_config.json`.

<sup>Written for commit 19fa620794f630d227048e61ce2227581908ca03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

