### PR TITLE
chore: ignore .feedback/ local tool state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ tokens/
 .claude-cache/
 .gemini-cache/
 .ai-history/
+.feedback/
 
 # =========================================================
 # LOCAL ARCHIVES & DEPRECATED STATE


### PR DESCRIPTION
## Summary
- `.feedback/` (Pincushion's local feedback pins directory) was never committed, but also was not covered by `.gitignore`, leaving it exposed to an accidental `git add -A`
- Adds `.feedback/` to the host-runtime-artifacts section of `.gitignore`

## Test plan
- [x] `git status` confirms `.feedback/` no longer appears as untracked

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.feedback/` to `.gitignore` to prevent accidental commits of Pincushion’s local feedback pins. Keeps local markdown/JSON state out of the repo and published packages.

<sup>Written for commit e640ac5dc4362cd5264b67c2866d9eade5ee7ed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

