### PR TITLE
feat(guardian): wire the Guardian and Token Crusher into OpenCode via an in-process plugin

### DIFF
--- a/scripts/hooks/opencode-egc-plugin.js
+++ b/scripts/hooks/opencode-egc-plugin.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// EGC Guardian + Token Crusher plugin for OpenCode (docs:
+// https://opencode.ai/docs/plugins). Unlike Claude Code/Cursor/Windsurf --
+// an external hook script spawned as a subprocess per invocation, with an
+// event-specific wire contract on stdin/stdout -- OpenCode loads a plugin
+// file like this one IN-PROCESS: `tool.execute.before(input, output)` runs
+// directly inside OpenCode's own Bun runtime, `output` is a mutable object,
+// and throwing blocks the tool call. That lets this plugin call straight
+// into the same run() functions the other hosts' adapters spawn as
+// subprocesses -- no translation adapter needed, just the two requires
+// below.
+//
+// EGC-498: OpenCode is the only one of the four newly-researched hosts
+// (Windsurf, Cursor, OpenCode, Kiro) whose hook contract supports mutating
+// the tool call before it runs (`output.args.command = ...`), which the
+// Token Crusher's rewrite-based design requires. Windsurf/Cursor/Kiro are
+// block-only, so they only get the Guardian, not the Crusher, until a
+// non-rewrite mechanism exists for them.
+//
+// pre-bash-guardian-validate.js's run() and pre-bash-crusher-rewrite.js's
+// run() are copied alongside this file (same targetRoot, preserve-relative-
+// path), so these requires resolve at install time.
+
+const { run: runGuardian } = require('../scripts/hooks/pre-bash-guardian-validate');
+const { run: runCrusherRewrite } = require('../scripts/hooks/pre-bash-crusher-rewrite');
+
+const EgcGuardianCrusher = async ({ directory } = {}) => {
+  return {
+    'tool.execute.before': async (input, output) => {
+      if (!input || input.tool !== 'bash' || typeof output?.args?.command !== 'string') {
+        return;
+      }
+
+      const command = output.args.command;
+
+      // Guardian first: a blocked command must never reach the Crusher
+      // rewrite below -- rewriting a command that is about to be denied
+      // anyway is pointless work on the hot path.
+      const guardianResult = runGuardian({ tool_name: 'Bash', tool_input: { command }, cwd: directory });
+      if (guardianResult.exitCode === 2) {
+        throw new Error(guardianResult.stderr || 'Blocked by the EGC Guardian.');
+      }
+
+      // Crusher: run() is fail-open by design (returns the input JSON
+      // unchanged on any error, missing engine, or non-crushable command --
+      // see pre-bash-crusher-rewrite.js), so no try/catch is needed here.
+      const rewritten = JSON.parse(runCrusherRewrite({ tool_input: { command } }));
+      if (typeof rewritten?.tool_input?.command === 'string') {
+        output.args.command = rewritten.tool_input.command;
+      }
+    },
+  };
+};
+
+module.exports = { EgcGuardianCrusher };

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -6,6 +6,50 @@ const {
   isForeignPlatformPath,
   normalizeRelativePath,
 } = require('./helpers');
+const {
+  BASH_GUARDIAN_HOOK_MODULE_ID,
+  createBashGuardianScriptCopyOperations,
+  createCrusherScriptCopyOperations,
+} = require('../claude-settings-hooks');
+
+// OpenCode plugins run IN-PROCESS (Bun runtime), unlike every other target's
+// externally-spawned hooks.json subprocess -- opencode-egc-plugin.js
+// `require()`s pre-bash-guardian-validate.js's and
+// pre-bash-crusher-rewrite.js's own run() functions directly, so there is no
+// stdin/stdout translation adapter to wire, only a plugin file to drop into
+// OpenCode's auto-discovered plugins/ directory (docs:
+// https://opencode.ai/docs/plugins) alongside the same Guardian/Crusher
+// script trees every other target copies via the shared builders below.
+// EGC-498: OpenCode is the only one of the newly-researched hosts (Windsurf,
+// Cursor, OpenCode, Kiro) whose hook contract can mutate the tool call
+// (`output.args.command = ...`) before it runs, which the Token Crusher's
+// rewrite-based design requires -- so it is the only one of the four wired
+// for both the Guardian and the Crusher, not the Guardian alone.
+const PLUGIN_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/opencode-egc-plugin.js';
+
+function resolvePluginScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'plugins', 'opencode-egc-plugin.js');
+}
+
+function createOpenCodeGuardianCrusherOperations(adapter, targetRoot) {
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+
+  const pluginCopyOperation = createRemappedOperation(
+    adapter,
+    BASH_GUARDIAN_HOOK_MODULE_ID,
+    PLUGIN_SCRIPT_SOURCE_RELATIVE_PATH,
+    resolvePluginScriptDestination(targetRoot),
+    { strategy: 'preserve-relative-path' }
+  );
+
+  return [
+    ...createBashGuardianScriptCopyOperations(remap, targetRoot),
+    ...createCrusherScriptCopyOperations(remap, targetRoot),
+    pluginCopyOperation,
+  ];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'opencode-home',
@@ -30,7 +74,7 @@ module.exports = createInstallTargetAdapter({
     };
     const targetRoot = adapter.resolveRoot(planningInput);
 
-    return modules.flatMap(module => {
+    const moduleOperations = modules.flatMap(module => {
       const paths = (Array.isArray(module.paths) ? module.paths : [])
         .filter(p => !isForeignPlatformPath(p, adapter.target));
       return paths.flatMap(sourceRelativePath => {
@@ -55,5 +99,10 @@ module.exports = createInstallTargetAdapter({
         return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
       });
     });
+
+    return [
+      ...moduleOperations,
+      ...createOpenCodeGuardianCrusherOperations(adapter, targetRoot),
+    ];
   },
 });

--- a/tests/hooks/opencode-egc-plugin.test.js
+++ b/tests/hooks/opencode-egc-plugin.test.js
@@ -1,0 +1,126 @@
+/**
+ * Tests for scripts/hooks/opencode-egc-plugin.js
+ *
+ * Unlike every other host's hooks.json subprocess adapter, this plugin's
+ * require() calls are DESTINATION-relative (`../scripts/hooks/...`), not
+ * sibling-relative -- they only resolve once installed at
+ * <targetRoot>/plugins/opencode-egc-plugin.js alongside a real
+ * <targetRoot>/scripts/hooks and <targetRoot>/scripts/lib tree (see the
+ * plugin's own header comment). So these tests drive the real
+ * opencode-home.js install plan to materialize that exact shape in a temp
+ * dir, then require() the plugin from ITS INSTALLED location -- this
+ * exercises the real require-path contract, not a stand-in.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { planInstallTargetScaffold } = require('../../scripts/lib/install-targets/registry');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const FAKE_CLI = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+
+function installOpenCodePlugin(homeDir) {
+  const plan = planInstallTargetScaffold({ target: 'opencode', repoRoot: REPO_ROOT, homeDir, modules: [] });
+  for (const operation of plan.operations) {
+    const sourcePath = path.join(REPO_ROOT, operation.sourceRelativePath);
+    if (!fs.existsSync(sourcePath) || !fs.statSync(sourcePath).isFile()) continue;
+    fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
+    fs.copyFileSync(sourcePath, operation.destinationPath);
+  }
+  return path.join(homeDir, '.config', 'opencode', 'plugins', 'opencode-egc-plugin.js');
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing opencode-egc-plugin ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-plugin-'));
+  const originalGuardianCli = process.env.EGC_GUARDIAN_CLI;
+  const originalAssumeEgcCli = process.env.EGC_ASSUME_EGC_CLI;
+  process.env.EGC_GUARDIAN_CLI = FAKE_CLI;
+  process.env.EGC_ASSUME_EGC_CLI = '0';
+
+  let EgcGuardianCrusher;
+  try {
+    const installedPluginPath = installOpenCodePlugin(tempDir);
+
+    if (test('installs the plugin and its Guardian/Crusher dependency tree so require() resolves', () => {
+      assert.ok(fs.existsSync(installedPluginPath), 'plugin file should be copied to plugins/');
+      // Throws if any destination-relative require() target is missing.
+      delete require.cache[require.resolve(installedPluginPath)];
+      ({ EgcGuardianCrusher } = require(installedPluginPath));
+      assert.strictEqual(typeof EgcGuardianCrusher, 'function');
+    })) passed++; else failed++;
+
+    if (test('ignores non-bash tools (no-op, does not throw)', async () => {
+      const hooks = await EgcGuardianCrusher({ directory: tempDir });
+      const output = { args: { filePath: '/tmp/x' } };
+      await hooks['tool.execute.before']({ tool: 'read' }, output);
+      assert.deepStrictEqual(output.args, { filePath: '/tmp/x' });
+    })) passed++; else failed++;
+
+    if (test('ignores a bash input with no command arg (no-op, does not throw)', async () => {
+      const hooks = await EgcGuardianCrusher({ directory: tempDir });
+      const output = { args: {} };
+      await hooks['tool.execute.before']({ tool: 'bash' }, output);
+      assert.deepStrictEqual(output.args, {});
+    })) passed++; else failed++;
+
+    if (test('blocks a destructive command by throwing (Guardian runs before the Crusher rewrite)', async () => {
+      const hooks = await EgcGuardianCrusher({ directory: tempDir });
+      const output = { args: { command: 'rm -rf /' } };
+      await assert.rejects(
+        () => hooks['tool.execute.before']({ tool: 'bash' }, output),
+        /EGC Guardian BLOCKED/
+      );
+      assert.strictEqual(output.args.command, 'rm -rf /', 'must not rewrite a command that gets blocked');
+    })) passed++; else failed++;
+
+    if (test('allows a safe command through unmodified when the Crusher has no CLI to route through', async () => {
+      const hooks = await EgcGuardianCrusher({ directory: tempDir });
+      const output = { args: { command: 'git status' } };
+      await hooks['tool.execute.before']({ tool: 'bash' }, output);
+      assert.strictEqual(output.args.command, 'git status');
+    })) passed++; else failed++;
+
+    if (test('rewrites a crushable safe command through `egc run` when the Crusher CLI is available', async () => {
+      process.env.EGC_ASSUME_EGC_CLI = '1';
+      try {
+        const hooks = await EgcGuardianCrusher({ directory: tempDir });
+        const output = { args: { command: 'npm test' } };
+        await hooks['tool.execute.before']({ tool: 'bash' }, output);
+        assert.strictEqual(output.args.command, 'egc run npm test');
+      } finally {
+        process.env.EGC_ASSUME_EGC_CLI = '0';
+      }
+    })) passed++; else failed++;
+  } finally {
+    if (originalGuardianCli === undefined) delete process.env.EGC_GUARDIAN_CLI;
+    else process.env.EGC_GUARDIAN_CLI = originalGuardianCli;
+    if (originalAssumeEgcCli === undefined) delete process.env.EGC_ASSUME_EGC_CLI;
+    else process.env.EGC_ASSUME_EGC_CLI = originalAssumeEgcCli;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1192,6 +1192,35 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('opencode adapter always plans the Guardian+Crusher plugin, even with no modules selected (EGC-494/EGC-498)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'opencode',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+
+    const pluginDestination = path.join(homeDir, '.config', 'opencode', 'plugins', 'opencode-egc-plugin.js');
+    assert.ok(
+      plan.operations.some(op => (
+        normalizedRelativePath(op.sourceRelativePath) === 'scripts/hooks/opencode-egc-plugin.js'
+        && op.destinationPath === pluginDestination
+      )),
+      'Should copy the OpenCode Guardian+Crusher plugin into ~/.config/opencode/plugins/'
+    );
+    assert.ok(
+      plan.operations.some(op => normalizedRelativePath(op.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'),
+      'Should copy pre-bash-guardian-validate.js so the plugin\'s require() resolves'
+    );
+    assert.ok(
+      plan.operations.some(op => normalizedRelativePath(op.sourceRelativePath) === 'scripts/hooks/pre-bash-crusher-rewrite.js'),
+      'Should copy pre-bash-crusher-rewrite.js so the plugin\'s require() resolves'
+    );
+  })) passed++; else failed++;
+
   if (test('codebuddy adapter strips category from skill paths and installs flat', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';


### PR DESCRIPTION
## Summary
- OpenCode plugins run in-process (Bun runtime), so `tool.execute.before` can mutate `output.args.command` before the tool runs -- the only one of the four newly-researched hosts (Windsurf, Cursor, OpenCode, Kiro) that supports command rewriting, so it gets both the Guardian (block) and the Token Crusher (rewrite), not the Guardian alone.
- `opencode-egc-plugin.js` requires `pre-bash-guardian-validate.js`'s and `pre-bash-crusher-rewrite.js`'s own `run()` functions directly (no stdin/stdout translation adapter needed).
- Wired unconditionally into every OpenCode install via `opencode-home.js`.

## Test plan
- [x] `node tests/hooks/opencode-egc-plugin.test.js` -- exercises the plugin from its real installed location (materialized via the actual `planInstallTargetScaffold` operation plan), not a stand-in: block, allow, and Crusher-rewrite paths all covered.
- [x] `node tests/lib/install-targets.test.js` -- confirms the plugin + Guardian/Crusher dependency tree is planned unconditionally, even with no content modules selected.
- [x] Full suite: `npm test` (3031/3031 passed), `npx eslint` clean.

https://claude.ai/code/session_019BpofkJoGaxCkoKcX1RSrn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the EGC Guardian and Token Crusher into OpenCode via an in-process plugin that blocks unsafe bash commands and rewrites safe ones before execution. Installed for all OpenCode setups to satisfy EGC-494 and enable rewrite support per EGC-498.

- **New Features**
  - Added `opencode-egc-plugin.js` that runs inside OpenCode’s Bun runtime and rewrites `output.args.command` in `tool.execute.before`.
  - Guardian runs first and throws on destructive commands; Crusher then rewrites safe commands (fail-open if rewrite isn’t possible).
  - `opencode-home.js` now unconditionally installs the plugin plus `pre-bash-guardian-validate.js` and `pre-bash-crusher-rewrite.js`, ensuring requires resolve from the installed location.

<sup>Written for commit b77f176212301fead189de1511efb75074608c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

