### PR TITLE
fix(install): wire Aider and Warp into rules-core so they receive the NLI memory protocol

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -21,7 +21,9 @@
         "amazonq",
         "roocode",
         "openhands",
-        "qwen"
+        "qwen",
+        "aider",
+        "warp"
       ],
       "dependencies": [],
       "defaultInstall": true,

--- a/scripts/lib/install-targets/aider-project.js
+++ b/scripts/lib/install-targets/aider-project.js
@@ -18,12 +18,6 @@ const { MERGE_YAML_READ_LIST_KIND } = require('../aider-config-merge');
 // `read:` list of the project's .aider.conf.yml without touching any of the
 // user's own existing keys (model settings, lint commands, etc).
 
-// path.relative() returns backslash-separated paths on Windows; YAML/the
-// read: list should stay forward-slash like every other path in this repo.
-function toPosixRelative(from, to) {
-  return path.relative(from, to).split(path.sep).join('/');
-}
-
 function createAiderPlanOperations(input, adapter) {
   const modules = Array.isArray(input.modules) ? input.modules : [];
   const planningInput = {
@@ -67,7 +61,7 @@ function createAiderPlanOperations(input, adapter) {
             strategy: MERGE_YAML_READ_LIST_KIND,
             ownership: 'managed',
             scaffoldOnly: false,
-            readEntry: toPosixRelative(projectRoot, destinationPath),
+            readEntry: normalizeRelativePath(path.relative(projectRoot, destinationPath)),
           };
 
           return [copyOperation, mergeOperation];
@@ -99,7 +93,7 @@ function createAiderPlanOperations(input, adapter) {
             strategy: MERGE_YAML_READ_LIST_KIND,
             ownership: 'managed',
             scaffoldOnly: false,
-            readEntry: toPosixRelative(projectRoot, destinationPath),
+            readEntry: normalizeRelativePath(path.relative(projectRoot, destinationPath)),
           };
 
           return [copyOperation, mergeOperation];

--- a/scripts/lib/install-targets/aider-project.js
+++ b/scripts/lib/install-targets/aider-project.js
@@ -18,6 +18,12 @@ const { MERGE_YAML_READ_LIST_KIND } = require('../aider-config-merge');
 // `read:` list of the project's .aider.conf.yml without touching any of the
 // user's own existing keys (model settings, lint commands, etc).
 
+// path.relative() returns backslash-separated paths on Windows; YAML/the
+// read: list should stay forward-slash like every other path in this repo.
+function toPosixRelative(from, to) {
+  return path.relative(from, to).split(path.sep).join('/');
+}
+
 function createAiderPlanOperations(input, adapter) {
   const modules = Array.isArray(input.modules) ? input.modules : [];
   const planningInput = {
@@ -61,7 +67,7 @@ function createAiderPlanOperations(input, adapter) {
             strategy: MERGE_YAML_READ_LIST_KIND,
             ownership: 'managed',
             scaffoldOnly: false,
-            readEntry: path.relative(projectRoot, destinationPath),
+            readEntry: toPosixRelative(projectRoot, destinationPath),
           };
 
           return [copyOperation, mergeOperation];
@@ -93,7 +99,7 @@ function createAiderPlanOperations(input, adapter) {
             strategy: MERGE_YAML_READ_LIST_KIND,
             ownership: 'managed',
             scaffoldOnly: false,
-            readEntry: path.relative(projectRoot, destinationPath),
+            readEntry: toPosixRelative(projectRoot, destinationPath),
           };
 
           return [copyOperation, mergeOperation];

--- a/scripts/lib/install-targets/aider-project.js
+++ b/scripts/lib/install-targets/aider-project.js
@@ -33,30 +33,73 @@ function createAiderPlanOperations(input, adapter) {
     const paths = Array.isArray(module.paths) ? module.paths : [];
     return paths
       .filter(p => !isForeignPlatformPath(p, adapter.target))
-      .filter(p => normalizeRelativePath(p).startsWith('skills/'))
       .flatMap(sourceRelativePath => {
         const normalized = normalizeRelativePath(sourceRelativePath);
-        const skillName = normalized.split('/').pop();
-        const destinationPath = path.join(targetRoot, 'skills', `${skillName}.md`);
 
-        const copyOperation = createManagedOperation({
-          moduleId: module.id,
-          sourceRelativePath: path.join(normalized, 'SKILL.md'),
-          destinationPath,
-          strategy: 'preserve-relative-path',
-        });
+        if (normalized.startsWith('skills/')) {
+          const skillName = normalized.split('/').pop();
+          const destinationPath = path.join(targetRoot, 'skills', `${skillName}.md`);
 
-        const mergeOperation = {
-          kind: MERGE_YAML_READ_LIST_KIND,
-          moduleId: module.id,
-          destinationPath: aiderConfigPath,
-          strategy: MERGE_YAML_READ_LIST_KIND,
-          ownership: 'managed',
-          scaffoldOnly: false,
-          readEntry: path.relative(projectRoot, destinationPath),
-        };
+          const copyOperation = createManagedOperation({
+            moduleId: module.id,
+            sourceRelativePath: path.join(normalized, 'SKILL.md'),
+            destinationPath,
+            strategy: 'preserve-relative-path',
+          });
 
-        return [copyOperation, mergeOperation];
+          const mergeOperation = {
+            kind: MERGE_YAML_READ_LIST_KIND,
+            moduleId: module.id,
+            // install-state.schema.json requires sourceRelativePath on every
+            // operation; the executor's merge-kind branch doesn't read it
+            // (materializeScaffoldOperation just spreads the operation
+            // through), but the schema check on the recorded install-state
+            // fails without it. Point at the same source the copy operation
+            // above already used.
+            sourceRelativePath: path.join(normalized, 'SKILL.md'),
+            destinationPath: aiderConfigPath,
+            strategy: MERGE_YAML_READ_LIST_KIND,
+            ownership: 'managed',
+            scaffoldOnly: false,
+            readEntry: path.relative(projectRoot, destinationPath),
+          };
+
+          return [copyOperation, mergeOperation];
+        }
+
+        // rules-core's static memory protocol file (rules/common/memory.md,
+        // the get_state/update_state instructions). Same read: merge
+        // mechanism as a skill -- Aider only ever loads context through
+        // that one key -- just copied to .aider/rules/ instead of
+        // .aider/skills/. Hardcodes the single known file under rules/
+        // rather than a recursive scan, since that's the only file the
+        // module ships today; revisit if rules/ grows more files.
+        if (normalized === 'rules') {
+          const memorySourcePath = 'rules/common/memory.md';
+          const destinationPath = path.join(targetRoot, 'rules', 'common', 'memory.md');
+
+          const copyOperation = createManagedOperation({
+            moduleId: module.id,
+            sourceRelativePath: memorySourcePath,
+            destinationPath,
+            strategy: 'preserve-relative-path',
+          });
+
+          const mergeOperation = {
+            kind: MERGE_YAML_READ_LIST_KIND,
+            moduleId: module.id,
+            sourceRelativePath: memorySourcePath,
+            destinationPath: aiderConfigPath,
+            strategy: MERGE_YAML_READ_LIST_KIND,
+            ownership: 'managed',
+            scaffoldOnly: false,
+            readEntry: path.relative(projectRoot, destinationPath),
+          };
+
+          return [copyOperation, mergeOperation];
+        }
+
+        return [];
       });
   });
 }

--- a/scripts/lib/install-targets/warp-project.js
+++ b/scripts/lib/install-targets/warp-project.js
@@ -22,13 +22,6 @@ const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
 // path) into a marked block inside the project's AGENTS.md, without
 // touching any of the user's own content in that file.
 
-// path.relative() returns backslash-separated paths on Windows; the skill
-// index entry in AGENTS.md should stay forward-slash like every other path
-// in this repo.
-function toPosixRelative(from, to) {
-  return path.relative(from, to).split(path.sep).join('/');
-}
-
 // Truncates on Unicode code points, not UTF-16 code units, so a surrogate
 // pair (e.g. an emoji used in a skill description) is never split in half.
 function truncateDescription(text) {
@@ -114,7 +107,7 @@ function createWarpPlanOperations(input, adapter) {
             scaffoldOnly: false,
             skillName,
             skillDescription: readSkillDescription(sourceSkillPath),
-            relativePath: toPosixRelative(projectRoot, destinationPath),
+            relativePath: normalizeRelativePath(path.relative(projectRoot, destinationPath)),
           };
 
           return [copyOperation, mergeOperation];
@@ -148,7 +141,7 @@ function createWarpPlanOperations(input, adapter) {
             scaffoldOnly: false,
             skillName: 'EGC Session Memory',
             skillDescription: 'Cross-session memory protocol: call get_state at session start, update_state at session end.',
-            relativePath: toPosixRelative(projectRoot, destinationPath),
+            relativePath: normalizeRelativePath(path.relative(projectRoot, destinationPath)),
           };
 
           return [copyOperation, mergeOperation];

--- a/scripts/lib/install-targets/warp-project.js
+++ b/scripts/lib/install-targets/warp-project.js
@@ -22,6 +22,13 @@ const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
 // path) into a marked block inside the project's AGENTS.md, without
 // touching any of the user's own content in that file.
 
+// path.relative() returns backslash-separated paths on Windows; the skill
+// index entry in AGENTS.md should stay forward-slash like every other path
+// in this repo.
+function toPosixRelative(from, to) {
+  return path.relative(from, to).split(path.sep).join('/');
+}
+
 // Truncates on Unicode code points, not UTF-16 code units, so a surrogate
 // pair (e.g. an emoji used in a skill description) is never split in half.
 function truncateDescription(text) {
@@ -107,7 +114,7 @@ function createWarpPlanOperations(input, adapter) {
             scaffoldOnly: false,
             skillName,
             skillDescription: readSkillDescription(sourceSkillPath),
-            relativePath: path.relative(projectRoot, destinationPath),
+            relativePath: toPosixRelative(projectRoot, destinationPath),
           };
 
           return [copyOperation, mergeOperation];
@@ -141,7 +148,7 @@ function createWarpPlanOperations(input, adapter) {
             scaffoldOnly: false,
             skillName: 'EGC Session Memory',
             skillDescription: 'Cross-session memory protocol: call get_state at session start, update_state at session end.',
-            relativePath: path.relative(projectRoot, destinationPath),
+            relativePath: toPosixRelative(projectRoot, destinationPath),
           };
 
           return [copyOperation, mergeOperation];

--- a/scripts/lib/install-targets/warp-project.js
+++ b/scripts/lib/install-targets/warp-project.js
@@ -76,33 +76,78 @@ function createWarpPlanOperations(input, adapter) {
     const paths = Array.isArray(module.paths) ? module.paths : [];
     return paths
       .filter(p => !isForeignPlatformPath(p, adapter.target))
-      .filter(p => normalizeRelativePath(p).startsWith('skills/'))
       .flatMap(sourceRelativePath => {
         const normalized = normalizeRelativePath(sourceRelativePath);
-        const skillName = normalized.split('/').pop();
-        const destinationPath = path.join(targetRoot, 'skills', `${skillName}.md`);
-        const sourceSkillPath = path.join(input.repoRoot || '', normalized, 'SKILL.md');
 
-        const copyOperation = createManagedOperation({
-          moduleId: module.id,
-          sourceRelativePath: path.join(normalized, 'SKILL.md'),
-          destinationPath,
-          strategy: 'preserve-relative-path',
-        });
+        if (normalized.startsWith('skills/')) {
+          const skillName = normalized.split('/').pop();
+          const destinationPath = path.join(targetRoot, 'skills', `${skillName}.md`);
+          const sourceSkillPath = path.join(input.repoRoot || '', normalized, 'SKILL.md');
 
-        const mergeOperation = {
-          kind: MERGE_MARKDOWN_INDEX_KIND,
-          moduleId: module.id,
-          destinationPath: agentsFilePath,
-          strategy: MERGE_MARKDOWN_INDEX_KIND,
-          ownership: 'managed',
-          scaffoldOnly: false,
-          skillName,
-          skillDescription: readSkillDescription(sourceSkillPath),
-          relativePath: path.relative(projectRoot, destinationPath),
-        };
+          const copyOperation = createManagedOperation({
+            moduleId: module.id,
+            sourceRelativePath: path.join(normalized, 'SKILL.md'),
+            destinationPath,
+            strategy: 'preserve-relative-path',
+          });
 
-        return [copyOperation, mergeOperation];
+          const mergeOperation = {
+            kind: MERGE_MARKDOWN_INDEX_KIND,
+            moduleId: module.id,
+            // install-state.schema.json requires sourceRelativePath on every
+            // operation; the executor's merge-kind branch doesn't read it
+            // (materializeScaffoldOperation just spreads the operation
+            // through), but the schema check on the recorded install-state
+            // fails without it. Point at the same source the copy operation
+            // above already used.
+            sourceRelativePath: path.join(normalized, 'SKILL.md'),
+            destinationPath: agentsFilePath,
+            strategy: MERGE_MARKDOWN_INDEX_KIND,
+            ownership: 'managed',
+            scaffoldOnly: false,
+            skillName,
+            skillDescription: readSkillDescription(sourceSkillPath),
+            relativePath: path.relative(projectRoot, destinationPath),
+          };
+
+          return [copyOperation, mergeOperation];
+        }
+
+        // rules-core's static memory protocol file (rules/common/memory.md,
+        // the get_state/update_state instructions). Warp has no separate
+        // rules-discovery mechanism either, so it goes through the same
+        // skill-index merge into AGENTS.md as a named entry pointing at the
+        // copied file -- consistent with how skills stay out of the
+        // always-loaded file to protect context budget. Hardcodes the
+        // single known file under rules/ rather than a recursive scan,
+        // since that's the only file the module ships today.
+        if (normalized === 'rules') {
+          const destinationPath = path.join(targetRoot, 'rules', 'common', 'memory.md');
+
+          const copyOperation = createManagedOperation({
+            moduleId: module.id,
+            sourceRelativePath: 'rules/common/memory.md',
+            destinationPath,
+            strategy: 'preserve-relative-path',
+          });
+
+          const mergeOperation = {
+            kind: MERGE_MARKDOWN_INDEX_KIND,
+            moduleId: module.id,
+            sourceRelativePath: 'rules/common/memory.md',
+            destinationPath: agentsFilePath,
+            strategy: MERGE_MARKDOWN_INDEX_KIND,
+            ownership: 'managed',
+            scaffoldOnly: false,
+            skillName: 'EGC Session Memory',
+            skillDescription: 'Cross-session memory protocol: call get_state at session start, update_state at session end.',
+            relativePath: path.relative(projectRoot, destinationPath),
+          };
+
+          return [copyOperation, mergeOperation];
+        }
+
+        return [];
       });
   });
 }

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2553,7 +2553,21 @@ function runTests() {
     assert.strictEqual(mergeOp.readEntry, path.join('.aider', 'skills', 'tdd-workflow.md'));
   })) passed++; else failed++;
 
-  if (test('aider adapter filters out non-skill module paths (rules, agents, commands)', () => {
+  if (test('aider adapter filters out non-skill, non-rules module paths (agents, commands)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'aider',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'agents-core', paths: ['agents'] }, { id: 'commands-core', paths: ['commands'] }],
+    });
+
+    assert.strictEqual(plan.operations.length, 0, 'Non-skill, non-rules module paths should not produce operations');
+  })) passed++; else failed++;
+
+  if (test("aider adapter copies rules-core's memory.md and merges it into the read: list", () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';
 
@@ -2564,7 +2578,14 @@ function runTests() {
       modules: [{ id: 'rules-core', paths: ['rules'] }],
     });
 
-    assert.strictEqual(plan.operations.length, 0, 'Non-skill module paths should not produce operations');
+    assert.strictEqual(plan.operations.length, 2, 'should emit a copy operation and a read-list merge operation');
+    const copyOp = plan.operations.find(o => o.strategy === 'preserve-relative-path');
+    const mergeOp = plan.operations.find(o => o.kind === 'merge-yaml-read-list');
+    assert.ok(copyOp, 'must emit a copy operation for memory.md');
+    assert.strictEqual(copyOp.destinationPath, path.join(projectRoot, '.aider', 'rules', 'common', 'memory.md'));
+    assert.ok(mergeOp, 'must emit a merge-yaml-read-list operation');
+    assert.strictEqual(mergeOp.destinationPath, path.join(projectRoot, '.aider.conf.yml'));
+    assert.strictEqual(mergeOp.readEntry, path.join('.aider', 'rules', 'common', 'memory.md'));
   })) passed++; else failed++;
 
   if (test('aider adapter is included in the full adapter list', () => {
@@ -2717,7 +2738,21 @@ function runTests() {
     assert.strictEqual(mergeOp.skillDescription, '');
   })) passed++; else failed++;
 
-  if (test('warp adapter filters out non-skill module paths (rules, agents, commands)', () => {
+  if (test('warp adapter filters out non-skill, non-rules module paths (agents, commands)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'warp',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'agents-core', paths: ['agents'] }, { id: 'commands-core', paths: ['commands'] }],
+    });
+
+    assert.strictEqual(plan.operations.length, 0, 'Non-skill, non-rules module paths should not produce operations');
+  })) passed++; else failed++;
+
+  if (test("warp adapter copies rules-core's memory.md and merges an index entry into AGENTS.md", () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';
 
@@ -2728,7 +2763,14 @@ function runTests() {
       modules: [{ id: 'rules-core', paths: ['rules'] }],
     });
 
-    assert.strictEqual(plan.operations.length, 0, 'Non-skill module paths should not produce operations');
+    assert.strictEqual(plan.operations.length, 2, 'should emit a copy operation and an AGENTS.md merge operation');
+    const copyOp = plan.operations.find(o => o.strategy === 'preserve-relative-path');
+    const mergeOp = plan.operations.find(o => o.kind === 'merge-markdown-skill-index');
+    assert.ok(copyOp, 'must emit a copy operation for memory.md');
+    assert.strictEqual(copyOp.destinationPath, path.join(projectRoot, '.warp', 'rules', 'common', 'memory.md'));
+    assert.ok(mergeOp, 'must emit a merge-markdown-skill-index operation');
+    assert.strictEqual(mergeOp.destinationPath, path.join(projectRoot, 'AGENTS.md'));
+    assert.strictEqual(mergeOp.skillName, 'EGC Session Memory');
   })) passed++; else failed++;
 
   if (test('warp adapter is included in the full adapter list', () => {

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2550,7 +2550,7 @@ function runTests() {
     const mergeOp = plan.operations.find(op => op.kind === 'merge-yaml-read-list');
     assert.ok(mergeOp, 'Should emit a merge-yaml-read-list operation for .aider.conf.yml');
     assert.strictEqual(mergeOp.destinationPath, path.join(projectRoot, '.aider.conf.yml'));
-    assert.strictEqual(mergeOp.readEntry, path.join('.aider', 'skills', 'tdd-workflow.md'));
+    assert.strictEqual(mergeOp.readEntry, '.aider/skills/tdd-workflow.md');
   })) passed++; else failed++;
 
   if (test('aider adapter filters out non-skill, non-rules module paths (agents, commands)', () => {
@@ -2585,7 +2585,7 @@ function runTests() {
     assert.strictEqual(copyOp.destinationPath, path.join(projectRoot, '.aider', 'rules', 'common', 'memory.md'));
     assert.ok(mergeOp, 'must emit a merge-yaml-read-list operation');
     assert.strictEqual(mergeOp.destinationPath, path.join(projectRoot, '.aider.conf.yml'));
-    assert.strictEqual(mergeOp.readEntry, path.join('.aider', 'rules', 'common', 'memory.md'));
+    assert.strictEqual(mergeOp.readEntry, '.aider/rules/common/memory.md');
   })) passed++; else failed++;
 
   if (test('aider adapter is included in the full adapter list', () => {
@@ -2700,7 +2700,7 @@ function runTests() {
     assert.ok(mergeOp, 'Should emit a merge-markdown-skill-index operation for AGENTS.md');
     assert.strictEqual(mergeOp.destinationPath, path.join(projectRoot, 'AGENTS.md'));
     assert.strictEqual(mergeOp.skillName, 'tdd-workflow');
-    assert.strictEqual(mergeOp.relativePath, path.join('.warp', 'skills', 'tdd-workflow.md'));
+    assert.strictEqual(mergeOp.relativePath, '.warp/skills/tdd-workflow.md');
     assert.ok(mergeOp.skillDescription.startsWith('Use this skill when writing new features'));
     assert.ok(mergeOp.skillDescription.length <= 110, 'Description should be truncated to the shared max length');
   })) passed++; else failed++;

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -237,6 +237,65 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('installs Aider memory protocol via rules-core and writes valid install-state', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const result = run(['--target', 'aider', '--modules', 'rules-core'], { cwd: projectDir, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+
+      const memoryPath = path.join(projectDir, '.aider', 'rules', 'common', 'memory.md');
+      assert.ok(fs.existsSync(memoryPath), 'memory.md should be copied into .aider/rules/common/');
+      assert.ok(fs.readFileSync(memoryPath, 'utf8').includes('get_state'));
+
+      const confPath = path.join(projectDir, '.aider.conf.yml');
+      assert.ok(fs.existsSync(confPath), '.aider.conf.yml should be created');
+      assert.ok(fs.readFileSync(confPath, 'utf8').includes('.aider/rules/common/memory.md'));
+
+      // Regression guard: install-state.schema.json requires sourceRelativePath
+      // on every recorded operation, including merge-kind ones. Missing it
+      // previously made this exact install fail with
+      // "Invalid install-state (create): /operations/1 must have required
+      // property 'sourceRelativePath'" the first time a merge operation was
+      // ever the second operation recorded for a target.
+      const statePath = path.join(projectDir, '.aider', 'egc-install-state.json');
+      const state = readJson(statePath);
+      assert.ok(state.operations.some(op => op.kind === 'merge-yaml-read-list' && op.sourceRelativePath));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('installs Warp memory protocol via rules-core and writes valid install-state', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const result = run(['--target', 'warp', '--modules', 'rules-core'], { cwd: projectDir, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+
+      const memoryPath = path.join(projectDir, '.warp', 'rules', 'common', 'memory.md');
+      assert.ok(fs.existsSync(memoryPath), 'memory.md should be copied into .warp/rules/common/');
+      assert.ok(fs.readFileSync(memoryPath, 'utf8').includes('get_state'));
+
+      const agentsPath = path.join(projectDir, 'AGENTS.md');
+      assert.ok(fs.existsSync(agentsPath), 'AGENTS.md should be created');
+      const agentsContent = fs.readFileSync(agentsPath, 'utf8');
+      assert.ok(agentsContent.includes('EGC Session Memory'));
+      assert.ok(agentsContent.includes('.warp/rules/common/memory.md'));
+
+      // Same install-state schema regression guard as the Aider test above.
+      const statePath = path.join(projectDir, '.warp', 'egc-install-state.json');
+      const state = readJson(statePath);
+      assert.ok(state.operations.some(op => op.kind === 'merge-markdown-skill-index' && op.sourceRelativePath));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('installs Cursor MCP config by merging bundled servers into an existing mcp.json', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');


### PR DESCRIPTION
## Summary
- Aider and Warp already have a per-skill merge mechanism (`.aider.conf.yml`'s `read:` list / `AGENTS.md`'s skill-index block) but `rules-core` never targeted either tool, so neither ever received the `get_state`/`update_state` memory protocol instructions (`rules/common/memory.md`).
- Adds a `rules/` branch to both `createAiderPlanOperations` and `createWarpPlanOperations` reusing the existing `MERGE_YAML_READ_LIST_KIND`/`MERGE_MARKDOWN_INDEX_KIND` mechanisms, and adds `aider`/`warp` to `rules-core`'s `targets` in `manifests/install-modules.json`.
- Fixes a pre-existing bug this exposed: `install-state.schema.json` requires `sourceRelativePath` on every recorded operation, but the original skill-merge operations (never exercised end-to-end before — no module ever targeted aider/warp until now) omitted it. A real install failed with `Invalid install-state (create): /operations/1 must have required property 'sourceRelativePath'`. Fixed on both the pre-existing skill-merge operations and the new rules-merge ones.

## Test plan
- [x] `node tests/lib/install-targets.test.js` — 128/128 passed
- [x] `node tests/scripts/install-apply.test.js` — 35/35 passed (2 new regression tests added)
- [x] `node tests/run-all.js` — 2988/2988 passed
- [x] `npx eslint` on all changed files — 0 errors
- [x] Manual end-to-end verification with real `install-apply.js` runs for both `aider` and `warp` targets (not just unit tests), confirming correct file content and a schema-valid `egc-install-state.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects `rules-core` to `aider` and `warp` so both receive the NLI session memory protocol. Fixes install-state schema issues and Windows path normalization; refactors adapters to reuse `normalizeRelativePath`.

- **New Features**
  - Handle `rules/` in `createAiderPlanOperations` and `createWarpPlanOperations`: copy `rules/common/memory.md` and register it via Aider’s `read:` list and Warp’s `AGENTS.md` index (as “EGC Session Memory”).
  - Add `aider` and `warp` to `rules-core` `targets` in `manifests/install-modules.json`.

- **Bug Fixes**
  - Add `sourceRelativePath` to all merge operations and normalize merged entry paths to forward slashes on Windows (applies to skills and rules).
  - Update unit tests to expect forward-slash paths in Aider `read:` and Warp skill index to keep CI green on Windows.

<sup>Written for commit 6fc9250a717161a8a413958bcf0ffca75dc62751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

