### PR TITLE
fix(crusher): close 4 real gaps between README promises and commandKind() coverage

### DIFF
--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -141,14 +141,18 @@ function isTestRunnerCommand(normalized) {
 // that is super-linear on adversarial input (backtracking blowup on long
 // inputs with no "test" anywhere), so this checks the prefix and the
 // "test" keyword as two separate, individually-linear regexes instead --
-// but scoped to just the first line of `normalized`, not the whole
-// (possibly multi-line, compound) command string. Without that scoping,
-// an unrelated "test" on a later line of a compound command (e.g.
-// `mvn clean\necho "a test message"`) would wrongly flag the whole thing
-// as a test-runner command.
+// but scoped to just the first LOGICAL line of `normalized`, not the
+// whole (possibly multi-line, compound) command string. Without that
+// scoping, an unrelated "test" on a later line of a compound command
+// (e.g. `mvn clean\necho "a test message"`) would wrongly flag the whole
+// thing as a test-runner command. A backslash immediately before the
+// newline is a shell line continuation (e.g. `mvn clean \` + newline +
+// `test`), not a separate command, so those are joined back into one
+// logical line before splitting -- otherwise a goal on the continuation
+// line would be missed.
 function isMvnGradleTestCommand(normalized) {
-  const firstLine = normalized.split(/\r?\n/, 1)[0];
-  return /^(mvn|\.\/?gradlew|gradle)\s/.test(firstLine) && /\btest\b/.test(firstLine);
+  const logicalFirstLine = normalized.replace(/\\\r?\n/g, ' ').split(/\r?\n/, 1)[0];
+  return /^(mvn|\.\/?gradlew|gradle)\s/.test(logicalFirstLine) && /\btest\b/.test(logicalFirstLine);
 }
 
 // Package/dependency install commands across every language EGC installs

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -27,7 +27,33 @@ function tryRequire(modulePath) {
 // payloads stay uncompressed otherwise rather than duplicating that logic.
 const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-array-crusher.js');
 
-const KEEP_LINE_RE = /\b(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception)\b/i;
+// Keep-word list, English plus the error/warning/failure terms of the
+// locales EGC ships READMEs for (pt, es, fr, de, it) -- a localized CLI
+// (e.g. git or a test runner under LANG=pt_BR) must not have its failures
+// silently dropped just because they're not in English.
+const KEEP_LINE_RE = /\b(error|erro|erreur|fehler|errore|fail|failed|failing|falha|fallo|échec|panne|warn|warning|aviso|advertencia|avertissement|warnung|avviso|fatal|denied|negado|denegado|refused|recusado|rechazado|exception|exceção|excepción|panic|pânico)\b/i;
+
+// Stack-trace frame lines carry no keep-word of their own (a Python
+// traceback's `File "app.py", line 42, in main` or a JS `at Object.<...>`
+// line never says "error") but dropping them guts the exact context a
+// debugger -- human or model -- needs to find the failure. Matches the
+// common frame shapes across Python, JS/Node, Java, and C/C++ tracebacks.
+const STACK_FRAME_RE = /^\s*(at\s+\S+|File\s+"[^"]+",\s+line\s+\d+|#\d+\s+0x[0-9a-f]+|Caused by:|\.{3}\s+\d+\s+more)/i;
+
+// System-level failure signals that never contain the word "error": a
+// killed or crashed process, or an HTTP status line/code carrying a
+// standard reason phrase. The HTTP pattern requires a known reason phrase
+// (not just any 3-digit number) so it doesn't false-positive on ordinary
+// counts like "processed 404 items".
+const SYSTEM_FAILURE_RE = /\b(segmentation fault|core dumped|killed|out of memory|oom[- ]?killed|aborted|stack overflow)\b/i;
+const HTTP_ERROR_RE = /\b(?:HTTP\/[\d.]+\s+)?[45]\d{2}\s+(Bad Request|Unauthorized|Forbidden|Not Found|Method Not Allowed|Conflict|Gone|Too Many Requests|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout)\b/i;
+
+function shouldKeepLine(line) {
+  return KEEP_LINE_RE.test(line)
+    || STACK_FRAME_RE.test(line)
+    || SYSTEM_FAILURE_RE.test(line)
+    || HTTP_ERROR_RE.test(line);
+}
 
 // Terminal color codes glue onto words (ESC[31merror) and break the \b
 // word boundary, silently dropping colored error lines from the kept set.
@@ -63,12 +89,44 @@ function stripGitGlobalFlags(command) {
   return command.replace(GIT_GLOBAL_PREFIX_RE, 'git ');
 }
 
+// Test runners across every language EGC ships coding-style rules for, not
+// just the JS ones: go/cargo/dotnet/mvn/gradle/phpunit/pest/rspec/mix each
+// produce their own kind of noisy pass/fail spam that never touched
+// crushTestRunner() before, silently falling through to 'generic' (0%
+// compression) for the majority of the catalog's supported languages.
+function isTestRunnerCommand(normalized) {
+  return /\b(jest|vitest|pytest|mocha|phpunit|pest|rspec)\b/.test(normalized)
+    || /(?:^|\s)(npm|pnpm|yarn|bun)\s+(run\s+)?test\b/.test(normalized)
+    || /node\s+\S*tests?\//.test(normalized)
+    || /^go\s+test\b/.test(normalized)
+    || /^cargo\s+test\b/.test(normalized)
+    || /^dotnet\s+test\b/.test(normalized)
+    || /^(mvn|\.\/?gradlew|gradle)\s+.*\btest\b/.test(normalized)
+    || /^mix\s+test\b/.test(normalized);
+}
+
+// Package/dependency install commands across every language EGC installs
+// rules for, not just the npm ecosystem -- pip/poetry/cargo/go/composer/
+// bundle installs each emit their own kind of noisy install spam that fell
+// through to 'generic' before.
+function isPmInstallCommand(normalized) {
+  return /^(npm|yarn|pnpm|bun)\s+(install|ci|add|i)\b/.test(normalized)
+    || /^pip3?\s+install\b/.test(normalized)
+    || /^poetry\s+(install|add|update)\b/.test(normalized)
+    || /^pipenv\s+install\b/.test(normalized)
+    || /^uv\s+(sync|add|pip\s+install)\b/.test(normalized)
+    || /^cargo\s+(build|install|add)\b/.test(normalized)
+    || /^go\s+(mod\s+download|get)\b/.test(normalized)
+    || /^composer\s+(install|update|require)\b/.test(normalized)
+    || /^bundle\s+install\b/.test(normalized);
+}
+
 function commandKind(command) {
   const normalized = stripGitGlobalFlags(stripProxyPrefix(command));
   if (/^git\s+log\b/.test(normalized)) return 'git-log';
   if (/^git\s+diff\b/.test(normalized)) return 'git-diff';
-  if (/\b(jest|vitest|pytest|mocha)\b/.test(normalized) || /npm\s+(run\s+)?test\b/.test(normalized) || /node\s+\S*tests?\//.test(normalized)) return 'test-runner';
-  if (/^(npm|yarn|pnpm|bun)\s+(install|ci|add|i)\b/.test(normalized)) return 'pm-install';
+  if (isTestRunnerCommand(normalized)) return 'test-runner';
+  if (isPmInstallCommand(normalized)) return 'pm-install';
   if (/^gh\b.*--json\b/.test(normalized)) return 'gh-json';
   return 'generic';
 }
@@ -104,7 +162,7 @@ function crushTestRunner(output) {
   const lines = output.split('\n');
   const kept = lines.filter(raw => {
     const l = stripAnsi(raw);
-    return KEEP_LINE_RE.test(l)
+    return shouldKeepLine(l)
       || /^\s*(Tests|Test Suites|Snapshots|Time|Ran all|passed|failed|\u2715|\u2717|\u2716|FAIL|PASS:?\s*$)/i.test(l.trim())
       || /^\s*\d+ (passed|failed|skipped|pending)/i.test(l);
   });
@@ -116,7 +174,7 @@ function crushTestRunner(output) {
 
 function crushPmInstall(output) {
   const lines = output.split('\n');
-  const kept = lines.filter(l => KEEP_LINE_RE.test(stripAnsi(l)));
+  const kept = lines.filter(l => shouldKeepLine(stripAnsi(l)));
   const tail = lines.slice(-6).filter(l => l.trim());
   const merged = [...new Set([...kept, ...tail])];
   if (merged.length >= lines.length) return null;
@@ -130,12 +188,33 @@ function crushGhJson(output) {
   return `${result.crushed}\n(${result.rows_before} rows reduced to ${result.rows_after})`;
 }
 
+// `gh ... --json` was the only command pattern that ever routed to
+// crushGhJson, so a `curl`, `kubectl -o json`, or `cat big.json` payload
+// -- equally "giant JSON" by any reasonable reading of that promise --
+// fell through to 'generic' untouched. Detecting by the shape of the
+// OUTPUT rather than enumerating every possible JSON-emitting command
+// generalizes this without needing to keep chasing new command names.
+// Only runs past the byte-length gate crushOutput() already applies, and
+// only when the command didn't already match a more specific kind.
+function looksLikeJsonPayload(output) {
+  const trimmed = output.trim();
+  const first = trimmed[0];
+  if (first !== '{' && first !== '[') return false;
+  try {
+    JSON.parse(trimmed);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const CRUSHERS = {
   'git-log': crushGitLog,
   'git-diff': crushGitDiff,
   'test-runner': crushTestRunner,
   'pm-install': crushPmInstall,
   'gh-json': crushGhJson,
+  'json-output': crushGhJson,
   generic: () => null,
 };
 
@@ -145,7 +224,10 @@ function crushOutput(command, output) {
   if (!output || Buffer.byteLength(output, 'utf8') < MIN_BYTES_TO_CRUSH) return null;
   if (output.includes(CRUSH_MARKER)) return null;
 
-  const kind = commandKind(command);
+  let kind = commandKind(command);
+  if (kind === 'generic' && looksLikeJsonPayload(output)) {
+    kind = 'json-output';
+  }
   const crushed = CRUSHERS[kind](output);
   if (crushed === null || Buffer.byteLength(crushed, 'utf8') >= Buffer.byteLength(output, 'utf8')) {
     return null;

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -33,10 +33,17 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 // silently dropped just because they're not in English. Split into
 // per-language regexes (rather than one large alternation) to keep each
 // one's cyclomatic complexity within SonarCloud's limit.
-const KEEP_WORD_EN_RE = /\b(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception|panic)\b/i;
-const KEEP_WORD_PT_RE = /\b(erro|falha|aviso|negado|recusado|exceção|pânico)\b/i;
-const KEEP_WORD_ES_RE = /\b(fallo|advertencia|denegado|rechazado|excepción)\b/i;
-const KEEP_WORD_FR_DE_IT_RE = /\b(erreur|échec|panne|avertissement|warnung|fehler|errore|avviso)\b/i;
+//
+// \b in JavaScript regex is ASCII-only ([A-Za-z0-9_]): it does not treat
+// accented letters as "word" characters, so a standalone word starting
+// with one (e.g. "Échec", "Pânico") can sit between two non-word
+// positions and never trigger a \b boundary at all, silently failing to
+// match. \p{L}/\p{N} (with the u flag) are Unicode-aware, so lookaround
+// built from them correctly treats accented letters as word characters.
+const KEEP_WORD_EN_RE = /(?<![\p{L}\p{N}_])(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception|panic)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_PT_RE = /(?<![\p{L}\p{N}_])(erro|falha|aviso|negado|recusado|exceção|pânico)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_ES_RE = /(?<![\p{L}\p{N}_])(fallo|advertencia|denegado|rechazado|excepción)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_FR_DE_IT_RE = /(?<![\p{L}\p{N}_])(erreur|échec|panne|avertissement|warnung|fehler|errore|avviso)(?![\p{L}\p{N}_])/iu;
 
 function matchesKeepWord(line) {
   return KEEP_WORD_EN_RE.test(line)
@@ -125,14 +132,23 @@ function isTestRunnerCommand(normalized) {
     || /^go\s+test\b/.test(normalized)
     || /^cargo\s+test\b/.test(normalized)
     || /^dotnet\s+test\b/.test(normalized)
-    // mvn/gradle take a goal list (e.g. `mvn clean test`), so the goal can
-    // appear anywhere after the binary name. A single `.*\btest\b` regex
-    // for that is super-linear on adversarial input (backtracking blowup
-    // on long inputs with no "test" anywhere); checking the prefix and the
-    // "test" keyword as two separate, individually-linear regexes avoids
-    // that while matching the same commands.
-    || (/^(mvn|\.\/?gradlew|gradle)\s/.test(normalized) && /\btest\b/.test(normalized))
+    || isMvnGradleTestCommand(normalized)
     || /^mix\s+test\b/.test(normalized);
+}
+
+// mvn/gradle take a goal list (e.g. `mvn clean test`), so the goal can
+// appear anywhere after the binary name. A single `.*\btest\b` regex for
+// that is super-linear on adversarial input (backtracking blowup on long
+// inputs with no "test" anywhere), so this checks the prefix and the
+// "test" keyword as two separate, individually-linear regexes instead --
+// but scoped to just the first line of `normalized`, not the whole
+// (possibly multi-line, compound) command string. Without that scoping,
+// an unrelated "test" on a later line of a compound command (e.g.
+// `mvn clean\necho "a test message"`) would wrongly flag the whole thing
+// as a test-runner command.
+function isMvnGradleTestCommand(normalized) {
+  const firstLine = normalized.split(/\r?\n/, 1)[0];
+  return /^(mvn|\.\/?gradlew|gradle)\s/.test(firstLine) && /\btest\b/.test(firstLine);
 }
 
 // Package/dependency install commands across every language EGC installs

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -247,4 +247,5 @@ module.exports = {
   commandKind,
   crushOutput,
   estimateTokens,
+  looksLikeJsonPayload,
 };

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -30,15 +30,39 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 // Keep-word list, English plus the error/warning/failure terms of the
 // locales EGC ships READMEs for (pt, es, fr, de, it) -- a localized CLI
 // (e.g. git or a test runner under LANG=pt_BR) must not have its failures
-// silently dropped just because they're not in English.
-const KEEP_LINE_RE = /\b(error|erro|erreur|fehler|errore|fail|failed|failing|falha|fallo|échec|panne|warn|warning|aviso|advertencia|avertissement|warnung|avviso|fatal|denied|negado|denegado|refused|recusado|rechazado|exception|exceção|excepción|panic|pânico)\b/i;
+// silently dropped just because they're not in English. Split into
+// per-language regexes (rather than one large alternation) to keep each
+// one's cyclomatic complexity within SonarCloud's limit.
+const KEEP_WORD_EN_RE = /\b(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception|panic)\b/i;
+const KEEP_WORD_PT_RE = /\b(erro|falha|aviso|negado|recusado|exceção|pânico)\b/i;
+const KEEP_WORD_ES_RE = /\b(fallo|advertencia|denegado|rechazado|excepción)\b/i;
+const KEEP_WORD_FR_DE_IT_RE = /\b(erreur|échec|panne|avertissement|warnung|fehler|errore|avviso)\b/i;
+
+function matchesKeepWord(line) {
+  return KEEP_WORD_EN_RE.test(line)
+    || KEEP_WORD_PT_RE.test(line)
+    || KEEP_WORD_ES_RE.test(line)
+    || KEEP_WORD_FR_DE_IT_RE.test(line);
+}
 
 // Stack-trace frame lines carry no keep-word of their own (a Python
 // traceback's `File "app.py", line 42, in main` or a JS `at Object.<...>`
 // line never says "error") but dropping them guts the exact context a
 // debugger -- human or model -- needs to find the failure. Matches the
 // common frame shapes across Python, JS/Node, Java, and C/C++ tracebacks.
-const STACK_FRAME_RE = /^\s*(at\s+\S+|File\s+"[^"]+",\s+line\s+\d+|#\d+\s+0x[0-9a-f]+|Caused by:|\.{3}\s+\d+\s+more)/i;
+// Split into one regex per frame shape (rather than one alternation) to
+// keep each one's cyclomatic complexity within SonarCloud's limit.
+const STACK_FRAME_AT_RE = /^\s*at\s+\S+/i;
+const STACK_FRAME_PY_RE = /^\s*File\s+"[^"]+",\s+line\s+\d+/i;
+const STACK_FRAME_NATIVE_RE = /^\s*#\d+\s+0x[0-9a-f]+/i;
+const STACK_FRAME_CAUSE_RE = /^\s*(Caused by:|\.{3}\s+\d+\s+more)/i;
+
+function isStackFrame(line) {
+  return STACK_FRAME_AT_RE.test(line)
+    || STACK_FRAME_PY_RE.test(line)
+    || STACK_FRAME_NATIVE_RE.test(line)
+    || STACK_FRAME_CAUSE_RE.test(line);
+}
 
 // System-level failure signals that never contain the word "error": a
 // killed or crashed process, or an HTTP status line/code carrying a
@@ -49,8 +73,8 @@ const SYSTEM_FAILURE_RE = /\b(segmentation fault|core dumped|killed|out of memor
 const HTTP_ERROR_RE = /\b(?:HTTP\/[\d.]+\s+)?[45]\d{2}\s+(Bad Request|Unauthorized|Forbidden|Not Found|Method Not Allowed|Conflict|Gone|Too Many Requests|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout)\b/i;
 
 function shouldKeepLine(line) {
-  return KEEP_LINE_RE.test(line)
-    || STACK_FRAME_RE.test(line)
+  return matchesKeepWord(line)
+    || isStackFrame(line)
     || SYSTEM_FAILURE_RE.test(line)
     || HTTP_ERROR_RE.test(line);
 }
@@ -101,7 +125,13 @@ function isTestRunnerCommand(normalized) {
     || /^go\s+test\b/.test(normalized)
     || /^cargo\s+test\b/.test(normalized)
     || /^dotnet\s+test\b/.test(normalized)
-    || /^(mvn|\.\/?gradlew|gradle)\s+.*\btest\b/.test(normalized)
+    // mvn/gradle take a goal list (e.g. `mvn clean test`), so the goal can
+    // appear anywhere after the binary name. A single `.*\btest\b` regex
+    // for that is super-linear on adversarial input (backtracking blowup
+    // on long inputs with no "test" anywhere); checking the prefix and the
+    // "test" keyword as two separate, individually-linear regexes avoids
+    // that while matching the same commands.
+    || (/^(mvn|\.\/?gradlew|gradle)\s/.test(normalized) && /\btest\b/.test(normalized))
     || /^mix\s+test\b/.test(normalized);
 }
 

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -119,6 +119,31 @@ run('crushed output preserves localized (non-English) error/warning terms (audit
   assert.ok(result.crushed.includes('Erreur système'), 'French error line survives');
 });
 
+run('crushed output preserves localized failures that start with an accented letter (cubic review, audit EGC-490)', () => {
+  // \b in JS regex is ASCII-only, so a standalone word beginning with an
+  // accented letter (no preceding word-character to form a real boundary)
+  // could sit between two "non-word" positions and never match \b at all.
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok caso de teste ${i} passou normalmente`);
+  lines.push('Échec du build');
+  lines.push('Excepción no controlada');
+  lines.push('Exceção não tratada');
+  lines.push('Pânico: estado inválido');
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('Échec du build'), 'French failure line starting with an accented letter survives');
+  assert.ok(result.crushed.includes('Excepción no controlada'), 'Spanish exception line starting with an accented letter survives');
+  assert.ok(result.crushed.includes('Exceção não tratada'), 'Portuguese exception line starting with an accented letter survives');
+  assert.ok(result.crushed.includes('Pânico: estado inválido'), 'Portuguese panic line starting with an accented letter survives');
+});
+
+run('mvn/gradle test detection stays scoped to the first line, ignoring "test" on later lines of a compound command (cubic review, audit EGC-490)', () => {
+  assert.strictEqual(commandKind('mvn clean\necho "just a test message, unrelated to mvn goals"'), 'generic');
+  assert.strictEqual(commandKind('mvn clean test'), 'test-runner');
+  assert.strictEqual(commandKind('./gradlew clean test'), 'test-runner');
+});
+
 run('crushed output preserves system-failure signals with no "error" keyword (audit EGC-490)', () => {
   const lines = [];
   for (let i = 0; i < 300; i++) lines.push(`  ok step ${i} completed`);

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -60,6 +60,111 @@ run('classifies git commands with global flags before the subcommand', () => {
   assert.strictEqual(commandKind('git -C /path status'), 'generic');
 });
 
+run('classifies test runners across languages beyond the original JS-only set (audit EGC-490)', () => {
+  assert.strictEqual(commandKind('go test ./...'), 'test-runner');
+  assert.strictEqual(commandKind('cargo test'), 'test-runner');
+  assert.strictEqual(commandKind('dotnet test'), 'test-runner');
+  assert.strictEqual(commandKind('mvn test'), 'test-runner');
+  assert.strictEqual(commandKind('./gradlew test'), 'test-runner');
+  assert.strictEqual(commandKind('gradle test'), 'test-runner');
+  assert.strictEqual(commandKind('mix test'), 'test-runner');
+  assert.strictEqual(commandKind('phpunit'), 'test-runner');
+  assert.strictEqual(commandKind('pest'), 'test-runner');
+  assert.strictEqual(commandKind('rspec'), 'test-runner');
+  assert.strictEqual(commandKind('pnpm test'), 'test-runner');
+  assert.strictEqual(commandKind('yarn test'), 'test-runner');
+  assert.strictEqual(commandKind('bun test'), 'test-runner');
+});
+
+run('classifies package installs across languages beyond the original npm-only set (audit EGC-490)', () => {
+  assert.strictEqual(commandKind('pip install requests'), 'pm-install');
+  assert.strictEqual(commandKind('pip3 install requests'), 'pm-install');
+  assert.strictEqual(commandKind('poetry install'), 'pm-install');
+  assert.strictEqual(commandKind('pipenv install'), 'pm-install');
+  assert.strictEqual(commandKind('uv sync'), 'pm-install');
+  assert.strictEqual(commandKind('cargo build'), 'pm-install');
+  assert.strictEqual(commandKind('cargo install ripgrep'), 'pm-install');
+  assert.strictEqual(commandKind('go mod download'), 'pm-install');
+  assert.strictEqual(commandKind('go get ./...'), 'pm-install');
+  assert.strictEqual(commandKind('composer install'), 'pm-install');
+  assert.strictEqual(commandKind('bundle install'), 'pm-install');
+});
+
+run('crushed test/install output preserves stack-trace frames with no keep-word of their own (audit EGC-490)', () => {
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
+  lines.push('Traceback (most recent call last):');
+  lines.push('  File "app.py", line 42, in main');
+  lines.push('  File "app.py", line 10, in helper');
+  lines.push('ValueError: something broke');
+  lines.push('Tests: 1 failed, 300 passed, 301 total');
+  const result = crushOutput('pytest', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('File "app.py", line 42, in main'), 'traceback frame survives');
+  assert.ok(result.crushed.includes('File "app.py", line 10, in helper'), 'second traceback frame survives');
+  assert.ok(result.crushed.includes('ValueError: something broke'), 'exception line survives');
+});
+
+run('crushed output preserves localized (non-English) error/warning terms (audit EGC-490)', () => {
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok caso de teste ${i} passou normalmente`);
+  lines.push('Erro: arquivo não encontrado');
+  lines.push('Advertencia: uso obsoleto detectado');
+  lines.push('Erreur système: connexion refusée');
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('Erro: arquivo não encontrado'), 'Portuguese error line survives');
+  assert.ok(result.crushed.includes('Advertencia: uso obsoleto'), 'Spanish warning line survives');
+  assert.ok(result.crushed.includes('Erreur système'), 'French error line survives');
+});
+
+run('crushed output preserves system-failure signals with no "error" keyword (audit EGC-490)', () => {
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok step ${i} completed`);
+  lines.push('Segmentation fault (core dumped)');
+  lines.push('HTTP/1.1 404 Not Found');
+  lines.push('Request failed with 502 Bad Gateway');
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('Segmentation fault'), 'segfault line survives');
+  assert.ok(result.crushed.includes('404 Not Found'), 'HTTP 404 line survives');
+  assert.ok(result.crushed.includes('502 Bad Gateway'), 'HTTP 502 line survives');
+});
+
+run('HTTP-error keep pattern does not false-positive on ordinary 3-digit counts (audit EGC-490)', () => {
+  const lines = [];
+  for (let i = 0; i < 150; i++) lines.push(`  ok step ${i} completed`);
+  lines.push('processed 404 items successfully');
+  for (let i = 150; i < 300; i++) lines.push(`  ok step ${i} completed`);
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  // No real failure anywhere in this output, so nothing should force a
+  // keep beyond the summary tail -- the ordinary count line, buried well
+  // outside the tail, must not be mistaken for an HTTP error and kept.
+  if (result) {
+    assert.ok(
+      !result.crushed.includes('processed 404 items'),
+      'a bare count containing "404" must not be kept as an HTTP error line'
+    );
+  }
+});
+
+run('generic commands whose output looks like JSON are still crushed (audit EGC-490, "giant JSONs" gap)', () => {
+  const rows = Array.from({ length: 500 }, (_, i) => ({ id: i, name: `item-${i}`, active: i % 2 === 0 }));
+  const output = JSON.stringify(rows, null, 2);
+  const result = crushOutput('curl -s https://api.example.com/items', output);
+  assert.ok(result, 'a curl command emitting a large JSON array should be crushed even though curl matches no specific command kind');
+  assert.strictEqual(result.kind, 'json-output');
+});
+
+run('generic commands whose output is not valid JSON are left untouched (no false-positive json-output)', () => {
+  const output = `{ this is not valid json ${'x'.repeat(3000)}`;
+  const result = crushOutput('cat notes.txt', output);
+  assert.strictEqual(result, null, 'malformed content starting with { must not be misclassified as JSON');
+});
+
 run('small outputs pass through untouched', () => {
   assert.strictEqual(crushOutput('git log', 'short output'), null);
 });

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -11,7 +11,7 @@
 const assert = require('node:assert');
 const path = require('node:path');
 
-const { CRUSH_MARKER, commandKind, crushOutput, estimateTokens } = require(
+const { CRUSH_MARKER, commandKind, crushOutput, estimateTokens, looksLikeJsonPayload } = require(
   path.join(__dirname, '..', 'scripts', 'lib', 'crusher', 'engine.js')
 );
 const { aggregate } = require(
@@ -151,12 +151,38 @@ run('HTTP-error keep pattern does not false-positive on ordinary 3-digit counts 
   }
 });
 
-run('generic commands whose output looks like JSON are still crushed (audit EGC-490, "giant JSONs" gap)', () => {
+run('looksLikeJsonPayload detects JSON objects and arrays, rejects malformed lookalikes (audit EGC-490, "giant JSONs" gap)', () => {
+  // Tested as a pure function, not through crushOutput(): the actual
+  // compression for a detected JSON payload delegates to arrayCrusher from
+  // egc-guardian's build output, which the main CI workflow (unlike
+  // coverage.yml) never compiles -- asserting on crushOutput()'s result
+  // here would make this test's pass/fail depend on a build artifact from
+  // a different module entirely, not on the detection logic this PR adds.
+  const rows = Array.from({ length: 500 }, (_, i) => ({ id: i, name: `item-${i}` }));
+  assert.strictEqual(looksLikeJsonPayload(JSON.stringify(rows)), true, 'a JSON array must be detected');
+  assert.strictEqual(looksLikeJsonPayload(JSON.stringify({ ok: true, data: rows })), true, 'a JSON object must be detected');
+  assert.strictEqual(looksLikeJsonPayload(`{ this is not valid json ${'x'.repeat(3000)}`), false, 'malformed content starting with { must not be misclassified as JSON');
+  assert.strictEqual(looksLikeJsonPayload('plain text output, not json at all'), false, 'plain text must not be misclassified as JSON');
+});
+
+run('generic commands whose output looks like JSON route to json-output when the array-crusher build is present (audit EGC-490)', () => {
+  // Best-effort integration check: only asserts the strong "was crushed"
+  // claim when mcp/servers/egc-guardian/build/egc-array-crusher.js is
+  // actually present (built locally, or by workflows like coverage.yml
+  // that compile it first). Otherwise falls back to asserting the
+  // documented fail-open behavior (engine.js's own top-of-file comment:
+  // "JSON payloads stay uncompressed otherwise rather than duplicating
+  // that logic"), so this test is meaningful and non-flaky in both cases.
+  const guardianBuildPath = path.join(__dirname, '..', 'mcp', 'servers', 'egc-guardian', 'build', 'egc-array-crusher.js');
   const rows = Array.from({ length: 500 }, (_, i) => ({ id: i, name: `item-${i}`, active: i % 2 === 0 }));
   const output = JSON.stringify(rows, null, 2);
   const result = crushOutput('curl -s https://api.example.com/items', output);
-  assert.ok(result, 'a curl command emitting a large JSON array should be crushed even though curl matches no specific command kind');
-  assert.strictEqual(result.kind, 'json-output');
+  if (require('node:fs').existsSync(guardianBuildPath)) {
+    assert.ok(result, 'a curl command emitting a large JSON array should be crushed when the array-crusher build is present');
+    assert.strictEqual(result.kind, 'json-output');
+  } else {
+    assert.strictEqual(result, null, 'without the array-crusher build, detected JSON must fail open (pass through), not throw or fabricate a result');
+  }
 });
 
 run('generic commands whose output is not valid JSON are left untouched (no false-positive json-output)', () => {

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -144,6 +144,15 @@ run('mvn/gradle test detection stays scoped to the first line, ignoring "test" o
   assert.strictEqual(commandKind('./gradlew clean test'), 'test-runner');
 });
 
+run('mvn/gradle test detection joins shell line-continuations into one logical line (cubic review, audit EGC-490)', () => {
+  // A backslash right before the newline is a shell line continuation --
+  // `mvn clean \` + newline + `test` is one logical command, not two.
+  assert.strictEqual(commandKind('mvn clean \\\ntest'), 'test-runner');
+  assert.strictEqual(commandKind('./gradlew clean \\\ntest'), 'test-runner');
+  // Without a trailing backslash, it's genuinely a separate line/command.
+  assert.strictEqual(commandKind('mvn clean\ntest'), 'generic');
+});
+
 run('crushed output preserves system-failure signals with no "error" keyword (audit EGC-490)', () => {
   const lines = [];
   for (let i = 0; i < 300; i++) lines.push(`  ok step ${i} completed`);


### PR DESCRIPTION
## Summary
Squad audit (Multica EGC-490) compared the Crusher's README claims against the actual code and found 4 real gaps, closed here:

1. **CRITICAL — "preserving every error and warning" did not hold.** `KEEP_LINE_RE` only matched a handful of English keywords. Multi-line stack-trace frames (Python `File "...", line N`, JS `at ...`, Java `Caused by:`), localized error/warning terms (pt/es/fr/de/it), and system-level failures with no "error" keyword (`Segmentation fault`, HTTP 4xx/5xx) were silently dropped. Added `STACK_FRAME_RE`, `SYSTEM_FAILURE_RE`, and `HTTP_ERROR_RE` (the last requires a known reason phrase so it doesn't false-positive on ordinary counts like "processed 404 items"), unified behind `shouldKeepLine()`.
2. **HIGH — "test spam" only covered jest/vitest/pytest/mocha/npm test.** `go test`, `cargo test`, `dotnet test`, `mvn`/`gradle test`, `phpunit`, `pest`, `rspec`, `mix test`, and `pnpm`/`yarn`/`bun test` all fell through to `generic` (0% compression) despite EGC shipping coding-style rules for those languages.
3. **HIGH — "install noise" only covered npm/yarn/pnpm/bun.** `pip`, `poetry`, `pipenv`, `uv`, `cargo`, `go mod`, `composer`, `bundle install` all fell through too.
4. **HIGH — "giant JSONs" only covered `gh ... --json`.** Instead of chasing every JSON-emitting command by name, `crushOutput()` now falls back to treating any `generic`-classified output that parses as JSON (curl, `kubectl -o json`, `cat *.json`, etc.) as compressible, reusing the existing array-crusher path under a new `json-output` kind.

Other audit findings (fail-open on pipelines/redirection, the 2KB minimum-size gate, "up to 90%" being a ceiling not a session-wide average, "any language" depending on LLM prompt-following) are documented design trade-offs, not bugs, and were left as-is.

## Test plan
- [x] `node tests/crusher-engine.test.js` — 19/19 passed (8 new regression tests covering each gap, including a false-positive guard for the HTTP-error pattern)
- [x] `node tests/run-all.js` — full suite green (3007/3007)
- [x] `npx eslint` on changed files — 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes four audit gaps (EGC-490) so Crusher matches the README: keeps full error/warning context, expands `commandKind()` coverage, and crushes large JSON from any command. Also exports `looksLikeJsonPayload()` and fixes regex complexity/accuracy issues.

- **Bug Fixes**
  - Preserve non-English errors, stack frames, and system failures via `shouldKeepLine()`; use Unicode-aware word boundaries; HTTP errors require known reason phrases to avoid 3‑digit false positives.
  - Detect more test runners as `test-runner`: go/cargo/dotnet/mvn/gradle/phpunit/pest/rspec/mix and pnpm/yarn/bun.
  - Detect more installs as `pm-install`: pip/poetry/pipenv/uv/cargo/go mod/composer/bundle.
  - Crush “giant JSONs” from any command by routing JSON-looking `generic` output to `json-output`; export `looksLikeJsonPayload()` for direct testing.
  - For mvn/gradle, scope “test” detection to the first logical command line and join shell line continuations, avoiding false positives and misses.

- **Refactors**
  - Split high-complexity keep/stack-frame regexes into helpers and replaced a super‑linear mvn/gradle pattern; same coverage, no ReDoS risk, satisfies SonarCloud.

<sup>Written for commit 0cccd0001d745954e82fb978da70d8e088123604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

