### PR TITLE
feat(guardian): wire Guardian and Token Crusher into Trae

### DIFF
--- a/scripts/lib/install-targets/trae-project.js
+++ b/scripts/lib/install-targets/trae-project.js
@@ -6,13 +6,9 @@ const {
   isForeignPlatformPath,
 } = require('./helpers');
 const {
-  BASH_GUARDIAN_HOOK_MODULE_ID,
-  BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-  CRUSHER_HOOK_MODULE_ID,
-  CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-  HOOK_OPERATION_KIND,
-  PRE_TOOL_USE_EVENT,
+  createBashGuardianHookMergeOperationForDestination,
   createBashGuardianScriptCopyOperations,
+  createCrusherHookMergeOperationForDestination,
   createCrusherScriptCopyOperations,
 } = require('../claude-settings-hooks');
 
@@ -24,24 +20,15 @@ const {
 // states Trae can import an existing Claude Code hook configuration. The
 // shell/terminal tool's matcher is "RunCommand" (not "Bash" like Claude
 // Code/Codex, not "Shell" like Cursor) -- confirmed the same way, not
-// assumed from the other hosts' naming.
+// assumed from the other hosts' naming. Uses the same destination-driven
+// merge builders Copilot/Antigravity already share (cubic review, PR #1079)
+// instead of a Trae-local reimplementation of the operation shape.
 function resolveTraeRoot(adapter, input) {
   return adapter.resolveRoot(input);
 }
 
-function buildTraePreToolUseMergeOperation(traeRoot, moduleId, sourceRelativePath, hookScriptPath) {
-  return {
-    kind: HOOK_OPERATION_KIND,
-    moduleId,
-    sourceRelativePath,
-    destinationPath: path.join(traeRoot, 'hooks.json'),
-    strategy: HOOK_OPERATION_KIND,
-    ownership: 'managed',
-    scaffoldOnly: false,
-    hookEvent: PRE_TOOL_USE_EVENT,
-    hookMatcher: 'RunCommand',
-    hookScriptPath,
-  };
+function resolveTraeHooksJsonPath(traeRoot) {
+  return path.join(traeRoot, 'hooks.json');
 }
 
 // Every Trae install registers the Guardian Bash validator on
@@ -58,11 +45,10 @@ function createTraeGuardianOperations(adapter, traeRoot) {
     traeRoot
   );
 
-  const mergeOperation = buildTraePreToolUseMergeOperation(
-    traeRoot,
-    BASH_GUARDIAN_HOOK_MODULE_ID,
-    BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-    hookScriptPath
+  const mergeOperation = createBashGuardianHookMergeOperationForDestination(
+    resolveTraeHooksJsonPath(traeRoot),
+    hookScriptPath,
+    'RunCommand'
   );
 
   return [...copyOperations, mergeOperation];
@@ -81,11 +67,10 @@ function createTraeCrusherOperations(adapter, traeRoot) {
     traeRoot
   );
 
-  const mergeOperation = buildTraePreToolUseMergeOperation(
-    traeRoot,
-    CRUSHER_HOOK_MODULE_ID,
-    CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
-    hookScriptPath
+  const mergeOperation = createCrusherHookMergeOperationForDestination(
+    resolveTraeHooksJsonPath(traeRoot),
+    hookScriptPath,
+    'RunCommand'
   );
 
   return [...copyOperations, mergeOperation];

--- a/scripts/lib/install-targets/trae-project.js
+++ b/scripts/lib/install-targets/trae-project.js
@@ -1,4 +1,95 @@
-const { createInstallTargetAdapter } = require('./helpers');
+const path = require('node:path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+} = require('./helpers');
+const {
+  BASH_GUARDIAN_HOOK_MODULE_ID,
+  BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  CRUSHER_HOOK_MODULE_ID,
+  CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  HOOK_OPERATION_KIND,
+  PRE_TOOL_USE_EVENT,
+  createBashGuardianScriptCopyOperations,
+  createCrusherScriptCopyOperations,
+} = require('../claude-settings-hooks');
+
+// Trae reads the same {hooks: {PreToolUse: [{matcher, hooks: [{type,
+// command}]}]}} JSON schema as Claude Code, including
+// hookSpecificOutput.permissionDecision/updatedInput -- confirmed against
+// docs.trae.ai/ide/hook-configuration-reference, which documents the config
+// file at $PROJECT_FOLDER/.trae/hooks.json (project scope) and explicitly
+// states Trae can import an existing Claude Code hook configuration. The
+// shell/terminal tool's matcher is "RunCommand" (not "Bash" like Claude
+// Code/Codex, not "Shell" like Cursor) -- confirmed the same way, not
+// assumed from the other hosts' naming.
+function resolveTraeRoot(adapter, input) {
+  return adapter.resolveRoot(input);
+}
+
+function buildTraePreToolUseMergeOperation(traeRoot, moduleId, sourceRelativePath, hookScriptPath) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId,
+    sourceRelativePath,
+    destinationPath: path.join(traeRoot, 'hooks.json'),
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: 'RunCommand',
+    hookScriptPath,
+  };
+}
+
+// Every Trae install registers the Guardian Bash validator on
+// PreToolUse/RunCommand, unconditionally -- the same "deterministic,
+// regardless of selected modules" pattern every other host in this registry
+// uses for its own security hooks, so a minimal install is never silently
+// unprotected.
+function createTraeGuardianOperations(adapter, traeRoot) {
+  const hookScriptPath = path.join(traeRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+  const copyOperations = createBashGuardianScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    traeRoot
+  );
+
+  const mergeOperation = buildTraePreToolUseMergeOperation(
+    traeRoot,
+    BASH_GUARDIAN_HOOK_MODULE_ID,
+    BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    hookScriptPath
+  );
+
+  return [...copyOperations, mergeOperation];
+}
+
+// Token Crusher for Trae: same PreToolUse/updatedInput rewrite mechanism as
+// Claude Code and Codex, so the shared crusher-hook.js needs no host-specific
+// translation adapter here (unlike Cursor, whose beforeShellExecution slot
+// cannot rewrite a command -- see cursor-crusher-hooks.js).
+function createTraeCrusherOperations(adapter, traeRoot) {
+  const hookScriptPath = path.join(traeRoot, 'scripts', 'hooks', 'crusher-hook.js');
+  const copyOperations = createCrusherScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    traeRoot
+  );
+
+  const mergeOperation = buildTraePreToolUseMergeOperation(
+    traeRoot,
+    CRUSHER_HOOK_MODULE_ID,
+    CRUSHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    hookScriptPath
+  );
+
+  return [...copyOperations, mergeOperation];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'trae-project',
@@ -7,4 +98,32 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.trae'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.trae',
+  planOperations(input, adapter) {
+    // Same default scaffold createInstallTargetAdapter() itself would use
+    // when planOperations is omitted (this file's previous behavior) --
+    // preserved verbatim here only because a custom planOperations is now
+    // needed to also append the Guardian/Crusher operations below.
+    let modules;
+    if (Array.isArray(input.modules)) {
+      modules = input.modules;
+    } else if (input.module) {
+      modules = [input.module];
+    } else {
+      modules = [];
+    }
+
+    const moduleOperations = modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
+    });
+
+    const traeRoot = resolveTraeRoot(adapter, input);
+    return [
+      ...moduleOperations,
+      ...createTraeGuardianOperations(adapter, traeRoot),
+      ...createTraeCrusherOperations(adapter, traeRoot),
+    ];
+  },
 });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2592,6 +2592,38 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('trae adapter accepts a singular input.module and treats a fully empty input as no modules', () => {
+    // planInstallTargetScaffold() (used by the tests above) always normalizes
+    // to an array before calling adapter.planOperations(), so these two
+    // fallback branches are only reachable by calling the adapter directly --
+    // the same shape install-executor.js's non-array call sites use.
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+    const adapter = getInstallTargetAdapter('trae');
+    const planningInput = { repoRoot, projectRoot, homeDir: '/home/example' };
+
+    const singularModuleOperations = adapter.planOperations({
+      ...planningInput,
+      module: { id: 'workflow', paths: ['skills/workflow/tdd-workflow'] },
+    });
+    assert.ok(
+      singularModuleOperations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/workflow/tdd-workflow'
+      )),
+      'A singular input.module should still be scaffolded like a one-element modules array'
+    );
+
+    const noModulesOperations = adapter.planOperations({ ...planningInput });
+    const hooksJsonOps = noModulesOperations.filter(operation => (
+      operation.destinationPath === path.join(projectRoot, '.trae', 'hooks.json')
+    ));
+    assert.strictEqual(
+      hooksJsonOps.length,
+      2,
+      'Guardian and Crusher should still be planned unconditionally when neither modules nor module is present'
+    );
+  })) passed++; else failed++;
+
   if (test('resolves goose adapter root to ~/.agents (shared with Codex) and its own install-state path', () => {
     const adapter = getInstallTargetAdapter('goose');
     const homeDir = '/Users/example';

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2549,6 +2549,49 @@ function runTests() {
     assert.ok(targets.includes('trae'), 'Should include trae target');
   })) passed++; else failed++;
 
+  if (test('trae adapter always plans Guardian and Crusher on PreToolUse/RunCommand, even with no modules selected', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+    const targetRoot = path.join(projectRoot, '.trae');
+    const hooksJsonPath = path.join(targetRoot, 'hooks.json');
+
+    const plan = planInstallTargetScaffold({
+      target: 'trae',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+
+    const mergeOperations = plan.operations.filter(operation => operation.destinationPath === hooksJsonPath);
+    assert.strictEqual(mergeOperations.length, 2, 'Guardian and Crusher should each plan exactly one merge into .trae/hooks.json');
+    assert.ok(
+      mergeOperations.every(operation => operation.hookEvent === 'PreToolUse' && operation.hookMatcher === 'RunCommand'),
+      'Both merges must target PreToolUse with the RunCommand matcher (Trae\'s tool_name for shell, not Bash/Shell)'
+    );
+
+    const guardianMerge = mergeOperations.find(operation => operation.moduleId === 'egc-bash-guardian-hook');
+    const crusherMerge = mergeOperations.find(operation => operation.moduleId === 'egc-crusher-hook');
+    assert.ok(guardianMerge, 'Should plan the Guardian merge');
+    assert.ok(crusherMerge, 'Should plan the Crusher merge');
+    assert.strictEqual(guardianMerge.hookScriptPath, path.join(targetRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js'));
+    assert.strictEqual(crusherMerge.hookScriptPath, path.join(targetRoot, 'scripts', 'hooks', 'crusher-hook.js'));
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'
+        && operation.destinationPath === guardianMerge.hookScriptPath
+      )),
+      'Should plan the shared Guardian validator script copy even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/crusher-hook.js'
+        && operation.destinationPath === crusherMerge.hookScriptPath
+      )),
+      'Should plan the shared Crusher hook script copy even with no modules selected'
+    );
+  })) passed++; else failed++;
+
   if (test('resolves goose adapter root to ~/.agents (shared with Codex) and its own install-state path', () => {
     const adapter = getInstallTargetAdapter('goose');
     const homeDir = '/Users/example';


### PR DESCRIPTION
## Summary
- Confirmed via official docs (docs.trae.ai/ide/hook-configuration-reference): Trae reads the same `{hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}}` schema as Claude Code, config at `$PROJECT_FOLDER/.trae/hooks.json`, shell matcher is `"RunCommand"`.
- Same response envelope as Claude Code (`hookSpecificOutput.permissionDecision`/`updatedInput`), so both Guardian and Crusher reuse the existing shared merge helpers directly -- no translation adapter needed, unlike Cursor.

## Test plan
- [x] New unit test: both merges planned unconditionally (RunCommand matcher, correct script paths), even with no modules selected
- [x] Real isolated install + direct stdin invocation: Guardian allows a safe command; Crusher rewrites `git log --stat -n 300` to `egc run git log --stat -n 300`, leaves trivial commands untouched
- [x] Real `egc doctor` run: status "ok", zero issues
- [x] Full suite: 3038/3038

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires Guardian and Token Crusher into Trae by registering `PreToolUse`/`RunCommand` hooks and copying their scripts into `.trae`, enabling default command validation and safe rewrites. Reuses the Claude Code hook schema and shared merge helpers with no adapter; now uses shared PreToolUse merge builders to remove duplication.

- **New Features**
  - Always plans Guardian (`egc-bash-guardian-hook`) and Crusher (`egc-crusher-hook`) merges into `.trae/hooks.json` on `PreToolUse` with matcher `RunCommand`.
  - Copies `pre-bash-guardian-validate.js` and `crusher-hook.js` into `.trae/scripts/hooks/`.
  - Adds tests for unconditional planning and correct script paths; covers singular `input.module` and empty-input cases.

- **Refactors**
  - Replaced local Trae merge builder with shared `createBashGuardianHookMergeOperationForDestination` and `createCrusherHookMergeOperationForDestination` (no behavior change).

<sup>Written for commit 585bb3225173e7e5bf96453941f8345efaf2f491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

