### PR TITLE
test: close real coverage gaps flagged by CI on today's Guardian and Crusher work

### DIFF
--- a/tests/lib/amazonq-guardian-hooks.test.js
+++ b/tests/lib/amazonq-guardian-hooks.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tests for scripts/lib/amazonq-guardian-hooks.js
+ *
+ * Amazon Q's custom-agent config is a flat {hooks: {preToolUse:
+ * [{matcher, command}]}} shape, structurally identical to Kiro's, but the
+ * two hosts share neither the extraEntryFields (execute_bash matcher) nor
+ * the isOwnBasename migration logic, so they route through this dedicated
+ * module rather than kiro-guardian-hooks.js.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  AGENT_CONFIG_EVENT_KEY,
+  EXECUTE_BASH_MATCHER,
+  addAmazonQHookEntry,
+  applyAmazonQGuardianHookToFile,
+  inspectAmazonQGuardianHookFile,
+  removeAmazonQGuardianHookFromFile,
+  removeAmazonQHookEntry,
+  resolveAgentConfigPath,
+  resolveGuardianAdapterScriptDestination,
+} = require('../../scripts/lib/amazonq-guardian-hooks');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing amazonq-guardian-hooks ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('resolveAgentConfigPath and resolveGuardianAdapterScriptDestination compute paths under targetRoot', () => {
+    const targetRoot = '/home/user/project/.amazonq';
+    assert.strictEqual(resolveAgentConfigPath(targetRoot), path.join(targetRoot, 'cli-agents', 'egc-guardian.json'));
+    assert.strictEqual(
+      resolveGuardianAdapterScriptDestination(targetRoot),
+      path.join(targetRoot, 'scripts', 'hooks', 'amazonq-guardian-adapter.js')
+    );
+  })) passed++; else failed++;
+
+  if (test('addAmazonQHookEntry appends a new entry on an empty config, tagged with the execute_bash matcher', () => {
+    const { config, changed } = addAmazonQHookEntry({}, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config.hooks[AGENT_CONFIG_EVENT_KEY], [
+      { matcher: EXECUTE_BASH_MATCHER, command: 'node adapter.js' },
+    ]);
+  })) passed++; else failed++;
+
+  if (test('addAmazonQHookEntry is idempotent (no duplicate on re-add)', () => {
+    const first = addAmazonQHookEntry({}, 'node adapter.js');
+    const second = addAmazonQHookEntry(first.config, 'node adapter.js');
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.config.hooks[AGENT_CONFIG_EVENT_KEY].length, 1);
+  })) passed++; else failed++;
+
+  if (test('addAmazonQHookEntry migrates a stale entry (same adapter basename, different path) in place', () => {
+    const base = {
+      hooks: {
+        [AGENT_CONFIG_EVENT_KEY]: [{ matcher: EXECUTE_BASH_MATCHER, command: 'node /old/path/amazonq-guardian-adapter.js' }],
+      },
+    };
+    const { config, changed } = addAmazonQHookEntry(base, 'node /new/path/amazonq-guardian-adapter.js');
+    assert.strictEqual(changed, true);
+    assert.strictEqual(config.hooks[AGENT_CONFIG_EVENT_KEY].length, 1, 'must migrate in place, not append a duplicate');
+    assert.strictEqual(config.hooks[AGENT_CONFIG_EVENT_KEY][0].command, 'node /new/path/amazonq-guardian-adapter.js');
+  })) passed++; else failed++;
+
+  if (test('addAmazonQHookEntry preserves a third-party command instead of migrating it', () => {
+    const base = { hooks: { [AGENT_CONFIG_EVENT_KEY]: [{ matcher: EXECUTE_BASH_MATCHER, command: 'node .amazonq/hooks/other.js' }] } };
+    const { config } = addAmazonQHookEntry(base, 'node adapter.js');
+    assert.strictEqual(config.hooks[AGENT_CONFIG_EVENT_KEY].length, 2);
+    assert.ok(config.hooks[AGENT_CONFIG_EVENT_KEY].some(e => e.command === 'node .amazonq/hooks/other.js'));
+  })) passed++; else failed++;
+
+  if (test('addAmazonQHookEntry preserves unrelated top-level keys', () => {
+    const base = { name: 'egc-guardian', hooks: { postToolUse: [{ command: 'node log.js' }] } };
+    const { config } = addAmazonQHookEntry(base, 'node adapter.js');
+    assert.strictEqual(config.name, 'egc-guardian');
+    assert.deepStrictEqual(config.hooks.postToolUse, [{ command: 'node log.js' }]);
+  })) passed++; else failed++;
+
+  if (test('applyAmazonQGuardianHookToFile writes a fresh agent config and is idempotent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amazonq-hooks-apply-'));
+    const agentConfigPath = path.join(tempDir, 'egc-guardian.json');
+    try {
+      const first = applyAmazonQGuardianHookToFile(agentConfigPath, '/abs/adapter.js');
+      assert.strictEqual(first.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(agentConfigPath, 'utf8'));
+      assert.strictEqual(onDisk.hooks[AGENT_CONFIG_EVENT_KEY].length, 1);
+      assert.strictEqual(onDisk.hooks[AGENT_CONFIG_EVENT_KEY][0].matcher, EXECUTE_BASH_MATCHER);
+
+      const second = applyAmazonQGuardianHookToFile(agentConfigPath, '/abs/adapter.js');
+      assert.strictEqual(second.changed, false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyAmazonQGuardianHookToFile preserves a hand-written agent config on disk', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amazonq-hooks-preserve-'));
+    const agentConfigPath = path.join(tempDir, 'egc-guardian.json');
+    try {
+      fs.writeFileSync(agentConfigPath, JSON.stringify({
+        name: 'egc-guardian',
+        hooks: { postToolUse: [{ command: 'node .amazonq/hooks/log.js' }] },
+      }, null, 2));
+
+      applyAmazonQGuardianHookToFile(agentConfigPath, '/abs/adapter.js');
+
+      const onDisk = JSON.parse(fs.readFileSync(agentConfigPath, 'utf8'));
+      assert.strictEqual(onDisk.name, 'egc-guardian');
+      assert.deepStrictEqual(onDisk.hooks.postToolUse, [{ command: 'node .amazonq/hooks/log.js' }]);
+      assert.strictEqual(onDisk.hooks[AGENT_CONFIG_EVENT_KEY].length, 1);
+      assert.ok(onDisk.hooks[AGENT_CONFIG_EVENT_KEY][0].command.includes('adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('removeAmazonQHookEntry drops only the EGC entry, keeps third-party hooks and other events', () => {
+    const base = {
+      hooks: {
+        [AGENT_CONFIG_EVENT_KEY]: [
+          { matcher: EXECUTE_BASH_MATCHER, command: 'node .amazonq/hooks/other.js' },
+          { matcher: EXECUTE_BASH_MATCHER, command: 'node adapter.js' },
+        ],
+        postToolUse: [{ command: 'node log.js' }],
+      },
+    };
+    const { config, changed } = removeAmazonQHookEntry(base, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config.hooks[AGENT_CONFIG_EVENT_KEY], [
+      { matcher: EXECUTE_BASH_MATCHER, command: 'node .amazonq/hooks/other.js' },
+    ]);
+    assert.deepStrictEqual(config.hooks.postToolUse, [{ command: 'node log.js' }]);
+  })) passed++; else failed++;
+
+  if (test('removeAmazonQHookEntry deletes the event key entirely once empty', () => {
+    const base = { hooks: { [AGENT_CONFIG_EVENT_KEY]: [{ matcher: EXECUTE_BASH_MATCHER, command: 'node adapter.js' }] } };
+    const { config } = removeAmazonQHookEntry(base, 'node adapter.js');
+    assert.strictEqual(AGENT_CONFIG_EVENT_KEY in config.hooks, false);
+  })) passed++; else failed++;
+
+  if (test('removeAmazonQGuardianHookFromFile on a missing file is a no-op', () => {
+    const result = removeAmazonQGuardianHookFromFile('/nonexistent/egc-guardian.json', '/abs/adapter.js');
+    assert.strictEqual(result.changed, false);
+  })) passed++; else failed++;
+
+  if (test('removeAmazonQGuardianHookFromFile removes the entry from an existing file', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amazonq-hooks-remove-'));
+    const agentConfigPath = path.join(tempDir, 'egc-guardian.json');
+    try {
+      applyAmazonQGuardianHookToFile(agentConfigPath, '/abs/adapter.js');
+      const result = removeAmazonQGuardianHookFromFile(agentConfigPath, '/abs/adapter.js');
+      assert.strictEqual(result.changed, true);
+      const onDisk = JSON.parse(fs.readFileSync(agentConfigPath, 'utf8'));
+      assert.strictEqual(AGENT_CONFIG_EVENT_KEY in onDisk.hooks, false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectAmazonQGuardianHookFile reports ok when present, drifted when absent', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amazonq-hooks-inspect-'));
+    const agentConfigPath = path.join(tempDir, 'egc-guardian.json');
+    try {
+      assert.strictEqual(inspectAmazonQGuardianHookFile(agentConfigPath, '/abs/adapter.js'), 'drifted');
+      applyAmazonQGuardianHookToFile(agentConfigPath, '/abs/adapter.js');
+      assert.strictEqual(inspectAmazonQGuardianHookFile(agentConfigPath, '/abs/adapter.js'), 'ok');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectAmazonQGuardianHookFile reports drifted on invalid JSON instead of throwing', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amazonq-hooks-inspect-invalid-'));
+    const agentConfigPath = path.join(tempDir, 'egc-guardian.json');
+    try {
+      fs.writeFileSync(agentConfigPath, '{not valid json');
+      assert.strictEqual(inspectAmazonQGuardianHookFile(agentConfigPath, '/abs/adapter.js'), 'drifted');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/openhands-guardian-hooks.test.js
+++ b/tests/lib/openhands-guardian-hooks.test.js
@@ -58,8 +58,7 @@ function runTests() {
 
   if (test('buildHookCommand quotes the node binary and script path', () => {
     const command = buildHookCommand('/abs/adapter.js');
-    assert.ok(command.includes(process.execPath));
-    assert.ok(command.includes('/abs/adapter.js'));
+    assert.strictEqual(command, `"${process.execPath}" "/abs/adapter.js"`);
   })) passed++; else failed++;
 
   if (test('addOpenHandsHookEntry appends a brand-new matcher group on an empty config', () => {

--- a/tests/lib/openhands-guardian-hooks.test.js
+++ b/tests/lib/openhands-guardian-hooks.test.js
@@ -1,0 +1,280 @@
+/**
+ * Tests for scripts/lib/openhands-guardian-hooks.js
+ *
+ * OpenHands' hooks.json has no top-level "hooks" wrapper: event names sit
+ * directly at the document root, each value an array of {matcher, hooks:
+ * [{command, timeout}]} rule groups. That shape needs its own merge logic
+ * distinct from both flat-hooks-json-merge.js (Kiro/Amazon Q) and
+ * claude-settings-hooks.js (Claude/Goose), so it is exercised directly here.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  PRE_TOOL_USE_EVENT,
+  TERMINAL_MATCHER,
+  addOpenHandsHookEntry,
+  applyOpenHandsGuardianHookToFile,
+  buildHookCommand,
+  inspectOpenHandsGuardianHookFile,
+  removeOpenHandsGuardianHookFromFile,
+  removeOpenHandsHookEntry,
+  resolveGuardianAdapterScriptDestination,
+  resolveHooksJsonPath,
+} = require('../../scripts/lib/openhands-guardian-hooks');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing openhands-guardian-hooks ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('resolveGuardianAdapterScriptDestination and resolveHooksJsonPath compute paths under targetRoot/projectRoot', () => {
+    const targetRoot = '/home/user/project/.openhands';
+    assert.strictEqual(
+      resolveGuardianAdapterScriptDestination(targetRoot),
+      path.join(targetRoot, 'scripts', 'hooks', 'openhands-guardian-adapter.js')
+    );
+    assert.strictEqual(
+      resolveHooksJsonPath('/home/user/project'),
+      path.join('/home/user/project', '.openhands', 'hooks.json')
+    );
+  })) passed++; else failed++;
+
+  if (test('buildHookCommand quotes the node binary and script path', () => {
+    const command = buildHookCommand('/abs/adapter.js');
+    assert.ok(command.includes(process.execPath));
+    assert.ok(command.includes('/abs/adapter.js'));
+  })) passed++; else failed++;
+
+  if (test('addOpenHandsHookEntry appends a brand-new matcher group on an empty config', () => {
+    const { config, changed } = addOpenHandsHookEntry({}, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config[PRE_TOOL_USE_EVENT], [
+      { matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node adapter.js' }] },
+    ]);
+  })) passed++; else failed++;
+
+  if (test('addOpenHandsHookEntry does not duplicate an already-present command in the matching group', () => {
+    const first = addOpenHandsHookEntry({}, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    const second = addOpenHandsHookEntry(first.config, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(second.config[PRE_TOOL_USE_EVENT].length, 1);
+    assert.strictEqual(second.config[PRE_TOOL_USE_EVENT][0].hooks.length, 1);
+  })) passed++; else failed++;
+
+  if (test('addOpenHandsHookEntry appends into an existing matching group alongside other hooks', () => {
+    const base = {
+      [PRE_TOOL_USE_EVENT]: [
+        { matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node .openhands/hooks/other.js' }] },
+      ],
+    };
+    const { config } = addOpenHandsHookEntry(base, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(config[PRE_TOOL_USE_EVENT].length, 1);
+    assert.strictEqual(config[PRE_TOOL_USE_EVENT][0].hooks.length, 2);
+    assert.ok(config[PRE_TOOL_USE_EVENT][0].hooks.some(h => h.command === 'node .openhands/hooks/other.js'));
+    assert.ok(config[PRE_TOOL_USE_EVENT][0].hooks.some(h => h.command === 'node adapter.js'));
+  })) passed++; else failed++;
+
+  if (test('addOpenHandsHookEntry preserves unrelated matcher groups and event keys', () => {
+    const base = {
+      [PRE_TOOL_USE_EVENT]: [{ matcher: 'file_write', hooks: [{ type: 'command', command: 'node audit.js' }] }],
+      post_tool_use: [{ matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node log.js' }] }],
+    };
+    const { config } = addOpenHandsHookEntry(base, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(config[PRE_TOOL_USE_EVENT].length, 2);
+    assert.ok(config[PRE_TOOL_USE_EVENT].some(g => g.matcher === 'file_write'));
+    assert.deepStrictEqual(config.post_tool_use, base.post_tool_use);
+  })) passed++; else failed++;
+
+  if (test('applyOpenHandsGuardianHookToFile writes a fresh hooks.json and is idempotent on disk', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openhands-hooks-apply-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      const first = applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js');
+      assert.strictEqual(first.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDisk[PRE_TOOL_USE_EVENT][0].matcher, TERMINAL_MATCHER);
+      assert.strictEqual(onDisk[PRE_TOOL_USE_EVENT][0].hooks.length, 1);
+
+      applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js');
+      const onDiskAgain = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDiskAgain[PRE_TOOL_USE_EVENT][0].hooks.length, 1, 'must not duplicate the entry on re-apply');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyOpenHandsGuardianHookToFile preserves a hand-written hooks.json on disk', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openhands-hooks-preserve-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, JSON.stringify({
+        post_tool_use: [{ matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node log.js' }] }],
+      }, null, 2));
+
+      applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js');
+
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.deepStrictEqual(onDisk.post_tool_use, [
+        { matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node log.js' }] },
+      ]);
+      assert.ok(onDisk[PRE_TOOL_USE_EVENT][0].hooks[0].command.includes('adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyOpenHandsGuardianHookToFile on an empty file behaves like a missing one', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openhands-hooks-empty-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, '   ');
+      const result = applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js');
+      assert.strictEqual(result.changed, true);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyOpenHandsGuardianHookToFile throws a clear error on invalid JSON', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openhands-hooks-invalid-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, '{not valid json');
+      assert.throws(() => applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js'), /Failed to parse OpenHands hooks config/);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyOpenHandsGuardianHookToFile throws a clear error when the file is not a JSON object', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openhands-hooks-nonobject-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      fs.writeFileSync(hooksJsonPath, '[1, 2, 3]');
+      assert.throws(() => applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js'), /expected a JSON object/);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsHookEntry drops only the EGC hook, keeps sibling hooks in the same group', () => {
+    const base = {
+      [PRE_TOOL_USE_EVENT]: [
+        {
+          matcher: TERMINAL_MATCHER,
+          hooks: [
+            { type: 'command', command: 'node other.js' },
+            { type: 'command', command: 'node adapter.js' },
+          ],
+        },
+      ],
+    };
+    const { config, changed } = removeOpenHandsHookEntry(base, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(config[PRE_TOOL_USE_EVENT], [
+      { matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node other.js' }] },
+    ]);
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsHookEntry deletes the matcher group entirely once its hooks are empty', () => {
+    const base = {
+      [PRE_TOOL_USE_EVENT]: [{ matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node adapter.js' }] }],
+    };
+    const { config, changed } = removeOpenHandsHookEntry(base, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(changed, true);
+    assert.strictEqual(PRE_TOOL_USE_EVENT in config, false);
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsHookEntry preserves unrelated matcher groups after emptying ours', () => {
+    const base = {
+      [PRE_TOOL_USE_EVENT]: [
+        { matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node adapter.js' }] },
+        { matcher: 'file_write', hooks: [{ type: 'command', command: 'node audit.js' }] },
+      ],
+    };
+    const { config } = removeOpenHandsHookEntry(base, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(config[PRE_TOOL_USE_EVENT].length, 1);
+    assert.strictEqual(config[PRE_TOOL_USE_EVENT][0].matcher, 'file_write');
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsHookEntry treats a non-object config and a non-array event value as empty', () => {
+    const fromNull = removeOpenHandsHookEntry(null, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(fromNull.changed, false);
+
+    const fromMalformedEvent = removeOpenHandsHookEntry({ [PRE_TOOL_USE_EVENT]: 'not-an-array' }, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(fromMalformedEvent.changed, false);
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsHookEntry treats a matching group with a non-array hooks field as empty', () => {
+    const base = { [PRE_TOOL_USE_EVENT]: [{ matcher: TERMINAL_MATCHER, hooks: 'not-an-array' }] };
+    const { config, changed } = removeOpenHandsHookEntry(base, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(changed, false);
+    assert.strictEqual(config, base);
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsHookEntry is a no-op when the entry is not present', () => {
+    const base = { [PRE_TOOL_USE_EVENT]: [{ matcher: TERMINAL_MATCHER, hooks: [{ type: 'command', command: 'node other.js' }] }] };
+    const { config, changed } = removeOpenHandsHookEntry(base, PRE_TOOL_USE_EVENT, TERMINAL_MATCHER, 'node adapter.js');
+    assert.strictEqual(changed, false);
+    assert.strictEqual(config, base);
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsGuardianHookFromFile on a missing file is a no-op', () => {
+    const result = removeOpenHandsGuardianHookFromFile('/nonexistent/hooks.json', '/abs/adapter.js');
+    assert.strictEqual(result.changed, false);
+  })) passed++; else failed++;
+
+  if (test('removeOpenHandsGuardianHookFromFile removes the entry from an existing file', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openhands-hooks-remove-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js');
+      const result = removeOpenHandsGuardianHookFromFile(hooksJsonPath, '/abs/adapter.js');
+      assert.strictEqual(result.changed, true);
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(PRE_TOOL_USE_EVENT in onDisk, false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectOpenHandsGuardianHookFile reports drifted when missing, ok when present, drifted on parse error', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openhands-hooks-inspect-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      assert.strictEqual(inspectOpenHandsGuardianHookFile(hooksJsonPath, '/abs/adapter.js'), 'drifted');
+      applyOpenHandsGuardianHookToFile(hooksJsonPath, '/abs/adapter.js');
+      assert.strictEqual(inspectOpenHandsGuardianHookFile(hooksJsonPath, '/abs/adapter.js'), 'ok');
+
+      fs.writeFileSync(hooksJsonPath, '{not valid json');
+      assert.strictEqual(inspectOpenHandsGuardianHookFile(hooksJsonPath, '/abs/adapter.js'), 'drifted');
+
+      fs.writeFileSync(hooksJsonPath, JSON.stringify({ [PRE_TOOL_USE_EVENT]: 'not-an-array' }));
+      assert.strictEqual(inspectOpenHandsGuardianHookFile(hooksJsonPath, '/abs/adapter.js'), 'drifted');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/auto-update.test.js
+++ b/tests/scripts/auto-update.test.js
@@ -580,31 +580,39 @@ function runTests() {
   })) passed += 1; else failed += 1;
 
   if (test('deriveRepoRootFromState skips fallback entries missing a relative path or resolving to zero path segments', () => {
-    const state = {
-      operations: [
-        {
-          // Present sourcePath but no sourceRelativePath at all: the fallback
-          // loop must skip past it instead of dereferencing a missing field.
-          sourcePath: path.join('/tmp', 'egc-fallback', 'no-relative-path.js'),
-          sourceRelativePath: undefined,
-        },
-        {
-          // Backslashes are not path separators on POSIX, so path.join keeps
-          // this out of the __dirname fast path (the joined path never
-          // exists), while the fallback loop's split(/[\\/]+/) regex still
-          // treats them as separators and collapses this to zero segments.
-          sourcePath: path.join('/tmp', 'egc-fallback', 'zero-segments.js'),
-          sourceRelativePath: '\\\\',
-        },
-        {
-          sourcePath: path.join('/tmp', 'egc-fallback', 'pkg', 'nested', 'file.js'),
-          sourceRelativePath: 'custom-nonexistent-marker.js',
-        },
-      ],
-    };
+    const operations = [
+      {
+        // Present sourcePath but no sourceRelativePath at all: the fallback
+        // loop must skip past it instead of dereferencing a missing field.
+        sourcePath: path.join('/tmp', 'egc-fallback', 'no-relative-path.js'),
+        sourceRelativePath: undefined,
+      },
+    ];
+
+    // A sourceRelativePath made only of separator characters is what makes
+    // the fallback loop's split(/[\\/]+/) regex collapse to zero segments.
+    // On POSIX, backslashes are not path separators, so path.join keeps this
+    // entry out of the __dirname fast path (the joined path never exists) and
+    // the fallback loop reaches the zero-segments skip. On Windows, path.join
+    // treats backslashes exactly like forward slashes and normalizes a
+    // pure-separator argument away entirely, so the joined path collapses to
+    // the (always-existing) package root itself and wrongly satisfies the
+    // fast path. There is no separator-only string that defeats the fast
+    // path on Windows, so this specific sub-case is POSIX-only.
+    if (process.platform !== 'win32') {
+      operations.push({
+        sourcePath: path.join('/tmp', 'egc-fallback', 'zero-segments.js'),
+        sourceRelativePath: '\\\\',
+      });
+    }
+
+    operations.push({
+      sourcePath: path.join('/tmp', 'egc-fallback', 'pkg', 'nested', 'file.js'),
+      sourceRelativePath: 'custom-nonexistent-marker.js',
+    });
 
     assert.strictEqual(
-      deriveRepoRootFromState(state),
+      deriveRepoRootFromState({ operations }),
       path.resolve(path.join('/tmp', 'egc-fallback', 'pkg', 'nested'))
     );
   })) passed += 1; else failed += 1;

--- a/tests/scripts/auto-update.test.js
+++ b/tests/scripts/auto-update.test.js
@@ -6,17 +6,22 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const {
   parseArgs,
   deriveRepoRootFromState,
   buildInstallApplyArgs,
   determineInstallCwd,
+  runCognitiveBootstrap,
   runAutoUpdate,
 } = require('../../scripts/auto-update');
 const {
   createInstallState,
+  writeInstallState,
 } = require('../../scripts/lib/install-state');
+
+const AUTO_UPDATE_SCRIPT_PATH = path.join(__dirname, '..', '..', 'scripts', 'auto-update.js');
 
 function test(name, fn) {
   try {
@@ -79,6 +84,45 @@ function ensureFakeRepo(repoRoot) {
     JSON.stringify({ name: 'everything-gemini', version: '1.10.0' }, null, 2)
   );
   fs.writeFileSync(path.join(repoRoot, 'scripts', 'install-apply.js'), '#!/usr/bin/env node\n');
+}
+
+// Same shape as ensureFakeRepo but with no .git directory, matching an
+// npm-installed EGC checkout so performGitUpdate takes the "installed via
+// npm" branch instead of shelling out to real git.
+function ensureFakeNpmRepo(repoRoot) {
+  fs.mkdirSync(path.join(repoRoot, 'scripts'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoRoot, 'package.json'),
+    JSON.stringify({ name: 'everything-gemini', version: '1.10.0' }, null, 2)
+  );
+  fs.writeFileSync(path.join(repoRoot, 'scripts', 'install-apply.js'), '#!/usr/bin/env node\n');
+}
+
+function writeGeminiInstallState(projectRoot) {
+  const targetRoot = path.join(projectRoot, '.gemini');
+  const installStatePath = path.join(targetRoot, 'egc-install-state.json');
+  const state = createInstallState({
+    adapter: { id: 'gemini-project', target: 'gemini', kind: 'project' },
+    targetRoot,
+    installStatePath,
+    request: {
+      profile: null,
+      modules: [],
+      includeComponents: [],
+      excludeComponents: [],
+      legacyLanguages: [],
+      legacyMode: false,
+    },
+    resolution: { selectedModules: [], skippedModules: [] },
+    operations: [],
+    source: {
+      repoVersion: '1.0.0',
+      repoCommit: 'abc123',
+      manifestVersion: 1,
+    },
+  });
+  writeInstallState(installStatePath, state);
+  return installStatePath;
 }
 
 function runTests() {
@@ -533,6 +577,464 @@ function runTests() {
       cleanup(projectRoot);
       cleanup(repoRoot);
     }
+  })) passed += 1; else failed += 1;
+
+  if (test('deriveRepoRootFromState skips fallback entries missing a relative path or resolving to zero path segments', () => {
+    const state = {
+      operations: [
+        {
+          // Present sourcePath but no sourceRelativePath at all: the fallback
+          // loop must skip past it instead of dereferencing a missing field.
+          sourcePath: path.join('/tmp', 'egc-fallback', 'no-relative-path.js'),
+          sourceRelativePath: undefined,
+        },
+        {
+          // Backslashes are not path separators on POSIX, so path.join keeps
+          // this out of the __dirname fast path (the joined path never
+          // exists), while the fallback loop's split(/[\\/]+/) regex still
+          // treats them as separators and collapses this to zero segments.
+          sourcePath: path.join('/tmp', 'egc-fallback', 'zero-segments.js'),
+          sourceRelativePath: '\\\\',
+        },
+        {
+          sourcePath: path.join('/tmp', 'egc-fallback', 'pkg', 'nested', 'file.js'),
+          sourceRelativePath: 'custom-nonexistent-marker.js',
+        },
+      ],
+    };
+
+    assert.strictEqual(
+      deriveRepoRootFromState(state),
+      path.resolve(path.join('/tmp', 'egc-fallback', 'pkg', 'nested'))
+    );
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate rejects a repo root missing package.json', () => {
+    const repoRoot = createTempDir('auto-update-missing-pkg-');
+    try {
+      assert.throws(
+        () => runAutoUpdate(
+          { repoRoot },
+          { discoverInstalledStates: () => [] }
+        ),
+        /missing package\.json/
+      );
+    } finally {
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate rejects a repo root missing the install-apply.js script', () => {
+    const repoRoot = createTempDir('auto-update-missing-install-apply-');
+    try {
+      fs.writeFileSync(
+        path.join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'x', version: '1.0.0' })
+      );
+
+      assert.throws(
+        () => runAutoUpdate(
+          { repoRoot },
+          { discoverInstalledStates: () => [] }
+        ),
+        /missing install script/
+      );
+    } finally {
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate reports an error result and bails out when no repo root can be resolved', () => {
+    const homeDir = createTempDir('auto-update-norepo-home-');
+    const projectRoot = createTempDir('auto-update-norepo-project-');
+
+    try {
+      const brokenRecord = {
+        adapter: { id: 'broken-adapter', target: 'broken', kind: 'home' },
+        targetRoot: path.join(homeDir, '.broken'),
+        installStatePath: path.join(homeDir, '.broken', 'egc-install-state.json'),
+        exists: true,
+        state: null,
+        error: 'Corrupted install-state JSON',
+      };
+
+      const result = runAutoUpdate(
+        { homeDir, projectRoot, dryRun: true },
+        { discoverInstalledStates: () => [brokenRecord] }
+      );
+
+      assert.strictEqual(result.repoRoot, null);
+      assert.strictEqual(result.results.length, 1);
+      assert.strictEqual(result.results[0].status, 'error');
+      assert.strictEqual(result.results[0].error, 'Corrupted install-state JSON');
+      assert.strictEqual(result.summary.checkedCount, 1);
+      assert.strictEqual(result.summary.updatedCount, 0);
+      assert.strictEqual(result.summary.errorCount, 1);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runCognitiveBootstrap returns an error status when the bootstrap script execution throws', () => {
+    const repoRoot = createTempDir('auto-update-cognitive-error-');
+    try {
+      fs.mkdirSync(path.join(repoRoot, 'scripts'), { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, 'scripts', 'bootstrap-cognitive.js'), '#!/usr/bin/env node\n');
+
+      const result = runCognitiveBootstrap(repoRoot, process.env, () => {
+        throw new Error('bootstrap exploded');
+      });
+
+      assert.deepStrictEqual(result, { status: 'error', error: 'bootstrap exploded' });
+    } finally {
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate rethrows a git pull failure whose message does not mention upstream tracking', () => {
+    const homeDir = createTempDir('auto-update-pull-rethrow-home-');
+    const projectRoot = createTempDir('auto-update-pull-rethrow-project-');
+    const repoRoot = createTempDir('auto-update-pull-rethrow-repo-');
+
+    try {
+      ensureFakeRepo(repoRoot);
+
+      const records = [
+        makeRecord({
+          repoRoot,
+          homeDir,
+          projectRoot,
+          adapter: { id: 'cursor-project', target: 'cursor', kind: 'project' },
+          request: {
+            profile: 'core',
+            modules: [],
+            includeComponents: [],
+            excludeComponents: [],
+            legacyLanguages: [],
+            legacyMode: false,
+          },
+          resolution: { selectedModules: ['rules-core'], skippedModules: [] },
+          operations: [
+            {
+              kind: 'copy-file',
+              moduleId: 'rules-core',
+              sourcePath: path.join(repoRoot, '.cursor', 'mcp.json'),
+              sourceRelativePath: path.join('.cursor', 'mcp.json'),
+              destinationPath: path.join(projectRoot, '.cursor', 'mcp.json'),
+              strategy: 'sync-root-children',
+              ownership: 'managed',
+              scaffoldOnly: false,
+            },
+          ],
+        }),
+      ];
+
+      assert.throws(
+        () => runAutoUpdate(
+          { homeDir, projectRoot, repoRoot, dryRun: false },
+          {
+            discoverInstalledStates: () => records,
+            runExternalCommand: (command, args) => {
+              if (command === 'git' && args[0] === 'pull') {
+                throw new Error('fatal: Not possible to fast-forward, aborting.');
+              }
+              return { stdout: '', stderr: '' };
+            },
+          }
+        ),
+        /Not possible to fast-forward/
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate uses the real runExternalCommand to fetch and surfaces the friendly upstream error on a real git pull failure', () => {
+    const homeDir = createTempDir('auto-update-realgit-home-');
+    const projectRoot = createTempDir('auto-update-realgit-project-');
+    const repoRoot = createTempDir('auto-update-realgit-repo-');
+
+    try {
+      ensureFakeRepo(repoRoot);
+      // Replace the placeholder .git dir from ensureFakeRepo with a real,
+      // freshly initialized repo that has a commit but no remote/upstream,
+      // so the unmocked runExternalCommand really shells out to git.
+      fs.rmSync(path.join(repoRoot, '.git'), { recursive: true, force: true });
+      spawnSync('git', ['init'], { cwd: repoRoot, encoding: 'utf8' });
+      spawnSync('git', ['config', 'user.email', 'egc-test@example.com'], { cwd: repoRoot, encoding: 'utf8' });
+      spawnSync('git', ['config', 'user.name', 'EGC Test'], { cwd: repoRoot, encoding: 'utf8' });
+      fs.writeFileSync(path.join(repoRoot, 'README.md'), 'placeholder');
+      spawnSync('git', ['add', '.'], { cwd: repoRoot, encoding: 'utf8' });
+      spawnSync('git', ['commit', '-m', 'init'], { cwd: repoRoot, encoding: 'utf8' });
+
+      const records = [
+        makeRecord({
+          repoRoot,
+          homeDir,
+          projectRoot,
+          adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+          request: {
+            profile: null,
+            modules: [],
+            includeComponents: [],
+            excludeComponents: [],
+            legacyLanguages: ['typescript'],
+            legacyMode: true,
+          },
+          resolution: { selectedModules: ['legacy-egc-rules'], skippedModules: [] },
+          operations: [
+            {
+              kind: 'copy-file',
+              moduleId: 'legacy-egc-rules',
+              sourcePath: path.join(repoRoot, 'rules', 'common', 'coding-style.md'),
+              sourceRelativePath: path.join('rules', 'common', 'coding-style.md'),
+              destinationPath: path.join(homeDir, '.gemini', 'rules', 'common', 'coding-style.md'),
+              strategy: 'preserve-relative-path',
+              ownership: 'managed',
+              scaffoldOnly: false,
+            },
+          ],
+        }),
+      ];
+
+      // No runExternalCommand override: this exercises the real spawnSync-backed
+      // implementation, not the mocked one used by the other runAutoUpdate tests.
+      assert.throws(
+        () => runAutoUpdate(
+          { homeDir, projectRoot, repoRoot, dryRun: false },
+          { discoverInstalledStates: () => records }
+        ),
+        /git pull failed: no upstream tracking branch configured/
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('runAutoUpdate surfaces a real ENOENT spawn error when git is not resolvable on PATH', () => {
+    const homeDir = createTempDir('auto-update-enoent-home-');
+    const projectRoot = createTempDir('auto-update-enoent-project-');
+    const repoRoot = createTempDir('auto-update-enoent-repo-');
+    const emptyPathDir = createTempDir('auto-update-enoent-emptypath-');
+    const originalPath = process.env.PATH;
+
+    try {
+      ensureFakeRepo(repoRoot);
+
+      const records = [
+        makeRecord({
+          repoRoot,
+          homeDir,
+          projectRoot,
+          adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+          request: {
+            profile: null,
+            modules: [],
+            includeComponents: [],
+            excludeComponents: [],
+            legacyLanguages: ['typescript'],
+            legacyMode: true,
+          },
+          resolution: { selectedModules: ['legacy-egc-rules'], skippedModules: [] },
+          operations: [
+            {
+              kind: 'copy-file',
+              moduleId: 'legacy-egc-rules',
+              sourcePath: path.join(repoRoot, 'rules', 'common', 'coding-style.md'),
+              sourceRelativePath: path.join('rules', 'common', 'coding-style.md'),
+              destinationPath: path.join(homeDir, '.gemini', 'rules', 'common', 'coding-style.md'),
+              strategy: 'preserve-relative-path',
+              ownership: 'managed',
+              scaffoldOnly: false,
+            },
+          ],
+        }),
+      ];
+
+      // Point PATH at an empty directory so the real runExternalCommand's
+      // spawnSync('git', ...) call cannot resolve the git executable and
+      // surfaces result.error (ENOENT) instead of a status code.
+      process.env.PATH = emptyPathDir;
+
+      assert.throws(
+        () => runAutoUpdate(
+          { homeDir, projectRoot, repoRoot, dryRun: false },
+          { discoverInstalledStates: () => records }
+        ),
+        error => error.code === 'ENOENT'
+      );
+    } finally {
+      process.env.PATH = originalPath;
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+      cleanup(emptyPathDir);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('auto-update.js CLI prints the empty-state message and exits 0 when no install-state files exist', () => {
+    const homeDir = createTempDir('auto-update-cli-empty-home-');
+    const projectRoot = createTempDir('auto-update-cli-empty-project-');
+
+    try {
+      const result = spawnSync(process.execPath, [AUTO_UPDATE_SCRIPT_PATH], {
+        cwd: projectRoot,
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+        encoding: 'utf8',
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(
+        result.stdout.includes('No EGC install-state files found'),
+        result.stdout
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('auto-update.js CLI dry-run summary lists a planned target with reinstall args', () => {
+    const homeDir = createTempDir('auto-update-cli-dryrun-home-');
+    const projectRoot = createTempDir('auto-update-cli-dryrun-project-');
+    const repoRoot = createTempDir('auto-update-cli-dryrun-repo-');
+
+    try {
+      ensureFakeNpmRepo(repoRoot);
+      fs.writeFileSync(
+        path.join(repoRoot, 'scripts', 'install-apply.js'),
+        '#!/usr/bin/env node\nconsole.log(JSON.stringify({ dryRun: true, result: { ok: true } }));\n'
+      );
+      writeGeminiInstallState(projectRoot);
+
+      const result = spawnSync(process.execPath, [
+        AUTO_UPDATE_SCRIPT_PATH,
+        '--repo-root', repoRoot,
+        '--target', 'gemini',
+        '--dry-run',
+      ], {
+        cwd: projectRoot,
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+        encoding: 'utf8',
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('Auto-update dry run:'), result.stdout);
+      assert.ok(result.stdout.includes(`Repo root: ${repoRoot}`), result.stdout);
+      assert.ok(result.stdout.includes('- gemini-project'), result.stdout);
+      assert.ok(result.stdout.includes('Status: PLANNED'), result.stdout);
+      assert.ok(result.stdout.includes('Reinstall args:'), result.stdout);
+      assert.ok(result.stdout.includes('Summary: checked=1, planned=1, errors=0'), result.stdout);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('auto-update.js CLI full run prints cognitive bootstrap output and an updated summary', () => {
+    const homeDir = createTempDir('auto-update-cli-full-home-');
+    const projectRoot = createTempDir('auto-update-cli-full-project-');
+    const repoRoot = createTempDir('auto-update-cli-full-repo-');
+
+    try {
+      ensureFakeNpmRepo(repoRoot);
+      fs.writeFileSync(
+        path.join(repoRoot, 'scripts', 'install-apply.js'),
+        '#!/usr/bin/env node\nconsole.log(JSON.stringify({ dryRun: false, result: { ok: true } }));\n'
+      );
+      fs.writeFileSync(
+        path.join(repoRoot, 'scripts', 'bootstrap-cognitive.js'),
+        '#!/usr/bin/env node\nconsole.log("[cognitive] stub bootstrap executed successfully");\n'
+      );
+      writeGeminiInstallState(projectRoot);
+
+      const result = spawnSync(process.execPath, [
+        AUTO_UPDATE_SCRIPT_PATH,
+        '--repo-root', repoRoot,
+        '--target', 'gemini',
+      ], {
+        cwd: projectRoot,
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+        encoding: 'utf8',
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('EGC is installed via npm'), result.stdout);
+      assert.ok(result.stdout.includes('Auto-update summary:'), result.stdout);
+      assert.ok(result.stdout.includes('Cognitive protocol bootstrap: OK'), result.stdout);
+      assert.ok(
+        result.stdout.includes('[cognitive] stub bootstrap executed successfully'),
+        result.stdout
+      );
+      assert.ok(result.stdout.includes('- gemini-project'), result.stdout);
+      assert.ok(result.stdout.includes('Status: UPDATED'), result.stdout);
+      assert.ok(result.stdout.includes('Summary: checked=1, updated=1, errors=0'), result.stdout);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('auto-update.js CLI prints bootstrap and per-target errors, exiting with a non-zero status', () => {
+    const homeDir = createTempDir('auto-update-cli-err-home-');
+    const projectRoot = createTempDir('auto-update-cli-err-project-');
+    const repoRoot = createTempDir('auto-update-cli-err-repo-');
+
+    try {
+      ensureFakeNpmRepo(repoRoot);
+      fs.writeFileSync(
+        path.join(repoRoot, 'scripts', 'install-apply.js'),
+        '#!/usr/bin/env node\nconsole.error("install-apply stub failed intentionally");\nprocess.exit(1);\n'
+      );
+      fs.writeFileSync(
+        path.join(repoRoot, 'scripts', 'bootstrap-cognitive.js'),
+        '#!/usr/bin/env node\nconsole.error("bootstrap-cognitive stub failed intentionally");\nprocess.exit(1);\n'
+      );
+      writeGeminiInstallState(projectRoot);
+
+      const result = spawnSync(process.execPath, [
+        AUTO_UPDATE_SCRIPT_PATH,
+        '--repo-root', repoRoot,
+        '--target', 'gemini',
+      ], {
+        cwd: projectRoot,
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+        encoding: 'utf8',
+      });
+
+      assert.strictEqual(result.status, 1, result.stdout + result.stderr);
+      assert.ok(result.stdout.includes('Cognitive protocol bootstrap: ERROR'), result.stdout);
+      assert.ok(
+        result.stdout.includes('bootstrap-cognitive stub failed intentionally'),
+        result.stdout
+      );
+      assert.ok(result.stdout.includes('Status: ERROR'), result.stdout);
+      assert.ok(
+        result.stdout.includes('install-apply stub failed intentionally'),
+        result.stdout
+      );
+      assert.ok(result.stdout.includes('Summary: checked=1, updated=0, errors=1'), result.stdout);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(repoRoot);
+    }
+  })) passed += 1; else failed += 1;
+
+  if (test('auto-update.js CLI exits 1 and prints an error for unknown arguments', () => {
+    const result = spawnSync(process.execPath, [AUTO_UPDATE_SCRIPT_PATH, '--bogus'], {
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes('Error: Unknown argument: --bogus'), result.stderr);
   })) passed += 1; else failed += 1;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);

--- a/tests/scripts/bootstrap-cognitive.test.js
+++ b/tests/scripts/bootstrap-cognitive.test.js
@@ -65,6 +65,78 @@ const SESSION_BUS_COMMANDS = [
   'working_memory_get', 'working_memory_set', 'working_memory_list',
 ];
 
+// Claude Code and Gemini CLI share injectProtocol() with Windsurf/Zed below,
+// but unlike those two, no other test in this suite ever creates ~/.claude
+// or ~/.gemini, so their install and error-catch branches were never
+// exercised. Split out to keep runTests() shallow, same reasoning as the
+// helpers below.
+async function runClaudeCodeAndGeminiCliTests() {
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('Claude Code: appends the protocol block to an existing CLAUDE.md that has no marker at all, preserving prior content', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.claude'));
+      const target = path.join(home, '.claude', 'CLAUDE.md');
+      const original = '# My custom instructions\n\nKeep this line.\n';
+      fs.writeFileSync(target, original, 'utf8');
+
+      const output = run(home);
+      assert.ok(/Claude Code: memory protocol installed/.test(output), `should report install, got: ${output}`);
+
+      const content = fs.readFileSync(target, 'utf8');
+      assert.ok(content.includes('Keep this line.'), 'prior content must be preserved, not overwritten');
+      assert.ok(content.includes('<!-- egc-memory-protocol:v2 -->'), 'protocol block must be appended');
+      assert.strictEqual(fs.readFileSync(target + '.egc.bak', 'utf8'), original, 'backup must hold the pre-append content');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Claude Code: logs an error instead of crashing when the CLAUDE.md path is structurally broken', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.claude'));
+      // CLAUDE.md is a directory, not a file: readFileSync on it fails structurally
+      // (EISDIR) on every OS, unlike a permission-based failure.
+      fs.mkdirSync(path.join(home, '.claude', 'CLAUDE.md'));
+      const output = run(home);
+      assert.ok(/Claude Code: unexpected error:/.test(output), 'should report the error, not crash');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('writes Gemini CLI GEMINI.md when ~/.gemini exists', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.gemini'));
+      const output = run(home);
+      assert.ok(/Gemini CLI: memory protocol installed/.test(output), 'should report install');
+      const target = path.join(home, '.gemini', 'GEMINI.md');
+      const content = fs.readFileSync(target, 'utf8');
+      assert.ok(/<!-- egc-memory-protocol(?::v\d+)? -->/.test(content), 'marker must be present');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Gemini CLI: logs an error instead of crashing when the GEMINI.md path is structurally broken', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.gemini'));
+      fs.mkdirSync(path.join(home, '.gemini', 'GEMINI.md'));
+      const output = run(home);
+      assert.ok(/Gemini CLI: unexpected error:/.test(output), 'should report the error, not crash');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  return [passed, failed];
+}
+
 // Split out from runTests() to keep its cyclomatic complexity down: covers
 // the two non-markdown protocol formats (Cursor's JSON cursor.rules, Codex's
 // TOML persistent_instructions), each needing its own upgrade-from-legacy
@@ -190,6 +262,134 @@ async function runCursorAndCodexUpgradeTests() {
   return [passed, failed];
 }
 
+// Additional Cursor/Codex branches not covered by the upgrade-focused tests
+// above: the injectProtocol() fallback used when no settings.json exists at
+// all, the invalid-JSON skip path, Codex's two skip statuses (multiline and
+// unrecognized), Codex appending fresh when the key is entirely absent, and
+// both bootstrap functions' own top-level catch blocks. Split out for the
+// same complexity-budget reason as runCursorAndCodexUpgradeTests().
+async function runCursorAndCodexEdgeCaseTests() {
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('Cursor: falls back to injectProtocol on ~/.cursor/rules when no settings.json exists anywhere', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.cursor'));
+      const output = run(home);
+      assert.ok(/Cursor: memory protocol installed/.test(output), `should report install, got: ${output}`);
+      const target = path.join(home, '.cursor', 'rules');
+      const content = fs.readFileSync(target, 'utf8');
+      assert.ok(content.includes('<!-- egc-memory-protocol:v2 -->'), 'protocol block must be written to ~/.cursor/rules');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Cursor: settings.json with invalid JSON (JSONC-style) is skipped without modification', () => {
+    const home = mktempHome();
+    try {
+      const cursorSettingsDir = path.join(home, '.config', 'Cursor', 'User');
+      fs.mkdirSync(cursorSettingsDir, { recursive: true });
+      const settingsFile = path.join(cursorSettingsDir, 'settings.json');
+      const invalidJson = '{\n  // a JSONC comment, invalid in strict JSON\n  "editor.fontSize": 14,\n}\n';
+      fs.writeFileSync(settingsFile, invalidJson, 'utf8');
+
+      const output = run(home);
+      assert.ok(/settings\.json is not valid JSON \(JSONC\?\): skipping/.test(output), `should report the skip, got: ${output}`);
+      assert.strictEqual(fs.readFileSync(settingsFile, 'utf8'), invalidJson, 'invalid settings.json must be left untouched');
+      assert.ok(!fs.existsSync(settingsFile + '.egc.bak'), 'no backup should be written when the file is skipped');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Cursor: logs an error instead of crashing when the settings.json path is structurally broken', () => {
+    const home = mktempHome();
+    try {
+      const cursorSettingsDir = path.join(home, '.config', 'Cursor', 'User');
+      fs.mkdirSync(cursorSettingsDir, { recursive: true });
+      // settings.json is a directory, not a file: readFileSync on it fails
+      // structurally (EISDIR) on every OS, unlike a permission-based failure.
+      fs.mkdirSync(path.join(cursorSettingsDir, 'settings.json'));
+      const output = run(home);
+      assert.ok(/Cursor: unexpected error:/.test(output), 'should report the error, not crash');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Codex: a triple-quoted multiline persistent_instructions is skipped without modification', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      const tomlPath = path.join(home, '.codex', 'config.toml');
+      const original = 'persistent_instructions = """\nLegacy multiline text mentioning get_state.\n"""\n';
+      fs.writeFileSync(tomlPath, original, 'utf8');
+
+      const output = run(home);
+      assert.ok(/Codex: persistent_instructions multiline: skipping/.test(output), `should report the skip, got: ${output}`);
+      assert.strictEqual(fs.readFileSync(tomlPath, 'utf8'), original, 'multiline persistent_instructions must be left untouched');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Codex: an unrecognized (non-string) persistent_instructions value is skipped without modification', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      const tomlPath = path.join(home, '.codex', 'config.toml');
+      const original = 'persistent_instructions = 12345\n';
+      fs.writeFileSync(tomlPath, original, 'utf8');
+
+      const output = run(home);
+      assert.ok(/Codex: persistent_instructions in unrecognized format: skipping/.test(output), `should report the skip, got: ${output}`);
+      assert.strictEqual(fs.readFileSync(tomlPath, 'utf8'), original, 'unrecognized persistent_instructions must be left untouched');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Codex: an existing config.toml with no persistent_instructions key at all gets one appended fresh', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      const tomlPath = path.join(home, '.codex', 'config.toml');
+      const original = '[some_other_section]\nfoo = "bar"\n';
+      fs.writeFileSync(tomlPath, original, 'utf8');
+
+      const output = run(home);
+      assert.ok(/Codex: memory protocol installed/.test(output), `should report a fresh install, got: ${output}`);
+
+      const content = fs.readFileSync(tomlPath, 'utf8');
+      assert.ok(content.includes('[some_other_section]'), 'pre-existing unrelated TOML content must be preserved');
+      assert.ok(content.includes('foo = "bar"'), 'pre-existing unrelated TOML content must be preserved');
+      const match = content.match(/^persistent_instructions = "(.*)"$/m);
+      assert.ok(match, 'persistent_instructions must be appended as a single-line double-quoted TOML string');
+      assert.ok(match[1].includes('[egc-protocol:v2]'), 'appended value must carry the current version marker');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Codex: logs an error instead of crashing when the config.toml path is structurally broken', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.codex'));
+      // config.toml is a directory, not a file: readFileSync on it fails
+      // structurally (EISDIR) on every OS, unlike a permission-based failure.
+      fs.mkdirSync(path.join(home, '.codex', 'config.toml'));
+      const output = run(home);
+      assert.ok(/Codex: unexpected error:/.test(output), 'should report the error, not crash');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  return [passed, failed];
+}
+
 // Same complexity-budget reasoning as above: the 4 standalone markdown
 // targets (OpenCode, Trae, CodeBuddy, Continue.dev) each need the same pair
 // of upgrade-from-legacy / stay-idempotent-at-v2 cases.
@@ -241,15 +441,115 @@ async function runStandaloneTargetUpgradeTests() {
   return [passed, failed];
 }
 
+// Each standalone markdown target's own top-level catch block (OpenCode,
+// Trae, CodeBuddy, Continue.dev) was never exercised by any existing test,
+// since none of them ever hand injectStandaloneProtocol() a structurally
+// broken path. Split out for the same complexity-budget reason as the
+// helpers above.
+async function runStandaloneCatchBlockTests() {
+  const BROKEN_PATH_TARGETS = [
+    { home: '.opencode', target: ['.opencode', 'instructions', 'EGC_MEMORY.md'], label: 'OpenCode' },
+    { home: '.trae', target: ['.trae', 'MEMORY.md'], label: 'Trae' },
+    { home: '.codebuddy', target: ['.codebuddy', 'MEMORY.md'], label: 'CodeBuddy' },
+    { home: '.continue', target: ['.continue', 'prompts', 'egc-memory.prompt'], label: 'Continue.dev' },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const spec of BROKEN_PATH_TARGETS) {
+    if (await test(`${spec.label}: logs an error instead of crashing when its target path is structurally broken`, () => {
+      const home = mktempHome();
+      try {
+        fs.mkdirSync(path.join(home, spec.home), { recursive: true });
+        // The target file is itself a directory: readFileSync on it fails
+        // structurally (EISDIR) on every OS, unlike a permission-based failure.
+        fs.mkdirSync(path.join(home, ...spec.target), { recursive: true });
+        const output = run(home);
+        assert.ok(output.includes(`${spec.label}: unexpected error:`), `should report the error for ${spec.label}, not crash, got: ${output}`);
+      } finally {
+        cleanup(home);
+      }
+    })) passed++; else failed++;
+  }
+
+  return [passed, failed];
+}
+
+// Kiro's bootstrap function was entirely untested: with no ~/.kiro directory
+// created by any test above, the early existsSync guard always took the
+// false branch, so the hook-copy loop, the installed/already-configured
+// messages, and the catch block never ran.
+async function runKiroTests() {
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('Kiro: installs session hooks when ~/.kiro exists and the hooks directory is missing', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.kiro'));
+      const output = run(home);
+      assert.ok(/Kiro: session hooks installed/.test(output), `should report install, got: ${output}`);
+
+      const hooksDir = path.join(home, '.kiro', 'hooks');
+      for (const hook of ['session-restore.kiro.hook', 'session-save.kiro.hook']) {
+        assert.ok(fs.existsSync(path.join(hooksDir, hook)), `${hook} must be copied into ~/.kiro/hooks`);
+      }
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Kiro: already-installed hooks are left untouched on rerun (idempotent)', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.kiro'));
+      run(home);
+      const second = run(home);
+      assert.ok(/Kiro: already configured/.test(second), `second run should report already configured, got: ${second}`);
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  if (await test('Kiro: logs an error instead of crashing when the hooks path is structurally broken', () => {
+    const home = mktempHome();
+    try {
+      fs.mkdirSync(path.join(home, '.kiro'));
+      // hooks is a file, not a directory: copying a hook into it fails
+      // structurally (ENOTDIR) on every OS, unlike a permission-based failure.
+      fs.writeFileSync(path.join(home, '.kiro', 'hooks'), 'not a directory', 'utf8');
+      const output = run(home);
+      assert.ok(/Kiro: unexpected error:/.test(output), 'should report the error, not crash');
+    } finally {
+      cleanup(home);
+    }
+  })) passed++; else failed++;
+
+  return [passed, failed];
+}
+
 async function runTests() {
   console.log('\n=== Testing scripts/bootstrap-cognitive.js ===\n');
   let passed = 0;
   let failed = 0;
 
   {
+    const [claudeGeminiPassed, claudeGeminiFailed] = await runClaudeCodeAndGeminiCliTests();
+    passed += claudeGeminiPassed;
+    failed += claudeGeminiFailed;
+  }
+
+  {
     const [cursorCodexPassed, cursorCodexFailed] = await runCursorAndCodexUpgradeTests();
     passed += cursorCodexPassed;
     failed += cursorCodexFailed;
+  }
+
+  {
+    const [cursorCodexEdgePassed, cursorCodexEdgeFailed] = await runCursorAndCodexEdgeCaseTests();
+    passed += cursorCodexEdgePassed;
+    failed += cursorCodexEdgeFailed;
   }
 
   if (await test('BLOCK advertises all 9 session bus commands', () => {
@@ -453,6 +753,18 @@ async function runTests() {
     const [standalonePassed, standaloneFailed] = await runStandaloneTargetUpgradeTests();
     passed += standalonePassed;
     failed += standaloneFailed;
+  }
+
+  {
+    const [standaloneCatchPassed, standaloneCatchFailed] = await runStandaloneCatchBlockTests();
+    passed += standaloneCatchPassed;
+    failed += standaloneCatchFailed;
+  }
+
+  {
+    const [kiroPassed, kiroFailed] = await runKiroTests();
+    passed += kiroPassed;
+    failed += kiroFailed;
   }
 
   if (await test('writes Zed AGENTS.md when ~/.config/zed exists', () => {

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -20,6 +20,7 @@ const {
   createInstallState,
   writeInstallState,
 } = require('../../scripts/lib/install-state');
+const { getEGCDir } = require('../../scripts/lib/utils');
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -32,6 +33,30 @@ function cleanup(dirPath) {
 function writeState(filePath, options) {
   const state = createInstallState(options);
   writeInstallState(filePath, state);
+}
+
+// getEGCDir() resolves purely from process.env at call time, so swapping
+// HOME/USERPROFILE here and calling it in-process reproduces exactly what
+// the spawned child (run() below, which sets the same two vars) will resolve.
+function computeEGCDirForHome(homeDir) {
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+  try {
+    return getEGCDir();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    if (previousUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = previousUserProfile;
+    }
+  }
 }
 
 function run(args = [], options = {}) {
@@ -282,6 +307,167 @@ function runTests() {
       const result = run(['--repo-root'], { cwd: projectRoot, homeDir });
       assert.strictEqual(result.code, 1);
       assert.ok(result.stderr.includes('--repo-root requires a path argument'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('--help prints usage and exits 0 without running a diagnosis', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const result = run(['--help'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('Usage: node scripts/doctor.js'));
+      assert.ok(result.stdout.includes('--repo-root <path>'));
+      assert.ok(result.stdout.includes('egc auto-update --repo-root'));
+      assert.ok(!result.stdout.includes('Doctor report'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('-h prints usage and exits 0', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const result = run(['-h'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('Usage: node scripts/doctor.js'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('reports a drifted install as WARNING with issue detail in human-readable output', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const targetRoot = path.join(homeDir, '.gemini');
+      const statePath = path.join(targetRoot, 'egc', 'install-state.json');
+      const managedFile = path.join(targetRoot, 'rules', 'common', 'coding-style.md');
+      fs.mkdirSync(path.dirname(managedFile), { recursive: true });
+      fs.writeFileSync(managedFile, 'DRIFTED CONTENT, does not match the repo file\n');
+
+      writeState(statePath, {
+        adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+        targetRoot,
+        installStatePath: statePath,
+        request: {
+          profile: null,
+          modules: [],
+          legacyLanguages: ['typescript'],
+          legacyMode: true,
+        },
+        resolution: {
+          selectedModules: ['legacy-egc-rules'],
+          skippedModules: [],
+        },
+        operations: [
+          {
+            kind: 'copy-file',
+            moduleId: 'legacy-egc-rules',
+            sourceRelativePath: 'rules/common/coding-style.md',
+            destinationPath: managedFile,
+            strategy: 'preserve-relative-path',
+            ownership: 'managed',
+            scaffoldOnly: false,
+          },
+        ],
+        source: {
+          repoVersion: CURRENT_PACKAGE_VERSION,
+          repoCommit: 'abc123',
+          manifestVersion: CURRENT_MANIFEST_VERSION,
+        },
+      });
+
+      const result = run(['--target', 'egc'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 1, result.stderr);
+      assert.ok(result.stdout.includes('Status: WARNING'));
+      assert.ok(result.stdout.includes('[warning] drifted-managed-files'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('reports missing managed files as ERROR with issue detail in human-readable output', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const targetRoot = path.join(projectRoot, '.cursor');
+      const statePath = path.join(targetRoot, 'egc-install-state.json');
+      fs.mkdirSync(targetRoot, { recursive: true });
+
+      writeState(statePath, {
+        adapter: { id: 'cursor-project', target: 'cursor', kind: 'project' },
+        targetRoot,
+        installStatePath: statePath,
+        request: {
+          profile: null,
+          modules: ['platform-configs'],
+          legacyLanguages: [],
+          legacyMode: false,
+        },
+        resolution: {
+          selectedModules: ['platform-configs'],
+          skippedModules: [],
+        },
+        operations: [
+          {
+            kind: 'copy-file',
+            moduleId: 'platform-configs',
+            sourceRelativePath: '.cursor/hooks.json',
+            destinationPath: path.join(targetRoot, 'hooks.json'),
+            strategy: 'sync-root-children',
+            ownership: 'managed',
+            scaffoldOnly: false,
+          },
+        ],
+        source: {
+          repoVersion: CURRENT_PACKAGE_VERSION,
+          repoCommit: 'abc123',
+          manifestVersion: CURRENT_MANIFEST_VERSION,
+        },
+      });
+
+      const result = run(['--target', 'cursor'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 1);
+      assert.ok(result.stdout.includes('Status: ERROR'));
+      assert.ok(result.stdout.includes('[error] missing-managed-files'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('warns about a divergent database architecture when both harness and memory state.db exist', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const egcDir = computeEGCDirForHome(homeDir);
+      const dbPath = path.join(egcDir, 'egc', 'state.db');
+      const memoryDbPath = path.join(egcDir, 'memory', 'state.db');
+      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+      fs.mkdirSync(path.dirname(memoryDbPath), { recursive: true });
+      fs.writeFileSync(dbPath, '');
+      fs.writeFileSync(memoryDbPath, '');
+
+      const result = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('State store:'));
+      assert.ok(result.stdout.includes('WARNING: Divergent database architecture detected!'));
+      assert.ok(result.stdout.includes(`Harness DB: ${dbPath}`));
+      assert.ok(result.stdout.includes(`Memory DB:  ${memoryDbPath}`));
+      assert.ok(result.stdout.includes('known architectural limitation'));
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -299,6 +299,196 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('prints a human-readable message when no install-state files exist', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(repairResult.code, 0, repairResult.stderr);
+      assert.ok(repairResult.stdout.includes(
+        'No EGC install-state files found for the current home/project context.'
+      ));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('prints a human-readable repair summary for repaired entries', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const targetRoot = path.join(projectRoot, '.cursor');
+      fs.mkdirSync(targetRoot, { recursive: true });
+      const normalizedTargetRoot = fs.realpathSync(targetRoot);
+      const statePath = path.join(normalizedTargetRoot, 'egc-install-state.json');
+      const jsonPath = path.join(normalizedTargetRoot, 'hooks.json');
+      fs.writeFileSync(jsonPath, JSON.stringify({ existing: true, managed: false }, null, 2));
+
+      writeState(statePath, {
+        adapter: { id: 'cursor-project', target: 'cursor', kind: 'project' },
+        targetRoot: normalizedTargetRoot,
+        installStatePath: statePath,
+        request: {
+          profile: null,
+          modules: ['platform-configs'],
+          includeComponents: [],
+          excludeComponents: [],
+          legacyLanguages: [],
+          legacyMode: false,
+        },
+        resolution: {
+          selectedModules: ['platform-configs'],
+          skippedModules: [],
+        },
+        operations: [
+          {
+            kind: 'merge-json',
+            moduleId: 'platform-configs',
+            sourceRelativePath: '.cursor/hooks.json',
+            destinationPath: jsonPath,
+            strategy: 'merge-json',
+            ownership: 'managed',
+            scaffoldOnly: false,
+            mergePayload: {
+              managed: true,
+            },
+          },
+        ],
+        source: {
+          repoVersion: CURRENT_PACKAGE_VERSION,
+          repoCommit: 'abc123',
+          manifestVersion: CURRENT_MANIFEST_VERSION,
+        },
+      });
+
+      const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(repairResult.code, 0, repairResult.stderr);
+      assert.ok(repairResult.stdout.includes('Repair summary:'));
+      assert.ok(repairResult.stdout.includes('- cursor-project'));
+      assert.ok(repairResult.stdout.includes('Status: REPAIRED'));
+      assert.ok(repairResult.stdout.includes(`Install-state: ${statePath}`));
+      assert.ok(repairResult.stdout.includes('Repaired paths: 1'));
+      assert.ok(/Summary: checked=1, repaired=1, errors=0/.test(repairResult.stdout));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('prints a human-readable error line when an install-state entry cannot be read', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const targetRoot = path.join(projectRoot, '.cursor');
+      fs.mkdirSync(targetRoot, { recursive: true });
+      const normalizedTargetRoot = fs.realpathSync(targetRoot);
+      const statePath = path.join(normalizedTargetRoot, 'egc-install-state.json');
+      fs.writeFileSync(statePath, '{ not valid json');
+
+      const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(repairResult.code, 1, repairResult.stderr);
+      assert.ok(repairResult.stdout.includes('Repair summary:'));
+      assert.ok(repairResult.stdout.includes('Status: ERROR'));
+      assert.ok(repairResult.stdout.includes('Error: '));
+      assert.ok(!repairResult.stdout.includes('Repaired paths:'));
+      assert.ok(/Summary: checked=1, repaired=0, errors=1/.test(repairResult.stdout));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('includes plugin reinstall results in JSON output when plugins are installed', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const pluginsDir = path.join(homeDir, '.egc', 'plugins');
+      fs.mkdirSync(pluginsDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginsDir, 'plugins.json'), JSON.stringify({
+        schemaVersion: 'egc.plugins.v1',
+        installed: {
+          'example-plugin': { name: 'example-plugin', version: '1.0.0' },
+        },
+      }, null, 2));
+
+      const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor', '--json'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(repairResult.code, 1, repairResult.stderr);
+
+      const parsed = JSON.parse(repairResult.stdout);
+      assert.ok(Array.isArray(parsed.pluginRepairs));
+      assert.strictEqual(parsed.pluginRepairs.length, 1);
+      assert.strictEqual(parsed.pluginRepairs[0].name, 'example-plugin');
+      assert.strictEqual(parsed.pluginRepairs[0].success, false);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('prints plugin reinstall results in human-readable output', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const pluginsDir = path.join(homeDir, '.egc', 'plugins');
+      fs.mkdirSync(pluginsDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginsDir, 'plugins.json'), JSON.stringify({
+        schemaVersion: 'egc.plugins.v1',
+        installed: {
+          'example-plugin': { name: 'example-plugin', version: '1.0.0' },
+        },
+      }, null, 2));
+
+      const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(repairResult.code, 1, repairResult.stderr);
+      assert.ok(repairResult.stdout.includes(
+        'No EGC install-state files found for the current home/project context.'
+      ));
+      assert.ok(repairResult.stdout.includes('Plugin reinstall:'));
+      assert.ok(repairResult.stdout.includes('✗ example-plugin: plugin.json missing; cannot reinstall'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('exits with an error message for an unknown CLI argument', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const repairResult = runNode(REPAIR_SCRIPT, ['--not-a-real-flag'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(repairResult.code, 1);
+      assert.ok(repairResult.stderr.includes('Error: Unknown argument: --not-a-real-flag'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary
- openhands-guardian-hooks.js and amazonq-guardian-hooks.js had zero dedicated tests since they were introduced (34.53% and 74.03% line coverage); both now sit at 100%.
- doctor.js, repair.js, bootstrap-cognitive.js, and auto-update.js accumulated real coverage gaps across the day's incremental commits that were never closed. All four now sit at 98.5-100% line coverage.
- The two remaining small gaps are documented in the test files as unreachable defensive fallbacks, not skipped work.

## Test plan
- [x] `node tests/scripts/<file>.test.js` run in isolation for each of the six touched test files, all green
- [x] Full suite: `npx c8 --reporter=text node tests/run-all.js` -> 3793/3793 passed, 0 failed
- [x] `npm run lint` -> no new errors or warnings introduced by these changes (2 pre-existing errors in fuzz/validator.cjs, untouched by this PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive tests to close coverage gaps in Guardian hooks and maintenance scripts, bringing `auto-update`, `bootstrap-cognitive`, `doctor`, and `repair` to 98.5–100%. Also stabilizes cross-platform CI by scoping a path fallback test to POSIX systems.

- **Test Coverage**
  - New dedicated suites for `amazonq-guardian-hooks` and `openhands-guardian-hooks`.
  - Expanded `auto-update`, `bootstrap-cognitive`, `doctor`, and `repair` tests: CLI flows, real `git`/ENOENT behavior, cognitive bootstrap, help/arg errors, plugin reinstall, and human-readable summaries. Remaining uncovered lines are unreachable fallbacks.

- **Bug Fixes**
  - Made the zero-path-segments fallback test POSIX-only to avoid Windows false positives.
  - Strengthened the `buildHookCommand` test to assert exact quoting of the `node` executable and script path.

<sup>Written for commit 7b3f1cde862eb7ec7be922c5b90e41d8eca458b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

