### PR TITLE
docs(roadmap): document the Guardian Cursor/OpenCode/Kiro expansion

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,16 @@
 
 This document describes the planned development direction for EGC (Extended Global Context).
 
+## Unreleased
+
+- Guardian Bash command validator extended to three more hosts with a genuine pre-action blocking hook: Cursor (#1071), OpenCode (#1072), and Kiro CLI (#1073), each wired through a host-specific translation adapter that reuses shared stdin-parsing and hooks-merge libraries; Token Crusher wired into OpenCode (#1072) and into Antigravity's global hooks.json (#1067)
+- Guardian command validator hardened against wrapper and quoting bypasses across every CLI, plus npm packaging, Codex/TOML, and Copilot/CodeBuddy gaps (#1051-#1055)
+- A truncated-but-still-JSON-valid stdin payload could bypass the Guardian's 1MB cap check; the truncation flag is now checked unconditionally in every translation adapter (#1074, and closed for Cursor/Windsurf/Kiro alike)
+- NLI session bus and memory protocol coverage extended to 8+ more harnesses, including Aider, Warp, Windsurf, and Zed (#1059-#1062)
+- `update_state` no longer clobbers project rule files on propagation (#1058); `$HOME` is now resolved fresh on every key lookup instead of once at process boot (#1065)
+- Uncatalogued commands that write to protected files now hard-block instead of only warning (#1070)
+- Claude Code re-injects project context after compaction (#1069)
+
 ## v1.1.2: Bidirectional Sync (Released 2026-06-20)
 
 - `egc watch`: bidirectional sync daemon - edits in any tool config file propagate to all others and back to `~/.egc/state/` automatically (issues #302, #303)


### PR DESCRIPTION
## Summary
- Adds an `## Unreleased` section to `docs/ROADMAP.md` documenting the work merged since v1.1.17 (2026-07-27): the Guardian Bash validator's extension to Cursor (#1071), OpenCode (#1072), and Kiro CLI (#1073), the truncation-flag security hotfix (#1074), and the other merged fixes/hardening in between (#1051-#1070).

## Test plan
- [x] Docs-only change, no code affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Unreleased section to `docs/ROADMAP.md` summarizing post‑v1.1.17 work: the Guardian Bash validator now blocks in `Cursor`, `OpenCode`, and `Kiro CLI` via host adapters, with `Token Crusher` wired into `OpenCode` and global `hooks.json`. It also documents the truncation‑flag security hotfix, cross‑CLI hardening, expanded NLI session coverage, stricter blocking for protected writes, config propagation fixes, fresh `$HOME` resolution, and Claude Code context reinjection.

<sup>Written for commit a5fc8a8f49493ff795fc1441f2f8837a6d037b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

