### PR TITLE
feat(guardian): wire the Bash command validator into Cline

### DIFF
--- a/scripts/hooks/cline-guardian-adapter.js
+++ b/scripts/hooks/cline-guardian-adapter.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Cline (VS Code extension) adapter for the EGC Guardian command validator.
+ *
+ * Confirmed against the real cline/cline source (apps/vscode/src/core/hooks/
+ * hook-factory.ts and templates.ts, fetched 2026-07-29): Cline discovers a
+ * PreToolUse hook by looking for an EXECUTABLE file literally named
+ * `PreToolUse` (no extension) inside `.clinerules/hooks/` (project scope) or
+ * `~/Documents/Cline/Hooks/` (global scope), and spawns it directly -- there
+ * is no hooks.json to merge into. Input on stdin is
+ * `{ taskId, preToolUse: { toolName, parameters }, clineVersion, timestamp,
+ * workspaceRoots, userId, model, ... }`; for a shell command, toolName is
+ * `execute_command` and the command string is `parameters.command`.
+ *
+ * Cline's hook output schema (validateHookOutput in hook-factory.ts) only
+ * recognizes `cancel` (boolean), `contextModification` (string) and
+ * `errorMessage` (string) -- there is no field to rewrite the command, so
+ * only Guardian (block) is possible here, not the Token Crusher, the same
+ * block-only status as Kiro and Windsurf. `cancel: true` blocks the tool
+ * call; Cline's own runner treats hooks as fail-open (only an explicit
+ * `cancel: true` blocks, a crashed/timed-out hook does not).
+ */
+
+'use strict';
+
+const { run } = require('./pre-bash-guardian-validate');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+
+function respond(cancel, errorMessage) {
+  // process.exitCode (not process.exit()) so Node drains stdout naturally:
+  // on POSIX a forced exit can race the pipe write and truncate the
+  // response before Cline reads it (same cubic-dev-ai finding applied to
+  // every EGC translation adapter, PR #1081).
+  const payload = errorMessage ? { cancel, errorMessage } : { cancel };
+  process.exitCode = 0;
+  process.stdout.write(JSON.stringify(payload));
+}
+
+function main() {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    // Same fail-closed-on-truncation guard as every other EGC translation
+    // adapter: a capped-length prefix can still happen to be syntactically
+    // valid JSON, so truncation is checked unconditionally, before `ok`.
+    if (truncated) {
+      respond(true, 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+        'this validator can safely read, so it could not be parsed or validated. ' +
+        'Simplify the command.');
+      return;
+    }
+    if (!ok) {
+      respond(false);
+      return;
+    }
+
+    const event = value;
+    const toolName = event && typeof event === 'object' ? event.preToolUse?.toolName : undefined;
+    const command = toolName === 'execute_command' ? event.preToolUse?.parameters?.command : undefined;
+    if (!command || typeof command !== 'string') {
+      respond(false);
+      return;
+    }
+
+    const result = run({ tool_name: 'Bash', tool_input: { command } });
+    if (result.exitCode === 2) {
+      respond(true, result.stderr || 'Blocked by the EGC Guardian.');
+      return;
+    }
+
+    respond(false);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {};

--- a/scripts/hooks/cline-guardian-adapter.ps1
+++ b/scripts/hooks/cline-guardian-adapter.ps1
@@ -11,6 +11,11 @@
 # This wrapper pipes stdin through unchanged to that real implementation via
 # `node`, and forwards its stdout and exit code.
 
+# Console::In defaults to the system code page, not UTF-8 -- the JS adapter
+# on the other end of this pipe reads stdin as UTF-8, so non-ASCII bytes in
+# the JSON payload would otherwise be corrupted before reaching the
+# validator (cubic-dev-ai finding, PR #1087).
+[Console]::InputEncoding = [System.Text.Encoding]::UTF8
 $stdin = [Console]::In.ReadToEnd()
 $hooksDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $clinerulesDir = Split-Path -Parent $hooksDir

--- a/scripts/hooks/cline-guardian-adapter.ps1
+++ b/scripts/hooks/cline-guardian-adapter.ps1
@@ -1,0 +1,20 @@
+# Cline (VS Code extension) Guardian hook -- Windows.
+#
+# Confirmed against the real cline/cline source (hook-factory.ts
+# findWindowsHook, fetched 2026-07-29): on win32, Cline only looks for
+# `<HookName>.ps1` and runs it via PowerShell -- the extensionless
+# `PreToolUse` file that Unix uses is ignored on Windows. Cline discovers
+# this file by its exact filename, not by a require()'d module, so it
+# cannot live next to its own dependencies the way cline-guardian-adapter.js
+# does (installed at .clinerules/scripts/hooks/, alongside its own copied
+# ./pre-bash-guardian-validate and ../lib/adapter-stdin-json dependencies).
+# This wrapper pipes stdin through unchanged to that real implementation via
+# `node`, and forwards its stdout and exit code.
+
+$stdin = [Console]::In.ReadToEnd()
+$hooksDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$clinerulesDir = Split-Path -Parent $hooksDir
+$target = Join-Path $clinerulesDir 'scripts\hooks\cline-guardian-adapter.js'
+
+$stdin | & node $target
+exit $LASTEXITCODE

--- a/scripts/hooks/cline-pretooluse-shim.js
+++ b/scripts/hooks/cline-pretooluse-shim.js
@@ -13,10 +13,63 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
-const target = path.join(__dirname, '..', 'scripts', 'hooks', 'cline-guardian-adapter.js');
-const result = spawnSync(process.execPath, [target], { stdio: 'inherit' });
+// Cline spawns this file with the PreToolUse event JSON on stdin. Read it
+// fully upfront (synchronously -- this whole shim is a small, blocking
+// relay) so it can be forwarded to the real adapter via spawnSync's `input`
+// option below; a blank/unreadable stdin is passed through as an empty
+// string and left for the adapter's own fail-open-on-malformed-input logic
+// to handle, the same as if it had been invoked directly.
+let stdin = '';
+try {
+  stdin = fs.readFileSync(0, 'utf8');
+} catch {
+  stdin = '';
+}
 
-process.exitCode = typeof result.status === 'number' ? result.status : 0;
+const target = path.join(__dirname, '..', 'scripts', 'hooks', 'cline-guardian-adapter.js');
+const result = spawnSync(process.execPath, [target], { input: stdin, encoding: 'utf8' });
+
+// Deliberately NOT stdio: 'inherit' -- the real failure mode this guards
+// against (cubic-dev-ai P0 finding, PR #1087) isn't just "spawn couldn't
+// launch node at all" (result.error), it's node launching fine and then
+// crashing before printing anything (missing/broken target file, a
+// MODULE_NOT_FOUND from a partial install, ...): with stdio: 'inherit'
+// that leaves stdout genuinely empty with some exit code, which Cline
+// treats as an unconditional ALLOW ("no JSON response found" -> no
+// cancellation) -- the Guardian would silently stop protecting anything.
+// So the child's stdout is captured and validated as JSON before being
+// passed through; anything else (empty, malformed, a crash) falls back to
+// an explicit {cancel: true} emitted by this shim itself, since Guardian
+// is a security boundary and an infra failure must fail CLOSED here, the
+// same policy as every other infra-crash path in this repo
+// (lesson-1785035260946).
+const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+let parsed = null;
+if (stdout) {
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    parsed = null;
+  }
+}
+
+if (parsed && typeof parsed === 'object') {
+  process.stdout.write(stdout);
+  process.exitCode = 0;
+} else {
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  const reason = result.error
+    ? result.error.message
+    : `the validator exited without a usable response (code ${result.status ?? 'unknown'})`;
+  process.stdout.write(JSON.stringify({
+    cancel: true,
+    errorMessage: `EGC Guardian could not run: ${reason}.`,
+  }));
+  process.exitCode = 1;
+}

--- a/scripts/hooks/cline-pretooluse-shim.js
+++ b/scripts/hooks/cline-pretooluse-shim.js
@@ -27,7 +27,8 @@ let stdin = '';
 try {
   stdin = fs.readFileSync(0, 'utf8');
 } catch {
-  stdin = '';
+  // Left as '' -- the target's own fail-open-on-malformed-input logic
+  // handles a blank stdin the same as if it had been invoked directly.
 }
 
 const target = path.join(__dirname, '..', 'scripts', 'hooks', 'cline-guardian-adapter.js');

--- a/scripts/hooks/cline-pretooluse-shim.js
+++ b/scripts/hooks/cline-pretooluse-shim.js
@@ -7,70 +7,94 @@
  * other EGC translation adapter does -- cline-guardian-adapter.js (with its
  * `./pre-bash-guardian-validate` and `../lib/adapter-stdin-json` requires)
  * is instead installed at the normal .clinerules/scripts/hooks/ location,
- * alongside its own copied dependencies, and this shim just spawns it with
- * stdin/stdout/stderr passed through unchanged.
+ * alongside its own copied dependencies, and this shim just spawns it,
+ * relaying stdin in and stdout out.
  */
 
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+// NOT '../lib/adapter-stdin-json': this shim is installed at <root>/hooks/
+// PreToolUse, a sibling of <root>/scripts/ (not inside it) -- unlike
+// cline-guardian-adapter.js, which lives at <root>/scripts/hooks/ and so
+// reaches the same file via '../lib/adapter-stdin-json'. Confirmed via a
+// real isolated install; see cline-project.js's copy operation for this
+// exact destination.
+const { readAdapterStdinJson } = require('../scripts/lib/adapter-stdin-json');
 
-// Cline spawns this file with the PreToolUse event JSON on stdin. Read it
-// fully upfront (synchronously -- this whole shim is a small, blocking
-// relay) so it can be forwarded to the real adapter via spawnSync's `input`
-// option below; a blank/unreadable stdin is passed through as an empty
-// string and left for the adapter's own fail-open-on-malformed-input logic
-// to handle, the same as if it had been invoked directly.
-let stdin = '';
-try {
-  stdin = fs.readFileSync(0, 'utf8');
-} catch {
-  // Left as '' -- the target's own fail-open-on-malformed-input logic
-  // handles a blank stdin the same as if it had been invoked directly.
+function respond(cancel, errorMessage) {
+  process.exitCode = cancel ? 1 : 0;
+  process.stdout.write(JSON.stringify(errorMessage ? { cancel, errorMessage } : { cancel }));
 }
 
-const target = path.join(__dirname, '..', 'scripts', 'hooks', 'cline-guardian-adapter.js');
-const result = spawnSync(process.execPath, [target], { input: stdin, encoding: 'utf8' });
+// Validates the target's stdout the same way Cline's own validateHookOutput
+// does: cancel must be present and boolean. typeof [] === 'object' in JS,
+// so a bare object/array check isn't enough -- an array or a {}-with-no-
+// cancel-field response would otherwise be relayed as-is and, since Cline
+// treats a missing cancel as "no cancellation," silently turn into an
+// allow (cubic-dev-ai finding, PR #1087).
+function isUsableHookOutput(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value) && typeof value.cancel === 'boolean';
+}
 
-// Deliberately NOT stdio: 'inherit' -- the real failure mode this guards
-// against (cubic-dev-ai P0 finding, PR #1087) isn't just "spawn couldn't
-// launch node at all" (result.error), it's node launching fine and then
-// crashing before printing anything (missing/broken target file, a
-// MODULE_NOT_FOUND from a partial install, ...): with stdio: 'inherit'
-// that leaves stdout genuinely empty with some exit code, which Cline
-// treats as an unconditional ALLOW ("no JSON response found" -> no
-// cancellation) -- the Guardian would silently stop protecting anything.
-// So the child's stdout is captured and validated as JSON before being
-// passed through; anything else (empty, malformed, a crash) falls back to
-// an explicit {cancel: true} emitted by this shim itself, since Guardian
-// is a security boundary and an infra failure must fail CLOSED here, the
-// same policy as every other infra-crash path in this repo
-// (lesson-1785035260946).
-const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
-let parsed = null;
-if (stdout) {
-  try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    parsed = null;
+readAdapterStdinJson(({ truncated, ok, value }) => {
+  // Reuses the same 1 MiB cap every other EGC translation adapter enforces
+  // on its own stdin, instead of this shim's own fs.readFileSync(0) buffering
+  // an unbounded payload in full before the real adapter ever gets a chance
+  // to apply that same guard (cubic-dev-ai finding, PR #1087).
+  if (truncated) {
+    respond(true, 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+      'this validator can safely read, so it could not be parsed or validated. ' +
+      'Simplify the command.');
+    return;
   }
-}
 
-if (parsed && typeof parsed === 'object') {
-  process.stdout.write(stdout);
-  process.exitCode = 0;
-} else {
+  // Re-serialized rather than relaying the raw bytes: readAdapterStdinJson
+  // already fully consumed stdin above, so there is nothing left to pipe
+  // through a second time. Malformed (ok: false) input becomes an empty
+  // string, which the real adapter's own readAdapterStdinJson call treats
+  // exactly the same way it would if invoked directly (fails open).
+  const stdinPayload = ok ? JSON.stringify(value) : '';
+
+  const target = path.join(__dirname, '..', 'scripts', 'hooks', 'cline-guardian-adapter.js');
+  const result = spawnSync(process.execPath, [target], { input: stdinPayload, encoding: 'utf8' });
+
+  // The real failure mode this guards against (cubic-dev-ai P0 finding,
+  // PR #1087) isn't just "spawn couldn't launch node at all" (result.error),
+  // it's node launching fine and then crashing before printing anything
+  // (missing/broken target file, a MODULE_NOT_FOUND from a partial install,
+  // ...): with stdio: 'inherit' that would leave stdout genuinely empty
+  // with some exit code, which Cline treats as an unconditional ALLOW ("no
+  // JSON response found" -> no cancellation) -- the Guardian would silently
+  // stop protecting anything. So the child's stdout is captured and
+  // validated before being passed through; anything else (empty,
+  // malformed, wrong shape, a crash) falls back to an explicit
+  // {cancel: true} emitted by this shim itself, since Guardian is a
+  // security boundary and an infra failure must fail CLOSED here, the same
+  // policy as every other infra-crash path in this repo
+  // (lesson-1785035260946).
+  const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+  let parsed = null;
+  if (stdout) {
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (isUsableHookOutput(parsed)) {
+    process.stdout.write(stdout);
+    process.exitCode = 0;
+    return;
+  }
+
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
   const reason = result.error
     ? result.error.message
     : `the validator exited without a usable response (code ${result.status ?? 'unknown'})`;
-  process.stdout.write(JSON.stringify({
-    cancel: true,
-    errorMessage: `EGC Guardian could not run: ${reason}.`,
-  }));
-  process.exitCode = 1;
-}
+  respond(true, `EGC Guardian could not run: ${reason}.`);
+});

--- a/scripts/hooks/cline-pretooluse-shim.js
+++ b/scripts/hooks/cline-pretooluse-shim.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Installed verbatim as .clinerules/hooks/PreToolUse (Unix, executable).
+ *
+ * Cline discovers this file by its exact filename, not by a require()'d
+ * module, so it cannot live next to its own dependencies the way every
+ * other EGC translation adapter does -- cline-guardian-adapter.js (with its
+ * `./pre-bash-guardian-validate` and `../lib/adapter-stdin-json` requires)
+ * is instead installed at the normal .clinerules/scripts/hooks/ location,
+ * alongside its own copied dependencies, and this shim just spawns it with
+ * stdin/stdout/stderr passed through unchanged.
+ */
+
+'use strict';
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const target = path.join(__dirname, '..', 'scripts', 'hooks', 'cline-guardian-adapter.js');
+const result = spawnSync(process.execPath, [target], { stdio: 'inherit' });
+
+process.exitCode = typeof result.status === 'number' ? result.status : 0;

--- a/scripts/hooks/cline-pretooluse-shim.js
+++ b/scripts/hooks/cline-pretooluse-shim.js
@@ -13,8 +13,8 @@
 
 'use strict';
 
-const path = require('path');
-const { spawnSync } = require('child_process');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 // NOT '../lib/adapter-stdin-json': this shim is installed at <root>/hooks/
 // PreToolUse, a sibling of <root>/scripts/ (not inside it) -- unlike
 // cline-guardian-adapter.js, which lives at <root>/scripts/hooks/ and so

--- a/scripts/lib/install-targets/cline-project.js
+++ b/scripts/lib/install-targets/cline-project.js
@@ -46,14 +46,25 @@ const CLINE_HOOK_OWNERSHIP_MARKERS = {
 };
 
 function isForeignHookFile(destinationPath, marker) {
-  if (!fs.existsSync(destinationPath)) {
-    return false;
+  let stats;
+  try {
+    stats = fs.lstatSync(destinationPath);
+  } catch {
+    return false; // Doesn't exist yet -- safe to install.
+  }
+  if (!stats.isFile()) {
+    // A FIFO at this exact path would make fs.readFileSync block
+    // indefinitely waiting for a writer, hanging the whole install
+    // (cubic-dev-ai finding, PR #1087); a directory, socket, or symlink to
+    // either is equally not something to read as text. Only a plain file
+    // is safe to inspect -- anything else is foreign, refuse to touch it.
+    return true;
   }
   try {
     return !fs.readFileSync(destinationPath, 'utf8').includes(marker);
   } catch {
-    // Unreadable (permissions, not a regular file, ...): treat as foreign
-    // rather than risk clobbering something we can't even inspect.
+    // Unreadable (permissions, ...): treat as foreign rather than risk
+    // clobbering something we can't even inspect.
     return true;
   }
 }

--- a/scripts/lib/install-targets/cline-project.js
+++ b/scripts/lib/install-targets/cline-project.js
@@ -1,8 +1,65 @@
+const path = require('node:path');
 const {
   createFlatRuleOperations,
   createInstallTargetAdapter,
+  createRemappedOperation,
   isForeignPlatformPath,
 } = require('./helpers');
+const {
+  createAdapterStdinJsonCopyOperation,
+  createBashGuardianScriptCopyOperations,
+} = require('../claude-settings-hooks');
+
+// Cline discovers a PreToolUse hook by looking for a file literally named
+// `PreToolUse` (Unix, must be executable) or `PreToolUse.ps1` (Windows)
+// inside .clinerules/hooks/ -- there is no hooks.json to merge into, so this
+// is a plain file copy, not a HOOK_OPERATION_KIND merge like every other
+// host. Confirmed against the real cline/cline source (hook-factory.ts),
+// not just the docs (2026-07-29): see cline-guardian-adapter.js for why only
+// Guardian (block) is possible here, not the Token Crusher.
+//
+// cline-guardian-adapter.js requires ./pre-bash-guardian-validate and
+// ../lib/adapter-stdin-json as normal siblings, so it (and those deps)
+// install at the usual .clinerules/scripts/hooks|lib/ location, same as
+// every other host. But the file Cline actually discovers by name
+// (.clinerules/hooks/PreToolUse[.ps1]) can't live there too -- confirmed
+// empirically via a real isolated install (2026-07-29): a standalone copy
+// of cline-guardian-adapter.js at hooks/PreToolUse crashes with
+// MODULE_NOT_FOUND, since its sibling deps aren't copied alongside it. So
+// PreToolUse/PreToolUse.ps1 are instead thin shims that spawn the real,
+// properly-sited adapter and pass stdin/stdout/exit code through unchanged.
+const CLINE_GUARDIAN_HOOK_MODULE_ID = 'egc-guardian-cline-hook';
+const CLINE_GUARDIAN_ADAPTER_SOURCE_RELATIVE_PATH = 'scripts/hooks/cline-guardian-adapter.js';
+
+function createClineGuardianHookOperations(adapter, targetRoot) {
+  const hooksDir = path.join(targetRoot, 'hooks');
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+
+  return [
+    ...createBashGuardianScriptCopyOperations(remap, targetRoot),
+    createAdapterStdinJsonCopyOperation(remap, targetRoot),
+    remap(
+      CLINE_GUARDIAN_HOOK_MODULE_ID,
+      CLINE_GUARDIAN_ADAPTER_SOURCE_RELATIVE_PATH,
+      path.join(targetRoot, ...CLINE_GUARDIAN_ADAPTER_SOURCE_RELATIVE_PATH.split('/')),
+      { strategy: 'preserve-relative-path' }
+    ),
+    remap(
+      CLINE_GUARDIAN_HOOK_MODULE_ID,
+      'scripts/hooks/cline-pretooluse-shim.js',
+      path.join(hooksDir, 'PreToolUse'),
+      { strategy: 'preserve-relative-path' }
+    ),
+    remap(
+      CLINE_GUARDIAN_HOOK_MODULE_ID,
+      'scripts/hooks/cline-guardian-adapter.ps1',
+      path.join(hooksDir, 'PreToolUse.ps1'),
+      { strategy: 'preserve-relative-path' }
+    ),
+  ];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'cline-project',
@@ -34,8 +91,9 @@ module.exports = createInstallTargetAdapter({
     };
 
     const targetRoot = adapter.resolveRoot(planningInput);
+    const guardianHookOperations = createClineGuardianHookOperations(adapter, targetRoot);
 
-    return modules.flatMap(module => {
+    return guardianHookOperations.concat(modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];
 
       return paths
@@ -58,6 +116,6 @@ module.exports = createInstallTargetAdapter({
             ),
           ];
         });
-    });
+    }));
   },
 });

--- a/scripts/lib/install-targets/cline-project.js
+++ b/scripts/lib/install-targets/cline-project.js
@@ -1,3 +1,4 @@
+const fs = require('node:fs');
 const path = require('node:path');
 const {
   createFlatRuleOperations,
@@ -31,11 +32,52 @@ const {
 const CLINE_GUARDIAN_HOOK_MODULE_ID = 'egc-guardian-cline-hook';
 const CLINE_GUARDIAN_ADAPTER_SOURCE_RELATIVE_PATH = 'scripts/hooks/cline-guardian-adapter.js';
 
+// Unlike every other host, Cline has no hooks.json to MERGE a new entry
+// into -- it looks up exactly one file per hook name, so a user's own
+// pre-existing .clinerules/hooks/PreToolUse (unrelated to EGC) would be
+// silently overwritten by install and then permanently deleted by
+// uninstall, with no way to preserve or restore it (cubic-dev-ai P1
+// finding, PR #1087). These markers, taken verbatim from each shim's own
+// header comment, let install recognize "this file is already ours" (safe
+// to overwrite/reinstall) versus a foreign file (refuse to touch).
+const CLINE_HOOK_OWNERSHIP_MARKERS = {
+  PreToolUse: 'Installed verbatim as .clinerules/hooks/PreToolUse (Unix, executable).',
+  'PreToolUse.ps1': 'Cline (VS Code extension) Guardian hook -- Windows.',
+};
+
+function isForeignHookFile(destinationPath, marker) {
+  if (!fs.existsSync(destinationPath)) {
+    return false;
+  }
+  try {
+    return !fs.readFileSync(destinationPath, 'utf8').includes(marker);
+  } catch {
+    // Unreadable (permissions, not a regular file, ...): treat as foreign
+    // rather than risk clobbering something we can't even inspect.
+    return true;
+  }
+}
+
 function createClineGuardianHookOperations(adapter, targetRoot) {
   const hooksDir = path.join(targetRoot, 'hooks');
   const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
     createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
+
+  const hookFileOperations = [
+    ['scripts/hooks/cline-pretooluse-shim.js', path.join(hooksDir, 'PreToolUse'), 'PreToolUse'],
+    ['scripts/hooks/cline-guardian-adapter.ps1', path.join(hooksDir, 'PreToolUse.ps1'), 'PreToolUse.ps1'],
+  ].flatMap(([sourceRelativePath, destinationPath, hookFileName]) => {
+    if (isForeignHookFile(destinationPath, CLINE_HOOK_OWNERSHIP_MARKERS[hookFileName])) {
+      console.error(
+        `Warning: ${destinationPath} already exists and was not installed by EGC -- ` +
+        'leaving it untouched. The EGC Guardian will not be active for Cline in this project ' +
+        'until the conflicting file is removed or merged manually.'
+      );
+      return [];
+    }
+    return [remap(CLINE_GUARDIAN_HOOK_MODULE_ID, sourceRelativePath, destinationPath, { strategy: 'preserve-relative-path' })];
+  });
 
   return [
     ...createBashGuardianScriptCopyOperations(remap, targetRoot),
@@ -46,18 +88,7 @@ function createClineGuardianHookOperations(adapter, targetRoot) {
       path.join(targetRoot, ...CLINE_GUARDIAN_ADAPTER_SOURCE_RELATIVE_PATH.split('/')),
       { strategy: 'preserve-relative-path' }
     ),
-    remap(
-      CLINE_GUARDIAN_HOOK_MODULE_ID,
-      'scripts/hooks/cline-pretooluse-shim.js',
-      path.join(hooksDir, 'PreToolUse'),
-      { strategy: 'preserve-relative-path' }
-    ),
-    remap(
-      CLINE_GUARDIAN_HOOK_MODULE_ID,
-      'scripts/hooks/cline-guardian-adapter.ps1',
-      path.join(hooksDir, 'PreToolUse.ps1'),
-      { strategy: 'preserve-relative-path' }
-    ),
+    ...hookFileOperations,
   ];
 }
 

--- a/tests/hooks/cline-guardian-adapter.test.js
+++ b/tests/hooks/cline-guardian-adapter.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for scripts/hooks/cline-guardian-adapter.js
+ *
+ * Cline's PreToolUse input shape is {preToolUse: {toolName, parameters}},
+ * not Claude Code's {tool_name, tool_input}, so the remapping IS tested
+ * here (unlike Junie). Cline's output schema (validateHookOutput in the
+ * real cline/cline source, confirmed 2026-07-29) only recognizes cancel/
+ * contextModification/errorMessage -- there is no exit-code contract like
+ * Junie's (Cline honors the JSON body regardless of exit code), so every
+ * case here asserts exit 0 and checks `cancel` in the body instead.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const adapterScript = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'cline-guardian-adapter.js');
+const fakeCli = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runAdapterCli(input, env = {}) {
+  const result = spawnSync('node', [adapterScript], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, EGC_GUARDIAN_CLI: fakeCli, ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing cline-guardian-adapter ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('CLI: allows a safe execute_command (exit 0, {cancel: false})', () => {
+    const result = runAdapterCli({ preToolUse: { toolName: 'execute_command', parameters: { command: 'git status' } } });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { cancel: false });
+  })) passed++; else failed++;
+
+  if (test('CLI: blocks a destructive execute_command ({cancel: true, errorMessage})', () => {
+    const result = runAdapterCli({ preToolUse: { toolName: 'execute_command', parameters: { command: 'rm -rf /' } } });
+    assert.strictEqual(result.code, 0, 'Cline honors the JSON body regardless of exit code');
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.cancel, true);
+    assert.ok(response.errorMessage && response.errorMessage.length > 0, 'expected a non-empty errorMessage');
+  })) passed++; else failed++;
+
+  if (test('CLI: a non-execute_command tool (e.g. read_file) allows untouched', () => {
+    const result = runAdapterCli({ preToolUse: { toolName: 'read_file', parameters: { command: 'rm -rf /', path: '/etc/passwd' } } });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { cancel: false });
+  })) passed++; else failed++;
+
+  if (test('CLI: execute_command with no command parameter allows (exit 0)', () => {
+    const result = runAdapterCli({ preToolUse: { toolName: 'execute_command', parameters: {} } });
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { cancel: false });
+  })) passed++; else failed++;
+
+  if (test('CLI: malformed stdin JSON fails open ({cancel: false})', () => {
+    const result = runAdapterCli('not json');
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { cancel: false });
+  })) passed++; else failed++;
+
+  if (test('CLI: a truncated oversized payload fails CLOSED ({cancel: true}) -- Guardian is a security boundary', () => {
+    const oversizedPadding = 'x'.repeat(2 * 1024 * 1024);
+    const oversizedInput = JSON.stringify({
+      preToolUse: { toolName: 'execute_command', parameters: { command: 'git status' } },
+      padding: oversizedPadding,
+    });
+    const result = runAdapterCli(oversizedInput);
+    assert.strictEqual(result.code, 0);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.cancel, true, 'Expected fail-closed on truncated oversized input');
+  })) passed++; else failed++;
+
+  if (test('CLI: full stdout is present at exit (no truncation from exitCode-based exit)', () => {
+    for (let i = 0; i < 20; i += 1) {
+      const result = runAdapterCli({ preToolUse: { toolName: 'execute_command', parameters: { command: 'git status' } } });
+      assert.doesNotThrow(() => JSON.parse(result.stdout), `Run ${i}: stdout was not valid JSON: ${JSON.stringify(result.stdout)}`);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/cline-pretooluse-shim.test.js
+++ b/tests/hooks/cline-pretooluse-shim.test.js
@@ -62,12 +62,28 @@ function runShim(shimPath, input) {
 // decisions for real commands are covered where they belong, at the
 // adapter layer (tests/hooks/cline-guardian-adapter.test.js) and by a real
 // isolated `egc install` end-to-end check.
+const tempRoots = [];
+
 function buildInstalledLayout({ targetScript }) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-cline-shim-test-'));
+  tempRoots.push(root);
   const hooksDir = path.join(root, 'hooks');
   fs.mkdirSync(hooksDir, { recursive: true });
   const shimPath = path.join(hooksDir, 'PreToolUse');
   fs.copyFileSync(shimSource, shimPath);
+
+  // Matches the exact destination cline-project.js's planOperations
+  // produces for the shared adapter-stdin-json.js dependency, which the
+  // shim itself now requires (../scripts/lib/adapter-stdin-json relative to
+  // <root>/hooks/PreToolUse) to read ITS OWN stdin -- unconditional,
+  // independent of whether a target adapter is present, since the shim
+  // needs this before it even attempts to spawn one.
+  const scriptsLibDir = path.join(root, 'scripts', 'lib');
+  fs.mkdirSync(scriptsLibDir, { recursive: true });
+  fs.copyFileSync(
+    path.join(repoRoot, 'scripts', 'lib', 'adapter-stdin-json.js'),
+    path.join(scriptsLibDir, 'adapter-stdin-json.js')
+  );
 
   if (targetScript) {
     const scriptsHooksDir = path.join(root, 'scripts', 'hooks');
@@ -76,6 +92,12 @@ function buildInstalledLayout({ targetScript }) {
   }
 
   return shimPath;
+}
+
+function cleanupTempRoots() {
+  for (const root of tempRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }
 
 function runTests() {
@@ -100,6 +122,7 @@ function runTests() {
 
     const result = runShim(isolatedShim, JSON.stringify({ preToolUse: { toolName: 'execute_command', parameters: { command: 'git status' } } }));
 
+    assert.notStrictEqual(result.code, 0, 'Expected a non-zero exit when the target never produced a usable response');
     const response = JSON.parse(result.stdout);
     assert.strictEqual(response.cancel, true, 'A crashed/malformed target response must not be treated as an implicit allow');
   })) passed++; else failed++;
@@ -137,6 +160,8 @@ function runTests() {
     const response = JSON.parse(result.stdout);
     assert.strictEqual(response.echoedStdin, payload, 'The exact stdin this test sent to the shim must reach the target unchanged');
   })) passed++; else failed++;
+
+  cleanupTempRoots();
 
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/cline-pretooluse-shim.test.js
+++ b/tests/hooks/cline-pretooluse-shim.test.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for scripts/hooks/cline-pretooluse-shim.js
+ *
+ * This is the literal file Cline discovers and spawns directly as
+ * .clinerules/hooks/PreToolUse -- it just relays stdin/stdout/exit code to
+ * the real adapter at ../scripts/hooks/cline-guardian-adapter.js. Covers
+ * the cubic-dev-ai P0 finding (PR #1087): if that target can't even be
+ * spawned, the shim must fail CLOSED ({cancel: true}), not silently report
+ * exit 0 with no output (which Cline would treat as an unconditional
+ * allow, running the Guardian in name only).
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const shimSource = path.join(repoRoot, 'scripts', 'hooks', 'cline-pretooluse-shim.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runShim(shimPath, input) {
+  const result = spawnSync('node', [shimPath], {
+    input,
+    encoding: 'utf8',
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+// The shim resolves its target as __dirname/../scripts/hooks/cline-guardian-
+// adapter.js, i.e. it assumes it lives at <root>/hooks/PreToolUse with the
+// real adapter at <root>/scripts/hooks/ -- the exact layout
+// cline-project.js's planOperations produces. Reproduces that layout in an
+// isolated temp dir so the test exercises the real path relationship
+// instead of running the shim from its own source location (a different,
+// unrelated relative layout).
+//
+// For the "relay unchanged" cases, the target is a trivial stand-in script,
+// not the real cline-guardian-adapter.js -- this test's job is only to
+// prove the shim relays whatever valid JSON its target prints, verbatim
+// (or fails closed when it doesn't); the Guardian's own allow/deny
+// decisions for real commands are covered where they belong, at the
+// adapter layer (tests/hooks/cline-guardian-adapter.test.js) and by a real
+// isolated `egc install` end-to-end check.
+function buildInstalledLayout({ targetScript }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-cline-shim-test-'));
+  const hooksDir = path.join(root, 'hooks');
+  fs.mkdirSync(hooksDir, { recursive: true });
+  const shimPath = path.join(hooksDir, 'PreToolUse');
+  fs.copyFileSync(shimSource, shimPath);
+
+  if (targetScript) {
+    const scriptsHooksDir = path.join(root, 'scripts', 'hooks');
+    fs.mkdirSync(scriptsHooksDir, { recursive: true });
+    fs.writeFileSync(path.join(scriptsHooksDir, 'cline-guardian-adapter.js'), targetScript);
+  }
+
+  return shimPath;
+}
+
+function runTests() {
+  console.log('\n=== Testing cline-pretooluse-shim ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('fails CLOSED ({cancel: true}, non-zero exit) when the real adapter cannot be spawned', () => {
+    const isolatedShim = buildInstalledLayout({ targetScript: null });
+
+    const result = runShim(isolatedShim, JSON.stringify({ preToolUse: { toolName: 'execute_command', parameters: { command: 'git status' } } }));
+
+    assert.notStrictEqual(result.code, 0, 'Expected a non-zero exit when the target adapter is missing');
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.cancel, true, 'Must fail closed, not silently allow, when the Guardian could not even run');
+    assert.ok(response.errorMessage && response.errorMessage.length > 0, 'expected a non-empty errorMessage explaining the failure');
+  })) passed++; else failed++;
+
+  if (test('fails CLOSED when the target runs but never prints valid JSON', () => {
+    const isolatedShim = buildInstalledLayout({ targetScript: '#!/usr/bin/env node\nprocess.stdin.resume();\nprocess.stdout.write("not json");\n' });
+
+    const result = runShim(isolatedShim, JSON.stringify({ preToolUse: { toolName: 'execute_command', parameters: { command: 'git status' } } }));
+
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.cancel, true, 'A crashed/malformed target response must not be treated as an implicit allow');
+  })) passed++; else failed++;
+
+  if (test('relays a target\'s allow decision unchanged when it runs normally', () => {
+    const installedShim = buildInstalledLayout({ targetScript: '#!/usr/bin/env node\nprocess.stdin.resume();\nprocess.stdout.write(JSON.stringify({cancel:false}));\n' });
+    const result = runShim(installedShim, JSON.stringify({ preToolUse: { toolName: 'execute_command', parameters: { command: 'git status' } } }));
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { cancel: false });
+  })) passed++; else failed++;
+
+  if (test('relays a target\'s deny decision unchanged when it runs normally', () => {
+    const installedShim = buildInstalledLayout({ targetScript: '#!/usr/bin/env node\nprocess.stdin.resume();\nprocess.stdout.write(JSON.stringify({cancel:true,errorMessage:"blocked"}));\n' });
+    const result = runShim(installedShim, JSON.stringify({ preToolUse: { toolName: 'execute_command', parameters: { command: 'rm -rf /' } } }));
+    assert.strictEqual(result.code, 0, 'Cline honors the JSON body regardless of exit code');
+    assert.deepStrictEqual(JSON.parse(result.stdout), { cancel: true, errorMessage: 'blocked' });
+  })) passed++; else failed++;
+
+  if (test('forwards the real stdin payload to the target, not an empty/detached stream', () => {
+    // Regression guard for a real bug found while verifying this fix end
+    // to end: an earlier version of the shim captured the target's stdout
+    // via spawnSync without also passing the shim's OWN received stdin
+    // through as `input`, so the target always saw an empty stdin -- a
+    // real isolated `egc install` + direct invocation showed EVERY command
+    // (including "rm -rf /") coming back {cancel:false}, because the
+    // target's own stdin-parsing fell through its malformed/empty-input
+    // fail-open path every time, never seeing the actual command at all.
+    const echoTarget = '#!/usr/bin/env node\nlet raw="";process.stdin.on("data",c=>raw+=c);process.stdin.on("end",()=>process.stdout.write(JSON.stringify({cancel:false,echoedStdin:raw})));\n';
+    const installedShim = buildInstalledLayout({ targetScript: echoTarget });
+    const payload = JSON.stringify({ preToolUse: { toolName: 'execute_command', parameters: { command: 'echo distinctive-marker-38fa21' } } });
+
+    const result = runShim(installedShim, payload);
+
+    assert.strictEqual(result.code, 0);
+    const response = JSON.parse(result.stdout);
+    assert.strictEqual(response.echoedStdin, payload, 'The exact stdin this test sent to the shim must reach the target unchanged');
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -755,14 +755,49 @@ function runTests() {
     assert.ok(
       plan.operations.some(operation => (
         normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'
+        && operation.destinationPath === path.join(targetRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js')
       )),
-      'Should plan the shared Guardian validator script copy even with no modules selected'
+      'Should plan the shared Guardian validator script copy at the destination cline-guardian-adapter.js requires as a sibling'
     );
     assert.ok(
       plan.operations.some(operation => (
         normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/adapter-stdin-json.js'
+        && operation.destinationPath === path.join(targetRoot, 'scripts', 'lib', 'adapter-stdin-json.js')
       )),
-      'Should plan the shared adapter-stdin-json.js dependency copy even with no modules selected'
+      'Should plan the shared adapter-stdin-json.js dependency copy at the destination cline-guardian-adapter.js requires as a sibling'
+    );
+  })) passed++; else failed++;
+
+  if (test('cline adapter refuses to overwrite a pre-existing, non-EGC PreToolUse hook, but reinstalls over its own', () => {
+    // Cline has no hooks.json to merge into -- unlike every other host, it
+    // looks up exactly one file per hook name, so silently overwriting a
+    // user's own unrelated .clinerules/hooks/PreToolUse (and later deleting
+    // it on uninstall, with no restore) would destroy their file with no
+    // way back (cubic-dev-ai P1 finding, PR #1087). This needs a real
+    // filesystem, not the synthetic /workspace/app paths every other test
+    // in this file uses, since the check reads the actual destination.
+    const fs = require('fs');
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-cline-hook-test-'));
+    const hooksDir = path.join(projectRoot, '.clinerules', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+
+    const foreignHookPath = path.join(hooksDir, 'PreToolUse');
+    fs.writeFileSync(foreignHookPath, '#!/usr/bin/env node\n// a user\'s own unrelated hook, nothing to do with EGC\n');
+
+    const planWithForeignFile = planInstallTargetScaffold({ target: 'cline', repoRoot, projectRoot, modules: [] });
+    assert.ok(
+      !planWithForeignFile.operations.some(operation => operation.destinationPath === foreignHookPath),
+      'Should NOT plan an operation that would overwrite the pre-existing foreign PreToolUse file'
+    );
+
+    // Once EGC's own shim is the one on disk (recognizable by its header
+    // marker), reinstall/repair must still work normally.
+    fs.copyFileSync(path.join(repoRoot, 'scripts', 'hooks', 'cline-pretooluse-shim.js'), foreignHookPath);
+    const planOverOwnFile = planInstallTargetScaffold({ target: 'cline', repoRoot, projectRoot, modules: [] });
+    assert.ok(
+      planOverOwnFile.operations.some(operation => operation.destinationPath === foreignHookPath),
+      'Should plan the normal reinstall operation once the existing file is recognizably EGC\'s own'
     );
   })) passed++; else failed++;
 

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -779,26 +779,30 @@ function runTests() {
     const fs = require('fs');
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-cline-hook-test-'));
-    const hooksDir = path.join(projectRoot, '.clinerules', 'hooks');
-    fs.mkdirSync(hooksDir, { recursive: true });
+    try {
+      const hooksDir = path.join(projectRoot, '.clinerules', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
 
-    const foreignHookPath = path.join(hooksDir, 'PreToolUse');
-    fs.writeFileSync(foreignHookPath, '#!/usr/bin/env node\n// a user\'s own unrelated hook, nothing to do with EGC\n');
+      const foreignHookPath = path.join(hooksDir, 'PreToolUse');
+      fs.writeFileSync(foreignHookPath, '#!/usr/bin/env node\n// a user\'s own unrelated hook, nothing to do with EGC\n');
 
-    const planWithForeignFile = planInstallTargetScaffold({ target: 'cline', repoRoot, projectRoot, modules: [] });
-    assert.ok(
-      !planWithForeignFile.operations.some(operation => operation.destinationPath === foreignHookPath),
-      'Should NOT plan an operation that would overwrite the pre-existing foreign PreToolUse file'
-    );
+      const planWithForeignFile = planInstallTargetScaffold({ target: 'cline', repoRoot, projectRoot, modules: [] });
+      assert.ok(
+        !planWithForeignFile.operations.some(operation => operation.destinationPath === foreignHookPath),
+        'Should NOT plan an operation that would overwrite the pre-existing foreign PreToolUse file'
+      );
 
-    // Once EGC's own shim is the one on disk (recognizable by its header
-    // marker), reinstall/repair must still work normally.
-    fs.copyFileSync(path.join(repoRoot, 'scripts', 'hooks', 'cline-pretooluse-shim.js'), foreignHookPath);
-    const planOverOwnFile = planInstallTargetScaffold({ target: 'cline', repoRoot, projectRoot, modules: [] });
-    assert.ok(
-      planOverOwnFile.operations.some(operation => operation.destinationPath === foreignHookPath),
-      'Should plan the normal reinstall operation once the existing file is recognizably EGC\'s own'
-    );
+      // Once EGC's own shim is the one on disk (recognizable by its header
+      // marker), reinstall/repair must still work normally.
+      fs.copyFileSync(path.join(repoRoot, 'scripts', 'hooks', 'cline-pretooluse-shim.js'), foreignHookPath);
+      const planOverOwnFile = planInstallTargetScaffold({ target: 'cline', repoRoot, projectRoot, modules: [] });
+      assert.ok(
+        planOverOwnFile.operations.some(operation => operation.destinationPath === foreignHookPath),
+        'Should plan the normal reinstall operation once the existing file is recognizably EGC\'s own'
+      );
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
   })) passed++; else failed++;
 
   if (test('codebuddy adapter supports lookup by target and adapter id', () => {

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -718,6 +718,54 @@ function runTests() {
     assert.ok(targets.includes('cline'), 'Should include cline target');
   })) passed++; else failed++;
 
+  if (test('cline adapter always plans the Guardian PreToolUse hook (Unix + Windows), even with no modules selected', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+    const targetRoot = path.join(projectRoot, '.clinerules');
+    const hooksDir = path.join(targetRoot, 'hooks');
+
+    const plan = planInstallTargetScaffold({
+      target: 'cline',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+
+    // Cline has no hooks.json to merge into -- discovery is by filename, so
+    // this is a plain file copy per platform, not a HOOK_OPERATION_KIND merge.
+    // PreToolUse/PreToolUse.ps1 are thin shims (Cline requires this exact
+    // filename); the real adapter, with its own require()'d dependencies,
+    // installs at the normal .clinerules/scripts/hooks/ location instead.
+    const unixShim = plan.operations.find(operation => operation.destinationPath === path.join(hooksDir, 'PreToolUse'));
+    const windowsShim = plan.operations.find(operation => operation.destinationPath === path.join(hooksDir, 'PreToolUse.ps1'));
+
+    assert.ok(unixShim, 'Should plan the Unix PreToolUse shim copy even with no modules selected');
+    assert.ok(windowsShim, 'Should plan the Windows PreToolUse.ps1 shim copy even with no modules selected');
+    assert.strictEqual(normalizedRelativePath(unixShim.sourceRelativePath), 'scripts/hooks/cline-pretooluse-shim.js');
+    assert.strictEqual(normalizedRelativePath(windowsShim.sourceRelativePath), 'scripts/hooks/cline-guardian-adapter.ps1');
+
+    const realAdapterDestination = path.join(targetRoot, 'scripts', 'hooks', 'cline-guardian-adapter.js');
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/cline-guardian-adapter.js'
+        && operation.destinationPath === realAdapterDestination
+      )),
+      'Should plan the real adapter at .clinerules/scripts/hooks/, next to its own dependencies'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-bash-guardian-validate.js'
+      )),
+      'Should plan the shared Guardian validator script copy even with no modules selected'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/adapter-stdin-json.js'
+      )),
+      'Should plan the shared adapter-stdin-json.js dependency copy even with no modules selected'
+    );
+  })) passed++; else failed++;
+
   if (test('codebuddy adapter supports lookup by target and adapter id', () => {
     const byTarget = getInstallTargetAdapter('codebuddy');
     const byId = getInstallTargetAdapter('codebuddy-project');


### PR DESCRIPTION
## Summary
- Guardian (block-only) wired into Cline's PreToolUse hook, researched directly against the real cline/cline source rather than the docs (mid-migration to a new SDK plugin system not yet applicable to the VS Code extension)
- Token Crusher confirmed impossible: Cline's hook output schema only supports `cancel`/`contextModification`/`errorMessage`, no command-rewrite field -- same status as Kiro and Windsurf
- Cline discovers hooks by exact filename (`.clinerules/hooks/PreToolUse`, `.ps1` on Windows), not a config merge, so the real adapter installs at the normal `.clinerules/scripts/hooks/` location next to its dependencies, and `PreToolUse`/`PreToolUse.ps1` are thin shims that spawn it

## Test plan
- [x] Unit tests (`tests/hooks/cline-guardian-adapter.test.js`, 7 cases: allow/deny/non-execute_command/no-command/malformed-stdin/truncated-payload/no-truncation-on-exit)
- [x] `tests/lib/install-targets.test.js` wiring test asserting the hook + its dependencies are always planned
- [x] Real isolated install (`egc install --target cline --profile full`) + `egc doctor` -- OK
- [x] Direct execution of the installed hook file exactly as Cline would spawn it (X_OK check, no explicit `node` invocation) -- allow and deny cases both verified
- [x] Full suite: 3643/3643 green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Bash Guardian validator into Cline’s `PreToolUse` hook to block unsafe shell commands before they run. Hardened shim I/O and install checks across Unix and Windows without clobbering user hooks, and aligned Node built-in requires to the `node:` protocol for consistency.

- **New Features**
  - Added `scripts/hooks/cline-guardian-adapter.js` that maps Cline’s input to Guardian and returns `{ cancel, errorMessage }` (no command rewrite; Token Crusher not supported by Cline’s schema).
  - Added Unix `PreToolUse` and Windows `PreToolUse.ps1` shims that spawn the real adapter; adapter and deps install under `.clinerules/scripts/` for reliable `require()`s.
  - Updated `cline` install target to always plan the shims, adapter, and shared deps; added tests for allow/deny, malformed/truncated input, shim behavior, and install planning.

- **Bug Fixes**
  - Shim now fails closed when the adapter crashes or prints no JSON, and forwards stdin correctly; regression tests added.
  - Shim reads stdin via the shared 1 MiB–capped reader and validates child output shape (must include a boolean `cancel`); empty/malformed responses now fail closed.
  - Installer refuses to overwrite non-EGC `PreToolUse` files and reinstalls over EGC’s own shims; logs a warning on conflicts.
  - Installer avoids FIFO hangs by checking `isFile()` before reading hook paths.
  - Windows shim sets `Console.InputEncoding` to UTF-8 to prevent JSON payload corruption.
  - Removed redundant stdin assignment flagged by lint; no behavior change.

<sup>Written for commit 1cc7df14722094406b0e3c32e22dba7da5af530b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

