### PR TITLE
fix(crusher): use String.raw instead of manually escaped backslashes

### DIFF
--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -55,9 +55,9 @@ function stripProxyPrefix(command) {
 // `git -C /repo log`, common in scripts and CI). Each alternative consumes
 // its own trailing whitespace so the group can repeat for stacked flags.
 const GIT_GLOBAL_FLAG =
-  '(?:-C|-c|--git-dir|--work-tree|--namespace)(?:=\\S+|\\s+\\S+)\\s+'
-  + '|(?:--no-pager|--paginate|-p)\\s+';
-const GIT_GLOBAL_PREFIX_RE = new RegExp(`^git\\s+(?:${GIT_GLOBAL_FLAG})*`); // NOSONAR: bounded alternation over a fixed flag set, no backtracking blowup
+  String.raw`(?:-C|-c|--git-dir|--work-tree|--namespace)(?:=\S+|\s+\S+)\s+`
+  + String.raw`|(?:--no-pager|--paginate|-p)\s+`;
+const GIT_GLOBAL_PREFIX_RE = new RegExp(String.raw`^git\s+(?:${GIT_GLOBAL_FLAG})*`); // NOSONAR: bounded alternation over a fixed flag set, no backtracking blowup
 
 function stripGitGlobalFlags(command) {
   return command.replace(GIT_GLOBAL_PREFIX_RE, 'git ');


### PR DESCRIPTION
## Summary
- Found by reading the SonarCloud PR comment via Gmail after PR #1063 had already merged (the Quality Gate passed so I only checked the check status, not the comment's content — 2 new MINOR issues don't block the gate but shouldn't have shipped either).
- SonarCloud S7780 flagged both lines of `GIT_GLOBAL_FLAG` in `scripts/lib/crusher/engine.js` for manually escaping backslashes in regular string literals instead of using `String.raw` template literals.
- Applied the same pattern to the `new RegExp()` construction line for consistency, even though Sonar only flagged the two `GIT_GLOBAL_FLAG` lines. No behavior change — same regex, same semantics.

## Test plan
- [x] `node tests/crusher-engine.test.js` — 11/11 passed
- [x] `node tests/run-all.js` — full suite green (3003/3003)
- [x] `npx eslint scripts/lib/crusher/engine.js` — 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch regex strings in `scripts/lib/crusher/engine.js` to `String.raw` template literals to satisfy SonarCloud S7780 and improve readability. Updated `GIT_GLOBAL_FLAG` and the `RegExp` construction; behavior unchanged.

<sup>Written for commit 3160a9ca49c77baed3cc2adb04dfa9bbb5fbd97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

