### PR TITLE
fix(crusher): wire Token Crusher into Antigravity's global hooks.json

### DIFF
--- a/scripts/lib/antigravity-settings-hooks.js
+++ b/scripts/lib/antigravity-settings-hooks.js
@@ -62,6 +62,19 @@ function createProjectCrusherHookMergeOperation(targetRoot, projectRoot, matcher
   );
 }
 
+// Global counterpart of the above: registers at ~/.gemini/antigravity-cli/hooks.json
+// instead of the per-project file. Only Antigravity's global GateGuard/Guardian
+// wiring existed until now (egc-home target) -- this closed the gap where a
+// user who only installs the `egc` target (not `antigravity`) never got Crusher
+// compression on Antigravity's global-scope Bash calls.
+function createGlobalCrusherHookMergeOperation(targetRoot, homeDir, matcher) {
+  return createCrusherHookMergeOperationForDestination(
+    resolveAntigravityGlobalHooksFilePath(homeDir),
+    resolveCrusherHookScriptDestination(targetRoot),
+    matcher
+  );
+}
+
 // EGC Guardian: same hooks.json shape; GateGuard above only forces
 // investigation before a risky action, it never checks a Bash command
 // against the Guardian's actual allowlist/denylist. 2026-07-27 audit
@@ -89,6 +102,7 @@ module.exports = {
   createGlobalGateGuardHookMergeOperation,
   createProjectGateGuardHookMergeOperation,
   createProjectCrusherHookMergeOperation,
+  createGlobalCrusherHookMergeOperation,
   createProjectBashGuardianHookMergeOperation,
   createGlobalBashGuardianHookMergeOperation,
   resolveAntigravityGlobalHooksFilePath,

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -9,10 +9,12 @@ const {
 } = require('./helpers');
 const {
   createGlobalGateGuardHookMergeOperation,
+  createGlobalCrusherHookMergeOperation,
   createGlobalBashGuardianHookMergeOperation,
 } = require('../antigravity-settings-hooks');
 const {
   createGateGuardScriptCopyOperations,
+  createCrusherScriptCopyOperations,
   createBashGuardianScriptCopyOperations,
 } = require('../claude-settings-hooks');
 
@@ -40,6 +42,22 @@ function createAntigravityGlobalGateGuardOperations(targetRoot, homeDir, createR
     createGlobalGateGuardHookMergeOperation(targetRoot, homeDir, matcher)
   ));
   return [...scriptCopyOperations, ...mergeOperations];
+}
+
+// Token Crusher: same reasoning as GateGuard above -- copy the standalone
+// crusher hook + its deps explicitly (needed for minimal installs that skip
+// hooks-runtime), then register it on Bash only (the Crusher compresses
+// shell output, it does not touch file writes). Antigravity's PROJECT-level
+// registration (.agents/hooks.json, antigravity-project.js) already had this;
+// the GLOBAL registration (this file, ~/.gemini/antigravity-cli/hooks.json)
+// did not, so a user who only installs the `egc` target (not `antigravity`)
+// never got Crusher compression on Antigravity's global-scope Bash calls.
+function createAntigravityGlobalCrusherOperations(targetRoot, homeDir, createRemap) {
+  const scriptCopyOperations = createCrusherScriptCopyOperations(createRemap, targetRoot);
+  return [
+    ...scriptCopyOperations,
+    createGlobalCrusherHookMergeOperation(targetRoot, homeDir, 'Bash'),
+  ];
 }
 
 // EGC Guardian: same reasoning as GateGuard above -- copy
@@ -229,6 +247,7 @@ module.exports = createInstallTargetAdapter({
     return dedupeCopyOperations([
       ...moduleOperations,
       ...createAntigravityGlobalGateGuardOperations(targetRoot, homeDir, remap),
+      ...createAntigravityGlobalCrusherOperations(targetRoot, homeDir, remap),
       ...createAntigravityGlobalGuardianOperations(targetRoot, homeDir, remap),
     ]);
   },

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2012,6 +2012,46 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // Token Crusher: 2026-07-21 audit left Antigravity's PROJECT-level
+  // registration (.agents/hooks.json, antigravity-project.js) wired but its
+  // GLOBAL registration (this egc-home target, ~/.gemini/antigravity-cli/
+  // hooks.json) unverified/unwired -- same pattern as the GateGuard/Guardian
+  // global gaps above. Closed 2026-07-28.
+  if (test('egc-home adapter registers the Token Crusher on Bash for Antigravity global scope too', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'egc',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+    const hooksFilePath = path.join(homeDir, '.gemini', 'antigravity-cli', 'hooks.json');
+    const crusherScriptPath = path.join(
+      homeDir, '.gemini', 'scripts', 'hooks', 'crusher-hook.js'
+    );
+
+    const crusherOperations = plan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.hookEvent === 'PreToolUse'
+      && operation.destinationPath === hooksFilePath
+      && operation.hookScriptPath === crusherScriptPath
+    ));
+    assert.strictEqual(crusherOperations.length, 1, 'Crusher registered once for the Antigravity global hooks.json');
+    assert.strictEqual(crusherOperations[0].hookMatcher, 'Bash', 'Crusher only needs the Bash matcher');
+
+    for (const src of ['scripts/hooks/crusher-hook.js', 'scripts/hooks/pre-bash-crusher-rewrite.js', 'scripts/hooks/pretooluse-output.js', 'scripts/lib/crusher/engine.js']) {
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === src
+          && operation.destinationPath === path.join(homeDir, '.gemini', ...src.split('/'))
+        )),
+        `${src} must be copied unconditionally (modules: []), not only via the hooks-runtime module`
+      );
+    }
+  })) passed++; else failed++;
+
   // cubic-dev-ai review (PR #1052, 2026-07-27): making the copies above
   // unconditional meant a DEFAULT install (which does select hooks-runtime)
   // now recorded two copy-path operations per script -- one from
@@ -2049,6 +2089,10 @@ function runTests() {
       'scripts/hooks/pre-bash-guardian-validate.js',
       'scripts/lib/guardian-bin.js',
       'scripts/lib/shell-split.js',
+      'scripts/hooks/crusher-hook.js',
+      'scripts/hooks/pre-bash-crusher-rewrite.js',
+      'scripts/hooks/pretooluse-output.js',
+      'scripts/lib/crusher/engine.js',
     ]) {
       const destination = path.join(homeDir, '.gemini', ...src.split('/'));
       const fileLevelCopies = plan.operations.filter(operation => (


### PR DESCRIPTION
## Summary
- Antigravity's project-level Crusher registration (`.agents/hooks.json`) was already wired, but the global registration (`~/.gemini/antigravity-cli/hooks.json`, `egc-home` target) was not
- Adds `createGlobalCrusherHookMergeOperation`, mirroring the existing global GateGuard/Guardian pattern already in `gemini-home.js`
- Closes a pendency tracked since 2026-07-21 (Crusher universal audit left Copilot/Antigravity/Continue unverified for rewrite capability)

## Test plan
- [x] `npm test`: 3008/3008 passing
- [x] `node tests/lib/install-targets.test.js`: 131/131 passing (includes 1 new dedicated test + extended dedup coverage)
- [x] Manual smoke test confirms the global hooks.json merge and unconditional script scaffold

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Token Crusher into Antigravity’s global hooks (`~/.gemini/antigravity-cli/hooks.json`) so Bash output is compressed even when only the `egc` target is installed.

- **Bug Fixes**
  - Added `createGlobalCrusherHookMergeOperation` and registered it in `gemini-home.js` (Bash-only) to mirror GateGuard/Guardian.
  - Copied Crusher scripts unconditionally for minimal installs and extended tests to verify global registration and copy dedupe.

<sup>Written for commit 1672a7a52bda615b4aeb9c7595ca477cfe81bd5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

