### PR TITLE
fix(guardian): copy adapter-stdin-json.js for Cursor, Windsurf, and Kiro installs

### DIFF
--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -803,6 +803,31 @@ function createBashGuardianScriptCopyOperations(createRemappedOperation, targetR
   ];
 }
 
+// Windsurf's, Cursor's, and Kiro's translation adapters
+// (windsurf-guardian-adapter.js, cursor-guardian-adapter.js,
+// kiro-guardian-adapter.js) all require ../lib/adapter-stdin-json.js for
+// their truncation-aware stdin reader -- unlike pre-bash-guardian-
+// validate.js itself, which every other target (Claude Code, Codex,
+// Copilot, CodeBuddy, Antigravity) calls directly with no translation
+// layer and so never needs this file. Kept separate from
+// createBashGuardianScriptCopyOperations (shared by every target,
+// including ones with no adapter) instead of folding it into
+// BASH_GUARDIAN_HOOK_LIB_SOURCES, so targets without an adapter don't get
+// a copy of a file they never require(). Confirmed missing on the real
+// machine for all three hosts after merge (2026-07-29): the adapter
+// crashed with MODULE_NOT_FOUND on every invocation because this file was
+// never part of any target's copy operations.
+const ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH = 'scripts/lib/adapter-stdin-json.js';
+
+function createAdapterStdinJsonCopyOperation(createRemappedOperation, targetRoot) {
+  return createRemappedOperation(
+    BASH_GUARDIAN_HOOK_MODULE_ID,
+    ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH,
+    path.join(targetRoot, ...ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH.split('/')),
+    { strategy: 'preserve-relative-path' }
+  );
+}
+
 // PreCompact -> egc-memory-save hook: closes EGC-495 (no mechanism re-injected
 // state after a context compaction). egc-memory-save.js writes a guaranteed
 // on-disk snapshot (writeSnapshotToDisk, no AI cooperation required) and
@@ -1022,6 +1047,8 @@ module.exports = {
   createPreToolUseBashGuardianHookMergeOperation,
   createBashGuardianHookMergeOperationForDestination,
   resolveBashGuardianHookScriptDestination,
+  ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH,
+  createAdapterStdinJsonCopyOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -13,6 +13,8 @@ const {
 const {
   HOOK_OPERATION_KIND,
   createBashGuardianScriptCopyOperations,
+  createAdapterStdinJsonCopyOperation,
+  ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH,
 } = require('../claude-settings-hooks');
 const {
   BEFORE_SHELL_EXECUTION_EVENT,
@@ -76,9 +78,14 @@ function createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot) 
     ...(seedPath ? { seedPath } : {}),
   };
 
+  const adapterStdinJsonCopyOperation = alreadyScaffolded(ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH)
+    ? null
+    : createAdapterStdinJsonCopyOperation(remap, targetRoot);
+
   return [
     ...guardianScriptCopyOperations,
     ...(adapterCopyOperation ? [adapterCopyOperation] : []),
+    ...(adapterStdinJsonCopyOperation ? [adapterStdinJsonCopyOperation] : []),
     mergeOperation,
   ];
 }

--- a/scripts/lib/kiro-guardian-operations.js
+++ b/scripts/lib/kiro-guardian-operations.js
@@ -13,6 +13,7 @@ const {
   BASH_GUARDIAN_HOOK_MODULE_ID,
   HOOK_OPERATION_KIND,
   createBashGuardianScriptCopyOperations,
+  createAdapterStdinJsonCopyOperation,
 } = require('./claude-settings-hooks');
 const {
   GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -50,9 +51,12 @@ function createKiroGuardianOperations(adapter, targetRoot, createRemappedOperati
     hookScriptPath: adapterScriptDestination,
   };
 
+  const adapterStdinJsonCopyOperation = createAdapterStdinJsonCopyOperation(remap, targetRoot);
+
   return [
     ...guardianScriptCopyOperations,
     adapterCopyOperation,
+    adapterStdinJsonCopyOperation,
     mergeOperation,
   ];
 }

--- a/scripts/lib/windsurf-gateguard-operations.js
+++ b/scripts/lib/windsurf-gateguard-operations.js
@@ -18,6 +18,7 @@ const {
   BASH_GUARDIAN_HOOK_MODULE_ID,
   createGateGuardScriptCopyOperations,
   createBashGuardianScriptCopyOperations,
+  createAdapterStdinJsonCopyOperation,
 } = require('./claude-settings-hooks');
 const {
   ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
@@ -85,12 +86,15 @@ function createWindsurfGateGuardOperations(adapter, targetRoot, createRemappedOp
     hookScriptPath: guardianAdapterScriptDestination,
   };
 
+  const adapterStdinJsonCopyOperation = createAdapterStdinJsonCopyOperation(remap, targetRoot);
+
   return [
     ...scriptCopyOperations,
     adapterCopyOperation,
     ...mergeOperations,
     ...guardianScriptCopyOperations,
     guardianAdapterCopyOperation,
+    adapterStdinJsonCopyOperation,
     guardianMergeOperation,
   ];
 }

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2420,6 +2420,39 @@ function runTests() {
     assert.ok(targets.includes('kiro'), 'Should include kiro target');
   })) passed++; else failed++;
 
+  if (test('Cursor/Windsurf/Kiro all plan a copy of adapter-stdin-json.js, the shared dependency their translation adapters require() (2026-07-29 MODULE_NOT_FOUND regression)', () => {
+    // cubic-dev-ai flagged this on PR #1073 (Kiro) as a P1: the adapter
+    // scripts require('../lib/adapter-stdin-json') for their
+    // truncation-aware stdin reader, but none of the three hosts' copy
+    // operations ever included that file -- confirmed for real on the
+    // local machine after merge: every one of the three adapters crashed
+    // with MODULE_NOT_FOUND on its very first invocation. No prior test
+    // caught it because every other test either stubs the adapter's
+    // require() away or only checks the hooks.json/agent-config merge
+    // content, never the full file set an install actually produces.
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+    const projectRoot = '/workspace/app';
+    const adapterStdinJsonSource = 'scripts/lib/adapter-stdin-json.js';
+
+    for (const { label, target, targetRoot, extra, modules } of [
+      { label: 'cursor', target: 'cursor', targetRoot: path.join(projectRoot, '.cursor'), extra: { projectRoot }, modules: [] },
+      { label: 'windsurf-home', target: 'windsurf', targetRoot: path.join(homeDir, '.codeium', 'windsurf'), extra: { homeDir }, modules: [] },
+      { label: 'windsurf-project', target: 'windsurf-project', targetRoot: path.join(projectRoot, '.windsurf'), extra: { projectRoot }, modules: [] },
+      { label: 'kiro-home', target: 'kiro', targetRoot: path.join(homeDir, '.kiro'), extra: { homeDir }, modules: [] },
+      { label: 'kiro-project', target: 'kiro-project', targetRoot: path.join(projectRoot, '.kiro'), extra: { projectRoot }, modules: [] },
+    ]) {
+      const plan = planInstallTargetScaffold({ target, repoRoot, modules, ...extra });
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizedRelativePath(operation.sourceRelativePath) === adapterStdinJsonSource
+          && operation.destinationPath === path.join(targetRoot, 'scripts', 'lib', 'adapter-stdin-json.js')
+        )),
+        `[${label}] Should plan a copy of adapter-stdin-json.js alongside the Guardian adapter`
+      );
+    }
+  })) passed++; else failed++;
+
   if (test('resolves trae adapter root and install-state path from project root', () => {
     const adapter = getInstallTargetAdapter('trae');
     const projectRoot = '/workspace/app';


### PR DESCRIPTION
## Summary
- The Guardian translation adapters for Cursor, Windsurf, and Kiro all `require('../lib/adapter-stdin-json')` for their truncation-aware stdin reader, but no install target ever copied that file to the destination -- only `guardian-bin.js` and `shell-split.js` were included.
- Result: every real install of these three hosts crashed the Guardian adapter with `MODULE_NOT_FOUND` on its very first invocation, silently leaving Bash commands completely unvalidated.
- Fix adds a dedicated `createAdapterStdinJsonCopyOperation` helper in `claude-settings-hooks.js` and wires it into all three targets' operation lists (Cursor also respects the existing `alreadyScaffolded` dedup guard for `hooks-runtime` installs).

## Root cause
Confirmed live in production on the local machine after last night's Cursor/Windsurf/Kiro Guardian merge (PRs #1071-#1073): the adapter scripts require this shared module, but `createBashGuardianScriptCopyOperations`/`BASH_GUARDIAN_HOOK_LIB_SOURCES` never included it, and no existing test asserted on the full file set an install actually produces (tests only check hooks.json/agent-config merge content).

## Test plan
- [x] Added a regression test in `tests/lib/install-targets.test.js` asserting the copy operation for `adapter-stdin-json.js` is planned for Cursor, Windsurf (home + project), and Kiro (home + project)
- [x] Full suite green: 3037/3037
- [x] Real isolated installs for all 3 hosts confirm the file now lands at the correct destination
- [x] Direct piped-stdin invocation of each installed adapter confirms both allow (`git status`) and block (destructive command) paths now work without `MODULE_NOT_FOUND`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in Cursor, Windsurf, and Kiro Guardian adapters by copying the required adapter-stdin-json.js during install, restoring stdin handling and Bash validation.

- **Bug Fixes**
  - Added `createAdapterStdinJsonCopyOperation` and wired it into Cursor, Windsurf, and Kiro install targets.
  - Cursor honors `alreadyScaffolded` to avoid duplicate copies.
  - Added regression tests to ensure the file is copied for all three hosts (home and project variants).

<sup>Written for commit 49f60244747b2e9daa29dd57bfd5208ca900fd48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

