### PR TITLE
fix(crusher): recognize git log/diff behind global flags like -C <path>

### DIFF
--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -51,8 +51,20 @@ function stripProxyPrefix(command) {
   return trimmed;
 }
 
+// Global git flags that can appear between `git` and the subcommand (e.g.
+// `git -C /repo log`, common in scripts and CI). Each alternative consumes
+// its own trailing whitespace so the group can repeat for stacked flags.
+const GIT_GLOBAL_FLAG =
+  '(?:-C|-c|--git-dir|--work-tree|--namespace)(?:=\\S+|\\s+\\S+)\\s+'
+  + '|(?:--no-pager|--paginate|-p)\\s+';
+const GIT_GLOBAL_PREFIX_RE = new RegExp(`^git\\s+(?:${GIT_GLOBAL_FLAG})*`); // NOSONAR: bounded alternation over a fixed flag set, no backtracking blowup
+
+function stripGitGlobalFlags(command) {
+  return command.replace(GIT_GLOBAL_PREFIX_RE, 'git ');
+}
+
 function commandKind(command) {
-  const normalized = stripProxyPrefix(command);
+  const normalized = stripGitGlobalFlags(stripProxyPrefix(command));
   if (/^git\s+log\b/.test(normalized)) return 'git-log';
   if (/^git\s+diff\b/.test(normalized)) return 'git-diff';
   if (/\b(jest|vitest|pytest|mocha)\b/.test(normalized) || /npm\s+(run\s+)?test\b/.test(normalized) || /node\s+\S*tests?\//.test(normalized)) return 'test-runner';

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -49,6 +49,17 @@ run('classifies commands into kinds', () => {
   delete process.env.EGC_CRUSHER_SKIP_PREFIXES;
 });
 
+run('classifies git commands with global flags before the subcommand', () => {
+  assert.strictEqual(commandKind('git -C /path/to/repo log --stat -n 300'), 'git-log');
+  assert.strictEqual(commandKind('git -C /path/to/repo diff HEAD~1'), 'git-diff');
+  assert.strictEqual(commandKind('git --git-dir=/repo/.git log'), 'git-log');
+  assert.strictEqual(commandKind('git --git-dir /repo/.git log'), 'git-log');
+  assert.strictEqual(commandKind('git --work-tree=/repo log'), 'git-log');
+  assert.strictEqual(commandKind('git -c user.name=x log'), 'git-log');
+  assert.strictEqual(commandKind('git -C /a -c user.name=x --no-pager log'), 'git-log');
+  assert.strictEqual(commandKind('git -C /path status'), 'generic');
+});
+
 run('small outputs pass through untouched', () => {
   assert.strictEqual(crushOutput('git log', 'short output'), null);
 });


### PR DESCRIPTION
## Summary
- `commandKind()` matched `git log`/`git diff` directly at the start of the command, so any global git flag between `git` and the subcommand (`-C <path>`, `-c key=value`, `--git-dir`, `--work-tree`, `--no-pager`, `--paginate`) made the classifier fall through to `'generic'` and skip crushing entirely.
- Found this session while verifying the Token Crusher: `git -C <path> log --stat -n 300` produced no ledger entry despite running repeatedly, because the classifier never recognized it as a `git-log` command.
- Adds `stripGitGlobalFlags()`, applied ahead of the existing kind checks, that strips a leading run of these flags before subcommand matching.

## Test plan
- [x] `node tests/crusher-engine.test.js` — 11/11 passed (1 new regression test covering `-C`, `--git-dir`, `--work-tree`, `-c`, `--no-pager`, and stacked flags)
- [x] `node tests/hooks/pre-bash-crusher-rewrite.test.js` — 14/14 passed
- [x] `node tests/crusher-gain-discover.test.js` — 4/4 passed
- [x] `node tests/run-all.js` — full suite green
- [x] `npx eslint` on changed files — 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes command classification so `git log` and `git diff` are recognized even when global flags come right after `git`. This restores crushing and ledger entries for commands like `git -C /repo log`.

- **Bug Fixes**
  - Added stripGitGlobalFlags() to remove leading git global flags before matching the subcommand.
  - Supports `-C`, `-c`, `--git-dir`, `--work-tree`, `--no-pager`, `--paginate`, and stacked flags.
  - Added tests for these cases; full test suite passes.

<sup>Written for commit 0f939e8946f6c3093dd43ad4c960937e1b353cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

