### PR TITLE
feat(guardian): wire Guardian and Token Crusher into Qwen Code

### DIFF
--- a/scripts/lib/install-targets/qwen-project.js
+++ b/scripts/lib/install-targets/qwen-project.js
@@ -1,10 +1,51 @@
 const {
   createFlatSkillPlanOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
 } = require('./helpers');
+const {
+  createBashGuardianScriptCopyOperations,
+  createCrusherScriptCopyOperations,
+  createPreToolUseBashGuardianHookMergeOperation,
+  createPreToolUseCrusherHookMergeOperation,
+} = require('../claude-settings-hooks');
 
-// Qwen Code discovers project skills from
-// .qwen/skills/<skill-name>/SKILL.md.
+// Qwen Code discovers project skills from .qwen/skills/<skill-name>/SKILL.md.
+//
+// Its hook config is a near-literal copy of Claude Code's own contract --
+// confirmed against github.com/QwenLM/qwen-code/blob/main/docs/users/features/hooks.md,
+// down to hookSpecificOutput.permissionDecision/updatedInput and even a
+// residual doc line referring to "Claude" instead of "Qwen" (the event
+// table's Stop row). Config lives at .qwen/settings.json -- the exact same
+// {hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}} shape and
+// filename Claude Code itself uses -- so this reuses the generic
+// createPreToolUseBashGuardianHookMergeOperation/createPreToolUseCrusherHookMergeOperation
+// builders directly (targetRoot-driven, no destination override needed,
+// unlike Trae/Copilot/Antigravity). The shell tool's matcher is
+// "run_shell_command" (not "Bash"/"Shell"/"RunCommand") -- confirmed the
+// same way, not assumed from the other hosts' naming.
+function createQwenGuardianOperations(adapter, targetRoot) {
+  const copyOperations = createBashGuardianScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  return [...copyOperations, createPreToolUseBashGuardianHookMergeOperation(targetRoot, 'run_shell_command')];
+}
+
+function createQwenCrusherOperations(adapter, targetRoot) {
+  const copyOperations = createCrusherScriptCopyOperations(
+    (moduleId, sourceRelativePath, destinationPath, options) => (
+      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+    ),
+    targetRoot
+  );
+
+  return [...copyOperations, createPreToolUseCrusherHookMergeOperation(targetRoot, 'run_shell_command')];
+}
+
 module.exports = createInstallTargetAdapter({
   id: 'qwen-project',
   target: 'qwen',
@@ -12,5 +53,13 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.qwen'],
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.qwen',
-  planOperations: createFlatSkillPlanOperations,
+  planOperations(input, adapter) {
+    const planningInput = { repoRoot: input.repoRoot, projectRoot: input.projectRoot, homeDir: input.homeDir };
+    const targetRoot = adapter.resolveRoot(planningInput);
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createQwenGuardianOperations(adapter, targetRoot),
+      ...createQwenCrusherOperations(adapter, targetRoot),
+    ];
+  },
 });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -3020,14 +3020,12 @@ function runTests() {
     });
 
     assert.strictEqual(plan.adapter.id, 'qwen-project');
-    assert.strictEqual(plan.operations.length, 1);
 
-    const operation = plan.operations[0];
+    const operation = plan.operations.find(op => (
+      normalizedRelativePath(op.sourceRelativePath) === 'skills/testing/tdd-workflow'
+    ));
+    assert.ok(operation, 'Should plan the skill copy operation');
     assert.strictEqual(operation.kind, 'copy-path');
-    assert.strictEqual(
-      normalizedRelativePath(operation.sourceRelativePath),
-      'skills/testing/tdd-workflow'
-    );
     assert.strictEqual(
       operation.destinationPath,
       path.join(projectRoot, '.qwen', 'skills', 'tdd-workflow')
@@ -3045,14 +3043,53 @@ function runTests() {
       modules: [{ id: 'rules-core', paths: ['rules'] }],
     });
 
-    assert.strictEqual(plan.operations.length, 1);
-    assert.strictEqual(
-      plan.operations[0].destinationPath,
-      path.join(projectRoot, '.qwen', 'rules')
-    );
+    const rulesOperation = plan.operations.find(operation => (
+      operation.destinationPath === path.join(projectRoot, '.qwen', 'rules')
+    ));
+    assert.ok(rulesOperation, 'Should pass the non-skill rules path through unchanged');
     assert.ok(
       listInstallTargetAdapters().some(adapter => adapter.target === 'qwen'),
       'Should include qwen target'
+    );
+  })) passed++; else failed++;
+
+  if (test('qwen adapter always plans Guardian and Crusher on PreToolUse/run_shell_command, even with no modules selected', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+    const settingsJsonPath = path.join(projectRoot, '.qwen', 'settings.json');
+
+    const plan = planInstallTargetScaffold({
+      target: 'qwen',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+
+    const mergeOperations = plan.operations.filter(operation => operation.destinationPath === settingsJsonPath);
+    assert.strictEqual(mergeOperations.length, 2, 'Guardian and Crusher should each plan exactly one merge into .qwen/settings.json');
+    assert.ok(
+      mergeOperations.every(operation => operation.hookEvent === 'PreToolUse' && operation.hookMatcher === 'run_shell_command'),
+      'Both merges must target PreToolUse with the run_shell_command matcher (Qwen\'s tool_name for shell)'
+    );
+
+    const guardianMerge = mergeOperations.find(operation => operation.moduleId === 'egc-bash-guardian-hook');
+    const crusherMerge = mergeOperations.find(operation => operation.moduleId === 'egc-crusher-hook');
+    assert.ok(guardianMerge, 'Should plan the Guardian merge');
+    assert.ok(crusherMerge, 'Should plan the Crusher merge');
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'
+        && operation.destinationPath === guardianMerge.hookScriptPath
+      )),
+      'Should plan the shared Guardian validator script copy even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/crusher-hook.js'
+        && operation.destinationPath === crusherMerge.hookScriptPath
+      )),
+      'Should plan the shared Crusher hook script copy even with no modules selected'
     );
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
- Confirmed via official docs (github.com/QwenLM/qwen-code/blob/main/docs/users/features/hooks.md): Qwen Code's hook config is a near-literal copy of Claude Code's contract, config at `.qwen/settings.json` (same filename/shape Claude Code uses), shell matcher is `"run_shell_command"`.
- Since the config path derives straight from targetRoot, reuses the fully generic `createPreToolUseBashGuardianHookMergeOperation`/`createPreToolUseCrusherHookMergeOperation` builders directly -- applying the lesson from PR #1079 (Trae), where a host-local reimplementation of the same operation shape drew a cubic duplication finding.

## Test plan
- [x] New unit test: both merges planned unconditionally (run_shell_command matcher), even with no modules selected
- [x] 2 existing tests fixed (assumed `operations.length === 1`, no longer true now that Guardian/Crusher are always planned)
- [x] Real isolated install + direct stdin invocation: Guardian allows a safe command; Crusher rewrites `git log --stat -n 300` to `egc run git log --stat -n 300`, leaves trivial commands untouched
- [x] Real `egc doctor` run: status "ok", zero issues
- [x] Full suite: 3040/3040

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires Bash Guardian and Token Crusher into Qwen Code by merging PreToolUse hooks into `.qwen/settings.json` with the `run_shell_command` matcher. This enables command validation and safe rewriting by default in Qwen projects.

- **New Features**
  - Always plans two merges into `.qwen/settings.json` for `PreToolUse/run_shell_command`, even with no modules selected.
  - Copies the shared Guardian validator and Crusher hook scripts into the project.
  - Keeps existing skill and rules planning unchanged.

- **Refactors**
  - Reuses generic hook-merge builders with a targetRoot-derived config path to avoid host-specific duplication.

<sup>Written for commit ee235b006dddebcc71fa7a6975bd11417cd4647a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

