### PR TITLE
fix(guardian): trust Antigravity's and OpenCode's own MCP config files

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -605,6 +605,15 @@ export const PROTECTED_FILE_PATTERNS: RegExp[] = [
   // prompt-injected agent could repoint egc-guardian's own MCP entry at an
   // arbitrary script and have this validator treat it as authoritative.
   /\.gemini[\\/]config[\\/]mcp_config\.json$/,
+  // Antigravity CLI's own MCP server registration file — a separate file
+  // from Gemini CLI's above despite sharing the ~/.gemini home root
+  // (scripts/lib/mcp-register.js's "Antigravity CLI" target). Multica squad
+  // audit (EGC-460/461, 2026-07-27) found guardian-bin.js now also trusts
+  // this file, for the same reasoning as the Gemini CLI entry above.
+  /\.gemini[\\/]antigravity-cli[\\/]mcp_config\.json$/,
+  // OpenCode's real MCP server registration file (scripts/lib/
+  // mcp-register.js's "OpenCode" target); same reasoning and same audit.
+  /\.config[\\/]opencode[\\/]config\.json$/,
   // Codex CLI: OAuth/API key auth file.
   /\.codex[\\/]auth\.json$/,
   // Amp: OAuth tokens live under this subfolder; config is elsewhere.

--- a/scripts/lib/guardian-bin.js
+++ b/scripts/lib/guardian-bin.js
@@ -43,6 +43,18 @@ function fromMcpConfigs() {
     // Gemini-CLI-only install (no ~/.claude.json alongside it) had no
     // working fallback here and failed open silently.
     path.join(os.homedir(), '.gemini', 'config', 'mcp_config.json'),
+    // Antigravity CLI's own MCP registration file — a SEPARATE file from
+    // Gemini CLI's above despite sharing the ~/.gemini home root (see
+    // scripts/lib/mcp-register.js's "Antigravity CLI" target). Multica
+    // squad audit (EGC-460/461, 2026-07-27) confirmed a pure-Antigravity
+    // install (no Claude Code, no Gemini CLI alongside it) had no working
+    // fallback here either, for the same fail-open reason as Gemini CLI
+    // above.
+    path.join(os.homedir(), '.gemini', 'antigravity-cli', 'mcp_config.json'),
+    // OpenCode's real MCP registration file (scripts/lib/mcp-register.js's
+    // "OpenCode" target) — same audit, same fail-open gap for a
+    // pure-OpenCode install.
+    path.join(os.homedir(), '.config', 'opencode', 'config.json'),
   ];
 
   // Resolved candidates must live under the user's home directory. This

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -175,5 +175,15 @@ run('.gemini/GEMINI.md write stays allowed (functional file, not a credential/tr
   assert.strictEqual(v.allowed, true, `expected .gemini/GEMINI.md to stay allowed, got: ${v.reason}`);
 });
 
+console.log('\nAntigravity/OpenCode cross-CLI fail-open fix (Multica audit EGC-460/461, 2026-07-27):');
+run('.gemini/antigravity-cli/mcp_config.json write is blocked (guardian-bin.js now trusts this file too)', () => {
+  const v = validateWrite('.gemini/antigravity-cli/mcp_config.json');
+  assert.strictEqual(v.allowed, false, 'expected .gemini/antigravity-cli/mcp_config.json write to be blocked');
+});
+run('.config/opencode/config.json write is blocked (guardian-bin.js now trusts this file too)', () => {
+  const v = validateWrite('.config/opencode/config.json');
+  assert.strictEqual(v.allowed, false, 'expected .config/opencode/config.json write to be blocked');
+});
+
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
 if (failed > 0) process.exit(1);

--- a/tests/lib/guardian-bin.test.js
+++ b/tests/lib/guardian-bin.test.js
@@ -256,6 +256,71 @@ function main() {
     }
   });
 
+  run('resolves via ~/.gemini/antigravity-cli/mcp_config.json on an Antigravity-only install', () => {
+    // Multica squad audit (EGC-460/461, 2026-07-27): this is a SEPARATE file
+    // from ~/.gemini/config/mcp_config.json above despite sharing the
+    // ~/.gemini home root -- a pure-Antigravity install (no Claude Code, no
+    // Gemini CLI alongside it) had no working config-based fallback here
+    // either and failed open silently.
+    const fakeHome = createTempDir('egc-guardian-bin-home-');
+    try {
+      const installDir = path.join(fakeHome, 'somewhere', 'egc-guardian', 'build');
+      fs.mkdirSync(installDir, { recursive: true });
+      fs.writeFileSync(path.join(installDir, 'guardian-cli.js'), '// real cli\n');
+      fs.mkdirSync(path.join(fakeHome, '.gemini', 'antigravity-cli'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeHome, '.gemini', 'antigravity-cli', 'mcp_config.json'),
+        JSON.stringify({
+          mcpServers: {
+            'egc-guardian': {
+              command: 'node',
+              args: [path.join(installDir, 'index.js')],
+            },
+          },
+        }),
+      );
+
+      withEnv({ HOME: fakeHome, USERPROFILE: fakeHome }, () => {
+        const { fromMcpConfigs } = freshGuardianBin();
+        const resolved = fromMcpConfigs();
+        assert.strictEqual(resolved, path.join(installDir, 'guardian-cli.js'));
+      });
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  run('resolves via ~/.config/opencode/config.json on an OpenCode-only install', () => {
+    // Same audit: OpenCode's real MCP registration file (scripts/lib/
+    // mcp-register.js's "OpenCode" target) was never consulted either.
+    const fakeHome = createTempDir('egc-guardian-bin-home-');
+    try {
+      const installDir = path.join(fakeHome, 'somewhere', 'egc-guardian', 'build');
+      fs.mkdirSync(installDir, { recursive: true });
+      fs.writeFileSync(path.join(installDir, 'guardian-cli.js'), '// real cli\n');
+      fs.mkdirSync(path.join(fakeHome, '.config', 'opencode'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeHome, '.config', 'opencode', 'config.json'),
+        JSON.stringify({
+          mcpServers: {
+            'egc-guardian': {
+              command: 'node',
+              args: [path.join(installDir, 'index.js')],
+            },
+          },
+        }),
+      );
+
+      withEnv({ HOME: fakeHome, USERPROFILE: fakeHome }, () => {
+        const { fromMcpConfigs } = freshGuardianBin();
+        const resolved = fromMcpConfigs();
+        assert.strictEqual(resolved, path.join(installDir, 'guardian-cli.js'));
+      });
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   run('no longer checks the dead ~/.gemini/settings.json path', () => {
     const fakeHome = createTempDir('egc-guardian-bin-home-');
     try {


### PR DESCRIPTION
## Summary
- Multica squad audit (EGC-460/461) found `resolveGuardianCli()`'s `fromMcpConfigs()` strategy never checked Antigravity CLI's own MCP registration file (`~/.gemini/antigravity-cli/mcp_config.json`, separate from Gemini CLI's own config file despite sharing the `~/.gemini` home root) nor OpenCode's (`~/.config/opencode/config.json`)
- A pure-Antigravity or pure-OpenCode install (no Claude Code, no Gemini CLI alongside it) had no working config-based fallback and failed open silently
- Both files use the same trusted-server shape already handled by `fromMcpConfigs()`; this adds the two paths to the trusted list and protects both in `PROTECTED_FILE_PATTERNS`, mirroring the fix already shipped for Gemini CLI in PR #1051

## Test plan
- [x] New regression tests in `tests/lib/guardian-bin.test.js` (resolves via each new config path) and `tests/egc-guardian-bypass-hardening.test.js` (writes to both paths are blocked)
- [x] Full local suite green (`node tests/run-all.js`)
- [x] `mcp/servers/egc-guardian` rebuilt and verified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fail-open in guardian CLI resolution by trusting Antigravity and OpenCode MCP config files and blocking writes to them. Addresses Multica audit EGC-460/461 for pure-Antigravity and pure-OpenCode installs.

- **Bug Fixes**
  - Add `~/.gemini/antigravity-cli/mcp_config.json` and `~/.config/opencode/config.json` to `fromMcpConfigs()` trusted paths.
  - Protect both paths in `PROTECTED_FILE_PATTERNS` to prevent tampering.
  - Add regression tests for resolution via both configs and for write blocking.

<sup>Written for commit d32cc4f5ca54842f5dc609279bed73f5165e0e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

