### PR TITLE
fix(install): cover 6 missing session bus commands and add Windsurf/Zed to bootstrap-cognitive.js

### DIFF
--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -34,6 +34,12 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - I need the full/raw output of that command → rerun it through \`egc run --raw\`
 - Did another session/tab leave me anything? What are the others doing? → call \`session_events\` (and \`session_peers\`)
 - Tell the other session/tab something, hand work off → call \`session_send\`
+- Join session / announce presence → call \`session_announce\`
+- Lock / claim a file path to avoid conflicts with other sessions → call \`claim_path\`
+- Unlock / release a claimed file path → call \`release_path\`
+- Read shared working memory → call \`working_memory_get\`
+- Save a key/value to shared working memory → call \`working_memory_set\`
+- List shared working memory keys → call \`working_memory_list\`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
 
@@ -297,5 +303,28 @@ try {
     }
   } catch (e) {
     console.log(`  [cognitive] Kiro: unexpected error: ${e.message}`);
+  }
+})();
+
+// ── Windsurf (~/.codeium/windsurf/memories/global_rules.md) ──────────────────
+(function bootstrapWindsurf() {
+  try {
+    const codeiumDir = path.join(HOME, '.codeium');
+    if (!fs.existsSync(codeiumDir)) return;
+    const target = path.join(codeiumDir, 'windsurf', 'memories', 'global_rules.md');
+    injectProtocol(target, 'Windsurf');
+  } catch (e) {
+    console.log(`  [cognitive] Windsurf: unexpected error: ${e.message}`);
+  }
+})();
+
+// ── Zed (~/.config/zed/AGENTS.md) ─────────────────────────────────────────────
+(function bootstrapZed() {
+  try {
+    const zedDir = path.join(HOME, '.config', 'zed');
+    if (!fs.existsSync(zedDir)) return;
+    injectProtocol(path.join(zedDir, 'AGENTS.md'), 'Zed');
+  } catch (e) {
+    console.log(`  [cognitive] Zed: unexpected error: ${e.message}`);
   }
 })();

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts', 'bootstrap-cognitive.js');
+const SCRIPT_SOURCE = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+function mktempHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-bootstrap-cognitive-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function run(homeDir) {
+  return execFileSync('node', [SCRIPT_PATH], {
+    env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+    encoding: 'utf8',
+  });
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+async function runTests() {
+  console.log('\n=== Testing scripts/bootstrap-cognitive.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('BLOCK advertises all 9 session bus commands', () => {
+    for (const cmd of [
+      'session_announce',
+      'session_peers',
+      'session_events',
+      'session_send',
+      'claim_path',
+      'release_path',
+      'working_memory_get',
+      'working_memory_set',
+      'working_memory_list',
+    ]) {
+      assert.ok(SCRIPT_SOURCE.includes(cmd), `BLOCK must reference ${cmd}`);
+    }
+  })) passed++; else failed++;
+
+  if (await test('BLOCK advertises all 5 Guardian commands', () => {
+    for (const cmd of ['orchestrate_task', 'validate_command', 'validate_write', 'reduce_context', 'auto_learn']) {
+      assert.ok(SCRIPT_SOURCE.includes(cmd), `BLOCK must reference ${cmd}`);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes Windsurf global_rules.md when ~/.codeium exists', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codeium'));
+      const output = run(home);
+      assert.ok(/Windsurf: memory protocol installed/.test(output), 'should report install');
+      const target = path.join(home, '.codeium', 'windsurf', 'memories', 'global_rules.md');
+      const content = fs.readFileSync(target, 'utf8');
+      assert.ok(content.includes('<!-- egc-memory-protocol -->'), 'marker must be present');
+      assert.ok(content.includes('EGC Session Memory'), 'protocol block must be present');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('skips Windsurf when ~/.codeium does not exist', () => {
+    const home = mktempHome();
+    try {
+      const output = run(home);
+      assert.ok(!/\[cognitive\] Windsurf:/.test(output), 'should not mention Windsurf at all');
+      assert.ok(!fs.existsSync(path.join(home, '.codeium')), 'must not create ~/.codeium');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Windsurf install is idempotent (no duplicate marker on rerun)', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codeium'));
+      run(home);
+      const second = run(home);
+      assert.ok(/Windsurf: already configured/.test(second), 'second run should detect existing config');
+      const target = path.join(home, '.codeium', 'windsurf', 'memories', 'global_rules.md');
+      const content = fs.readFileSync(target, 'utf8');
+      assert.strictEqual(
+        (content.match(/<!-- egc-memory-protocol -->/g) || []).length,
+        1,
+        'only one protocol marker after two runs'
+      );
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes Zed AGENTS.md when ~/.config/zed exists', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.config', 'zed'), { recursive: true });
+      const output = run(home);
+      assert.ok(/Zed: memory protocol installed/.test(output), 'should report install');
+      const target = path.join(home, '.config', 'zed', 'AGENTS.md');
+      const content = fs.readFileSync(target, 'utf8');
+      assert.ok(content.includes('<!-- egc-memory-protocol -->'), 'marker must be present');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('skips Zed when ~/.config/zed does not exist', () => {
+    const home = mktempHome();
+    try {
+      const output = run(home);
+      assert.ok(!/\[cognitive\] Zed:/.test(output), 'should not mention Zed at all');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('does not target a home-level file for Cline or Aider (project-only harnesses)', () => {
+    assert.ok(
+      !SCRIPT_SOURCE.includes("'.clinerules'"),
+      'Cline has no home target per docs/spec/integration-tiers.md -- must not be added here'
+    );
+    assert.ok(
+      !SCRIPT_SOURCE.includes('.aider.conf.yml'),
+      'Aider has no home target per docs/spec/integration-tiers.md -- must not be added here'
+    );
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -58,7 +58,7 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
-  if (await test('BLOCK advertises all 5 Guardian commands', () => {
+  if (await test('BLOCK advertises all 5 core protocol commands (Guardian Protocol + reduce_context)', () => {
     for (const cmd of ['orchestrate_task', 'validate_command', 'validate_write', 'reduce_context', 'auto_learn']) {
       assert.ok(SCRIPT_SOURCE.includes(cmd), `BLOCK must reference ${cmd}`);
     }
@@ -128,6 +128,35 @@ async function runTests() {
     try {
       const output = run(home);
       assert.ok(!/\[cognitive\] Zed:/.test(output), 'should not mention Zed at all');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('logs an error instead of crashing when the Windsurf target path is structurally broken', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codeium'));
+      // 'windsurf' is a file, not a directory: mkdirSync('.codeium/windsurf/memories', {recursive:true})
+      // fails structurally (ENOTDIR) on every OS, unlike a permission-based failure.
+      fs.writeFileSync(path.join(home, '.codeium', 'windsurf'), 'not a directory', 'utf8');
+      const output = run(home);
+      assert.ok(/Windsurf: unexpected error:/.test(output), 'should report the error, not crash');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('logs an error instead of crashing when the Zed AGENTS.md path is structurally broken', () => {
+    const home = mktempHome();
+    try {
+      const zedDir = path.join(home, '.config', 'zed');
+      fs.mkdirSync(zedDir, { recursive: true });
+      // AGENTS.md is a directory, not a file: readFileSync on it fails structurally
+      // (EISDIR) on every OS, unlike a permission-based failure.
+      fs.mkdirSync(path.join(zedDir, 'AGENTS.md'));
+      const output = run(home);
+      assert.ok(/Zed: unexpected error:/.test(output), 'should report the error, not crash');
     } finally {
       cleanup(home);
     }


### PR DESCRIPTION
## Summary
- The NLI block only advertised 3 of the 9 session bus commands (`session_events`, `session_peers`, `session_send`); added the other 6 (`session_announce`, `claim_path`, `release_path`, `working_memory_get`/`set`/`list`).
- Added Windsurf (`~/.codeium/windsurf/memories/global_rules.md`) and Zed (`~/.config/zed/AGENTS.md`) to the protocol injection. Zed's target path follows `docs/spec/integration-tiers.md`, not a `settings.json` approach — `zed-home.js` confirms nothing currently writes there.
- Cline and Aider are intentionally left out: `docs/spec/integration-tiers.md` and their install-targets (`cline-project.js`, `aider-project.js`) document both as project-only with no home target. Adding a home-level file for either here would contradict that already-researched decision.

## Test plan
- [x] `node --check scripts/bootstrap-cognitive.js`
- [x] New `tests/scripts/bootstrap-cognitive.test.js` (no coverage existed before) — 8/8 pass, including sandboxed `$HOME` runs for Windsurf/Zed install, idempotency, and skip-when-absent
- [x] `node tests/spec/integration-tiers.test.js` — 5/5 pass, no regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `bootstrap-cognitive.js` to advertise all 9 session bus commands and to install the memory protocol for Windsurf and Zed. Adds cross-platform tests and ensures idempotent, skip-when-absent behavior.

- New Features
  - Installs the memory protocol for Windsurf (`~/.codeium/windsurf/memories/global_rules.md`) and Zed (`~/.config/zed/AGENTS.md`); follows `docs/spec/integration-tiers.md` (no home-level files for Cline/Aider).

- Bug Fixes
  - NLI block now includes all 9 session bus commands by adding `session_announce`, `claim_path`, `release_path`, `working_memory_get`, `working_memory_set`, `working_memory_list`.
  - Tests: add idempotency/skip checks and error-path coverage for Windsurf/Zed (structural ENOTDIR/EISDIR) for reliable cross-platform runs; rename the core-command test to reflect `reduce_context` is under Auto-Intuition, not Guardian Protocol.

<sup>Written for commit 842b275f452df5d21e43ee1afcfe5341ca34fb9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

