### PR TITLE
fix(install): link the egc command to a from-source checkout during install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -293,7 +293,7 @@ You never need to type any of these. Talk to your AI naturally, in any language,
 | `egc claw` | NanoClaw REPL: persistent session-aware agent loop with Markdown history |
 | `egc harness-audit` | Score the harness setup across tool coverage, quality gates, memory, and security |
 
-`egc doctor`, `egc repair`, and `egc auto-update` all accept `--repo-root <path>`, pointing them at a local development checkout instead of wherever the running `egc` binary was installed from. Without it, they compare your managed files against the published npm package, which reports every unreleased change as missing or drifted. Pass the same `--repo-root` you use to sync a machine from a checkout so all three agree on the source of truth.
+`egc doctor`, `egc repair`, and `egc auto-update` all accept `--repo-root <path>`, pointing them at a local development checkout instead of wherever the running `egc` binary was installed from. Without it, they compare your managed files against the published npm package, which reports every unreleased change as missing or drifted. Pass a `--repo-root` pointing at your local checkout when running any of these three commands so all agree on the source of truth.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -293,6 +293,8 @@ You never need to type any of these. Talk to your AI naturally, in any language,
 | `egc claw` | NanoClaw REPL: persistent session-aware agent loop with Markdown history |
 | `egc harness-audit` | Score the harness setup across tool coverage, quality gates, memory, and security |
 
+`egc doctor`, `egc repair`, and `egc auto-update` all accept `--repo-root <path>`, pointing them at a local development checkout instead of wherever the running `egc` binary was installed from. Without it, they compare your managed files against the published npm package, which reports every unreleased change as missing or drifted. Pass the same `--repo-root` you use to sync a machine from a checkout so all three agree on the source of truth.
+
 ---
 
 ## Troubleshooting

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -57,6 +57,19 @@ if (-not $DryRun) {
     Set-Location -Path $RootDir
     Install-Deps
 
+    # Point the "egc" command at this checkout, so the "egc doctor" the
+    # message at the end of this script tells the user to run (and anything
+    # else they type afterward) targets the code that was just installed
+    # rather than a stale prior global install left on PATH from an earlier
+    # npm publish. Best-effort: some environments lack permission to the
+    # global npm prefix, and that must not abort the rest of the install.
+    Write-Host "  linking the egc command to this checkout..."
+    try {
+        npm link --silent 2>$null
+    } catch {
+        Write-Host "  note: npm link failed (no permission to the global npm prefix?). Run 'npm link' manually, or use 'node scripts\egc.js <command>' from this checkout." -ForegroundColor Yellow
+    }
+
     # Verify native modules (better-sqlite3 requires Build Tools on Windows)
     $nativeOk = $true
     try {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -64,9 +64,12 @@ if (-not $DryRun) {
     # npm publish. Best-effort: some environments lack permission to the
     # global npm prefix, and that must not abort the rest of the install.
     Write-Host "  linking the egc command to this checkout..."
-    try {
-        npm link --silent 2>$null
-    } catch {
+    # PowerShell does not treat a non-zero exit code from a native command as
+    # a terminating error, so a try/catch here would never fire: check
+    # $LASTEXITCODE explicitly instead, matching the "||" pattern install.sh
+    # uses for the same fallback (cubic review, PR #1096).
+    npm link --silent 2>$null
+    if ($LASTEXITCODE -ne 0) {
         Write-Host "  note: npm link failed (no permission to the global npm prefix?). Run 'npm link' manually, or use 'node scripts\egc.js <command>' from this checkout." -ForegroundColor Yellow
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,6 +81,15 @@ if [ "$DRY_RUN" = false ]; then
   cd "$ROOT_DIR"
   install_deps
 
+  # Point the "egc" command at this checkout, so the "egc doctor" the message
+  # at the end of this script tells the user to run (and anything else they
+  # type afterward) targets the code that was just installed rather than a
+  # stale prior global install left on PATH from an earlier npm publish.
+  # Best-effort: some environments lack permission to the global npm prefix,
+  # and that must not abort the rest of the install.
+  echo "  linking the egc command to this checkout..."
+  npm link --silent 2>/dev/null || echo "  note: npm link failed (no permission to the global npm prefix?). Run 'npm link' manually, or use 'node scripts/egc.js <command>' from this checkout."
+
   # egc-guardian
   echo "  building egc-guardian..."
   GUARDIAN_DIR="$ROOT_DIR/mcp/servers/egc-guardian"


### PR DESCRIPTION
## Summary
- `install.sh`/`install.ps1` never pointed the `egc` command at the checkout they just set up, only at content installed under home/project targets. A stale prior global install elsewhere on PATH would keep shadowing it after a from-source install, misreporting its own version and failing to find install-state the fresh install had actually written correctly. Confirmed live via a contributor's Windows install report.
- Both scripts now run `npm link` right after installing root dependencies. Best-effort: a permission failure logs a note (manual `npm link`, or `node scripts/egc.js` directly) without aborting the rest of the install.
- Documents the existing `--repo-root` flag shared by `doctor`, `repair`, and `auto-update` in the command reference.

## Test plan
- [x] `node tests/scripts/install-sh.test.js` - 5/5 passing
- [x] `node tests/scripts/install-ps1.test.js` - 6/6 passing (2 skipped, no PowerShell in this environment)
- [x] `node tests/scripts/install-onboarding.test.js` - 7/7 passing
- [x] `bash -n scripts/install.sh` - syntax check clean
- [x] `sh scripts/install.sh --dry-run` - confirms the new step stays inside the existing dry-run guard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes from-source installs by linking the `egc` CLI to the local checkout using `npm link`, preventing stale global installs on PATH from shadowing it. Also documents the shared `--repo-root` flag for maintenance commands.

- **Bug Fixes**
  - Run `npm link` in `install.sh` and `install.ps1`, and on PowerShell check `$LASTEXITCODE` to surface failures; on permission errors, continue and print a note to run `npm link` manually or use `node scripts/egc.js <command>`.
  - Add docs for `--repo-root` used by `egc doctor`, `egc repair`, and `egc auto-update` with clear guidance.

<sup>Written for commit 8e0d7b4bfff1175005e468d29d62704ddaeb000c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

