### PR TITLE
feat(cli): credit the author in the egc init banner

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -236,11 +236,19 @@ function runDoctor() {
   }
 }
 
+const AUTHOR_NAME = 'Felipe Marzochi';
+const AUTHOR_URL = 'https://github.com/Fmarzochi';
+const authorText = `Powered by ${AUTHOR_NAME}`;
+const authorDisplay = isTTY
+  ? `\x1b]8;;${AUTHOR_URL}\x1b\\${authorText}\x1b]8;;\x1b\\`
+  : authorText;
+
 const banner = [
   '',
   `  ${c.cyan}${c.bold}╭──────────────────────────────────────────╮${c.reset}`,
-  `  ${c.cyan}${c.bold}│${c.reset}  ${c.bold}EGC${c.reset} ${c.dim}·${c.reset} AI context manager${' '.repeat(16)}${c.cyan}${c.bold}│${c.reset}`,
+  `  ${c.cyan}${c.bold}│${c.reset}  ${c.bold}EGC${c.reset} ${c.dim}·${c.reset} Extended Global Context${' '.repeat(11)}${c.cyan}${c.bold}│${c.reset}`,
   `  ${c.cyan}${c.bold}│${c.reset}  ${c.dim}v${PKG_VERSION}${' '.repeat(39 - PKG_VERSION.length)}${c.reset}${c.cyan}${c.bold}│${c.reset}`,
+  `  ${c.cyan}${c.bold}│${c.reset}  ${c.dim}${authorDisplay}${' '.repeat(40 - authorText.length)}${c.reset}${c.cyan}${c.bold}│${c.reset}`,
   `  ${c.cyan}${c.bold}╰──────────────────────────────────────────╯${c.reset}`,
   '',
 ];


### PR DESCRIPTION
## Summary
- Swap the generic "AI context manager" tagline for the project's full name, Extended Global Context.
- Add a "Powered by Felipe Marzochi" line to the banner, linking to the GitHub profile via an OSC 8 terminal hyperlink (falls back to plain text on non-TTY output).

## Test plan
- [x] `npm test` (3649 tests passed)
- [x] `node scripts/init.js --dry-run` to visually confirm banner alignment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the CLI init banner to use the full project name, Extended Global Context. Add a "Powered by" line that links to the maintainer's GitHub via an OSC 8 terminal hyperlink, with a plain-text fallback on non-TTY output.

<sup>Written for commit 2f5a73f149c267e896a50e805264fa0ac9f57684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

