### PR TITLE
feat(guardian): wire the Bash command validator into Cursor

### DIFF
--- a/scripts/hooks/cursor-guardian-adapter.js
+++ b/scripts/hooks/cursor-guardian-adapter.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Cursor Agent Hooks adapter for the EGC Guardian command validator.
+ *
+ * Cursor's beforeShellExecution hook uses a different wire contract than
+ * Claude Code's PreToolUse hook (see windsurf-guardian-adapter.js for the
+ * same distinction this file mirrors): {command, cwd, ...} on stdin instead
+ * of {tool_name, tool_input}, and a JSON {permission, user_message,
+ * agent_message} response on stdout in addition to the block/allow exit
+ * code (docs: https://cursor.com/docs/agent/hooks -- exit code 2 blocks
+ * regardless of stdout, other codes fail open).
+ *
+ * pre-bash-guardian-validate.js's own run() already returns {exitCode,
+ * stderr} directly (no JSON envelope to unwrap), so unlike the GateGuard
+ * adapter this translation only needs to build its input shape and relay
+ * its output as-is, plus the permission JSON Cursor's contract expects.
+ */
+
+'use strict';
+
+const { run } = require('./pre-bash-guardian-validate');
+
+function buildGuardianInput(cursorEvent) {
+  const command = cursorEvent.command || '';
+  if (!command) {
+    return null;
+  }
+  // cwd matters here (unlike for GateGuard's fact-forcing gate): the
+  // Guardian resolves relative protected paths (e.g. `cat .ssh/id_rsa`)
+  // against it. Without it, those checks fall back to this adapter
+  // process's own cwd instead of the directory Cursor actually runs the
+  // command in.
+  const input = { tool_name: 'Bash', tool_input: { command } };
+  if (typeof cursorEvent.cwd === 'string') {
+    input.cwd = cursorEvent.cwd;
+  }
+  return input;
+}
+
+function main() {
+  const MAX_STDIN = 1024 * 1024;
+  let raw = '';
+  let truncated = false;
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+    if (raw.length >= MAX_STDIN) {
+      truncated = true;
+    }
+  });
+  process.stdin.on('end', () => {
+    let cursorEvent;
+    try {
+      cursorEvent = JSON.parse(raw);
+    } catch {
+      // A parse failure caused by hitting the size cap is not the same as
+      // ordinary malformed input: an attacker can pad a command past
+      // MAX_STDIN specifically to land here and fail open. Only genuinely
+      // malformed (non-truncated) input gets the fail-open policy the other
+      // adapters use; a truncated payload is unanalyzable and fails closed.
+      if (truncated) {
+        const message = 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+          'this validator can safely read, so it could not be parsed or validated. ' +
+          'Simplify the command.';
+        process.stdout.write(JSON.stringify({ permission: 'deny', user_message: message, agent_message: message }));
+        process.exit(2);
+      }
+      process.stdout.write(JSON.stringify({ permission: 'allow' }));
+      process.exit(0);
+    }
+
+    const guardianInput = buildGuardianInput(cursorEvent);
+    if (!guardianInput) {
+      process.stdout.write(JSON.stringify({ permission: 'allow' }));
+      process.exit(0);
+    }
+
+    const result = run(guardianInput);
+    if (result.exitCode === 2) {
+      const reason = result.stderr || 'Blocked by the EGC Guardian.';
+      process.stdout.write(JSON.stringify({ permission: 'deny', user_message: reason, agent_message: reason }));
+      process.exit(2);
+    }
+
+    process.stdout.write(JSON.stringify({ permission: 'allow' }));
+    process.exit(0);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { buildGuardianInput };

--- a/scripts/hooks/cursor-guardian-adapter.js
+++ b/scripts/hooks/cursor-guardian-adapter.js
@@ -22,6 +22,9 @@ const { run } = require('./pre-bash-guardian-validate');
 const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
 
 function buildGuardianInput(cursorEvent) {
+  if (!cursorEvent || typeof cursorEvent !== 'object') {
+    return null;
+  }
   const command = cursorEvent.command || '';
   if (!command) {
     return null;

--- a/scripts/hooks/cursor-guardian-adapter.js
+++ b/scripts/hooks/cursor-guardian-adapter.js
@@ -19,6 +19,7 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
 
 function buildGuardianInput(cursorEvent) {
   const command = cursorEvent.command || '';
@@ -37,55 +38,43 @@ function buildGuardianInput(cursorEvent) {
   return input;
 }
 
+function respond(permission, message) {
+  const payload = message ? { permission, user_message: message, agent_message: message } : { permission };
+  process.stdout.write(JSON.stringify(payload));
+  process.exit(permission === 'deny' ? 2 : 0);
+}
+
 function main() {
-  const MAX_STDIN = 1024 * 1024;
-  let raw = '';
-  let truncated = false;
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', chunk => {
-    if (raw.length < MAX_STDIN) {
-      raw += chunk.substring(0, MAX_STDIN - raw.length);
-    }
-    if (raw.length >= MAX_STDIN) {
-      truncated = true;
-    }
-  });
-  process.stdin.on('end', () => {
-    let cursorEvent;
-    try {
-      cursorEvent = JSON.parse(raw);
-    } catch {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    if (!ok) {
       // A parse failure caused by hitting the size cap is not the same as
-      // ordinary malformed input: an attacker can pad a command past
-      // MAX_STDIN specifically to land here and fail open. Only genuinely
+      // ordinary malformed input: an attacker can pad a command past the
+      // stdin cap specifically to land here and fail open. Only genuinely
       // malformed (non-truncated) input gets the fail-open policy the other
       // adapters use; a truncated payload is unanalyzable and fails closed.
       if (truncated) {
-        const message = 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+        respond('deny', 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
           'this validator can safely read, so it could not be parsed or validated. ' +
-          'Simplify the command.';
-        process.stdout.write(JSON.stringify({ permission: 'deny', user_message: message, agent_message: message }));
-        process.exit(2);
+          'Simplify the command.');
+        return;
       }
-      process.stdout.write(JSON.stringify({ permission: 'allow' }));
-      process.exit(0);
+      respond('allow');
+      return;
     }
 
-    const guardianInput = buildGuardianInput(cursorEvent);
+    const guardianInput = buildGuardianInput(value);
     if (!guardianInput) {
-      process.stdout.write(JSON.stringify({ permission: 'allow' }));
-      process.exit(0);
+      respond('allow');
+      return;
     }
 
     const result = run(guardianInput);
     if (result.exitCode === 2) {
-      const reason = result.stderr || 'Blocked by the EGC Guardian.';
-      process.stdout.write(JSON.stringify({ permission: 'deny', user_message: reason, agent_message: reason }));
-      process.exit(2);
+      respond('deny', result.stderr || 'Blocked by the EGC Guardian.');
+      return;
     }
 
-    process.stdout.write(JSON.stringify({ permission: 'allow' }));
-    process.exit(0);
+    respond('allow');
   });
 }
 

--- a/scripts/hooks/windsurf-guardian-adapter.js
+++ b/scripts/hooks/windsurf-guardian-adapter.js
@@ -21,8 +21,12 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
 
 function buildGuardianInput(windsurfEvent) {
+  if (!windsurfEvent || typeof windsurfEvent !== 'object') {
+    return null;
+  }
   const actionName = windsurfEvent.agent_action_name || '';
   if (actionName !== 'pre_run_command') {
     return null;
@@ -45,26 +49,11 @@ function buildGuardianInput(windsurfEvent) {
 }
 
 function main() {
-  const MAX_STDIN = 1024 * 1024;
-  let raw = '';
-  let truncated = false;
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', chunk => {
-    if (raw.length < MAX_STDIN) {
-      raw += chunk.substring(0, MAX_STDIN - raw.length);
-    }
-    if (raw.length >= MAX_STDIN) {
-      truncated = true;
-    }
-  });
-  process.stdin.on('end', () => {
-    let windsurfEvent;
-    try {
-      windsurfEvent = JSON.parse(raw);
-    } catch {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    if (!ok) {
       // A parse failure caused by hitting the size cap is not the same as
-      // ordinary malformed input: an attacker can pad a command past
-      // MAX_STDIN specifically to land here and fail open. Only genuinely
+      // ordinary malformed input: an attacker can pad a command past the
+      // stdin cap specifically to land here and fail open. Only genuinely
       // malformed (non-truncated) input gets the fail-open policy the other
       // adapters use; a truncated payload is unanalyzable and fails closed.
       if (truncated) {
@@ -78,7 +67,7 @@ function main() {
       process.exit(0);
     }
 
-    const guardianInput = buildGuardianInput(windsurfEvent);
+    const guardianInput = buildGuardianInput(value);
     if (!guardianInput) {
       process.exit(0);
     }

--- a/scripts/lib/adapter-stdin-json.js
+++ b/scripts/lib/adapter-stdin-json.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// Shared truncation-aware stdin JSON reader for host-hook adapters
+// (Windsurf, Cursor, and future hosts with the same "one JSON event object
+// on stdin" contract). A parse failure caused by hitting the size cap is
+// not the same as ordinary malformed input: an attacker can pad a command
+// past MAX_STDIN specifically to land here and dodge validation. Callers
+// get a `truncated` flag so they can fail closed on that case while still
+// failing open on genuinely malformed (non-truncated) input, matching the
+// policy every adapter using this module needs.
+
+const MAX_STDIN = 1024 * 1024;
+
+function readAdapterStdinJson(onComplete) {
+  let raw = '';
+  let truncated = false;
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+    if (raw.length >= MAX_STDIN) {
+      truncated = true;
+    }
+  });
+  process.stdin.on('end', () => {
+    let value;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      onComplete({ ok: false, truncated });
+      return;
+    }
+    onComplete({ ok: true, truncated, value });
+  });
+}
+
+module.exports = { MAX_STDIN, readAdapterStdinJson };

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -16,6 +16,10 @@ const {
   PRE_WRITE_CODE_EVENT: WINDSURF_PRE_WRITE_CODE_EVENT,
   applyWindsurfGateGuardHookToFile,
 } = require('./windsurf-gateguard-hooks');
+const {
+  BEFORE_SHELL_EXECUTION_EVENT: CURSOR_BEFORE_SHELL_EXECUTION_EVENT,
+  applyCursorGuardianHookToFile,
+} = require('./cursor-guardian-hooks');
 
 const MANAGED_WINDSURF_HOOK_EVENTS = new Set([WINDSURF_PRE_WRITE_CODE_EVENT, WINDSURF_PRE_RUN_COMMAND_EVENT]);
 
@@ -943,6 +947,8 @@ function applyManagedHookOperation(operation) {
     // handled above
   } else if (MANAGED_WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
+  } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
+    applyCursorGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
     applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
   }

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -948,7 +948,7 @@ function applyManagedHookOperation(operation) {
   } else if (MANAGED_WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
-    applyCursorGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
+    applyCursorGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath, { seedPath: operation.seedPath });
   } else {
     applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
   }

--- a/scripts/lib/cursor-guardian-hooks.js
+++ b/scripts/lib/cursor-guardian-hooks.js
@@ -1,0 +1,172 @@
+'use strict';
+
+// Manages the Guardian entry inside a Cursor Agent Hooks project-level
+// .cursor/hooks.json file. Cursor's schema is a flat
+// {version, hooks: {<event>: [{command, timeout?, matcher?}]}} map -- no
+// matcher/group wrapper and no "type": "command" field like Claude Code's
+// settings.json -- so it needs its own merge logic instead of reusing
+// claude-settings-hooks.js's addHookEntry(). Mirrors
+// windsurf-gateguard-hooks.js's approach for the same reason (a different
+// non-Claude hooks.json shape). Docs: https://cursor.com/docs/agent/hooks
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const BEFORE_SHELL_EXECUTION_EVENT = 'beforeShellExecution';
+const GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/cursor-guardian-adapter.js';
+const HOOKS_CONFIG_VERSION = 1;
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildHookCommand(scriptPath) {
+  return `"${process.execPath}" "${scriptPath}"`; // NOSONAR jssecurity:S8705
+}
+
+function resolveGuardianAdapterScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'cursor-guardian-adapter.js');
+}
+
+function resolveHooksJsonPath(targetRoot) {
+  return path.join(targetRoot, 'hooks.json');
+}
+
+function readHooksFile(hooksJsonPath) {
+  if (!fs.existsSync(hooksJsonPath)) {
+    return {};
+  }
+  const raw = fs.readFileSync(hooksJsonPath, 'utf8');
+  if (!raw.trim()) {
+    return {};
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse Cursor hooks config at ${hooksJsonPath}: ${error.message}`, { cause: error });
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Invalid Cursor hooks config at ${hooksJsonPath}: expected a JSON object`);
+  }
+  return parsed;
+}
+
+function writeHooksFile(hooksJsonPath, config) {
+  fs.mkdirSync(path.dirname(hooksJsonPath), { recursive: true });
+  fs.writeFileSync(hooksJsonPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+function isEgcEntry(entry, command) {
+  return isPlainObject(entry) && entry.command === command;
+}
+
+const EGC_ADAPTER_BASENAME = path.basename(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH);
+
+function isStaleEgcEntry(entry, command) {
+  if (!isPlainObject(entry) || typeof entry.command !== 'string' || entry.command === command) {
+    return false;
+  }
+  return entry.command.includes(EGC_ADAPTER_BASENAME);
+}
+
+function addCursorHookEntry(config, event, command) {
+  const base = isPlainObject(config) ? config : {};
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+
+  if (existing.some(entry => isEgcEntry(entry, command))) {
+    return { config: base, changed: false };
+  }
+
+  // Migrate a stale entry in place (same adapter script, different install
+  // path) instead of appending a duplicate.
+  let migrated = false;
+  const nextEntries = existing.map(entry => {
+    if (!migrated && isStaleEgcEntry(entry, command)) {
+      migrated = true;
+      return { ...entry, command };
+    }
+    return entry;
+  });
+
+  if (!migrated) {
+    nextEntries.push({ command });
+  }
+
+  hooks[event] = nextEntries;
+  return {
+    config: { version: base.version || HOOKS_CONFIG_VERSION, ...base, hooks },
+    changed: true,
+  };
+}
+
+function applyCursorGuardianHookToFile(hooksJsonPath, event, adapterScriptPath) {
+  const command = buildHookCommand(adapterScriptPath);
+  const current = readHooksFile(hooksJsonPath);
+  const { config, changed } = addCursorHookEntry(current, event, command);
+  if (changed) {
+    writeHooksFile(hooksJsonPath, config);
+  }
+  return { changed };
+}
+
+// Pure counterpart to addCursorHookEntry: drops only the EGC-managed entry
+// (matched by exact command) from hooks[event], leaving every other entry
+// (third-party hooks, other events) untouched. Deletes the event key
+// entirely once it is empty, rather than leaving a dangling `[]` in the
+// user's hooks.json.
+function removeCursorHookEntry(config, event, command) {
+  const base = isPlainObject(config) ? config : {};
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+  const nextEntries = existing.filter(entry => !isEgcEntry(entry, command));
+
+  if (nextEntries.length === existing.length) {
+    return { config: base, changed: false };
+  }
+
+  if (nextEntries.length > 0) {
+    hooks[event] = nextEntries;
+  } else {
+    delete hooks[event];
+  }
+  return { config: { ...base, hooks }, changed: true };
+}
+
+function removeCursorGuardianHookFromFile(hooksJsonPath, event, adapterScriptPath) {
+  if (!fs.existsSync(hooksJsonPath)) {
+    return { changed: false };
+  }
+  const command = buildHookCommand(adapterScriptPath);
+  const current = readHooksFile(hooksJsonPath);
+  const { config, changed } = removeCursorHookEntry(current, event, command);
+  if (changed) {
+    writeHooksFile(hooksJsonPath, config);
+  }
+  return { changed };
+}
+
+function inspectCursorGuardianHookFile(hooksJsonPath, event, adapterScriptPath) {
+  try {
+    const command = buildHookCommand(adapterScriptPath);
+    const current = readHooksFile(hooksJsonPath);
+    const hooks = isPlainObject(current.hooks) ? current.hooks : {};
+    const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+    return existing.some(entry => isEgcEntry(entry, command)) ? 'ok' : 'drifted';
+  } catch {
+    return 'drifted';
+  }
+}
+
+module.exports = {
+  BEFORE_SHELL_EXECUTION_EVENT,
+  GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  addCursorHookEntry,
+  applyCursorGuardianHookToFile,
+  inspectCursorGuardianHookFile,
+  removeCursorGuardianHookFromFile,
+  removeCursorHookEntry,
+  resolveGuardianAdapterScriptDestination,
+  resolveHooksJsonPath,
+};

--- a/scripts/lib/cursor-guardian-hooks.js
+++ b/scripts/lib/cursor-guardian-hooks.js
@@ -2,26 +2,33 @@
 
 // Manages the Guardian entry inside a Cursor Agent Hooks project-level
 // .cursor/hooks.json file. Cursor's schema is a flat
-// {version, hooks: {<event>: [{command, timeout?, matcher?}]}} map -- no
-// matcher/group wrapper and no "type": "command" field like Claude Code's
-// settings.json -- so it needs its own merge logic instead of reusing
-// claude-settings-hooks.js's addHookEntry(). Mirrors
-// windsurf-gateguard-hooks.js's approach for the same reason (a different
-// non-Claude hooks.json shape). Docs: https://cursor.com/docs/agent/hooks
+// {version, hooks: {<event>: [{command, timeout?, matcher?}]}} map -- the
+// same shape flat-hooks-json-merge.js handles for Windsurf's hooks.json
+// too, plus a top-level `version` field Windsurf's file does not have.
+// Docs: https://cursor.com/docs/agent/hooks
 
-const fs = require('node:fs');
 const path = require('node:path');
+const {
+  addFlatHookEntry,
+  applyFlatHookToFile,
+  buildHookCommand,
+  inspectFlatHookFile,
+  removeFlatHookEntry,
+  removeFlatHookFromFile,
+} = require('./flat-hooks-json-merge');
 
+const HOST_LABEL = 'Cursor';
 const BEFORE_SHELL_EXECUTION_EVENT = 'beforeShellExecution';
 const GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/cursor-guardian-adapter.js';
 const HOOKS_CONFIG_VERSION = 1;
+const EGC_ADAPTER_BASENAME = path.basename(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH);
 
-function isPlainObject(value) {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+function isOwnBasename(command) {
+  return command.includes(EGC_ADAPTER_BASENAME);
 }
 
-function buildHookCommand(scriptPath) {
-  return `"${process.execPath}" "${scriptPath}"`; // NOSONAR jssecurity:S8705
+function buildExtraTopLevel(base) {
+  return { version: base.version || HOOKS_CONFIG_VERSION };
 }
 
 function resolveGuardianAdapterScriptDestination(targetRoot) {
@@ -32,131 +39,27 @@ function resolveHooksJsonPath(targetRoot) {
   return path.join(targetRoot, 'hooks.json');
 }
 
-function readHooksFile(hooksJsonPath) {
-  if (!fs.existsSync(hooksJsonPath)) {
-    return {};
-  }
-  const raw = fs.readFileSync(hooksJsonPath, 'utf8');
-  if (!raw.trim()) {
-    return {};
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`Failed to parse Cursor hooks config at ${hooksJsonPath}: ${error.message}`, { cause: error });
-  }
-  if (!isPlainObject(parsed)) {
-    throw new Error(`Invalid Cursor hooks config at ${hooksJsonPath}: expected a JSON object`);
-  }
-  return parsed;
-}
-
-function writeHooksFile(hooksJsonPath, config) {
-  fs.mkdirSync(path.dirname(hooksJsonPath), { recursive: true });
-  fs.writeFileSync(hooksJsonPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-}
-
-function isEgcEntry(entry, command) {
-  return isPlainObject(entry) && entry.command === command;
-}
-
-const EGC_ADAPTER_BASENAME = path.basename(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH);
-
-function isStaleEgcEntry(entry, command) {
-  if (!isPlainObject(entry) || typeof entry.command !== 'string' || entry.command === command) {
-    return false;
-  }
-  return entry.command.includes(EGC_ADAPTER_BASENAME);
-}
-
 function addCursorHookEntry(config, event, command) {
-  const base = isPlainObject(config) ? config : {};
-  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
-  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
-
-  if (existing.some(entry => isEgcEntry(entry, command))) {
-    return { config: base, changed: false };
-  }
-
-  // Migrate a stale entry in place (same adapter script, different install
-  // path) instead of appending a duplicate.
-  let migrated = false;
-  const nextEntries = existing.map(entry => {
-    if (!migrated && isStaleEgcEntry(entry, command)) {
-      migrated = true;
-      return { ...entry, command };
-    }
-    return entry;
-  });
-
-  if (!migrated) {
-    nextEntries.push({ command });
-  }
-
-  hooks[event] = nextEntries;
-  return {
-    config: { version: base.version || HOOKS_CONFIG_VERSION, ...base, hooks },
-    changed: true,
-  };
+  return addFlatHookEntry(config, event, command, { isOwnBasename, buildExtraTopLevel });
 }
 
 function applyCursorGuardianHookToFile(hooksJsonPath, event, adapterScriptPath) {
-  const command = buildHookCommand(adapterScriptPath);
-  const current = readHooksFile(hooksJsonPath);
-  const { config, changed } = addCursorHookEntry(current, event, command);
-  if (changed) {
-    writeHooksFile(hooksJsonPath, config);
-  }
-  return { changed };
+  return applyFlatHookToFile(hooksJsonPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath), {
+    isOwnBasename,
+    buildExtraTopLevel,
+  });
 }
 
-// Pure counterpart to addCursorHookEntry: drops only the EGC-managed entry
-// (matched by exact command) from hooks[event], leaving every other entry
-// (third-party hooks, other events) untouched. Deletes the event key
-// entirely once it is empty, rather than leaving a dangling `[]` in the
-// user's hooks.json.
 function removeCursorHookEntry(config, event, command) {
-  const base = isPlainObject(config) ? config : {};
-  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
-  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
-  const nextEntries = existing.filter(entry => !isEgcEntry(entry, command));
-
-  if (nextEntries.length === existing.length) {
-    return { config: base, changed: false };
-  }
-
-  if (nextEntries.length > 0) {
-    hooks[event] = nextEntries;
-  } else {
-    delete hooks[event];
-  }
-  return { config: { ...base, hooks }, changed: true };
+  return removeFlatHookEntry(config, event, command);
 }
 
 function removeCursorGuardianHookFromFile(hooksJsonPath, event, adapterScriptPath) {
-  if (!fs.existsSync(hooksJsonPath)) {
-    return { changed: false };
-  }
-  const command = buildHookCommand(adapterScriptPath);
-  const current = readHooksFile(hooksJsonPath);
-  const { config, changed } = removeCursorHookEntry(current, event, command);
-  if (changed) {
-    writeHooksFile(hooksJsonPath, config);
-  }
-  return { changed };
+  return removeFlatHookFromFile(hooksJsonPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath));
 }
 
 function inspectCursorGuardianHookFile(hooksJsonPath, event, adapterScriptPath) {
-  try {
-    const command = buildHookCommand(adapterScriptPath);
-    const current = readHooksFile(hooksJsonPath);
-    const hooks = isPlainObject(current.hooks) ? current.hooks : {};
-    const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
-    return existing.some(entry => isEgcEntry(entry, command)) ? 'ok' : 'drifted';
-  } catch {
-    return 'drifted';
-  }
+  return inspectFlatHookFile(hooksJsonPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath));
 }
 
 module.exports = {

--- a/scripts/lib/cursor-guardian-hooks.js
+++ b/scripts/lib/cursor-guardian-hooks.js
@@ -7,6 +7,7 @@
 // too, plus a top-level `version` field Windsurf's file does not have.
 // Docs: https://cursor.com/docs/agent/hooks
 
+const fs = require('node:fs');
 const path = require('node:path');
 const {
   addFlatHookEntry,
@@ -15,6 +16,7 @@ const {
   inspectFlatHookFile,
   removeFlatHookEntry,
   removeFlatHookFromFile,
+  writeFlatHooksFile,
 } = require('./flat-hooks-json-merge');
 
 const HOST_LABEL = 'Cursor';
@@ -43,7 +45,23 @@ function addCursorHookEntry(config, event, command) {
   return addFlatHookEntry(config, event, command, { isOwnBasename, buildExtraTopLevel });
 }
 
-function applyCursorGuardianHookToFile(hooksJsonPath, event, adapterScriptPath) {
+function applyCursorGuardianHookToFile(hooksJsonPath, event, adapterScriptPath, options = {}) {
+  const seedPath = options?.seedPath;
+  if (seedPath && !fs.existsSync(hooksJsonPath) && fs.existsSync(seedPath)) {
+    try {
+      const seedConfig = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+      const command = buildHookCommand(adapterScriptPath);
+      const { config } = addFlatHookEntry(seedConfig, event, command, {
+        isOwnBasename,
+        buildExtraTopLevel,
+      });
+      writeFlatHooksFile(hooksJsonPath, config);
+      return { changed: true };
+    } catch {
+      // Fall back to default empty-file merge if seed read fails
+    }
+  }
+
   return applyFlatHookToFile(hooksJsonPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath), {
     isOwnBasename,
     buildExtraTopLevel,

--- a/scripts/lib/flat-hooks-json-merge.js
+++ b/scripts/lib/flat-hooks-json-merge.js
@@ -1,0 +1,160 @@
+'use strict';
+
+// Shared merge/read/write primitives for "flat {hooks: {<event>:
+// [{command}]}}" hook config files -- the shape used by Windsurf's
+// hooks.json and Cursor's .cursor/hooks.json alike (no matcher/group
+// wrapper, no "type": "command" field like Claude Code's settings.json).
+// Both hosts need the same idempotent, array-preserving merge logic
+// instead of claude-settings-hooks.js's addHookEntry() or a generic
+// deep-merge-json strategy (which replaces arrays wholesale and would
+// clobber a user's other entries in the same event array).
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildHookCommand(scriptPath) {
+  return `"${process.execPath}" "${scriptPath}"`; // NOSONAR jssecurity:S8705
+}
+
+function readFlatHooksFile(hooksJsonPath, hostLabel) {
+  if (!fs.existsSync(hooksJsonPath)) {
+    return {};
+  }
+  const raw = fs.readFileSync(hooksJsonPath, 'utf8');
+  if (!raw.trim()) {
+    return {};
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse ${hostLabel} hooks config at ${hooksJsonPath}: ${error.message}`, { cause: error });
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Invalid ${hostLabel} hooks config at ${hooksJsonPath}: expected a JSON object`);
+  }
+  return parsed;
+}
+
+function writeFlatHooksFile(hooksJsonPath, config) {
+  fs.mkdirSync(path.dirname(hooksJsonPath), { recursive: true });
+  fs.writeFileSync(hooksJsonPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+function isEgcEntry(entry, command) {
+  return isPlainObject(entry) && entry.command === command;
+}
+
+// isOwnBasename: (command: string) => boolean, lets each host decide which
+// basenames identify ITS OWN managed adapter scripts (Windsurf has two:
+// GateGuard + Guardian; Cursor has one: Guardian only).
+function isStaleEgcEntry(entry, command, isOwnBasename) {
+  if (!isPlainObject(entry) || typeof entry.command !== 'string' || entry.command === command) {
+    return false;
+  }
+  return isOwnBasename(entry.command);
+}
+
+// buildExtraTopLevel: (base: object) => object, merged into the result
+// alongside `hooks` -- e.g. Cursor's {version} field, which Windsurf's
+// hooks.json does not have.
+function addFlatHookEntry(config, event, command, { isOwnBasename, buildExtraTopLevel } = {}) {
+  const base = isPlainObject(config) ? config : {};
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+
+  if (existing.some(entry => isEgcEntry(entry, command))) {
+    return { config: base, changed: false };
+  }
+
+  // Migrate a stale entry in place (same adapter script, different install
+  // path) instead of appending a duplicate.
+  let migrated = false;
+  const nextEntries = existing.map(entry => {
+    if (!migrated && isOwnBasename && isStaleEgcEntry(entry, command, isOwnBasename)) {
+      migrated = true;
+      return { ...entry, command };
+    }
+    return entry;
+  });
+
+  if (!migrated) {
+    nextEntries.push({ command });
+  }
+
+  hooks[event] = nextEntries;
+  const extraTopLevel = buildExtraTopLevel ? buildExtraTopLevel(base) : {};
+  return { config: { ...base, ...extraTopLevel, hooks }, changed: true };
+}
+
+function applyFlatHookToFile(hooksJsonPath, hostLabel, event, command, options) {
+  const current = readFlatHooksFile(hooksJsonPath, hostLabel);
+  const { config, changed } = addFlatHookEntry(current, event, command, options);
+  if (changed) {
+    writeFlatHooksFile(hooksJsonPath, config);
+  }
+  return { changed };
+}
+
+// Pure counterpart to addFlatHookEntry: drops only the EGC-managed entry
+// (matched by exact command) from hooks[event], leaving every other entry
+// (third-party hooks, other events) untouched. Deletes the event key
+// entirely once it is empty, rather than leaving a dangling `[]` behind.
+function removeFlatHookEntry(config, event, command) {
+  const base = isPlainObject(config) ? config : {};
+  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
+  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+  const nextEntries = existing.filter(entry => !isEgcEntry(entry, command));
+
+  if (nextEntries.length === existing.length) {
+    return { config: base, changed: false };
+  }
+
+  if (nextEntries.length > 0) {
+    hooks[event] = nextEntries;
+  } else {
+    delete hooks[event];
+  }
+  return { config: { ...base, hooks }, changed: true };
+}
+
+function removeFlatHookFromFile(hooksJsonPath, hostLabel, event, command) {
+  if (!fs.existsSync(hooksJsonPath)) {
+    return { changed: false };
+  }
+  const current = readFlatHooksFile(hooksJsonPath, hostLabel);
+  const { config, changed } = removeFlatHookEntry(current, event, command);
+  if (changed) {
+    writeFlatHooksFile(hooksJsonPath, config);
+  }
+  return { changed };
+}
+
+function inspectFlatHookFile(hooksJsonPath, hostLabel, event, command) {
+  try {
+    const current = readFlatHooksFile(hooksJsonPath, hostLabel);
+    const hooks = isPlainObject(current.hooks) ? current.hooks : {};
+    const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
+    return existing.some(entry => isEgcEntry(entry, command)) ? 'ok' : 'drifted';
+  } catch {
+    return 'drifted';
+  }
+}
+
+module.exports = {
+  addFlatHookEntry,
+  applyFlatHookToFile,
+  buildHookCommand,
+  inspectFlatHookFile,
+  isEgcEntry,
+  isPlainObject,
+  isStaleEgcEntry,
+  readFlatHooksFile,
+  removeFlatHookEntry,
+  removeFlatHookFromFile,
+  writeFlatHooksFile,
+};

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -37,6 +37,11 @@ const {
   inspectWindsurfGateGuardHookFile,
   removeWindsurfGateGuardHookFromFile,
 } = require('./windsurf-gateguard-hooks');
+const {
+  BEFORE_SHELL_EXECUTION_EVENT: CURSOR_BEFORE_SHELL_EXECUTION_EVENT,
+  inspectCursorGuardianHookFile,
+  removeCursorGuardianHookFromFile,
+} = require('./cursor-guardian-hooks');
 
 // Windsurf's hooks.json is a flat {hooks: {<event>: [...]}} map, not
 // Claude's matcher/group settings.json schema -- an operation whose
@@ -543,6 +548,8 @@ function uninstallManagedHookOperation(operation) {
     removeHookEntryFromFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
   } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
     removeWindsurfGateGuardHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
+  } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
+    removeCursorGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
     removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
   }
@@ -681,6 +688,9 @@ function inspectManagedOperation(repoRoot, operation) {
     }
     if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
       return inspectResult(inspectWindsurfGateGuardHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
+    }
+    if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
+      return inspectResult(inspectCursorGuardianHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
     }
     return inspectResult(inspectSessionStartHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
   }

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -7,8 +7,58 @@ const {
   createFlatRuleOperations,
   createInstallTargetAdapter,
   createManagedOperation,
+  createRemappedOperation,
   isForeignPlatformPath,
 } = require('./helpers');
+const {
+  HOOK_OPERATION_KIND,
+  createBashGuardianScriptCopyOperations,
+} = require('../claude-settings-hooks');
+const {
+  BEFORE_SHELL_EXECUTION_EVENT,
+  GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  resolveGuardianAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('../cursor-guardian-hooks');
+
+// EGC-494/EGC-498: every Cursor install registers the Guardian Bash
+// validator on beforeShellExecution, even when no content modules are
+// selected -- the same "deterministic, unconditional" pattern
+// claude-home.js/windsurf-gateguard-operations.js already use for their own
+// security hooks, so a minimal install is never silently unprotected.
+function createCursorGuardianOperations(adapter, targetRoot) {
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+
+  const guardianScriptCopyOperations = createBashGuardianScriptCopyOperations(remap, targetRoot);
+  const adapterModuleId = 'egc-cursor-guardian-hook';
+  const adapterScriptDestination = resolveGuardianAdapterScriptDestination(targetRoot);
+  const adapterCopyOperation = createRemappedOperation(
+    adapter,
+    adapterModuleId,
+    GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    adapterScriptDestination,
+    { strategy: 'preserve-relative-path' }
+  );
+  const mergeOperation = {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: adapterModuleId,
+    sourceRelativePath: GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: resolveHooksJsonPath(targetRoot),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: BEFORE_SHELL_EXECUTION_EVENT,
+    hookScriptPath: adapterScriptDestination,
+  };
+
+  return [
+    ...guardianScriptCopyOperations,
+    adapterCopyOperation,
+    mergeOperation,
+  ];
+}
 
 function toCursorRuleFileName(fileName, sourceRelativeFile) {
   if (path.basename(sourceRelativeFile).toLowerCase() === 'readme.md') {
@@ -132,7 +182,7 @@ module.exports = createInstallTargetAdapter({
       });
     }
 
-    return entries.flatMap(({ module, sourceRelativePath }) => {
+    return [...entries.flatMap(({ module, sourceRelativePath }) => {
       const cursorMcpOperation = createJsonMergeOperation({
         moduleId: module.id,
         repoRoot,
@@ -210,6 +260,6 @@ module.exports = createInstallTargetAdapter({
       return takeUniqueOperations([
         adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput),
       ]);
-    });
+    }), ...createCursorGuardianOperations(adapter, targetRoot)];
   },
 });

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -26,21 +26,37 @@ const {
 // selected -- the same "deterministic, unconditional" pattern
 // claude-home.js/windsurf-gateguard-operations.js already use for their own
 // security hooks, so a minimal install is never silently unprotected.
-function createCursorGuardianOperations(adapter, targetRoot) {
+function createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot) {
   const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
     createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
 
-  const guardianScriptCopyOperations = createBashGuardianScriptCopyOperations(remap, targetRoot);
+  // hooks-runtime already scaffolds the whole scripts/hooks and scripts/lib
+  // trees (install-modules.json), which includes every file the Guardian
+  // copy operations below would otherwise duplicate -- drop the redundant
+  // per-file copies when that module is selected, keeping only the merge
+  // operation (never redundant: it is the sole writer of hooks.json's
+  // Guardian entry).
+  const selectedPaths = new Set(modules.flatMap(module => (Array.isArray(module.paths) ? module.paths : [])));
+  const alreadyScaffolded = sourceRelativePath => (
+    (selectedPaths.has('scripts/hooks') && sourceRelativePath.startsWith('scripts/hooks/'))
+    || (selectedPaths.has('scripts/lib') && sourceRelativePath.startsWith('scripts/lib/'))
+  );
+
+  const guardianScriptCopyOperations = createBashGuardianScriptCopyOperations(remap, targetRoot)
+    .filter(operation => !alreadyScaffolded(operation.sourceRelativePath));
   const adapterModuleId = 'egc-cursor-guardian-hook';
   const adapterScriptDestination = resolveGuardianAdapterScriptDestination(targetRoot);
-  const adapterCopyOperation = createRemappedOperation(
-    adapter,
-    adapterModuleId,
-    GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
-    adapterScriptDestination,
-    { strategy: 'preserve-relative-path' }
-  );
+  const adapterCopyOperation = alreadyScaffolded(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH)
+    ? null
+    : createRemappedOperation(
+      adapter,
+      adapterModuleId,
+      GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+      adapterScriptDestination,
+      { strategy: 'preserve-relative-path' }
+    );
+  const seedPath = repoRoot ? path.join(repoRoot, '.cursor', 'hooks.json') : null;
   const mergeOperation = {
     kind: HOOK_OPERATION_KIND,
     moduleId: adapterModuleId,
@@ -51,11 +67,12 @@ function createCursorGuardianOperations(adapter, targetRoot) {
     scaffoldOnly: false,
     hookEvent: BEFORE_SHELL_EXECUTION_EVENT,
     hookScriptPath: adapterScriptDestination,
+    ...(seedPath ? { seedPath } : {}),
   };
 
   return [
     ...guardianScriptCopyOperations,
-    adapterCopyOperation,
+    ...(adapterCopyOperation ? [adapterCopyOperation] : []),
     mergeOperation,
   ];
 }
@@ -224,7 +241,7 @@ module.exports = createInstallTargetAdapter({
 
         const childOperations = fs.readdirSync(cursorRoot, { withFileTypes: true })
           .sort((left, right) => left.name.localeCompare(right.name))
-          .filter(entry => entry.name !== 'rules')
+          .filter(entry => entry.name !== 'rules' && entry.name !== 'hooks.json')
           .map(entry => createManagedOperation({
             moduleId: module.id,
             sourceRelativePath: path.join('.cursor', entry.name),
@@ -260,6 +277,6 @@ module.exports = createInstallTargetAdapter({
       return takeUniqueOperations([
         adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput),
       ]);
-    }), ...createCursorGuardianOperations(adapter, targetRoot)];
+    }), ...createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot)];
   },
 });

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -56,7 +56,13 @@ function createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot) 
       adapterScriptDestination,
       { strategy: 'preserve-relative-path' }
     );
-  const seedPath = repoRoot ? path.join(repoRoot, '.cursor', 'hooks.json') : null;
+  // Only seed from this repo's own .cursor/hooks.json (sessionStart,
+  // dashboard-emit, tmux blocker, etc.) when the install actually selected
+  // the .cursor module path -- a minimal or rules-only install that never
+  // asked for EGC's platform hooks should not have them silently enabled
+  // just because the Guardian's merge operation happens to seed a fresh
+  // destination file.
+  const seedPath = repoRoot && selectedPaths.has('.cursor') ? path.join(repoRoot, '.cursor', 'hooks.json') : null;
   const mergeOperation = {
     kind: HOOK_OPERATION_KIND,
     moduleId: adapterModuleId,

--- a/scripts/lib/windsurf-gateguard-hooks.js
+++ b/scripts/lib/windsurf-gateguard-hooks.js
@@ -4,25 +4,40 @@
 // (.windsurf/hooks.json project-level, or ~/.codeium/windsurf/hooks.json
 // user-level). Windsurf's hooks.json schema is a flat
 // {hooks: {<event>: [{command, ...}]}} map - no matcher/group wrapper and no
-// "type": "command" field like Claude Code's settings.json - so it needs its
-// own merge logic instead of reusing claude-settings-hooks.js's
-// addHookEntry(). Docs: https://docs.windsurf.com/windsurf/cascade/hooks
-// (redirects to https://docs.devin.ai/desktop/cascade/hooks).
+// "type": "command" field like Claude Code's settings.json - so it shares
+// flat-hooks-json-merge.js's merge logic (also used by Cursor's
+// .cursor/hooks.json, the same non-Claude flat shape) instead of reusing
+// claude-settings-hooks.js's addHookEntry(). Docs:
+// https://docs.windsurf.com/windsurf/cascade/hooks (redirects to
+// https://docs.devin.ai/desktop/cascade/hooks).
 
-const fs = require('node:fs');
 const path = require('node:path');
+const {
+  addFlatHookEntry,
+  applyFlatHookToFile,
+  buildHookCommand,
+  inspectFlatHookFile,
+  removeFlatHookEntry,
+  removeFlatHookFromFile,
+} = require('./flat-hooks-json-merge');
 
+const HOST_LABEL = 'Windsurf';
 const PRE_WRITE_CODE_EVENT = 'pre_write_code';
 const PRE_RUN_COMMAND_EVENT = 'pre_run_command';
 const ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/windsurf-gateguard-adapter.js';
 const GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/windsurf-guardian-adapter.js';
 
-function isPlainObject(value) {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
+// Only checking the GateGuard adapter's basename meant a relocated Guardian
+// entry (e.g. after an install path change) was never recognized as stale
+// here, so repair appended a duplicate pointing at the new path instead of
+// migrating the old one in place, leaving both in hooks.json.
+const EGC_ADAPTER_BASENAMES = [
+  path.basename(ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH),
+  path.basename(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH),
+];
 
-function buildHookCommand(scriptPath) {
-  return `"${process.execPath}" "${scriptPath}"`; // NOSONAR jssecurity:S8705
+function isOwnBasename(command) {
+  return EGC_ADAPTER_BASENAMES.some(basename => command.includes(basename));
 }
 
 function resolveAdapterScriptDestination(targetRoot) {
@@ -37,111 +52,16 @@ function resolveHooksJsonPath(targetRoot) {
   return path.join(targetRoot, 'hooks.json');
 }
 
-function readHooksFile(hooksJsonPath) {
-  if (!fs.existsSync(hooksJsonPath)) {
-    return {};
-  }
-  const raw = fs.readFileSync(hooksJsonPath, 'utf8');
-  if (!raw.trim()) {
-    return {};
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`Failed to parse Windsurf hooks config at ${hooksJsonPath}: ${error.message}`, { cause: error });
-  }
-  if (!isPlainObject(parsed)) {
-    throw new Error(`Invalid Windsurf hooks config at ${hooksJsonPath}: expected a JSON object`);
-  }
-  return parsed;
-}
-
-function writeHooksFile(hooksJsonPath, config) {
-  fs.mkdirSync(path.dirname(hooksJsonPath), { recursive: true });
-  fs.writeFileSync(hooksJsonPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-}
-
-function isEgcEntry(entry, command) {
-  return isPlainObject(entry) && entry.command === command;
-}
-
-const EGC_ADAPTER_BASENAMES = [
-  path.basename(ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH),
-  path.basename(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH),
-];
-
-function isStaleEgcEntry(entry, command) {
-  if (!isPlainObject(entry) || typeof entry.command !== 'string' || entry.command === command) {
-    return false;
-  }
-  // Only checking the GateGuard adapter's basename meant a relocated
-  // Guardian entry (e.g. after an install path change) was never
-  // recognized as stale here, so repair appended a duplicate pointing at
-  // the new path instead of migrating the old one in place, leaving both
-  // in hooks.json.
-  return EGC_ADAPTER_BASENAMES.some(basename => entry.command.includes(basename));
-}
-
 function addWindsurfHookEntry(config, event, command) {
-  const base = isPlainObject(config) ? config : {};
-  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
-  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
-
-  if (existing.some(entry => isEgcEntry(entry, command))) {
-    return { config: base, changed: false };
-  }
-
-  // Migrate a stale entry in place (same adapter script, different install
-  // path) instead of appending a duplicate.
-  let migrated = false;
-  const nextEntries = existing.map(entry => {
-    if (!migrated && isStaleEgcEntry(entry, command)) {
-      migrated = true;
-      return { ...entry, command };
-    }
-    return entry;
-  });
-
-  if (!migrated) {
-    nextEntries.push({ command });
-  }
-
-  hooks[event] = nextEntries;
-  return { config: { ...base, hooks }, changed: true };
+  return addFlatHookEntry(config, event, command, { isOwnBasename });
 }
 
 function applyWindsurfGateGuardHookToFile(hooksJsonPath, event, adapterScriptPath) {
-  const command = buildHookCommand(adapterScriptPath);
-  const current = readHooksFile(hooksJsonPath);
-  const { config, changed } = addWindsurfHookEntry(current, event, command);
-  if (changed) {
-    writeHooksFile(hooksJsonPath, config);
-  }
-  return { changed };
+  return applyFlatHookToFile(hooksJsonPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath), { isOwnBasename });
 }
 
-// Pure counterpart to addWindsurfHookEntry: drops only the EGC-managed
-// entry (matched by exact command) from hooks[event], leaving every other
-// entry (third-party hooks, other events) untouched. Deletes the event key
-// entirely once it is empty, rather than leaving a dangling `[]` in the
-// user's hooks.json.
 function removeWindsurfHookEntry(config, event, command) {
-  const base = isPlainObject(config) ? config : {};
-  const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
-  const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
-  const nextEntries = existing.filter(entry => !isEgcEntry(entry, command));
-
-  if (nextEntries.length === existing.length) {
-    return { config: base, changed: false };
-  }
-
-  if (nextEntries.length > 0) {
-    hooks[event] = nextEntries;
-  } else {
-    delete hooks[event];
-  }
-  return { config: { ...base, hooks }, changed: true };
+  return removeFlatHookEntry(config, event, command);
 }
 
 // install-lifecycle.js's install-manifests.js-driven repair/inspect/
@@ -155,28 +75,11 @@ function removeWindsurfHookEntry(config, event, command) {
 // already deleted. These two functions give install-lifecycle.js the same
 // remove/inspect primitives it already has for Claude's schema.
 function removeWindsurfGateGuardHookFromFile(hooksJsonPath, event, adapterScriptPath) {
-  if (!fs.existsSync(hooksJsonPath)) {
-    return { changed: false };
-  }
-  const command = buildHookCommand(adapterScriptPath);
-  const current = readHooksFile(hooksJsonPath);
-  const { config, changed } = removeWindsurfHookEntry(current, event, command);
-  if (changed) {
-    writeHooksFile(hooksJsonPath, config);
-  }
-  return { changed };
+  return removeFlatHookFromFile(hooksJsonPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath));
 }
 
 function inspectWindsurfGateGuardHookFile(hooksJsonPath, event, adapterScriptPath) {
-  try {
-    const command = buildHookCommand(adapterScriptPath);
-    const current = readHooksFile(hooksJsonPath);
-    const hooks = isPlainObject(current.hooks) ? current.hooks : {};
-    const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
-    return existing.some(entry => isEgcEntry(entry, command)) ? 'ok' : 'drifted';
-  } catch {
-    return 'drifted';
-  }
+  return inspectFlatHookFile(hooksJsonPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath));
 }
 
 module.exports = {

--- a/tests/hooks/cursor-guardian-adapter.test.js
+++ b/tests/hooks/cursor-guardian-adapter.test.js
@@ -62,6 +62,18 @@ function runTests() {
     assert.strictEqual(buildGuardianInput({ cwd: '/tmp' }), null);
   })) passed++; else failed++;
 
+  if (test('returns null (does not throw) for a non-object event, e.g. valid JSON "null"', () => {
+    assert.strictEqual(buildGuardianInput(null), null);
+    assert.strictEqual(buildGuardianInput('a string'), null);
+    assert.strictEqual(buildGuardianInput(42), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: a valid JSON "null" payload allows (exit 0) instead of crashing', () => {
+    const result = runAdapterCli('null');
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
   if (test('CLI: blocks a destructive command with exit 2 and a JSON deny response', () => {
     const result = runAdapterCli({ command: 'rm -rf /', cwd: '/tmp' });
     assert.strictEqual(result.code, 2);
@@ -92,9 +104,13 @@ function runTests() {
   if (test('CLI: an oversized payload that gets truncated into invalid JSON fails CLOSED (exit 2), not open', () => {
     // Same fail-closed-on-truncation guard as windsurf-guardian-adapter.js:
     // padding the payload past the 1MB stdin cap must not let an attacker
-    // dodge validation by making the JSON unparseable.
+    // dodge validation by making the JSON unparseable. Uses a SAFE command
+    // (not a command the Guardian would block on its own merits) so this
+    // only passes when the truncation guard itself fires -- with a
+    // destructive command, a regression that dropped the 1MB cap entirely
+    // would still exit 2 (ordinary command validation), masking the bug.
     const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
-    const oversizedInput = JSON.stringify({ command: 'rm -rf /', cwd: '/tmp', padding: oversizedPadding });
+    const oversizedInput = JSON.stringify({ command: 'git status', cwd: '/tmp', padding: oversizedPadding });
     const result = runAdapterCli(oversizedInput);
     assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
     const response = JSON.parse(result.stdout);

--- a/tests/hooks/cursor-guardian-adapter.test.js
+++ b/tests/hooks/cursor-guardian-adapter.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for scripts/hooks/cursor-guardian-adapter.js
+ *
+ * Cursor's beforeShellExecution hook uses a different wire contract than
+ * Claude Code's PreToolUse hook (see windsurf-guardian-adapter.test.js for
+ * the same pattern this mirrors) -- this file exercises both the pure
+ * translation function and the real CLI entrypoint end to end.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'cursor-guardian-adapter.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+const { buildGuardianInput } = require(adapterScript);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const result = spawnSync('node', [adapterScript], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, EGC_GUARDIAN_CLI: fakeCli, ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing cursor-guardian-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('maps a Cursor beforeShellExecution event to a Guardian Bash input', () => {
+    const mapped = buildGuardianInput({ command: 'echo hi', cwd: '/Users/example/project' });
+    assert.deepStrictEqual(mapped, { tool_name: 'Bash', tool_input: { command: 'echo hi' }, cwd: '/Users/example/project' });
+  })) passed++; else failed++;
+
+  if (test('omits cwd when the event has none (not a string)', () => {
+    const mapped = buildGuardianInput({ command: 'echo hi' });
+    assert.strictEqual('cwd' in mapped, false);
+  })) passed++; else failed++;
+
+  if (test('returns null for an event with no command', () => {
+    assert.strictEqual(buildGuardianInput({ cwd: '/tmp' }), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: blocks a destructive command with exit 2 and a JSON deny response', () => {
+    const result = runAdapterCli({ command: 'rm -rf /', cwd: '/tmp' });
+    assert.strictEqual(result.code, 2);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.permission, 'deny');
+    assert.ok(response.user_message.length > 0, 'expected a user_message');
+    assert.ok(response.agent_message.length > 0, 'expected an agent_message');
+  })) passed++; else failed++;
+
+  if (test('CLI: allows a safe allowlisted command (exit 0, permission allow)', () => {
+    const result = runAdapterCli({ command: 'git status', cwd: '/tmp' });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: event with no command allows (exit 0, permission allow)', () => {
+    const result = runAdapterCli({ cwd: '/tmp' });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed (non-truncated) stdin JSON fails open (exit 0, allow)', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: an oversized payload that gets truncated into invalid JSON fails CLOSED (exit 2), not open', () => {
+    // Same fail-closed-on-truncation guard as windsurf-guardian-adapter.js:
+    // padding the payload past the 1MB stdin cap must not let an attacker
+    // dodge validation by making the JSON unparseable.
+    const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({ command: 'rm -rf /', cwd: '/tmp', padding: oversizedPadding });
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.permission, 'deny');
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/windsurf-guardian-adapter.test.js
+++ b/tests/hooks/windsurf-guardian-adapter.test.js
@@ -83,6 +83,17 @@ function runTests() {
     assert.strictEqual(buildGuardianInput({ agent_action_name: 'pre_run_command', tool_info: {} }), null);
   })) passed++; else failed++;
 
+  if (test('returns null (does not throw) for a non-object event, e.g. valid JSON "null"', () => {
+    assert.strictEqual(buildGuardianInput(null), null);
+    assert.strictEqual(buildGuardianInput('a string'), null);
+    assert.strictEqual(buildGuardianInput(42), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: a valid JSON "null" payload allows (exit 0) instead of crashing', () => {
+    const result = runAdapterCli('null');
+    assert.strictEqual(result.code, 0);
+  })) passed++; else failed++;
+
   if (test('CLI: blocks a destructive command with exit 2 and a reason on stderr', () => {
     const result = runAdapterCli({
       agent_action_name: 'pre_run_command',
@@ -121,11 +132,15 @@ function runTests() {
     // truncated, syntactically invalid document -- before the fix this hit
     // the generic "malformed input" catch and allowed the command through
     // unvalidated, letting an attacker pad any command past the cap to
-    // bypass the Guardian entirely.
+    // bypass the Guardian entirely. Uses a SAFE command (not one the
+    // Guardian would block on its own merits) so this only passes when the
+    // truncation guard itself fires -- with a destructive command, a
+    // regression that dropped the 1MB cap entirely would still exit 2 via
+    // ordinary command validation, masking the bug.
     const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
     const oversizedInput = JSON.stringify({
       agent_action_name: 'pre_run_command',
-      tool_info: { command_line: 'rm -rf /', padding: oversizedPadding },
+      tool_info: { command_line: 'git status', padding: oversizedPadding },
     });
     const result = runAdapterCli(oversizedInput);
     assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);

--- a/tests/lib/cursor-guardian-hooks.test.js
+++ b/tests/lib/cursor-guardian-hooks.test.js
@@ -115,6 +115,53 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('applyCursorGuardianHookToFile seeds a fresh file from seedPath, keeping the seed\'s other hooks', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-hooks-seed-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    const seedPath = path.join(tempDir, 'seed-hooks.json');
+    try {
+      fs.writeFileSync(seedPath, JSON.stringify({
+        version: 1,
+        hooks: { sessionStart: [{ command: 'node .cursor/hooks/session-start.js' }] },
+      }, null, 2));
+
+      const result = applyCursorGuardianHookToFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js', { seedPath });
+      assert.strictEqual(result.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(onDisk.hooks.sessionStart, [{ command: 'node .cursor/hooks/session-start.js' }]);
+      assert.strictEqual(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 1);
+      assert.ok(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT][0].command.includes('adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyCursorGuardianHookToFile ignores seedPath once the destination already exists', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-hooks-seed-existing-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    const seedPath = path.join(tempDir, 'seed-hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, JSON.stringify({
+        version: 1,
+        hooks: { afterFileEdit: [{ command: 'node .cursor/hooks/after-file-edit.js' }] },
+      }, null, 2));
+      fs.writeFileSync(seedPath, JSON.stringify({
+        version: 1,
+        hooks: { sessionStart: [{ command: 'node .cursor/hooks/session-start.js' }] },
+      }, null, 2));
+
+      applyCursorGuardianHookToFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js', { seedPath });
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(onDisk.hooks.afterFileEdit, [{ command: 'node .cursor/hooks/after-file-edit.js' }]);
+      assert.strictEqual(onDisk.hooks.sessionStart, undefined, 'Should not pull in the seed once the real file already exists');
+      assert.strictEqual(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 1);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('applyCursorGuardianHookToFile preserves a hand-written hooks.json on disk', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-hooks-preserve-'));
     const hooksJsonPath = path.join(tempDir, 'hooks.json');

--- a/tests/lib/cursor-guardian-hooks.test.js
+++ b/tests/lib/cursor-guardian-hooks.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests for scripts/lib/cursor-guardian-hooks.js
+ *
+ * Cursor's hooks.json schema is a flat {version, hooks: {<event>: [{command}]}}
+ * map (no matcher/group wrapper, no "type": "command" field), unlike Claude
+ * Code's settings.json, so it needs its own merge logic. These tests exercise
+ * that merge logic directly (additive, idempotent, preserves unrelated keys
+ * and third-party hooks).
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  BEFORE_SHELL_EXECUTION_EVENT,
+  addCursorHookEntry,
+  applyCursorGuardianHookToFile,
+  inspectCursorGuardianHookFile,
+  removeCursorGuardianHookFromFile,
+  removeCursorHookEntry,
+  resolveGuardianAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('../../scripts/lib/cursor-guardian-hooks');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing cursor-guardian-hooks ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('resolveHooksJsonPath and resolveGuardianAdapterScriptDestination compute paths under targetRoot', () => {
+    const targetRoot = '/home/user/project/.cursor';
+    assert.strictEqual(resolveHooksJsonPath(targetRoot), path.join(targetRoot, 'hooks.json'));
+    assert.strictEqual(
+      resolveGuardianAdapterScriptDestination(targetRoot),
+      path.join(targetRoot, 'scripts', 'hooks', 'cursor-guardian-adapter.js')
+    );
+  })) passed++; else failed++;
+
+  if (test('addCursorHookEntry appends a new event array on an empty config, defaulting version', () => {
+    const { config, changed } = addCursorHookEntry({}, BEFORE_SHELL_EXECUTION_EVENT, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.strictEqual(config.version, 1);
+    assert.deepStrictEqual(config.hooks[BEFORE_SHELL_EXECUTION_EVENT], [{ command: 'node adapter.js' }]);
+  })) passed++; else failed++;
+
+  if (test('addCursorHookEntry is idempotent (no duplicate on re-add)', () => {
+    const first = addCursorHookEntry({}, BEFORE_SHELL_EXECUTION_EVENT, 'node adapter.js');
+    const second = addCursorHookEntry(first.config, BEFORE_SHELL_EXECUTION_EVENT, 'node adapter.js');
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.config.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 1);
+  })) passed++; else failed++;
+
+  if (test('addCursorHookEntry preserves third-party hooks in the same event array', () => {
+    const base = {
+      version: 1,
+      hooks: { [BEFORE_SHELL_EXECUTION_EVENT]: [{ command: 'node .cursor/hooks/before-shell-execution.js' }] },
+    };
+    const { config } = addCursorHookEntry(base, BEFORE_SHELL_EXECUTION_EVENT, 'node adapter.js');
+    assert.strictEqual(config.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 2);
+    assert.ok(config.hooks[BEFORE_SHELL_EXECUTION_EVENT].some(entry => entry.command === 'node .cursor/hooks/before-shell-execution.js'));
+    assert.ok(config.hooks[BEFORE_SHELL_EXECUTION_EVENT].some(entry => entry.command === 'node adapter.js'));
+  })) passed++; else failed++;
+
+  if (test('addCursorHookEntry preserves unrelated events and top-level keys', () => {
+    const base = { version: 1, hooks: { preToolUse: [{ command: 'node before-tool-use.js' }] } };
+    const { config } = addCursorHookEntry(base, BEFORE_SHELL_EXECUTION_EVENT, 'node adapter.js');
+    assert.strictEqual(config.version, 1);
+    assert.deepStrictEqual(config.hooks.preToolUse, [{ command: 'node before-tool-use.js' }]);
+    assert.deepStrictEqual(config.hooks[BEFORE_SHELL_EXECUTION_EVENT], [{ command: 'node adapter.js' }]);
+  })) passed++; else failed++;
+
+  if (test('addCursorHookEntry migrates a stale entry (same script, different path) in place instead of duplicating', () => {
+    const base = {
+      version: 1,
+      hooks: {
+        [BEFORE_SHELL_EXECUTION_EVENT]: [{ command: 'node /old/path/cursor-guardian-adapter.js' }],
+      },
+    };
+    const { config, changed } = addCursorHookEntry(base, BEFORE_SHELL_EXECUTION_EVENT, 'node /new/path/cursor-guardian-adapter.js');
+    assert.strictEqual(changed, true);
+    assert.strictEqual(config.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 1, 'must migrate in place, not append a duplicate');
+    assert.strictEqual(config.hooks[BEFORE_SHELL_EXECUTION_EVENT][0].command, 'node /new/path/cursor-guardian-adapter.js');
+  })) passed++; else failed++;
+
+  if (test('applyCursorGuardianHookToFile writes the event to a fresh file and is idempotent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-hooks-apply-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      const first = applyCursorGuardianHookToFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js');
+      assert.strictEqual(first.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDisk.version, 1);
+      assert.strictEqual(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 1);
+
+      const second = applyCursorGuardianHookToFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js');
+      assert.strictEqual(second.changed, false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyCursorGuardianHookToFile preserves a hand-written hooks.json on disk', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-hooks-preserve-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, JSON.stringify({
+        version: 1,
+        hooks: { afterFileEdit: [{ command: 'node .cursor/hooks/after-file-edit.js' }] },
+      }, null, 2));
+
+      applyCursorGuardianHookToFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js');
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(onDisk.hooks.afterFileEdit, [{ command: 'node .cursor/hooks/after-file-edit.js' }]);
+      assert.strictEqual(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 1);
+      assert.ok(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT][0].command.includes('adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('removeCursorHookEntry drops only the EGC entry, keeps third-party hooks and other events', () => {
+    const base = {
+      version: 1,
+      hooks: {
+        [BEFORE_SHELL_EXECUTION_EVENT]: [
+          { command: 'node .cursor/hooks/before-shell-execution.js' },
+          { command: 'node adapter.js' },
+        ],
+        afterFileEdit: [{ command: 'node .cursor/hooks/after-file-edit.js' }],
+      },
+    };
+    const { config, changed } = removeCursorHookEntry(base, BEFORE_SHELL_EXECUTION_EVENT, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config.hooks[BEFORE_SHELL_EXECUTION_EVENT], [{ command: 'node .cursor/hooks/before-shell-execution.js' }]);
+    assert.deepStrictEqual(config.hooks.afterFileEdit, [{ command: 'node .cursor/hooks/after-file-edit.js' }]);
+  })) passed++; else failed++;
+
+  if (test('removeCursorHookEntry deletes the event key entirely once empty', () => {
+    const base = { version: 1, hooks: { [BEFORE_SHELL_EXECUTION_EVENT]: [{ command: 'node adapter.js' }] } };
+    const { config } = removeCursorHookEntry(base, BEFORE_SHELL_EXECUTION_EVENT, 'node adapter.js');
+    assert.strictEqual(BEFORE_SHELL_EXECUTION_EVENT in config.hooks, false);
+  })) passed++; else failed++;
+
+  if (test('removeCursorGuardianHookFromFile on a missing file is a no-op', () => {
+    const result = removeCursorGuardianHookFromFile('/nonexistent/hooks.json', BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js');
+    assert.strictEqual(result.changed, false);
+  })) passed++; else failed++;
+
+  if (test('inspectCursorGuardianHookFile reports ok when present, drifted when absent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-hooks-inspect-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      assert.strictEqual(inspectCursorGuardianHookFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js'), 'drifted');
+      applyCursorGuardianHookToFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js');
+      assert.strictEqual(inspectCursorGuardianHookFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/adapter.js'), 'ok');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-manifests.test.js
+++ b/tests/lib/install-manifests.test.js
@@ -172,12 +172,15 @@ function runTests() {
     assert.strictEqual(plan.installStatePath, path.join(projectRoot, '.cursor', 'egc-install-state.json'));
     assert.ok(plan.operations.length > 0, 'Should include scaffold operations');
     assert.ok(
+      !plan.operations.some(operation => operation.sourceRelativePath === '.cursor/hooks.json'),
+      'Should not copy the repo\'s own .cursor/hooks.json raw -- the Guardian merge operation owns that destination alone'
+    );
+    assert.ok(
       plan.operations.some(operation => (
-        operation.sourceRelativePath === '.cursor/hooks.json'
-        && operation.destinationPath === path.join(projectRoot, '.cursor', 'hooks.json')
-        && operation.strategy === 'preserve-relative-path'
+        operation.destinationPath === path.join(projectRoot, '.cursor', 'hooks.json')
+        && operation.kind === 'merge-claude-settings-hooks'
       )),
-      'Should preserve non-rule Cursor platform files'
+      'hooks.json should still be planned, but only via the Guardian merge operation'
     );
     assert.ok(
       plan.operations.some(operation => (

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -135,8 +135,12 @@ function runTests() {
     assert.strictEqual(plan.targetRoot, path.join(projectRoot, '.cursor'));
     assert.strictEqual(plan.installStatePath, path.join(projectRoot, '.cursor', 'egc-install-state.json'));
 
-    const hooksJson = plan.operations.find(operation => (
+    const hooksJsonRawCopy = plan.operations.find(operation => (
       normalizedRelativePath(operation.sourceRelativePath) === '.cursor/hooks.json'
+    ));
+    const hooksJsonMerge = plan.operations.find(operation => (
+      operation.destinationPath === path.join(projectRoot, '.cursor', 'hooks.json')
+      && operation.kind === 'merge-claude-settings-hooks'
     ));
     const mcpJson = plan.operations.find(operation => (
       normalizedRelativePath(operation.sourceRelativePath) === '.mcp.json'
@@ -145,9 +149,11 @@ function runTests() {
       normalizedRelativePath(operation.sourceRelativePath) === '.cursor/rules/common-coding-style.md'
     ));
 
-    assert.ok(hooksJson, 'Should preserve non-rule Cursor platform config files');
-    assert.strictEqual(hooksJson.strategy, 'preserve-relative-path');
-    assert.strictEqual(hooksJson.destinationPath, path.join(projectRoot, '.cursor', 'hooks.json'));
+    assert.ok(
+      !hooksJsonRawCopy,
+      'Should not copy the repo\'s own .cursor/hooks.json raw -- the Guardian merge operation owns that destination alone'
+    );
+    assert.ok(hooksJsonMerge, 'hooks.json should still be planned, but only via the Guardian merge operation');
     assert.ok(mcpJson, 'Should materialize a Cursor MCP config from the shared root MCP config');
     assert.strictEqual(mcpJson.kind, 'merge-json');
     assert.strictEqual(mcpJson.strategy, 'merge-json');
@@ -195,6 +201,50 @@ function runTests() {
     assert.ok(mergeOperation, 'Should plan the beforeShellExecution hooks.json merge');
     assert.strictEqual(mergeOperation.destinationPath, path.join(targetRoot, 'hooks.json'));
     assert.strictEqual(mergeOperation.hookScriptPath, adapterScriptDestination);
+  })) passed++; else failed++;
+
+  if (test('cursor .cursor module never copies the repo\'s own hooks.json raw (the Guardian merge owns that destination alone)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'cursor',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'platform-configs', paths: ['.cursor'] }],
+    });
+    const targetRoot = path.join(projectRoot, '.cursor');
+    const hooksJsonDestination = path.join(targetRoot, 'hooks.json');
+
+    const operationsForHooksJson = plan.operations.filter(operation => operation.destinationPath === hooksJsonDestination);
+    assert.strictEqual(operationsForHooksJson.length, 1, 'Exactly one operation should target hooks.json (the Guardian merge)');
+    assert.strictEqual(operationsForHooksJson[0].kind, 'merge-claude-settings-hooks');
+    assert.strictEqual(
+      operationsForHooksJson[0].seedPath,
+      path.join(repoRoot, '.cursor', 'hooks.json'),
+      'The merge operation should carry the repo\'s own hooks.json as a seed, so a fresh install still gets EGC\'s other platform hooks (sessionStart, GateGuard, etc.), not just the Guardian entry'
+    );
+  })) passed++; else failed++;
+
+  if (test('cursor hooks-runtime module does not duplicate the Guardian\'s own per-file copies (its directory scaffold already covers them)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'cursor',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'hooks-runtime', paths: ['scripts/hooks', 'scripts/lib'] }],
+    });
+
+    const guardianAdapterCopies = plan.operations.filter(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/cursor-guardian-adapter.js'
+    ));
+    assert.strictEqual(
+      guardianAdapterCopies.length,
+      1,
+      'The adapter script should come from the scripts/hooks directory scaffold exactly once, not also as a redundant standalone copy'
+    );
   })) passed++; else failed++;
 
   if (test('plans cursor rules with flat namespaced filenames to avoid rule collisions', () => {
@@ -351,11 +401,15 @@ function runTests() {
       'Should not preserve .md Cursor platform rule files'
     );
     assert.ok(
+      !plan.operations.some(operation => normalizedRelativePath(operation.sourceRelativePath) === '.cursor/hooks.json'),
+      'Should not copy the repo\'s own .cursor/hooks.json raw -- the Guardian merge operation owns that destination alone'
+    );
+    assert.ok(
       plan.operations.some(operation => (
-        normalizedRelativePath(operation.sourceRelativePath) === '.cursor/hooks.json'
-        && operation.destinationPath === path.join(projectRoot, '.cursor', 'hooks.json')
+        operation.destinationPath === path.join(projectRoot, '.cursor', 'hooks.json')
+        && operation.kind === 'merge-claude-settings-hooks'
       )),
-      'Should preserve non-rule Cursor platform config files'
+      'hooks.json should still be planned, but only via the Guardian merge operation'
     );
     assert.ok(
       plan.operations.some(operation => (

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -161,6 +161,42 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('cursor adapter always plans the Guardian beforeShellExecution hook, even with no modules selected (EGC-494/EGC-498)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'cursor',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+    const targetRoot = path.join(projectRoot, '.cursor');
+    const adapterScriptDestination = path.join(targetRoot, 'scripts', 'hooks', 'cursor-guardian-adapter.js');
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'
+        && operation.destinationPath === path.join(targetRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js')
+      )),
+      'Should plan the shared Guardian validator copy even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/cursor-guardian-adapter.js'
+        && operation.destinationPath === adapterScriptDestination
+      )),
+      'Should plan the Cursor-specific adapter copy even with no modules selected'
+    );
+
+    const mergeOperation = plan.operations.find(
+      operation => operation.kind === 'merge-claude-settings-hooks' && operation.hookEvent === 'beforeShellExecution'
+    );
+    assert.ok(mergeOperation, 'Should plan the beforeShellExecution hooks.json merge');
+    assert.strictEqual(mergeOperation.destinationPath, path.join(targetRoot, 'hooks.json'));
+    assert.strictEqual(mergeOperation.hookScriptPath, adapterScriptDestination);
+  })) passed++; else failed++;
+
   if (test('plans cursor rules with flat namespaced filenames to avoid rule collisions', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -226,6 +226,28 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('cursor Guardian merge omits seedPath when the .cursor module was not selected (minimal/rules-only installs stay minimal)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'cursor',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'rules-core', paths: ['rules'] }],
+    });
+    const targetRoot = path.join(projectRoot, '.cursor');
+    const hooksJsonDestination = path.join(targetRoot, 'hooks.json');
+
+    const mergeOperation = plan.operations.find(operation => operation.destinationPath === hooksJsonDestination);
+    assert.ok(mergeOperation, 'The Guardian merge should still be planned unconditionally');
+    assert.strictEqual(
+      mergeOperation.seedPath,
+      undefined,
+      'Should not seed this repo\'s own platform hooks (dashboard-emit, tmux blocker, etc.) into an install that never selected .cursor'
+    );
+  })) passed++; else failed++;
+
   if (test('cursor hooks-runtime module does not duplicate the Guardian\'s own per-file copies (its directory scaffold already covers them)', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -97,7 +97,7 @@ function runTests() {
       assert.ok(installStdout.includes('Done. Install-state written'));
 
       const normalizedProjectRoot = fs.realpathSync(projectRoot);
-      const managedPath = path.join(normalizedProjectRoot, '.cursor', 'hooks.json');
+      const managedPath = path.join(normalizedProjectRoot, '.cursor', 'scripts', 'hooks', 'cursor-guardian-adapter.js');
       const statePath = path.join(normalizedProjectRoot, '.cursor', 'egc-install-state.json');
       const unrelatedPath = path.join(normalizedProjectRoot, '.cursor', 'custom-user-note.txt');
       fs.writeFileSync(unrelatedPath, 'leave me alone');


### PR DESCRIPTION
## Summary
- Cursor's `beforeShellExecution` hook confirmed viable for the Guardian (EGC-498 research, verified directly against Cursor's official docs): block/allow via a `{permission, ...}` JSON response and exit code 2.
- Adds `scripts/hooks/cursor-guardian-adapter.js`, translating Cursor's `{command, cwd}` wire shape to the shared `pre-bash-guardian-validate.js` contract (same pattern as the existing Windsurf adapter).
- Adds `scripts/lib/cursor-guardian-hooks.js`: Cursor's `.cursor/hooks.json` is a flat `{version, hooks: {<event>: [{command}]}}` map, not Claude's matcher/group schema, so it needs its own idempotent array-merge logic instead of the generic deep-merge-json strategy (which would silently overwrite a user's other `beforeShellExecution` entries).
- Wired unconditionally into `cursor-project.js` (every install registers the hook, even with no content modules selected) and into `install-lifecycle.js`'s uninstall/inspect dispatchers.

## Test plan
- [x] `npm test` full suite: 3031/3031 passing
- [x] New unit coverage: `tests/lib/cursor-guardian-hooks.test.js` (12/12), `tests/hooks/cursor-guardian-adapter.test.js` (8/8)
- [x] New install-plan coverage in `tests/lib/install-targets.test.js` confirming the hook plans even with zero modules selected
- [x] Verified end-to-end on a real isolated install (`HOME` override, `--target cursor --profile full`): confirmed the merge preserves every pre-existing `beforeShellExecution` entry (dashboard-emit, block-no-verify, before-shell-execution.js) and only appends the Guardian entry; confirmed the real adapter blocks `wget -O ~/.bashrc <url>` (exit 2) and allows `git status` (exit 0)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Guardian Bash command validator into Cursor’s `beforeShellExecution` hook to block risky shell commands and allow safe ones, meeting EGC-494/EGC-498. The hook installs unconditionally and preserves existing platform hooks.

- **New Features**
  - Added `scripts/hooks/cursor-guardian-adapter.js` to translate Cursor `{command, cwd}` and emit `{permission, ...}` JSON.
  - Added `scripts/lib/cursor-guardian-hooks.js` with idempotent `.cursor/hooks.json` merging via `scripts/lib/flat-hooks-json-merge.js`.
  - Updated Cursor install to always register the hook and support uninstall/inspect via `scripts/lib/install-lifecycle.js` and `scripts/lib/claude-settings-hooks.js`.

- **Bug Fixes**
  - Guarded null/non-object events in both adapters; Windsurf now uses the shared `scripts/lib/adapter-stdin-json.js`.
  - Seed the Cursor merge from the repo’s `.cursor/hooks.json` on fresh installs and stop raw copying that file to keep all other hooks and avoid drift.
  - Scope that seed to installs that selected `.cursor`, so minimal or rules-only installs don’t silently enable extra platform hooks.
  - Avoid duplicate Guardian copies when `hooks-runtime` scaffolds `scripts/hooks` and `scripts/lib`.

<sup>Written for commit 38fe1032a348501cdd27333cab1d1c86da68fc2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

