### PR TITLE
fix(install): clarify first-time setup lifecycle

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,6 +56,44 @@ No `--target` flag is needed -- Continue.dev is auto-detected during install.
 
 ---
 
+## Installation lifecycle
+
+EGC setup has three distinct stages. You can stop after the stage that matches what you need.
+
+### 1. Bare install
+
+```bash
+egc install
+```
+
+This prepares the core runtime, initializes the shared state store, and registers the MCP servers in detected tools. A bare install does **not** create managed target install-state files, so `egc doctor` may report that none exist. That is expected, not an error.
+
+The dashboard also does not start automatically after a bare install. Start it manually with `egc dashboard`, or continue with project setup.
+
+### 2. Project setup
+
+Run this from the root of a project you want EGC to manage:
+
+```bash
+egc init
+```
+
+This bootstraps the cognitive protocol, registers MCP servers, configures project-local memory protections, verifies the setup, and starts the dashboard.
+
+### 3. Full profile
+
+Install the complete managed content set for a specific target when you want rules, skills, agents, commands, and platform configuration tracked by `egc doctor` and `egc repair`:
+
+```bash
+egc install --target <target> --profile full
+```
+
+Use `egc catalog` to inspect available targets, profiles, and components before installing.
+
+> **Optional dependency:** `uv` is required only for the Jira and omega-memory MCP servers. Core EGC installation and all other targets are unaffected when `uv` is not installed.
+
+---
+
 ## Linux / macOS (from source)
 
 Not sure if you have Node.js 20? Run `node --version`. If it shows 20 or higher, you're ready.
@@ -154,15 +192,17 @@ egc telemetry status
 
 ## Dashboard
 
-After install, EGC starts a local dashboard server at `http://localhost:7890`. It streams everything your AI does in real time: tool calls, file edits, shell commands, token usage, cost per session, and agent status, across every IDE you have running.
+The dashboard starts automatically when you run `egc init`. A bare `egc install` configures the runtime but does not start the dashboard.
 
-The dashboard starts automatically when you run `egc init`. You can also control it manually:
+You can control it manually:
 
 ```bash
 egc dashboard          # start the dashboard server
 egc dashboard stop     # stop it
 egc dashboard status   # check if it is running
 ```
+
+The local server is available at `http://localhost:7890`. It streams everything your AI does in real time: tool calls, file edits, shell commands, token usage, cost per session, and agent status, across every IDE you have running.
 
 **What you see:**
 

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -61,6 +61,8 @@ function statusLabel(status) {
 function printHuman(report) {
   if (report.results.length === 0) {
     console.log('No EGC install-state files found for the current home/project context.');
+    console.log('This is expected after a bare `egc install`; the core runtime is installed without a managed target profile.');
+    console.log('Run `egc install --target <target> --profile full` when you want to install managed content.');
     return;
   }
 

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -163,7 +163,18 @@ function main() {
       if (spawned.error) {
         process.stderr.write(`Error: failed to launch ${wrapper.cmd}: ${spawned.error.message}\n`);
       }
-      process.exit(spawned.status === null ? 1 : spawned.status);
+      const exitCode = spawned.status === null ? 1 : spawned.status;
+      if (exitCode === 0) {
+        const uvProbe = spawnSync('uv', ['--version'], { stdio: 'ignore' });
+        if (uvProbe.error?.code === 'ENOENT') {
+          console.log('\nOptional dependency not found: uv');
+          console.log('  Required only for Jira and omega-memory MCP servers.');
+          console.log('  Core EGC installation is unaffected.');
+        }
+        console.log('\nDashboard was not started automatically.');
+        console.log("Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup.");
+      }
+      process.exit(exitCode);
     }
     const request = normalizeInstallRequest({
       ...options,

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -163,18 +163,7 @@ function main() {
       if (spawned.error) {
         process.stderr.write(`Error: failed to launch ${wrapper.cmd}: ${spawned.error.message}\n`);
       }
-      const exitCode = spawned.status === null ? 1 : spawned.status;
-      if (exitCode === 0) {
-        const uvProbe = spawnSync('uv', ['--version'], { stdio: 'ignore' });
-        if (uvProbe.error?.code === 'ENOENT') {
-          console.log('\nOptional dependency not found: uv');
-          console.log('  Required only for Jira and omega-memory MCP servers.');
-          console.log('  Core EGC installation is unaffected.');
-        }
-        console.log('\nDashboard was not started automatically.');
-        console.log("Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup.");
-      }
-      process.exit(exitCode);
+      process.exit(spawned.status === null ? 1 : spawned.status);
     }
     const request = normalizeInstallRequest({
       ...options,

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -135,6 +135,10 @@ foreach ($arg in $args) {
 }
 if ($hasInstallArgs) {
     node $EgcInstall @args
+    $installExitCode = $LASTEXITCODE
+    if ($DryRun) {
+        exit $installExitCode
+    }
 }
 
 # Interactive ecosystem install (skipped in headless/CI)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -44,6 +44,13 @@ try {
 
 $DryRun = $args -contains '--dry-run'
 
+# Optional dependency hints (non-blocking)
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Host "  Optional dependency not found: uv"
+    Write-Host "    Required only for Jira and omega-memory MCP servers."
+    Write-Host "    Core EGC installation is unaffected. Install: https://docs.astral.sh/uv/"
+}
+
 if (-not $DryRun) {
     # Root dependencies
     Write-Host "  installing root dependencies..."
@@ -334,5 +341,9 @@ fs.writeFileSync(t,JSON.stringify(obj,null,2)+"\n");
 
     Write-Host ""
     Write-Host "Installation complete."
+    if (-not $hasInstallArgs) {
+        Write-Host "Dashboard was not started automatically."
+        Write-Host "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup."
+    }
     Write-Host "Run 'egc doctor' to verify."
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,7 +67,9 @@ fi
 
 # Optional dependency hints (non-blocking)
 if ! command -v uv >/dev/null 2>&1; then
-  echo "  note: uv not found: jira and omega-memory MCP servers require it (https://docs.astral.sh/uv/)"
+  echo "  Optional dependency not found: uv"
+  echo "    Required only for Jira and omega-memory MCP servers."
+  echo "    Core EGC installation is unaffected. Install: https://docs.astral.sh/uv/"
 fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "  note: python3 not found: evalview MCP server requires it"
@@ -440,4 +442,8 @@ fi
 
 echo ""
 echo "Installation complete."
+if [ "$_has_install_args" = false ]; then
+  echo "Dashboard was not started automatically."
+  echo "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup."
+fi
 echo "Run 'egc doctor' to verify."

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -77,6 +77,21 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
+  if (test('explains that no install-state is expected after a bare install', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const result = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('This is expected after a bare `egc install`'));
+      assert.ok(result.stdout.includes('egc install --target <target> --profile full'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('reports a healthy install with exit code 0', () => {
     const homeDir = createTempDir('doctor-home-');
     const projectRoot = createTempDir('doctor-project-');

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -38,6 +38,7 @@ function run(args = [], options = {}) {
   const env = {
     ...process.env,
     HOME: options.homeDir || process.env.HOME,
+    USERPROFILE: options.homeDir || process.env.USERPROFILE,
   };
 
   try {

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -1,0 +1,57 @@
+/**
+ * Regression checks for first-install guidance.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const INSTALL_APPLY = path.join(REPO_ROOT, 'scripts', 'install-apply.js');
+const INSTALLATION_GUIDE = path.join(REPO_ROOT, 'docs', 'installation.md');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing install onboarding guidance ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  const installSource = fs.readFileSync(INSTALL_APPLY, 'utf8');
+  const guide = fs.readFileSync(INSTALLATION_GUIDE, 'utf8');
+
+  if (test('bare install labels uv as optional and scoped', () => {
+    assert.ok(installSource.includes('Optional dependency not found: uv'));
+    assert.ok(installSource.includes('Required only for Jira and omega-memory MCP servers.'));
+    assert.ok(installSource.includes('Core EGC installation is unaffected.'));
+  })) passed++; else failed++;
+
+  if (test('bare install states that the dashboard was not started', () => {
+    assert.ok(installSource.includes('Dashboard was not started automatically.'));
+    assert.ok(installSource.includes("Run 'egc dashboard' to start it"));
+  })) passed++; else failed++;
+
+  if (test('installation guide explains the three setup stages', () => {
+    assert.ok(guide.includes('## Installation lifecycle'));
+    assert.ok(guide.includes('### 1. Bare install'));
+    assert.ok(guide.includes('### 2. Project setup'));
+    assert.ok(guide.includes('### 3. Full profile'));
+    assert.ok(guide.includes('egc install --target <target> --profile full'));
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -8,7 +8,19 @@ const path = require('path');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const INSTALL_APPLY = path.join(REPO_ROOT, 'scripts', 'install-apply.js');
+const INSTALL_SH = path.join(REPO_ROOT, 'scripts', 'install.sh');
+const INSTALL_PS1 = path.join(REPO_ROOT, 'scripts', 'install.ps1');
 const INSTALLATION_GUIDE = path.join(REPO_ROOT, 'docs', 'installation.md');
+
+const UV_MESSAGES = [
+  'Optional dependency not found: uv',
+  'Required only for Jira and omega-memory MCP servers.',
+  'Core EGC installation is unaffected.',
+];
+const DASHBOARD_MESSAGES = [
+  'Dashboard was not started automatically.',
+  "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup.",
+];
 
 function test(name, fn) {
   try {
@@ -28,18 +40,31 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
-  const installSource = fs.readFileSync(INSTALL_APPLY, 'utf8');
+  const installApplySource = fs.readFileSync(INSTALL_APPLY, 'utf8');
+  const bashSource = fs.readFileSync(INSTALL_SH, 'utf8');
+  const powerShellSource = fs.readFileSync(INSTALL_PS1, 'utf8');
   const guide = fs.readFileSync(INSTALLATION_GUIDE, 'utf8');
 
-  if (test('bare install labels uv as optional and scoped', () => {
-    assert.ok(installSource.includes('Optional dependency not found: uv'));
-    assert.ok(installSource.includes('Required only for Jira and omega-memory MCP servers.'));
-    assert.ok(installSource.includes('Core EGC installation is unaffected.'));
+  if (test('bash and PowerShell label uv as optional and scoped', () => {
+    for (const message of UV_MESSAGES) {
+      assert.ok(bashSource.includes(message), `install.sh missing: ${message}`);
+      assert.ok(powerShellSource.includes(message), `install.ps1 missing: ${message}`);
+    }
   })) passed++; else failed++;
 
-  if (test('bare install states that the dashboard was not started', () => {
-    assert.ok(installSource.includes('Dashboard was not started automatically.'));
-    assert.ok(installSource.includes("Run 'egc dashboard' to start it"));
+  if (test('bash and PowerShell explain dashboard startup after bare installs only', () => {
+    for (const message of DASHBOARD_MESSAGES) {
+      assert.ok(bashSource.includes(message), `install.sh missing: ${message}`);
+      assert.ok(powerShellSource.includes(message), `install.ps1 missing: ${message}`);
+    }
+    assert.ok(bashSource.includes('if [ "$_has_install_args" = false ]; then'));
+    assert.ok(powerShellSource.includes('if (-not $hasInstallArgs)'));
+  })) passed++; else failed++;
+
+  if (test('delegating installer does not duplicate wrapper guidance', () => {
+    for (const message of [...UV_MESSAGES, ...DASHBOARD_MESSAGES]) {
+      assert.ok(!installApplySource.includes(message), `install-apply.js should not repeat: ${message}`);
+    }
   })) passed++; else failed++;
 
   if (test('installation guide explains the three setup stages', () => {

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -3,7 +3,9 @@
  */
 
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
@@ -11,6 +13,7 @@ const INSTALL_APPLY = path.join(REPO_ROOT, 'scripts', 'install-apply.js');
 const INSTALL_SH = path.join(REPO_ROOT, 'scripts', 'install.sh');
 const INSTALL_PS1 = path.join(REPO_ROOT, 'scripts', 'install.ps1');
 const INSTALLATION_GUIDE = path.join(REPO_ROOT, 'docs', 'installation.md');
+const INSTALL_TIMEOUT_MS = 2000;
 
 const UV_MESSAGES = [
   'Optional dependency not found: uv',
@@ -32,6 +35,97 @@ function test(name, fn) {
     console.log(`    Error: ${error.message}`);
     return false;
   }
+}
+
+function findExecutable(command) {
+  for (const directory of (process.env.PATH || '').split(path.delimiter)) {
+    if (!directory) continue;
+    const candidate = path.join(directory, command);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch (_) {
+      // Keep searching PATH.
+    }
+  }
+  return null;
+}
+
+function writeExecutable(filePath, content) {
+  fs.writeFileSync(filePath, content, { mode: 0o755 });
+}
+
+function createInstallerFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-install-onboarding-'));
+  const scriptsDir = path.join(root, 'scripts');
+  const binDir = path.join(root, 'bin');
+  const homeDir = path.join(root, 'home');
+  const installScript = path.join(scriptsDir, 'install.sh');
+
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(homeDir, { recursive: true });
+  fs.copyFileSync(INSTALL_SH, installScript);
+  fs.chmodSync(installScript, 0o755);
+
+  for (const server of ['egc-guardian', 'egc-memory']) {
+    const buildDir = path.join(root, 'mcp', 'servers', server, 'build');
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, 'index.js'), '');
+  }
+
+  for (const command of ['cat', 'dirname', 'grep', 'uname']) {
+    const executable = findExecutable(command);
+    assert.ok(executable, `required test command not found: ${command}`);
+    fs.symlinkSync(executable, path.join(binDir, command));
+  }
+
+  writeExecutable(path.join(binDir, 'node'), `#!/bin/sh
+case "$1" in
+  -e) printf '20' ;;
+  --version) printf 'v20.0.0\\n' ;;
+esac
+exit 0
+`);
+  writeExecutable(path.join(binDir, 'npm'), `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '10.0.0\\n'
+fi
+exit 0
+`);
+  writeExecutable(path.join(binDir, 'npx'), '#!/bin/sh\nexit 0\n');
+
+  const bash = findExecutable('bash');
+  assert.ok(bash, 'bash is required for install.sh execution coverage');
+
+  return { root, binDir, homeDir, installScript, bash };
+}
+
+function runBashInstaller(args = []) {
+  const fixture = createInstallerFixture();
+  const result = spawnSync(fixture.bash, [fixture.installScript, ...args], {
+    cwd: fixture.root,
+    env: {
+      ...process.env,
+      CI: '1',
+      HOME: fixture.homeDir,
+      USERPROFILE: fixture.homeDir,
+      PATH: fixture.binDir,
+    },
+    encoding: 'utf8',
+    timeout: INSTALL_TIMEOUT_MS,
+  });
+
+  return {
+    result,
+    cleanup: () => fs.rmSync(fixture.root, { recursive: true, force: true }),
+  };
+}
+
+function assertSuccessfulRun(result) {
+  assert.ifError(result.error);
+  assert.strictEqual(result.status, 0, `installer failed:\n${result.stderr}\n${result.stdout}`);
+  assert.ok(result.stdout.includes('Installation complete.'), 'installer did not reach completion');
 }
 
 function runTests() {
@@ -69,6 +163,34 @@ function runTests() {
     }
     assert.ok(sources.bash.includes('if [ "$_has_install_args" = false ]; then'));
     assert.ok(sources.powerShell.includes('if (-not $hasInstallArgs)'));
+  })) passed++; else failed++;
+
+  if (test('bare Bash install emits onboarding notices at runtime', () => {
+    if (process.platform === 'win32') return;
+
+    const { result, cleanup } = runBashInstaller();
+    try {
+      assertSuccessfulRun(result);
+      for (const message of [...UV_MESSAGES, ...DASHBOARD_MESSAGES]) {
+        assert.ok(result.stdout.includes(message), `bare install output missing: ${message}`);
+      }
+    } finally {
+      cleanup();
+    }
+  })) passed++; else failed++;
+
+  if (test('Bash install arguments suppress the bare-install dashboard notice', () => {
+    if (process.platform === 'win32') return;
+
+    const { result, cleanup } = runBashInstaller(['--target', 'codex']);
+    try {
+      assertSuccessfulRun(result);
+      for (const message of DASHBOARD_MESSAGES) {
+        assert.ok(!result.stdout.includes(message), `argument install should omit: ${message}`);
+      }
+    } finally {
+      cleanup();
+    }
   })) passed++; else failed++;
 
   if (test('delegating installer does not duplicate wrapper guidance', () => {

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -39,40 +39,50 @@ function runTests() {
 
   let passed = 0;
   let failed = 0;
+  let sources;
 
-  const installApplySource = fs.readFileSync(INSTALL_APPLY, 'utf8');
-  const bashSource = fs.readFileSync(INSTALL_SH, 'utf8');
-  const powerShellSource = fs.readFileSync(INSTALL_PS1, 'utf8');
-  const guide = fs.readFileSync(INSTALLATION_GUIDE, 'utf8');
+  if (test('loads installer onboarding contract sources', () => {
+    sources = {
+      installApply: fs.readFileSync(INSTALL_APPLY, 'utf8'),
+      bash: fs.readFileSync(INSTALL_SH, 'utf8'),
+      powerShell: fs.readFileSync(INSTALL_PS1, 'utf8'),
+      guide: fs.readFileSync(INSTALLATION_GUIDE, 'utf8'),
+    };
+  })) passed++; else failed++;
+
+  if (!sources) {
+    console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+    process.exit(1);
+  }
 
   if (test('bash and PowerShell label uv as optional and scoped', () => {
     for (const message of UV_MESSAGES) {
-      assert.ok(bashSource.includes(message), `install.sh missing: ${message}`);
-      assert.ok(powerShellSource.includes(message), `install.ps1 missing: ${message}`);
+      assert.ok(sources.bash.includes(message), `install.sh missing: ${message}`);
+      assert.ok(sources.powerShell.includes(message), `install.ps1 missing: ${message}`);
     }
   })) passed++; else failed++;
 
   if (test('bash and PowerShell explain dashboard startup after bare installs only', () => {
     for (const message of DASHBOARD_MESSAGES) {
-      assert.ok(bashSource.includes(message), `install.sh missing: ${message}`);
-      assert.ok(powerShellSource.includes(message), `install.ps1 missing: ${message}`);
+      assert.ok(sources.bash.includes(message), `install.sh missing: ${message}`);
+      assert.ok(sources.powerShell.includes(message), `install.ps1 missing: ${message}`);
     }
-    assert.ok(bashSource.includes('if [ "$_has_install_args" = false ]; then'));
-    assert.ok(powerShellSource.includes('if (-not $hasInstallArgs)'));
+    assert.ok(sources.bash.includes('if [ "$_has_install_args" = false ]; then'));
+    assert.ok(sources.powerShell.includes('if (-not $hasInstallArgs)'));
   })) passed++; else failed++;
 
   if (test('delegating installer does not duplicate wrapper guidance', () => {
     for (const message of [...UV_MESSAGES, ...DASHBOARD_MESSAGES]) {
-      assert.ok(!installApplySource.includes(message), `install-apply.js should not repeat: ${message}`);
+      assert.ok(!sources.installApply.includes(message), `install-apply.js should not repeat: ${message}`);
     }
   })) passed++; else failed++;
 
   if (test('installation guide explains the three setup stages', () => {
-    assert.ok(guide.includes('## Installation lifecycle'));
-    assert.ok(guide.includes('### 1. Bare install'));
-    assert.ok(guide.includes('### 2. Project setup'));
-    assert.ok(guide.includes('### 3. Full profile'));
-    assert.ok(guide.includes('egc install --target <target> --profile full'));
+    assert.ok(sources.guide.includes('## Installation lifecycle'));
+    assert.ok(sources.guide.includes('### 1. Bare install'));
+    assert.ok(sources.guide.includes('### 2. Project setup'));
+    assert.ok(sources.guide.includes('### 3. Full profile'));
+    assert.ok(sources.guide.includes('egc install --target <target> --profile full'));
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Summary

Clarifies the first-time EGC installation lifecycle following the Ubuntu WSL2 findings in #643.

A successful bare `egc install` prepares the core runtime, shared state store, and MCP registration, but it does not create managed target install-state files or automatically start the dashboard. The previous CLI output and installation guide did not make those distinctions clear.

This PR:

* explains that an empty `egc doctor` result is expected after a bare install;
* points users to `egc install --target <target> --profile full` when they want managed content;
* labels `uv` as an optional dependency required only by Jira and omega-memory;
* aligns the onboarding output across Bash and PowerShell installers;
* explains that the dashboard is not started after a bare install, while avoiding that notice for targeted/profile installs;
* documents bare installation, project setup with `egc init`, and full profile installation;
* adds regression coverage for doctor guidance and cross-platform installer-message parity.

## Component Type

* [x] Core Engine / Orchestrator
* [ ] MCP Server (egc-guardian / egc-memory)
* [ ] Agent
* [ ] Skill
* [ ] Hook
* [ ] Command

## Validation

* Added a process-level `doctor.js` regression test using isolated temporary home and project directories.
* Isolated both `HOME` and `USERPROFILE` so the doctor test does not inspect the real user home on Windows.
* Added source-contract regression checks that keep Bash and PowerShell onboarding messages aligned.
* Added a regression check preventing the delegated Node installer from duplicating wrapper guidance.
* Kept dashboard guidance conditional on a true no-argument bare install.
* Based on upstream `main` at `051eafcb99256bcdaaa0637288eb2f43903daa86`.
* All commits include the required DCO sign-off.

The full test suite was not executed locally because the available execution environment could not obtain a fresh checkout. GitHub Actions is the source of truth for full Linux, macOS, Windows, Node, and package-manager validation.

Not yet manually verified:

* interactive bare-install output on native Windows PowerShell;
* interactive bare-install output on macOS;
* dashboard behavior on a completely fresh machine.

## Checklist

* [ ] CLA signed, if required for this contribution
* [x] All commits carry `Signed-off-by`
* [ ] `node tests/run-all.js` passes locally with zero failures
* [ ] `npm audit --audit-level=high` shows no high or critical vulnerabilities locally
* [x] No Markdown files under `agents/`, `skills/`, `commands/`, or `rules/` were added or modified
* [x] PR changes fewer than 150 code files
* [x] No install-state read/write or concurrent-access behavior was changed
* [ ] Tested manually on Linux, macOS, and Windows
* [x] Preserves EGC identity and formatting
* [x] No sensitive data committed
* [x] Does not modify `runtime-map.json`

Refs #643



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies first-time setup: a bare `egc install` installs the runtime only (no managed state), `uv` is optional, and the dashboard doesn’t auto-start. Aligns onboarding across Bash/PowerShell, documents the install lifecycle, and preserves the PowerShell dry-run exit code.

- **Bug Fixes**
  - Doctor: clarify bare install state; suggest `egc install --target <target> --profile full`.
  - Installers: `uv` optional (Jira/omega-memory only); dashboard notice only for bare installs; avoid duplicate guidance in `install-apply.js`; preserve PowerShell `--dry-run` exit code.
  - Docs: add “Installation lifecycle” (bare install, project setup, full profile) and clarify dashboard behavior and local URL.

- **Tests**
  - Add `install-onboarding` runtime tests for Bash to assert `uv`/dashboard notices and suppress the dashboard notice when args are provided.
  - Enforce cross-shell messaging parity and prevent guidance duplication.
  - Doctor tests: isolate Windows home resolution and cover bare-install guidance.

<sup>Written for commit cfc8bedb49c94e424395fda17f7554b61eaa2d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an installation lifecycle guide covering bare installs, project setup, and full profiles.
  - Clarified dashboard startup behavior, manual controls, local access, and optional `uv` requirements.

- **Installation Experience**
  - Installers now explain when the dashboard is not started automatically.
  - Added non-blocking guidance when optional `uv` dependencies are unavailable.

- **Diagnostics**
  - Added clearer guidance when no managed target profile is present, including the command to install a full profile.

- **Tests**
  - Added coverage for cross-platform onboarding messages, bare-install behavior, dashboard guidance, and profile setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->