### PR TITLE
fix(guardian): cover the two genuinely new lines Codecov flagged on PR #1054

### DIFF
--- a/scripts/lib/guardian-bin.js
+++ b/scripts/lib/guardian-bin.js
@@ -240,12 +240,10 @@ function fromCodexToml() {
     return null;
   }
 
-  let servers;
-  try {
-    servers = parseCodexMcpServers(content);
-  } catch {
-    return null;
-  }
+  // parseCodexMcpServers() never throws for any string input (it skips
+  // unrecognized syntax rather than raising), so this has no try/catch --
+  // one would be dead code, unreachable by construction.
+  const servers = parseCodexMcpServers(content);
 
   const server = servers.find(s => s.name === 'egc-guardian');
   if (!server) return null;

--- a/tests/lib/guardian-bin.test.js
+++ b/tests/lib/guardian-bin.test.js
@@ -413,6 +413,34 @@ function main() {
     }
   });
 
+  run('unescapes a backslash inside a TOML basic string (round-trip through the real tomlEscape())', () => {
+    // path.join() never produces a '\' on Linux, so a path built the normal
+    // way never actually exercises tomlUnescapeBasicString's escape-
+    // resolution branch (it would just take the pass-through path every
+    // time). A literal backslash is a perfectly legal filename character on
+    // Linux, so embedding one in the install dir name forces registerToml()'s
+    // real tomlEscape() to double it, and fromCodexToml() must reverse that
+    // correctly to find the file back.
+    const fakeHome = createTempDir('egc-guardian-bin-home-');
+    try {
+      const { registerToml } = require('../../scripts/lib/mcp-register');
+      const installDir = path.join(fakeHome, 'somewhere', 'weird\\dir', 'egc-guardian', 'build');
+      fs.mkdirSync(installDir, { recursive: true });
+      fs.writeFileSync(path.join(installDir, 'guardian-cli.js'), '// real cli\n');
+      registerToml(path.join(fakeHome, '.codex', 'config.toml'), {
+        guardianBin: path.join(installDir, 'index.js'),
+        memoryBin: path.join(installDir, '..', 'egc-memory', 'index.js'),
+      });
+
+      withEnv({ HOME: fakeHome, USERPROFILE: fakeHome }, () => {
+        const { fromCodexToml } = freshGuardianBin();
+        assert.strictEqual(fromCodexToml(), path.join(installDir, 'guardian-cli.js'));
+      });
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   run('handles a multi-line args array', () => {
     const fakeHome = createTempDir('egc-guardian-bin-home-');
     try {

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -411,6 +411,47 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('a Guardian CLI marker write failure warns but does not fail the install (EGC-465)', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      // A plain file sitting where the marker's parent directory needs to be
+      // created: mkdirSync(..., {recursive: true}) cannot turn a file into a
+      // directory, so writeGuardianCliMarker()'s write fails -- this must be
+      // swallowed (logged, not thrown), since it is only one of four
+      // resolution strategies and must never break a real install.
+      fs.writeFileSync(path.join(homeDir, '.egc'), 'not a directory');
+
+      // run()'s helper hardcodes stderr to '' on a successful (exit 0) run
+      // -- execFileSync only exposes stderr via the thrown error on
+      // failure. spawnSync captures both streams uniformly regardless of
+      // exit code, which this specific assertion needs.
+      const { spawnSync } = require('child_process');
+      const spawned = spawnSync('node', [SCRIPT, '--profile', 'core'], {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+        encoding: 'utf8',
+        timeout: DEFAULT_INSTALL_APPLY_TIMEOUT_MS,
+      });
+      const result = { code: spawned.status, stdout: spawned.stdout, stderr: spawned.stderr };
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(
+        result.stderr.includes('Failed to write Guardian CLI marker'),
+        `Expected a warning about the marker write failure, got stderr: ${result.stderr}`
+      );
+
+      const geminiRoot = path.join(homeDir, '.gemini');
+      assert.ok(
+        fs.existsSync(path.join(geminiRoot, 'egc', 'install-state.json')),
+        'the rest of the install should still complete normally'
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('installs the Claude Code SessionStart state hook and records install-state', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');


### PR DESCRIPTION
## Summary

Follow-up to #1054. Codecov flagged 6 uncovered lines across `guardian-bin.js` and `apply.js`. Checked each against the actual diff instead of trusting the percentage:

- 4 of the 6 are pre-existing, untouched code that only shows up in the patch report from diff-hunk proximity to real edits, not genuinely new code.
- The 2 real gaps:
  - `fromCodexToml()`'s `try/catch` around `parseCodexMcpServers()` was dead code (that function can't throw for any string input). Removed it.
  - `tomlUnescapeBasicString()`'s escape-resolution branch was never exercised (no existing test path produces a literal backslash on Linux). Added a test with a backslash in an install dir name, round-tripped through the real `tomlEscape()`/`registerToml()`.
  - `writeGuardianCliMarker()`'s catch (write failure must warn, not break the install) had no test. Added one, and along the way found the shared `run()` test helper hardcodes `stderr` to `''` on a successful subprocess exit — this one test uses `spawnSync` directly instead.

## Test plan
- [x] Full suite: 2963/2963 passing
- [x] Lint: 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to #1054 to fix Codecov patch coverage by removing dead code and adding targeted tests. Removes the unreachable try/catch in fromCodexToml(), adds a TOML backslash round-trip test, and verifies Guardian CLI marker write failures warn but don’t fail the install (EGC-465).

<sup>Written for commit 7d5547b718c84d85d31e89e9d523abec3c908eaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

