### PR TITLE
fix(memory): stop propagate.ts from discarding real content in .cursor context file

### DIFF
--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -82,9 +82,14 @@ function upsertFileSection(filePath: string, block: string, defaultContent = '')
 // below it -- permanent duplication. Recognize and strip it down to just
 // the frontmatter so only the new marked block survives.
 const LEGACY_CURSOR_FRONTMATTER = `---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n`;
+const LEGACY_BLOCK_HEADER = '## EGC Project Memory';
 function stripLegacyCursorContent(existing: string): string {
   if (existing.includes(EGC_START)) return existing;
-  return existing.startsWith(LEGACY_CURSOR_FRONTMATTER) ? LEGACY_CURSOR_FRONTMATTER : existing;
+  if (!existing.startsWith(LEGACY_CURSOR_FRONTMATTER)) return existing;
+  // Only the pre-marker writer's own auto-generated block is safe to drop here.
+  // Anything else after the frontmatter (a note a human added) must be kept.
+  const rest = existing.slice(LEGACY_CURSOR_FRONTMATTER.length);
+  return rest.trimStart().startsWith(LEGACY_BLOCK_HEADER) ? LEGACY_CURSOR_FRONTMATTER : existing;
 }
 
 function writeCursorContext(projectPath: string, block: string): string | null {

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -120,6 +120,21 @@ function isStaleWrite(existingContent, stateUpdated) {
   return stateMs <= existingMs;
 }
 
+const LEGACY_CURSOR_FRONTMATTER = `---\ndescription: EGC project memory (auto-updated)\nalwaysApply: true\n---\n\n`;
+const LEGACY_BLOCK_HEADER = '## EGC Project Memory';
+
+// Before this fix, writeCursorContext always overwrote the whole file with
+// just frontmatter + block, no markers -- destroying any real content a
+// human added below the frontmatter. Only the pre-marker writer's own
+// auto-generated block is safe to drop during migration; anything else
+// must be kept and the marked block appended below it.
+function stripLegacyCursorContent(existing) {
+  if (existing.includes(EGC_START)) return existing;
+  if (!existing.startsWith(LEGACY_CURSOR_FRONTMATTER)) return existing;
+  const rest = existing.slice(LEGACY_CURSOR_FRONTMATTER.length);
+  return rest.trimStart().startsWith(LEGACY_BLOCK_HEADER) ? LEGACY_CURSOR_FRONTMATTER : existing;
+}
+
 function writeCursorContext(projectPath, block, stateUpdated) {
   const cursorDir = path.join(projectPath, '.cursor');
   try {
@@ -132,10 +147,10 @@ function writeCursorContext(projectPath, block, stateUpdated) {
   fs.mkdirSync(rulesDir, { recursive: true });
 
   const filePath = path.join(rulesDir, 'egc-context.mdc');
-  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  const content = `---\ndescription: EGC project memory (auto-updated)\nalwaysApply: true\n---\n\n${block}\n`;
-  fs.writeFileSync(filePath, content, 'utf-8');
+  const existingRaw = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  if (isStaleWrite(existingRaw, stateUpdated)) return filePath;
+  const existing = existingRaw ? stripLegacyCursorContent(existingRaw) : LEGACY_CURSOR_FRONTMATTER;
+  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -222,6 +222,35 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('preserves real hand-written content added after the legacy frontmatter', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      // Same frontmatter the pre-marker writer used to produce, but with a
+      // real note a human added below it instead of the auto-generated
+      // block -- this must survive, unlike the pure-leftover case above.
+      const realContent = '---\ndescription: EGC project memory (auto-updated by update_state)\nalwaysApply: true\n---\n\n## My own rule -- never delete this\n';
+      fs.writeFileSync(filePath, realContent, 'utf-8');
+
+      propagateStateToTools({ projectPath: dir, ...args });
+      const first = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(first.includes('My own rule -- never delete this'), 'real content must survive the first call');
+
+      propagateStateToTools({
+        projectPath: dir,
+        context: 'Second call context.',
+        decisions: [{ what: 'Use ESM' }],
+        next: ['Deploy to prod'],
+      });
+      const second = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(second.includes('My own rule -- never delete this'), 'real content must survive a second call too');
+      assert.ok(second.includes('Second call context'), 'egc block must still update');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (await test('upserts egc section in existing local CLAUDE.md', () => {
     const dir = mktemp();
     try {

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -70,6 +70,61 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('does not create cursor context when .cursor/ absent', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.strictEqual(result.cursor, null);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('preserves real hand-written content added after the legacy cursor frontmatter', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      // Same frontmatter this writer used to produce unconditionally before
+      // this fix, but with a real note a human added below it -- must survive.
+      const realContent = '---\ndescription: EGC project memory (auto-updated)\nalwaysApply: true\n---\n\n## My own rule -- never delete this\n';
+      fs.writeFileSync(filePath, realContent, 'utf-8');
+
+      propagateStateContent(dir, SAMPLE_STATE);
+      const first = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(first.includes('My own rule -- never delete this'), 'real content must survive the first call');
+
+      const newerState = SAMPLE_STATE.replace('updated: 2026-06-20T00:00:00.000Z', 'updated: 2026-07-01T00:00:00.000Z');
+      propagateStateContent(dir, newerState);
+      const second = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(second.includes('My own rule -- never delete this'), 'real content must survive a second call too');
+      assert.ok(second.includes('<!-- egc:start -->'), 'egc block must be present');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('migrates a pre-fix unmarked cursor context without duplicating memory', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      // Exactly what this writer used to produce before this fix: frontmatter
+      // + block, no markers at all.
+      const legacyContent = '---\ndescription: EGC project memory (auto-updated)\nalwaysApply: true\n---\n\n## EGC Project Memory\n\n**Context:** Old stale context from before the fix.\n';
+      fs.writeFileSync(filePath, legacyContent, 'utf-8');
+
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      const content = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(!content.includes('Old stale context from before the fix'), 'legacy unmarked block must not survive as duplicate content');
+      assert.ok(content.includes('description: EGC project memory'), 'frontmatter must be preserved');
+      assert.strictEqual((content.match(/<!-- egc:start -->/g) || []).length, 1, 'exactly one egc block after migration');
+      assert.ok(content.includes('EGC v1.1.1 stable'), 'new context must be present');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('does not create copilot-instructions.md when only .github/ exists', () => {
     const dir = mktemp();
     try {


### PR DESCRIPTION
## Summary
- writeCursorContext's legacy-migration heuristic in propagate.ts stripped everything after the old unmarked frontmatter in .cursor/rules/egc-context.mdc whenever no `<!-- egc:start -->` marker existed yet, including content a human had added there by hand, not just the pre-marker writer's own auto-generated block.
- Now it only strips when what follows the frontmatter is literally the old auto-generated block header ("## EGC Project Memory"), and leaves any other content untouched so the marked EGC block gets appended below it instead of replacing it.
- This is one of the causes behind update_state / propagateStateToTools silently discarding real content in the .cursor context file on every call.

## Test plan
- [x] Isolated Node script against the built module (not the MCP server) covering three scenarios: (1) real hand-written content after the legacy frontmatter survives two consecutive propagate calls, (2) a purely auto-generated legacy leftover still migrates cleanly without duplicating the block, (3) AGENTS.md-style files with real content survive unchanged. All 9 checks pass with the fix; the same script reproduces the original data-loss bug without it.
- [ ] CI matrix (Linux/Windows/macOS) green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops both propagate paths from discarding real content in `.cursor/rules/egc-context.mdc` when migrating legacy files without `<!-- egc:start -->`; only the old auto-generated block is removed and a marked EGC block is appended (EGC-513).

- **Bug Fixes**
  - In both `mcp/servers/egc-memory/src/propagate.ts` and `scripts/lib/propagate-state.js`, strip after the legacy frontmatter only when the next line is "## EGC Project Memory"; otherwise keep content and append the marked block via `upsertEgcSection`.
  - Added tests to cover preservation, clean migration (no duplicates), and skipping writes when `.cursor/` is absent.

<sup>Written for commit ab9033b9fa8b85f07829a9d74caea1f675fb40dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

