### PR TITLE
fix(memory): resolve $HOME fresh on every key lookup, not once at process boot

### DIFF
--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -15,12 +15,22 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const KEY_DIR = path.join(os.homedir(), '.egc');
-const ENC_KEY_PATH = path.join(KEY_DIR, 'encryption.key');
 const ALGORITHM = 'aes-256-gcm';
 const IV_BYTES = 12;
 const AUTH_TAG_BYTES = 16;
 const MAGIC = 'EGC1:';
+
+// A function, not a module-level constant: os.homedir() must be read fresh
+// on every call. A frozen constant would keep resolving to whatever $HOME
+// was in effect when this module first loaded, even if the MCP server
+// process later observes a different $HOME — silently diverging from
+// getStateDir() (index.ts), which already recomputes os.homedir() per call.
+// That divergence is what let a state file get encrypted under one key and
+// later fail decryption under another, long after the key file itself had
+// stopped changing.
+function defaultEncKeyPath(): string {
+  return path.join(os.homedir(), '.egc', 'encryption.key');
+}
 
 /**
  * Load or create the AES-256-GCM encryption key at ~/.egc/encryption.key.
@@ -28,7 +38,7 @@ const MAGIC = 'EGC1:';
  * Throws if the key file exists but cannot be read or is malformed —
  * only generates a new key when the file genuinely does not exist.
  */
-export function loadOrCreateEncKey(keyPath: string = ENC_KEY_PATH): Buffer {
+export function loadOrCreateEncKey(keyPath: string = defaultEncKeyPath()): Buffer {
   const dir = path.dirname(keyPath);
   try {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
@@ -156,10 +166,21 @@ export function readStateFile(filePath: string, key: Buffer): string {
  */
 export function writeStateFile(filePath: string, plaintext: string, key: Buffer): void {
   const encrypted = encryptState(plaintext, key);
-  const tmpPath = `${filePath}.tmp`;
-  fs.writeFileSync(tmpPath, encrypted);
-  try { fs.chmodSync(tmpPath, 0o600); } catch { /* chmod not supported on Windows */ }
-  fs.renameSync(tmpPath, filePath);
+  // Unique per call, not just per file: a fixed `${filePath}.tmp` name lets
+  // two concurrent writers to the same state file (different processes, or
+  // a lock timeout letting a second write through) overwrite each other's
+  // temp file before either renames, producing ciphertext with bytes from
+  // both writes — undecryptable garbage that looks like corruption. Mirrors
+  // the same pid+random suffix loadOrCreateEncKey() already uses for its
+  // own temp file below.
+  const tmpPath = `${filePath}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
+  try {
+    fs.writeFileSync(tmpPath, encrypted);
+    try { fs.chmodSync(tmpPath, 0o600); } catch { /* chmod not supported on Windows */ }
+    fs.renameSync(tmpPath, filePath);
+  } finally {
+    try { fs.unlinkSync(tmpPath); } catch { /* already renamed away; best-effort cleanup */ }
+  }
 }
 
 /**

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -170,10 +170,11 @@ export function writeStateFile(filePath: string, plaintext: string, key: Buffer)
   // two concurrent writers to the same state file (different processes, or
   // a lock timeout letting a second write through) overwrite each other's
   // temp file before either renames, producing ciphertext with bytes from
-  // both writes — undecryptable garbage that looks like corruption. Mirrors
-  // the same pid+random suffix loadOrCreateEncKey() already uses for its
-  // own temp file below.
-  const tmpPath = `${filePath}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
+  // both writes — undecryptable garbage that looks like corruption. A
+  // randomUUID (122 bits of entropy) makes a same-process collision
+  // practically impossible even under heavy concurrency; a 32-bit suffix
+  // (crypto.randomBytes(4)) does not carry the same guarantee.
+  const tmpPath = `${filePath}.tmp-${process.pid}-${crypto.randomUUID()}`;
   try {
     fs.writeFileSync(tmpPath, encrypted);
     try { fs.chmodSync(tmpPath, 0o600); } catch { /* chmod not supported on Windows */ }

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -450,8 +450,22 @@ async function getDb(): Promise<Database> {
 }
 
 const server = new Server({ name: "egc-memory-orchestrator", version: "3.0.0" }, { capabilities: { tools: {} } });
-const _integrityKey: Buffer = loadOrCreateKey();
-const _encKey: Buffer = loadOrCreateEncKey();
+// Functions, not module-level constants: both loadOrCreateKey() and
+// loadOrCreateEncKey() resolve their key path from os.homedir() internally.
+// Caching the returned Buffer once at process boot (the previous shape:
+// `const _encKey = loadOrCreateEncKey()`) meant getStateDir() below — which
+// already recomputes os.homedir() on every call — could point at a state
+// file directory computed under a different $HOME than the one the cached
+// key was derived from, if this process ever observed $HOME change after
+// boot. Writes and reads would then silently use different keys against
+// the same file: GCM auth-tag verification fails on read, indistinguishable
+// from disk corruption. Recomputing per call costs one ~64-byte file read.
+function getIntegrityKey(): Buffer {
+  return loadOrCreateKey();
+}
+function getEncKey(): Buffer {
+  return loadOrCreateEncKey();
+}
 
 function getStateDir(): string {
   const dir = path.join(os.homedir(), '.egc', 'state');
@@ -511,7 +525,7 @@ function resolveProjectPath(provided?: string): string {
 const H2_RE = /^## (.+)/;
 function readStateDoc(filePath: string): Record<string, string[]|string> {
   if (!fs.existsSync(filePath)) return {};
-  const content = readStateFile(filePath, _encKey);
+  const content = readStateFile(filePath, getEncKey());
   const result: Record<string, string[]|string> = {};
   let currentSection = '';
   for (const line of content.split('\n')) {
@@ -577,7 +591,7 @@ function writeStateDoc(filePath: string, projectPath: string, data: {
     ``
   ];
 
-  writeStateFile(filePath, lines.join('\n'), _encKey);
+  writeStateFile(filePath, lines.join('\n'), getEncKey());
 }
 
 const LESSON_REINFORCE_DELTA = 0.15;
@@ -1201,12 +1215,12 @@ async function handleGetState(db: Database, toolArgs: unknown) {
 
   let content: string;
   try {
-    content = readStateFile(resolved.filePath, _encKey);
+    content = readStateFile(resolved.filePath, getEncKey());
   } catch (err) {
     log('ERROR', '[EGC encryption] Failed to decrypt state file', { file: resolved.filePath, error: String(err) });
     return { content: [{ type: "text", text: `State file exists but could not be decrypted. The encryption key may have changed.\nPath: ${resolved.filePath}` }] };
   }
-  const verify = verifyHmac(resolved.filePath, content, _integrityKey);
+  const verify = verifyHmac(resolved.filePath, content, getIntegrityKey());
   if (!verify.ok) {
     log('WARN', '[EGC integrity] State file integrity check failed', { file: resolved.filePath, reason: (verify as { ok: false; reason: string }).reason });
     log('INFO', 'Project state retrieved', { project: projPath, branch: branch || 'none', source: resolved.source, integrity: (verify as { ok: false; reason: string }).reason });
@@ -1273,8 +1287,8 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
         }
       }
       writeStateDoc(globalFile, 'global', args, existingGlobal, null);
-      const writtenGlobal = readStateFile(globalFile, _encKey);
-      writeHmac(globalFile, writtenGlobal, _integrityKey);
+      const writtenGlobal = readStateFile(globalFile, getEncKey());
+      writeHmac(globalFile, writtenGlobal, getIntegrityKey());
       log('INFO', 'Global state updated', { decisions: args.decisions?.length || 0 });
       return { content: [{ type: "text", text: `Global memory updated (shared across all projects).\nFile: ${globalFile}\nDecisions saved: ${args.decisions?.length || 0}` }] };
     });
@@ -1304,8 +1318,8 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
 
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     writeStateDoc(filePath, projPath, args, existing, branch);
-    const writtenContent = readStateFile(filePath, _encKey);
-    writeHmac(filePath, writtenContent, _integrityKey);
+    const writtenContent = readStateFile(filePath, getEncKey());
+    writeHmac(filePath, writtenContent, getIntegrityKey());
   });
   // Propagate the merged, persisted doc rather than this call's raw args:
   // a partial update_state (e.g. next only) would otherwise blank out

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -16,15 +16,28 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const KEY_DIR = path.join(os.homedir(), '.egc');
-const KEY_PATH = path.join(KEY_DIR, 'integrity.key');
 const HMAC_ALGORITHM = 'sha256';
+
+// Functions, not module-level constants: see the matching comment on
+// defaultEncKeyPath() in encryption.ts — a frozen os.homedir() would keep
+// resolving to whatever $HOME was in effect when this module first loaded,
+// diverging from getStateDir() (index.ts) if the process later observes a
+// different $HOME.
+function keyDir(): string {
+  return path.join(os.homedir(), '.egc');
+}
+
+function keyPath(): string {
+  return path.join(keyDir(), 'integrity.key');
+}
 
 /**
  * Load or create the HMAC key at ~/.egc/integrity.key.
  * The key is 32 random bytes encoded as hex (64 hex chars on disk).
  */
 export function loadOrCreateKey(): Buffer {
+  const KEY_DIR = keyDir();
+  const KEY_PATH = keyPath();
   try {
     fs.mkdirSync(KEY_DIR, { recursive: true, mode: 0o700 });
   } catch {

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -171,6 +171,84 @@ if (test('loadOrCreateEncKey: TOCTOU race — a concurrent winner\'s key is read
   }
 })) passed++; else failed++;
 
+if (test('loadOrCreateEncKey: default keyPath resolves $HOME fresh on every call, not just at module load (regression)', () => {
+  // Regression for the bug behind repeated "encryption key may have
+  // changed" failures on main.md: ENC_KEY_PATH used to be a module-level
+  // constant computed once from os.homedir() at import time, so a $HOME
+  // change mid-process had no effect on which key file the default
+  // parameter resolved to — while getStateDir() in index.ts (a live
+  // os.homedir() lookup on every call) tracked the real $HOME, letting the
+  // encrypting key and the state file directory silently diverge.
+  const homeA = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-homeA-'));
+  const homeB = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-homeB-'));
+  const origHome = process.env.HOME;
+  try {
+    process.env.HOME = homeA;
+    const keyA = loadOrCreateEncKey();
+    process.env.HOME = homeB;
+    const keyB = loadOrCreateEncKey();
+    assert.ok(fs.existsSync(path.join(homeA, '.egc', 'encryption.key')), 'key A must land under homeA');
+    assert.ok(fs.existsSync(path.join(homeB, '.egc', 'encryption.key')), 'key B must land under homeB, not homeA');
+    assert.ok(!keyA.equals(keyB), 'each $HOME must get its own independently generated key');
+  } finally {
+    process.env.HOME = origHome;
+    fs.rmSync(homeA, { recursive: true, force: true });
+    fs.rmSync(homeB, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+// ── writeStateFile concurrency ──────────────────────────────────────────────
+
+if (test('writeStateFile: concurrent writers to the same path use distinct temp files (regression)', () => {
+  // Regression for the second cause behind repeated main.md corruption:
+  // writeStateFile used a fixed `${filePath}.tmp` name, so two concurrent
+  // writers (e.g. two egc-memory processes racing an update_state on the
+  // same state file) could each write to the same temp path and clobber
+  // each other's bytes before either renamed, producing ciphertext that
+  // decrypts to nothing — indistinguishable from disk corruption. This
+  // spies on fs.writeFileSync to capture every temp path writeStateFile
+  // uses across concurrent-looking calls and asserts none collide.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  const filePath = path.join(tmpDir, 'main.md');
+  const key = crypto.randomBytes(32);
+  const seenTmpPaths = [];
+  const originalWriteFileSync = fs.writeFileSync;
+  fs.writeFileSync = (target, ...rest) => {
+    if (typeof target === 'string' && target.startsWith(`${filePath}.tmp`)) {
+      seenTmpPaths.push(target);
+    }
+    return originalWriteFileSync(target, ...rest);
+  };
+  try {
+    for (let i = 0; i < 5; i++) {
+      writeStateFile(filePath, `write #${i}`, key);
+    }
+    assert.strictEqual(seenTmpPaths.length, 5, 'expected one temp-file write per call');
+    assert.strictEqual(
+      new Set(seenTmpPaths).size,
+      seenTmpPaths.length,
+      `every writeStateFile call must use a distinct temp path, got: ${JSON.stringify(seenTmpPaths)}`
+    );
+    assert.strictEqual(readStateFile(filePath, key), 'write #4', 'final content must be the last write, uncorrupted');
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('writeStateFile: cleans up its temp file after a successful write', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
+  try {
+    const filePath = path.join(tmpDir, 'state.md');
+    const key = crypto.randomBytes(32);
+    writeStateFile(filePath, 'content', key);
+    const leftoverTmp = fs.readdirSync(tmpDir).filter(name => name.includes('.tmp-'));
+    assert.deepStrictEqual(leftoverTmp, [], `no leftover temp files expected, found: ${JSON.stringify(leftoverTmp)}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
 // ── quarantineUndecryptableStateFile ────────────────────────────────────────
 
 if (test('quarantineUndecryptableStateFile: renames the corrupted file to a backup path and leaves it readable', () => {

--- a/tests/egc-memory-integrity.test.js
+++ b/tests/egc-memory-integrity.test.js
@@ -59,12 +59,45 @@ if (test('loadOrCreateKey: returns a 32-byte Buffer', () => {
 })) passed++; else failed++;
 
 if (test('loadOrCreateKey: key file is created with mode 0600', () => {
-  // KEY_PATH is resolved at module load time from os.homedir()
-  const keyPath = path.join(os.homedir(), '.egc', 'integrity.key');
-  loadOrCreateKey();
-  assert.ok(fs.existsSync(keyPath), 'key file should exist');
-  const mode = fs.statSync(keyPath).mode & 0o777;
-  assert.strictEqual(mode, 0o600, `expected mode 0600, got ${mode.toString(8)}`);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  try {
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    loadOrCreateKey();
+    process.env.HOME = origHome;
+    const keyPath = path.join(tmpDir, '.egc', 'integrity.key');
+    assert.ok(fs.existsSync(keyPath), 'key file should exist');
+    const mode = fs.statSync(keyPath).mode & 0o777;
+    assert.strictEqual(mode, 0o600, `expected mode 0600, got ${mode.toString(8)}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
+if (test('loadOrCreateKey: resolves $HOME fresh on every call, not just at module load (regression)', () => {
+  // Before the fix, KEY_DIR/KEY_PATH were module-level constants computed
+  // once from os.homedir() at import time, so a $HOME change mid-process
+  // (e.g. a different effective $HOME on a later process boot) had no
+  // effect: the key path stayed frozen while getStateDir() in index.ts
+  // (a live os.homedir() lookup on every call) tracked the real $HOME,
+  // producing a state directory and a key directory that could silently
+  // diverge from each other.
+  const homeA = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-homeA-'));
+  const homeB = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-homeB-'));
+  const origHome = process.env.HOME;
+  try {
+    process.env.HOME = homeA;
+    const keyA = loadOrCreateKey();
+    process.env.HOME = homeB;
+    const keyB = loadOrCreateKey();
+    assert.ok(fs.existsSync(path.join(homeA, '.egc', 'integrity.key')), 'key A must land under homeA');
+    assert.ok(fs.existsSync(path.join(homeB, '.egc', 'integrity.key')), 'key B must land under homeB, not homeA');
+    assert.ok(!keyA.equals(keyB), 'each $HOME must get its own independently generated key');
+  } finally {
+    process.env.HOME = origHome;
+    fs.rmSync(homeA, { recursive: true, force: true });
+    fs.rmSync(homeB, { recursive: true, force: true });
+  }
 })) passed++; else failed++;
 
 if (test('loadOrCreateKey: returns same key on second call', () => {

--- a/tests/egc-memory-integrity.test.js
+++ b/tests/egc-memory-integrity.test.js
@@ -45,31 +45,31 @@ console.log('\n=== Testing egc-memory integrity (issue #580) ===\n');
 
 if (test('loadOrCreateKey: returns a 32-byte Buffer', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  const origHome = process.env.HOME;
   try {
     // Override HOME so key is written to tmpDir
-    const origHome = process.env.HOME;
     process.env.HOME = tmpDir;
     const key = loadOrCreateKey();
-    process.env.HOME = origHome;
     assert.ok(Buffer.isBuffer(key), 'should be a Buffer');
     assert.strictEqual(key.length, 32, 'should be 32 bytes');
   } finally {
+    process.env.HOME = origHome;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 })) passed++; else failed++;
 
 if (test('loadOrCreateKey: key file is created with mode 0600', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  const origHome = process.env.HOME;
   try {
-    const origHome = process.env.HOME;
     process.env.HOME = tmpDir;
     loadOrCreateKey();
-    process.env.HOME = origHome;
     const keyPath = path.join(tmpDir, '.egc', 'integrity.key');
     assert.ok(fs.existsSync(keyPath), 'key file should exist');
     const mode = fs.statSync(keyPath).mode & 0o777;
     assert.strictEqual(mode, 0o600, `expected mode 0600, got ${mode.toString(8)}`);
   } finally {
+    process.env.HOME = origHome;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 })) passed++; else failed++;
@@ -102,14 +102,14 @@ if (test('loadOrCreateKey: resolves $HOME fresh on every call, not just at modul
 
 if (test('loadOrCreateKey: returns same key on second call', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-integrity-test-'));
+  const origHome = process.env.HOME;
   try {
-    const origHome = process.env.HOME;
     process.env.HOME = tmpDir;
     const key1 = loadOrCreateKey();
     const key2 = loadOrCreateKey();
-    process.env.HOME = origHome;
     assert.ok(key1.equals(key2), 'keys should be identical on second load');
   } finally {
+    process.env.HOME = origHome;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 })) passed++; else failed++;


### PR DESCRIPTION
## Summary
- `_encKey`/`_integrityKey` in `index.ts` were cached once at module load, and their default key paths (`ENC_KEY_PATH`, `KEY_PATH`) were themselves module-level constants derived from `os.homedir()` at import time — while `getStateDir()` in the same file already recomputes `os.homedir()` on every call. If this process ever observed a different effective `$HOME` after boot, the state directory would track it while the keys stayed frozen — writing and reading the same state file under different keys, which fails GCM auth-tag verification and is indistinguishable from disk corruption.
- Found via dozens of accumulated `.corrupted-backup-*` files going back to 2026-07-11, concentrated on the most-frequently-written `main.md`/`main--<hash>.md` state files (feature-branch state files, written far less often, had none).
- Converts the frozen constants to functions computed fresh per call (matching the pattern `getStateDir()` and `scripts/lib/state-crypto.js`'s `defaultKeyPath()` already use correctly).
- Second, independent contributor found during a squad review before implementing (Multica EGC-489): `writeStateFile()` used a fixed `${filePath}.tmp` name, so two concurrent writers to the same file could clobber each other's temp file before either renamed. Gives it a pid+random suffix, matching the pattern `loadOrCreateEncKey()` already uses for its own temp file.
- No corrupted files were touched or recovered — they stay quarantined at their existing `.corrupted-backup-*` paths.
- This is the shared `egc-memory` MCP server used by all 23 supported tools, so the fix applies uniformly regardless of which tool's session triggers `get_state`/`update_state`.

## Test plan
- [x] `node tests/egc-memory-encryption.test.js` — 12/12 passed (2 new regression tests: `$HOME`-fresh key resolution, concurrent-writer temp-file uniqueness)
- [x] `node tests/egc-memory-integrity.test.js` — 12/12 passed (1 new regression test; also fixed an existing test that wrote to the real machine's `~/.egc/integrity.key` instead of an isolated temp `$HOME`)
- [x] `node tests/run-all.js` — full suite green (3007/3007)
- [x] `tsc` build — 0 errors
- [x] Verified no real machine state (`~/.egc/encryption.key`, `~/.egc/integrity.key` mtimes) was touched by the test run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes state file corruption by resolving $HOME fresh on every key lookup and by using unique temp files for writes. Prevents key mismatches and concurrent temp-file clobbers in the shared `egc-memory` server.

- **Bug Fixes**
  - Resolve key paths from `os.homedir()` on every call; replace cached `_encKey`/`_integrityKey` with `getEncKey()`/`getIntegrityKey()`. Avoids encrypt/decrypt under different keys when `$HOME` changes.
  - Make `writeStateFile()` use `${file}.tmp-<pid>-<uuid>` via `crypto.randomUUID()` and clean up in `finally`, preventing concurrent writers from clobbering the same temp file (addresses EGC-489).
  - Add regression tests for fresh `$HOME` key resolution, temp-file uniqueness, and temp cleanup; fix integrity tests to isolate `$HOME` and restore it in `finally`. Existing `.corrupted-backup-*` files remain untouched.

<sup>Written for commit 50c45498a2350e630c4e8b3c7d6aee3f871570a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

