### PR TITLE
docs(changelog): credit Helal Ferrari Cabral for reporting EGC-513 and BUG-08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to EGC are documented here.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **Memory corruption from an orphaned marker fixed at the root**: a stale marker left behind in propagated context files (`.cursor`, `.trae`, `AGENTS.md`, `GEMINI.md` and 10 more) could delete real user content instead of just the EGC-managed section; an outdated MCP runtime made it worse by overwriting `.cursor` with no marker at all. Reported directly by Helal Ferrari Cabral (@helalferrari). 57 new tests, CI green on all 3 OSes (#1102, #1103).
+- **`egc doctor` / state-store divergence fixed**: a bare terminal invocation of `getEGCDir()` fell back to the first harness directory that happened to exist on disk (for example OpenCode) instead of the tool-agnostic `~/.egc` default, silently routing commands to the wrong `state.db`. Reported directly by Helal Ferrari Cabral (@helalferrari) (#1104).
+
 ## [1.1.17] - 2026-07-27
 
 ### Bug Fixes


### PR DESCRIPTION
Helal Ferrari Cabral (@helalferrari) reported both bugs directly, outside of GitHub, that #1102/#1103 (EGC-513) and #1104 (BUG-08) fixed. This adds an Unreleased changelog entry crediting him, with his co-authorship on the commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Unreleased changelog entry crediting Helal Ferrari Cabral for reporting EGC-513 and BUG-08. Documents the memory corruption fix and the `egc doctor` state-store divergence fix.

<sup>Written for commit 0cbc53603496952d877d6ba1b0608be854d634cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

