### PR TITLE
docs(roadmap): document the real coverage gap fix from PR #1099

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@ This document describes the planned development direction for EGC (Extended Glob
 - The cognitive protocol marker is now versioned across all 11 install targets (Claude Code, Gemini CLI, Cursor, Codex, Windsurf, Zed, OpenCode, Trae, Trae-CN, CodeBuddy, and Continue.dev), so an already-configured install picks up a new protocol section, like the Token Crusher one, on the next `egc init` or `auto-update` instead of staying frozen at whatever shipped on first install; `auto-update` now re-runs the bootstrap step itself so this reaches every user who runs the update command they already use, not just fresh installs (#1093, #1095)
 - `egc run`'s git log summary now counts real commits remaining instead of raw lines, which had wildly overstated the count for verbose formats like `--stat` (#1094)
 - `install.sh` and `install.ps1` link the `egc` command to the checkout they just set up, so running `egc doctor` or `egc --version` afterward targets the code that was installed rather than a stale prior global install left on PATH (#1096)
+- Closed real test-coverage gaps the CI had flagged and left unresolved across the day's work: `openhands-guardian-hooks.js` and `amazonq-guardian-hooks.js` went from 34.53%/74.03% to 100%, and `doctor.js`, `repair.js`, `bootstrap-cognitive.js`, `auto-update.js` from 65-88% to 98.5-100% (#1099)
 
 ## v1.1.2: Bidirectional Sync (Released 2026-06-20)
 


### PR DESCRIPTION
## Summary
- One-line roadmap entry documenting the coverage gap fix that just merged (#1099).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-line entry to `docs/ROADMAP.md` documenting the real test coverage gaps closed in #1099. Notes 100% for `openhands-guardian-hooks.js` and `amazonq-guardian-hooks.js`, and 98.5–100% for `doctor.js`, `repair.js`, `bootstrap-cognitive.js`, and `auto-update.js`.

<sup>Written for commit 747ae682f36e1796b77295e9d122459a99a3f5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

