### PR TITLE
docs(installation): clarify auto-update only pulls unreleased fixes on a git-based install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -295,6 +295,10 @@ You never need to type any of these. Talk to your AI naturally, in any language,
 
 `egc doctor`, `egc repair`, and `egc auto-update` all accept `--repo-root <path>`, pointing them at a local development checkout instead of wherever the running `egc` binary was installed from. Without it, they compare your managed files against the published npm package, which reports every unreleased change as missing or drifted. Pass a `--repo-root` pointing at your local checkout when running any of these three commands so all agree on the source of truth.
 
+### Getting a fix before it ships to npm
+
+`egc auto-update` only runs a real `git pull` when the install directory has a `.git` folder (i.e. you installed via `git clone`, not `npm install -g`). On a git-based install, `auto-update` pulls straight from `origin/main`, so a fix that has merged but not yet been published as an npm release still reaches you. On an npm-only install, there is no repository to pull from: `auto-update` prints a reminder to run `npm install -g @egchq/egc@latest`, which only helps once a new version has actually been published. If you need a fix that is on `main` but not yet released, `git clone` + `sh scripts/install.sh` (or `.\scripts\install.ps1`) is the reliable path, not `npm install -g`.
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
Documents the exact behavior confirmed today: auto-update only does a real git pull when the install has a .git directory. On a plain npm install there is nothing to pull from, and the reminder to run npm install -g only helps once a new version has actually shipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `egc auto-update` pulls unreleased fixes only on git-based installs with a `.git` directory; npm installs can’t pull and only update after a new `@egchq/egc` release. Adds guidance to use `git clone` + install script to get fixes from `main` before publish.

<sup>Written for commit 452292a944447e348b91dd6e8ec9dc936632c210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

