### PR TITLE
feat(guardian): wire the Bash command validator into Kiro CLI

### DIFF
--- a/scripts/hooks/kiro-guardian-adapter.js
+++ b/scripts/hooks/kiro-guardian-adapter.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Kiro CLI agent-hooks adapter for the EGC Guardian command validator.
+ *
+ * Kiro's preToolUse hook (docs: https://kiro.dev/docs/cli/hooks/) uses a
+ * different wire contract than Claude Code's PreToolUse hook: stdin JSON is
+ * {hook_event_name, cwd, session_id, tool_name, tool_input} instead of
+ * {tool_name, tool_input}, though the tool_name/tool_input fields
+ * themselves are named and shaped the same way. Blocking is exit code 2
+ * with the reason on stderr -- the exact contract
+ * pre-bash-guardian-validate.js's run() already returns, so this
+ * translation only needs to build the input shape, no output envelope.
+ *
+ * tool_input's exact field for the execute_bash command string is
+ * undocumented publicly (verified against kiro.dev/docs/cli/hooks/,
+ * .../reference/built-in-tools/, and .../custom-agents/configuration-
+ * reference/ -- none give the schema). This reads tool_input.command by
+ * convention, matching every other host wired today (Claude Code, Cursor,
+ * Windsurf, Codex all use that field name for their Bash/shell tool). If
+ * that guess is wrong, buildGuardianInput returns null and the hook fails
+ * open (allow) rather than crashing or blocking everything.
+ *
+ * Registered only on the execute_bash matcher (not fs_read/fs_write) --
+ * the Guardian validates shell commands, not file operations.
+ */
+
+'use strict';
+
+const { run } = require('./pre-bash-guardian-validate');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+
+const BASH_TOOL_NAMES = new Set(['execute_bash', 'shell', 'execute_cmd']);
+
+function buildGuardianInput(kiroEvent) {
+  if (!kiroEvent || typeof kiroEvent !== 'object') {
+    return null;
+  }
+  if (!BASH_TOOL_NAMES.has(kiroEvent.tool_name)) {
+    return null;
+  }
+  const command = kiroEvent.tool_input?.command;
+  if (!command || typeof command !== 'string') {
+    return null;
+  }
+  const input = { tool_name: 'Bash', tool_input: { command } };
+  if (typeof kiroEvent.cwd === 'string') {
+    input.cwd = kiroEvent.cwd;
+  }
+  return input;
+}
+
+function main() {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    if (!ok) {
+      // A parse failure caused by hitting the size cap is not the same as
+      // ordinary malformed input: an attacker can pad a command past the
+      // stdin cap specifically to land here and fail open. Only genuinely
+      // malformed (non-truncated) input gets the fail-open policy the other
+      // adapters use; a truncated payload is unanalyzable and fails closed.
+      if (truncated) {
+        process.stderr.write(
+          'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+          'this validator can safely read, so it could not be parsed or validated. ' +
+          'Simplify the command.\n'
+        );
+        process.exit(2);
+      }
+      process.exit(0);
+    }
+
+    const guardianInput = buildGuardianInput(value);
+    if (!guardianInput) {
+      process.exit(0);
+    }
+
+    const result = run(guardianInput);
+    if (result.exitCode === 2) {
+      const reason = result.stderr || 'Blocked by the EGC Guardian.';
+      process.stderr.write(reason.endsWith('\n') ? reason : `${reason}\n`);
+      process.exit(2);
+    }
+
+    process.exit(0);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { buildGuardianInput };

--- a/scripts/hooks/kiro-guardian-adapter.js
+++ b/scripts/hooks/kiro-guardian-adapter.js
@@ -27,7 +27,7 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
-const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+const { runPlainExitCodeGuardianAdapter } = require('../lib/adapter-stdin-json');
 
 const BASH_TOOL_NAMES = new Set(['execute_bash', 'shell', 'execute_cmd']);
 
@@ -50,38 +50,7 @@ function buildGuardianInput(kiroEvent) {
 }
 
 function main() {
-  readAdapterStdinJson(({ ok, truncated, value }) => {
-    if (!ok) {
-      // A parse failure caused by hitting the size cap is not the same as
-      // ordinary malformed input: an attacker can pad a command past the
-      // stdin cap specifically to land here and fail open. Only genuinely
-      // malformed (non-truncated) input gets the fail-open policy the other
-      // adapters use; a truncated payload is unanalyzable and fails closed.
-      if (truncated) {
-        process.stderr.write(
-          'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
-          'this validator can safely read, so it could not be parsed or validated. ' +
-          'Simplify the command.\n'
-        );
-        process.exit(2);
-      }
-      process.exit(0);
-    }
-
-    const guardianInput = buildGuardianInput(value);
-    if (!guardianInput) {
-      process.exit(0);
-    }
-
-    const result = run(guardianInput);
-    if (result.exitCode === 2) {
-      const reason = result.stderr || 'Blocked by the EGC Guardian.';
-      process.stderr.write(reason.endsWith('\n') ? reason : `${reason}\n`);
-      process.exit(2);
-    }
-
-    process.exit(0);
-  });
+  runPlainExitCodeGuardianAdapter(buildGuardianInput, run);
 }
 
 if (require.main === module) {

--- a/scripts/hooks/windsurf-guardian-adapter.js
+++ b/scripts/hooks/windsurf-guardian-adapter.js
@@ -21,7 +21,7 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
-const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+const { runPlainExitCodeGuardianAdapter } = require('../lib/adapter-stdin-json');
 
 function buildGuardianInput(windsurfEvent) {
   if (!windsurfEvent || typeof windsurfEvent !== 'object') {
@@ -49,38 +49,7 @@ function buildGuardianInput(windsurfEvent) {
 }
 
 function main() {
-  readAdapterStdinJson(({ ok, truncated, value }) => {
-    if (!ok) {
-      // A parse failure caused by hitting the size cap is not the same as
-      // ordinary malformed input: an attacker can pad a command past the
-      // stdin cap specifically to land here and fail open. Only genuinely
-      // malformed (non-truncated) input gets the fail-open policy the other
-      // adapters use; a truncated payload is unanalyzable and fails closed.
-      if (truncated) {
-        process.stderr.write(
-          'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
-          'this validator can safely read, so it could not be parsed or validated. ' +
-          'Simplify the command.\n'
-        );
-        process.exit(2);
-      }
-      process.exit(0);
-    }
-
-    const guardianInput = buildGuardianInput(value);
-    if (!guardianInput) {
-      process.exit(0);
-    }
-
-    const result = run(guardianInput);
-    if (result.exitCode === 2) {
-      const reason = result.stderr || 'Blocked by the EGC Guardian.';
-      process.stderr.write(reason.endsWith('\n') ? reason : `${reason}\n`);
-      process.exit(2);
-    }
-
-    process.exit(0);
-  });
+  runPlainExitCodeGuardianAdapter(buildGuardianInput, run);
 }
 
 if (require.main === module) {

--- a/scripts/lib/adapter-stdin-json.js
+++ b/scripts/lib/adapter-stdin-json.js
@@ -43,20 +43,22 @@ function readAdapterStdinJson(onComplete) {
 // runGuardian: pre-bash-guardian-validate.js's own run().
 function runPlainExitCodeGuardianAdapter(buildGuardianInput, runGuardian) {
   readAdapterStdinJson(({ ok, truncated, value }) => {
+    // Checked before `ok`, unconditionally: a capped-length prefix can
+    // still happen to be syntactically valid JSON (e.g. the cut lands
+    // exactly at the end of a complete value), which previously reached
+    // the `ok: true` branch below with truncated data treated as trusted.
+    // Any truncated payload is unanalyzable -- some of what the caller
+    // sent was discarded -- so it always fails closed, regardless of
+    // whether JSON.parse happened to succeed on what remained.
+    if (truncated) {
+      process.stderr.write(
+        'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+        'this validator can safely read, so it could not be parsed or validated. ' +
+        'Simplify the command.\n'
+      );
+      process.exit(2);
+    }
     if (!ok) {
-      // A parse failure caused by hitting the size cap is not the same as
-      // ordinary malformed input: an attacker can pad a command past the
-      // stdin cap specifically to land here and fail open. Only genuinely
-      // malformed (non-truncated) input gets the fail-open policy the other
-      // adapters use; a truncated payload is unanalyzable and fails closed.
-      if (truncated) {
-        process.stderr.write(
-          'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
-          'this validator can safely read, so it could not be parsed or validated. ' +
-          'Simplify the command.\n'
-        );
-        process.exit(2);
-      }
       process.exit(0);
     }
 

--- a/scripts/lib/adapter-stdin-json.js
+++ b/scripts/lib/adapter-stdin-json.js
@@ -35,4 +35,45 @@ function readAdapterStdinJson(onComplete) {
   });
 }
 
-module.exports = { MAX_STDIN, readAdapterStdinJson };
+// Shared main() body for host adapters that block with a plain exit-code-2-
+// plus-stderr contract (Windsurf, Kiro) -- as opposed to Cursor, which also
+// needs a {permission, ...} JSON envelope on stdout and so builds its own
+// main() around readAdapterStdinJson directly instead of this helper.
+// buildGuardianInput: (parsedEvent) => Guardian input object | null.
+// runGuardian: pre-bash-guardian-validate.js's own run().
+function runPlainExitCodeGuardianAdapter(buildGuardianInput, runGuardian) {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    if (!ok) {
+      // A parse failure caused by hitting the size cap is not the same as
+      // ordinary malformed input: an attacker can pad a command past the
+      // stdin cap specifically to land here and fail open. Only genuinely
+      // malformed (non-truncated) input gets the fail-open policy the other
+      // adapters use; a truncated payload is unanalyzable and fails closed.
+      if (truncated) {
+        process.stderr.write(
+          'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+          'this validator can safely read, so it could not be parsed or validated. ' +
+          'Simplify the command.\n'
+        );
+        process.exit(2);
+      }
+      process.exit(0);
+    }
+
+    const guardianInput = buildGuardianInput(value);
+    if (!guardianInput) {
+      process.exit(0);
+    }
+
+    const result = runGuardian(guardianInput);
+    if (result.exitCode === 2) {
+      const reason = result.stderr || 'Blocked by the EGC Guardian.';
+      process.stderr.write(reason.endsWith('\n') ? reason : `${reason}\n`);
+      process.exit(2);
+    }
+
+    process.exit(0);
+  });
+}
+
+module.exports = { MAX_STDIN, readAdapterStdinJson, runPlainExitCodeGuardianAdapter };

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -20,6 +20,10 @@ const {
   BEFORE_SHELL_EXECUTION_EVENT: CURSOR_BEFORE_SHELL_EXECUTION_EVENT,
   applyCursorGuardianHookToFile,
 } = require('./cursor-guardian-hooks');
+const {
+  PRE_TOOL_USE_EVENT: KIRO_PRE_TOOL_USE_EVENT,
+  applyKiroGuardianHookToFile,
+} = require('./kiro-guardian-hooks');
 
 const MANAGED_WINDSURF_HOOK_EVENTS = new Set([WINDSURF_PRE_WRITE_CODE_EVENT, WINDSURF_PRE_RUN_COMMAND_EVENT]);
 
@@ -949,6 +953,8 @@ function applyManagedHookOperation(operation) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
     applyCursorGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath, { seedPath: operation.seedPath });
+  } else if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
+    applyKiroGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
     applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
   }

--- a/scripts/lib/flat-hooks-json-merge.js
+++ b/scripts/lib/flat-hooks-json-merge.js
@@ -62,7 +62,11 @@ function isStaleEgcEntry(entry, command, isOwnBasename) {
 // buildExtraTopLevel: (base: object) => object, merged into the result
 // alongside `hooks` -- e.g. Cursor's {version} field, which Windsurf's
 // hooks.json does not have.
-function addFlatHookEntry(config, event, command, { isOwnBasename, buildExtraTopLevel } = {}) {
+// extraEntryFields: object merged into a newly-appended entry alongside
+// `command` -- e.g. Kiro's {matcher: 'execute_bash'}, needed because its
+// preToolUse array covers every tool (fs_read, fs_write, execute_bash), not
+// just shell commands the way Cursor's beforeShellExecution already is.
+function addFlatHookEntry(config, event, command, { isOwnBasename, buildExtraTopLevel, extraEntryFields } = {}) {
   const base = isPlainObject(config) ? config : {};
   const hooks = isPlainObject(base.hooks) ? { ...base.hooks } : {};
   const existing = Array.isArray(hooks[event]) ? hooks[event] : [];
@@ -83,7 +87,7 @@ function addFlatHookEntry(config, event, command, { isOwnBasename, buildExtraTop
   });
 
   if (!migrated) {
-    nextEntries.push({ command });
+    nextEntries.push({ ...(extraEntryFields || {}), command });
   }
 
   hooks[event] = nextEntries;

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -42,6 +42,11 @@ const {
   inspectCursorGuardianHookFile,
   removeCursorGuardianHookFromFile,
 } = require('./cursor-guardian-hooks');
+const {
+  PRE_TOOL_USE_EVENT: KIRO_PRE_TOOL_USE_EVENT,
+  inspectKiroGuardianHookFile,
+  removeKiroGuardianHookFromFile,
+} = require('./kiro-guardian-hooks');
 
 // Windsurf's hooks.json is a flat {hooks: {<event>: [...]}} map, not
 // Claude's matcher/group settings.json schema -- an operation whose
@@ -550,6 +555,8 @@ function uninstallManagedHookOperation(operation) {
     removeWindsurfGateGuardHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
     removeCursorGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
+  } else if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
+    removeKiroGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
     removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
   }
@@ -691,6 +698,9 @@ function inspectManagedOperation(repoRoot, operation) {
     }
     if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
       return inspectResult(inspectCursorGuardianHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
+    }
+    if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
+      return inspectResult(inspectKiroGuardianHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
     }
     return inspectResult(inspectSessionStartHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
   }

--- a/scripts/lib/install-targets/kiro-home.js
+++ b/scripts/lib/install-targets/kiro-home.js
@@ -1,7 +1,9 @@
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const { createKiroGuardianOperations } = require('../kiro-guardian-operations');
 
 module.exports = createInstallTargetAdapter({
   id: 'kiro-home',
@@ -10,5 +12,17 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.kiro'],
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.kiro',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createKiroGuardianOperations(adapter, targetRoot, createRemappedOperation),
+    ];
+  },
 });

--- a/scripts/lib/install-targets/kiro-project.js
+++ b/scripts/lib/install-targets/kiro-project.js
@@ -1,7 +1,9 @@
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const { createKiroGuardianOperations } = require('../kiro-guardian-operations');
 
 module.exports = createInstallTargetAdapter({
   id: 'kiro-project',
@@ -10,5 +12,17 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.kiro'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.kiro',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createKiroGuardianOperations(adapter, targetRoot, createRemappedOperation),
+    ];
+  },
 });

--- a/scripts/lib/kiro-guardian-hooks.js
+++ b/scripts/lib/kiro-guardian-hooks.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// Manages the Guardian entry inside a Kiro CLI agent config file
+// (.kiro/agents/default.json project-level, or ~/.kiro/agents/default.json
+// global). Kiro CLI agents are one JSON file per agent (the filename minus
+// .json is the agent's name; `default` is the documented convention and
+// what `chat.defaultAgent` points to unless a user overrides it) with a
+// flat {hooks: {<event>: [{matcher, command}]}} map inside -- the same
+// non-Claude-schema shape flat-hooks-json-merge.js already handles for
+// Windsurf/Cursor, plus a `matcher` field on each entry (Kiro's preToolUse
+// fires for every tool -- fs_read, fs_write, execute_bash -- not just shell
+// commands the way Cursor's beforeShellExecution already is scoped, so the
+// Guardian's own entry needs `matcher: "execute_bash"` to avoid running on
+// file tools it was never meant to validate).
+// Docs: https://kiro.dev/docs/cli/hooks/,
+// https://kiro.dev/docs/cli/custom-agents/configuration-reference/
+//
+// Two upstream inconsistencies confirmed via kirodotdev/Kiro's own issue
+// tracker before wiring this (not guessed): the IDE's preToolUse runCommand
+// hooks currently pass an empty tool_input ({}), only the CLI passes the
+// full {tool_name, tool_input, cwd, ...} context (kirodotdev/Kiro#7375) --
+// so this integration targets the CLI's agent-config hooks specifically,
+// not the IDE's separate .kiro/hooks/*.kiro.hook panel. CLI and IDE also
+// read different shapes from the same ~/.kiro/agents/ directory
+// (kirodotdev/Kiro#8040). The exact tool_input field holding the shell
+// command string for execute_bash is undocumented publicly as of this
+// writing; kiro-guardian-adapter.js reads tool_input.command by convention
+// (every other host wired today -- Claude Code, Cursor, Windsurf, Codex --
+// uses that exact field name) and fails open (allow) if it is absent,
+// so a wrong guess degrades to a no-op instead of blocking everything.
+
+const path = require('node:path');
+const {
+  addFlatHookEntry,
+  applyFlatHookToFile,
+  buildHookCommand,
+  inspectFlatHookFile,
+  removeFlatHookEntry,
+  removeFlatHookFromFile,
+} = require('./flat-hooks-json-merge');
+
+const HOST_LABEL = 'Kiro';
+const PRE_TOOL_USE_EVENT = 'preToolUse';
+const EXECUTE_BASH_MATCHER = 'execute_bash';
+const GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/kiro-guardian-adapter.js';
+const DEFAULT_AGENT_FILE_NAME = 'default.json';
+const EGC_ADAPTER_BASENAME = path.basename(GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH);
+
+function isOwnBasename(command) {
+  return command.includes(EGC_ADAPTER_BASENAME);
+}
+
+function buildExtraEntryFields() {
+  return { matcher: EXECUTE_BASH_MATCHER };
+}
+
+function resolveGuardianAdapterScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'kiro-guardian-adapter.js');
+}
+
+function resolveAgentConfigPath(targetRoot) {
+  return path.join(targetRoot, 'agents', DEFAULT_AGENT_FILE_NAME);
+}
+
+function addKiroHookEntry(config, event, command) {
+  return addFlatHookEntry(config, event, command, { isOwnBasename, extraEntryFields: buildExtraEntryFields() });
+}
+
+function applyKiroGuardianHookToFile(agentConfigPath, event, adapterScriptPath) {
+  return applyFlatHookToFile(agentConfigPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath), {
+    isOwnBasename,
+    extraEntryFields: buildExtraEntryFields(),
+  });
+}
+
+function removeKiroHookEntry(config, event, command) {
+  return removeFlatHookEntry(config, event, command);
+}
+
+function removeKiroGuardianHookFromFile(agentConfigPath, event, adapterScriptPath) {
+  return removeFlatHookFromFile(agentConfigPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath));
+}
+
+function inspectKiroGuardianHookFile(agentConfigPath, event, adapterScriptPath) {
+  return inspectFlatHookFile(agentConfigPath, HOST_LABEL, event, buildHookCommand(adapterScriptPath));
+}
+
+module.exports = {
+  EXECUTE_BASH_MATCHER,
+  GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_TOOL_USE_EVENT,
+  addKiroHookEntry,
+  applyKiroGuardianHookToFile,
+  inspectKiroGuardianHookFile,
+  removeKiroGuardianHookFromFile,
+  removeKiroHookEntry,
+  resolveAgentConfigPath,
+  resolveGuardianAdapterScriptDestination,
+};

--- a/scripts/lib/kiro-guardian-operations.js
+++ b/scripts/lib/kiro-guardian-operations.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// EGC-494/EGC-498: every Kiro install registers the Guardian Bash validator
+// on preToolUse (scoped to the execute_bash matcher, baked into the
+// merged entry by kiro-guardian-hooks.js), even when no content modules
+// are selected -- the same "deterministic, unconditional" pattern
+// windsurf-gateguard-operations.js already uses for its own security
+// hooks. Shared between kiro-home.js and kiro-project.js: both roots use
+// this identical operation shape, differing only in rootSegments/
+// installStatePathSegments.
+
+const {
+  BASH_GUARDIAN_HOOK_MODULE_ID,
+  HOOK_OPERATION_KIND,
+  createBashGuardianScriptCopyOperations,
+} = require('./claude-settings-hooks');
+const {
+  GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  PRE_TOOL_USE_EVENT,
+  resolveAgentConfigPath,
+  resolveGuardianAdapterScriptDestination,
+} = require('./kiro-guardian-hooks');
+
+function createKiroGuardianOperations(adapter, targetRoot, createRemappedOperation) {
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+
+  const guardianScriptCopyOperations = createBashGuardianScriptCopyOperations(remap, targetRoot);
+
+  const adapterScriptDestination = resolveGuardianAdapterScriptDestination(targetRoot);
+  const adapterCopyOperation = createRemappedOperation(
+    adapter,
+    BASH_GUARDIAN_HOOK_MODULE_ID,
+    GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    adapterScriptDestination,
+    { strategy: 'preserve-relative-path' }
+  );
+
+  const agentConfigPath = resolveAgentConfigPath(targetRoot);
+  const mergeOperation = {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: BASH_GUARDIAN_HOOK_MODULE_ID,
+    sourceRelativePath: GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: agentConfigPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookScriptPath: adapterScriptDestination,
+  };
+
+  return [
+    ...guardianScriptCopyOperations,
+    adapterCopyOperation,
+    mergeOperation,
+  ];
+}
+
+module.exports = { createKiroGuardianOperations };

--- a/tests/hooks/kiro-guardian-adapter.test.js
+++ b/tests/hooks/kiro-guardian-adapter.test.js
@@ -1,0 +1,146 @@
+/**
+ * Tests for scripts/hooks/kiro-guardian-adapter.js
+ *
+ * Kiro's preToolUse hook uses a different wire contract than Claude Code's
+ * PreToolUse hook (see cursor-guardian-adapter.test.js for the same
+ * pattern this mirrors) -- this file exercises both the pure translation
+ * function and the real CLI entrypoint end to end.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'kiro-guardian-adapter.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+const { buildGuardianInput } = require(adapterScript);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const result = spawnSync('node', [adapterScript], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, EGC_GUARDIAN_CLI: fakeCli, ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing kiro-guardian-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('maps an execute_bash preToolUse event to a Guardian Bash input', () => {
+    const mapped = buildGuardianInput({
+      hook_event_name: 'preToolUse',
+      cwd: '/Users/example/project',
+      tool_name: 'execute_bash',
+      tool_input: { command: 'echo hi' },
+    });
+    assert.deepStrictEqual(mapped, { tool_name: 'Bash', tool_input: { command: 'echo hi' }, cwd: '/Users/example/project' });
+  })) passed++; else failed++;
+
+  if (test('also maps the "shell" and "execute_cmd" tool_name aliases', () => {
+    assert.ok(buildGuardianInput({ tool_name: 'shell', tool_input: { command: 'echo hi' } }));
+    assert.ok(buildGuardianInput({ tool_name: 'execute_cmd', tool_input: { command: 'echo hi' } }));
+  })) passed++; else failed++;
+
+  if (test('omits cwd when the event has none (not a string)', () => {
+    const mapped = buildGuardianInput({ tool_name: 'execute_bash', tool_input: { command: 'echo hi' } });
+    assert.strictEqual('cwd' in mapped, false);
+  })) passed++; else failed++;
+
+  if (test('returns null for a non-bash tool_name (fs_read, fs_write, ...)', () => {
+    assert.strictEqual(buildGuardianInput({ tool_name: 'fs_read', tool_input: {} }), null);
+    assert.strictEqual(buildGuardianInput({ tool_name: 'fs_write', tool_input: {} }), null);
+  })) passed++; else failed++;
+
+  if (test('returns null for an execute_bash event with no tool_input.command', () => {
+    assert.strictEqual(buildGuardianInput({ tool_name: 'execute_bash', tool_input: {} }), null);
+    assert.strictEqual(buildGuardianInput({ tool_name: 'execute_bash' }), null);
+  })) passed++; else failed++;
+
+  if (test('returns null (does not throw) for a non-object event, e.g. valid JSON "null"', () => {
+    assert.strictEqual(buildGuardianInput(null), null);
+    assert.strictEqual(buildGuardianInput('a string'), null);
+    assert.strictEqual(buildGuardianInput(42), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: a valid JSON "null" payload allows (exit 0) instead of crashing', () => {
+    const result = runAdapterCli('null');
+    assert.strictEqual(result.code, 0);
+  })) passed++; else failed++;
+
+  if (test('CLI: blocks a destructive command with exit 2 and a reason on stderr', () => {
+    const result = runAdapterCli({
+      hook_event_name: 'preToolUse',
+      tool_name: 'execute_bash',
+      tool_input: { command: 'rm -rf /' },
+    });
+    assert.strictEqual(result.code, 2);
+    assert.ok(result.stderr.length > 0, 'expected a reason on stderr');
+  })) passed++; else failed++;
+
+  if (test('CLI: allows a safe allowlisted command (exit 0)', () => {
+    const result = runAdapterCli({
+      hook_event_name: 'preToolUse',
+      tool_name: 'execute_bash',
+      tool_input: { command: 'git status' },
+    });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stderr, '');
+  })) passed++; else failed++;
+
+  if (test('CLI: non-bash tool_name (fs_write) exits 0 with no output', () => {
+    const result = runAdapterCli({
+      hook_event_name: 'preToolUse',
+      tool_name: 'fs_write',
+      tool_input: { path: '/tmp/some-file.js' },
+    });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, '');
+    assert.strictEqual(result.stderr, '');
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed (non-truncated) stdin JSON fails open (exit 0)', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+  })) passed++; else failed++;
+
+  if (test('CLI: an oversized payload that gets truncated into invalid JSON fails CLOSED (exit 2), not open', () => {
+    // Same fail-closed-on-truncation guard as the other adapters. Uses a
+    // SAFE command so this only passes when the truncation guard itself
+    // fires, not because the command would be blocked on its own merits.
+    const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      hook_event_name: 'preToolUse',
+      tool_name: 'execute_bash',
+      tool_input: { command: 'git status', padding: oversizedPadding },
+    });
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/kiro-guardian-adapter.test.js
+++ b/tests/hooks/kiro-guardian-adapter.test.js
@@ -139,6 +139,23 @@ function runTests() {
     assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
   })) passed++; else failed++;
 
+  if (test('CLI: a truncated payload that still happens to parse as valid JSON also fails CLOSED (exit 2)', () => {
+    // Distinct from the test above: JSON.parse allows trailing whitespace
+    // after a complete value, so padding with spaces (instead of 'x') past
+    // the 1MB cap produces a capped-length prefix that is STILL valid JSON
+    // -- the truncated flag must be checked unconditionally, not only when
+    // parsing also happened to fail, or this exact shape would slip through
+    // as a trusted "ok: true" result (cubic-dev-ai finding on PR #1073).
+    const oversizedWhitespacePadding = ' '.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      hook_event_name: 'preToolUse',
+      tool_name: 'execute_bash',
+      tool_input: { command: 'git status' },
+    }) + oversizedWhitespacePadding;
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 2, `Expected fail-closed on a truncated-but-parseable payload, got exit ${result.code}`);
+  })) passed++; else failed++;
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/hooks/windsurf-guardian-adapter.test.js
+++ b/tests/hooks/windsurf-guardian-adapter.test.js
@@ -146,6 +146,22 @@ function runTests() {
     assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
   })) passed++; else failed++;
 
+  if (test('CLI: a truncated payload that still happens to parse as valid JSON also fails CLOSED (exit 2)', () => {
+    // Distinct from the test above: JSON.parse allows trailing whitespace
+    // after a complete value, so padding with spaces (instead of 'x') past
+    // the 1MB cap produces a capped-length prefix that is STILL valid JSON
+    // -- the truncated flag must be checked unconditionally, not only when
+    // parsing also happened to fail, or this exact shape would slip through
+    // as a trusted "ok: true" result (cubic-dev-ai finding on PR #1073).
+    const oversizedWhitespacePadding = ' '.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      agent_action_name: 'pre_run_command',
+      tool_info: { command_line: 'git status' },
+    }) + oversizedWhitespacePadding;
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 2, `Expected fail-closed on a truncated-but-parseable payload, got exit ${result.code}`);
+  })) passed++; else failed++;
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2378,6 +2378,42 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('kiro home and project adapters always plan the Guardian preToolUse hook, even with no modules selected (EGC-494/EGC-498)', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+    const projectRoot = '/workspace/app';
+
+    for (const { target, targetRoot, extra } of [
+      { target: 'kiro', targetRoot: path.join(homeDir, '.kiro'), extra: { homeDir } },
+      { target: 'kiro-project', targetRoot: path.join(projectRoot, '.kiro'), extra: { projectRoot } },
+    ]) {
+      const plan = planInstallTargetScaffold({ target, repoRoot, modules: [], ...extra });
+      const adapterScriptDestination = path.join(targetRoot, 'scripts', 'hooks', 'kiro-guardian-adapter.js');
+
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'
+          && operation.destinationPath === path.join(targetRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js')
+        )),
+        `[${target}] Should plan the shared Guardian validator copy even with no modules selected`
+      );
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/kiro-guardian-adapter.js'
+          && operation.destinationPath === adapterScriptDestination
+        )),
+        `[${target}] Should plan the Kiro-specific adapter copy even with no modules selected`
+      );
+
+      const mergeOperation = plan.operations.find(
+        operation => operation.kind === 'merge-claude-settings-hooks' && operation.hookEvent === 'preToolUse'
+      );
+      assert.ok(mergeOperation, `[${target}] Should plan the preToolUse agent-config merge`);
+      assert.strictEqual(mergeOperation.destinationPath, path.join(targetRoot, 'agents', 'default.json'));
+      assert.strictEqual(mergeOperation.hookScriptPath, adapterScriptDestination);
+    }
+  })) passed++; else failed++;
+
   if (test('kiro adapters are included in the full adapter list', () => {
     const adapters = listInstallTargetAdapters();
     const targets = adapters.map(a => a.target);

--- a/tests/lib/kiro-guardian-hooks.test.js
+++ b/tests/lib/kiro-guardian-hooks.test.js
@@ -1,0 +1,181 @@
+/**
+ * Tests for scripts/lib/kiro-guardian-hooks.js
+ *
+ * Kiro CLI agent config is a flat {hooks: {<event>: [{matcher, command}]}}
+ * map (no matcher/group wrapper, no "type": "command" field), unlike Claude
+ * Code's settings.json, so it needs its own merge logic. These tests
+ * exercise that merge logic directly (additive, idempotent, preserves
+ * unrelated keys and third-party hooks), plus the execute_bash matcher
+ * this host's preToolUse event needs that Cursor's beforeShellExecution
+ * does not (Cursor's event already only fires for shell commands).
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  EXECUTE_BASH_MATCHER,
+  PRE_TOOL_USE_EVENT,
+  addKiroHookEntry,
+  applyKiroGuardianHookToFile,
+  inspectKiroGuardianHookFile,
+  removeKiroGuardianHookFromFile,
+  removeKiroHookEntry,
+  resolveAgentConfigPath,
+  resolveGuardianAdapterScriptDestination,
+} = require('../../scripts/lib/kiro-guardian-hooks');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing kiro-guardian-hooks ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('resolveAgentConfigPath and resolveGuardianAdapterScriptDestination compute paths under targetRoot', () => {
+    const targetRoot = '/home/user/project/.kiro';
+    assert.strictEqual(resolveAgentConfigPath(targetRoot), path.join(targetRoot, 'agents', 'default.json'));
+    assert.strictEqual(
+      resolveGuardianAdapterScriptDestination(targetRoot),
+      path.join(targetRoot, 'scripts', 'hooks', 'kiro-guardian-adapter.js')
+    );
+  })) passed++; else failed++;
+
+  if (test('addKiroHookEntry appends a new event array on an empty config, with the execute_bash matcher', () => {
+    const { config, changed } = addKiroHookEntry({}, PRE_TOOL_USE_EVENT, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config.hooks[PRE_TOOL_USE_EVENT], [{ matcher: EXECUTE_BASH_MATCHER, command: 'node adapter.js' }]);
+  })) passed++; else failed++;
+
+  if (test('addKiroHookEntry is idempotent (no duplicate on re-add)', () => {
+    const first = addKiroHookEntry({}, PRE_TOOL_USE_EVENT, 'node adapter.js');
+    const second = addKiroHookEntry(first.config, PRE_TOOL_USE_EVENT, 'node adapter.js');
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.config.hooks[PRE_TOOL_USE_EVENT].length, 1);
+  })) passed++; else failed++;
+
+  if (test('addKiroHookEntry preserves third-party hooks in the same event array', () => {
+    const base = {
+      hooks: { [PRE_TOOL_USE_EVENT]: [{ matcher: 'fs_write', command: 'node .kiro/hooks/audit-write.js' }] },
+    };
+    const { config } = addKiroHookEntry(base, PRE_TOOL_USE_EVENT, 'node adapter.js');
+    assert.strictEqual(config.hooks[PRE_TOOL_USE_EVENT].length, 2);
+    assert.ok(config.hooks[PRE_TOOL_USE_EVENT].some(entry => entry.matcher === 'fs_write'));
+    assert.ok(config.hooks[PRE_TOOL_USE_EVENT].some(entry => entry.command === 'node adapter.js' && entry.matcher === EXECUTE_BASH_MATCHER));
+  })) passed++; else failed++;
+
+  if (test('addKiroHookEntry preserves unrelated events and top-level keys', () => {
+    const base = { name: 'default', hooks: { postToolUse: [{ command: 'node log.js' }] } };
+    const { config } = addKiroHookEntry(base, PRE_TOOL_USE_EVENT, 'node adapter.js');
+    assert.strictEqual(config.name, 'default');
+    assert.deepStrictEqual(config.hooks.postToolUse, [{ command: 'node log.js' }]);
+  })) passed++; else failed++;
+
+  if (test('addKiroHookEntry migrates a stale entry (same script, different path) in place instead of duplicating', () => {
+    const base = {
+      hooks: {
+        [PRE_TOOL_USE_EVENT]: [{ matcher: EXECUTE_BASH_MATCHER, command: 'node /old/path/kiro-guardian-adapter.js' }],
+      },
+    };
+    const { config, changed } = addKiroHookEntry(base, PRE_TOOL_USE_EVENT, 'node /new/path/kiro-guardian-adapter.js');
+    assert.strictEqual(changed, true);
+    assert.strictEqual(config.hooks[PRE_TOOL_USE_EVENT].length, 1, 'must migrate in place, not append a duplicate');
+    assert.strictEqual(config.hooks[PRE_TOOL_USE_EVENT][0].command, 'node /new/path/kiro-guardian-adapter.js');
+  })) passed++; else failed++;
+
+  if (test('applyKiroGuardianHookToFile writes the event to a fresh file and is idempotent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-hooks-apply-'));
+    const agentConfigPath = path.join(tempDir, 'default.json');
+    try {
+      const first = applyKiroGuardianHookToFile(agentConfigPath, PRE_TOOL_USE_EVENT, '/abs/adapter.js');
+      assert.strictEqual(first.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(agentConfigPath, 'utf8'));
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT].length, 1);
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT][0].matcher, EXECUTE_BASH_MATCHER);
+
+      const second = applyKiroGuardianHookToFile(agentConfigPath, PRE_TOOL_USE_EVENT, '/abs/adapter.js');
+      assert.strictEqual(second.changed, false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyKiroGuardianHookToFile preserves a hand-written agent config on disk', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-hooks-preserve-'));
+    const agentConfigPath = path.join(tempDir, 'default.json');
+    try {
+      fs.writeFileSync(agentConfigPath, JSON.stringify({
+        name: 'default',
+        hooks: { postToolUse: [{ command: 'node .kiro/hooks/log.js' }] },
+      }, null, 2));
+
+      applyKiroGuardianHookToFile(agentConfigPath, PRE_TOOL_USE_EVENT, '/abs/adapter.js');
+
+      const onDisk = JSON.parse(fs.readFileSync(agentConfigPath, 'utf8'));
+      assert.strictEqual(onDisk.name, 'default');
+      assert.deepStrictEqual(onDisk.hooks.postToolUse, [{ command: 'node .kiro/hooks/log.js' }]);
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT].length, 1);
+      assert.ok(onDisk.hooks[PRE_TOOL_USE_EVENT][0].command.includes('adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('removeKiroHookEntry drops only the EGC entry, keeps third-party hooks and other events', () => {
+    const base = {
+      hooks: {
+        [PRE_TOOL_USE_EVENT]: [
+          { matcher: 'fs_write', command: 'node .kiro/hooks/audit-write.js' },
+          { matcher: EXECUTE_BASH_MATCHER, command: 'node adapter.js' },
+        ],
+        postToolUse: [{ command: 'node log.js' }],
+      },
+    };
+    const { config, changed } = removeKiroHookEntry(base, PRE_TOOL_USE_EVENT, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config.hooks[PRE_TOOL_USE_EVENT], [{ matcher: 'fs_write', command: 'node .kiro/hooks/audit-write.js' }]);
+    assert.deepStrictEqual(config.hooks.postToolUse, [{ command: 'node log.js' }]);
+  })) passed++; else failed++;
+
+  if (test('removeKiroHookEntry deletes the event key entirely once empty', () => {
+    const base = { hooks: { [PRE_TOOL_USE_EVENT]: [{ matcher: EXECUTE_BASH_MATCHER, command: 'node adapter.js' }] } };
+    const { config } = removeKiroHookEntry(base, PRE_TOOL_USE_EVENT, 'node adapter.js');
+    assert.strictEqual(PRE_TOOL_USE_EVENT in config.hooks, false);
+  })) passed++; else failed++;
+
+  if (test('removeKiroGuardianHookFromFile on a missing file is a no-op', () => {
+    const result = removeKiroGuardianHookFromFile('/nonexistent/default.json', PRE_TOOL_USE_EVENT, '/abs/adapter.js');
+    assert.strictEqual(result.changed, false);
+  })) passed++; else failed++;
+
+  if (test('inspectKiroGuardianHookFile reports ok when present, drifted when absent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-hooks-inspect-'));
+    const agentConfigPath = path.join(tempDir, 'default.json');
+    try {
+      assert.strictEqual(inspectKiroGuardianHookFile(agentConfigPath, PRE_TOOL_USE_EVENT, '/abs/adapter.js'), 'drifted');
+      applyKiroGuardianHookToFile(agentConfigPath, PRE_TOOL_USE_EVENT, '/abs/adapter.js');
+      assert.strictEqual(inspectKiroGuardianHookFile(agentConfigPath, PRE_TOOL_USE_EVENT, '/abs/adapter.js'), 'ok');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- Kiro's `preToolUse` hook uses a different wire contract than Claude Code's (stdin JSON `{hook_event_name, cwd, session_id, tool_name, tool_input}` against a flat `{hooks: {<event>: [{matcher, command}]}}` agent config file, not Claude's matcher/group settings.json schema) -- confirmed against the CLI hooks docs, built-in tools reference, and agent configuration reference before wiring.
- Two upstream inconsistencies confirmed via `kirodotdev/Kiro`'s own issue tracker before choosing a target: the IDE's `preToolUse` `runCommand` hooks currently pass an empty `tool_input` (`kirodotdev/Kiro#7375`), and CLI/IDE read different shapes from the same `~/.kiro/agents/` directory (`kirodotdev/Kiro#8040`) -- this wires the CLI's agent-config hooks specifically, the one with confirmed full tool context.
- `tool_input`'s exact field for `execute_bash`'s command string is undocumented publicly; the adapter reads `tool_input.command` by convention (matching Claude Code/Cursor/Windsurf/Codex) and fails open if absent.
- `flat-hooks-json-merge.js` gained an `extraEntryFields` option so Kiro's entry can carry `matcher: "execute_bash"` (its `preToolUse` array covers every tool, not just shell commands).

## Test plan
- [x] `node tests/lib/kiro-guardian-hooks.test.js`, `node tests/hooks/kiro-guardian-adapter.test.js` -- merge logic and adapter translation, including the null-crash guard and truncation fail-closed guard from today's cubic findings on the sibling Cursor PR, applied here from the start.
- [x] `node tests/lib/install-targets.test.js` -- Guardian hook planned unconditionally for both `kiro-home` and `kiro-project`, even with no modules selected.
- [x] Real end-to-end install: `node scripts/install-apply.js --target kiro --profile full` against an isolated `HOME`, then `node scripts/doctor.js --target kiro` -- 0 warnings, exact expected `{hooks: {preToolUse: [{matcher, command}]}}` shape confirmed on disk.
- [x] Full suite: `npm test` (3036/3036 passed), `npx eslint` clean.

https://claude.ai/code/session_019BpofkJoGaxCkoKcX1RSrn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the EGC Guardian Bash command validator into Kiro CLI `preToolUse` (scoped to `execute_bash`) and hardens the adapter to fail closed on any truncated payloads. Implements EGC-494/EGC-498 for both Kiro home and project installs, with a shared stdin adapter.

- **New Features**
  - Added `scripts/hooks/kiro-guardian-adapter.js` to translate Kiro `preToolUse` stdin JSON to Guardian input, read `tool_input.command`, allow non-bash tools, and block with exit code 2 and a reason on stderr.
  - Introduced Kiro hook management (`scripts/lib/kiro-guardian-hooks.js`) and operations (`scripts/lib/kiro-guardian-operations.js`) to write `{matcher: "execute_bash", command}` into `.kiro/agents/default.json`, plus apply/remove/inspect wired via `claude-settings-hooks.js` and `install-lifecycle.js`. `flat-hooks-json-merge.js` now supports `extraEntryFields` for the matcher.
  - Updated `kiro-home` and `kiro-project` to always plan the Guardian install (adapter + validator + merge), independent of selected modules.

- **Bug Fixes**
  - In `runPlainExitCodeGuardianAdapter`, check `truncated` unconditionally so truncated-but-parseable JSON also fails closed (exit 2). Added regression tests for both Windsurf and Kiro adapters.

<sup>Written for commit f3fd373f231421fd3c109b8951489c2a7adf80ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

