### PR TITLE
fix(memory): stop upsertEgcSection from deleting content on orphaned markers

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -6,11 +6,14 @@ sonar.sources=src,mcp/servers,scripts
 # These tests run in CI on every push; CI remains their quality gate.
 sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,**/*.tgz,**/legacy-command-shims/**
 sonar.sourceEncoding=UTF-8
-# branch-state and global-state are deliberate CommonJS mirrors of their TS
-# counterparts: session hooks cannot require the compiled server build.
-# tests/egc-memory-global-state.test.js asserts the global-state pair stays
-# behaviorally identical.
-sonar.cpd.exclusions=scripts/lib/branch-state.js,mcp/servers/egc-memory/src/branch-state.ts,mcp/servers/egc-guardian/src/catalog-index.ts,scripts/lib/global-state.js,mcp/servers/egc-memory/src/global-state.ts
+# branch-state, global-state and propagate-state are deliberate CommonJS
+# mirrors of their TS counterparts: session hooks and the CLI cannot require
+# the compiled MCP server build. tests/egc-memory-global-state.test.js
+# asserts the global-state pair stays behaviorally identical; the
+# propagate-state pair has matching scenarios across
+# tests/scripts/propagate-state.test.js and
+# tests/scripts/egc-memory-propagate.test.js instead.
+sonar.cpd.exclusions=scripts/lib/branch-state.js,mcp/servers/egc-memory/src/branch-state.ts,mcp/servers/egc-guardian/src/catalog-index.ts,scripts/lib/global-state.js,mcp/servers/egc-memory/src/global-state.ts,scripts/lib/propagate-state.js,mcp/servers/egc-memory/src/propagate.ts
 
 # Rule S2187 cannot detect the zero-dependency runner's plain-function test
 # pattern; the tests/ tree is covered by CI, not Sonar test detection.

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -57,14 +57,22 @@ function buildSummaryBlock(args: PropagateArgs): string {
 
 function upsertEgcSection(existing: string, block: string): string {
   const section = `${EGC_START}\n${block}\n${EGC_END}`;
+  const startCount = (existing.match(/<!-- egc:start -->/g) ?? []).length;
+  const endCount = (existing.match(/<!-- egc:end -->/g) ?? []).length;
   const startIdx = existing.indexOf(EGC_START);
   const endIdx = existing.indexOf(EGC_END);
 
-  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+  if (startCount === 1 && endCount === 1 && startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
     return existing.slice(0, startIdx) + section + existing.slice(endIdx + EGC_END.length);
   }
 
-  return existing ? `${existing.trimEnd()}\n\n${section}\n` : `${section}\n`;
+  // Anything other than exactly one correctly paired marker set (missing,
+  // orphaned, duplicated, or inverted) is not safe to slice in place -- an
+  // orphaned <!-- egc:start --> left over from a stray edit previously made
+  // the NEXT call delete everything between it and a fresh end marker.
+  // Strip only the bare marker tags and append one fresh, paired block.
+  const stripped = existing.replace(/<!-- egc:(start|end) -->/g, '').trim();
+  return stripped ? `${stripped}\n\n${section}\n` : `${section}\n`;
 }
 
 // Shared by the harness writers below: upsert the EGC block into filePath,
@@ -85,10 +93,13 @@ const LEGACY_CURSOR_FRONTMATTER = `---\ndescription: EGC project memory (auto-up
 const LEGACY_BLOCK_HEADER = '## EGC Project Memory';
 function stripLegacyCursorContent(existing: string): string {
   if (existing.includes(EGC_START)) return existing;
-  if (!existing.startsWith(LEGACY_CURSOR_FRONTMATTER)) return existing;
+  // Normalize CRLF for the comparison only -- a file saved with Windows line
+  // endings must still be recognized as the legacy auto-generated shape.
+  const normalized = existing.replace(/\r\n/g, '\n');
+  if (!normalized.startsWith(LEGACY_CURSOR_FRONTMATTER)) return existing;
   // Only the pre-marker writer's own auto-generated block is safe to drop here.
   // Anything else after the frontmatter (a note a human added) must be kept.
-  const rest = existing.slice(LEGACY_CURSOR_FRONTMATTER.length);
+  const rest = normalized.slice(LEGACY_CURSOR_FRONTMATTER.length);
   return rest.trimStart().startsWith(LEGACY_BLOCK_HEADER) ? LEGACY_CURSOR_FRONTMATTER : existing;
 }
 

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -90,14 +90,22 @@ function buildSummaryBlock(parsed) {
 
 function upsertEgcSection(existing, block) {
   const section = `${EGC_START}\n${block}\n${EGC_END}`;
+  const startCount = (existing.match(/<!-- egc:start -->/g) ?? []).length;
+  const endCount = (existing.match(/<!-- egc:end -->/g) ?? []).length;
   const startIdx = existing.indexOf(EGC_START);
   const endIdx = existing.indexOf(EGC_END);
 
-  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+  if (startCount === 1 && endCount === 1 && startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
     return existing.slice(0, startIdx) + section + existing.slice(endIdx + EGC_END.length);
   }
 
-  return existing ? `${existing.trimEnd()}\n\n${section}\n` : `${section}\n`;
+  // Anything other than exactly one correctly paired marker set (missing,
+  // orphaned, duplicated, or inverted) is not safe to slice in place -- an
+  // orphaned <!-- egc:start --> left over from a stray edit previously made
+  // the NEXT call delete everything between it and a fresh end marker.
+  // Strip only the bare marker tags and append one fresh, paired block.
+  const stripped = existing.replace(/<!-- egc:(start|end) -->/g, '').trim();
+  return stripped ? `${stripped}\n\n${section}\n` : `${section}\n`;
 }
 
 const STATE_UPDATED_RE = /<!-- egc:state-updated:(\S+) -->/;
@@ -130,8 +138,11 @@ const LEGACY_BLOCK_HEADER = '## EGC Project Memory';
 // must be kept and the marked block appended below it.
 function stripLegacyCursorContent(existing) {
   if (existing.includes(EGC_START)) return existing;
-  if (!existing.startsWith(LEGACY_CURSOR_FRONTMATTER)) return existing;
-  const rest = existing.slice(LEGACY_CURSOR_FRONTMATTER.length);
+  // Normalize CRLF for the comparison only -- a file saved with Windows line
+  // endings must still be recognized as the legacy auto-generated shape.
+  const normalized = existing.replace(/\r\n/g, '\n');
+  if (!normalized.startsWith(LEGACY_CURSOR_FRONTMATTER)) return existing;
+  const rest = normalized.slice(LEGACY_CURSOR_FRONTMATTER.length);
   return rest.trimStart().startsWith(LEGACY_BLOCK_HEADER) ? LEGACY_CURSOR_FRONTMATTER : existing;
 }
 

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -251,6 +251,71 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('does not delete real content when the end marker is orphaned (missing)', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      const REAL = 'REAL CONTENT BEFORE ORPHAN MARKER -- MUST SURVIVE';
+      // A stray edit removed <!-- egc:end --> at some point, leaving a lone
+      // start marker. This historically made the SECOND call below delete
+      // everything between the orphan and the freshly appended block.
+      fs.writeFileSync(filePath, `${REAL}\n<!-- egc:start -->\nold block, no end marker\n`, 'utf-8');
+
+      propagateStateToTools({ projectPath: dir, ...args });
+      const after1 = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(after1.includes(REAL), 'real content must survive the first call');
+
+      propagateStateToTools({ projectPath: dir, ...args });
+      const after2 = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(after2.includes(REAL), 'real content must survive the second call too');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('collapses duplicated marker pairs to one without losing real content', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), 'REAL AGENTS CONTENT\n<!-- egc:start -->\nblock A\n<!-- egc:end -->\n<!-- egc:start -->\nblock B\n<!-- egc:end -->\n', 'utf-8');
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      const content = fs.readFileSync(result.agents, 'utf-8');
+      assert.ok(content.includes('REAL AGENTS CONTENT'), 'real content must survive');
+      assert.strictEqual((content.match(/<!-- egc:start -->/g) || []).length, 1, 'exactly one start marker should remain');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('does not delete real content when markers are in inverted order', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'GEMINI.md'), 'REAL GEMINI CONTENT\n<!-- egc:end -->\nstray\n<!-- egc:start -->\n', 'utf-8');
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      const content = fs.readFileSync(result.gemini, 'utf-8');
+      assert.ok(content.includes('REAL GEMINI CONTENT'), 'real content must survive inverted markers');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('migrates a legacy cursor file saved with CRLF line endings', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      const crlf = '---\r\ndescription: EGC project memory (auto-updated by update_state)\r\nalwaysApply: true\r\n---\r\n\r\n## EGC Project Memory\r\n\r\n**Context:** old\r\n';
+      fs.writeFileSync(filePath, crlf, 'utf-8');
+
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      const content = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(!content.includes('**Context:** old'), 'old CRLF-saved block must not survive as a duplicate');
+      assert.strictEqual((content.match(/<!-- egc:start -->/g) || []).length, 1, 'exactly one start marker after migration');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (await test('upserts egc section in existing local CLAUDE.md', () => {
     const dir = mktemp();
     try {

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -125,6 +125,69 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('does not delete real content when the end marker is orphaned (missing)', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      const REAL = 'REAL CONTENT BEFORE ORPHAN MARKER -- MUST SURVIVE';
+      fs.writeFileSync(filePath, `${REAL}\n<!-- egc:start -->\nold block, no end marker\n`, 'utf-8');
+
+      propagateStateContent(dir, SAMPLE_STATE);
+      const after1 = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(after1.includes(REAL), 'real content must survive the first call');
+
+      const newerState = SAMPLE_STATE.replace('updated: 2026-06-20T00:00:00.000Z', 'updated: 2026-07-01T00:00:00.000Z');
+      propagateStateContent(dir, newerState);
+      const after2 = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(after2.includes(REAL), 'real content must survive the second call too');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('collapses duplicated marker pairs to one without losing real content', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), 'REAL AGENTS CONTENT\n<!-- egc:start -->\nblock A\n<!-- egc:end -->\n<!-- egc:start -->\nblock B\n<!-- egc:end -->\n', 'utf-8');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      const content = fs.readFileSync(result.agents, 'utf-8');
+      assert.ok(content.includes('REAL AGENTS CONTENT'), 'real content must survive');
+      assert.strictEqual((content.match(/<!-- egc:start -->/g) || []).length, 1, 'exactly one start marker should remain');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not delete real content when markers are in inverted order', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'GEMINI.md'), 'REAL GEMINI CONTENT\n<!-- egc:end -->\nstray\n<!-- egc:start -->\n', 'utf-8');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      const content = fs.readFileSync(result.gemini, 'utf-8');
+      assert.ok(content.includes('REAL GEMINI CONTENT'), 'real content must survive inverted markers');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('migrates a legacy cursor file saved with CRLF line endings', () => {
+    const dir = mktemp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor', 'rules'), { recursive: true });
+      const filePath = path.join(dir, '.cursor', 'rules', 'egc-context.mdc');
+      const crlf = '---\r\ndescription: EGC project memory (auto-updated)\r\nalwaysApply: true\r\n---\r\n\r\n## EGC Project Memory\r\n\r\n**Context:** old\r\n';
+      fs.writeFileSync(filePath, crlf, 'utf-8');
+
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      const content = fs.readFileSync(result.cursor, 'utf-8');
+      assert.ok(!content.includes('**Context:** old'), 'old CRLF-saved block must not survive as a duplicate');
+      assert.strictEqual((content.match(/<!-- egc:start -->/g) || []).length, 1, 'exactly one start marker after migration');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('does not create copilot-instructions.md when only .github/ exists', () => {
     const dir = mktemp();
     try {


### PR DESCRIPTION
## Summary
- Squad review (EGC-514) of the previous EGC-513 fix found a more serious variant of the same bug: `upsertEgcSection` itself -- shared by all 14 propagated files (AGENTS.md, GEMINI.md, CLAUDE.md, .cursor, etc.), not just the .cursor migration path -- could permanently delete real content if `<!-- egc:end -->` was ever removed or corrupted while `<!-- egc:start -->` survived. The call after that would slice-and-replace everything between an orphaned start marker and a freshly appended end marker.
- `upsertEgcSection` (in both `mcp/servers/egc-memory/src/propagate.ts` and `scripts/lib/propagate-state.js`) now only does the in-place slice when there is exactly one correctly paired start/end marker set. Any other shape (missing, orphaned, duplicated, or inverted markers) strips just the bare marker tags and appends one fresh, correctly paired block -- it never slices on marker positions it can't be sure are matched.
- Also normalizes CRLF before comparing against the legacy cursor frontmatter, so files saved with Windows line endings are recognized and migrated instead of silently duplicating the block.

## Test plan
- [x] 4 new scenarios added to both test suites: orphaned end marker survives two consecutive calls, duplicated marker pairs collapse to one without losing real content, inverted marker order doesn't delete real content, CRLF-saved legacy cursor file still migrates cleanly.
- [x] `tests/scripts/egc-memory-propagate.test.js`: 24/24 passing locally.
- [x] `tests/scripts/propagate-state.test.js`: 33/33 passing locally.
- [ ] CI matrix (Linux/Windows/macOS) green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss by making `upsertEgcSection` safe when EGC markers are broken across all propagated files. Addresses EGC-513 (found during EGC-514 review) and ensures CRLF legacy `.cursor` files migrate without duplicate blocks.

- **Bug Fixes**
  - `upsertEgcSection` now slices only when there is exactly one matched start/end pair; for missing, orphaned, duplicated, or inverted markers it strips bare tags and appends a fresh paired block.
  - Normalizes CRLF before checking legacy `.cursor` frontmatter so Windows-saved files are recognized and migrated cleanly.
  - Excludes the `scripts/lib/propagate-state.js` and `mcp/servers/egc-memory/src/propagate.ts` mirror pair from Sonar duplication to avoid false positives; no runtime changes.

<sup>Written for commit a8a52b78a92a4801e4571340c3b2a5e29353899e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

