### PR TITLE
feat(guardian): wire Guardian and Token Crusher into Junie CLI

### DIFF
--- a/scripts/hooks/cursor-crusher-adapter.js
+++ b/scripts/hooks/cursor-crusher-adapter.js
@@ -17,12 +17,16 @@
  *
  * Fail-open throughout: Crusher is a performance optimization, never a
  * security boundary (unlike cursor-guardian-adapter.js), so any error or
- * ambiguity here just means the original command runs unmodified.
+ * ambiguity here just means the original command runs unmodified. Uses
+ * computeCrushedCommand (shared with junie-crusher-adapter.js) for the
+ * actual rewrite decision, rather than each host reimplementing its own
+ * JSON.parse(run(JSON.stringify(...))) wrapper (cubic-dev-ai finding, PR
+ * #1081).
  */
 
 'use strict';
 
-const { run: runCrusherRewrite } = require('./pre-bash-crusher-rewrite');
+const { computeCrushedCommand } = require('./pre-bash-crusher-rewrite');
 const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
 
 // Returns the rewritten tool_input object, or null when nothing should
@@ -32,28 +36,18 @@ function computeUpdatedInput(event) {
     return null;
   }
   const command = event.tool_input?.command;
-  if (!command) {
-    return null;
-  }
-
-  let rewritten;
-  try {
-    const result = JSON.parse(runCrusherRewrite(JSON.stringify({ tool_input: { command } })));
-    rewritten = result?.tool_input?.command;
-  } catch {
-    return null;
-  }
-
-  if (typeof rewritten !== 'string' || rewritten === command) {
-    return null;
-  }
-
-  return { ...event.tool_input, command: rewritten };
+  const rewritten = command ? computeCrushedCommand(command) : null;
+  return rewritten ? { ...event.tool_input, command: rewritten } : null;
 }
 
 function respond(payload) {
+  // Sets exitCode and lets Node drain stdout naturally instead of forcing
+  // process.exit() right after write(): on POSIX, stdout writes to a pipe
+  // are asynchronous, so a forced exit can race the write and truncate the
+  // response before Cursor reads it (same class of bug cubic-dev-ai found
+  // in junie-crusher-adapter.js, PR #1081).
+  process.exitCode = 0;
   process.stdout.write(JSON.stringify(payload));
-  process.exit(0);
 }
 
 function main() {

--- a/scripts/hooks/junie-crusher-adapter.js
+++ b/scripts/hooks/junie-crusher-adapter.js
@@ -7,7 +7,11 @@
  * pre-bash-crusher-rewrite.js rewrite decision applies unchanged -- only its
  * output needs translating into Junie's flat {decision, updatedInput}
  * envelope (confirmed against junie.jetbrains.com/docs/junie-cli-hooks.html),
- * instead of Claude Code's hookSpecificOutput wrapper.
+ * instead of Claude Code's hookSpecificOutput wrapper. Uses
+ * computeCrushedCommand (shared with cursor-crusher-adapter.js) for the
+ * actual rewrite decision, rather than each host reimplementing its own
+ * JSON.parse(run(JSON.stringify(...))) wrapper (cubic-dev-ai finding, PR
+ * #1081).
  *
  * Fail-open throughout: the Crusher is never a security boundary (unlike
  * junie-guardian-adapter.js), so any error or ambiguity here just means the
@@ -16,30 +20,22 @@
 
 'use strict';
 
-const { run: runCrusherRewrite } = require('./pre-bash-crusher-rewrite');
+const { computeCrushedCommand } = require('./pre-bash-crusher-rewrite');
 const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
 
 // Returns the rewritten command string, or null when nothing should change.
 function computeRewrittenCommand(event) {
   const command = event && typeof event === 'object' ? event.tool_input?.command : undefined;
-  if (!command) {
-    return null;
-  }
-
-  let rewritten;
-  try {
-    const result = JSON.parse(runCrusherRewrite(JSON.stringify({ tool_input: { command } })));
-    rewritten = result?.tool_input?.command;
-  } catch {
-    return null;
-  }
-
-  return typeof rewritten === 'string' && rewritten !== command ? rewritten : null;
+  return command ? computeCrushedCommand(command) : null;
 }
 
 function respond(payload) {
+  // Sets exitCode and lets Node drain stdout naturally instead of forcing
+  // process.exit() right after write(): on POSIX, stdout writes to a pipe
+  // are asynchronous, so a forced exit can race the write and truncate the
+  // response before Junie reads it (cubic-dev-ai finding, PR #1081).
+  process.exitCode = 0;
   process.stdout.write(JSON.stringify(payload));
-  process.exit(0);
 }
 
 function main() {

--- a/scripts/hooks/junie-crusher-adapter.js
+++ b/scripts/hooks/junie-crusher-adapter.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Junie CLI adapter for the Token Crusher.
+ *
+ * Same input/output split as junie-guardian-adapter.js: Junie's PreToolUse
+ * input already matches {tool_name, tool_input: {command}}, so the shared
+ * pre-bash-crusher-rewrite.js rewrite decision applies unchanged -- only its
+ * output needs translating into Junie's flat {decision, updatedInput}
+ * envelope (confirmed against junie.jetbrains.com/docs/junie-cli-hooks.html),
+ * instead of Claude Code's hookSpecificOutput wrapper.
+ *
+ * Fail-open throughout: the Crusher is never a security boundary (unlike
+ * junie-guardian-adapter.js), so any error or ambiguity here just means the
+ * original command runs unmodified.
+ */
+
+'use strict';
+
+const { run: runCrusherRewrite } = require('./pre-bash-crusher-rewrite');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+
+// Returns the rewritten command string, or null when nothing should change.
+function computeRewrittenCommand(event) {
+  const command = event && typeof event === 'object' ? event.tool_input?.command : undefined;
+  if (!command) {
+    return null;
+  }
+
+  let rewritten;
+  try {
+    const result = JSON.parse(runCrusherRewrite(JSON.stringify({ tool_input: { command } })));
+    rewritten = result?.tool_input?.command;
+  } catch {
+    return null;
+  }
+
+  return typeof rewritten === 'string' && rewritten !== command ? rewritten : null;
+}
+
+function respond(payload) {
+  process.stdout.write(JSON.stringify(payload));
+  process.exit(0);
+}
+
+function main() {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    if (truncated || !ok) {
+      respond({ decision: 'allow' });
+      return;
+    }
+
+    const rewritten = computeRewrittenCommand(value);
+    if (rewritten) {
+      respond({ decision: 'allow', updatedInput: { ...value.tool_input, command: rewritten } });
+      return;
+    }
+
+    respond({ decision: 'allow' });
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { computeRewrittenCommand };

--- a/scripts/hooks/junie-guardian-adapter.js
+++ b/scripts/hooks/junie-guardian-adapter.js
@@ -20,9 +20,14 @@ const { run } = require('./pre-bash-guardian-validate');
 const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
 
 function respond(decision, reason) {
+  // Sets exitCode and lets Node drain stdout naturally instead of forcing
+  // process.exit() right after write(): on POSIX, stdout writes to a pipe
+  // (which is what a hook subprocess always has) are asynchronous, so a
+  // forced exit can race the write and truncate the response before Junie
+  // reads it (cubic-dev-ai finding, PR #1081).
   const payload = reason ? { decision, reason } : { decision };
+  process.exitCode = decision === 'deny' ? 2 : 0;
   process.stdout.write(JSON.stringify(payload));
-  process.exit(decision === 'deny' ? 2 : 0);
 }
 
 function main() {

--- a/scripts/hooks/junie-guardian-adapter.js
+++ b/scripts/hooks/junie-guardian-adapter.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Junie CLI adapter for the EGC Guardian command validator.
+ *
+ * Junie's PreToolUse hook input already matches Claude Code's own shape
+ * ({tool_name, tool_input: {command}}) -- confirmed against
+ * junie.jetbrains.com/docs/junie-cli-hooks.html -- so no input remapping is
+ * needed, unlike Cursor/Windsurf. Only the OUTPUT envelope differs: Junie
+ * expects a FLAT {decision, reason, updatedInput} object on stdout, not
+ * Claude Code's {hookSpecificOutput: {permissionDecision, updatedInput}}.
+ * pre-bash-guardian-validate.js's own run() already returns {exitCode,
+ * stderr} directly, so this only needs to translate that into Junie's
+ * decision vocabulary ("allow" | "deny") plus exit code 2 to block
+ * regardless of stdout, per the doc's documented alternative contract.
+ */
+
+'use strict';
+
+const { run } = require('./pre-bash-guardian-validate');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+
+function respond(decision, reason) {
+  const payload = reason ? { decision, reason } : { decision };
+  process.stdout.write(JSON.stringify(payload));
+  process.exit(decision === 'deny' ? 2 : 0);
+}
+
+function main() {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    // Same fail-closed-on-truncation guard as the Cursor/Windsurf/Kiro
+    // adapters (cubic-dev-ai finding, PR #1073/#1074): a capped-length
+    // prefix can still happen to be syntactically valid JSON, so truncation
+    // is checked unconditionally, before `ok`.
+    if (truncated) {
+      respond('deny', 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+        'this validator can safely read, so it could not be parsed or validated. ' +
+        'Simplify the command.');
+      return;
+    }
+    if (!ok) {
+      respond('allow');
+      return;
+    }
+
+    const event = value;
+    const command = event && typeof event === 'object' ? event.tool_input?.command : undefined;
+    if (!command) {
+      respond('allow');
+      return;
+    }
+
+    const guardianInput = { tool_name: 'Bash', tool_input: { command } };
+    if (event && typeof event.cwd === 'string') {
+      guardianInput.cwd = event.cwd;
+    }
+
+    const result = run(guardianInput);
+    if (result.exitCode === 2) {
+      respond('deny', result.stderr || 'Blocked by the EGC Guardian.');
+      return;
+    }
+
+    respond('allow');
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {};

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -108,15 +108,17 @@ function run(rawInput) {
 // identical JSON.parse(run(JSON.stringify(...))) wrapper). Returns the
 // rewritten command, or null when nothing should change (no CLI, no engine,
 // already wrapped, or a generic/non-crushable command).
+//
+// No try/catch here: run()'s own contract (see its header comment) is to
+// fail open on any internal error by echoing back the exact JSON string it
+// was given, so JSON.parse can never fail on run()'s output -- it is always
+// either the rewritten object or the same valid JSON this function just
+// built. A defensive catch around that would be unreachable dead code
+// (confirmed: Codecov flagged it as uncovered on this exact PR).
 function computeCrushedCommand(command) {
   if (!command) return null;
-  let rewritten;
-  try {
-    const result = JSON.parse(run(JSON.stringify({ tool_input: { command } })));
-    rewritten = result?.tool_input?.command;
-  } catch {
-    return null;
-  }
+  const result = JSON.parse(run(JSON.stringify({ tool_input: { command } })));
+  const rewritten = result?.tool_input?.command;
   return typeof rewritten === 'string' && rewritten !== command ? rewritten : null;
 }
 

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -101,4 +101,23 @@ function run(rawInput) {
   }
 }
 
-module.exports = { run };
+// Shared by every host-specific translation adapter that needs the rewrite
+// decision for a single command string, without Claude Code's own
+// {tool_input: {command}} envelope round-trip (Cursor, Junie -- cubic-dev-ai
+// duplication finding, PR #1081: both adapters had grown their own near-
+// identical JSON.parse(run(JSON.stringify(...))) wrapper). Returns the
+// rewritten command, or null when nothing should change (no CLI, no engine,
+// already wrapped, or a generic/non-crushable command).
+function computeCrushedCommand(command) {
+  if (!command) return null;
+  let rewritten;
+  try {
+    const result = JSON.parse(run(JSON.stringify({ tool_input: { command } })));
+    rewritten = result?.tool_input?.command;
+  } catch {
+    return null;
+  }
+  return typeof rewritten === 'string' && rewritten !== command ? rewritten : null;
+}
+
+module.exports = { run, computeCrushedCommand };

--- a/scripts/lib/adapter-stdin-json.js
+++ b/scripts/lib/adapter-stdin-json.js
@@ -14,6 +14,13 @@ const MAX_STDIN = 1024 * 1024;
 function readAdapterStdinJson(onComplete) {
   let raw = '';
   let truncated = false;
+  let done = false;
+  const complete = result => {
+    if (done) return;
+    done = true;
+    onComplete(result);
+  };
+
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', chunk => {
     if (raw.length < MAX_STDIN) {
@@ -23,15 +30,21 @@ function readAdapterStdinJson(onComplete) {
       truncated = true;
     }
   });
+  // Without this, a stream error (e.g. the parent process closing the pipe
+  // abruptly) leaves onComplete never called -- the adapter hangs, and since
+  // stdin is an EventEmitter, an 'error' event with no listener throws an
+  // uncaught exception by default. Fails open (ok: false), matching every
+  // other unreadable-input path this reader already has.
+  process.stdin.on('error', () => complete({ ok: false, truncated }));
   process.stdin.on('end', () => {
     let value;
     try {
       value = JSON.parse(raw);
     } catch {
-      onComplete({ ok: false, truncated });
+      complete({ ok: false, truncated });
       return;
     }
-    onComplete({ ok: true, truncated, value });
+    complete({ ok: true, truncated, value });
   });
 }
 

--- a/scripts/lib/install-targets/junie-home.js
+++ b/scripts/lib/install-targets/junie-home.js
@@ -1,0 +1,107 @@
+const path = require('node:path');
+
+const {
+  createFlatSkillPlanOperations,
+  createInstallTargetAdapter,
+  createRemappedOperation,
+} = require('./helpers');
+const {
+  createAdapterStdinJsonCopyOperation,
+  createBashGuardianHookMergeOperationForDestination,
+  createBashGuardianScriptCopyOperations,
+  createCrusherHookMergeOperationForDestination,
+  createCrusherScriptCopyOperations,
+} = require('../claude-settings-hooks');
+
+// Junie CLI hooks ONLY work from the home-scope config by default --
+// confirmed against junie.jetbrains.com/docs/junie-cli-hooks.html:
+// "Project-local hooks from <project-root>/.junie/config.json are ignored
+// by default for safety. If you intentionally want to run hooks from a
+// project file, pass that file explicitly with --config-location." So
+// Guardian/Crusher are wired here (kind: 'home', ~/.junie/config.json),
+// mirroring the established kiro-home.js/kiro-project.js split, INCLUDING
+// its choice to also scaffold skills here (not just junie-project.js):
+// getInstallTargetAdapter('junie') resolves to this file first (registered
+// ahead of junie-project.js in registry.js's ADAPTERS array, same ordering
+// kiro-home/kiro-project already use), and the top-level CLI's --target
+// flag only accepts the bare 'junie' string, never 'junie-project' --
+// confirmed empirically. Without the skill scaffold here too, a plain
+// `egc install --target junie --profile full` would install Guardian and
+// Crusher but silently stop installing skills, a real regression from
+// today's behavior.
+//
+// config.json's own JSON structure is the exact same
+// {hooks: {PreToolUse: [{matcher, hooks: [{type, command}]}]}} shape as
+// Claude Code's settings.json -- confirmed the same way -- but the
+// filename differs (config.json, not settings.json), so this uses the
+// destination-driven merge builders (same pattern as Trae, PR #1079) rather
+// than the plain targetRoot-driven ones (which assume settings.json).
+//
+// The response ENVELOPE a hook script must print is NOT the same as Claude
+// Code's, though: Junie expects a flat {decision, reason, updatedInput}
+// object, not {hookSpecificOutput: {permissionDecision, updatedInput}} --
+// confirmed the same way. That mismatch is why this wires dedicated
+// translation adapters (junie-guardian-adapter.js, junie-crusher-adapter.js)
+// instead of the shared pre-bash-guardian-validate.js/crusher-hook.js
+// scripts directly, the same reasoning Cursor's beforeShellExecution
+// adapter already established for a different contract mismatch.
+function resolveJunieConfigJsonPath(targetRoot) {
+  return path.join(targetRoot, 'config.json');
+}
+
+function createJunieGuardianOperations(adapter, targetRoot) {
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+
+  const adapterModuleId = 'egc-junie-guardian-hook';
+  const adapterScriptDestination = path.join(targetRoot, 'scripts', 'hooks', 'junie-guardian-adapter.js');
+
+  return [
+    ...createBashGuardianScriptCopyOperations(remap, targetRoot),
+    remap(adapterModuleId, 'scripts/hooks/junie-guardian-adapter.js', adapterScriptDestination, { strategy: 'preserve-relative-path' }),
+    createAdapterStdinJsonCopyOperation(remap, targetRoot),
+    createBashGuardianHookMergeOperationForDestination(
+      resolveJunieConfigJsonPath(targetRoot),
+      adapterScriptDestination,
+      'Bash'
+    ),
+  ];
+}
+
+function createJunieCrusherOperations(adapter, targetRoot) {
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+
+  const adapterModuleId = 'egc-junie-crusher-hook';
+  const adapterScriptDestination = path.join(targetRoot, 'scripts', 'hooks', 'junie-crusher-adapter.js');
+
+  return [
+    ...createCrusherScriptCopyOperations(remap, targetRoot),
+    remap(adapterModuleId, 'scripts/hooks/junie-crusher-adapter.js', adapterScriptDestination, { strategy: 'preserve-relative-path' }),
+    createCrusherHookMergeOperationForDestination(
+      resolveJunieConfigJsonPath(targetRoot),
+      adapterScriptDestination,
+      'Bash'
+    ),
+  ];
+}
+
+module.exports = createInstallTargetAdapter({
+  id: 'junie-home',
+  target: 'junie',
+  kind: 'home',
+  rootSegments: ['.junie'],
+  installStatePathSegments: ['egc', 'install-state.json'],
+  nativeRootRelativePath: '.junie',
+  planOperations(input, adapter) {
+    const planningInput = { repoRoot: input.repoRoot, projectRoot: input.projectRoot, homeDir: input.homeDir };
+    const targetRoot = adapter.resolveRoot(planningInput);
+    return [
+      ...createFlatSkillPlanOperations(input, adapter),
+      ...createJunieGuardianOperations(adapter, targetRoot),
+      ...createJunieCrusherOperations(adapter, targetRoot),
+    ];
+  },
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -24,6 +24,7 @@ const zedHome = require('./zed-home');
 const continueHome = require('./continue-home');
 const continueProject = require('./continue-project');
 const traeProject = require('./trae-project');
+const junieHome = require('./junie-home');
 const junieProject = require('./junie-project');
 const warpProject = require('./warp-project');
 
@@ -54,6 +55,7 @@ const ADAPTERS = Object.freeze([
   continueHome,
   continueProject,
   traeProject,
+  junieHome,
   junieProject,
   warpProject,
 ]);

--- a/tests/hooks/cursor-crusher-adapter.test.js
+++ b/tests/hooks/cursor-crusher-adapter.test.js
@@ -96,45 +96,6 @@ function runTests() {
     assert.strictEqual(computeUpdatedInput(42), null);
   })) passed++; else failed++;
 
-  if (test('computeUpdatedInput returns null (does not throw) when the shared rewrite dependency itself throws', () => {
-    // pre-bash-crusher-rewrite.js's own run() always self-catches and
-    // returns a valid JSON string, so this catch branch is unreachable via
-    // any real input through the normal path -- reproduced the same way
-    // tests/hooks/pre-bash-guardian-validate.test.js covers its own
-    // unreachable-via-real-input branch: stub the dependency in this
-    // process's require.cache and re-require the adapter fresh, so c8
-    // still credits the coverage to the real file path.
-    const rewritePath = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-crusher-rewrite.js');
-    const originalRewriteEntry = require.cache[rewritePath];
-    const originalAdapterEntry = require.cache[adapterScript];
-    try {
-      delete require.cache[rewritePath];
-      delete require.cache[adapterScript];
-      require.cache[rewritePath] = {
-        id: rewritePath,
-        filename: rewritePath,
-        loaded: true,
-        exports: {
-          run: () => {
-            throw new Error('simulated dependency failure');
-          },
-        },
-      };
-
-      const { computeUpdatedInput: computeWithThrowingDependency } = require(adapterScript);
-      const result = computeWithThrowingDependency({
-        tool_name: 'Shell',
-        tool_input: { command: 'git log --stat -n 300' },
-      });
-      assert.strictEqual(result, null, 'Expected null when the rewrite dependency throws, not a crash');
-    } finally {
-      delete require.cache[rewritePath];
-      delete require.cache[adapterScript];
-      if (originalRewriteEntry) require.cache[rewritePath] = originalRewriteEntry;
-      if (originalAdapterEntry) require.cache[adapterScript] = originalAdapterEntry;
-    }
-  })) passed++; else failed++;
-
   if (test('CLI: rewrites a crushable Shell command with updated_input.command', () => {
     const result = runAdapterCli({
       tool_name: 'Shell',

--- a/tests/hooks/junie-crusher-adapter.test.js
+++ b/tests/hooks/junie-crusher-adapter.test.js
@@ -1,0 +1,132 @@
+/**
+ * Tests for scripts/hooks/junie-crusher-adapter.js
+ *
+ * Junie's PreToolUse input already matches Claude Code's own shape, so this
+ * only exercises the flat {decision, updatedInput} output translation and
+ * the exitCode-vs-forced-exit fix (cubic-dev-ai finding, PR #1081). The
+ * Crusher is never a security boundary (unlike junie-guardian-adapter.js),
+ * so every failure mode here fails OPEN, never closed.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'junie-crusher-adapter.js');
+const { computeRewrittenCommand } = require(adapterScript);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const result = spawnSync('node', [adapterScript], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, EGC_ASSUME_EGC_CLI: '1', ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing junie-crusher-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('computeRewrittenCommand rewrites a crushable command', () => {
+    process.env.EGC_ASSUME_EGC_CLI = '1';
+    try {
+      assert.strictEqual(
+        computeRewrittenCommand({ tool_name: 'Bash', tool_input: { command: 'git log --stat -n 300' } }),
+        'egc run git log --stat -n 300'
+      );
+    } finally {
+      delete process.env.EGC_ASSUME_EGC_CLI;
+    }
+  })) passed++; else failed++;
+
+  if (test('computeRewrittenCommand returns null for a non-crushable command', () => {
+    process.env.EGC_ASSUME_EGC_CLI = '1';
+    try {
+      assert.strictEqual(computeRewrittenCommand({ tool_name: 'Bash', tool_input: { command: 'echo hi' } }), null);
+    } finally {
+      delete process.env.EGC_ASSUME_EGC_CLI;
+    }
+  })) passed++; else failed++;
+
+  if (test('computeRewrittenCommand returns null when there is no command', () => {
+    assert.strictEqual(computeRewrittenCommand({ tool_name: 'Bash', tool_input: {} }), null);
+  })) passed++; else failed++;
+
+  if (test('computeRewrittenCommand returns null (does not throw) for a non-object event', () => {
+    assert.strictEqual(computeRewrittenCommand(null), null);
+    assert.strictEqual(computeRewrittenCommand('a string'), null);
+    assert.strictEqual(computeRewrittenCommand(42), null);
+  })) passed++; else failed++;
+
+  if (test('CLI: rewrites a crushable command with updatedInput.command', () => {
+    const result = runAdapterCli({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'git log --stat -n 300' } });
+    assert.strictEqual(result.code, 0);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.decision, 'allow');
+    assert.strictEqual(response.updatedInput.command, 'egc run git log --stat -n 300');
+  })) passed++; else failed++;
+
+  if (test('CLI: a trivial command allows with no updatedInput (no false positive)', () => {
+    const result = runAdapterCli({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'echo hi' } });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed stdin JSON fails OPEN (allow)', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: a truncated oversized payload fails OPEN (allow), unlike the Guardian adapter\'s fail-closed', () => {
+    const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git log --stat -n 300' },
+      padding: oversizedPadding,
+    });
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: full stdout is present at exit (no truncation from exitCode-based exit)', () => {
+    // Regression guard for the cubic-dev-ai finding (PR #1081): a forced
+    // process.exit() right after stdout.write() can race the pipe flush on
+    // POSIX, potentially delivering a truncated response that Junie would
+    // then ignore (falling back to the original, un-crushed command).
+    for (let i = 0; i < 20; i += 1) {
+      const result = runAdapterCli({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'git log --stat -n 300' } });
+      let parsed;
+      assert.doesNotThrow(() => { parsed = JSON.parse(result.stdout); }, `Run ${i}: stdout was not valid JSON: ${JSON.stringify(result.stdout)}`);
+      assert.strictEqual(parsed.updatedInput.command, 'egc run git log --stat -n 300', `Run ${i}: incomplete updatedInput`);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/junie-guardian-adapter.test.js
+++ b/tests/hooks/junie-guardian-adapter.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for scripts/hooks/junie-guardian-adapter.js
+ *
+ * Junie's PreToolUse input already matches Claude Code's own shape
+ * ({tool_name, tool_input: {command}}), so unlike Cursor/Windsurf, no input
+ * remapping is tested here -- only the flat {decision, reason} output
+ * envelope translation and the exit-code contract (0 allow, 2 deny), plus
+ * the exitCode-vs-forced-exit fix (cubic-dev-ai finding, PR #1081).
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'junie-guardian-adapter.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const result = spawnSync('node', [adapterScript], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, EGC_GUARDIAN_CLI: fakeCli, ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing junie-guardian-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('CLI: allows a safe command (exit 0, {decision: "allow"})', () => {
+    const result = runAdapterCli({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'git status' } });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: blocks a destructive command (exit 2, {decision: "deny", reason})', () => {
+    const result = runAdapterCli({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'rm -rf /' } });
+    assert.strictEqual(result.code, 2);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.decision, 'deny');
+    assert.ok(response.reason && response.reason.length > 0, 'expected a non-empty reason');
+  })) passed++; else failed++;
+
+  if (test('CLI: event with no command allows (exit 0)', () => {
+    const result = runAdapterCli({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: {} });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: forwards cwd to the Guardian for relative path resolution', () => {
+    // A destructive command scoped by cwd (relative path) must resolve
+    // against the event's cwd, not this adapter process's own cwd -- same
+    // check cursor-guardian-adapter.js's own test asserts for its
+    // equivalent field.
+    const result = runAdapterCli({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git status' },
+      cwd: '/tmp',
+    });
+    assert.strictEqual(result.code, 0);
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed stdin JSON fails open (exit 0, allow)', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: 'allow' });
+  })) passed++; else failed++;
+
+  if (test('CLI: a truncated oversized payload fails CLOSED (exit 2, deny) -- Guardian is a security boundary', () => {
+    const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git status' },
+      padding: oversizedPadding,
+    });
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.decision, 'deny');
+  })) passed++; else failed++;
+
+  if (test('CLI: full stdout is present at exit (no truncation from exitCode-based exit)', () => {
+    // Regression guard for the cubic-dev-ai finding (PR #1081): a forced
+    // process.exit() right after stdout.write() can race the pipe flush on
+    // POSIX. Asserting the full JSON parses (not just non-empty) proves the
+    // exitCode-based fix delivers the complete response every time, not
+    // just usually.
+    for (let i = 0; i < 20; i += 1) {
+      const result = runAdapterCli({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'git status' } });
+      assert.doesNotThrow(() => JSON.parse(result.stdout), `Run ${i}: stdout was not valid JSON: ${JSON.stringify(result.stdout)}`);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/pre-bash-crusher-rewrite.test.js
+++ b/tests/hooks/pre-bash-crusher-rewrite.test.js
@@ -15,7 +15,8 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
-const { run } = require(path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-crusher-rewrite.js'));
+const rewriteScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-crusher-rewrite.js');
+const { run, computeCrushedCommand } = require(rewriteScript);
 
 const POSIX = process.platform !== 'win32';
 
@@ -133,6 +134,32 @@ if (POSIX) {
     assert.strictEqual(invoke('git log && git status'), 'git log && git status');
   });
 }
+
+// --- computeCrushedCommand: shared by cursor-crusher-adapter.js and
+// junie-crusher-adapter.js (cubic-dev-ai duplication finding, PR #1081) ---
+
+runCase('computeCrushedCommand returns the rewritten command for a crushable input', () => {
+  assert.strictEqual(computeCrushedCommand('git log --stat -n 300'), 'egc run git log --stat -n 300');
+});
+
+runCase('computeCrushedCommand returns null for a non-crushable command', () => {
+  assert.strictEqual(computeCrushedCommand('echo hi'), null);
+});
+
+runCase('computeCrushedCommand returns null for an empty/falsy command', () => {
+  assert.strictEqual(computeCrushedCommand(''), null);
+  assert.strictEqual(computeCrushedCommand(undefined), null);
+});
+
+// computeCrushedCommand's own try/catch around JSON.parse(run(...)) is
+// unreachable via any real input the same way run()'s own internal catch
+// already is (see the file-level coverage note: run() always self-catches
+// and returns a valid JSON string for any string input, so JSON.parse never
+// throws downstream either) -- run and computeCrushedCommand share this
+// module's closure, not a require()'d dependency, so the require.cache
+// substitution trick other adapters use to reach an equivalent branch does
+// not apply here. Left uncovered, matching the pre-existing, accepted gap
+// on run()'s own analogous catch branch in this exact file.
 
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/pre-bash-crusher-rewrite.test.js
+++ b/tests/hooks/pre-bash-crusher-rewrite.test.js
@@ -151,15 +151,5 @@ runCase('computeCrushedCommand returns null for an empty/falsy command', () => {
   assert.strictEqual(computeCrushedCommand(undefined), null);
 });
 
-// computeCrushedCommand's own try/catch around JSON.parse(run(...)) is
-// unreachable via any real input the same way run()'s own internal catch
-// already is (see the file-level coverage note: run() always self-catches
-// and returns a valid JSON string for any string input, so JSON.parse never
-// throws downstream either) -- run and computeCrushedCommand share this
-// module's closure, not a require()'d dependency, so the require.cache
-// substitution trick other adapters use to reach an equivalent branch does
-// not apply here. Left uncovered, matching the pre-existing, accepted gap
-// on run()'s own analogous catch branch in this exact file.
-
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2489,8 +2489,21 @@ function runTests() {
     assert.strictEqual(statePath, path.join(projectRoot, '.trae', 'egc-install-state.json'));
   })) passed++; else failed++;
 
-     if (test('resolves junie adapter root and install-state path from project root', () => {
+  if (test('resolves junie home adapter root to ~/.junie and install-state path', () => {
     const adapter = getInstallTargetAdapter('junie');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'junie-home');
+    assert.strictEqual(adapter.target, 'junie');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.junie'));
+    assert.strictEqual(statePath, path.join(homeDir, '.junie', 'egc', 'install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('resolves junie project adapter root and install-state path from project root', () => {
+    const adapter = getInstallTargetAdapter('junie-project');
     const projectRoot = '/workspace/app';
     const root = adapter.resolveRoot({ projectRoot });
     const statePath = adapter.getInstallStatePath({ projectRoot });
@@ -2501,15 +2514,69 @@ function runTests() {
     assert.strictEqual(root, path.join(projectRoot, '.junie'));
     assert.strictEqual(statePath, path.join(projectRoot, '.junie', 'egc-install-state.json'));
   })) passed++; else failed++;
- 
-    if (test('junie adapter supports lookup by target and adapter id', () => {
-    const byTarget = getInstallTargetAdapter('junie');
-    const byId = getInstallTargetAdapter('junie-project');
 
-    assert.strictEqual(byTarget.id, 'junie-project');
-    assert.strictEqual(byId.id, 'junie-project');
+  if (test('junie adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('junie');
+    const byId = getInstallTargetAdapter('junie-home');
+    const projectById = getInstallTargetAdapter('junie-project');
+
+    assert.strictEqual(byTarget.id, 'junie-home');
+    assert.strictEqual(byId.id, 'junie-home');
+    assert.strictEqual(projectById.id, 'junie-project');
     assert.ok(byTarget.supports('junie'));
-    assert.ok(byTarget.supports('junie-project'));
+    assert.ok(byTarget.supports('junie-home'));
+    assert.ok(projectById.supports('junie'));
+    assert.ok(projectById.supports('junie-project'));
+  })) passed++; else failed++;
+
+  if (test('junie home adapter always plans Guardian and Crusher on PreToolUse/Bash, even with no modules selected', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+    const targetRoot = path.join(homeDir, '.junie');
+    const configJsonPath = path.join(targetRoot, 'config.json');
+
+    const plan = planInstallTargetScaffold({
+      target: 'junie',
+      repoRoot,
+      homeDir,
+      modules: [],
+    });
+
+    const mergeOperations = plan.operations.filter(operation => operation.destinationPath === configJsonPath);
+    assert.strictEqual(mergeOperations.length, 2, 'Guardian and Crusher should each plan exactly one merge into ~/.junie/config.json');
+    assert.ok(
+      mergeOperations.every(operation => operation.hookEvent === 'PreToolUse' && operation.hookMatcher === 'Bash'),
+      'Both merges must target PreToolUse with the Bash matcher'
+    );
+
+    const guardianMerge = mergeOperations.find(operation => operation.moduleId === 'egc-bash-guardian-hook');
+    const crusherMerge = mergeOperations.find(operation => operation.moduleId === 'egc-crusher-hook');
+    assert.ok(guardianMerge, 'Should plan the Guardian merge');
+    assert.ok(crusherMerge, 'Should plan the Crusher merge');
+    assert.strictEqual(guardianMerge.hookScriptPath, path.join(targetRoot, 'scripts', 'hooks', 'junie-guardian-adapter.js'));
+    assert.strictEqual(crusherMerge.hookScriptPath, path.join(targetRoot, 'scripts', 'hooks', 'junie-crusher-adapter.js'));
+
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/junie-guardian-adapter.js'
+        && operation.destinationPath === guardianMerge.hookScriptPath
+      )),
+      'Should plan the Junie-specific Guardian translation adapter copy even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/junie-crusher-adapter.js'
+        && operation.destinationPath === crusherMerge.hookScriptPath
+      )),
+      'Should plan the Junie-specific Crusher translation adapter copy even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/adapter-stdin-json.js'
+        && operation.destinationPath === path.join(targetRoot, 'scripts', 'lib', 'adapter-stdin-json.js')
+      )),
+      'Should plan the shared adapter-stdin-json.js copy (both Junie adapters require it) -- regression guard for the exact MODULE_NOT_FOUND gap fixed in #1076'
+    );
   })) passed++; else failed++;
 
   if (test('trae adapter supports lookup by target and adapter id', () => {

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -85,9 +85,18 @@ for (const testFile of testFiles) {
   if (stdout) console.log(stdout);
   if (stderr) console.log(stderr);
 
+  // Test files in this repo report their summary in two different casings:
+  // "Passed: N" / "Results: Passed: N, Failed: M" (most files), or
+  // "N passed, M failed" (adapter CLI tests like cursor-guardian-adapter.test.js,
+  // predating this fix). Falling back to the lowercase form when the first
+  // doesn't match means every file's real count is aggregated here, instead
+  // of silently contributing 0 to the total the way the lowercase-only files
+  // did before -- discovered while adding junie-guardian-adapter.test.js and
+  // junie-crusher-adapter.test.js (PR #1081), whose 16 passing assertions
+  // never moved this script's own "Total Tests" figure.
   const combined = stdout + stderr;
-  const passedMatch = combined.match(/Passed:\s*(\d+)/);
-  const failedMatch = combined.match(/Failed:\s*(\d+)/);
+  const passedMatch = combined.match(/Passed:\s*(\d+)/i) || combined.match(/(\d+)\s+passed\b/i);
+  const failedMatch = combined.match(/Failed:\s*(\d+)/i) || combined.match(/(\d+)\s+failed\b/i);
 
   if (passedMatch) totalPassed += parseInt(passedMatch[1], 10);
   if (failedMatch) totalFailed += parseInt(failedMatch[1], 10);


### PR DESCRIPTION
## Summary
- Confirmed via official docs (junie.jetbrains.com/docs/junie-cli-hooks.html): Junie's PreToolUse hooks are **home-scope only by default** ("Project-local hooks... are ignored by default for safety"). New `junie-home.js` adapter (kind: `home`, `~/.junie/config.json`), registered ahead of the existing `junie-project.js` in `registry.js` -- same ordering `kiro-home.js`/`kiro-project.js` already use.
- `junie-home.js` also scaffolds skills, matching Kiro's precedent -- the CLI's `--target` flag never accepts `junie-project` directly (confirmed empirically), so without this a plain `--target junie --profile full` would silently stop installing skills.
- `config.json`'s structure matches Claude Code's `settings.json` shape, so this reuses the destination-driven merge builders (Trae, PR #1079). But the **response envelope** a hook script must print differs: Junie expects a flat `{decision, reason, updatedInput}`, not `{hookSpecificOutput: {...}}`. Two new translation adapters bridge that gap, reusing the shared decision logic unchanged.

## Test plan
- [x] Real isolated install (separate HOME/project dirs) + direct stdin invocation: Guardian allows a safe command; Crusher rewrites `git log --stat -n 300` to `egc run git log --stat -n 300`, leaves trivial commands untouched
- [x] Real `egc doctor` run: status "ok", zero issues
- [x] Confirmed empirically that skills (`rules/`) and hooks (`config.json`) both materialize together under a single `--target junie --profile full` install
- [x] 2 existing tests updated (byTarget resolution), new test covers wiring + a regression guard for the `adapter-stdin-json.js` copy gap fixed in #1076
- [x] Full suite: 3042/3042

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired EGC Guardian and Token Crusher into the Junie CLI with a home-scope install and Junie-specific adapters. Also improved IO reliability and simplified Crusher logic, including removing an unreachable catch in `computeCrushedCommand`.

- **New Features**
  - Added `junie-home` adapter (kind: home) that writes to `~/.junie/config.json`, registered before `junie-project`.
  - Scaffolds skills so `--target junie --profile full` installs hooks and skills together.
  - Added `junie-guardian-adapter.js` and `junie-crusher-adapter.js` with flat `{decision, reason, updatedInput}` output; both reuse shared rewrite logic via `computeCrushedCommand`.

- **Bug Fixes**
  - Prevented stdout truncation by using `process.exitCode` and letting stdout drain; applied to Junie and Cursor Crusher adapters.
  - Added stdin `error` handling and a single-callback guard in `adapter-stdin-json.js` (fail open).
  - Fixed test-runner aggregation to count all tests (supports both summary formats).
  - Removed an unreachable try/catch in `computeCrushedCommand` (keeps behavior unchanged, clarifies intent).

<sup>Written for commit e0f97b90165fae98276e5cc7f383bf291082ddb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

