### PR TITLE
ci(fuzzing): complete fork bypass in cflite_pr.yml, pin revert SHA in all workflows

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -25,7 +25,7 @@ jobs:
         id: build
         # Pinned to Maqbool61/clusterfuzzlite@fix/js-sanitizer-none (EGC#910):
         # patches config_utils.py inside the Docker image to allow SANITIZER=none
-        # for JavaScript projects. Revert to google/clusterfuzzlite/actions/build_fuzzers@v1
+        # for JavaScript projects. Revert to google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
         # once google/oss-fuzz#15907 is resolved upstream.
         uses: Maqbool61/clusterfuzzlite/actions/build_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -25,7 +25,7 @@ jobs:
         id: build
         # Pinned to Maqbool61/clusterfuzzlite@fix/js-sanitizer-none (EGC#910):
         # patches config_utils.py inside the Docker image to allow SANITIZER=none
-        # for JavaScript projects. Revert to google/clusterfuzzlite/actions/build_fuzzers@v1
+        # for JavaScript projects. Revert to google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
         # once google/oss-fuzz#15907 is resolved upstream.
         uses: Maqbool61/clusterfuzzlite/actions/build_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -17,20 +17,25 @@ jobs:
     steps:
       - name: Build Fuzzers
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        # Pinned to Maqbool61/clusterfuzzlite@fix/js-sanitizer-none (EGC#910):
+        # patches config_utils.py inside the Docker image to allow SANITIZER=none
+        # for JavaScript projects. Revert to google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        # once google/oss-fuzz#15907 is resolved upstream.
+        uses: Maqbool61/clusterfuzzlite/actions/build_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:
           language: javascript
-          sanitizer: address
+          sanitizer: none
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Fuzzers
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        uses: Maqbool61/clusterfuzzlite/actions/run_fuzzers@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 300
           mode: code-change
-          sanitizer: address
+          language: javascript
+          sanitizer: none
           output-sarif: true
 
       - name: Upload SARIF


### PR DESCRIPTION
Follow-up to #1075.

Three fixes after the CIFuzz fork merge:

1. cflite_pr.yml was not updated in #1075 -- now points to Maqbool61/clusterfuzzlite@f3fd422 with sanitizer: none and language: javascript, matching batch and cron.

2. Revert comment in all three workflow files referenced `@v1` (floating tag). Now references the reviewed pinned SHA `884713a6c30a92e5e8544c39945cd7cb630abcd1`, so a future revert stays reproducible.

3. Permissions confirmed at minimum: `contents: read` + `security-events: write` (required for SARIF upload). No scope reduction possible without splitting jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the ClusterFuzzLite fork bypass and pins revert SHAs to keep CI fuzzing stable and reproducible. Aligns `cflite_pr.yml` with batch/cron using `sanitizer: none` for JavaScript and minimal permissions.

- **Bug Fixes**
  - Switches `cflite_pr.yml` to `Maqbool61/clusterfuzzlite@f3fd422fd0d55f2b4b2c3c1795ed4bcb7084ca41` for build/run; sets `language: javascript` and `sanitizer: none` to match batch/cron.
  - Replaces floating revert hint to `google/clusterfuzzlite/actions/build_fuzzers@v1` with pinned `@884713a6c30a92e5e8544c39945cd7cb630abcd1` in all workflows.
  - Confirms minimum permissions for SARIF upload: `contents: read`, `security-events: write`.

<sup>Written for commit 5a99e73155e4392c958981330dd0d686f79c6148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

