### PR TITLE
fix(guardian): check the truncated flag unconditionally in the Cursor adapter

### DIFF
--- a/scripts/hooks/cursor-guardian-adapter.js
+++ b/scripts/hooks/cursor-guardian-adapter.js
@@ -49,18 +49,21 @@ function respond(permission, message) {
 
 function main() {
   readAdapterStdinJson(({ ok, truncated, value }) => {
+    // Checked before `ok`, unconditionally: a capped-length prefix can
+    // still happen to be syntactically valid JSON (e.g. the cut lands
+    // exactly at the end of a complete value, or JSON.parse's tolerance
+    // for trailing whitespace after a value), which previously reached the
+    // `ok: true` branch below with truncated data treated as trusted. Any
+    // truncated payload is unanalyzable -- some of what the caller sent
+    // was discarded -- so it always fails closed, regardless of whether
+    // JSON.parse happened to succeed on what remained.
+    if (truncated) {
+      respond('deny', 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+        'this validator can safely read, so it could not be parsed or validated. ' +
+        'Simplify the command.');
+      return;
+    }
     if (!ok) {
-      // A parse failure caused by hitting the size cap is not the same as
-      // ordinary malformed input: an attacker can pad a command past the
-      // stdin cap specifically to land here and fail open. Only genuinely
-      // malformed (non-truncated) input gets the fail-open policy the other
-      // adapters use; a truncated payload is unanalyzable and fails closed.
-      if (truncated) {
-        respond('deny', 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
-          'this validator can safely read, so it could not be parsed or validated. ' +
-          'Simplify the command.');
-        return;
-      }
       respond('allow');
       return;
     }

--- a/tests/hooks/cursor-guardian-adapter.test.js
+++ b/tests/hooks/cursor-guardian-adapter.test.js
@@ -117,6 +117,22 @@ function runTests() {
     assert.strictEqual(response.permission, 'deny');
   })) passed++; else failed++;
 
+  if (test('CLI: a truncated payload that still happens to parse as valid JSON also fails CLOSED (exit 2)', () => {
+    // Distinct from the test above: JSON.parse allows trailing whitespace
+    // after a complete value, so padding with spaces (instead of 'x') past
+    // the 1MB cap produces a capped-length prefix that is STILL valid JSON
+    // -- the truncated flag must be checked unconditionally, not only when
+    // parsing also happened to fail, or this exact shape would slip through
+    // as a trusted "ok: true" result (cubic-dev-ai finding on PR #1073,
+    // also present here since this file predates the shared helper fix).
+    const oversizedWhitespacePadding = ' '.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({ command: 'git status', cwd: '/tmp' }) + oversizedWhitespacePadding;
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 2, `Expected fail-closed on a truncated-but-parseable payload, got exit ${result.code}`);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.permission, 'deny');
+  })) passed++; else failed++;
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary
- Same gap cubic-dev-ai found on the Kiro PR (#1073): `JSON.parse` allows trailing whitespace after a complete value, so a capped-length prefix can still parse successfully even though data past the 1MB stdin cap was discarded.
- `cursor-guardian-adapter.js` (merged via #1071, before the shared `runPlainExitCodeGuardianAdapter` helper existed) only checked `truncated` inside the `!ok` (parse-failed) branch, so a truncated-but-still-parseable payload reached the `ok: true` path and was treated as fully trusted.
- Moved the `truncated` check ahead of the `ok` check so any truncated payload fails closed unconditionally, regardless of whether `JSON.parse` happened to succeed on what remained.
- Direct hotfix (not folded into an in-flight PR) since the vulnerable code is already live on `main`.

## Test plan
- [x] New regression test: whitespace-padded payload past the cap (parses successfully, unlike the existing 'x'-padded test which produces invalid JSON on its own) -- confirms fail-closed (exit 2, `permission: deny`).
- [x] Full suite: `npm test` (3035/3035 passed), `npx eslint` clean.

https://claude.ai/code/session_019BpofkJoGaxCkoKcX1RSrn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-close truncated Cursor adapter payloads by checking the `truncated` flag before parse results. This blocks truncated-but-parseable JSON (e.g., trailing whitespace) from being treated as trusted.

- **Bug Fixes**
  - Check `truncated` before `ok` in `scripts/hooks/cursor-guardian-adapter.js` so any truncated input returns `deny` (exit 2).
  - Add regression test for whitespace-padded payload beyond the 1MB cap that still parses; now correctly denied.

<sup>Written for commit 4cfa82ea2b13b30d06535349bd6e0df884662e43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

