### PR TITLE
fix(memory): stop propagate.ts from clobbering project rule files on update_state

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -1314,7 +1314,7 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
   const mergedForPropagation = readStateDoc(filePath);
   const propagated = propagateStateToTools({
     projectPath: projPath,
-    context: (mergedForPropagation['Context'] as string) || undefined,
+    context: ((mergedForPropagation['Context'] as string[] | undefined) ?? []).join('\n') || undefined,
     decisions: ((mergedForPropagation['Active Decisions'] as string[]) || []).map(what => ({ what })),
     next: (mergedForPropagation['Next Session'] as string[]) || undefined,
   });

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -1307,11 +1307,16 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
     const writtenContent = readStateFile(filePath, _encKey);
     writeHmac(filePath, writtenContent, _integrityKey);
   });
+  // Propagate the merged, persisted doc rather than this call's raw args:
+  // a partial update_state (e.g. next only) would otherwise blank out
+  // context/decisions in every mirror file even though the state file
+  // itself still has them merged in.
+  const mergedForPropagation = readStateDoc(filePath);
   const propagated = propagateStateToTools({
     projectPath: projPath,
-    context: args.context,
-    decisions: args.decisions,
-    next: args.next,
+    context: (mergedForPropagation['Context'] as string) || undefined,
+    decisions: ((mergedForPropagation['Active Decisions'] as string[]) || []).map(what => ({ what })),
+    next: (mergedForPropagation['Next Session'] as string[]) || undefined,
   });
   const propagatedTools = Object.entries(propagated)
     .filter(([, p]) => p !== null)

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -20,6 +20,9 @@ export interface PropagateResult {
   cursorrules: string | null;
   agents: string | null;
   llms: string | null;
+  claude: string | null;
+  roo: string | null;
+  continue: string | null;
 }
 
 const EGC_START = '<!-- egc:start -->';
@@ -76,8 +79,67 @@ function writeCursorContext(projectPath: string, block: string): string | null {
   fs.mkdirSync(rulesDir, { recursive: true });
 
   const filePath = path.join(rulesDir, 'egc-context.mdc');
-  const content = `---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n${block}\n`;
-  fs.writeFileSync(filePath, content, 'utf-8');
+  const defaultFrontmatter = `---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n`;
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : defaultFrontmatter;
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeClaudeContext(projectPath: string, block: string): string | null {
+  const filePath = path.join(projectPath, 'CLAUDE.md');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+  } catch {
+    return null;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeRooCodeContext(projectPath: string, block: string): string | null {
+  const rooRulesPath = path.join(projectPath, '.roorules');
+  try {
+    if (fs.existsSync(rooRulesPath)) {
+      const existing = fs.readFileSync(rooRulesPath, 'utf-8');
+      fs.writeFileSync(rooRulesPath, upsertEgcSection(existing, block), 'utf-8');
+      return rooRulesPath;
+    }
+  } catch {
+    return null;
+  }
+
+  const rooDir = path.join(projectPath, '.roo');
+  try {
+    if (!fs.existsSync(rooDir) || !fs.statSync(rooDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const rulesDir = path.join(rooDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+function writeContinueContext(projectPath: string, block: string): string | null {
+  const continueDir = path.join(projectPath, '.continue');
+  try {
+    if (!fs.existsSync(continueDir) || !fs.statSync(continueDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const rulesDir = path.join(continueDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
@@ -241,5 +303,8 @@ export function propagateStateToTools(args: PropagateArgs): PropagateResult {
     cursorrules: writeLegacyCursorRules(args.projectPath, block),
     agents: writeAgentsContext(args.projectPath, block),
     llms: writeLlmsTxt(args.projectPath, args),
+    claude: writeClaudeContext(args.projectPath, block),
+    roo: writeRooCodeContext(args.projectPath, block),
+    continue: writeContinueContext(args.projectPath, block),
   };
 }

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -67,6 +67,26 @@ function upsertEgcSection(existing: string, block: string): string {
   return existing ? `${existing.trimEnd()}\n\n${section}\n` : `${section}\n`;
 }
 
+// Shared by the harness writers below: upsert the EGC block into filePath,
+// using defaultContent as the starting point when the file doesn't exist yet.
+function upsertFileSection(filePath: string, block: string, defaultContent = ''): string {
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : defaultContent;
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
+  return filePath;
+}
+
+// Before this fix, writeCursorContext always overwrote the whole file with
+// just this frontmatter + block, no markers. On the first run after the
+// fix, that old unmarked content would otherwise be preserved as "user
+// content" by upsertEgcSection and get a second, marked block appended
+// below it -- permanent duplication. Recognize and strip it down to just
+// the frontmatter so only the new marked block survives.
+const LEGACY_CURSOR_FRONTMATTER = `---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n`;
+function stripLegacyCursorContent(existing: string): string {
+  if (existing.includes(EGC_START)) return existing;
+  return existing.startsWith(LEGACY_CURSOR_FRONTMATTER) ? LEGACY_CURSOR_FRONTMATTER : existing;
+}
+
 function writeCursorContext(projectPath: string, block: string): string | null {
   const cursorDir = path.join(projectPath, '.cursor');
   try {
@@ -79,8 +99,9 @@ function writeCursorContext(projectPath: string, block: string): string | null {
   fs.mkdirSync(rulesDir, { recursive: true });
 
   const filePath = path.join(rulesDir, 'egc-context.mdc');
-  const defaultFrontmatter = `---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n`;
-  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : defaultFrontmatter;
+  const existing = fs.existsSync(filePath)
+    ? stripLegacyCursorContent(fs.readFileSync(filePath, 'utf-8'))
+    : LEGACY_CURSOR_FRONTMATTER;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
@@ -93,37 +114,42 @@ function writeClaudeContext(projectPath: string, block: string): string | null {
     return null;
   }
 
-  const existing = fs.readFileSync(filePath, 'utf-8');
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return upsertFileSection(filePath, block);
 }
 
 function writeRooCodeContext(projectPath: string, block: string): string | null {
-  const rooRulesPath = path.join(projectPath, '.roorules');
+  const rooDir = path.join(projectPath, '.roo');
+  const rulesDir = path.join(rooDir, 'rules');
+  let rulesDirHasContent = false;
   try {
-    if (fs.existsSync(rooRulesPath)) {
-      const existing = fs.readFileSync(rooRulesPath, 'utf-8');
-      fs.writeFileSync(rooRulesPath, upsertEgcSection(existing, block), 'utf-8');
-      return rooRulesPath;
-    }
+    rulesDirHasContent = fs.existsSync(rulesDir) && fs.statSync(rulesDir).isDirectory() && fs.readdirSync(rulesDir).length > 0;
   } catch {
-    return null;
+    rulesDirHasContent = false;
   }
 
-  const rooDir = path.join(projectPath, '.roo');
+  let rooRulesExists = false;
+  const rooRulesPath = path.join(projectPath, '.roorules');
+  try {
+    rooRulesExists = fs.existsSync(rooRulesPath);
+  } catch {
+    rooRulesExists = false;
+  }
+
+  // Roo Code discovers .roo/rules/ over the legacy flat .roorules file when
+  // both exist -- .roorules is the documented fallback, not the default.
+  if (!rulesDirHasContent && rooRulesExists) {
+    return upsertFileSection(rooRulesPath, block);
+  }
+
   try {
     if (!fs.existsSync(rooDir) || !fs.statSync(rooDir).isDirectory()) return null;
   } catch {
     return null;
   }
 
-  const rulesDir = path.join(rooDir, 'rules');
   fs.mkdirSync(rulesDir, { recursive: true });
-
   const filePath = path.join(rulesDir, 'egc-context.md');
-  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return upsertFileSection(filePath, block);
 }
 
 function writeContinueContext(projectPath: string, block: string): string | null {
@@ -136,11 +162,8 @@ function writeContinueContext(projectPath: string, block: string): string | null
 
   const rulesDir = path.join(continueDir, 'rules');
   fs.mkdirSync(rulesDir, { recursive: true });
-
   const filePath = path.join(rulesDir, 'egc-context.md');
-  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return upsertFileSection(filePath, block);
 }
 
 function writeCopilotContext(projectPath: string, block: string): string | null {

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -138,7 +138,11 @@ function writeRooCodeContext(projectPath: string, block: string): string | null 
   // Roo Code discovers .roo/rules/ over the legacy flat .roorules file when
   // both exist -- .roorules is the documented fallback, not the default.
   if (!rulesDirHasContent && rooRulesExists) {
-    return upsertFileSection(rooRulesPath, block);
+    try {
+      return upsertFileSection(rooRulesPath, block);
+    } catch {
+      return null;
+    }
   }
 
   try {

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -294,6 +294,22 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('returns null instead of throwing when .roorules is structurally unreadable', () => {
+    const dir = mktemp();
+    try {
+      // .roorules is a directory, not a file: readFileSync on it fails
+      // (EISDIR) on every OS. update_state must not crash because Roo
+      // Code propagation hit a bad path -- it should just skip it.
+      fs.mkdirSync(path.join(dir, '.roorules'));
+      assert.doesNotThrow(() => {
+        const result = propagateStateToTools({ projectPath: dir, ...args });
+        assert.strictEqual(result.roo, null, 'roo should be null, not throw, on a structural read error');
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (await test('skips Roo Code when neither .roorules nor .roo/ exist', () => {
     const dir = mktemp();
     try {

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -168,6 +168,124 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('upserts egc section in .cursor/rules/egc-context.mdc without destroying user content', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      fs.writeFileSync(filePath, '---\ndescription: custom\n---\n\nDo not use var.\n', 'utf-8');
+
+      propagateStateToTools({ projectPath: dir, ...args });
+      const first = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(first.includes('Do not use var'), 'original content must be preserved');
+      assert.ok(first.includes('<!-- egc:start -->'), 'egc block must be present');
+
+      propagateStateToTools({
+        projectPath: dir,
+        context: 'Updated context.',
+        decisions: [{ what: 'Use ESM' }],
+        next: ['Deploy to prod'],
+      });
+      const second = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(second.includes('Do not use var'), 'original content preserved after update');
+      assert.ok(second.includes('Updated context'), 'context should be updated');
+      assert.ok(!second.includes('Test project in alpha phase'), 'old context should be gone');
+      assert.strictEqual(
+        (second.match(/<!-- egc:start -->/g) || []).length,
+        1,
+        'only one egc block'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('upserts egc section in existing local CLAUDE.md', () => {
+    const dir = mktemp();
+    try {
+      const claudePath = path.join(dir, 'CLAUDE.md');
+      fs.writeFileSync(claudePath, '# Project instructions\n\nUse strict mode.\n', 'utf-8');
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.claude, 'claude path should be returned');
+      const content = fs.readFileSync(result.claude, 'utf-8');
+      assert.ok(content.includes('Use strict mode'), 'original content preserved');
+      assert.ok(content.includes('<!-- egc:start -->'), 'egc block added');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('skips local CLAUDE.md when file does not exist', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.strictEqual(result.claude, null, 'claude should be null when file absent');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('upserts egc section in existing .roorules', () => {
+    const dir = mktemp();
+    try {
+      const rooPath = path.join(dir, '.roorules');
+      fs.writeFileSync(rooPath, '# Roo rules\n', 'utf-8');
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.roo, 'roo path should be returned');
+      assert.strictEqual(result.roo, rooPath, 'should prefer flat .roorules over .roo/rules/');
+      const content = fs.readFileSync(result.roo, 'utf-8');
+      assert.ok(content.includes('<!-- egc:start -->'), 'egc block added');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes .roo/rules/egc-context.md when .roo/ exists and no .roorules', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.roo'));
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.roo, 'roo path should be returned');
+      assert.ok(result.roo.endsWith(path.join('.roo', 'rules', 'egc-context.md')), 'should write under .roo/rules/');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('skips Roo Code when neither .roorules nor .roo/ exist', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.strictEqual(result.roo, null, 'roo should be null when nothing exists');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes .continue/rules/egc-context.md when .continue/ exists', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.continue'));
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.continue, 'continue path should be returned');
+      const content = fs.readFileSync(result.continue, 'utf-8');
+      assert.ok(content.includes('<!-- egc:start -->'), 'egc block added');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('skips Continue.dev when .continue/ does not exist', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.strictEqual(result.continue, null, 'continue should be null when dir absent');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (await test('handles missing context and next gracefully', () => {
     const dir = mktemp();
     try {

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -201,6 +201,27 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('migrates a pre-fix unmarked egc-context.mdc without duplicating memory', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      // Exactly what the old writeCursorContext used to write: frontmatter +
+      // block, no markers at all.
+      const legacyContent = '---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n## EGC Project Memory\n\n**Context:** Old stale context from before the fix.\n';
+      fs.writeFileSync(filePath, legacyContent, 'utf-8');
+
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      const content = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(!content.includes('Old stale context from before the fix'), 'legacy unmarked block must not survive as duplicate content');
+      assert.ok(content.includes('description: EGC project memory'), 'frontmatter must be preserved');
+      assert.strictEqual((content.match(/<!-- egc:start -->/g) || []).length, 1, 'exactly one egc block after migration');
+      assert.ok(content.includes('Test project in alpha phase'), 'new context must be present');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (await test('upserts egc section in existing local CLAUDE.md', () => {
     const dir = mktemp();
     try {
@@ -226,14 +247,14 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
-  if (await test('upserts egc section in existing .roorules', () => {
+  if (await test('upserts egc section in .roorules when .roo/rules/ has no content (fallback)', () => {
     const dir = mktemp();
     try {
       const rooPath = path.join(dir, '.roorules');
       fs.writeFileSync(rooPath, '# Roo rules\n', 'utf-8');
       const result = propagateStateToTools({ projectPath: dir, ...args });
       assert.ok(result.roo, 'roo path should be returned');
-      assert.strictEqual(result.roo, rooPath, 'should prefer flat .roorules over .roo/rules/');
+      assert.strictEqual(result.roo, rooPath, 'should fall back to flat .roorules when .roo/rules/ is absent');
       const content = fs.readFileSync(result.roo, 'utf-8');
       assert.ok(content.includes('<!-- egc:start -->'), 'egc block added');
     } finally {
@@ -248,6 +269,26 @@ async function runTests() {
       const result = propagateStateToTools({ projectPath: dir, ...args });
       assert.ok(result.roo, 'roo path should be returned');
       assert.ok(result.roo.endsWith(path.join('.roo', 'rules', 'egc-context.md')), 'should write under .roo/rules/');
+      const content = fs.readFileSync(result.roo, 'utf-8');
+      assert.ok(content.includes('<!-- egc:start -->'), 'egc block added');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('prefers populated .roo/rules/ over legacy .roorules when both exist', () => {
+    const dir = mktemp();
+    try {
+      const rooRulesPath = path.join(dir, '.roorules');
+      fs.writeFileSync(rooRulesPath, '# legacy roo rules\n', 'utf-8');
+      const rulesDir = path.join(dir, '.roo', 'rules');
+      fs.mkdirSync(rulesDir, { recursive: true });
+      fs.writeFileSync(path.join(rulesDir, 'custom.md'), '# custom rule\n', 'utf-8');
+
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.ok(result.roo.endsWith(path.join('.roo', 'rules', 'egc-context.md')), 'should prefer the populated directory');
+      const legacyContent = fs.readFileSync(rooRulesPath, 'utf-8');
+      assert.ok(!legacyContent.includes('<!-- egc:start -->'), 'legacy .roorules must be left untouched');
     } finally {
       cleanup(dir);
     }


### PR DESCRIPTION
## Summary
- `writeCursorContext` overwrote `.cursor/rules/egc-context.mdc` in full on every `update_state`, destroying any content outside the EGC block. Switched to `upsertEgcSection`, same as every other harness writer.
- Added the 3 harnesses `propagateStateToTools` was missing: local `CLAUDE.md`, Roo Code (`.roorules` / `.roo/rules/`), and Continue.dev (`.continue/rules/`).

Validated against the Multica squad's independent review (analysis + second-opinion pass) before implementing, not just the initial audit.

## Test plan
- [x] `npm run build` (mcp/servers/egc-memory) compiles clean
- [x] `node tests/scripts/egc-memory-propagate.test.js` — 16/16 pass, including 8 new cases for Cursor upsert, local CLAUDE.md, Roo Code (both paths), Continue.dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents rule file clobbering and mirror blanking, and adds propagation to local `CLAUDE.md`, Roo Code, and Continue.dev.

- **Bug Fixes**
  - Cursor: upsert the EGC block and migrate pre-fix unmarked files to avoid duplicate blocks.
  - Propagation: use the merged persisted state and correctly join multi-line `Context` to prevent blanking.
  - Roo Code: prefer `.roo/rules/` over legacy `.roorules`, and guard the `.roorules` fallback with try/catch to skip unreadable paths.

- **New Features**
  - Propagate to `CLAUDE.md`, Roo Code, Continue.dev; return `claude`, `roo`, `continue` paths in `PropagateResult`.

<sup>Written for commit 466c0444b5c6c1cbbe374d94896eda075fe6b582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

