### PR TITLE
fix(claude-code): re-inject project context after compaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,8 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 - Tell the other session/tab something, hand work off → call `session_send`
 
 Judge by the full conversation context, never by literal words. A remark to someone nearby is not a command. When intent is ambiguous, keep working.
+
+<!-- egc:start -->
+## EGC Project Memory
+
+<!-- egc:end -->

--- a/rules/common/memory.md
+++ b/rules/common/memory.md
@@ -37,6 +37,7 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 
 - Session ending (goodbye, break, sleep, done, closing) → call `update_state`
 - Session starting or resuming → call `get_state`
+- Context was just compacted/summarized (short recap, missing earlier detail, references to work you don't remember doing) → call `get_state` again immediately, do not wait to be asked
 - Save/remember this decision → call `lesson_save` or `store_decision`
 - What failed? What did we decide? → call `search_history` or `query_history`
 - Review code or a PR → spawn `/review-pr` agents

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -16,6 +16,7 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 
 - Session ending (goodbye, break, sleep, done, closing) → call \`update_state\`
 - Session starting or resuming → call \`get_state\`
+- Context was just compacted/summarized (short recap, missing earlier detail, references to work you don't remember doing) → call \`get_state\` again immediately, do not wait to be asked
 - Save/remember this decision → call \`lesson_save\` or \`store_decision\`
 - What failed? What did we decide? → call \`search_history\` or \`query_history\`
 - Review code or a PR → spawn \`/review-pr\` agents

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -11,6 +11,13 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const {
+  PRE_RUN_COMMAND_EVENT: WINDSURF_PRE_RUN_COMMAND_EVENT,
+  PRE_WRITE_CODE_EVENT: WINDSURF_PRE_WRITE_CODE_EVENT,
+  applyWindsurfGateGuardHookToFile,
+} = require('./windsurf-gateguard-hooks');
+
+const MANAGED_WINDSURF_HOOK_EVENTS = new Set([WINDSURF_PRE_WRITE_CODE_EVENT, WINDSURF_PRE_RUN_COMMAND_EVENT]);
 
 const SESSION_START_EVENT = 'SessionStart';
 const STOP_EVENT = 'Stop';
@@ -909,10 +916,6 @@ function createPostCompactHookMergeOperation(targetRoot) {
   };
 }
 
-// Shared by every HOOK_OPERATION_KIND dispatcher that applies an operation
-// (install/apply.js's applyHookOperation, install-lifecycle.js's
-// repairManagedHookOperation): both need the identical PreCompact/PostCompact
-// branch, so the logic lives here once instead of being duplicated per caller.
 function applyCompactHookOperation(operation) {
   if (operation.hookEvent === PRE_COMPACT_EVENT) {
     applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath);
@@ -923,6 +926,26 @@ function applyCompactHookOperation(operation) {
     return true;
   }
   return false;
+}
+
+// Shared by install/apply.js and install-lifecycle.js's repair path: both
+// need the exact same HOOK_OPERATION_KIND dispatch (SessionStart is the
+// fallback for any event not explicitly handled above it), so it lives here
+// once instead of being duplicated per caller.
+function applyManagedHookOperation(operation) {
+  if (operation.hookEvent === STOP_EVENT) {
+    applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
+    applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
+    applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
+  } else if (applyCompactHookOperation(operation)) {
+    // handled above
+  } else if (MANAGED_WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
+    applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
+  } else {
+    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
+  }
 }
 
 module.exports = {
@@ -963,10 +986,10 @@ module.exports = {
   addStopHook,
   addWriteValidatorHook,
   applyBashDispatcherHookToFile,
-  applyCompactHookOperation,
   applyGateGuardHookToFile,
   applyHookEntryToFile,
   applyIntuitionHookToFile,
+  applyManagedHookOperation,
   applyPreCompactHookToFile,
   applyRouterHookToFile,
   applySessionStartHookToFile,

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -995,6 +995,7 @@ module.exports = {
   applySessionStartHookToFile,
   applyStopHookToFile,
   applyWriteValidatorHookToFile,
+  buildHookCommand,
   buildSessionStartCommand,
   buildStopCommand,
   createGateGuardHookMergeOperationForDestination,

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -35,6 +35,10 @@ const BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/pre-bash-g
 const BASH_GUARDIAN_HOOK_MODULE_ID = 'egc-bash-guardian-hook';
 const CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/crusher-hook.js';
 const CRUSHER_HOOK_MODULE_ID = 'egc-crusher-hook';
+const PRE_COMPACT_EVENT = 'PreCompact';
+const POST_COMPACT_EVENT = 'PostCompact';
+const EGC_MEMORY_SAVE_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/egc-memory-save.js';
+const EGC_MEMORY_SAVE_HOOK_MODULE_ID = 'egc-memory-save-hook';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -784,6 +788,127 @@ function createBashGuardianScriptCopyOperations(createRemappedOperation, targetR
   ];
 }
 
+// PreCompact -> egc-memory-save hook: closes EGC-495 (no mechanism re-injected
+// state after a context compaction). egc-memory-save.js writes a guaranteed
+// on-disk snapshot (writeSnapshotToDisk, no AI cooperation required) and
+// echoes a promptForAssistant asking the model to call update_state with the
+// session's decisions/preferences/next-steps -- this stdout is what a
+// PreCompact hook contributes to the surviving post-compaction context
+// (confirmed empirically: PreCompact hook stdout is not swept away by
+// summarization the way regular turn history is). Its dependency chain is
+// egc-memory-save.js -> lib/state-snapshot.js -> lib/branch-state.js.
+const EGC_MEMORY_SAVE_HOOK_LIB_SOURCES = [
+  'scripts/lib/state-snapshot.js',
+  'scripts/lib/branch-state.js',
+];
+
+function resolveEgcMemorySaveHookScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'egc-memory-save.js');
+}
+
+function hasPreCompactHook(settings, hookScriptPath) {
+  return hasHookEntry(settings, PRE_COMPACT_EVENT, hookScriptPath);
+}
+
+function addPreCompactHook(settings, hookScriptPath) {
+  return addHookEntry(settings, PRE_COMPACT_EVENT, hookScriptPath);
+}
+
+function removePreCompactHook(settings, hookScriptPath) {
+  return removeHookEntry(settings, PRE_COMPACT_EVENT, hookScriptPath);
+}
+
+function applyPreCompactHookToFile(settingsPath, hookScriptPath) {
+  return applyHookEntryToFile(settingsPath, PRE_COMPACT_EVENT, hookScriptPath);
+}
+
+function removePreCompactHookFromFile(settingsPath, hookScriptPath) {
+  return removeHookEntryFromFile(settingsPath, PRE_COMPACT_EVENT, hookScriptPath);
+}
+
+function inspectPreCompactHookFile(settingsPath, hookScriptPath) {
+  return inspectHookEntryFile(settingsPath, PRE_COMPACT_EVENT, hookScriptPath);
+}
+
+function createPreCompactHookMergeOperation(targetRoot) {
+  const hookScriptPath = resolveEgcMemorySaveHookScriptDestination(targetRoot);
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: EGC_MEMORY_SAVE_HOOK_MODULE_ID,
+    sourceRelativePath: EGC_MEMORY_SAVE_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: resolveSettingsPath(targetRoot),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_COMPACT_EVENT,
+    hookScriptPath,
+    hookCommand: buildHookCommand(hookScriptPath),
+  };
+}
+
+// Destination-driven variant, for hosts whose hooks.json path is not
+// derivable from targetRoot (Copilot ~/.copilot/hooks, Antigravity's
+// project/global split). Same Claude hooks.json schema. Only wire this for a
+// host confirmed to actually fire PreCompact -- unlike PreToolUse, this event
+// is not documented publicly for every host, so callers must verify first
+// (see EGC-497) rather than wiring it blindly the way Crusher's Fase B did.
+function createPreCompactHookMergeOperationForDestination(destinationPath, hookScriptPath) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: EGC_MEMORY_SAVE_HOOK_MODULE_ID,
+    sourceRelativePath: EGC_MEMORY_SAVE_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_COMPACT_EVENT,
+    hookScriptPath,
+    hookCommand: buildHookCommand(hookScriptPath),
+  };
+}
+
+function createEgcMemorySaveScriptCopyOperations(createRemappedOperation, targetRoot) {
+  return [
+    createRemappedOperation(
+      EGC_MEMORY_SAVE_HOOK_MODULE_ID,
+      EGC_MEMORY_SAVE_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveEgcMemorySaveHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ),
+    ...EGC_MEMORY_SAVE_HOOK_LIB_SOURCES.map(src => createRemappedOperation(
+      EGC_MEMORY_SAVE_HOOK_MODULE_ID,
+      src,
+      path.join(targetRoot, ...src.split('/')),
+      { strategy: 'preserve-relative-path' }
+    )),
+  ];
+}
+
+// PostCompact -> reuses claude-session-start.js (already scaffolded for
+// SessionStart, no extra copy operation needed). readStdinJson() there
+// already falls back to {} on missing/invalid stdin and resolveProjectPath()
+// falls back to CLAUDE_PROJECT_DIR/PWD/cwd() when input.cwd is absent, so the
+// exact same tested, proven state-load-and-print logic that opens every
+// session also re-injects state right after a compaction finishes -- closes
+// EGC-495 without inventing new untested logic. Confirmed real by the
+// Multica squad (EGC-497) via Claude Code binary inspection: PostCompact is
+// an actual hook event (executePostCompactHooks, markPostCompaction).
+function createPostCompactHookMergeOperation(targetRoot) {
+  const hookScriptPath = resolveHookScriptDestination(targetRoot);
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: HOOK_MODULE_ID,
+    sourceRelativePath: HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: resolveSettingsPath(targetRoot),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: POST_COMPACT_EVENT,
+    hookScriptPath,
+    hookCommand: buildHookCommand(hookScriptPath),
+  };
+}
+
 module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -794,6 +919,10 @@ module.exports = {
   GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
   CRUSHER_HOOK_MODULE_ID,
   CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_COMPACT_EVENT,
+  POST_COMPACT_EVENT,
+  EGC_MEMORY_SAVE_HOOK_MODULE_ID,
+  EGC_MEMORY_SAVE_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
   HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -812,6 +941,7 @@ module.exports = {
   addBashDispatcherHook,
   addGateGuardHook,
   addIntuitionHook,
+  addPreCompactHook,
   addRouterHook,
   addSessionStartHook,
   addStopHook,
@@ -820,6 +950,7 @@ module.exports = {
   applyGateGuardHookToFile,
   applyHookEntryToFile,
   applyIntuitionHookToFile,
+  applyPreCompactHookToFile,
   applyRouterHookToFile,
   applySessionStartHookToFile,
   applyStopHookToFile,
@@ -843,9 +974,15 @@ module.exports = {
   createStopHookMergeOperation,
   createUserPromptSubmitHookMergeOperation,
   createUserPromptSubmitRouterHookMergeOperation,
+  createEgcMemorySaveScriptCopyOperations,
+  createPreCompactHookMergeOperation,
+  createPreCompactHookMergeOperationForDestination,
+  createPostCompactHookMergeOperation,
+  resolveEgcMemorySaveHookScriptDestination,
   hasBashDispatcherHook,
   hasGateGuardHook,
   hasIntuitionHook,
+  hasPreCompactHook,
   hasRouterHook,
   hasSessionStartHook,
   hasStopHook,
@@ -854,6 +991,7 @@ module.exports = {
   inspectGateGuardHookFile,
   inspectHookEntryFile,
   inspectIntuitionHookFile,
+  inspectPreCompactHookFile,
   inspectRouterHookFile,
   inspectSessionStartHookFile,
   inspectStopHookFile,
@@ -866,6 +1004,8 @@ module.exports = {
   removeHookEntryFromFile,
   removeIntuitionHook,
   removeIntuitionHookFromFile,
+  removePreCompactHook,
+  removePreCompactHookFromFile,
   removeRouterHook,
   removeRouterHookFromFile,
   removeSessionStartHook,

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -909,6 +909,22 @@ function createPostCompactHookMergeOperation(targetRoot) {
   };
 }
 
+// Shared by every HOOK_OPERATION_KIND dispatcher that applies an operation
+// (install/apply.js's applyHookOperation, install-lifecycle.js's
+// repairManagedHookOperation): both need the identical PreCompact/PostCompact
+// branch, so the logic lives here once instead of being duplicated per caller.
+function applyCompactHookOperation(operation) {
+  if (operation.hookEvent === PRE_COMPACT_EVENT) {
+    applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath);
+    return true;
+  }
+  if (operation.hookEvent === POST_COMPACT_EVENT) {
+    applyHookEntryToFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -947,6 +963,7 @@ module.exports = {
   addStopHook,
   addWriteValidatorHook,
   applyBashDispatcherHookToFile,
+  applyCompactHookOperation,
   applyGateGuardHookToFile,
   applyHookEntryToFile,
   applyIntuitionHookToFile,

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -19,11 +19,7 @@ const {
   POST_COMPACT_EVENT,
   STOP_EVENT,
   USER_PROMPT_SUBMIT_EVENT,
-  applyCompactHookOperation,
-  applyHookEntryToFile,
-  applyIntuitionHookToFile,
-  applySessionStartHookToFile,
-  applyStopHookToFile,
+  applyManagedHookOperation,
   inspectHookEntryFile,
   inspectIntuitionHookFile,
   inspectPreCompactHookFile,
@@ -38,7 +34,6 @@ const {
 const {
   PRE_RUN_COMMAND_EVENT: WINDSURF_PRE_RUN_COMMAND_EVENT,
   PRE_WRITE_CODE_EVENT: WINDSURF_PRE_WRITE_CODE_EVENT,
-  applyWindsurfGateGuardHookToFile,
   inspectWindsurfGateGuardHookFile,
   removeWindsurfGateGuardHookFromFile,
 } = require('./windsurf-gateguard-hooks');
@@ -347,22 +342,6 @@ function shouldRepairFromRecordedOperations(state) {
   return getManagedOperations(state).some(operation => operation.kind !== 'copy-file');
 }
 
-function repairManagedHookOperation(operation) {
-  if (operation.hookEvent === STOP_EVENT) {
-    applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
-    applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
-    applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
-  } else if (applyCompactHookOperation(operation)) {
-    // EGC-495: PreCompact/PostCompact handled by the shared helper.
-  } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
-    applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-  } else {
-    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
-  }
-}
-
 function repairCopyFile(repoRoot, operation) {
   const sourcePath = resolveOperationSourcePath(repoRoot, operation);
   if (!sourcePath || !fs.existsSync(sourcePath)) {
@@ -437,7 +416,7 @@ function executeRepairOperation(repoRoot, operation) {
   } else if (operation.kind === 'remove') {
     repairRemove(operation);
   } else if (operation.kind === HOOK_OPERATION_KIND) {
-    repairManagedHookOperation(operation);
+    applyManagedHookOperation(operation);
   } else if (operation.kind === MERGE_YAML_READ_LIST_KIND) {
     repairMergeYamlReadList(operation);
   } else if (operation.kind === MERGE_MARKDOWN_INDEX_KIND) {

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -15,18 +15,23 @@ const {
 const {
   HOOK_OPERATION_KIND,
   PRE_TOOL_USE_EVENT,
+  PRE_COMPACT_EVENT,
+  POST_COMPACT_EVENT,
   STOP_EVENT,
   USER_PROMPT_SUBMIT_EVENT,
   applyHookEntryToFile,
   applyIntuitionHookToFile,
+  applyPreCompactHookToFile,
   applySessionStartHookToFile,
   applyStopHookToFile,
   inspectHookEntryFile,
   inspectIntuitionHookFile,
+  inspectPreCompactHookFile,
   inspectSessionStartHookFile,
   inspectStopHookFile,
   removeHookEntryFromFile,
   removeIntuitionHookFromFile,
+  removePreCompactHookFromFile,
   removeSessionStartHookFromFile,
   removeStopHookFromFile,
 } = require('./claude-settings-hooks');
@@ -349,6 +354,10 @@ function repairManagedHookOperation(operation) {
     applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
     applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
+  } else if (operation.hookEvent === PRE_COMPACT_EVENT) {
+    applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === POST_COMPACT_EVENT) {
+    applyHookEntryToFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
   } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
@@ -551,6 +560,10 @@ function uninstallManagedHookOperation(operation) {
     removeIntuitionHookFromFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
     removeHookEntryFromFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath);
+  } else if (operation.hookEvent === PRE_COMPACT_EVENT) {
+    removePreCompactHookFromFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === POST_COMPACT_EVENT) {
+    removeHookEntryFromFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
   } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     removeWindsurfGateGuardHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
@@ -682,6 +695,12 @@ function inspectManagedOperation(repoRoot, operation) {
     }
     if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
       return inspectResult(inspectHookEntryFile(destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, operation.hookMatcher), operation, destinationPath);
+    }
+    if (operation.hookEvent === PRE_COMPACT_EVENT) {
+      return inspectResult(inspectPreCompactHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
+    }
+    if (operation.hookEvent === POST_COMPACT_EVENT) {
+      return inspectResult(inspectHookEntryFile(destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath), operation, destinationPath);
     }
     if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
       return inspectResult(inspectWindsurfGateGuardHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -19,9 +19,9 @@ const {
   POST_COMPACT_EVENT,
   STOP_EVENT,
   USER_PROMPT_SUBMIT_EVENT,
+  applyCompactHookOperation,
   applyHookEntryToFile,
   applyIntuitionHookToFile,
-  applyPreCompactHookToFile,
   applySessionStartHookToFile,
   applyStopHookToFile,
   inspectHookEntryFile,
@@ -354,10 +354,8 @@ function repairManagedHookOperation(operation) {
     applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
     applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
-  } else if (operation.hookEvent === PRE_COMPACT_EVENT) {
-    applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === POST_COMPACT_EVENT) {
-    applyHookEntryToFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
+  } else if (applyCompactHookOperation(operation)) {
+    // EGC-495: PreCompact/PostCompact handled by the shared helper.
   } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -34,6 +34,7 @@ const {
   createPreToolUseGateGuardHookMergeOperation,
   createPreCompactHookMergeOperation,
   createPostCompactHookMergeOperation,
+  createEgcMemorySaveScriptCopyOperations,
   resolveHookScriptDestination,
   resolveStopHookScriptDestination,
 } = require('../claude-settings-hooks');
@@ -78,11 +79,18 @@ function createSessionStateHookOperations(adapter, targetRoot) {
     createStopHookMergeOperation(targetRoot),
     // PreCompact -> egc-memory-save.js (guaranteed snapshot save + prompts
     // update_state), PostCompact -> reuses claude-session-start.js (same
-    // proven state-load-and-print logic SessionStart already uses). Closes
-    // EGC-495 (no mechanism previously re-injected state after a context
-    // compaction). Scripts are covered by the default hooks-runtime module's
-    // scripts/hooks + scripts/lib directory scaffold, same as the Crusher/
-    // GateGuard/BashDispatcher hooks above -- no extra copy operation needed.
+    // proven state-load-and-print logic SessionStart already uses, already
+    // copied above via HOOK_SCRIPT_SOURCE_RELATIVE_PATH/libOperations).
+    // Closes EGC-495 (no mechanism previously re-injected state after a
+    // context compaction). Like SessionStart/Stop above, egc-memory-save.js
+    // and its lib dependencies are copied unconditionally here rather than
+    // left to an optional module, so a minimal install never registers a
+    // PreCompact hook pointing at a script that was never copied to disk.
+    ...createEgcMemorySaveScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) =>
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options),
+      targetRoot
+    ),
     createPreCompactHookMergeOperation(targetRoot),
     createPostCompactHookMergeOperation(targetRoot),
     createUserPromptSubmitHookMergeOperation(targetRoot),

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -32,6 +32,8 @@ const {
   createPreToolUseBashDispatcherHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
   createPreToolUseGateGuardHookMergeOperation,
+  createPreCompactHookMergeOperation,
+  createPostCompactHookMergeOperation,
   resolveHookScriptDestination,
   resolveStopHookScriptDestination,
 } = require('../claude-settings-hooks');
@@ -74,6 +76,15 @@ function createSessionStateHookOperations(adapter, targetRoot) {
       { strategy: 'preserve-relative-path' }
     ),
     createStopHookMergeOperation(targetRoot),
+    // PreCompact -> egc-memory-save.js (guaranteed snapshot save + prompts
+    // update_state), PostCompact -> reuses claude-session-start.js (same
+    // proven state-load-and-print logic SessionStart already uses). Closes
+    // EGC-495 (no mechanism previously re-injected state after a context
+    // compaction). Scripts are covered by the default hooks-runtime module's
+    // scripts/hooks + scripts/lib directory scaffold, same as the Crusher/
+    // GateGuard/BashDispatcher hooks above -- no extra copy operation needed.
+    createPreCompactHookMergeOperation(targetRoot),
+    createPostCompactHookMergeOperation(targetRoot),
     createUserPromptSubmitHookMergeOperation(targetRoot),
     createUserPromptSubmitRouterHookMergeOperation(targetRoot),
     createPreToolUseBashDispatcherHookMergeOperation(targetRoot),

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -10,10 +10,13 @@ const { filterMcpConfig, parseDisabledMcpServers } = require('../mcp-config');
 const {
   HOOK_OPERATION_KIND,
   PRE_TOOL_USE_EVENT,
+  PRE_COMPACT_EVENT,
+  POST_COMPACT_EVENT,
   STOP_EVENT,
   USER_PROMPT_SUBMIT_EVENT,
   applyHookEntryToFile,
   applyIntuitionHookToFile,
+  applyPreCompactHookToFile,
   applySessionStartHookToFile,
   applyStopHookToFile,
 } = require('../claude-settings-hooks');
@@ -149,6 +152,18 @@ function applyHookOperation(operation) {
     applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
     applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
+  } else if (operation.hookEvent === PRE_COMPACT_EVENT) {
+    // EGC-495: PreCompact -> egc-memory-save.js, a script distinct from
+    // SessionStart's, so it must NOT fall through to the SessionStart
+    // default below (that bug shipped PreCompact entries into
+    // hooks.SessionStart instead of hooks.PreCompact until this fix).
+    applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === POST_COMPACT_EVENT) {
+    // EGC-495: PostCompact intentionally reuses claude-session-start.js
+    // (same script/module as SessionStart), so applying it via the generic
+    // event-aware helper under its own event name is correct and distinct
+    // from the SessionStart default below.
+    applyHookEntryToFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
   } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -9,20 +9,8 @@ const { syncInstallStateToStore } = require('../install-state-store-sync');
 const { filterMcpConfig, parseDisabledMcpServers } = require('../mcp-config');
 const {
   HOOK_OPERATION_KIND,
-  PRE_TOOL_USE_EVENT,
-  STOP_EVENT,
-  USER_PROMPT_SUBMIT_EVENT,
-  applyCompactHookOperation,
-  applyHookEntryToFile,
-  applyIntuitionHookToFile,
-  applySessionStartHookToFile,
-  applyStopHookToFile,
+  applyManagedHookOperation,
 } = require('../claude-settings-hooks');
-const {
-  PRE_RUN_COMMAND_EVENT,
-  PRE_WRITE_CODE_EVENT,
-  applyWindsurfGateGuardHookToFile,
-} = require('../windsurf-gateguard-hooks');
 const {
   MERGE_YAML_READ_LIST_KIND,
   mergeAiderConfigReadList,
@@ -31,8 +19,6 @@ const {
   MERGE_MARKDOWN_INDEX_KIND,
   mergeSkillIndexEntry,
 } = require('../warp-agents-merge');
-
-const WINDSURF_HOOK_EVENTS = new Set([PRE_WRITE_CODE_EVENT, PRE_RUN_COMMAND_EVENT]);
 
 function readJsonObject(filePath, label) {
   let parsed;
@@ -141,24 +127,6 @@ function buildResolvedClaudeHooks(plan) {
       hooks: resolvedHooks,
     },
   };
-}
-
-function applyHookOperation(operation) {
-  if (operation.hookEvent === STOP_EVENT) {
-    applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
-    applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
-    applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
-  } else if (applyCompactHookOperation(operation)) {
-    // EGC-495: PreCompact/PostCompact handled by the shared helper (both
-    // must NOT fall through to the SessionStart default below -- that bug
-    // shipped PreCompact entries into hooks.SessionStart until this fix).
-  } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
-    applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-  } else {
-    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
-  }
 }
 
 function applyMergeJsonOperation(operation, disabledServers) {
@@ -271,7 +239,7 @@ function applyInstallPlan(plan) {
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
 
     if (operation.kind === HOOK_OPERATION_KIND) {
-      applyHookOperation(operation);
+      applyManagedHookOperation(operation);
     } else if (operation.kind === 'merge-json') {
       applyMergeJsonOperation(operation, disabledServers);
     } else if (operation.kind === MERGE_YAML_READ_LIST_KIND) {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -10,13 +10,11 @@ const { filterMcpConfig, parseDisabledMcpServers } = require('../mcp-config');
 const {
   HOOK_OPERATION_KIND,
   PRE_TOOL_USE_EVENT,
-  PRE_COMPACT_EVENT,
-  POST_COMPACT_EVENT,
   STOP_EVENT,
   USER_PROMPT_SUBMIT_EVENT,
+  applyCompactHookOperation,
   applyHookEntryToFile,
   applyIntuitionHookToFile,
-  applyPreCompactHookToFile,
   applySessionStartHookToFile,
   applyStopHookToFile,
 } = require('../claude-settings-hooks');
@@ -152,18 +150,10 @@ function applyHookOperation(operation) {
     applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
     applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
-  } else if (operation.hookEvent === PRE_COMPACT_EVENT) {
-    // EGC-495: PreCompact -> egc-memory-save.js, a script distinct from
-    // SessionStart's, so it must NOT fall through to the SessionStart
-    // default below (that bug shipped PreCompact entries into
-    // hooks.SessionStart instead of hooks.PreCompact until this fix).
-    applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === POST_COMPACT_EVENT) {
-    // EGC-495: PostCompact intentionally reuses claude-session-start.js
-    // (same script/module as SessionStart), so applying it via the generic
-    // event-aware helper under its own event name is correct and distinct
-    // from the SessionStart default below.
-    applyHookEntryToFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
+  } else if (applyCompactHookOperation(operation)) {
+    // EGC-495: PreCompact/PostCompact handled by the shared helper (both
+    // must NOT fall through to the SessionStart default below -- that bug
+    // shipped PreCompact entries into hooks.SessionStart until this fix).
   } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -32,6 +32,9 @@ const PROPAGATION_FILES = [
   '.cursorrules',
   'CONVENTIONS.md',
   'llms.txt',
+  'CLAUDE.md',
+  '.roo/rules/egc-context.md',
+  '.continue/rules/egc-context.md',
 ];
 
 function gitDir(projectDir) {

--- a/tests/lib/claude-settings-hooks.test.js
+++ b/tests/lib/claude-settings-hooks.test.js
@@ -18,6 +18,10 @@ const {
   INTUITION_HOOK_MODULE_ID,
   INTUITION_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   PRE_TOOL_USE_EVENT,
+  PRE_COMPACT_EVENT,
+  POST_COMPACT_EVENT,
+  EGC_MEMORY_SAVE_HOOK_MODULE_ID,
+  EGC_MEMORY_SAVE_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   SESSION_START_EVENT,
   STOP_EVENT,
   STOP_HOOK_MODULE_ID,
@@ -28,12 +32,15 @@ const {
   addBashDispatcherHook,
   addGateGuardHook,
   addIntuitionHook,
+  addPreCompactHook,
   addSessionStartHook,
   addStopHook,
   addWriteValidatorHook,
   applyBashDispatcherHookToFile,
   applyGateGuardHookToFile,
+  applyHookEntryToFile,
   applyIntuitionHookToFile,
+  applyPreCompactHookToFile,
   applyRouterHookToFile,
   applySessionStartHookToFile,
   applyStopHookToFile,
@@ -46,9 +53,14 @@ const {
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,
   createUserPromptSubmitHookMergeOperation,
+  createPreCompactHookMergeOperation,
+  createPreCompactHookMergeOperationForDestination,
+  createPostCompactHookMergeOperation,
+  resolveEgcMemorySaveHookScriptDestination,
   hasBashDispatcherHook,
   hasGateGuardHook,
   hasIntuitionHook,
+  hasPreCompactHook,
   hasRouterHook,
   hasSessionStartHook,
   hasStopHook,
@@ -56,12 +68,15 @@ const {
   inspectBashDispatcherHookFile,
   inspectGateGuardHookFile,
   inspectIntuitionHookFile,
+  inspectPreCompactHookFile,
   inspectSessionStartHookFile,
   inspectStopHookFile,
   inspectWriteValidatorHookFile,
   removeBashDispatcherHook,
   removeGateGuardHook,
   removeIntuitionHook,
+  removePreCompactHook,
+  removePreCompactHookFromFile,
   removeSessionStartHook,
   removeSessionStartHookFromFile,
   removeStopHook,
@@ -82,6 +97,7 @@ const INTUITION_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/prompt-intu
 const BASH_DISPATCHER_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/bash-hook-dispatcher.js';
 const WRITE_VALIDATOR_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/pre-write-guardian-validate.js';
 const GATEGUARD_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/gateguard-fact-force.js';
+const EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH = '/home/user/.claude/scripts/hooks/egc-memory-save.js';
 
 function test(name, fn) {
   try {
@@ -510,6 +526,164 @@ function runTests() {
       operation.hookCommand,
       buildStopCommand(resolveStopHookScriptDestination(targetRoot))
     );
+  })) passed++; else failed++;
+
+  console.log('\n--- PreCompact hook (egc-memory-save.js, closes EGC-495) ---\n');
+
+  if (test('addPreCompactHook adds the PreCompact hook to empty settings', () => {
+    const { settings, changed } = addPreCompactHook({}, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings.hooks[PRE_COMPACT_EVENT], [
+      { hooks: [{ type: 'command', command: buildStopCommand(EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH) }] },
+    ]);
+    assert.ok(hasPreCompactHook(settings, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('addPreCompactHook is idempotent and reports no change when the hook exists', () => {
+    const first = addPreCompactHook({}, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+    const second = addPreCompactHook(first.settings, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.settings.hooks[PRE_COMPACT_EVENT].length, 1);
+  })) passed++; else failed++;
+
+  if (test('addPreCompactHook preserves third-party PreCompact hooks and unrelated settings keys', () => {
+    const base = {
+      model: 'opus',
+      hooks: {
+        PreCompact: [
+          { hooks: [{ type: 'command', command: 'echo third-party-precompact' }] },
+        ],
+      },
+    };
+    const { settings } = addPreCompactHook(base, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(settings.model, 'opus');
+    assert.strictEqual(settings.hooks[PRE_COMPACT_EVENT].length, 2);
+    assert.strictEqual(
+      settings.hooks[PRE_COMPACT_EVENT][0].hooks[0].command,
+      'echo third-party-precompact'
+    );
+    assert.ok(hasPreCompactHook(settings, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('removePreCompactHook strips only the EGC PreCompact entry', () => {
+    const installed = addPreCompactHook({ model: 'opus' }, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH).settings;
+    const { settings, changed } = removePreCompactHook(installed, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings, { model: 'opus' });
+    assert.ok(!hasPreCompactHook(settings, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH));
+  })) passed++; else failed++;
+
+  if (test('applyPreCompactHookToFile creates settings.json with PreCompact hook when absent', () => {
+    const homeDir = createTempDir('claude-precompact-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, '.claude', 'settings.json');
+      const result = applyPreCompactHookToFile(settingsPath, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, true);
+      assert.ok(hasPreCompactHook(readJson(settingsPath), EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('removePreCompactHookFromFile is a no-op when settings.json is absent', () => {
+    const homeDir = createTempDir('claude-precompact-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      const result = removePreCompactHookFromFile(settingsPath, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+
+      assert.strictEqual(result.changed, false);
+      assert.ok(!fs.existsSync(settingsPath));
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectPreCompactHookFile reports ok, drifted, and invalid JSON as drifted', () => {
+    const homeDir = createTempDir('claude-precompact-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+
+      fs.writeFileSync(settingsPath, JSON.stringify({ model: 'opus' }));
+      assert.strictEqual(inspectPreCompactHookFile(settingsPath, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH), 'drifted');
+
+      applyPreCompactHookToFile(settingsPath, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+      assert.strictEqual(inspectPreCompactHookFile(settingsPath, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH), 'ok');
+
+      fs.writeFileSync(settingsPath, '{ not json');
+      assert.strictEqual(inspectPreCompactHookFile(settingsPath, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH), 'drifted');
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('createPreCompactHookMergeOperation builds a managed operation for the target root', () => {
+    const targetRoot = path.join('/home/user', '.claude');
+    const operation = createPreCompactHookMergeOperation(targetRoot);
+
+    assert.strictEqual(operation.kind, HOOK_OPERATION_KIND);
+    assert.strictEqual(operation.moduleId, EGC_MEMORY_SAVE_HOOK_MODULE_ID);
+    assert.strictEqual(operation.sourceRelativePath, EGC_MEMORY_SAVE_HOOK_SCRIPT_SOURCE_RELATIVE_PATH);
+    assert.strictEqual(operation.destinationPath, resolveSettingsPath(targetRoot));
+    assert.strictEqual(operation.ownership, 'managed');
+    assert.strictEqual(operation.scaffoldOnly, false);
+    assert.strictEqual(operation.hookEvent, PRE_COMPACT_EVENT);
+    assert.strictEqual(operation.hookScriptPath, resolveEgcMemorySaveHookScriptDestination(targetRoot));
+  })) passed++; else failed++;
+
+  if (test('createPreCompactHookMergeOperationForDestination targets an arbitrary hooks.json path', () => {
+    const destination = '/home/user/.copilot/hooks/hooks.json';
+    const hookScriptPath = '/home/user/.copilot/scripts/hooks/egc-memory-save.js';
+    const operation = createPreCompactHookMergeOperationForDestination(destination, hookScriptPath);
+
+    assert.strictEqual(operation.destinationPath, destination);
+    assert.strictEqual(operation.hookEvent, PRE_COMPACT_EVENT);
+    assert.strictEqual(operation.hookScriptPath, hookScriptPath);
+    assert.strictEqual(operation.moduleId, EGC_MEMORY_SAVE_HOOK_MODULE_ID);
+  })) passed++; else failed++;
+
+  console.log('\n--- PostCompact hook (reuses claude-session-start.js, closes EGC-495) ---\n');
+
+  if (test('createPostCompactHookMergeOperation reuses the SessionStart script and module id', () => {
+    const targetRoot = path.join('/home/user', '.claude');
+    const operation = createPostCompactHookMergeOperation(targetRoot);
+
+    assert.strictEqual(operation.kind, HOOK_OPERATION_KIND);
+    assert.strictEqual(operation.moduleId, HOOK_MODULE_ID);
+    assert.strictEqual(operation.sourceRelativePath, HOOK_SCRIPT_SOURCE_RELATIVE_PATH);
+    assert.strictEqual(operation.destinationPath, resolveSettingsPath(targetRoot));
+    assert.strictEqual(operation.hookEvent, POST_COMPACT_EVENT);
+    assert.strictEqual(operation.hookScriptPath, resolveHookScriptDestination(targetRoot));
+    assert.strictEqual(
+      operation.hookCommand,
+      buildSessionStartCommand(resolveHookScriptDestination(targetRoot))
+    );
+  })) passed++; else failed++;
+
+  if (test('PreCompact and PostCompact operations coexist without clobbering the SessionStart entry', () => {
+    const homeDir = createTempDir('claude-compact-hooks-');
+    try {
+      const settingsPath = path.join(homeDir, 'settings.json');
+      applySessionStartHookToFile(settingsPath, HOOK_SCRIPT_PATH);
+      applyPreCompactHookToFile(settingsPath, EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH);
+      const result = applyHookEntryToFile(settingsPath, POST_COMPACT_EVENT, HOOK_SCRIPT_PATH);
+      assert.strictEqual(result.changed, true);
+
+      const final = readJson(settingsPath);
+      assert.strictEqual(final.hooks[SESSION_START_EVENT].length, 1);
+      assert.strictEqual(final.hooks[PRE_COMPACT_EVENT].length, 1);
+      assert.strictEqual(final.hooks[POST_COMPACT_EVENT].length, 1);
+      assert.strictEqual(
+        final.hooks[PRE_COMPACT_EVENT][0].hooks[0].command,
+        buildStopCommand(EGC_MEMORY_SAVE_HOOK_SCRIPT_PATH)
+      );
+    } finally {
+      cleanup(homeDir);
+    }
   })) passed++; else failed++;
 
   console.log('\n--- UserPromptSubmit (intuition) hook ---\n');

--- a/tests/lib/claude-settings-hooks.test.js
+++ b/tests/lib/claude-settings-hooks.test.js
@@ -45,6 +45,7 @@ const {
   applySessionStartHookToFile,
   applyStopHookToFile,
   applyWriteValidatorHookToFile,
+  buildHookCommand,
   buildSessionStartCommand,
   buildStopCommand,
   createPreToolUseBashDispatcherHookMergeOperation,
@@ -633,6 +634,10 @@ function runTests() {
     assert.strictEqual(operation.scaffoldOnly, false);
     assert.strictEqual(operation.hookEvent, PRE_COMPACT_EVENT);
     assert.strictEqual(operation.hookScriptPath, resolveEgcMemorySaveHookScriptDestination(targetRoot));
+    assert.strictEqual(
+      operation.hookCommand,
+      buildHookCommand(resolveEgcMemorySaveHookScriptDestination(targetRoot))
+    );
   })) passed++; else failed++;
 
   if (test('createPreCompactHookMergeOperationForDestination targets an arbitrary hooks.json path', () => {

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -717,6 +717,45 @@ function runTests() {
     assert.ok(mergeOperation.hookCommand.includes(hookScriptPath));
   })) passed++; else failed++;
 
+  if (test('claude adapter copies egc-memory-save.js and its lib deps even with no modules selected (EGC-495)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'claude',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+    const scriptDestination = path.join(
+      homeDir, '.claude', 'scripts', 'hooks', 'egc-memory-save.js'
+    );
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/egc-memory-save.js'
+        && operation.destinationPath === scriptDestination
+      )),
+      'Should plan the egc-memory-save.js copy even with no modules selected, so PreCompact never points at a missing script'
+    );
+
+    for (const libSource of ['scripts/lib/state-snapshot.js', 'scripts/lib/branch-state.js']) {
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === libSource
+          && operation.destinationPath === path.join(homeDir, '.claude', ...libSource.split('/'))
+        )),
+        `Should plan the ${libSource} copy even with no modules selected`
+      );
+    }
+
+    const preCompactMergeOperation = plan.operations.find(
+      operation => operation.kind === 'merge-claude-settings-hooks' && operation.hookEvent === 'PreCompact'
+    );
+    assert.ok(preCompactMergeOperation, 'Should plan the PreCompact settings.json hook merge');
+    assert.strictEqual(preCompactMergeOperation.hookScriptPath, scriptDestination);
+  })) passed++; else failed++;
+
   if (test('claude adapter registers the GateGuard fact-force hook on Edit/Write/MultiEdit, not just Bash', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const homeDir = '/Users/example';


### PR DESCRIPTION
## Summary
- Wires `PreCompact`/`PostCompact` into the real Claude Code install path (`claude-settings-hooks.js`, `claude-home.js`): PreCompact saves a state snapshot to disk (`egc-memory-save.js`), PostCompact reloads it (reuses `claude-session-start.js`).
- Fixes a silent catch-all in `install/apply.js` and `install-lifecycle.js` (repair/uninstall/inspect) that would have mis-filed the two new hook events as SessionStart entries.
- Adds a universal prompt-level instruction (`bootstrap-cognitive.js`, `rules/common/memory.md`) telling the model to call `get_state` again after detecting a compaction, covering every supported tool regardless of native hook support.
- Closes a related gap: the local git clean filter (`memory-filters.js`) that strips populated memory blocks from propagation files before commit was missing `CLAUDE.md`, `.roo/rules/egc-context.md` and `.continue/rules/egc-context.md`.

## Test plan
- [x] `node --check` on every touched file
- [x] `npm test` full suite: 3019/3019 passing
- [x] `tests/lib/claude-settings-hooks.test.js`: 68/68, including PreCompact + PostCompact coexisting with SessionStart/Stop in the same settings.json
- [x] `tests/memory-filters.test.js` and `tests/check-state-leak.test.js` passing after the filter list change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores project context after Claude Code compaction by wiring `PreCompact` to save state and `PostCompact` to reload it. Meets Linear EGC-495 and also ensures the save script is present to prevent failures.

- **New Features**
  - Wire `PreCompact` to `scripts/hooks/egc-memory-save.js` (snapshot to disk) and `PostCompact` to reuse `claude-session-start.js` (reload) in `claude-settings-hooks.js` and `install-targets/claude-home.js`.
  - Add a universal rule in `bootstrap-cognitive.js` and `rules/common/memory.md` to call `get_state` immediately after compaction.
  - Extend the git clean filter to strip memory blocks from `CLAUDE.md`, `.roo/rules/egc-context.md`, and `.continue/rules/egc-context.md`.

- **Bug Fixes**
  - Copy `egc-memory-save.js` and its lib deps unconditionally in `claude-home.js` so `PreCompact` never points at a missing script; add a regression test in `install-targets.test.js`.
  - Correct hook dispatch in `install/apply.js` and `install-lifecycle.js` so `PreCompact`/`PostCompact` are handled in repair/uninstall/inspect and not misfiled under `SessionStart`.
  - Centralize the `HOOK_OPERATION_KIND` dispatcher as `applyManagedHookOperation` in `claude-settings-hooks.js`; both installers now delegate to it to remove duplicated logic.

<sup>Written for commit bd78d90d9b6bd6f3e63c3ec951f86e986461dbb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

