### PR TITLE
feat(guardian): wire the Token Crusher into Cursor via preToolUse

### DIFF
--- a/scripts/hooks/cursor-crusher-adapter.js
+++ b/scripts/hooks/cursor-crusher-adapter.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Cursor Agent Hooks adapter for the Token Crusher.
+ *
+ * Cursor's beforeShellExecution event (where cursor-guardian-adapter.js
+ * runs) only returns a permission decision -- it cannot rewrite the
+ * command (confirmed against https://cursor.com/docs/agent/hooks: the
+ * response schema for that event is {permission, user_message,
+ * agent_message}, nothing else). The generic preToolUse event fires for
+ * every tool call (Shell, Read, Write, MCP, Task, ...) and its response
+ * DOES support `updated_input`, which replaces the tool's parameters
+ * before it runs -- the same mechanism Claude Code, Codex, Trae, Qwen
+ * Code and Junie CLI already use for the Crusher. This adapter registers
+ * on preToolUse, ignores every tool_name other than "Shell", and reuses
+ * the shared crusher rewrite decision (pre-bash-crusher-rewrite) to
+ * route a crushable command through `egc run` before Cursor executes it.
+ *
+ * Fail-open throughout: Crusher is a performance optimization, never a
+ * security boundary (unlike cursor-guardian-adapter.js), so any error or
+ * ambiguity here just means the original command runs unmodified.
+ */
+
+'use strict';
+
+const { run: runCrusherRewrite } = require('./pre-bash-crusher-rewrite');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+
+// Returns the rewritten tool_input object, or null when nothing should
+// change (wrong tool, no command, rewrite decided against it, or error).
+function computeUpdatedInput(event) {
+  if (!event || typeof event !== 'object' || event.tool_name !== 'Shell') {
+    return null;
+  }
+  const command = event.tool_input && event.tool_input.command;
+  if (!command) {
+    return null;
+  }
+
+  let rewritten;
+  try {
+    const result = JSON.parse(runCrusherRewrite(JSON.stringify({ tool_input: { command } })));
+    rewritten = result && result.tool_input && result.tool_input.command;
+  } catch {
+    return null;
+  }
+
+  if (typeof rewritten !== 'string' || rewritten === command) {
+    return null;
+  }
+
+  return { ...event.tool_input, command: rewritten };
+}
+
+function respond(payload) {
+  process.stdout.write(JSON.stringify(payload));
+  process.exit(0);
+}
+
+function main() {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    if (truncated || !ok) {
+      respond({ permission: 'allow' });
+      return;
+    }
+
+    const updatedInput = computeUpdatedInput(value);
+    if (updatedInput) {
+      respond({ permission: 'allow', updated_input: updatedInput });
+      return;
+    }
+
+    respond({ permission: 'allow' });
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { computeUpdatedInput };

--- a/scripts/hooks/cursor-crusher-adapter.js
+++ b/scripts/hooks/cursor-crusher-adapter.js
@@ -31,7 +31,7 @@ function computeUpdatedInput(event) {
   if (!event || typeof event !== 'object' || event.tool_name !== 'Shell') {
     return null;
   }
-  const command = event.tool_input && event.tool_input.command;
+  const command = event.tool_input?.command;
   if (!command) {
     return null;
   }
@@ -39,7 +39,7 @@ function computeUpdatedInput(event) {
   let rewritten;
   try {
     const result = JSON.parse(runCrusherRewrite(JSON.stringify({ tool_input: { command } })));
-    rewritten = result && result.tool_input && result.tool_input.command;
+    rewritten = result?.tool_input?.command;
   } catch {
     return null;
   }

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -21,6 +21,10 @@ const {
   applyCursorGuardianHookToFile,
 } = require('./cursor-guardian-hooks');
 const {
+  CRUSHER_HOOK_DISPATCH_EVENT: CURSOR_CRUSHER_HOOK_DISPATCH_EVENT,
+  applyCursorCrusherHookToFile,
+} = require('./cursor-crusher-hooks');
+const {
   PRE_TOOL_USE_EVENT: KIRO_PRE_TOOL_USE_EVENT,
   applyKiroGuardianHookToFile,
 } = require('./kiro-guardian-hooks');
@@ -978,6 +982,8 @@ function applyManagedHookOperation(operation) {
     applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
     applyCursorGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath, { seedPath: operation.seedPath });
+  } else if (operation.hookEvent === CURSOR_CRUSHER_HOOK_DISPATCH_EVENT) {
+    applyCursorCrusherHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
     applyKiroGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
@@ -993,6 +999,7 @@ module.exports = {
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
+  CRUSHER_HOOK_LIB_SOURCES,
   CRUSHER_HOOK_MODULE_ID,
   CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   PRE_COMPACT_EVENT,

--- a/scripts/lib/cursor-crusher-hooks.js
+++ b/scripts/lib/cursor-crusher-hooks.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// Manages the Token Crusher entry inside a Cursor Agent Hooks project-level
+// .cursor/hooks.json file. Unlike the Guardian validator (registered on
+// beforeShellExecution, whose response can only allow/deny/ask -- confirmed
+// against https://cursor.com/docs/agent/hooks), the Crusher needs to
+// REWRITE the command before it runs, which only the generic preToolUse
+// event supports, via `updated_input` in the response. Reuses the same flat
+// {hooks: {<event>: [{command}]}} merge primitives cursor-guardian-hooks.js
+// uses for beforeShellExecution, targeting preToolUse instead -- a
+// SEPARATE entry in the same hooks.json, since Cursor's preToolUse fires
+// for every tool (Shell, Read, Write, MCP, Task), not just shell commands.
+
+const path = require('node:path');
+const {
+  applyFlatHookToFile,
+  buildHookCommand,
+  inspectFlatHookFile,
+  removeFlatHookFromFile,
+} = require('./flat-hooks-json-merge');
+const { buildExtraTopLevel, resolveHooksJsonPath } = require('./cursor-guardian-hooks');
+
+const HOST_LABEL = 'Cursor';
+// The real Cursor event name written into hooks.json. Only used as the
+// dispatch key inside THIS file's own functions -- claude-settings-hooks.js
+// must NOT reuse this literal value as an operation.hookEvent dispatch key,
+// because Kiro's own preToolUse event constant is the same string; see
+// CRUSHER_HOOK_DISPATCH_EVENT below for the collision-free key.
+const PRE_TOOL_USE_EVENT = 'preToolUse';
+// Internal dispatch key for applyManagedHookOperation() in
+// claude-settings-hooks.js -- deliberately NOT equal to 'preToolUse' (which
+// Kiro's own operation.hookEvent already uses for a different merge
+// function/schema). The real JSON event name Cursor expects is always
+// PRE_TOOL_USE_EVENT above, hardcoded inside applyCursorCrusherHookToFile
+// below, regardless of what dispatch key routed the call here.
+const CRUSHER_HOOK_DISPATCH_EVENT = 'cursor:preToolUse';
+const CRUSHER_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/cursor-crusher-adapter.js';
+const EGC_ADAPTER_BASENAME = path.basename(CRUSHER_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH);
+
+function isOwnBasename(command) {
+  return command.includes(EGC_ADAPTER_BASENAME);
+}
+
+function resolveCrusherAdapterScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'cursor-crusher-adapter.js');
+}
+
+function applyCursorCrusherHookToFile(hooksJsonPath, adapterScriptPath) {
+  return applyFlatHookToFile(hooksJsonPath, HOST_LABEL, PRE_TOOL_USE_EVENT, buildHookCommand(adapterScriptPath), {
+    isOwnBasename,
+    buildExtraTopLevel,
+  });
+}
+
+function removeCursorCrusherHookFromFile(hooksJsonPath, adapterScriptPath) {
+  return removeFlatHookFromFile(hooksJsonPath, HOST_LABEL, PRE_TOOL_USE_EVENT, buildHookCommand(adapterScriptPath));
+}
+
+function inspectCursorCrusherHookFile(hooksJsonPath, adapterScriptPath) {
+  return inspectFlatHookFile(hooksJsonPath, HOST_LABEL, PRE_TOOL_USE_EVENT, buildHookCommand(adapterScriptPath));
+}
+
+module.exports = {
+  CRUSHER_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  CRUSHER_HOOK_DISPATCH_EVENT,
+  PRE_TOOL_USE_EVENT,
+  applyCursorCrusherHookToFile,
+  inspectCursorCrusherHookFile,
+  removeCursorCrusherHookFromFile,
+  resolveCrusherAdapterScriptDestination,
+  resolveHooksJsonPath,
+};

--- a/scripts/lib/cursor-guardian-hooks.js
+++ b/scripts/lib/cursor-guardian-hooks.js
@@ -85,6 +85,7 @@ module.exports = {
   GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
   addCursorHookEntry,
   applyCursorGuardianHookToFile,
+  buildExtraTopLevel,
   inspectCursorGuardianHookFile,
   removeCursorGuardianHookFromFile,
   removeCursorHookEntry,

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -43,6 +43,11 @@ const {
   removeCursorGuardianHookFromFile,
 } = require('./cursor-guardian-hooks');
 const {
+  CRUSHER_HOOK_DISPATCH_EVENT: CURSOR_CRUSHER_HOOK_DISPATCH_EVENT,
+  inspectCursorCrusherHookFile,
+  removeCursorCrusherHookFromFile,
+} = require('./cursor-crusher-hooks');
+const {
   PRE_TOOL_USE_EVENT: KIRO_PRE_TOOL_USE_EVENT,
   inspectKiroGuardianHookFile,
   removeKiroGuardianHookFromFile,
@@ -555,6 +560,8 @@ function uninstallManagedHookOperation(operation) {
     removeWindsurfGateGuardHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
     removeCursorGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
+  } else if (operation.hookEvent === CURSOR_CRUSHER_HOOK_DISPATCH_EVENT) {
+    removeCursorCrusherHookFromFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
     removeKiroGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
   } else {
@@ -698,6 +705,9 @@ function inspectManagedOperation(repoRoot, operation) {
     }
     if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
       return inspectResult(inspectCursorGuardianHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
+    }
+    if (operation.hookEvent === CURSOR_CRUSHER_HOOK_DISPATCH_EVENT) {
+      return inspectResult(inspectCursorCrusherHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
     }
     if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
       return inspectResult(inspectKiroGuardianHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -12,6 +12,7 @@ const {
 } = require('./helpers');
 const {
   HOOK_OPERATION_KIND,
+  CRUSHER_HOOK_LIB_SOURCES,
   createBashGuardianScriptCopyOperations,
   createAdapterStdinJsonCopyOperation,
   ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH,
@@ -22,6 +23,11 @@ const {
   resolveGuardianAdapterScriptDestination,
   resolveHooksJsonPath,
 } = require('../cursor-guardian-hooks');
+const {
+  CRUSHER_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+  CRUSHER_HOOK_DISPATCH_EVENT,
+  resolveCrusherAdapterScriptDestination,
+} = require('../cursor-crusher-hooks');
 
 // EGC-494/EGC-498: every Cursor install registers the Guardian Bash
 // validator on beforeShellExecution, even when no content modules are
@@ -86,6 +92,62 @@ function createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot) 
     ...guardianScriptCopyOperations,
     ...(adapterCopyOperation ? [adapterCopyOperation] : []),
     ...(adapterStdinJsonCopyOperation ? [adapterStdinJsonCopyOperation] : []),
+    mergeOperation,
+  ];
+}
+
+// Every Cursor install also registers the Token Crusher on preToolUse,
+// unconditionally, the same way createCursorGuardianOperations above always
+// registers the Guardian validator on beforeShellExecution -- a minimal
+// install is never silently uncompressed. Cursor's beforeShellExecution
+// response cannot rewrite a command (confirmed against
+// https://cursor.com/docs/agent/hooks), so the Crusher needs its own
+// adapter script on a different event (preToolUse) rather than reusing the
+// Guardian's. adapter-stdin-json.js itself is NOT copied here: the Guardian
+// operations above always run too and already guarantee it exists.
+function createCursorCrusherOperations(adapter, targetRoot, modules) {
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+
+  const selectedPaths = new Set(modules.flatMap(module => (Array.isArray(module.paths) ? module.paths : [])));
+  const alreadyScaffolded = sourceRelativePath => (
+    (selectedPaths.has('scripts/hooks') && sourceRelativePath.startsWith('scripts/hooks/'))
+    || (selectedPaths.has('scripts/lib') && sourceRelativePath.startsWith('scripts/lib/'))
+  );
+
+  const adapterModuleId = 'egc-cursor-crusher-hook';
+  const adapterScriptDestination = resolveCrusherAdapterScriptDestination(targetRoot);
+
+  const adapterCopyOperation = alreadyScaffolded(CRUSHER_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH)
+    ? null
+    : createRemappedOperation(
+      adapter,
+      adapterModuleId,
+      CRUSHER_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+      adapterScriptDestination,
+      { strategy: 'preserve-relative-path' }
+    );
+
+  const libCopyOperations = CRUSHER_HOOK_LIB_SOURCES
+    .filter(src => !alreadyScaffolded(src))
+    .map(src => remap(adapterModuleId, src, path.join(targetRoot, ...src.split('/')), { strategy: 'preserve-relative-path' }));
+
+  const mergeOperation = {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: adapterModuleId,
+    sourceRelativePath: CRUSHER_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath: resolveHooksJsonPath(targetRoot),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: CRUSHER_HOOK_DISPATCH_EVENT,
+    hookScriptPath: adapterScriptDestination,
+  };
+
+  return [
+    ...libCopyOperations,
+    ...(adapterCopyOperation ? [adapterCopyOperation] : []),
     mergeOperation,
   ];
 }
@@ -290,6 +352,7 @@ module.exports = createInstallTargetAdapter({
       return takeUniqueOperations([
         adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput),
       ]);
-    }), ...createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot)];
+    }), ...createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot),
+    ...createCursorCrusherOperations(adapter, targetRoot, modules)];
   },
 });

--- a/tests/hooks/cursor-crusher-adapter.test.js
+++ b/tests/hooks/cursor-crusher-adapter.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for scripts/hooks/cursor-crusher-adapter.js
+ *
+ * Cursor's beforeShellExecution event (Guardian's slot) cannot rewrite a
+ * command -- confirmed against https://cursor.com/docs/agent/hooks, whose
+ * response schema for that event is only {permission, user_message,
+ * agent_message}. This adapter instead runs on the generic preToolUse
+ * event, whose response DOES support `updated_input`. Unlike the Guardian
+ * adapter (see cursor-guardian-adapter.test.js), the Crusher is never a
+ * security boundary: every failure mode here fails OPEN, never closed.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'cursor-crusher-adapter.js');
+const { computeUpdatedInput } = require(adapterScript);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const result = spawnSync('node', [adapterScript], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, EGC_ASSUME_EGC_CLI: '1', ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing cursor-crusher-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('computeUpdatedInput rewrites a crushable Shell command', () => {
+    process.env.EGC_ASSUME_EGC_CLI = '1';
+    const updated = computeUpdatedInput({
+      tool_name: 'Shell',
+      tool_input: { command: 'git log --stat -n 300', working_directory: '/repo' },
+    });
+    assert.ok(updated, 'expected a rewritten tool_input');
+    assert.strictEqual(updated.command, 'egc run git log --stat -n 300');
+    assert.strictEqual(updated.working_directory, '/repo', 'must preserve other tool_input fields');
+    delete process.env.EGC_ASSUME_EGC_CLI;
+  })) passed++; else failed++;
+
+  if (test('computeUpdatedInput returns null for a non-crushable Shell command', () => {
+    process.env.EGC_ASSUME_EGC_CLI = '1';
+    assert.strictEqual(computeUpdatedInput({ tool_name: 'Shell', tool_input: { command: 'echo hi' } }), null);
+    delete process.env.EGC_ASSUME_EGC_CLI;
+  })) passed++; else failed++;
+
+  if (test('computeUpdatedInput returns null for a non-Shell tool_name', () => {
+    process.env.EGC_ASSUME_EGC_CLI = '1';
+    assert.strictEqual(
+      computeUpdatedInput({ tool_name: 'Read', tool_input: { command: 'git log --stat -n 300' } }),
+      null
+    );
+    delete process.env.EGC_ASSUME_EGC_CLI;
+  })) passed++; else failed++;
+
+  if (test('computeUpdatedInput returns null when there is no command', () => {
+    assert.strictEqual(computeUpdatedInput({ tool_name: 'Shell', tool_input: {} }), null);
+  })) passed++; else failed++;
+
+  if (test('computeUpdatedInput returns null (does not throw) for a non-object event', () => {
+    assert.strictEqual(computeUpdatedInput(null), null);
+    assert.strictEqual(computeUpdatedInput('a string'), null);
+    assert.strictEqual(computeUpdatedInput(42), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: rewrites a crushable Shell command with updated_input.command', () => {
+    const result = runAdapterCli({
+      tool_name: 'Shell',
+      tool_input: { command: 'git log --stat -n 300' },
+      tool_use_id: 'abc123',
+    });
+    assert.strictEqual(result.code, 0);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.permission, 'allow');
+    assert.strictEqual(response.updated_input.command, 'egc run git log --stat -n 300');
+  })) passed++; else failed++;
+
+  if (test('CLI: a trivial Shell command allows with no updated_input (no false positive)', () => {
+    const result = runAdapterCli({ tool_name: 'Shell', tool_input: { command: 'echo hi' } });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: a non-Shell tool call (e.g. Read) allows untouched', () => {
+    const result = runAdapterCli({ tool_name: 'Read', tool_input: { path: '/etc/passwd' } });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed stdin JSON fails OPEN (allow) -- Crusher is never a security boundary', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: a truncated oversized payload fails OPEN (allow), unlike the Guardian adapter\'s fail-closed', () => {
+    const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      tool_name: 'Shell',
+      tool_input: { command: 'git log --stat -n 300' },
+      padding: oversizedPadding,
+    });
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { permission: 'allow' });
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/cursor-crusher-adapter.test.js
+++ b/tests/hooks/cursor-crusher-adapter.test.js
@@ -87,6 +87,45 @@ function runTests() {
     assert.strictEqual(computeUpdatedInput(42), null);
   })) passed++; else failed++;
 
+  if (test('computeUpdatedInput returns null (does not throw) when the shared rewrite dependency itself throws', () => {
+    // pre-bash-crusher-rewrite.js's own run() always self-catches and
+    // returns a valid JSON string, so this catch branch is unreachable via
+    // any real input through the normal path -- reproduced the same way
+    // tests/hooks/pre-bash-guardian-validate.test.js covers its own
+    // unreachable-via-real-input branch: stub the dependency in this
+    // process's require.cache and re-require the adapter fresh, so c8
+    // still credits the coverage to the real file path.
+    const rewritePath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-crusher-rewrite.js');
+    const originalRewriteEntry = require.cache[rewritePath];
+    const originalAdapterEntry = require.cache[adapterScript];
+    try {
+      delete require.cache[rewritePath];
+      delete require.cache[adapterScript];
+      require.cache[rewritePath] = {
+        id: rewritePath,
+        filename: rewritePath,
+        loaded: true,
+        exports: {
+          run: () => {
+            throw new Error('simulated dependency failure');
+          },
+        },
+      };
+
+      const { computeUpdatedInput: computeWithThrowingDependency } = require(adapterScript);
+      const result = computeWithThrowingDependency({
+        tool_name: 'Shell',
+        tool_input: { command: 'git log --stat -n 300' },
+      });
+      assert.strictEqual(result, null, 'Expected null when the rewrite dependency throws, not a crash');
+    } finally {
+      delete require.cache[rewritePath];
+      delete require.cache[adapterScript];
+      if (originalRewriteEntry) require.cache[rewritePath] = originalRewriteEntry;
+      if (originalAdapterEntry) require.cache[adapterScript] = originalAdapterEntry;
+    }
+  })) passed++; else failed++;
+
   if (test('CLI: rewrites a crushable Shell command with updated_input.command', () => {
     const result = runAdapterCli({
       tool_name: 'Shell',

--- a/tests/hooks/cursor-crusher-adapter.test.js
+++ b/tests/hooks/cursor-crusher-adapter.test.js
@@ -52,29 +52,38 @@ function runTests() {
 
   if (test('computeUpdatedInput rewrites a crushable Shell command', () => {
     process.env.EGC_ASSUME_EGC_CLI = '1';
-    const updated = computeUpdatedInput({
-      tool_name: 'Shell',
-      tool_input: { command: 'git log --stat -n 300', working_directory: '/repo' },
-    });
-    assert.ok(updated, 'expected a rewritten tool_input');
-    assert.strictEqual(updated.command, 'egc run git log --stat -n 300');
-    assert.strictEqual(updated.working_directory, '/repo', 'must preserve other tool_input fields');
-    delete process.env.EGC_ASSUME_EGC_CLI;
+    try {
+      const updated = computeUpdatedInput({
+        tool_name: 'Shell',
+        tool_input: { command: 'git log --stat -n 300', working_directory: '/repo' },
+      });
+      assert.ok(updated, 'expected a rewritten tool_input');
+      assert.strictEqual(updated.command, 'egc run git log --stat -n 300');
+      assert.strictEqual(updated.working_directory, '/repo', 'must preserve other tool_input fields');
+    } finally {
+      delete process.env.EGC_ASSUME_EGC_CLI;
+    }
   })) passed++; else failed++;
 
   if (test('computeUpdatedInput returns null for a non-crushable Shell command', () => {
     process.env.EGC_ASSUME_EGC_CLI = '1';
-    assert.strictEqual(computeUpdatedInput({ tool_name: 'Shell', tool_input: { command: 'echo hi' } }), null);
-    delete process.env.EGC_ASSUME_EGC_CLI;
+    try {
+      assert.strictEqual(computeUpdatedInput({ tool_name: 'Shell', tool_input: { command: 'echo hi' } }), null);
+    } finally {
+      delete process.env.EGC_ASSUME_EGC_CLI;
+    }
   })) passed++; else failed++;
 
   if (test('computeUpdatedInput returns null for a non-Shell tool_name', () => {
     process.env.EGC_ASSUME_EGC_CLI = '1';
-    assert.strictEqual(
-      computeUpdatedInput({ tool_name: 'Read', tool_input: { command: 'git log --stat -n 300' } }),
-      null
-    );
-    delete process.env.EGC_ASSUME_EGC_CLI;
+    try {
+      assert.strictEqual(
+        computeUpdatedInput({ tool_name: 'Read', tool_input: { command: 'git log --stat -n 300' } }),
+        null
+      );
+    } finally {
+      delete process.env.EGC_ASSUME_EGC_CLI;
+    }
   })) passed++; else failed++;
 
   if (test('computeUpdatedInput returns null when there is no command', () => {

--- a/tests/lib/cursor-crusher-hooks.test.js
+++ b/tests/lib/cursor-crusher-hooks.test.js
@@ -1,0 +1,146 @@
+/**
+ * Tests for scripts/lib/cursor-crusher-hooks.js
+ *
+ * Mirrors tests/lib/cursor-guardian-hooks.test.js's structure, but for the
+ * Crusher's preToolUse entry instead of the Guardian's beforeShellExecution
+ * entry -- both live in the same flat hooks.json, so these tests also cover
+ * that the two never collide on the same event array.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  PRE_TOOL_USE_EVENT,
+  applyCursorCrusherHookToFile,
+  inspectCursorCrusherHookFile,
+  removeCursorCrusherHookFromFile,
+  resolveCrusherAdapterScriptDestination,
+} = require('../../scripts/lib/cursor-crusher-hooks');
+const { BEFORE_SHELL_EXECUTION_EVENT, applyCursorGuardianHookToFile } = require('../../scripts/lib/cursor-guardian-hooks');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing cursor-crusher-hooks ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('PRE_TOOL_USE_EVENT is Cursor\'s real event name', () => {
+    assert.strictEqual(PRE_TOOL_USE_EVENT, 'preToolUse');
+  })) passed++; else failed++;
+
+  if (test('resolveCrusherAdapterScriptDestination computes a path under targetRoot', () => {
+    const dest = resolveCrusherAdapterScriptDestination('/proj/.cursor');
+    assert.strictEqual(dest, path.join('/proj/.cursor', 'scripts', 'hooks', 'cursor-crusher-adapter.js'));
+  })) passed++; else failed++;
+
+  if (test('applyCursorCrusherHookToFile writes preToolUse to a fresh file and is idempotent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-crusher-hooks-apply-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      const first = applyCursorCrusherHookToFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js');
+      assert.strictEqual(first.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDisk.version, 1);
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT].length, 1);
+      assert.ok(onDisk.hooks[PRE_TOOL_USE_EVENT][0].command.includes('cursor-crusher-adapter.js'));
+
+      const second = applyCursorCrusherHookToFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js');
+      assert.strictEqual(second.changed, false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyCursorCrusherHookToFile preserves a pre-existing third-party preToolUse entry', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-crusher-hooks-thirdparty-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, JSON.stringify({
+        version: 1,
+        hooks: { [PRE_TOOL_USE_EVENT]: [{ command: 'node .cursor/hooks/before-tool-use.js' }] },
+      }));
+      applyCursorCrusherHookToFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js');
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT].length, 2);
+      assert.ok(onDisk.hooks[PRE_TOOL_USE_EVENT].some(entry => entry.command === 'node .cursor/hooks/before-tool-use.js'));
+      assert.ok(onDisk.hooks[PRE_TOOL_USE_EVENT].some(entry => entry.command.includes('cursor-crusher-adapter.js')));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('the Crusher preToolUse entry and the Guardian beforeShellExecution entry coexist without colliding', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-crusher-vs-guardian-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      applyCursorGuardianHookToFile(hooksJsonPath, BEFORE_SHELL_EXECUTION_EVENT, '/abs/cursor-guardian-adapter.js');
+      applyCursorCrusherHookToFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js');
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT].length, 1);
+      assert.ok(onDisk.hooks[BEFORE_SHELL_EXECUTION_EVENT][0].command.includes('cursor-guardian-adapter.js'));
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT].length, 1);
+      assert.ok(onDisk.hooks[PRE_TOOL_USE_EVENT][0].command.includes('cursor-crusher-adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('removeCursorCrusherHookFromFile drops only the EGC entry, keeps third-party hooks', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-crusher-hooks-remove-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, JSON.stringify({
+        version: 1,
+        hooks: { [PRE_TOOL_USE_EVENT]: [{ command: 'node .cursor/hooks/before-tool-use.js' }] },
+      }));
+      applyCursorCrusherHookToFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js');
+      const result = removeCursorCrusherHookFromFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js');
+      assert.strictEqual(result.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT].length, 1);
+      assert.strictEqual(onDisk.hooks[PRE_TOOL_USE_EVENT][0].command, 'node .cursor/hooks/before-tool-use.js');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('removeCursorCrusherHookFromFile on a missing file is a no-op', () => {
+    const result = removeCursorCrusherHookFromFile('/nonexistent/hooks.json', '/abs/cursor-crusher-adapter.js');
+    assert.strictEqual(result.changed, false);
+  })) passed++; else failed++;
+
+  if (test('inspectCursorCrusherHookFile reports ok when present, drifted when absent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-crusher-hooks-inspect-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      assert.strictEqual(inspectCursorCrusherHookFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js'), 'drifted');
+      applyCursorCrusherHookToFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js');
+      assert.strictEqual(inspectCursorCrusherHookFile(hooksJsonPath, '/abs/cursor-crusher-adapter.js'), 'ok');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -217,12 +217,35 @@ function runTests() {
     const hooksJsonDestination = path.join(targetRoot, 'hooks.json');
 
     const operationsForHooksJson = plan.operations.filter(operation => operation.destinationPath === hooksJsonDestination);
-    assert.strictEqual(operationsForHooksJson.length, 1, 'Exactly one operation should target hooks.json (the Guardian merge)');
-    assert.strictEqual(operationsForHooksJson[0].kind, 'merge-claude-settings-hooks');
     assert.strictEqual(
-      operationsForHooksJson[0].seedPath,
+      operationsForHooksJson.length,
+      2,
+      'Exactly two operations should target hooks.json: the Guardian merge (beforeShellExecution) and the Crusher merge (preToolUse) -- never a raw copy'
+    );
+    assert.ok(
+      operationsForHooksJson.every(operation => operation.kind === 'merge-claude-settings-hooks'),
+      'Every operation targeting hooks.json must be a merge, never a raw copy that would clobber the other event\'s entry'
+    );
+
+    const guardianMerge = operationsForHooksJson.find(operation => operation.hookEvent === 'beforeShellExecution');
+    assert.ok(guardianMerge, 'Should include the Guardian beforeShellExecution merge');
+    assert.strictEqual(
+      guardianMerge.seedPath,
       path.join(repoRoot, '.cursor', 'hooks.json'),
-      'The merge operation should carry the repo\'s own hooks.json as a seed, so a fresh install still gets EGC\'s other platform hooks (sessionStart, GateGuard, etc.), not just the Guardian entry'
+      'The Guardian merge operation should carry the repo\'s own hooks.json as a seed, so a fresh install still gets EGC\'s other platform hooks (sessionStart, GateGuard, etc.), not just the Guardian entry'
+    );
+
+    const crusherMerge = operationsForHooksJson.find(operation => operation !== guardianMerge);
+    assert.ok(crusherMerge, 'Should include the Crusher preToolUse merge');
+    assert.strictEqual(
+      crusherMerge.hookEvent,
+      'cursor:preToolUse',
+      'The Crusher merge must use its own internal dispatch key, distinct from Kiro\'s preToolUse operation.hookEvent, which uses the same literal event name for a different merge schema'
+    );
+    assert.strictEqual(
+      crusherMerge.seedPath,
+      undefined,
+      'The Crusher merge should never carry a seedPath -- only the Guardian merge seeds the fresh file, so the repo\'s own hooks.json is never seeded twice'
     );
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
- Cursor's `beforeShellExecution` (Guardian's slot) can only allow/deny/ask -- confirmed against the official docs, it cannot rewrite a command.
- The generic `preToolUse` event fires for every tool call and its response supports `updated_input`, the same mechanism already used for Claude Code, Codex, Trae, Qwen Code and Junie CLI.
- Adds a dedicated `preToolUse` adapter (matching `tool_name=="Shell"`) reusing the shared crusher rewrite decision, registered as a second, independent entry in the same `hooks.json` the Guardian already writes to. Distinct dispatch key from Kiro's own `preToolUse` operation, which targets a different merge schema under the same literal event name.

## Test plan
- [x] 18 new unit tests (adapter CLI + pure function, hooks.json merge/idempotency, coexistence with the Guardian entry)
- [x] Fixed an existing `install-targets.test.js` invariant that assumed only one operation could ever target `hooks.json`
- [x] Real isolated install (HOME/project outside the repo) + direct stdin invocation: `git log --stat -n 300` rewrites to `egc run git log --stat -n 300`; trivial command passes through untouched; non-Shell tool calls ignored
- [x] Full suite: 3037/3037

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cursor `preToolUse` adapter that rewrites crushable Shell commands to run via `egc run`, coexisting with the Guardian which can’t rewrite on `beforeShellExecution`. Also wires the new hook into install inspect/uninstall so `egc doctor` recognizes it and uninstall cleans it up.

- **New Features**
  - Added `scripts/hooks/cursor-crusher-adapter.js` for `tool_name: "Shell"`, returning `updated_input.command` via the shared rewrite; fails open on errors, ignores non-Shell, and passes through trivial commands.
  - Introduced `scripts/lib/cursor-crusher-hooks.js` with a distinct dispatch key (`cursor:preToolUse`), idempotent merge into `.cursor/hooks.json` that coexists with the Guardian and preserves third-party entries.
  - Installer now registers the Crusher on `preToolUse` via `createCursorCrusherOperations`, without seeding the file twice; updated tests for adapter CLI/pure function, merge/idempotency, and coexistence; patch coverage 100%.

- **Bug Fixes**
  - Wired `cursor:preToolUse` into `install-lifecycle.js` inspect and uninstall paths, fixing false "drifted" reports and ensuring uninstall removes the hook entry.
  - Tightened test hygiene by cleaning `EGC_ASSUME_EGC_CLI` with try/finally; updated `install-targets.test.js` to expect two merge ops targeting `hooks.json` (Guardian and Crusher).

<sup>Written for commit a18f54172dcd6d669d72763da721054995947ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

