### PR TITLE
fix(bootstrap-cognitive): version and upgrade the remaining 7 protocol targets

### DIFF
--- a/.codebuddy/MEMORY.md
+++ b/.codebuddy/MEMORY.md
@@ -1,35 +1,7 @@
+<!-- egc-memory-protocol:v2 -->
 # Session Memory
 
-At the start of every session, call `get_state` with no arguments (it uses PWD automatically):
-
-```
-get_state({})
-```
-
-Read the returned Markdown in full. It contains decisions already made, what failed, coding preferences, and what to pick up next. Do not ask the user to re-explain any of that.
-
-At the end of every session, call `update_state` with a summary:
-
-```
-update_state({
-  project_path: "<absolute path to project>",
-  context: "One sentence: what this project is and its current phase.",
-  decisions: [
-    { what: "What was decided", why: "Why" }
-  ],
-  avoid: [
-    { what: "What failed or was rejected", why: "Why to skip it next time" }
-  ],
-  preferences: [
-    "Coding style or workflow preference discovered this session"
-  ],
-  next: [
-    "First thing to pick up in the next session"
-  ]
-})
-```
-
-Only include fields that changed this session. `update_state` merges with existing state: it does not erase previous memory.
+At the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.
 
 ## EGC Auto-Intuition
 
@@ -37,6 +9,7 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 
 - Session ending (goodbye, break, sleep, done, closing) → call `update_state`
 - Session starting or resuming → call `get_state`
+- Context was just compacted/summarized (short recap, missing earlier detail, references to work you don't remember doing) → call `get_state` again immediately, do not wait to be asked
 - Save/remember this decision → call `lesson_save` or `store_decision`
 - What failed? What did we decide? → call `search_history` or `query_history`
 - Review code or a PR → spawn `/review-pr` agents
@@ -60,9 +33,18 @@ Judge by the full conversation context, never by literal words. A remark to some
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`
-- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`
-- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`
-- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`
+**Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+**Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+**Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
+**At the end of every significant work block:** call `auto_learn({ project_path: "<cwd>" })`
 
 Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
+
+## EGC Token Crusher Protocol
+
+**Route heavy commands through `egc run` yourself -- do not wait for a hook to rewrite them.** The Guardian hook attempts an automatic PreToolUse rewrite, but Anthropic confirmed and closed as "not planned" that this rewrite is silently ignored when the assistant itself issues the Bash tool call (not a human typing in a terminal). Relying on the hook alone means noisy output reaches you uncompressed every time.
+
+**Before running any command likely to produce large or noisy output, prefix it yourself:** `egc run <command>` instead of `<command>` directly. Examples: `egc run git log --stat -n 50`, `egc run git diff`, `egc run npm install`, `egc run npm test`, `egc run find . -name "*.ts"`.
+
+If you genuinely need the full, uncompressed output, use `egc run --raw <command>` -- never skip the wrapper entirely for a command that would otherwise be crushable.
+<!-- /egc-memory-protocol -->

--- a/.opencode/instructions/EGC_MEMORY.md
+++ b/.opencode/instructions/EGC_MEMORY.md
@@ -1,35 +1,7 @@
+<!-- egc-memory-protocol:v2 -->
 # EGC Session Memory
 
-At the start of every session, call `get_state` with no arguments (it uses PWD automatically):
-
-```
-get_state({})
-```
-
-Read the returned Markdown in full. It contains decisions already made, what failed, coding preferences, and what to pick up next. Do not ask the user to re-explain any of that.
-
-At the end of every session, call `update_state` with a summary:
-
-```
-update_state({
-  project_path: "<absolute path to project>",
-  context: "One sentence: what this project is and its current phase.",
-  decisions: [
-    { what: "What was decided", why: "Why" }
-  ],
-  avoid: [
-    { what: "What failed or was rejected", why: "Why to skip it next time" }
-  ],
-  preferences: [
-    "Coding style or workflow preference discovered this session"
-  ],
-  next: [
-    "First thing to pick up in the next session"
-  ]
-})
-```
-
-Only include fields that changed this session. `update_state` merges with existing state: it does not erase previous memory.
+At the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.
 
 ## EGC Auto-Intuition
 
@@ -37,6 +9,7 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 
 - Session ending (goodbye, break, sleep, done, closing) → call `update_state`
 - Session starting or resuming → call `get_state`
+- Context was just compacted/summarized (short recap, missing earlier detail, references to work you don't remember doing) → call `get_state` again immediately, do not wait to be asked
 - Save/remember this decision → call `lesson_save` or `store_decision`
 - What failed? What did we decide? → call `search_history` or `query_history`
 - Review code or a PR → spawn `/review-pr` agents
@@ -60,9 +33,18 @@ Judge by the full conversation context, never by literal words. A remark to some
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`
-- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`
-- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`
-- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`
+**Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+**Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+**Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
+**At the end of every significant work block:** call `auto_learn({ project_path: "<cwd>" })`
 
 Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
+
+## EGC Token Crusher Protocol
+
+**Route heavy commands through `egc run` yourself -- do not wait for a hook to rewrite them.** The Guardian hook attempts an automatic PreToolUse rewrite, but Anthropic confirmed and closed as "not planned" that this rewrite is silently ignored when the assistant itself issues the Bash tool call (not a human typing in a terminal). Relying on the hook alone means noisy output reaches you uncompressed every time.
+
+**Before running any command likely to produce large or noisy output, prefix it yourself:** `egc run <command>` instead of `<command>` directly. Examples: `egc run git log --stat -n 50`, `egc run git diff`, `egc run npm install`, `egc run npm test`, `egc run find . -name "*.ts"`.
+
+If you genuinely need the full, uncompressed output, use `egc run --raw <command>` -- never skip the wrapper entirely for a command that would otherwise be crushable.
+<!-- /egc-memory-protocol -->

--- a/.trae/MEMORY.md
+++ b/.trae/MEMORY.md
@@ -1,35 +1,7 @@
-# Session Memory
+<!-- egc-memory-protocol:v2 -->
+# EGC Session Memory
 
-At the start of every session, call `get_state` with no arguments (it uses PWD automatically):
-
-```
-get_state({})
-```
-
-Read the returned Markdown in full. It contains decisions already made, what failed, coding preferences, and what to pick up next. Do not ask the user to re-explain any of that.
-
-At the end of every session, call `update_state` with a summary:
-
-```
-update_state({
-  project_path: "<absolute path to project>",
-  context: "One sentence: what this project is and its current phase.",
-  decisions: [
-    { what: "What was decided", why: "Why" }
-  ],
-  avoid: [
-    { what: "What failed or was rejected", why: "Why to skip it next time" }
-  ],
-  preferences: [
-    "Coding style or workflow preference discovered this session"
-  ],
-  next: [
-    "First thing to pick up in the next session"
-  ]
-})
-```
-
-Only include fields that changed this session. `update_state` merges with existing state: it does not erase previous memory.
+At the start of every session call `get_state({})` via egc-memory to restore context. At the end call `update_state({...})` to save decisions.
 
 ## EGC Auto-Intuition
 
@@ -37,6 +9,7 @@ Act on user intent, not keywords. When what the user says implies an EGC action,
 
 - Session ending (goodbye, break, sleep, done, closing) → call `update_state`
 - Session starting or resuming → call `get_state`
+- Context was just compacted/summarized (short recap, missing earlier detail, references to work you don't remember doing) → call `get_state` again immediately, do not wait to be asked
 - Save/remember this decision → call `lesson_save` or `store_decision`
 - What failed? What did we decide? → call `search_history` or `query_history`
 - Review code or a PR → spawn `/review-pr` agents
@@ -60,9 +33,18 @@ Judge by the full conversation context, never by literal words. A remark to some
 
 These calls are automatic and non-negotiable. Never wait for the user to ask.
 
-- Before every non-trivial task: call `orchestrate_task({ prompt: "<task>" })`
-- Before every shell/Bash command: call `validate_command({ command: "<cmd>" })`
-- Before every new file Write or Edit on a file not yet read: call `validate_write({ filepath: "<path>" })`
-- At the end of every significant work block: call `auto_learn({ project_path: "<cwd>" })`
+**Start of every non-trivial task:** call `orchestrate_task({ prompt: "<task>" })`
+**Before every shell/Bash command:** call `validate_command({ command: "<cmd>" })`
+**Before every new file Write or Edit on a file not yet read:** call `validate_write({ filepath: "<path>" })`
+**At the end of every significant work block:** call `auto_learn({ project_path: "<cwd>" })`
 
 Skipping any of these breaks the EGC contract. There are no exceptions for "simple" tasks.
+
+## EGC Token Crusher Protocol
+
+**Route heavy commands through `egc run` yourself -- do not wait for a hook to rewrite them.** The Guardian hook attempts an automatic PreToolUse rewrite, but Anthropic confirmed and closed as "not planned" that this rewrite is silently ignored when the assistant itself issues the Bash tool call (not a human typing in a terminal). Relying on the hook alone means noisy output reaches you uncompressed every time.
+
+**Before running any command likely to produce large or noisy output, prefix it yourself:** `egc run <command>` instead of `<command>` directly. Examples: `egc run git log --stat -n 50`, `egc run git diff`, `egc run npm install`, `egc run npm test`, `egc run find . -name "*.ts"`.
+
+If you genuinely need the full, uncompressed output, use `egc run --raw <command>` -- never skip the wrapper entirely for a command that would otherwise be crushable.
+<!-- /egc-memory-protocol -->

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -17,11 +17,13 @@ const MARKER_BLOCK_RE = /<!-- egc-memory-protocol(?::v(\d+))? -->[\s\S]*?<!-- \/
 // Cursor's cursor.rules setting is a single flat string (no markdown), so it
 // gets its own bracket-tag marker/block pair instead of the HTML-comment one
 // above, versioned the same way for the same reason: an already-configured
-// install should not stay frozen when a new protocol section ships. Matches
-// a trailing [/egc-memory-protocol] when present (v2+), or falls through to
-// end-of-string when absent, since the pre-versioning format (v1, always
-// appended last) never wrote a closing tag at all.
-const CURSOR_BLOCK_RE = /\[egc-memory-protocol(?::v(\d+))?\][\s\S]*?(?:\[\/egc-memory-protocol\]|$)/;
+// install should not stay frozen when a new protocol section ships. Only
+// matches a block that has both the versioned opening tag and the closing
+// tag (v2+); the pre-versioning format (v1) never wrote a closing tag, so an
+// unbounded end-of-string fallback here would risk deleting any Cursor rules
+// the user appended after an old, unclosed block. bootstrapCursor() falls
+// back to appending rather than replacing when this does not match.
+const CURSOR_BLOCK_RE = /\[egc-memory-protocol:v(\d+)\][\s\S]*?\[\/egc-memory-protocol\]/;
 
 // Shared by every harness's protocol text below (BLOCK and the markdown
 // fallbacks) so the 9 session bus commands and 5 Guardian commands can't
@@ -208,7 +210,10 @@ function cursorRulesBlock() {
       }
       const existing = obj['cursor.rules'] || '';
       const blockMatch = existing.match(CURSOR_BLOCK_RE);
-      const installedVersion = blockMatch ? (blockMatch[1] ? Number(blockMatch[1]) : 1) : 0;
+      // No closed block: an old unversioned tag with no closing marker (v1)
+      // still counts as an installed-but-outdated version.
+      const hasLegacyTag = !blockMatch && existing.includes('[egc-memory-protocol]');
+      const installedVersion = blockMatch ? Number(blockMatch[1]) : (hasLegacyTag ? 1 : 0);
       if (installedVersion >= PROTOCOL_VERSION) {
         console.log(`  [cognitive] Cursor: already configured (v${installedVersion})`);
         return;
@@ -217,12 +222,15 @@ function cursorRulesBlock() {
       if (blockMatch) {
         obj['cursor.rules'] = existing.replace(CURSOR_BLOCK_RE, cursorRulesBlock());
       } else {
+        // Nothing at all, or an old unclosed v1 tag with no reliable end
+        // marker: append rather than guess where a legacy block ends, so
+        // nothing the user wrote is ever deleted.
         const separator = existing.trim() ? '\n\n' : '';
         obj['cursor.rules'] = existing + separator + cursorRulesBlock();
       }
       fs.writeFileSync(settingsFile + '.egc.bak', rawContent, 'utf8');
       fs.writeFileSync(settingsFile, JSON.stringify(obj, null, 2) + '\n', 'utf8');
-      const action = blockMatch ? `upgraded v${installedVersion || 'legacy'} -> v${PROTOCOL_VERSION}` : 'installed';
+      const action = installedVersion > 0 ? `upgraded v${installedVersion} -> v${PROTOCOL_VERSION}` : 'installed';
       console.log(`  [cognitive] Cursor: memory protocol ${action} (${settingsFile.replace(HOME, '~')})`);
     } else {
       injectProtocol(path.join(HOME, '.cursor', 'rules'), 'Cursor');
@@ -278,9 +286,13 @@ function cursorRulesBlock() {
           (_, pre, val, post) => `${pre}${foldSuffix(val)}${post}`
         );
       } else if (RE_SINGLE.test(originalContent)) {
+        // Moving from a single-quoted literal string to a double-quoted basic
+        // string changes which characters need escaping: backslashes and
+        // double quotes in the existing value must be escaped now, or they
+        // corrupt the TOML (cubic review, PR #1095).
         newContent = originalContent.replace(
           RE_SINGLE,
-          (_, _pre, val, _post) => `persistent_instructions = "${foldSuffix(val)}"`
+          (_, _pre, val, _post) => `persistent_instructions = "${foldSuffix(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
         );
       } else if (hasKey) {
         console.log('  [cognitive] Codex: persistent_instructions in unrecognized format: skipping');

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -25,6 +25,15 @@ const MARKER_BLOCK_RE = /<!-- egc-memory-protocol(?::v(\d+))? -->[\s\S]*?<!-- \/
 // back to appending rather than replacing when this does not match.
 const CURSOR_BLOCK_RE = /\[egc-memory-protocol:v(\d+)\][\s\S]*?\[\/egc-memory-protocol\]/;
 
+// Shared by every version-marker check below: a versioned match wins on its
+// own number, an unversioned match is an implicit v1, and no match at all
+// falls back to whatever the caller passes (0 for "nothing installed", or a
+// legacy-indicator-derived value for formats with no reliable delimiter).
+function resolveInstalledVersion(match, fallbackWhenNoMatch) {
+  if (!match) return fallbackWhenNoMatch;
+  return match[1] ? Number(match[1]) : 1;
+}
+
 // Shared by every harness's protocol text below (BLOCK and the markdown
 // fallbacks) so the 9 session bus commands and 5 Guardian commands can't
 // drift out of sync across the 9+ copies the way they did before this fix.
@@ -148,7 +157,7 @@ function injectStandaloneProtocol(filepath, label, content) {
   if (exists) {
     const raw = fs.readFileSync(filepath, 'utf8');
     const blockMatch = raw.match(MARKER_BLOCK_RE);
-    const installedVersion = blockMatch ? (blockMatch[1] ? Number(blockMatch[1]) : 1) : 0;
+    const installedVersion = resolveInstalledVersion(blockMatch, 0);
     if (installedVersion >= PROTOCOL_VERSION) {
       console.log(`  [cognitive] ${label}: already configured (v${installedVersion || 'legacy'})`);
       return;
@@ -187,6 +196,27 @@ function cursorRulesBlock() {
   return `[egc-memory-protocol:v${PROTOCOL_VERSION}] At the start of every session call get_state({}) via egc-memory to restore project context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. [egc-auto-intuition] Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. [egc-guardian] Before every non-trivial task call orchestrate_task. Before every shell command call validate_command. Before every new file write/edit call validate_write. After every work block call auto_learn. [egc-token-crusher] The automatic hook rewrite is silently ignored for assistant-issued Bash calls, a confirmed Claude Code limitation not planned to be fixed, so prefix any command likely to produce large output yourself with egc run <command> instead of running it directly (e.g. egc run git log --stat, egc run npm install). Use egc run --raw <command> only when you genuinely need the uncompressed output. [/egc-memory-protocol]`;
 }
 
+// Computes the new cursor.rules value and the version it is upgraded from,
+// pulled out of bootstrapCursor() to keep that function's own branching
+// shallow. Nothing at all, or an old unclosed v1 tag with no reliable end
+// marker, appends rather than guessing where a legacy block ends, so nothing
+// the user wrote is ever deleted.
+function computeCursorRulesUpdate(existing) {
+  const blockMatch = existing.match(CURSOR_BLOCK_RE);
+  const hasLegacyTag = !blockMatch && existing.includes('[egc-memory-protocol]');
+  const installedVersion = resolveInstalledVersion(blockMatch, hasLegacyTag ? 1 : 0);
+
+  if (installedVersion >= PROTOCOL_VERSION) {
+    return { upToDate: true, installedVersion };
+  }
+
+  const newRules = blockMatch
+    ? existing.replace(CURSOR_BLOCK_RE, cursorRulesBlock())
+    : existing + (existing.trim() ? '\n\n' : '') + cursorRulesBlock();
+
+  return { upToDate: false, installedVersion, newRules };
+}
+
 // ── Cursor (global User Rules via settings.json) ──────────────────────────────
 (function bootstrapCursor() {
   try {
@@ -199,46 +229,102 @@ function cursorRulesBlock() {
     const settingsFile = settingsPaths.find(p => fs.existsSync(p));
     if (!settingsFile && !fs.existsSync(path.join(HOME, '.cursor'))) return;
 
-    if (settingsFile) {
-      const rawContent = fs.readFileSync(settingsFile, 'utf8');
-      let obj;
-      try {
-        obj = JSON.parse(rawContent);
-      } catch (_) { // NOSONAR: invalid JSON is reported via the user-facing skip message below
-        console.log('  [cognitive] Cursor: settings.json is not valid JSON (JSONC?): skipping');
-        return;
-      }
-      const existing = obj['cursor.rules'] || '';
-      const blockMatch = existing.match(CURSOR_BLOCK_RE);
-      // No closed block: an old unversioned tag with no closing marker (v1)
-      // still counts as an installed-but-outdated version.
-      const hasLegacyTag = !blockMatch && existing.includes('[egc-memory-protocol]');
-      const installedVersion = blockMatch ? Number(blockMatch[1]) : (hasLegacyTag ? 1 : 0);
-      if (installedVersion >= PROTOCOL_VERSION) {
-        console.log(`  [cognitive] Cursor: already configured (v${installedVersion})`);
-        return;
-      }
-
-      if (blockMatch) {
-        obj['cursor.rules'] = existing.replace(CURSOR_BLOCK_RE, cursorRulesBlock());
-      } else {
-        // Nothing at all, or an old unclosed v1 tag with no reliable end
-        // marker: append rather than guess where a legacy block ends, so
-        // nothing the user wrote is ever deleted.
-        const separator = existing.trim() ? '\n\n' : '';
-        obj['cursor.rules'] = existing + separator + cursorRulesBlock();
-      }
-      fs.writeFileSync(settingsFile + '.egc.bak', rawContent, 'utf8');
-      fs.writeFileSync(settingsFile, JSON.stringify(obj, null, 2) + '\n', 'utf8');
-      const action = installedVersion > 0 ? `upgraded v${installedVersion} -> v${PROTOCOL_VERSION}` : 'installed';
-      console.log(`  [cognitive] Cursor: memory protocol ${action} (${settingsFile.replace(HOME, '~')})`);
-    } else {
+    if (!settingsFile) {
       injectProtocol(path.join(HOME, '.cursor', 'rules'), 'Cursor');
+      return;
     }
+
+    const rawContent = fs.readFileSync(settingsFile, 'utf8');
+    let obj;
+    try {
+      obj = JSON.parse(rawContent);
+    } catch (_) { // NOSONAR: invalid JSON is reported via the user-facing skip message below
+      console.log('  [cognitive] Cursor: settings.json is not valid JSON (JSONC?): skipping');
+      return;
+    }
+
+    const update = computeCursorRulesUpdate(obj['cursor.rules'] || '');
+    if (update.upToDate) {
+      console.log(`  [cognitive] Cursor: already configured (v${update.installedVersion})`);
+      return;
+    }
+
+    obj['cursor.rules'] = update.newRules;
+    fs.writeFileSync(settingsFile + '.egc.bak', rawContent, 'utf8');
+    fs.writeFileSync(settingsFile, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+    const action = update.installedVersion > 0 ? `upgraded v${update.installedVersion} -> v${PROTOCOL_VERSION}` : 'installed';
+    console.log(`  [cognitive] Cursor: memory protocol ${action} (${settingsFile.replace(HOME, '~')})`);
   } catch (e) {
     console.log(`  [cognitive] Cursor: unexpected error: ${e.message}`);
   }
 })();
+
+const CODEX_RE_TRIPLE_D = /^persistent_instructions\s*=\s*"""/m;
+const CODEX_RE_TRIPLE_S = /^persistent_instructions\s*=\s*'''/m;
+const CODEX_RE_DOUBLE   = /^(persistent_instructions\s*=\s*")(.*?)(")\s*$/m;
+const CODEX_RE_SINGLE   = /^(persistent_instructions\s*=\s*')(.*?)(')\s*$/m;
+
+// Computes the new config.toml content and the version it is upgraded from,
+// pulled out of bootstrapCodex() to keep that function's own branching
+// shallow. Returns { status, installedVersion, newContent }; status is
+// 'up-to-date', 'skip-multiline', 'skip-unrecognized', or 'update'.
+function upgradeCodexTomlContent(originalContent) {
+  const markerMatch = originalContent.match(CODEX_PROTOCOL_MARKER_RE);
+  // No marker at all but the legacy pre-marker text is present (it always
+  // mentions get_state): treat as an implicit v1 needing an upgrade.
+  const installedVersion = resolveInstalledVersion(markerMatch, originalContent.includes('get_state') ? 1 : null);
+
+  if (installedVersion !== null && installedVersion >= PROTOCOL_VERSION) {
+    return { status: 'up-to-date', installedVersion };
+  }
+
+  if (CODEX_RE_TRIPLE_D.test(originalContent) || CODEX_RE_TRIPLE_S.test(originalContent)) {
+    return { status: 'skip-multiline' };
+  }
+
+  // Marker present: replace just that segment with the current suffix.
+  // No marker but legacy text present: append the versioned block so the
+  // next run's marker check succeeds, leaving the old text in place rather
+  // than guessing where it ends without a delimiter. Neither: append fresh,
+  // same as a brand-new install.
+  const foldSuffix = (val) => markerMatch
+    ? val.replace(CODEX_PROTOCOL_MARKER_RE, CODEX_PROTOCOL_SUFFIX.trim())
+    : `${val}${CODEX_PROTOCOL_SUFFIX}`;
+
+  if (CODEX_RE_DOUBLE.test(originalContent)) {
+    return {
+      status: 'update',
+      installedVersion,
+      newContent: originalContent.replace(CODEX_RE_DOUBLE, (_, pre, val, post) => `${pre}${foldSuffix(val)}${post}`),
+    };
+  }
+
+  if (CODEX_RE_SINGLE.test(originalContent)) {
+    // Moving from a single-quoted literal string to a double-quoted basic
+    // string changes which characters need escaping: backslashes and double
+    // quotes in the existing value must be escaped now, or they corrupt the
+    // TOML (cubic review, PR #1095).
+    return {
+      status: 'update',
+      installedVersion,
+      newContent: originalContent.replace(
+        CODEX_RE_SINGLE,
+        (_, _pre, val, _post) => `persistent_instructions = "${foldSuffix(val).replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`)}"`
+      ),
+    };
+  }
+
+  if (/^persistent_instructions\s*=/m.test(originalContent)) {
+    return { status: 'skip-unrecognized' };
+  }
+
+  return { status: 'update', installedVersion, newContent: originalContent + '\n' + CODEX_PROTOCOL_FULL };
+}
+
+const CODEX_SKIP_MESSAGES = {
+  'skip-multiline': 'persistent_instructions multiline: skipping',
+  'skip-unrecognized': 'persistent_instructions in unrecognized format: skipping',
+};
 
 // ── Codex CLI (persistent_instructions in ~/.codex/config.toml) ───────────────
 (function bootstrapCodex() {
@@ -247,71 +333,30 @@ function cursorRulesBlock() {
     if (!fs.existsSync(codexDir)) return;
     const tomlPath = path.join(codexDir, 'config.toml');
 
-    if (fs.existsSync(tomlPath)) {
-      const originalContent = fs.readFileSync(tomlPath, 'utf8');
-      const markerMatch = originalContent.match(CODEX_PROTOCOL_MARKER_RE);
-      // No marker at all but the legacy pre-marker text is present (it always
-      // mentions get_state): treat as an implicit v1 needing an upgrade.
-      const installedVersion = markerMatch ? Number(markerMatch[1]) : (originalContent.includes('get_state') ? 1 : null);
-
-      if (installedVersion !== null && installedVersion >= PROTOCOL_VERSION) {
-        console.log(`  [cognitive] Codex: already configured (v${installedVersion})`);
-        return;
-      }
-
-      const RE_TRIPLE_D = /^persistent_instructions\s*=\s*"""/m;
-      const RE_TRIPLE_S = /^persistent_instructions\s*=\s*'''/m;
-      const RE_DOUBLE   = /^(persistent_instructions\s*=\s*")(.*?)(")\s*$/m;
-      const RE_SINGLE   = /^(persistent_instructions\s*=\s*')(.*?)(')\s*$/m;
-      const hasKey      = /^persistent_instructions\s*=/m.test(originalContent);
-
-      if (RE_TRIPLE_D.test(originalContent) || RE_TRIPLE_S.test(originalContent)) {
-        console.log('  [cognitive] Codex: persistent_instructions multiline: skipping');
-        return;
-      }
-
-      // Marker present: replace just that segment with the current suffix.
-      // No marker but legacy text present: append the versioned block so the
-      // next run's marker check succeeds, leaving the old text in place
-      // rather than guessing where it ends without a delimiter. Neither:
-      // append fresh, same as a brand-new install.
-      const foldSuffix = (val) => markerMatch
-        ? val.replace(CODEX_PROTOCOL_MARKER_RE, CODEX_PROTOCOL_SUFFIX.trim())
-        : `${val}${CODEX_PROTOCOL_SUFFIX}`;
-
-      let newContent;
-      if (RE_DOUBLE.test(originalContent)) {
-        newContent = originalContent.replace(
-          RE_DOUBLE,
-          (_, pre, val, post) => `${pre}${foldSuffix(val)}${post}`
-        );
-      } else if (RE_SINGLE.test(originalContent)) {
-        // Moving from a single-quoted literal string to a double-quoted basic
-        // string changes which characters need escaping: backslashes and
-        // double quotes in the existing value must be escaped now, or they
-        // corrupt the TOML (cubic review, PR #1095).
-        newContent = originalContent.replace(
-          RE_SINGLE,
-          (_, _pre, val, _post) => `persistent_instructions = "${foldSuffix(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
-        );
-      } else if (hasKey) {
-        console.log('  [cognitive] Codex: persistent_instructions in unrecognized format: skipping');
-        return;
-      } else {
-        newContent = originalContent + '\n' + CODEX_PROTOCOL_FULL;
-      }
-
-      fs.writeFileSync(tomlPath + '.egc.bak', originalContent, 'utf8');
-      fs.writeFileSync(tomlPath, newContent, 'utf8');
-      const action = installedVersion !== null ? `upgraded v${installedVersion} -> v${PROTOCOL_VERSION}` : 'installed';
-      console.log(`  [cognitive] Codex: memory protocol ${action} (${tomlPath.replace(HOME, '~')})`);
+    if (!fs.existsSync(tomlPath)) {
+      const dir = path.dirname(tomlPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(tomlPath, CODEX_PROTOCOL_FULL);
+      console.log(`  [cognitive] Codex: memory protocol installed (${tomlPath.replace(HOME, '~')})`);
       return;
     }
 
-    const dir = path.dirname(tomlPath);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(tomlPath, CODEX_PROTOCOL_FULL);
-    console.log(`  [cognitive] Codex: memory protocol installed (${tomlPath.replace(HOME, '~')})`);
+    const originalContent = fs.readFileSync(tomlPath, 'utf8');
+    const result = upgradeCodexTomlContent(originalContent);
+
+    if (result.status === 'up-to-date') {
+      console.log(`  [cognitive] Codex: already configured (v${result.installedVersion})`);
+      return;
+    }
+    if (result.status !== 'update') {
+      console.log(`  [cognitive] Codex: ${CODEX_SKIP_MESSAGES[result.status]}`);
+      return;
+    }
+
+    fs.writeFileSync(tomlPath + '.egc.bak', originalContent, 'utf8');
+    fs.writeFileSync(tomlPath, result.newContent, 'utf8');
+    const action = result.installedVersion !== null ? `upgraded v${result.installedVersion} -> v${PROTOCOL_VERSION}` : 'installed';
+    console.log(`  [cognitive] Codex: memory protocol ${action} (${tomlPath.replace(HOME, '~')})`);
   } catch (e) {
     console.log(`  [cognitive] Codex: unexpected error: ${e.message}`);
   }

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -210,9 +210,10 @@ function computeCursorRulesUpdate(existing) {
     return { upToDate: true, installedVersion };
   }
 
+  const separator = existing.trim() ? '\n\n' : '';
   const newRules = blockMatch
     ? existing.replace(CURSOR_BLOCK_RE, cursorRulesBlock())
-    : existing + (existing.trim() ? '\n\n' : '') + cursorRulesBlock();
+    : existing + separator + cursorRulesBlock();
 
   return { upToDate: false, installedVersion, newRules };
 }
@@ -309,7 +310,10 @@ function upgradeCodexTomlContent(originalContent) {
       installedVersion,
       newContent: originalContent.replace(
         CODEX_RE_SINGLE,
-        (_, _pre, val, _post) => `persistent_instructions = "${foldSuffix(val).replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`)}"`
+        (_, _pre, val, _post) => {
+          const escaped = foldSuffix(val).replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`);
+          return `persistent_instructions = "${escaped}"`;
+        }
       ),
     };
   }

--- a/scripts/bootstrap-cognitive.js
+++ b/scripts/bootstrap-cognitive.js
@@ -14,6 +14,15 @@ const PROTOCOL_VERSION = 2;
 const MARKER = `<!-- egc-memory-protocol:v${PROTOCOL_VERSION} -->`;
 const MARKER_BLOCK_RE = /<!-- egc-memory-protocol(?::v(\d+))? -->[\s\S]*?<!-- \/egc-memory-protocol -->\n?/;
 
+// Cursor's cursor.rules setting is a single flat string (no markdown), so it
+// gets its own bracket-tag marker/block pair instead of the HTML-comment one
+// above, versioned the same way for the same reason: an already-configured
+// install should not stay frozen when a new protocol section ships. Matches
+// a trailing [/egc-memory-protocol] when present (v2+), or falls through to
+// end-of-string when absent, since the pre-versioning format (v1, always
+// appended last) never wrote a closing tag at all.
+const CURSOR_BLOCK_RE = /\[egc-memory-protocol(?::v(\d+))?\][\s\S]*?(?:\[\/egc-memory-protocol\]|$)/;
+
 // Shared by every harness's protocol text below (BLOCK and the markdown
 // fallbacks) so the 9 session bus commands and 5 Guardian commands can't
 // drift out of sync across the 9+ copies the way they did before this fix.
@@ -82,17 +91,23 @@ ${CRUSHER_MD}
 `;
 
 // Standalone Markdown file used by harnesses that read a static instructions
-// file instead of a global rules block (OpenCode/CodeBuddy fallback content,
-// mirrors the .opencode/.codebuddy source files copied below).
+// file instead of a global rules block (OpenCode/Trae/CodeBuddy/Continue.dev).
+// Carries the same version marker as BLOCK so injectStandaloneProtocol() can
+// detect and upgrade an already-installed copy instead of leaving it frozen.
 function markdownProtocolBody(title) {
-  return `# ${title}\n\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n\n${CRUSHER_MD}\n`;
+  return `${MARKER}\n# ${title}\n\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n\n${CRUSHER_MD}\n<!-- /egc-memory-protocol -->\n`;
 }
 
 // Single-line TOML string (matches the pre-existing persistent_instructions
 // format): kept flattened rather than switched to a triple-quoted multiline
 // TOML string, to avoid restructuring a value format that already installs
 // correctly in production rather than risk a new TOML parsing edge case.
-const CODEX_PROTOCOL_SUFFIX = ' At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn. Token Crusher Protocol (mandatory): the automatic hook rewrite is silently ignored for assistant-issued Bash calls (confirmed Claude Code limitation, not planned to be fixed) -- prefix any command likely to produce large output yourself with egc run <command> instead of running it directly, e.g. egc run git log --stat, egc run npm install, egc run npm test; use egc run --raw <command> only when you genuinely need the uncompressed output.';
+// Wrapped in its own [egc-protocol:vN]...[/egc-protocol] marker (distinct
+// from the HTML-comment MARKER above, since this lives inside a TOML string
+// value) so bootstrapCodex() can detect and upgrade an outdated segment
+// in place instead of leaving already-configured installs frozen.
+const CODEX_PROTOCOL_MARKER_RE = /\[egc-protocol:v(\d+)\][\s\S]*?\[\/egc-protocol\]/;
+const CODEX_PROTOCOL_SUFFIX = ` [egc-protocol:v${PROTOCOL_VERSION}] At the start of every session call get_state({}) via egc-memory to restore context. At the end call update_state({...}) to save decisions. Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. Guardian Protocol (mandatory): before every non-trivial task call orchestrate_task, before every shell command call validate_command, before every new file write/edit call validate_write, after every work block call auto_learn. Token Crusher Protocol (mandatory): the automatic hook rewrite is silently ignored for assistant-issued Bash calls (confirmed Claude Code limitation, not planned to be fixed), so prefix any command likely to produce large output yourself with egc run <command> instead of running it directly, e.g. egc run git log --stat, egc run npm install, egc run npm test; use egc run --raw <command> only when you genuinely need the uncompressed output. [/egc-protocol]`;
 const CODEX_PROTOCOL_FULL   = `persistent_instructions = "State lives at ~/.egc/state/<slug>.md.${CODEX_PROTOCOL_SUFFIX}"\n`;
 
 const HOME = os.homedir();
@@ -123,6 +138,31 @@ function injectProtocol(filepath, label) {
   console.log(`  [cognitive] ${label}: memory protocol installed (${filepath.replace(HOME, '~')})`);
 }
 
+// Variant of injectProtocol() for targets whose file is entirely EGC-managed
+// (no surrounding user content to preserve), so an outdated copy is replaced
+// wholesale rather than block-patched in place.
+function injectStandaloneProtocol(filepath, label, content) {
+  const exists = fs.existsSync(filepath);
+  if (exists) {
+    const raw = fs.readFileSync(filepath, 'utf8');
+    const blockMatch = raw.match(MARKER_BLOCK_RE);
+    const installedVersion = blockMatch ? (blockMatch[1] ? Number(blockMatch[1]) : 1) : 0;
+    if (installedVersion >= PROTOCOL_VERSION) {
+      console.log(`  [cognitive] ${label}: already configured (v${installedVersion || 'legacy'})`);
+      return;
+    }
+    fs.writeFileSync(filepath + '.egc.bak', raw, 'utf8');
+    fs.writeFileSync(filepath, content, 'utf8');
+    console.log(`  [cognitive] ${label}: memory protocol upgraded v${installedVersion || 'legacy'} -> v${PROTOCOL_VERSION} (${filepath.replace(HOME, '~')})`);
+    return;
+  }
+
+  const dir = path.dirname(filepath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filepath, content, 'utf8');
+  console.log(`  [cognitive] ${label}: memory protocol installed (${filepath.replace(HOME, '~')})`);
+}
+
 // ── Claude Code ───────────────────────────────────────────────────────────────
 try {
   if (fs.existsSync(path.join(HOME, '.claude'))) {
@@ -139,6 +179,10 @@ try {
   }
 } catch (e) {
   console.log(`  [cognitive] Gemini CLI: unexpected error: ${e.message}`);
+}
+
+function cursorRulesBlock() {
+  return `[egc-memory-protocol:v${PROTOCOL_VERSION}] At the start of every session call get_state({}) via egc-memory to restore project context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. [egc-auto-intuition] Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. [egc-guardian] Before every non-trivial task call orchestrate_task. Before every shell command call validate_command. Before every new file write/edit call validate_write. After every work block call auto_learn. [egc-token-crusher] The automatic hook rewrite is silently ignored for assistant-issued Bash calls, a confirmed Claude Code limitation not planned to be fixed, so prefix any command likely to produce large output yourself with egc run <command> instead of running it directly (e.g. egc run git log --stat, egc run npm install). Use egc run --raw <command> only when you genuinely need the uncompressed output. [/egc-memory-protocol]`;
 }
 
 // ── Cursor (global User Rules via settings.json) ──────────────────────────────
@@ -163,15 +207,23 @@ try {
         return;
       }
       const existing = obj['cursor.rules'] || '';
-      if (existing.includes('[egc-memory-protocol]')) {
-        console.log('  [cognitive] Cursor: already configured');
+      const blockMatch = existing.match(CURSOR_BLOCK_RE);
+      const installedVersion = blockMatch ? (blockMatch[1] ? Number(blockMatch[1]) : 1) : 0;
+      if (installedVersion >= PROTOCOL_VERSION) {
+        console.log(`  [cognitive] Cursor: already configured (v${installedVersion})`);
         return;
       }
-      const separator = existing.trim() ? '\n\n' : '';
-      obj['cursor.rules'] = existing + separator + '[egc-memory-protocol] At the start of every session call get_state({}) via egc-memory to restore project context. At the end call update_state({...}) to save decisions. State lives at ~/.egc/state/<slug>.md. [egc-auto-intuition] Act on user intent not keywords: session ending->update_state, session start->get_state, save this->lesson_save or store_decision, what failed->search_history, review PR->review-pr agents, context heavy->reduce_context, how much did I save->egc gain, missed savings->egc discover, another session left something->session_events/session_peers, hand off work->session_send, join session->session_announce, lock a path->claim_path, unlock a path->release_path, read shared memory->working_memory_get, save shared memory->working_memory_set, list shared memory->working_memory_list. Judge by full context not literal words. [egc-guardian] Before every non-trivial task call orchestrate_task. Before every shell command call validate_command. Before every new file write/edit call validate_write. After every work block call auto_learn.';
+
+      if (blockMatch) {
+        obj['cursor.rules'] = existing.replace(CURSOR_BLOCK_RE, cursorRulesBlock());
+      } else {
+        const separator = existing.trim() ? '\n\n' : '';
+        obj['cursor.rules'] = existing + separator + cursorRulesBlock();
+      }
       fs.writeFileSync(settingsFile + '.egc.bak', rawContent, 'utf8');
       fs.writeFileSync(settingsFile, JSON.stringify(obj, null, 2) + '\n', 'utf8');
-      console.log(`  [cognitive] Cursor: memory protocol installed (${settingsFile.replace(HOME, '~')})`);
+      const action = blockMatch ? `upgraded v${installedVersion || 'legacy'} -> v${PROTOCOL_VERSION}` : 'installed';
+      console.log(`  [cognitive] Cursor: memory protocol ${action} (${settingsFile.replace(HOME, '~')})`);
     } else {
       injectProtocol(path.join(HOME, '.cursor', 'rules'), 'Cursor');
     }
@@ -189,8 +241,13 @@ try {
 
     if (fs.existsSync(tomlPath)) {
       const originalContent = fs.readFileSync(tomlPath, 'utf8');
-      if (originalContent.includes('egc-memory-protocol') || originalContent.includes('get_state')) {
-        console.log('  [cognitive] Codex: already configured');
+      const markerMatch = originalContent.match(CODEX_PROTOCOL_MARKER_RE);
+      // No marker at all but the legacy pre-marker text is present (it always
+      // mentions get_state): treat as an implicit v1 needing an upgrade.
+      const installedVersion = markerMatch ? Number(markerMatch[1]) : (originalContent.includes('get_state') ? 1 : null);
+
+      if (installedVersion !== null && installedVersion >= PROTOCOL_VERSION) {
+        console.log(`  [cognitive] Codex: already configured (v${installedVersion})`);
         return;
       }
 
@@ -205,16 +262,25 @@ try {
         return;
       }
 
+      // Marker present: replace just that segment with the current suffix.
+      // No marker but legacy text present: append the versioned block so the
+      // next run's marker check succeeds, leaving the old text in place
+      // rather than guessing where it ends without a delimiter. Neither:
+      // append fresh, same as a brand-new install.
+      const foldSuffix = (val) => markerMatch
+        ? val.replace(CODEX_PROTOCOL_MARKER_RE, CODEX_PROTOCOL_SUFFIX.trim())
+        : `${val}${CODEX_PROTOCOL_SUFFIX}`;
+
       let newContent;
       if (RE_DOUBLE.test(originalContent)) {
         newContent = originalContent.replace(
           RE_DOUBLE,
-          (_, pre, val, post) => `${pre}${val}${CODEX_PROTOCOL_SUFFIX}${post}`
+          (_, pre, val, post) => `${pre}${foldSuffix(val)}${post}`
         );
       } else if (RE_SINGLE.test(originalContent)) {
         newContent = originalContent.replace(
           RE_SINGLE,
-          (_, _pre, val, _post) => `persistent_instructions = "${val}${CODEX_PROTOCOL_SUFFIX}"`
+          (_, _pre, val, _post) => `persistent_instructions = "${foldSuffix(val)}"`
         );
       } else if (hasKey) {
         console.log('  [cognitive] Codex: persistent_instructions in unrecognized format: skipping');
@@ -225,11 +291,14 @@ try {
 
       fs.writeFileSync(tomlPath + '.egc.bak', originalContent, 'utf8');
       fs.writeFileSync(tomlPath, newContent, 'utf8');
-    } else {
-      const dir = path.dirname(tomlPath);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(tomlPath, CODEX_PROTOCOL_FULL);
+      const action = installedVersion !== null ? `upgraded v${installedVersion} -> v${PROTOCOL_VERSION}` : 'installed';
+      console.log(`  [cognitive] Codex: memory protocol ${action} (${tomlPath.replace(HOME, '~')})`);
+      return;
     }
+
+    const dir = path.dirname(tomlPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(tomlPath, CODEX_PROTOCOL_FULL);
     console.log(`  [cognitive] Codex: memory protocol installed (${tomlPath.replace(HOME, '~')})`);
   } catch (e) {
     console.log(`  [cognitive] Codex: unexpected error: ${e.message}`);
@@ -237,24 +306,17 @@ try {
 })();
 
 // ── OpenCode (~/.opencode/instructions/EGC_MEMORY.md) ────────────────────────
+// Generated straight from markdownProtocolBody() rather than copied from a
+// static repo file, so its content can never drift out of sync with the
+// canonical protocol text the way the old copied-file version did.
 (function bootstrapOpenCode() {
   try {
     const opencodeDir = path.join(HOME, '.opencode');
     if (!fs.existsSync(opencodeDir)) return;
     const instructionsDir = path.join(opencodeDir, 'instructions');
-    const target = path.join(instructionsDir, 'EGC_MEMORY.md');
-    if (fs.existsSync(target)) {
-      console.log('  [cognitive] OpenCode: already configured');
-      return;
-    }
     if (!fs.existsSync(instructionsDir)) fs.mkdirSync(instructionsDir, { recursive: true });
-    const src = path.join(__dirname, '..', '.opencode', 'instructions', 'EGC_MEMORY.md');
-    if (fs.existsSync(src)) {
-      fs.copyFileSync(src, target);
-    } else {
-      fs.writeFileSync(target, markdownProtocolBody('EGC Session Memory'));
-    }
-    console.log(`  [cognitive] OpenCode: memory protocol installed (${target.replace(HOME, '~')})`);
+    const target = path.join(instructionsDir, 'EGC_MEMORY.md');
+    injectStandaloneProtocol(target, 'OpenCode', markdownProtocolBody('EGC Session Memory'));
   } catch (e) {
     console.log(`  [cognitive] OpenCode: unexpected error: ${e.message}`);
   }
@@ -263,18 +325,11 @@ try {
 // ── Trae (~/.trae/MEMORY.md and ~/.trae-cn/MEMORY.md) ────────────────────────
 (function bootstrapTrae() {
   try {
-    const src = path.join(__dirname, '..', '.trae', 'MEMORY.md');
-    if (!fs.existsSync(src)) return;
     for (const dir of ['.trae', '.trae-cn']) {
       const traeDir = path.join(HOME, dir);
       if (!fs.existsSync(traeDir)) continue;
       const target = path.join(traeDir, 'MEMORY.md');
-      if (fs.existsSync(target)) {
-        console.log(`  [cognitive] Trae (${dir}): already configured`);
-        continue;
-      }
-      fs.copyFileSync(src, target);
-      console.log(`  [cognitive] Trae (${dir}): memory protocol installed (~/${dir}/MEMORY.md)`);
+      injectStandaloneProtocol(target, `Trae (${dir})`, markdownProtocolBody('EGC Session Memory'));
     }
   } catch (e) {
     console.log(`  [cognitive] Trae: unexpected error: ${e.message}`);
@@ -287,17 +342,7 @@ try {
     const codebuddyDir = path.join(HOME, '.codebuddy');
     if (!fs.existsSync(codebuddyDir)) return;
     const target = path.join(codebuddyDir, 'MEMORY.md');
-    if (fs.existsSync(target)) {
-      console.log('  [cognitive] CodeBuddy: already configured');
-      return;
-    }
-    const src = path.join(__dirname, '..', '.codebuddy', 'MEMORY.md');
-    if (fs.existsSync(src)) {
-      fs.copyFileSync(src, target);
-    } else {
-      fs.writeFileSync(target, markdownProtocolBody('Session Memory'));
-    }
-    console.log('  [cognitive] CodeBuddy: memory protocol installed (~/.codebuddy/MEMORY.md)');
+    injectStandaloneProtocol(target, 'CodeBuddy', markdownProtocolBody('Session Memory'));
   } catch (e) {
     console.log(`  [cognitive] CodeBuddy: unexpected error: ${e.message}`);
   }
@@ -309,14 +354,10 @@ try {
     const continueDir = path.join(HOME, '.continue');
     if (!fs.existsSync(continueDir)) return;
     const promptsDir = path.join(continueDir, 'prompts');
-    const target = path.join(promptsDir, 'egc-memory.prompt');
-    if (fs.existsSync(target)) {
-      console.log('  [cognitive] Continue.dev: already configured');
-      return;
-    }
     if (!fs.existsSync(promptsDir)) fs.mkdirSync(promptsDir, { recursive: true });
-    fs.writeFileSync(target, `name: EGC Session Memory\ndescription: Restore and persist EGC cross-session memory\n---\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n\n${CRUSHER_MD}\n`);
-    console.log('  [cognitive] Continue.dev: memory protocol installed (~/.continue/prompts/egc-memory.prompt)');
+    const target = path.join(promptsDir, 'egc-memory.prompt');
+    const content = `name: EGC Session Memory\ndescription: Restore and persist EGC cross-session memory\n---\n${MARKER}\nAt the start of every session call \`get_state({})\` via egc-memory to restore context. At the end call \`update_state({...})\` to save decisions.\n\n${AUTO_INTUITION_MD}\n\n${GUARDIAN_MD}\n\n${CRUSHER_MD}\n<!-- /egc-memory-protocol -->\n`;
+    injectStandaloneProtocol(target, 'Continue.dev', content);
   } catch (e) {
     console.log(`  [cognitive] Continue.dev: unexpected error: ${e.message}`);
   }

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -65,10 +65,155 @@ const SESSION_BUS_COMMANDS = [
   'working_memory_get', 'working_memory_set', 'working_memory_list',
 ];
 
+// Split out from runTests() to keep its cyclomatic complexity down: covers
+// the two non-markdown protocol formats (Cursor's JSON cursor.rules, Codex's
+// TOML persistent_instructions), each needing its own upgrade-from-legacy
+// and stay-idempotent-at-v2 case.
+async function runCursorAndCodexUpgradeTests() {
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('Cursor settings.json: a pre-versioning legacy cursor.rules (no marker) is upgraded to v2 with the Crusher tag, preserving unrelated settings', () => {
+    const home = mktempHome();
+    try {
+      const cursorSettingsDir = path.join(home, '.config', 'Cursor', 'User');
+      fs.mkdirSync(cursorSettingsDir, { recursive: true });
+      const settingsFile = path.join(cursorSettingsDir, 'settings.json');
+      fs.writeFileSync(settingsFile, JSON.stringify({
+        'editor.fontSize': 14,
+        'cursor.rules': '[egc-memory-protocol] Legacy pre-Crusher rules mentioning get_state and update_state.',
+      }), 'utf8');
+
+      const output = run(home);
+      assert.ok(/Cursor: memory protocol upgraded/.test(output), `should report an upgrade, got: ${output}`);
+
+      const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+      assert.strictEqual(parsed['editor.fontSize'], 14, 'unrelated settings must be preserved');
+      assert.ok(parsed['cursor.rules'].includes('[egc-token-crusher]'), 'upgraded cursor.rules must include the Crusher tag');
+      assert.ok(parsed['cursor.rules'].includes('[egc-memory-protocol:v2]'), 'marker must be stamped with the current version');
+      assert.strictEqual(
+        (parsed['cursor.rules'].match(/\[egc-memory-protocol(?::v\d+)?\]/g) || []).length,
+        1,
+        'exactly one protocol marker after the upgrade, no duplication'
+      );
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Cursor settings.json: a v2 install is left untouched on rerun (idempotent)', () => {
+    const home = mktempHome();
+    try {
+      const cursorSettingsDir = path.join(home, '.config', 'Cursor', 'User');
+      fs.mkdirSync(cursorSettingsDir, { recursive: true });
+      const settingsFile = path.join(cursorSettingsDir, 'settings.json');
+      fs.writeFileSync(settingsFile, JSON.stringify({ 'editor.fontSize': 14 }), 'utf8');
+
+      run(home);
+      const second = run(home);
+      assert.ok(/Cursor: already configured \(v2\)/.test(second), `second run should report already configured, got: ${second}`);
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Codex config.toml: a pre-versioning legacy persistent_instructions (no marker) is upgraded to v2 with the Crusher text, staying a valid single-line TOML string', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      const tomlPath = path.join(home, '.codex', 'config.toml');
+      fs.writeFileSync(tomlPath, 'persistent_instructions = "State lives at ~/.egc/state/<slug>.md. Legacy pre-Crusher text mentioning get_state and update_state."\n', 'utf8');
+
+      const output = run(home);
+      assert.ok(/Codex: memory protocol upgraded v1 -> v2/.test(output), `should report a v1 -> v2 upgrade, got: ${output}`);
+
+      const content = fs.readFileSync(tomlPath, 'utf8');
+      const match = content.match(/^persistent_instructions = "(.*)"$/m);
+      assert.ok(match, 'persistent_instructions must remain a single-line double-quoted TOML string');
+      assert.ok(!match[1].includes('"'), 'the TOML string value must not contain an unescaped double-quote');
+      assert.ok(match[1].includes('[egc-protocol:v2]'), 'upgraded value must carry the current version marker');
+      assert.ok(match[1].includes('Token Crusher Protocol'), 'upgraded value must include the Crusher section');
+      assert.ok(match[1].includes('Legacy pre-Crusher text'), 'pre-marker legacy text is left in place rather than guessed-and-removed');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Codex config.toml: a v2 install is left untouched on rerun (idempotent)', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      run(home);
+      const second = run(home);
+      assert.ok(/Codex: already configured \(v2\)/.test(second), `second run should report already configured, got: ${second}`);
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  return [passed, failed];
+}
+
+// Same complexity-budget reasoning as above: the 4 standalone markdown
+// targets (OpenCode, Trae, CodeBuddy, Continue.dev) each need the same pair
+// of upgrade-from-legacy / stay-idempotent-at-v2 cases.
+async function runStandaloneTargetUpgradeTests() {
+  const STANDALONE_TARGETS = [
+    { home: '.opencode', target: ['.opencode', 'instructions', 'EGC_MEMORY.md'], label: 'OpenCode' },
+    { home: '.trae', target: ['.trae', 'MEMORY.md'], label: 'Trae (.trae)' },
+    { home: '.codebuddy', target: ['.codebuddy', 'MEMORY.md'], label: 'CodeBuddy' },
+    { home: '.continue', target: ['.continue', 'prompts', 'egc-memory.prompt'], label: 'Continue.dev' },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const spec of STANDALONE_TARGETS) {
+    if (await test(`${spec.label}: a pre-versioning legacy install (no marker at all) is upgraded to v2 with the Crusher section, not left frozen`, () => {
+      const home = mktempHome();
+      try {
+        fs.mkdirSync(path.join(home, spec.home), { recursive: true });
+        const target = path.join(home, ...spec.target);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, '# EGC Session Memory\n\nLegacy pre-marker content, written before versioning existed. Mentions get_state and update_state so the old plain existsSync check would have skipped it forever.\n', 'utf8');
+
+        const output = run(home);
+        assert.ok(output.includes(`${spec.label}: memory protocol upgraded`), `should report an upgrade for ${spec.label}, got: ${output}`);
+
+        const content = fs.readFileSync(target, 'utf8');
+        assert.ok(content.includes('EGC Token Crusher Protocol'), 'upgraded content must include the Crusher section');
+        assert.ok(content.includes('<!-- egc-memory-protocol:v2 -->'), 'upgraded content must carry the current version marker');
+      } finally {
+        cleanup(home);
+      }
+    })) passed++; else failed++;
+
+    if (await test(`${spec.label}: a v2 install is left untouched on rerun (idempotent)`, () => {
+      const home = mktempHome();
+      try {
+        fs.mkdirSync(path.join(home, spec.home), { recursive: true });
+        run(home);
+        const second = run(home);
+        assert.ok(second.includes(`${spec.label}: already configured (v2)`), `second run should report ${spec.label} as already configured, got: ${second}`);
+      } finally {
+        cleanup(home);
+      }
+    })) passed++; else failed++;
+  }
+
+  return [passed, failed];
+}
+
 async function runTests() {
   console.log('\n=== Testing scripts/bootstrap-cognitive.js ===\n');
   let passed = 0;
   let failed = 0;
+
+  {
+    const [cursorCodexPassed, cursorCodexFailed] = await runCursorAndCodexUpgradeTests();
+    passed += cursorCodexPassed;
+    failed += cursorCodexFailed;
+  }
 
   if (await test('BLOCK advertises all 9 session bus commands', () => {
     for (const cmd of SESSION_BUS_COMMANDS) {
@@ -266,6 +411,12 @@ async function runTests() {
       cleanup(home);
     }
   })) passed++; else failed++;
+
+  {
+    const [standalonePassed, standaloneFailed] = await runStandaloneTargetUpgradeTests();
+    passed += standalonePassed;
+    failed += standaloneFailed;
+  }
 
   if (await test('writes Zed AGENTS.md when ~/.config/zed exists', () => {
     const home = mktempHome();

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -73,7 +73,7 @@ async function runCursorAndCodexUpgradeTests() {
   let passed = 0;
   let failed = 0;
 
-  if (await test('Cursor settings.json: a pre-versioning legacy cursor.rules (no marker) is upgraded to v2 with the Crusher tag, preserving unrelated settings', () => {
+  if (await test('Cursor settings.json: a pre-versioning legacy cursor.rules (no marker, no closing tag) is upgraded by appending v2 with the Crusher tag, never deleting the old text', () => {
     const home = mktempHome();
     try {
       const cursorSettingsDir = path.join(home, '.config', 'Cursor', 'User');
@@ -85,16 +85,34 @@ async function runCursorAndCodexUpgradeTests() {
       }), 'utf8');
 
       const output = run(home);
-      assert.ok(/Cursor: memory protocol upgraded/.test(output), `should report an upgrade, got: ${output}`);
+      assert.ok(/Cursor: memory protocol upgraded v1 -> v2/.test(output), `should report a v1 -> v2 upgrade, got: ${output}`);
 
       const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
       assert.strictEqual(parsed['editor.fontSize'], 14, 'unrelated settings must be preserved');
+      assert.ok(parsed['cursor.rules'].includes('Legacy pre-Crusher rules'), 'the old unclosed legacy block is never deleted, since there is no reliable end marker to cut it at');
       assert.ok(parsed['cursor.rules'].includes('[egc-token-crusher]'), 'upgraded cursor.rules must include the Crusher tag');
       assert.ok(parsed['cursor.rules'].includes('[egc-memory-protocol:v2]'), 'marker must be stamped with the current version');
-      assert.strictEqual(
-        (parsed['cursor.rules'].match(/\[egc-memory-protocol(?::v\d+)?\]/g) || []).length,
-        1,
-        'exactly one protocol marker after the upgrade, no duplication'
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Cursor settings.json: rules the user appended after an old unclosed legacy block survive the upgrade (cubic review, PR #1095)', () => {
+    const home = mktempHome();
+    try {
+      const cursorSettingsDir = path.join(home, '.config', 'Cursor', 'User');
+      fs.mkdirSync(cursorSettingsDir, { recursive: true });
+      const settingsFile = path.join(cursorSettingsDir, 'settings.json');
+      fs.writeFileSync(settingsFile, JSON.stringify({
+        'cursor.rules': '[egc-memory-protocol] Legacy pre-Crusher rules mentioning get_state and update_state.\n\nAlways use tabs, never spaces, in this project.',
+      }), 'utf8');
+
+      run(home);
+
+      const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+      assert.ok(
+        parsed['cursor.rules'].includes('Always use tabs, never spaces, in this project.'),
+        'a rule the user appended after the old unclosed EGC block must survive the upgrade, not be silently deleted'
       );
     } finally {
       cleanup(home);
@@ -139,6 +157,24 @@ async function runCursorAndCodexUpgradeTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('Codex config.toml: escapes double quotes and backslashes when upgrading a single-quoted persistent_instructions (cubic review, PR #1095)', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      const tomlPath = path.join(home, '.codex', 'config.toml');
+      fs.writeFileSync(tomlPath, 'persistent_instructions = \'Legacy text mentioning get_state with a "quoted word" and a backslash \\ here.\'\n', 'utf8');
+
+      run(home);
+
+      const content = fs.readFileSync(tomlPath, 'utf8');
+      assert.ok(/^persistent_instructions = "/m.test(content), 'must be rewritten as a double-quoted TOML string');
+      assert.ok(content.includes('\\"quoted word\\"'), 'the original double quotes must be escaped, not left bare inside the new double-quoted string');
+      assert.ok(content.includes('backslash \\\\ here'), 'the original backslash must be escaped (doubled), not left bare');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
   if (await test('Codex config.toml: a v2 install is left untouched on rerun (idempotent)', () => {
     const home = mktempHome();
     try {
@@ -161,6 +197,7 @@ async function runStandaloneTargetUpgradeTests() {
   const STANDALONE_TARGETS = [
     { home: '.opencode', target: ['.opencode', 'instructions', 'EGC_MEMORY.md'], label: 'OpenCode' },
     { home: '.trae', target: ['.trae', 'MEMORY.md'], label: 'Trae (.trae)' },
+    { home: '.trae-cn', target: ['.trae-cn', 'MEMORY.md'], label: 'Trae (.trae-cn)' },
     { home: '.codebuddy', target: ['.codebuddy', 'MEMORY.md'], label: 'CodeBuddy' },
     { home: '.continue', target: ['.continue', 'prompts', 'egc-memory.prompt'], label: 'Continue.dev' },
   ];


### PR DESCRIPTION
## Summary
- Versions and upgrades the remaining 7 bootstrap targets (Cursor settings.json, Codex config.toml, OpenCode, Trae, Trae-CN, CodeBuddy, Continue.dev) using the same upgrade-in-place logic already proven for Claude Code, Gemini CLI, Windsurf, and Zed.
- Fixes a real content gap: the static template files those 5 markdown targets used to copy from did not have the Token Crusher section, so even fresh installs missed it. They now generate from the shared protocol body instead.
- Syncs the 3 static template files in the repo to the current content for consistency.

## Test plan
- [x] `node tests/scripts/bootstrap-cognitive.test.js` - 28/28 passing (14 new tests covering upgrade-from-legacy and stay-idempotent-at-v2 for all 7 targets)
- [x] `node tests/run-all.js` - full suite 3713/3713 passing
- [x] `npx eslint` clean on all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds versioned, upgrade-in-place support for the remaining seven bootstrap targets and includes the EGC Token Crusher protocol everywhere. Also refactors and cleans up Cursor/Codex upgrade logic to reduce complexity with no behavior changes.

- **New Features**
  - Versioned upgrades for all 7 remaining targets; legacy installs move to v2 with backups and idempotent runs.
  - Standalone targets (`OpenCode`, `Trae`, `Trae-CN`, `CodeBuddy`, `Continue.dev`) now generate a versioned protocol from the shared source; outdated copies are replaced and repo templates are synced.

- **Bug Fixes**
  - Cursor: stop replacing unclosed legacy `[egc-memory-protocol]` blocks; append a closed, versioned block instead so user-appended rules aren’t deleted.
  - Codex: when upgrading a single-quoted `persistent_instructions`, escape backslashes and double quotes before switching to a double-quoted string to keep TOML valid.

<sup>Written for commit 13c9e812bc3fff896c34da1fad5cfba461c5d716. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

