### PR TITLE
fix(install): extend NLI session bus coverage to 8 more harnesses

### DIFF
--- a/.codebuddy/MEMORY.md
+++ b/.codebuddy/MEMORY.md
@@ -31,7 +31,7 @@ update_state({
 
 Only include fields that changed this session. `update_state` merges with existing state: it does not erase previous memory.
 
-## Auto-Intuition
+## EGC Auto-Intuition
 
 Act on user intent, not keywords. When what the user says implies an EGC action, call the right tool immediately -- no explicit command needed.
 
@@ -41,6 +41,18 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - What failed? What did we decide? → call `search_history` or `query_history`
 - Review code or a PR → spawn `/review-pr` agents
 - Context is heavy or slow → call `reduce_context`
+- How much did I save? How many tokens did this session save or cost? → run `egc gain` (short form: `egc saved`)
+- What savings am I missing? What is wasting my tokens? → run `egc discover`
+- Show me the savings history → run `egc gain --history`
+- I need the full/raw output of that command → rerun it through `egc run --raw`
+- Did another session/tab leave me anything? What are the others doing? → call `session_events` (and `session_peers`)
+- Tell the other session/tab something, hand work off → call `session_send`
+- Join session / announce presence → call `session_announce`
+- Lock / claim a file path to avoid conflicts with other sessions → call `claim_path`
+- Unlock / release a claimed file path → call `release_path`
+- Read shared working memory → call `working_memory_get`
+- Save a key/value to shared working memory → call `working_memory_set`
+- List shared working memory keys → call `working_memory_list`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
 

--- a/.opencode/instructions/EGC_MEMORY.md
+++ b/.opencode/instructions/EGC_MEMORY.md
@@ -31,7 +31,7 @@ update_state({
 
 Only include fields that changed this session. `update_state` merges with existing state: it does not erase previous memory.
 
-## Auto-Intuition
+## EGC Auto-Intuition
 
 Act on user intent, not keywords. When what the user says implies an EGC action, call the right tool immediately -- no explicit command needed.
 
@@ -41,6 +41,18 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - What failed? What did we decide? → call `search_history` or `query_history`
 - Review code or a PR → spawn `/review-pr` agents
 - Context is heavy or slow → call `reduce_context`
+- How much did I save? How many tokens did this session save or cost? → run `egc gain` (short form: `egc saved`)
+- What savings am I missing? What is wasting my tokens? → run `egc discover`
+- Show me the savings history → run `egc gain --history`
+- I need the full/raw output of that command → rerun it through `egc run --raw`
+- Did another session/tab leave me anything? What are the others doing? → call `session_events` (and `session_peers`)
+- Tell the other session/tab something, hand work off → call `session_send`
+- Join session / announce presence → call `session_announce`
+- Lock / claim a file path to avoid conflicts with other sessions → call `claim_path`
+- Unlock / release a claimed file path → call `release_path`
+- Read shared working memory → call `working_memory_get`
+- Save a key/value to shared working memory → call `working_memory_set`
+- List shared working memory keys → call `working_memory_list`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
 

--- a/.trae/MEMORY.md
+++ b/.trae/MEMORY.md
@@ -31,7 +31,7 @@ update_state({
 
 Only include fields that changed this session. `update_state` merges with existing state: it does not erase previous memory.
 
-## Auto-Intuition
+## EGC Auto-Intuition
 
 Act on user intent, not keywords. When what the user says implies an EGC action, call the right tool immediately -- no explicit command needed.
 
@@ -41,6 +41,18 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - What failed? What did we decide? → call `search_history` or `query_history`
 - Review code or a PR → spawn `/review-pr` agents
 - Context is heavy or slow → call `reduce_context`
+- How much did I save? How many tokens did this session save or cost? → run `egc gain` (short form: `egc saved`)
+- What savings am I missing? What is wasting my tokens? → run `egc discover`
+- Show me the savings history → run `egc gain --history`
+- I need the full/raw output of that command → rerun it through `egc run --raw`
+- Did another session/tab leave me anything? What are the others doing? → call `session_events` (and `session_peers`)
+- Tell the other session/tab something, hand work off → call `session_send`
+- Join session / announce presence → call `session_announce`
+- Lock / claim a file path to avoid conflicts with other sessions → call `claim_path`
+- Unlock / release a claimed file path → call `release_path`
+- Read shared working memory → call `working_memory_get`
+- Save a key/value to shared working memory → call `working_memory_set`
+- List shared working memory keys → call `working_memory_list`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
 

--- a/rules/common/memory.md
+++ b/rules/common/memory.md
@@ -30,3 +30,39 @@ update_state({
 ```
 
 Only include fields that changed this session. `update_state` merges with existing state: it does not erase previous memory.
+
+## EGC Auto-Intuition
+
+Act on user intent, not keywords. When what the user says implies an EGC action, call the right tool immediately -- no explicit command needed.
+
+- Session ending (goodbye, break, sleep, done, closing) → call `update_state`
+- Session starting or resuming → call `get_state`
+- Save/remember this decision → call `lesson_save` or `store_decision`
+- What failed? What did we decide? → call `search_history` or `query_history`
+- Review code or a PR → spawn `/review-pr` agents
+- Context is heavy or slow → call `reduce_context`
+- How much did I save? How many tokens did this session save or cost? → run `egc gain` (short form: `egc saved`)
+- What savings am I missing? What is wasting my tokens? → run `egc discover`
+- Show me the savings history → run `egc gain --history`
+- I need the full/raw output of that command → rerun it through `egc run --raw`
+- Did another session/tab leave me anything? What are the others doing? → call `session_events` (and `session_peers`)
+- Tell the other session/tab something, hand work off → call `session_send`
+- Join session / announce presence → call `session_announce`
+- Lock / claim a file path to avoid conflicts with other sessions → call `claim_path`
+- Unlock / release a claimed file path → call `release_path`
+- Read shared working memory → call `working_memory_get`
+- Save a key/value to shared working memory → call `working_memory_set`
+- List shared working memory keys → call `working_memory_list`
+
+Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
+
+## EGC Guardian Protocol
+
+These calls are automatic and non-negotiable. Never wait for the user to ask.
+
+**Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+**Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+**Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
+**At the end of every significant work block:** call `auto_learn({ project_path: "<cwd>" })`
+
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -7,18 +7,10 @@ const os   = require('node:os');
 
 const MARKER = '<!-- egc-memory-protocol -->';
 
-const BLOCK = `
-<!-- egc-memory-protocol -->
-## EGC Session Memory
-
-The \`egc-memory\` MCP server is installed. Use it to maintain cross-session memory:
-
-**Start of every session:** Call \`get_state({})\` to restore project context: decisions made, what failed, what to pick up next.
-**End of every session:** Call \`update_state({...})\` to save decisions, preferences, and next steps.
-
-State files live at \`~/.egc/state/<project-slug>.md\`: plain Markdown, one file per project.
-
-## EGC Auto-Intuition
+// Shared by every harness's protocol text below (BLOCK and the markdown
+// fallbacks) so the 9 session bus commands and 5 Guardian commands can't
+// drift out of sync across the 9+ copies the way they did before this fix.
+const AUTO_INTUITION_MD = `## EGC Auto-Intuition
 
 Act on user intent, not keywords. When what the user says implies an EGC action, call the right tool immediately -- no explicit command needed.
 
@@ -41,9 +33,9 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - Save a key/value to shared working memory → call \`working_memory_set\`
 - List shared working memory keys → call \`working_memory_list\`
 
-Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
+Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.`;
 
-## EGC Guardian Protocol
+const GUARDIAN_MD = `## EGC Guardian Protocol
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
@@ -52,12 +44,38 @@ These calls are automatic and non-negotiable. Never wait for the user to ask.
 **Before every new file Write or Edit on a file not yet read:** call \`validate_write({ filepath: "<path>" })\`
 **At the end of every significant work block:** call \`auto_learn({ project_path: "<cwd>" })\`
 
-Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
+Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.`;
+
+const BLOCK = `
+<!-- egc-memory-protocol -->
+## EGC Session Memory
+
+The \`egc-memory\` MCP server is installed. Use it to maintain cross-session memory:
+
+**Start of every session:** Call \`get_state({})\` to restore project context: decisions made, what failed, what to pick up next.
+**End of every session:** Call \`update_state({...})\` to save decisions, preferences, and next steps.
+
+State files live at \`~/.egc/state/<project-slug>.md\`: plain Markdown, one file per project.
+
+${AUTO_INTUITION_MD}
+
+${GUARDIAN_MD}
 <!-- /egc-memory-protocol -->
 `;
 
-const CODEX_PROTOCOL_SUFFIX = ' At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn.';
-const CODEX_PROTOCOL_FULL   = `persistent_instructions = "At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn."\n`;
+// Standalone Markdown file used by harnesses that read a static instructions
+// file instead of a global rules block (OpenCode/CodeBuddy fallback content,
+// mirrors the .opencode/.codebuddy source files copied below).
+function markdownProtocolBody(title) {
+  return `# ${title}\n\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n`;
+}
+
+// Single-line TOML string (matches the pre-existing persistent_instructions
+// format): kept flattened rather than switched to a triple-quoted multiline
+// TOML string, to avoid restructuring a value format that already installs
+// correctly in production rather than risk a new TOML parsing edge case.
+const CODEX_PROTOCOL_SUFFIX = ' At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn.';
+const CODEX_PROTOCOL_FULL   = `persistent_instructions = "State lives at ~/.egc/state/<slug>.md.${CODEX_PROTOCOL_SUFFIX}"\n`;
 
 const HOME = os.homedir();
 
@@ -124,7 +142,7 @@ try {
         return;
       }
       const separator = existing.trim() ? '\n\n' : '';
-      obj['cursor.rules'] = existing + separator + '[egc-memory-protocol] At the start of every session call get_state({}) via egc-memory to restore project context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. [egc-auto-intuition] Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, how much did I save->egc gain, missed savings->egc discover. Judge by full context not literal words. [egc-guardian] Before every non-trivial task call orchestrate_task. Before every shell command call validate_command. Before every new file write/edit call validate_write. After every work block call auto_learn.';
+      obj['cursor.rules'] = existing + separator + '[egc-memory-protocol] At the start of every session call get_state({}) via egc-memory to restore project context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. [egc-auto-intuition] Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. [egc-guardian] Before every non-trivial task call orchestrate_task. Before every shell command call validate_command. Before every new file write/edit call validate_write. After every work block call auto_learn.';
       fs.writeFileSync(settingsFile + '.egc.bak', rawContent, 'utf8');
       fs.writeFileSync(settingsFile, JSON.stringify(obj, null, 2) + '\n', 'utf8');
       console.log(`  [cognitive] Cursor: memory protocol installed (${settingsFile.replace(HOME, '~')})`);
@@ -208,7 +226,7 @@ try {
     if (fs.existsSync(src)) {
       fs.copyFileSync(src, target);
     } else {
-      fs.writeFileSync(target, '# EGC Session Memory\n\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr, how much did I save->egc gain, missed savings->egc discover. Judge by full context not literal words.\n\n## EGC Guardian Protocol\n\nThese calls are automatic and non-negotiable. Never wait for the user to ask.\n\n- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`\n- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`\n- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`\n- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`\n\nSkipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.\n');
+      fs.writeFileSync(target, markdownProtocolBody('EGC Session Memory'));
     }
     console.log(`  [cognitive] OpenCode: memory protocol installed (${target.replace(HOME, '~')})`);
   } catch (e) {
@@ -251,7 +269,7 @@ try {
     if (fs.existsSync(src)) {
       fs.copyFileSync(src, target);
     } else {
-      fs.writeFileSync(target, '# Session Memory\n\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr, how much did I save->egc gain, missed savings->egc discover. Judge by full context not literal words.\n\n## EGC Guardian Protocol\n\nThese calls are automatic and non-negotiable. Never wait for the user to ask.\n\n- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`\n- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`\n- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`\n- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`\n\nSkipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.\n');
+      fs.writeFileSync(target, markdownProtocolBody('Session Memory'));
     }
     console.log('  [cognitive] CodeBuddy: memory protocol installed (~/.codebuddy/MEMORY.md)');
   } catch (e) {
@@ -271,7 +289,7 @@ try {
       return;
     }
     if (!fs.existsSync(promptsDir)) fs.mkdirSync(promptsDir, { recursive: true });
-    fs.writeFileSync(target, 'name: EGC Session Memory\ndescription: Restore and persist EGC cross-session memory\n---\nAt the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.\n\n## Auto-Intuition\n\nAct on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save, what failed->search_history, review PR->review-pr, how much did I save->egc gain, missed savings->egc discover. Judge by full context not literal words.\n\n## EGC Guardian Protocol\n\nThese calls are automatic and non-negotiable. Never wait for the user to ask.\n\n- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`\n- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`\n- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`\n- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`\n\nSkipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.\n');
+    fs.writeFileSync(target, `name: EGC Session Memory\ndescription: Restore and persist EGC cross-session memory\n---\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n`);
     console.log('  [cognitive] Continue.dev: memory protocol installed (~/.continue/prompts/egc-memory.prompt)');
   } catch (e) {
     console.log(`  [cognitive] Continue.dev: unexpected error: ${e.message}`);

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -114,9 +114,11 @@ async function runTests() {
   })) passed++; else failed++;
 
   if (await test('markdownProtocolBody fallback (OpenCode/CodeBuddy) has full session bus and Guardian if the repo source .md ever goes missing', () => {
-    const fakeScript = mktempFakeRepo();
-    const home = mktempHome();
+    let fakeScript;
+    let home;
     try {
+      fakeScript = mktempFakeRepo();
+      home = mktempHome();
       fs.mkdirSync(path.join(home, '.opencode'));
       fs.mkdirSync(path.join(home, '.codebuddy'));
       runScript(fakeScript, home);
@@ -130,8 +132,8 @@ async function runTests() {
         assert.ok(content.includes('orchestrate_task'), 'fallback content must include Guardian Protocol');
       }
     } finally {
-      cleanup(home);
-      cleanup(path.dirname(path.dirname(fakeScript)));
+      if (home) cleanup(home);
+      if (fakeScript) cleanup(path.dirname(path.dirname(fakeScript)));
     }
   })) passed++; else failed++;
 

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -64,6 +64,92 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  const SESSION_BUS_COMMANDS = [
+    'session_announce', 'session_peers', 'session_events', 'session_send',
+    'claim_path', 'release_path',
+    'working_memory_get', 'working_memory_set', 'working_memory_list',
+  ];
+
+  if (await test('installs all 9 session bus commands for Cursor, Codex, OpenCode, Trae, CodeBuddy, and Continue.dev', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      fs.mkdirSync(path.join(home, '.opencode'));
+      fs.mkdirSync(path.join(home, '.trae'));
+      fs.mkdirSync(path.join(home, '.codebuddy'));
+      fs.mkdirSync(path.join(home, '.continue'));
+      // No .cursor/.config/Cursor -> exercises the injectProtocol(BLOCK) fallback,
+      // already covered by the BLOCK-wide assertion above; here we cover the
+      // 5 harnesses that used to ship an abbreviated, hand-duplicated copy.
+      run(home);
+
+      const filesToCheck = [
+        path.join(home, '.codex', 'config.toml'),
+        path.join(home, '.opencode', 'instructions', 'EGC_MEMORY.md'),
+        path.join(home, '.trae', 'MEMORY.md'),
+        path.join(home, '.codebuddy', 'MEMORY.md'),
+        path.join(home, '.continue', 'prompts', 'egc-memory.prompt'),
+      ];
+      for (const filePath of filesToCheck) {
+        const content = fs.readFileSync(filePath, 'utf8');
+        for (const cmd of SESSION_BUS_COMMANDS) {
+          assert.ok(content.includes(cmd), `${filePath} must reference ${cmd}`);
+        }
+      }
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('installs all 9 session bus commands for Cursor via settings.json', () => {
+    const home = mktempHome();
+    try {
+      const cursorSettingsDir = path.join(home, '.config', 'Cursor', 'User');
+      fs.mkdirSync(cursorSettingsDir, { recursive: true });
+      const settingsFile = path.join(cursorSettingsDir, 'settings.json');
+      fs.writeFileSync(settingsFile, JSON.stringify({ 'editor.fontSize': 14 }), 'utf8');
+
+      run(home);
+
+      const written = fs.readFileSync(settingsFile, 'utf8');
+      const parsed = JSON.parse(written); // throws if bootstrap wrote invalid JSON
+      assert.strictEqual(parsed['editor.fontSize'], 14, 'unrelated settings must be preserved');
+      for (const cmd of SESSION_BUS_COMMANDS) {
+        assert.ok(parsed['cursor.rules'].includes(cmd), `cursor.rules must reference ${cmd}`);
+      }
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Codex config.toml stays a single-line valid TOML string after install', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      run(home);
+      const tomlPath = path.join(home, '.codex', 'config.toml');
+      const content = fs.readFileSync(tomlPath, 'utf8');
+      const match = content.match(/^persistent_instructions = "(.*)"$/m);
+      assert.ok(match, 'persistent_instructions must be a single-line double-quoted TOML string');
+      assert.ok(!match[1].includes('"'), 'the TOML string value must not contain an unescaped double-quote');
+      for (const cmd of SESSION_BUS_COMMANDS) {
+        assert.ok(match[1].includes(cmd), `Codex persistent_instructions must reference ${cmd}`);
+      }
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('rules/common/memory.md (Antigravity + Cline, via rules-core) has Guardian and all 9 session bus commands', () => {
+    const memoryMd = fs.readFileSync(path.join(REPO_ROOT, 'rules', 'common', 'memory.md'), 'utf8');
+    for (const cmd of ['orchestrate_task', 'validate_command', 'validate_write', 'reduce_context', 'auto_learn']) {
+      assert.ok(memoryMd.includes(cmd), `rules/common/memory.md must reference ${cmd}`);
+    }
+    for (const cmd of SESSION_BUS_COMMANDS) {
+      assert.ok(memoryMd.includes(cmd), `rules/common/memory.md must reference ${cmd}`);
+    }
+  })) passed++; else failed++;
+
   if (await test('writes Windsurf global_rules.md when ~/.codeium exists', () => {
     const home = mktempHome();
     try {

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -25,6 +25,28 @@ function run(homeDir) {
   });
 }
 
+// Copies bootstrap-cognitive.js into a throwaway "fake repo" whose
+// .opencode/.codebuddy source files are intentionally absent, so __dirname
+// resolution inside the copy sees them as missing without ever touching
+// this real repo's actual .opencode/instructions/EGC_MEMORY.md or
+// .codebuddy/MEMORY.md -- exercises the markdownProtocolBody() fallback
+// branch (only reachable if those repo files ever went missing, e.g. from
+// an npm package that excluded them).
+function mktempFakeRepo() {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-bootstrap-fakerepo-'));
+  const scriptsDir = path.join(repoDir, 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.copyFileSync(SCRIPT_PATH, path.join(scriptsDir, 'bootstrap-cognitive.js'));
+  return path.join(scriptsDir, 'bootstrap-cognitive.js');
+}
+
+function runScript(scriptPath, homeDir) {
+  return execFileSync('node', [scriptPath], {
+    env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+    encoding: 'utf8',
+  });
+}
+
 async function test(name, fn) {
   try {
     await fn();
@@ -37,23 +59,19 @@ async function test(name, fn) {
   }
 }
 
+const SESSION_BUS_COMMANDS = [
+  'session_announce', 'session_peers', 'session_events', 'session_send',
+  'claim_path', 'release_path',
+  'working_memory_get', 'working_memory_set', 'working_memory_list',
+];
+
 async function runTests() {
   console.log('\n=== Testing scripts/bootstrap-cognitive.js ===\n');
   let passed = 0;
   let failed = 0;
 
   if (await test('BLOCK advertises all 9 session bus commands', () => {
-    for (const cmd of [
-      'session_announce',
-      'session_peers',
-      'session_events',
-      'session_send',
-      'claim_path',
-      'release_path',
-      'working_memory_get',
-      'working_memory_set',
-      'working_memory_list',
-    ]) {
+    for (const cmd of SESSION_BUS_COMMANDS) {
       assert.ok(SCRIPT_SOURCE.includes(cmd), `BLOCK must reference ${cmd}`);
     }
   })) passed++; else failed++;
@@ -63,12 +81,6 @@ async function runTests() {
       assert.ok(SCRIPT_SOURCE.includes(cmd), `BLOCK must reference ${cmd}`);
     }
   })) passed++; else failed++;
-
-  const SESSION_BUS_COMMANDS = [
-    'session_announce', 'session_peers', 'session_events', 'session_send',
-    'claim_path', 'release_path',
-    'working_memory_get', 'working_memory_set', 'working_memory_list',
-  ];
 
   if (await test('installs all 9 session bus commands for Cursor, Codex, OpenCode, Trae, CodeBuddy, and Continue.dev', () => {
     const home = mktempHome();
@@ -98,6 +110,28 @@ async function runTests() {
       }
     } finally {
       cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('markdownProtocolBody fallback (OpenCode/CodeBuddy) has full session bus and Guardian if the repo source .md ever goes missing', () => {
+    const fakeScript = mktempFakeRepo();
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.opencode'));
+      fs.mkdirSync(path.join(home, '.codebuddy'));
+      runScript(fakeScript, home);
+
+      const opencodeContent = fs.readFileSync(path.join(home, '.opencode', 'instructions', 'EGC_MEMORY.md'), 'utf8');
+      const codebuddyContent = fs.readFileSync(path.join(home, '.codebuddy', 'MEMORY.md'), 'utf8');
+      for (const content of [opencodeContent, codebuddyContent]) {
+        for (const cmd of SESSION_BUS_COMMANDS) {
+          assert.ok(content.includes(cmd), `fallback content must reference ${cmd}`);
+        }
+        assert.ok(content.includes('orchestrate_task'), 'fallback content must include Guardian Protocol');
+      }
+    } finally {
+      cleanup(home);
+      cleanup(path.dirname(path.dirname(fakeScript)));
     }
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
- Earlier today's Fix NLI (PRs #1058/#1059) only reached the 4 harnesses using `scripts/bootstrap-cognitive.js`'s `BLOCK` constant directly (Claude Code, Gemini CLI, Windsurf, Zed). Audit found 8 more harnesses installing an abbreviated, hand-duplicated copy with 0/9 session bus commands (and, in several cases, missing `reduce_context` too): Cursor, Codex CLI, OpenCode, Trae, CodeBuddy, Continue.dev, Antigravity, and Cline (the last two via `rules/common/memory.md`, which had no Guardian Protocol or session bus at all — only bare `get_state`/`update_state`).
- Extracted `AUTO_INTUITION_MD` and `GUARDIAN_MD` as shared constants so `BLOCK` and the markdown-based fallbacks stop drifting out of sync.
- Kept Codex's TOML value as a single-line basic string (matching what already installs correctly in production) rather than switching to triple-quoted multiline.

## Multica squad review
Validated via EGC-488 (Multica). Two of the squad's recommendations were reviewed and **not** implemented after verification against the actual codebase: a home-level file for Cline/Aider (contradicts the already-verified "project only, no home target" architecture from PR #1059 earlier today) and a Roo Code path that doesn't match its real convention. Full reasoning in the EGC-488 comment thread.

## Test plan
- [x] `node tests/scripts/bootstrap-cognitive.test.js` — 14/14 pass, including 6 new cases (sandboxed installs for all 5 file-based harnesses, Cursor via real `settings.json`, Codex TOML single-line validity, `rules/common/memory.md` content)
- [x] `node tests/spec/integration-tiers.test.js` — 5/5 pass, no regression
- [x] `eslint` clean
- [x] Manually verified Codex `config.toml` stays valid single-line TOML and Cursor `settings.json` stays valid JSON after install

## Known follow-up (not in this PR)
10 harnesses (Amp, VS Code Copilot, JetBrains Junie, Goose, Amazon Q, Roo Code, OpenHands, Aider, Warp, Qwen Code) still have no memory protocol channel at all — tracked in EGC-487/488, needs manifest and/or adapter changes, not a text fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the EGC session memory protocol (Auto‑Intuition with `reduce_context`, all 9 session‑bus commands, and Guardian) to eight more harnesses—Cursor, Codex CLI, OpenCode, Trae, CodeBuddy, Continue.dev, Antigravity, and Cline—and de‑duplicates the protocol text to keep all harnesses in sync while adding coverage for markdown fallbacks. Aligns with EGC‑488; remaining non‑integrated harnesses are tracked separately.

- **Bug Fixes**
  - Injected the full protocol into all eight harnesses; `rules/common/memory.md` now includes Guardian and all 9 session‑bus commands.
  - Cursor `settings.json` (`cursor.rules`) and Codex `config.toml` (`persistent_instructions`) get the same content; Codex stays a single‑line TOML string; JSON/TOML remain valid.
  - Added tests to assert all 9 session‑bus commands across harnesses, cover fallback markdown generation, and verify Codex’s single‑line TOML.
  - Fixed a temp dir leak in the fallback test by moving allocations inside try/finally.

- **Refactors**
  - Centralized protocol text via `AUTO_INTUITION_MD` and `GUARDIAN_MD`; added `markdownProtocolBody()` for consistent markdown fallbacks.
  - Deduped test assertions via a shared `SESSION_BUS_COMMANDS` constant.

<sup>Written for commit 7833b83f5bdaa873cbd49e7818e1bdfff0e75aa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

