### PR TITLE
fix(cli): stop bare terminal invocations from misrouting to an installed harness dir (BUG-08)

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -40,56 +40,21 @@ function getClaudeDir() {
   return getEGCDir();
 }
 
-/**
- * Get the EGC config directory for the active harness.
- *
- * Resolution order:
- *   1. EGC_DIR env var (explicit override)
- *   2. Harness-specific env vars injected at hook time (see docs/spec/harness-env-vars.md)
- *   3. __dirname prefix match against known harness home dirs (production install)
- *   4. ~/.egc (harness-agnostic fallback)
- */
-function getEGCDir() {
-  if (process.env.EGC_DIR) return process.env.EGC_DIR;
+// Tier 1: harness-specific env vars injected at hook time (see docs/spec/harness-env-vars.md).
+// Gemini CLI is checked before Claude Code because Gemini CLI sets both as a compat alias.
+function resolveHarnessDirFromEnv(env, home) {
+  if (env.GEMINI_PROJECT_DIR || env.GEMINI_PLUGIN_ROOT) return path.join(home, '.gemini');
+  if (env.CLAUDE_PROJECT_DIR || env.CLAUDE_PLUGIN_ROOT) return path.join(home, '.claude');
+  if (env.CODEBUDDY_PROJECT_DIR || env.CODEBUDDY_PLUGIN_ROOT) return path.join(home, '.codebuddy');
+  if (env.VSCODE_AGENT || env.GITHUB_COPILOT_API_TOKEN) return path.join(home, '.github');
+  if (env.KIRO_HOOK_FILE || env.KIRO_FILE_PATH) return path.join(home, '.kiro');
+  if (env.TRAE_ENV) return path.join(home, env.TRAE_ENV === 'cn' ? '.trae-cn' : '.trae');
+  return null;
+}
 
-  const home = getHomeDir();
-  const env = process.env;
-
-  // Gemini CLI / Antigravity AGY: GEMINI_PROJECT_DIR is injected by the CLI at hook time.
-  // Check this before CLAUDE_PROJECT_DIR because Gemini CLI sets both as a compat alias.
-  if (env.GEMINI_PROJECT_DIR || env.GEMINI_PLUGIN_ROOT) {
-    return path.join(home, '.gemini');
-  }
-
-  // Claude Code: CLAUDE_PROJECT_DIR or CLAUDE_PLUGIN_ROOT is injected by the CLI.
-  if (env.CLAUDE_PROJECT_DIR || env.CLAUDE_PLUGIN_ROOT) {
-    return path.join(home, '.claude');
-  }
-
-  // CodeBuddy: CODEBUDDY_PROJECT_DIR or CODEBUDDY_PLUGIN_ROOT is injected at hook time.
-  if (env.CODEBUDDY_PROJECT_DIR || env.CODEBUDDY_PLUGIN_ROOT) {
-    return path.join(home, '.codebuddy');
-  }
-
-  // VS Code Copilot: VSCODE_AGENT is set when running inside a Copilot agent action.
-  if (env.VSCODE_AGENT || env.GITHUB_COPILOT_API_TOKEN) {
-    return path.join(home, '.github');
-  }
-
-  // Kiro (AWS): KIRO_HOOK_FILE is set for file-triggered hooks.
-  if (env.KIRO_HOOK_FILE || env.KIRO_FILE_PATH) {
-    return path.join(home, '.kiro');
-  }
-
-  // Trae (ByteDance): TRAE_ENV distinguishes China vs global build.
-  if (env.TRAE_ENV) {
-    return path.join(home, env.TRAE_ENV === 'cn' ? '.trae-cn' : '.trae');
-  }
-
-  // Tier 2: __dirname prefix match (harnesses without unique runtime env vars at hook time).
-  // Longest-prefix-first to avoid false matches (e.g. .config/opencode before .config).
-  const sep = path.sep;
-  const harnessDirs = [
+// Longest-prefix-first to avoid false matches (e.g. .config/opencode before .config).
+function getKnownHarnessDirs(home) {
+  return [
     path.join(home, '.codeium', 'windsurf'),
     path.join(home, '.config', 'opencode'),
     path.join(home, '.config', 'zed'),
@@ -104,32 +69,54 @@ function getEGCDir() {
     path.join(home, '.trae'),
     path.join(home, '.trae-cn'),
   ];
+}
 
+// Tier 2: __dirname prefix match (harnesses without unique runtime env vars at hook time).
+function resolveHarnessDirFromDirname(harnessDirs) {
+  const sep = path.sep;
   for (const dir of harnessDirs) {
-    if (__dirname === dir || __dirname.startsWith(dir + sep)) {
-      return dir;
-    }
+    if (__dirname === dir || __dirname.startsWith(dir + sep)) return dir;
   }
+  return null;
+}
 
-  // Tier 3a: the true tool-agnostic default wins if it already exists (BUG-08).
-  // Without this, a bare terminal invocation (no CLI hook env vars, __dirname
-  // outside every harness dir -- e.g. running from this source checkout, or
-  // any plain `egc <command>`) fell through to "first installed harness dir",
-  // which silently pointed CLI/doctor/state-store calls at whichever tool
-  // happened to be installed (often OpenCode) instead of the shared store
-  // the MCP memory server actually uses -- splitting state across two
-  // databases that never saw each other's writes.
-  const egcDir = path.join(home, '.egc');
-  if (fs.existsSync(egcDir)) return egcDir;
-
-  // Tier 3b: first existing harness dir under HOME (dev/test environments where
-  // __dirname points to the source repo rather than a harness install path,
-  // and ~/.egc hasn't been created yet).
+// Tier 3b: first existing harness dir under HOME (dev/test environments where
+// __dirname points to the source repo rather than a harness install path,
+// and ~/.egc hasn't been created yet).
+function resolveFirstExistingHarnessDir(harnessDirs) {
   for (const dir of harnessDirs) {
     if (fs.existsSync(dir)) return dir;
   }
+  return null;
+}
 
-  return egcDir;
+/**
+ * Get the EGC config directory for the active harness.
+ *
+ * Resolution order:
+ *   1. EGC_DIR env var (explicit override)
+ *   2. Harness-specific env vars injected at hook time
+ *   3. __dirname prefix match against known harness home dirs (production install)
+ *   4. ~/.egc if it already exists (BUG-08: the tool-agnostic default must win over
+ *      "first installed harness dir" once initialized, or a bare terminal invocation
+ *      silently splits state into whichever tool happens to be installed)
+ *   5. first existing harness dir under HOME, else ~/.egc (fresh dev/test environment)
+ */
+function getEGCDir() {
+  if (process.env.EGC_DIR) return process.env.EGC_DIR;
+
+  const home = getHomeDir();
+  const envMatch = resolveHarnessDirFromEnv(process.env, home);
+  if (envMatch) return envMatch;
+
+  const harnessDirs = getKnownHarnessDirs(home);
+  const dirnameMatch = resolveHarnessDirFromDirname(harnessDirs);
+  if (dirnameMatch) return dirnameMatch;
+
+  const egcDir = path.join(home, '.egc');
+  if (fs.existsSync(egcDir)) return egcDir;
+
+  return resolveFirstExistingHarnessDir(harnessDirs) || egcDir;
 }
 
 /**

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -111,13 +111,25 @@ function getEGCDir() {
     }
   }
 
-  // Tier 3: first existing harness dir under HOME (dev/test environments where
-  // __dirname points to the source repo rather than a harness install path).
+  // Tier 3a: the true tool-agnostic default wins if it already exists (BUG-08).
+  // Without this, a bare terminal invocation (no CLI hook env vars, __dirname
+  // outside every harness dir -- e.g. running from this source checkout, or
+  // any plain `egc <command>`) fell through to "first installed harness dir",
+  // which silently pointed CLI/doctor/state-store calls at whichever tool
+  // happened to be installed (often OpenCode) instead of the shared store
+  // the MCP memory server actually uses -- splitting state across two
+  // databases that never saw each other's writes.
+  const egcDir = path.join(home, '.egc');
+  if (fs.existsSync(egcDir)) return egcDir;
+
+  // Tier 3b: first existing harness dir under HOME (dev/test environments where
+  // __dirname points to the source repo rather than a harness install path,
+  // and ~/.egc hasn't been created yet).
   for (const dir of harnessDirs) {
     if (fs.existsSync(dir)) return dir;
   }
 
-  return path.join(home, '.egc');
+  return egcDir;
 }
 
 /**

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -111,6 +111,59 @@ function runTests() {
     assert.ok(egcDir !== homeDir, 'EGC dir should be a subdirectory of home');
   })) passed++; else failed++;
 
+  if (test('getEGCDir (BUG-08): ~/.egc wins over an installed harness dir in a bare context', () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalEgcDir = process.env.EGC_DIR;
+    const os = require('os');
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-getegcdir-test-'));
+    try {
+      delete process.env.EGC_DIR;
+      process.env.HOME = fakeHome;
+      process.env.USERPROFILE = '';
+
+      // Simulate the real machine: an unrelated harness (OpenCode) is
+      // installed, but ~/.egc also already exists. Before this fix, the
+      // "first existing harness dir" loop ran BEFORE checking ~/.egc, so
+      // OpenCode's dir won even for a plain, tool-agnostic invocation.
+      fs.mkdirSync(path.join(fakeHome, '.config', 'opencode'), { recursive: true });
+      fs.mkdirSync(path.join(fakeHome, '.egc'), { recursive: true });
+
+      const resolved = utils.getEGCDir();
+      assert.strictEqual(resolved, path.join(fakeHome, '.egc'), 'the tool-agnostic ~/.egc must win, not the first installed harness dir');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = originalUserProfile;
+      if (originalEgcDir === undefined) delete process.env.EGC_DIR; else process.env.EGC_DIR = originalEgcDir;
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('getEGCDir (BUG-08): still falls back to an installed harness dir when ~/.egc does not exist yet', () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalEgcDir = process.env.EGC_DIR;
+    const os = require('os');
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-getegcdir-test-'));
+    try {
+      delete process.env.EGC_DIR;
+      process.env.HOME = fakeHome;
+      process.env.USERPROFILE = '';
+
+      // Original dev/test scenario this tier was built for: no ~/.egc yet,
+      // but a harness dir is present -- must still resolve to it.
+      fs.mkdirSync(path.join(fakeHome, '.config', 'opencode'), { recursive: true });
+
+      const resolved = utils.getEGCDir();
+      assert.strictEqual(resolved, path.join(fakeHome, '.config', 'opencode'), 'should still fall back to the installed harness dir');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = originalUserProfile;
+      if (originalEgcDir === undefined) delete process.env.EGC_DIR; else process.env.EGC_DIR = originalEgcDir;
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('getSessionsDir returns path under EGC dir', () => {
     const sessionsDir = utils.getSessionsDir();
     const egcDir = utils.getEGCDir();


### PR DESCRIPTION
## Summary
- `getEGCDir()`'s Tier 3 fallback picked "the first harness dir that exists under HOME" whenever no CLI-specific env var or `__dirname` match applied (e.g. any plain `egc <command>` run from a terminal). On a machine with OpenCode installed, that silently pointed doctor/state-store calls at `~/.config/opencode/egc/state.db` instead of the shared `~/.egc` store, splitting state across databases that never saw each other's writes -- and making `egc doctor`'s own divergent-database warning unreliable, since it depends on both paths resolving under the same root.
- Tier 3 now checks the tool-agnostic `~/.egc` default first and only falls back to "first installed harness dir" when `~/.egc` doesn't exist yet, preserving the original dev/test intent for that narrower case.

## Test plan
- [x] 2 new scenarios in `tests/lib/utils.test.js`: `~/.egc` wins over an installed harness dir; still falls back to a harness dir when `~/.egc` doesn't exist yet.
- [x] `tests/lib/utils.test.js`: 185/185 passing locally.
- [x] `tests/scripts/doctor.test.js`: 11/11 passing locally (including the existing divergent-database test).
- [x] Manually confirmed `node scripts/doctor.js` now correctly reports the divergent-database warning from a bare terminal invocation.
- [ ] CI matrix (Linux/Windows/macOS) green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CLI path resolution so bare terminal `egc` runs use the shared `~/.egc` state store, not a harness dir, and refactor `getEGCDir()` into small helpers to reduce complexity. This prevents split state and keeps `egc doctor`'s divergent-database check reliable (EGC-513, BUG-08).

- **Bug Fixes**
  - Updated `getEGCDir()` Tier 3: prefer `~/.egc` if it exists; only fall back to the first installed harness dir when `~/.egc` is missing.
  - Added two tests to verify precedence and fallback behavior.

<sup>Written for commit 54836ce54284958e9b7e6535f2661c05051c4555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

