### PR TITLE
fix(install): wire 8 more targets into rules-core so they receive the NLI memory protocol

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -13,7 +13,15 @@
         "cursor",
         "antigravity",
         "codebuddy",
-        "cline"
+        "cline",
+        "amp",
+        "copilot",
+        "junie",
+        "goose",
+        "amazonq",
+        "roocode",
+        "openhands",
+        "qwen"
       ],
       "dependencies": [],
       "defaultInstall": true,

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -67,7 +67,10 @@
                 "openhands",
                 "aider",
                 "cline",
-                "warp"
+                "warp",
+                "junie",
+                "roocode",
+                "qwen"
               ]
             }
           },

--- a/scripts/lib/install-targets/amazonq-project.js
+++ b/scripts/lib/install-targets/amazonq-project.js
@@ -6,5 +6,9 @@ module.exports = createInstallTargetAdapter({
   kind: 'project',
   rootSegments: ['.amazonq', 'rules'],
   installStatePathSegments: ['egc-install-state.json'],
-  nativeRootRelativePath: '.amazonq',
+  // rootSegments already ends in 'rules', matching rules-core's own module
+  // path ('rules'): nativeRootRelativePath must equal that source path (not
+  // '.amazonq', never exercised by any module) so resolveDestinationPath
+  // syncs root children directly instead of nesting rules/rules/.
+  nativeRootRelativePath: 'rules',
 });

--- a/scripts/lib/install-targets/roocode-project.js
+++ b/scripts/lib/install-targets/roocode-project.js
@@ -6,5 +6,9 @@ module.exports = createInstallTargetAdapter({
   kind: 'project',
   rootSegments: ['.roo', 'rules'],
   installStatePathSegments: ['egc-install-state.json'],
-  nativeRootRelativePath: '.roo',
+  // rootSegments already ends in 'rules', matching rules-core's own module
+  // path ('rules'): nativeRootRelativePath must equal that source path (not
+  // '.roo', never exercised by any module) so resolveDestinationPath syncs
+  // root children directly instead of nesting rules/rules/.
+  nativeRootRelativePath: 'rules',
 });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2344,6 +2344,27 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('amazonq adapter does not double-nest a "rules" module path under .amazonq/rules/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'amazonq',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'rules-core', paths: ['rules'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'amazonq-project');
+    const op = plan.operations.find(o => normalizedRelativePath(o.sourceRelativePath) === 'rules');
+    assert.ok(op, 'should emit an operation for the rules module path');
+    assert.strictEqual(
+      op.destinationPath,
+      path.join(projectRoot, '.amazonq', 'rules'),
+      'rootSegments already ends in "rules": the module path must sync into that root directly, not .amazonq/rules/rules/'
+    );
+  })) passed++; else failed++;
+
   if (test('amazonq adapter is included in the full adapter list', () => {
     const adapters = listInstallTargetAdapters();
     const targets = adapters.map(a => a.target);
@@ -2398,6 +2419,27 @@ function runTests() {
         )
       )),
       'Should preserve skills/<category>/<name> structure under .roo/rules/'
+    );
+  })) passed++; else failed++;
+
+  if (test('roocode adapter does not double-nest a "rules" module path under .roo/rules/', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'roocode',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'rules-core', paths: ['rules'] }],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'roocode-project');
+    const op = plan.operations.find(o => normalizedRelativePath(o.sourceRelativePath) === 'rules');
+    assert.ok(op, 'should emit an operation for the rules module path');
+    assert.strictEqual(
+      op.destinationPath,
+      path.join(projectRoot, '.roo', 'rules'),
+      'rootSegments already ends in "rules": the module path must sync into that root directly, not .roo/rules/rules/'
     );
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
- `rules-core` (ships `rules/common/memory.md`, the `get_state`/`update_state` instructions) only listed 5 targets in `manifests/install-modules.json`. 8 more already have a working adapter that correctly handles a `"rules"` module path (confirmed per-adapter via a dedicated investigation) but were never wired to any module: **Amp, VS Code Copilot, JetBrains Junie, Goose, Amazon Q, Roo Code, OpenHands, Qwen Code**. `--target <any of these>` installed nothing at all before this change.
- Fixed a real bug found while verifying end-to-end: `amazonq-project.js` and `roocode-project.js` produced a double-nested `.amazonq/rules/rules/...` / `.roo/rules/rules/...` path. Root cause: `nativeRootRelativePath` was set to the tool's dotfolder instead of `'rules'`, even though `rootSegments` already ends in `'rules'`. Neither adapter was ever exercised by a live module before this PR, so this was a real, previously-dormant bug — safe to fix now.
- Fixed `schemas/install-modules.schema.json`'s `targets` enum, which was missing `junie`/`roocode`/`qwen` entirely — pre-existing gap, unrelated to this PR's own change, found because `tests/ci/validators` started failing once those 3 targets appeared in the manifest.

## Test plan
- [x] `node tests/lib/install-targets.test.js` — 128/128 pass (2 new regression cases for the nesting fix)
- [x] `node tests/lib/install-manifests.test.js` — 32/32 pass
- [x] `node tests/ci/validators.test.js` — 167/167 pass (was 166/167 before the schema fix)
- [x] `node tests/scripts/install-plan.test.js` — 10/10 pass
- [x] `node tests/scripts/install-apply.test.js` — 33/33 pass
- [x] `node tests/spec/integration-tiers.test.js` — 5/5 pass, no regression
- [x] `eslint` clean (no errors; pre-existing complexity warning on the 128-case test runner, not introduced here)
- [x] Verified end-to-end (not just plan/dry-run) via sandboxed `install-apply.js --target <t> --modules rules-core` for all 8 targets: `memory.md` materializes at the expected path for each, nesting bug confirmed fixed

## Known follow-up (not in this PR)
Aider and Warp still have no memory-protocol channel: both explicitly filter out any module path that doesn't start with `"skills/"` in their adapter, so they need new adapter code (not a manifest change) to receive `rules/common/memory.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the `rules-core` memory protocol for 8 more install targets and fix a path bug that double-nested the rules folder for Amazon Q and Roo Code. This makes `rules/common/memory.md` install to the right place across more tools.

- **New Features**
  - Wired these targets to `rules-core`: Amp, VS Code Copilot, JetBrains Junie, Goose, Amazon Q, Roo Code, OpenHands, Qwen Code.
  - `--target <t> --modules rules-core` now installs `rules/common/memory.md` for each.

- **Bug Fixes**
  - Fixed double-nesting in `amazonq-project` and `roocode-project` by setting `nativeRootRelativePath` to `rules`.
  - Extended the schema `targets` enum to include `junie`, `roocode`, and `qwen`.

<sup>Written for commit 23cdd68454f1949b55af31e3406e66f2d4df2877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

