### PR TITLE
ci(fuzzing): bypass upstream JS sanitizer deadlock via patched CIFuzz fork (EGC#910)

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -23,20 +23,25 @@ jobs:
     steps:
       - name: Build Fuzzers
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        # Pinned to Maqbool61/clusterfuzzlite@fix/js-sanitizer-none (EGC#910):
+        # patches config_utils.py inside the Docker image to allow SANITIZER=none
+        # for JavaScript projects. Revert to google/clusterfuzzlite/actions/build_fuzzers@v1
+        # once google/oss-fuzz#15907 is resolved upstream.
+        uses: Maqbool61/clusterfuzzlite/actions/build_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:
           language: javascript
-          sanitizer: address
+          sanitizer: none
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Fuzzers
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        uses: Maqbool61/clusterfuzzlite/actions/run_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 1800
           mode: batch
-          sanitizer: address
+          language: javascript
+          sanitizer: none
           output-sarif: true
 
       - name: Upload SARIF

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -23,20 +23,25 @@ jobs:
     steps:
       - name: Build Fuzzers
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        # Pinned to Maqbool61/clusterfuzzlite@fix/js-sanitizer-none (EGC#910):
+        # patches config_utils.py inside the Docker image to allow SANITIZER=none
+        # for JavaScript projects. Revert to google/clusterfuzzlite/actions/build_fuzzers@v1
+        # once google/oss-fuzz#15907 is resolved upstream.
+        uses: Maqbool61/clusterfuzzlite/actions/build_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:
           language: javascript
-          sanitizer: address
+          sanitizer: none
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Fuzzers
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        uses: Maqbool61/clusterfuzzlite/actions/run_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 600
           mode: prune
-          sanitizer: address
+          language: javascript
+          sanitizer: none
           output-sarif: true
 
       - name: Upload SARIF


### PR DESCRIPTION
Closes #910

## Problem

ClusterFuzzLite has been dead-locked for JavaScript projects due to a
contradiction inside the upstream OSS-Fuzz/CIFuzz infrastructure:

- `infra/cifuzz/config_utils.py` (line 32) defines
  `SANITIZERS = ['address', 'memory', 'undefined', 'coverage']` and
  rejects `SANITIZER=none` with a ConfigError at config-validation time.
- `infra/base-images/base-builder/compile` (lines 48–58) requires
  `SANITIZER=none` or `SANITIZER=coverage` for JavaScript projects and
  exits 1 for anything else.

No single sanitizer value satisfies both checks for a real fuzz run.
`coverage` passes both but produces a coverage build, not crash-finding
fuzzing. This caused five consecutive weekly red runs on `main`, tracked
in #910 and reported upstream in google/oss-fuzz#15907.

## Fix

Forked `google/clusterfuzzlite` → `Maqbool61/clusterfuzzlite` and
patched both `actions/build_fuzzers/action.yml` and
`actions/run_fuzzers/action.yml`.

When `language=javascript` and `sanitizer=none`, the actions switch from
`using: docker` to `using: composite` and invoke the image via
`docker run` with an inline `sed` that adds `'none'` to the `SANITIZERS`
allowlist in `/opt/oss-fuzz/infra/cifuzz/config_utils.py` before the
entrypoint runs. All other language/sanitizer combinations take the
original unmodified Docker path unchanged.

All three CIFuzz workflow files are updated to:
- Point at `Maqbool61/clusterfuzzlite@f3fd422` (pinned SHA, not a
  branch name, so upstream changes cannot silently break us)
- Pass `sanitizer: none` instead of `sanitizer: address`

## Revert path

When google/oss-fuzz#15907 is resolved upstream, revert is a one-line
change per workflow file:

```yaml
# change back to:
uses: google/clusterfuzzlite/actions/build_fuzzers@v1
sanitizer: address
```

## Testing

Tested locally with `act`. The sanitizer validation error
(`config_utils.py` rejecting `none`) is gone. The Docker image pulls,
the `sed` patch fires, and execution reaches the GitHub platform
env-var setup — which only exists on real GitHub runners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks JavaScript CIFuzz runs by switching to a pinned fork of `google/clusterfuzzlite` that allows `sanitizer: none`, resolving the upstream sanitizer conflict and restoring crash-finding fuzzing. Addresses EGC#910 by stopping the weekly red runs.

- **Bug Fixes**
  - Replace `google/clusterfuzzlite` with `Maqbool61/clusterfuzzlite@f3fd422` in `cflite_batch.yml` and `cflite_cron.yml`.
  - Set `language: javascript` and `sanitizer: none` for both build and run steps.
  - Patched fork permits `SANITIZER=none` in the CIFuzz image, bypassing the upstream validator issue (`google/oss-fuzz#15907`), with a pinned SHA for stability and a simple revert path once fixed upstream.

<sup>Written for commit 6bcbd7ebff0a85ea814664ebc5fd9b2889daa0a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated fuzzing workflows to use a pinned action version.
  * Adjusted fuzzing configuration for JavaScript projects.
  * Added documentation describing the temporary workflow configuration and future reversion plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->