### PR TITLE
fix(doctor,repair): honor --repo-root; add Token Crusher AI protocol

### DIFF
--- a/rules/common/memory.md
+++ b/rules/common/memory.md
@@ -67,3 +67,11 @@ These calls are automatic and non-negotiable. Never wait for the user to ask.
 **At the end of every significant work block:** call `auto_learn({ project_path: "<cwd>" })`
 
 Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
+
+## EGC Token Crusher Protocol
+
+**Route heavy commands through `egc run` yourself -- do not wait for a hook to rewrite them.** The Guardian hook attempts an automatic PreToolUse rewrite, but Anthropic confirmed and closed as "not planned" that this rewrite is silently ignored when the assistant itself issues the Bash tool call (not a human typing in a terminal). Relying on the hook alone means noisy output reaches you uncompressed every time.
+
+**Before running any command likely to produce large or noisy output, prefix it yourself:** `egc run <command>` instead of `<command>` directly. Examples: `egc run git log --stat -n 50`, `egc run git diff`, `egc run npm install`, `egc run npm test`, `egc run find . -name "*.ts"`.
+
+If you genuinely need the full, uncompressed output, use `egc run --raw <command>` -- never skip the wrapper entirely for a command that would otherwise be crushable.

--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -8,6 +8,7 @@ const { version: PKG_VERSION } = require('../package.json');
 
 const { discoverInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
+const { parseTargetArgs } = require('./lib/cli-target-args');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -20,36 +21,7 @@ using the original install-state request.
 }
 
 function parseArgs(argv) {
-  const args = argv.slice(2);
-  const parsed = {
-    targets: [],
-    repoRoot: null,
-    dryRun: false,
-    json: false,
-    help: false,
-  };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-
-    if (arg === '--target') {
-      parsed.targets.push(args[index + 1] || null);
-      index += 1;
-    } else if (arg === '--repo-root') {
-      parsed.repoRoot = args[index + 1] || null;
-      index += 1;
-    } else if (arg === '--dry-run') {
-      parsed.dryRun = true;
-    } else if (arg === '--json') {
-      parsed.json = true;
-    } else if (arg === '--help' || arg === '-h') {
-      parsed.help = true;
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  return parsed;
+  return parseTargetArgs(argv, { supportsDryRun: true });
 }
 
 function deriveRepoRootFromState(state) {
@@ -193,6 +165,20 @@ function performGitUpdate(repoRoot, env, execute) {
   }
 }
 
+function runCognitiveBootstrap(repoRoot, env, execute) {
+  const bootstrapScript = path.join(repoRoot, 'scripts', 'bootstrap-cognitive.js');
+  if (!fs.existsSync(bootstrapScript)) {
+    return null;
+  }
+
+  try {
+    const result = execute(process.execPath, [bootstrapScript], { cwd: repoRoot, env });
+    return { status: 'ok', output: (result.stdout || '').trim() };
+  } catch (error) {
+    return { status: 'error', error: error.message };
+  }
+}
+
 function applyInstalls(validRecords, options, repoRoot, env, execute) {
   const results = [];
   for (const entry of validRecords) {
@@ -241,32 +227,7 @@ function applyInstalls(validRecords, options, repoRoot, env, execute) {
   return results;
 }
 
-function runAutoUpdate(options = {}, dependencies = {}) {
-  const discover = dependencies.discoverInstalledStates || discoverInstalledStates;
-  const execute = dependencies.runExternalCommand || runExternalCommand;
-  const homeDir = options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
-  const projectRoot = options.projectRoot || process.cwd();
-  const requestedRepoRoot = options.repoRoot ? validateRepoRoot(options.repoRoot) : null;
-  const records = discover({
-    homeDir,
-    projectRoot,
-    targets: options.targets,
-  }).filter(record => record.exists);
-
-  const results = [];
-  if (records.length === 0) {
-    return {
-      dryRun: Boolean(options.dryRun),
-      repoRoot: requestedRepoRoot,
-      results,
-      summary: {
-        checkedCount: 0,
-        updatedCount: 0,
-        errorCount: 0,
-      },
-    };
-  }
-
+function resolveRepoRootForRecords(records, requestedRepoRoot, results) {
   const validRecords = [];
   const inferredRepoRoots = [];
   for (const record of records) {
@@ -295,7 +256,39 @@ function runAutoUpdate(options = {}, dependencies = {}) {
     }
   }
 
-  const repoRoot = requestedRepoRoot || inferredRepoRoots[0] || null;
+  return {
+    validRecords,
+    repoRoot: requestedRepoRoot || inferredRepoRoots[0] || null,
+  };
+}
+
+function runAutoUpdate(options = {}, dependencies = {}) {
+  const discover = dependencies.discoverInstalledStates || discoverInstalledStates;
+  const execute = dependencies.runExternalCommand || runExternalCommand;
+  const homeDir = options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
+  const projectRoot = options.projectRoot || process.cwd();
+  const requestedRepoRoot = options.repoRoot ? validateRepoRoot(options.repoRoot) : null;
+  const records = discover({
+    homeDir,
+    projectRoot,
+    targets: options.targets,
+  }).filter(record => record.exists);
+
+  const results = [];
+  if (records.length === 0) {
+    return {
+      dryRun: Boolean(options.dryRun),
+      repoRoot: requestedRepoRoot,
+      results,
+      summary: {
+        checkedCount: 0,
+        updatedCount: 0,
+        errorCount: 0,
+      },
+    };
+  }
+
+  const { validRecords, repoRoot } = resolveRepoRootForRecords(records, requestedRepoRoot, results);
   if (!repoRoot) {
     return {
       dryRun: Boolean(options.dryRun),
@@ -319,11 +312,14 @@ function runAutoUpdate(options = {}, dependencies = {}) {
     performGitUpdate(repoRoot, env, execute);
   }
 
+  const cognitiveBootstrap = options.dryRun ? null : runCognitiveBootstrap(repoRoot, env, execute);
+
   results.push(...applyInstalls(validRecords, options, repoRoot, env, execute));
 
   return {
     dryRun: Boolean(options.dryRun),
     repoRoot,
+    cognitiveBootstrap,
     results,
     summary: {
       checkedCount: results.length,
@@ -342,6 +338,17 @@ function printHuman(result) {
   console.log(`${result.dryRun ? 'Auto-update dry run' : 'Auto-update summary'}:\n`);
   if (result.repoRoot) {
     console.log(`Repo root: ${result.repoRoot}\n`);
+  }
+
+  if (result.cognitiveBootstrap) {
+    console.log(`Cognitive protocol bootstrap: ${result.cognitiveBootstrap.status.toUpperCase()}`);
+    if (result.cognitiveBootstrap.output) {
+      console.log(result.cognitiveBootstrap.output);
+    }
+    if (result.cognitiveBootstrap.error) {
+      console.log(`  Error: ${result.cognitiveBootstrap.error}`);
+    }
+    console.log('');
   }
 
   for (const entry of result.results) {
@@ -396,5 +403,6 @@ module.exports = {
   deriveRepoRootFromState,
   buildInstallApplyArgs,
   determineInstallCwd,
+  runCognitiveBootstrap,
   runAutoUpdate,
 };

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -47,6 +47,14 @@ These calls are automatic and non-negotiable. Never wait for the user to ask.
 
 Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.`;
 
+const CRUSHER_MD = `## EGC Token Crusher Protocol
+
+**Route heavy commands through \`egc run\` yourself -- do not wait for a hook to rewrite them.** The Guardian hook attempts an automatic PreToolUse rewrite, but Anthropic confirmed and closed as "not planned" that this rewrite is silently ignored when the assistant itself issues the Bash tool call (not a human typing in a terminal). Relying on the hook alone means noisy output reaches you uncompressed every time.
+
+**Before running any command likely to produce large or noisy output, prefix it yourself:** \`egc run <command>\` instead of \`<command>\` directly. Examples: \`egc run git log --stat -n 50\`, \`egc run git diff\`, \`egc run npm install\`, \`egc run npm test\`, \`egc run find . -name "*.ts"\`.
+
+If you genuinely need the full, uncompressed output, use \`egc run --raw <command>\` -- never skip the wrapper entirely for a command that would otherwise be crushable.`;
+
 const BLOCK = `
 <!-- egc-memory-protocol -->
 ## EGC Session Memory
@@ -61,6 +69,8 @@ State files live at \`~/.egc/state/<project-slug>.md\`: plain Markdown, one file
 ${AUTO_INTUITION_MD}
 
 ${GUARDIAN_MD}
+
+${CRUSHER_MD}
 <!-- /egc-memory-protocol -->
 `;
 
@@ -68,14 +78,14 @@ ${GUARDIAN_MD}
 // file instead of a global rules block (OpenCode/CodeBuddy fallback content,
 // mirrors the .opencode/.codebuddy source files copied below).
 function markdownProtocolBody(title) {
-  return `# ${title}\n\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n`;
+  return `# ${title}\n\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n\n${CRUSHER_MD}\n`;
 }
 
 // Single-line TOML string (matches the pre-existing persistent_instructions
 // format): kept flattened rather than switched to a triple-quoted multiline
 // TOML string, to avoid restructuring a value format that already installs
 // correctly in production rather than risk a new TOML parsing edge case.
-const CODEX_PROTOCOL_SUFFIX = ' At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn.';
+const CODEX_PROTOCOL_SUFFIX = ' At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn. Token Crusher Protocol (mandatory): the automatic hook rewrite is silently ignored for assistant-issued Bash calls (confirmed Claude Code limitation, not planned to be fixed) -- prefix any command likely to produce large output yourself with egc run <command> instead of running it directly, e.g. egc run git log --stat, egc run npm install, egc run npm test; use egc run --raw <command> only when you genuinely need the uncompressed output.';
 const CODEX_PROTOCOL_FULL   = `persistent_instructions = "State lives at ~/.egc/state/<slug>.md.${CODEX_PROTOCOL_SUFFIX}"\n`;
 
 const HOME = os.homedir();
@@ -290,7 +300,7 @@ try {
       return;
     }
     if (!fs.existsSync(promptsDir)) fs.mkdirSync(promptsDir, { recursive: true });
-    fs.writeFileSync(target, `name: EGC Session Memory\ndescription: Restore and persist EGC cross-session memory\n---\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n`);
+    fs.writeFileSync(target, `name: EGC Session Memory\ndescription: Restore and persist EGC cross-session memory\n---\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n\n${CRUSHER_MD}\n`);
     console.log('  [cognitive] Continue.dev: memory protocol installed (~/.continue/prompts/egc-memory.prompt)');
   } catch (e) {
     console.log(`  [cognitive] Continue.dev: unexpected error: ${e.message}`);

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -5,7 +5,14 @@ const fs   = require('node:fs');
 const path = require('node:path');
 const os   = require('node:os');
 
-const MARKER = '<!-- egc-memory-protocol -->';
+// Bump when BLOCK's content changes in a way that already-configured installs
+// should receive (e.g. a new protocol section). injectProtocol() upgrades any
+// file stamped with an older (or absent) version instead of skipping it, so
+// existing installs pick up new sections on the next `egc init`/auto-update
+// instead of staying frozen at whatever was present on first install.
+const PROTOCOL_VERSION = 2;
+const MARKER = `<!-- egc-memory-protocol:v${PROTOCOL_VERSION} -->`;
+const MARKER_BLOCK_RE = /<!-- egc-memory-protocol(?::v(\d+))? -->[\s\S]*?<!-- \/egc-memory-protocol -->\n?/;
 
 // Shared by every harness's protocol text below (BLOCK and the markdown
 // fallbacks) so the 9 session bus commands and 5 Guardian commands can't
@@ -56,7 +63,7 @@ const CRUSHER_MD = `## EGC Token Crusher Protocol
 If you genuinely need the full, uncompressed output, use \`egc run --raw <command>\` -- never skip the wrapper entirely for a command that would otherwise be crushable.`;
 
 const BLOCK = `
-<!-- egc-memory-protocol -->
+${MARKER}
 ## EGC Session Memory
 
 The \`egc-memory\` MCP server is installed. Use it to maintain cross-session memory:
@@ -94,8 +101,16 @@ function injectProtocol(filepath, label) {
   const exists = fs.existsSync(filepath);
   if (exists) {
     const raw = fs.readFileSync(filepath, 'utf8');
-    if (raw.includes(MARKER)) {
-      console.log(`  [cognitive] ${label}: already configured`);
+    const blockMatch = raw.match(MARKER_BLOCK_RE);
+    if (blockMatch) {
+      const installedVersion = blockMatch[1] ? Number(blockMatch[1]) : 1;
+      if (installedVersion >= PROTOCOL_VERSION) {
+        console.log(`  [cognitive] ${label}: already configured (v${installedVersion})`);
+        return;
+      }
+      fs.writeFileSync(filepath + '.egc.bak', raw, 'utf8');
+      fs.writeFileSync(filepath, raw.replace(MARKER_BLOCK_RE, BLOCK.trim() + '\n'), 'utf8');
+      console.log(`  [cognitive] ${label}: memory protocol upgraded v${installedVersion} -> v${PROTOCOL_VERSION} (${filepath.replace(HOME, '~')})`);
       return;
     }
     fs.writeFileSync(filepath + '.egc.bak', raw, 'utf8');

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -9,9 +9,16 @@ const { getEGCDir } = require('./lib/utils');
 
 function showHelp(exitCode = 0) {
   console.log(`
-Usage: node scripts/doctor.js [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--json]
+Usage: node scripts/doctor.js [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--repo-root <path>] [--json]
 
 Diagnose drift and missing managed files for EGC install-state in the current context.
+
+Without --repo-root, the reference repo is always wherever the running \`egc\`
+binary lives (the published npm package for a global install). If the install
+was synced from a local dev checkout via \`egc auto-update --repo-root\`
+instead of an npm publish, pass that same --repo-root here so doctor compares
+against the actual source instead of reporting every file the npm package
+doesn't have yet as missing.
 `);
   process.exit(exitCode);
 }
@@ -20,6 +27,7 @@ function parseArgs(argv) {
   const args = argv.slice(2);
   const parsed = {
     targets: [],
+    repoRoot: null,
     json: false,
     help: false,
   };
@@ -29,6 +37,9 @@ function parseArgs(argv) {
 
     if (arg === '--target') {
       parsed.targets.push(args[index + 1] || null);
+      index += 1;
+    } else if (arg === '--repo-root') {
+      parsed.repoRoot = args[index + 1] || null;
       index += 1;
     } else if (arg === '--json') {
       parsed.json = true;
@@ -109,7 +120,7 @@ function main() {
     }
 
     const report = buildDoctorReport({
-      repoRoot: path.join(__dirname, '..'),
+      repoRoot: options.repoRoot ? path.resolve(options.repoRoot) : path.join(__dirname, '..'),
       homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const { buildDoctorReport } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { getEGCDir } = require('./lib/utils');
+const { parseTargetArgs } = require('./lib/cli-target-args');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -24,33 +25,7 @@ doesn't have yet as missing.
 }
 
 function parseArgs(argv) {
-  const args = argv.slice(2);
-  const parsed = {
-    targets: [],
-    repoRoot: null,
-    json: false,
-    help: false,
-  };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-
-    if (arg === '--target') {
-      parsed.targets.push(args[index + 1] || null);
-      index += 1;
-    } else if (arg === '--repo-root') {
-      parsed.repoRoot = args[index + 1] || null;
-      index += 1;
-    } else if (arg === '--json') {
-      parsed.json = true;
-    } else if (arg === '--help' || arg === '-h') {
-      parsed.help = true;
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  return parsed;
+  return parseTargetArgs(argv);
 }
 
 function statusLabel(status) {
@@ -120,7 +95,7 @@ function main() {
     }
 
     const report = buildDoctorReport({
-      repoRoot: options.repoRoot ? path.resolve(options.repoRoot) : path.join(__dirname, '..'),
+      repoRoot: options.repoRoot || path.join(__dirname, '..'),
       homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -215,7 +215,9 @@ Examples:
   egc consolidate --dry-run
   egc list-installed --json
   egc doctor --target cursor
+  egc doctor --repo-root /path/to/dev/checkout
   egc repair --dry-run
+  egc repair --repo-root /path/to/dev/checkout
   egc auto-update --dry-run
   egc status --json
   egc overview

--- a/scripts/lib/cli-target-args.js
+++ b/scripts/lib/cli-target-args.js
@@ -1,0 +1,42 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseTargetArgs(argv, { supportsDryRun = false } = {}) {
+  const args = argv.slice(2);
+  const parsed = {
+    targets: [],
+    repoRoot: null,
+    dryRun: false,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--target') {
+      parsed.targets.push(args[index + 1] || null);
+      index += 1;
+    } else if (arg === '--repo-root') {
+      const rawRepoRoot = args[index + 1] || null;
+      parsed.repoRoot = rawRepoRoot ? path.resolve(rawRepoRoot) : null;
+      index += 1;
+    } else if (supportsDryRun && arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (parsed.repoRoot && !fs.existsSync(parsed.repoRoot)) {
+    throw new Error(`--repo-root path does not exist: ${parsed.repoRoot}`);
+  }
+
+  return parsed;
+}
+
+module.exports = { parseTargetArgs };

--- a/scripts/lib/cli-target-args.js
+++ b/scripts/lib/cli-target-args.js
@@ -15,7 +15,11 @@ function parseTargetArgs(argv, { supportsDryRun = false } = {}) {
     const arg = args[index];
 
     if (arg === '--target') {
-      parsed.targets.push(args[index + 1] || null);
+      const rawTarget = args[index + 1];
+      if (!rawTarget) {
+        throw new Error('--target requires a value');
+      }
+      parsed.targets.push(rawTarget);
       index += 1;
     } else if (arg === '--repo-root') {
       const rawRepoRoot = args[index + 1];

--- a/scripts/lib/cli-target-args.js
+++ b/scripts/lib/cli-target-args.js
@@ -18,8 +18,11 @@ function parseTargetArgs(argv, { supportsDryRun = false } = {}) {
       parsed.targets.push(args[index + 1] || null);
       index += 1;
     } else if (arg === '--repo-root') {
-      const rawRepoRoot = args[index + 1] || null;
-      parsed.repoRoot = rawRepoRoot ? path.resolve(rawRepoRoot) : null;
+      const rawRepoRoot = args[index + 1];
+      if (!rawRepoRoot) {
+        throw new Error('--repo-root requires a path argument');
+      }
+      parsed.repoRoot = path.resolve(rawRepoRoot);
       index += 1;
     } else if (supportsDryRun && arg === '--dry-run') {
       parsed.dryRun = true;

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -7,10 +7,16 @@ const { reinstallAllPlugins, listInstalledPlugins } = require('./lib/plugin-regi
 
 function showHelp(exitCode = 0) {
   console.log(`
-Usage: node scripts/repair.js [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--dry-run] [--json]
+Usage: node scripts/repair.js [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--repo-root <path>] [--dry-run] [--json]
 
 Rebuild EGC-managed files recorded in install-state for the current context.
 Also reinstalls all plugins from the plugin lock file.
+
+Without --repo-root, the reference repo is always wherever the running \`egc\`
+binary lives (the published npm package for a global install) -- pass the
+same --repo-root used with \`egc auto-update\` if the install was synced from
+a local dev checkout instead, or repair will report source files the npm
+package doesn't have yet as unrepairable.
 `);
   process.exit(exitCode);
 }
@@ -19,6 +25,7 @@ function parseArgs(argv) {
   const args = argv.slice(2);
   const parsed = {
     targets: [],
+    repoRoot: null,
     dryRun: false,
     json: false,
     help: false,
@@ -29,6 +36,9 @@ function parseArgs(argv) {
 
     if (arg === '--target') {
       parsed.targets.push(args[index + 1] || null);
+      index += 1;
+    } else if (arg === '--repo-root') {
+      parsed.repoRoot = args[index + 1] || null;
       index += 1;
     } else if (arg === '--dry-run') {
       parsed.dryRun = true;
@@ -101,7 +111,7 @@ function main() {
     }
 
     const result = repairInstalledStates({
-      repoRoot: require('node:path').join(__dirname, '..'),
+      repoRoot: options.repoRoot ? require('node:path').resolve(options.repoRoot) : require('node:path').join(__dirname, '..'),
       homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -4,6 +4,7 @@ const os = require('node:os');
 const { repairInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { reinstallAllPlugins, listInstalledPlugins } = require('./lib/plugin-registry');
+const { parseTargetArgs } = require('./lib/cli-target-args');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -22,36 +23,7 @@ package doesn't have yet as unrepairable.
 }
 
 function parseArgs(argv) {
-  const args = argv.slice(2);
-  const parsed = {
-    targets: [],
-    repoRoot: null,
-    dryRun: false,
-    json: false,
-    help: false,
-  };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-
-    if (arg === '--target') {
-      parsed.targets.push(args[index + 1] || null);
-      index += 1;
-    } else if (arg === '--repo-root') {
-      parsed.repoRoot = args[index + 1] || null;
-      index += 1;
-    } else if (arg === '--dry-run') {
-      parsed.dryRun = true;
-    } else if (arg === '--json') {
-      parsed.json = true;
-    } else if (arg === '--help' || arg === '-h') {
-      parsed.help = true;
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  return parsed;
+  return parseTargetArgs(argv, { supportsDryRun: true });
 }
 
 function printHuman(result) {
@@ -111,7 +83,7 @@ function main() {
     }
 
     const result = repairInstalledStates({
-      repoRoot: options.repoRoot ? require('node:path').resolve(options.repoRoot) : require('node:path').join(__dirname, '..'),
+      repoRoot: options.repoRoot || require('node:path').join(__dirname, '..'),
       homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,

--- a/tests/scripts/auto-update.test.js
+++ b/tests/scripts/auto-update.test.js
@@ -88,21 +88,26 @@ function runTests() {
   let failed = 0;
 
   if (test('parseArgs reads repo-root, target, dry-run, and json flags', () => {
-    const parsed = parseArgs([
-      'node',
-      'scripts/auto-update.js',
-      '--target',
-      'cursor',
-      '--repo-root',
-      '/tmp/egc',
-      '--dry-run',
-      '--json',
-    ]);
+    const repoRootDir = createTempDir('auto-update-parseargs-repo-');
+    try {
+      const parsed = parseArgs([
+        'node',
+        'scripts/auto-update.js',
+        '--target',
+        'cursor',
+        '--repo-root',
+        repoRootDir,
+        '--dry-run',
+        '--json',
+      ]);
 
-    assert.deepStrictEqual(parsed.targets, ['cursor']);
-    assert.strictEqual(parsed.repoRoot, '/tmp/egc');
-    assert.strictEqual(parsed.dryRun, true);
-    assert.strictEqual(parsed.json, true);
+      assert.deepStrictEqual(parsed.targets, ['cursor']);
+      assert.strictEqual(parsed.repoRoot, repoRootDir);
+      assert.strictEqual(parsed.dryRun, true);
+      assert.strictEqual(parsed.json, true);
+    } finally {
+      cleanup(repoRootDir);
+    }
   })) passed += 1; else failed += 1;
 
   if (test('parseArgs rejects unknown arguments', () => {
@@ -384,6 +389,145 @@ function runTests() {
         '--json',
       ]);
       assert.strictEqual(commands[2].options.cwd, projectRoot);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate also re-runs bootstrap-cognitive.js when the repo has it, so already-configured global protocol files get refreshed', () => {
+    const homeDir = createTempDir('auto-update-home-');
+    const projectRoot = createTempDir('auto-update-project-');
+    const repoRoot = createTempDir('auto-update-repo-');
+
+    try {
+      ensureFakeRepo(repoRoot);
+      fs.writeFileSync(
+        path.join(repoRoot, 'scripts', 'bootstrap-cognitive.js'),
+        '#!/usr/bin/env node\nconsole.log("[cognitive] Claude Code: memory protocol upgraded v1 -> v2");\n'
+      );
+
+      const records = [
+        makeRecord({
+          repoRoot,
+          homeDir,
+          projectRoot,
+          adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+          request: {
+            profile: null,
+            modules: [],
+            includeComponents: [],
+            excludeComponents: [],
+            legacyLanguages: ['typescript'],
+            legacyMode: true,
+          },
+          resolution: { selectedModules: ['legacy-egc-rules'], skippedModules: [] },
+          operations: [
+            {
+              kind: 'copy-file',
+              moduleId: 'legacy-egc-rules',
+              sourcePath: path.join(repoRoot, 'rules', 'common', 'coding-style.md'),
+              sourceRelativePath: path.join('rules', 'common', 'coding-style.md'),
+              destinationPath: path.join(homeDir, '.gemini', 'rules', 'common', 'coding-style.md'),
+              strategy: 'preserve-relative-path',
+              ownership: 'managed',
+              scaffoldOnly: false,
+            },
+          ],
+        }),
+      ];
+
+      const commands = [];
+      const result = runAutoUpdate(
+        {
+          homeDir,
+          projectRoot,
+          repoRoot,
+          dryRun: false,
+        },
+        {
+          discoverInstalledStates: () => records,
+          runExternalCommand: (command, args, options) => {
+            commands.push({ command, args, options });
+            if (args[0] === path.join(repoRoot, 'scripts', 'bootstrap-cognitive.js')) {
+              return { stdout: '[cognitive] Claude Code: memory protocol upgraded v1 -> v2\n', stderr: '' };
+            }
+            if (command === process.execPath) {
+              return { stdout: JSON.stringify({ dryRun: false, result: {} }), stderr: '' };
+            }
+            return { stdout: '', stderr: '' };
+          },
+        }
+      );
+
+      assert.deepStrictEqual(commands.map(entry => [entry.command, entry.args[0]]), [
+        ['git', 'fetch'],
+        ['git', 'pull'],
+        [process.execPath, path.join(repoRoot, 'scripts', 'bootstrap-cognitive.js')],
+        [process.execPath, path.join(repoRoot, 'scripts', 'install-apply.js')],
+      ]);
+      assert.strictEqual(result.cognitiveBootstrap.status, 'ok');
+      assert.ok(result.cognitiveBootstrap.output.includes('upgraded v1 -> v2'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate skips bootstrap-cognitive.js when the repo root does not have it (e.g. an npm package that excludes it) and does not run it on dry-run', () => {
+    const homeDir = createTempDir('auto-update-home-');
+    const projectRoot = createTempDir('auto-update-project-');
+    const repoRoot = createTempDir('auto-update-repo-');
+
+    try {
+      ensureFakeRepo(repoRoot);
+
+      const records = [
+        makeRecord({
+          repoRoot,
+          homeDir,
+          projectRoot,
+          adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+          request: {
+            profile: null,
+            modules: [],
+            includeComponents: [],
+            excludeComponents: [],
+            legacyLanguages: ['typescript'],
+            legacyMode: true,
+          },
+          resolution: { selectedModules: ['legacy-egc-rules'], skippedModules: [] },
+          operations: [
+            {
+              kind: 'copy-file',
+              moduleId: 'legacy-egc-rules',
+              sourcePath: path.join(repoRoot, 'rules', 'common', 'coding-style.md'),
+              sourceRelativePath: path.join('rules', 'common', 'coding-style.md'),
+              destinationPath: path.join(homeDir, '.gemini', 'rules', 'common', 'coding-style.md'),
+              strategy: 'preserve-relative-path',
+              ownership: 'managed',
+              scaffoldOnly: false,
+            },
+          ],
+        }),
+      ];
+
+      const result = runAutoUpdate(
+        {
+          homeDir,
+          projectRoot,
+          repoRoot,
+          dryRun: true,
+        },
+        {
+          discoverInstalledStates: () => records,
+          runExternalCommand: () => { throw new Error('should not be called on dry-run'); },
+        }
+      );
+
+      assert.strictEqual(result.cognitiveBootstrap, null);
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -194,7 +194,7 @@ async function runTests() {
       assert.ok(/Windsurf: memory protocol installed/.test(output), 'should report install');
       const target = path.join(home, '.codeium', 'windsurf', 'memories', 'global_rules.md');
       const content = fs.readFileSync(target, 'utf8');
-      assert.ok(content.includes('<!-- egc-memory-protocol -->'), 'marker must be present');
+      assert.ok(/<!-- egc-memory-protocol(?::v\d+)? -->/.test(content), 'marker must be present');
       assert.ok(content.includes('EGC Session Memory'), 'protocol block must be present');
     } finally {
       cleanup(home);
@@ -222,10 +222,46 @@ async function runTests() {
       const target = path.join(home, '.codeium', 'windsurf', 'memories', 'global_rules.md');
       const content = fs.readFileSync(target, 'utf8');
       assert.strictEqual(
-        (content.match(/<!-- egc-memory-protocol -->/g) || []).length,
+        (content.match(/<!-- egc-memory-protocol(?::v\d+)? -->/g) || []).length,
         1,
         'only one protocol marker after two runs'
       );
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('upgrades a v1-marked file (pre-Token-Crusher) to the current protocol version, preserving surrounding content', () => {
+    const home = mktempHome();
+    try {
+      const codeiumDir = path.join(home, '.codeium');
+      fs.mkdirSync(codeiumDir);
+      const targetDir = path.join(codeiumDir, 'windsurf', 'memories');
+      fs.mkdirSync(targetDir, { recursive: true });
+      const target = path.join(targetDir, 'global_rules.md');
+      const oldBlock = [
+        '<!-- egc-memory-protocol -->',
+        '## EGC Session Memory',
+        '',
+        'Old v1 content, no Token Crusher section yet.',
+        '<!-- /egc-memory-protocol -->',
+        '',
+      ].join('\n');
+      fs.writeFileSync(target, `# My custom rules\n\nKeep this line.\n\n${oldBlock}\nKeep this line too.\n`, 'utf8');
+
+      const output = run(home);
+      assert.ok(/Windsurf: memory protocol upgraded v1 -> v2/.test(output), 'should report a v1 -> v2 upgrade');
+
+      const content = fs.readFileSync(target, 'utf8');
+      assert.ok(content.includes('Keep this line.'), 'content before the block must survive');
+      assert.ok(content.includes('Keep this line too.'), 'content after the block must survive');
+      assert.ok(content.includes('EGC Token Crusher Protocol'), 'upgraded block must include the new Crusher section');
+      assert.strictEqual(
+        (content.match(/<!-- egc-memory-protocol(?::v\d+)? -->/g) || []).length,
+        1,
+        'exactly one protocol marker after the upgrade, no duplication'
+      );
+      assert.ok(content.includes('<!-- egc-memory-protocol:v2 -->'), 'marker must be stamped with the current version');
     } finally {
       cleanup(home);
     }
@@ -239,7 +275,7 @@ async function runTests() {
       assert.ok(/Zed: memory protocol installed/.test(output), 'should report install');
       const target = path.join(home, '.config', 'zed', 'AGENTS.md');
       const content = fs.readFileSync(target, 'utf8');
-      assert.ok(content.includes('<!-- egc-memory-protocol -->'), 'marker must be present');
+      assert.ok(/<!-- egc-memory-protocol(?::v\d+)? -->/.test(content), 'marker must be present');
     } finally {
       cleanup(home);
     }

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -199,6 +199,65 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('--repo-root overrides the default reference repo (dev-checkout sync scenario)', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+    const altRepoRoot = createTempDir('doctor-altrepo-');
+
+    try {
+      fs.cpSync(path.join(REPO_ROOT, 'manifests'), path.join(altRepoRoot, 'manifests'), { recursive: true });
+      const altSourcePath = path.join(altRepoRoot, 'rules', 'common', 'coding-style.md');
+      fs.mkdirSync(path.dirname(altSourcePath), { recursive: true });
+      fs.writeFileSync(altSourcePath, 'ALT REPO CONTENT, not the real repo file\n');
+
+      const targetRoot = path.join(homeDir, '.gemini');
+      const statePath = path.join(targetRoot, 'egc', 'install-state.json');
+      const managedFile = path.join(targetRoot, 'rules', 'common', 'coding-style.md');
+      fs.mkdirSync(path.dirname(managedFile), { recursive: true });
+      fs.writeFileSync(managedFile, 'ALT REPO CONTENT, not the real repo file\n');
+
+      writeState(statePath, {
+        adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+        targetRoot,
+        installStatePath: statePath,
+        request: { profile: null, modules: [], legacyLanguages: ['typescript'], legacyMode: true },
+        resolution: { selectedModules: ['legacy-egc-rules'], skippedModules: [] },
+        operations: [
+          {
+            kind: 'copy-file',
+            moduleId: 'legacy-egc-rules',
+            sourceRelativePath: 'rules/common/coding-style.md',
+            destinationPath: managedFile,
+            strategy: 'preserve-relative-path',
+            ownership: 'managed',
+            scaffoldOnly: false,
+          },
+        ],
+        source: { repoVersion: CURRENT_PACKAGE_VERSION, repoCommit: 'abc123', manifestVersion: CURRENT_MANIFEST_VERSION },
+      });
+
+      // Without --repo-root: compares against THIS repo's real coding-style.md,
+      // which does not match the installed "ALT REPO CONTENT" -- drifted.
+      const withoutOverride = run(['--target', 'egc', '--json'], { cwd: projectRoot, homeDir });
+      const withoutParsed = JSON.parse(withoutOverride.stdout);
+      assert.ok(
+        withoutParsed.results[0].issues.some(issue => issue.code === 'drifted-managed-files'),
+        'expected drift when comparing against the real repo, not the alt one the file actually came from'
+      );
+
+      // With --repo-root pointed at the alt repo: the installed file DOES
+      // match that repo's copy -- healthy.
+      const withOverride = run(['--target', 'egc', '--repo-root', altRepoRoot, '--json'], { cwd: projectRoot, homeDir });
+      const withParsed = JSON.parse(withOverride.stdout);
+      assert.strictEqual(withOverride.code, 0, withOverride.stderr);
+      assert.strictEqual(withParsed.results[0].status, 'ok');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(altRepoRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -258,6 +258,22 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('--repo-root rejects a path that does not exist with a clear error', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const missingPath = path.join(projectRoot, 'does-not-exist');
+      const result = run(['--repo-root', missingPath, '--json'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 1);
+      assert.ok(result.stderr.includes('--repo-root path does not exist'));
+      assert.ok(result.stderr.includes(missingPath));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -274,6 +274,20 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('--repo-root with no path argument fails loudly instead of silently falling back', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const result = run(['--repo-root'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 1);
+      assert.ok(result.stderr.includes('--repo-root requires a path argument'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary
- `doctor.js`/`repair.js` hardcoded their reference repo to wherever the running `egc` binary lives, ignoring the `repoRoot` option `buildDoctorReport`/`repairInstalledStates` already supported. Anyone who synced a global install from a local dev checkout via `egc auto-update --repo-root` (instead of an npm publish) got false missing/drifted-file reports compared against the stale npm package. Both CLIs now accept `--repo-root`.
- Added an explicit "EGC Token Crusher Protocol" instruction to `rules/common/memory.md` and `scripts/bootstrap-cognitive.js`: Claude Code silently ignores the PreToolUse `updatedInput` rewrite when the assistant itself issues a Bash tool call (confirmed upstream, closed not-planned), so the hook that would otherwise route commands through `egc run` never fires for agent-driven sessions. The AI is now told to prefix crushable commands with `egc run` itself.

## Test plan
- [x] `node tests/scripts/doctor.test.js` — 4/4 passing (new `--repo-root` regression test added)
- [x] `node tests/scripts/repair.test.js` — 3/3 passing
- [x] `node tests/run-all.js` — full suite 3695/3695 passing
- [x] `npx eslint` clean on all 6 changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `doctor` and `repair` to honor and validate `--repo-root`, preventing false drift/missing reports, and ensures existing installs pick up the Token Crusher section via a versioned memory protocol and an `auto-update` bootstrap step.

- **Bug Fixes**
  - `scripts/doctor.js` and `scripts/repair.js` accept `--repo-root` and forward it; updated CLI help and `egc` examples.
  - Extracted shared arg parsing to `scripts/lib/cli-target-args.js`; validates paths and rejects a bare `--repo-root` or `--target`.
  - `scripts/auto-update.js` uses the shared parser and re-runs `scripts/bootstrap-cognitive.js` after updating; shows status in output and skips on `--dry-run`.

- **New Features**
  - Versioned protocol marker (`<!-- egc-memory-protocol:v2 -->`) in `scripts/bootstrap-cognitive.js`; upgrades older blocks in place without touching surrounding content.
  - Documented the Token Crusher Protocol in `rules/common/memory.md` and the bootstrap: run crushable commands via `egc run <command>`; use `egc run --raw <command>` only when full output is needed.

<sup>Written for commit 366aed68898cee8cf848f3051c77e96a977d22d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

