### PR TITLE
feat(scripts): add read-only additive merge tool for fragmented state.db files

### DIFF
--- a/scripts/maintenance/merge-fragmented-state-dbs.js
+++ b/scripts/maintenance/merge-fragmented-state-dbs.js
@@ -1,0 +1,156 @@
+'use strict';
+
+// Manual, one-off maintenance tool (BUG-08 follow-up): additively merges rows
+// from fragmented per-harness state.db files into the canonical
+// ~/.egc/egc/state.db. Not wired into the egc CLI (scripts/egc.js COMMANDS) --
+// this is not a user-facing feature, it is a local data-repair operation.
+//
+// Guarantees:
+//   - Never UPDATEs or DELETEs anything, in source or destination.
+//   - Source files are opened read-only: only .prepare(sql).all()/.get() are
+//     ever called on them, never .exec()/.run()/.transaction(), so
+//     db-adapter's debounced persist path is never triggered for a source.
+//   - schema_migrations is never merged: each db file tracks its own
+//     migration history, copying those rows would be meaningless.
+//   - Dry-run by default; pass --apply to actually write.
+//
+// CLI usage:
+//   node merge-fragmented-state-dbs.js --canonical <path> --source <path> [--source <path> ...] [--apply]
+
+const path = require('node:path');
+const fs = require('node:fs');
+const { openDatabase } = require('../lib/state-store/db-adapter');
+const { applyMigrations } = require('../lib/state-store/migrations');
+
+const MERGE_TABLES = [
+  { name: 'sessions', pk: ['id'] },
+  { name: 'skill_runs', pk: ['id'] },
+  { name: 'skill_versions', pk: ['skill_id', 'version'] },
+  { name: 'decisions', pk: ['id'] },
+  { name: 'install_state', pk: ['target_id', 'target_root'] },
+  { name: 'governance_events', pk: ['id'] },
+  { name: 'instincts', pk: ['id'] },
+  { name: 'events', pk: ['id'] },
+  { name: 'lessons', pk: ['id'] },
+  { name: 'patterns', pk: ['id'] },
+];
+
+function tableExists(db, name) {
+  return !!db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get([name]);
+}
+
+function getColumns(db, name) {
+  return db.prepare(`PRAGMA table_info("${name}")`).all().map(r => r.name);
+}
+
+function pickPk(row, pk) {
+  const out = {};
+  for (const k of pk) out[k] = row[k];
+  return out;
+}
+
+async function mergeOneSource(canonicalDb, srcPath, apply) {
+  const srcReport = { source: srcPath, tables: {} };
+
+  if (!fs.existsSync(srcPath)) {
+    srcReport.error = 'file not found';
+    return srcReport;
+  }
+
+  const srcDb = await openDatabase(srcPath);
+
+  for (const { name, pk } of MERGE_TABLES) {
+    if (!tableExists(srcDb, name) || !tableExists(canonicalDb, name)) {
+      srcReport.tables[name] = { skipped: 'table missing in source or canonical' };
+      continue;
+    }
+
+    const srcCols = getColumns(srcDb, name);
+    const dstCols = getColumns(canonicalDb, name);
+    const commonCols = srcCols.filter(c => dstCols.includes(c));
+    const missingPk = pk.filter(k => !commonCols.includes(k));
+    if (missingPk.length > 0) {
+      srcReport.tables[name] = { skipped: `primary key column(s) missing: ${missingPk.join(', ')}` };
+      continue;
+    }
+
+    const colList = commonCols.map(c => `"${c}"`).join(', ');
+    const rows = srcDb.prepare(`SELECT ${colList} FROM "${name}"`).all();
+
+    let count = 0;
+    let alreadyPresent = 0;
+    const existsStmt = canonicalDb.prepare(
+      `SELECT 1 FROM "${name}" WHERE ${pk.map(k => `"${k}" = @${k}`).join(' AND ')}`
+    );
+    const insertStmt = canonicalDb.prepare(
+      `INSERT INTO "${name}" (${colList}) VALUES (${commonCols.map(c => `@${c}`).join(', ')})`
+    );
+
+    for (const row of rows) {
+      const exists = existsStmt.get(pickPk(row, pk));
+      if (exists) {
+        alreadyPresent++;
+        continue;
+      }
+      if (apply) insertStmt.run(row);
+      count++;
+    }
+
+    srcReport.tables[name] = {
+      rowsInSource: rows.length,
+      alreadyPresent,
+      [apply ? 'inserted' : 'wouldInsert']: count,
+      columnsCopied: commonCols,
+      columnsDroppedFromSource: srcCols.filter(c => !dstCols.includes(c)),
+    };
+  }
+
+  return srcReport;
+}
+
+async function mergeStateDbs({ canonicalPath, sourcePaths, apply = false }) {
+  const canonicalDb = await openDatabase(canonicalPath);
+  canonicalDb.pragma('foreign_keys = ON');
+  applyMigrations(canonicalDb); // idempotent, additive-only (CREATE TABLE IF NOT EXISTS / ALTER ADD COLUMN)
+
+  const reports = [];
+  const commit = canonicalDb.transaction(() => {});
+  for (const src of sourcePaths) reports.push(await mergeOneSource(canonicalDb, src, apply));
+  if (apply) commit(); // no-op body; forces a single persist after all inserts above
+
+  if (apply) await canonicalDb.flush();
+  canonicalDb.close();
+
+  return { apply, canonical: canonicalPath, reports };
+}
+
+function parseArgs(argv) {
+  const out = { sourcePaths: [], apply: false, canonicalPath: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--canonical') out.canonicalPath = argv[++i];
+    else if (a === '--source') out.sourcePaths.push(argv[++i]);
+    else if (a === '--apply') out.apply = true;
+  }
+  return out;
+}
+
+async function main() {
+  const { canonicalPath, sourcePaths, apply } = parseArgs(process.argv.slice(2));
+  if (!canonicalPath || sourcePaths.length === 0) {
+    console.error('Usage: node merge-fragmented-state-dbs.js --canonical <path> --source <path> [--source <path> ...] [--apply]');
+    process.exitCode = 1;
+    return;
+  }
+  const result = await mergeStateDbs({ canonicalPath, sourcePaths, apply });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { mergeStateDbs, MERGE_TABLES };

--- a/scripts/maintenance/merge-fragmented-state-dbs.js
+++ b/scripts/maintenance/merge-fragmented-state-dbs.js
@@ -17,10 +17,10 @@
 // CLI usage:
 //   node merge-fragmented-state-dbs.js --canonical <path> --source <path> [--source <path> ...] [--apply]
 
-const path = require('node:path');
 const fs = require('node:fs');
 const { openDatabase } = require('../lib/state-store/db-adapter');
 const { applyMigrations } = require('../lib/state-store/migrations');
+const { resolveStateStorePath } = require('../lib/state-store');
 
 const MERGE_TABLES = [
   { name: 'sessions', pk: ['id'] },
@@ -108,8 +108,19 @@ async function mergeOneSource(canonicalDb, srcPath, apply) {
   return srcReport;
 }
 
+function backupBeforeApply(canonicalPath) {
+  if (canonicalPath === ':memory:' || !fs.existsSync(canonicalPath)) return null;
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = `${canonicalPath}.backup-${stamp}`;
+  fs.copyFileSync(canonicalPath, backupPath);
+  return backupPath;
+}
+
 async function mergeStateDbs({ canonicalPath, sourcePaths, apply = false }) {
-  const canonicalDb = await openDatabase(canonicalPath);
+  const resolvedCanonicalPath = canonicalPath || resolveStateStorePath();
+  const backupPath = apply ? backupBeforeApply(resolvedCanonicalPath) : null;
+
+  const canonicalDb = await openDatabase(resolvedCanonicalPath);
   canonicalDb.pragma('foreign_keys = ON');
   applyMigrations(canonicalDb); // idempotent, additive-only (CREATE TABLE IF NOT EXISTS / ALTER ADD COLUMN)
 
@@ -121,7 +132,7 @@ async function mergeStateDbs({ canonicalPath, sourcePaths, apply = false }) {
   if (apply) await canonicalDb.flush();
   canonicalDb.close();
 
-  return { apply, canonical: canonicalPath, reports };
+  return { apply, canonical: resolvedCanonicalPath, backupPath, reports };
 }
 
 function parseArgs(argv) {
@@ -137,8 +148,9 @@ function parseArgs(argv) {
 
 async function main() {
   const { canonicalPath, sourcePaths, apply } = parseArgs(process.argv.slice(2));
-  if (!canonicalPath || sourcePaths.length === 0) {
-    console.error('Usage: node merge-fragmented-state-dbs.js --canonical <path> --source <path> [--source <path> ...] [--apply]');
+  if (sourcePaths.length === 0) {
+    console.error('Usage: node merge-fragmented-state-dbs.js [--canonical <path>] --source <path> [--source <path> ...] [--apply]');
+    console.error('  --canonical defaults to the real resolveStateStorePath() (~/.egc/egc/state.db) when omitted.');
     process.exitCode = 1;
     return;
   }

--- a/scripts/maintenance/merge-fragmented-state-dbs.js
+++ b/scripts/maintenance/merge-fragmented-state-dbs.js
@@ -49,6 +49,60 @@ function pickPk(row, pk) {
   return out;
 }
 
+function quoteColumns(cols) {
+  return cols.map(c => `"${c}"`).join(', ');
+}
+
+function buildPkWhereClause(pk) {
+  const conditions = pk.map(k => `"${k}" = @${k}`);
+  return conditions.join(' AND ');
+}
+
+function buildNamedPlaceholders(cols) {
+  const placeholders = cols.map(c => `@${c}`);
+  return placeholders.join(', ');
+}
+
+function mergeOneTable(canonicalDb, srcDb, name, pk, apply) {
+  if (!tableExists(srcDb, name) || !tableExists(canonicalDb, name)) {
+    return { skipped: 'table missing in source or canonical' };
+  }
+
+  const srcCols = getColumns(srcDb, name);
+  const dstCols = getColumns(canonicalDb, name);
+  const commonCols = srcCols.filter(c => dstCols.includes(c));
+  const missingPk = pk.filter(k => !commonCols.includes(k));
+  if (missingPk.length > 0) {
+    return { skipped: `primary key column(s) missing: ${missingPk.join(', ')}` };
+  }
+
+  const colList = quoteColumns(commonCols);
+  const rows = srcDb.prepare(`SELECT ${colList} FROM "${name}"`).all();
+  const whereClause = buildPkWhereClause(pk);
+  const placeholders = buildNamedPlaceholders(commonCols);
+  const existsStmt = canonicalDb.prepare(`SELECT 1 FROM "${name}" WHERE ${whereClause}`);
+  const insertStmt = canonicalDb.prepare(`INSERT INTO "${name}" (${colList}) VALUES (${placeholders})`);
+
+  let count = 0;
+  let alreadyPresent = 0;
+  for (const row of rows) {
+    if (existsStmt.get(pickPk(row, pk))) {
+      alreadyPresent++;
+      continue;
+    }
+    if (apply) insertStmt.run(row);
+    count++;
+  }
+
+  return {
+    rowsInSource: rows.length,
+    alreadyPresent,
+    [apply ? 'inserted' : 'wouldInsert']: count,
+    columnsCopied: commonCols,
+    columnsDroppedFromSource: srcCols.filter(c => !dstCols.includes(c)),
+  };
+}
+
 async function mergeOneSource(canonicalDb, srcPath, apply) {
   const srcReport = { source: srcPath, tables: {} };
 
@@ -58,51 +112,8 @@ async function mergeOneSource(canonicalDb, srcPath, apply) {
   }
 
   const srcDb = await openDatabase(srcPath);
-
   for (const { name, pk } of MERGE_TABLES) {
-    if (!tableExists(srcDb, name) || !tableExists(canonicalDb, name)) {
-      srcReport.tables[name] = { skipped: 'table missing in source or canonical' };
-      continue;
-    }
-
-    const srcCols = getColumns(srcDb, name);
-    const dstCols = getColumns(canonicalDb, name);
-    const commonCols = srcCols.filter(c => dstCols.includes(c));
-    const missingPk = pk.filter(k => !commonCols.includes(k));
-    if (missingPk.length > 0) {
-      srcReport.tables[name] = { skipped: `primary key column(s) missing: ${missingPk.join(', ')}` };
-      continue;
-    }
-
-    const colList = commonCols.map(c => `"${c}"`).join(', ');
-    const rows = srcDb.prepare(`SELECT ${colList} FROM "${name}"`).all();
-
-    let count = 0;
-    let alreadyPresent = 0;
-    const existsStmt = canonicalDb.prepare(
-      `SELECT 1 FROM "${name}" WHERE ${pk.map(k => `"${k}" = @${k}`).join(' AND ')}`
-    );
-    const insertStmt = canonicalDb.prepare(
-      `INSERT INTO "${name}" (${colList}) VALUES (${commonCols.map(c => `@${c}`).join(', ')})`
-    );
-
-    for (const row of rows) {
-      const exists = existsStmt.get(pickPk(row, pk));
-      if (exists) {
-        alreadyPresent++;
-        continue;
-      }
-      if (apply) insertStmt.run(row);
-      count++;
-    }
-
-    srcReport.tables[name] = {
-      rowsInSource: rows.length,
-      alreadyPresent,
-      [apply ? 'inserted' : 'wouldInsert']: count,
-      columnsCopied: commonCols,
-      columnsDroppedFromSource: srcCols.filter(c => !dstCols.includes(c)),
-    };
+    srcReport.tables[name] = mergeOneTable(canonicalDb, srcDb, name, pk, apply);
   }
 
   return srcReport;

--- a/tests/scripts/merge-fragmented-state-dbs.test.js
+++ b/tests/scripts/merge-fragmented-state-dbs.test.js
@@ -187,6 +187,26 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('--apply creates a timestamped backup of the canonical db before writing, dry-run does not', async () => {
+    const dir = createTempDir('egc-merge-backup-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+
+      const dryRun = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: false });
+      assert.strictEqual(dryRun.backupPath, null, 'dry run must not create a backup');
+
+      const applied = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      assert.ok(applied.backupPath, 'apply must create a backup');
+      assert.ok(fs.existsSync(applied.backupPath), 'backup file must actually exist on disk');
+      assert.ok(applied.backupPath.startsWith(canonicalPath), 'backup path must be derived from the canonical path');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (await test('a missing source path is reported as an error instead of throwing', async () => {
     const dir = createTempDir('egc-merge-missing-');
     try {

--- a/tests/scripts/merge-fragmented-state-dbs.test.js
+++ b/tests/scripts/merge-fragmented-state-dbs.test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { mergeStateDbs } = require('../../scripts/maintenance/merge-fragmented-state-dbs');
+const { openDatabase } = require('../../scripts/lib/state-store/db-adapter');
+const { applyMigrations } = require('../../scripts/lib/state-store/migrations');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+async function seedDb(dbPath, { skipLessons = false } = {}) {
+  const db = await openDatabase(dbPath);
+  db.pragma('foreign_keys = ON');
+  applyMigrations(db);
+  if (skipLessons) {
+    // Simulate an older fragment created before the lessons migration existed:
+    // the merge logic only cares whether the table exists, so dropping it
+    // here reproduces that shape closely enough for this test.
+    db.exec('DROP TABLE lessons');
+  }
+  await db.flush();
+  db.close();
+}
+
+function test(name, fn) {
+  try {
+    const result = fn();
+    if (result && typeof result.then === 'function') {
+      return result.then(() => {
+        console.log(`  ✓ ${name}`);
+        return true;
+      }).catch(err => {
+        console.log(`  ✗ ${name}`);
+        console.log(`    Error: ${err.stack || err.message}`);
+        return false;
+      });
+    }
+    console.log(`  ✓ ${name}`);
+    return Promise.resolve(true);
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.stack || err.message}`);
+    return Promise.resolve(false);
+  }
+}
+
+async function runTests() {
+  console.log('\n=== Testing scripts/maintenance/merge-fragmented-state-dbs.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (await test('dry-run reports rows that would be inserted without touching the canonical db', async () => {
+    const dir = createTempDir('egc-merge-dryrun-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+
+      const srcDb = await openDatabase(sourcePath);
+      srcDb.prepare(
+        `INSERT INTO instincts (id, project_id, trigger, content, confidence, created_at) VALUES (@id, @project_id, @trigger, @content, @confidence, @created_at)`
+      ).run({ id: 'inst-1', project_id: 'p1', trigger: 't1', content: 'c1', confidence: 0.5, created_at: '2026-01-01T00:00:00Z' });
+      await srcDb.flush();
+      srcDb.close();
+
+      const before = fs.readFileSync(canonicalPath);
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: false });
+      const after = fs.readFileSync(canonicalPath);
+
+      assert.deepStrictEqual(before, after, 'canonical db file must be byte-identical after a dry run');
+      assert.strictEqual(result.reports[0].tables.instincts.wouldInsert, 1);
+      assert.strictEqual(result.reports[0].tables.instincts.alreadyPresent, 0);
+
+      const canonicalDb = await openDatabase(canonicalPath);
+      const rows = canonicalDb.prepare('SELECT * FROM instincts').all();
+      assert.strictEqual(rows.length, 0, 'dry run must not actually insert anything');
+      canonicalDb.close();
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('--apply inserts only the rows missing from canonical, keyed by primary key', async () => {
+    const dir = createTempDir('egc-merge-apply-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+
+      const canonicalDb = await openDatabase(canonicalPath);
+      canonicalDb.prepare(
+        `INSERT INTO instincts (id, project_id, trigger, content, confidence, created_at) VALUES (@id, @project_id, @trigger, @content, @confidence, @created_at)`
+      ).run({ id: 'inst-shared', project_id: 'p1', trigger: 'existing', content: 'canonical-content', confidence: 0.9, created_at: '2026-01-01T00:00:00Z' });
+      await canonicalDb.flush();
+      canonicalDb.close();
+
+      const srcDb = await openDatabase(sourcePath);
+      const insertInstinct = srcDb.prepare(
+        `INSERT INTO instincts (id, project_id, trigger, content, confidence, created_at) VALUES (@id, @project_id, @trigger, @content, @confidence, @created_at)`
+      );
+      // Same PK as the canonical row, but different content -- must NOT overwrite.
+      insertInstinct.run({ id: 'inst-shared', project_id: 'p1', trigger: 'from-source', content: 'source-content', confidence: 0.1, created_at: '2026-01-02T00:00:00Z' });
+      // New PK -- must be added.
+      insertInstinct.run({ id: 'inst-new', project_id: 'p1', trigger: 'new', content: 'new-content', confidence: 0.5, created_at: '2026-01-03T00:00:00Z' });
+      await srcDb.flush();
+      srcDb.close();
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      assert.strictEqual(result.reports[0].tables.instincts.inserted, 1);
+      assert.strictEqual(result.reports[0].tables.instincts.alreadyPresent, 1);
+
+      const finalDb = await openDatabase(canonicalPath);
+      const rows = finalDb.prepare('SELECT * FROM instincts ORDER BY id').all();
+      assert.strictEqual(rows.length, 2);
+      const shared = rows.find(r => r.id === 'inst-shared');
+      assert.strictEqual(shared.content, 'canonical-content', 'existing canonical row must never be overwritten');
+      const fresh = rows.find(r => r.id === 'inst-new');
+      assert.strictEqual(fresh.content, 'new-content');
+      finalDb.close();
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a source db missing a table (older schema) is skipped without crashing, other tables still merge', async () => {
+    const dir = createTempDir('egc-merge-oldschema-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath, { skipLessons: true });
+
+      const srcDb = await openDatabase(sourcePath);
+      srcDb.prepare(
+        `INSERT INTO patterns (id, pattern_type, key, description, last_seen, first_seen) VALUES (@id, @pattern_type, @key, @description, @last_seen, @first_seen)`
+      ).run({ id: 'pat-1', pattern_type: 'pt', key: 'k', description: 'd', last_seen: '2026-01-01', first_seen: '2026-01-01' });
+      await srcDb.flush();
+      srcDb.close();
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      const tables = result.reports[0].tables;
+      assert.ok(tables.lessons.skipped, 'lessons must be skipped since the source has no such table');
+      assert.strictEqual(tables.patterns.inserted, 1, 'patterns must still merge normally');
+
+      const finalDb = await openDatabase(canonicalPath);
+      assert.strictEqual(finalDb.prepare('SELECT COUNT(*) AS n FROM patterns').get().n, 1);
+      finalDb.close();
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a source db file is never modified on disk, even when it has rows to merge', async () => {
+    const dir = createTempDir('egc-merge-readonly-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+
+      const srcDb = await openDatabase(sourcePath);
+      srcDb.prepare(
+        `INSERT INTO governance_events (id, event_type, payload, created_at) VALUES (@id, @event_type, @payload, @created_at)`
+      ).run({ id: 'gov-1', event_type: 'e', payload: '{}', created_at: '2026-01-01T00:00:00Z' });
+      await srcDb.flush();
+      srcDb.close();
+
+      const before = fs.readFileSync(sourcePath);
+      await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      const after = fs.readFileSync(sourcePath);
+
+      assert.deepStrictEqual(before, after, 'source db file must be byte-identical, merge is read-only on sources');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a missing source path is reported as an error instead of throwing', async () => {
+    const dir = createTempDir('egc-merge-missing-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      await seedDb(canonicalPath);
+
+      const result = await mergeStateDbs({
+        canonicalPath,
+        sourcePaths: [path.join(dir, 'does-not-exist.db')],
+        apply: true,
+      });
+      assert.strictEqual(result.reports[0].error, 'file not found');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
BUG-08 follow-up. The old getEGCDir() fallback (fixed in #1104) scattered install/session history across several harness directories instead of the canonical ~/.egc/egc/state.db. This adds a manual maintenance tool (scripts/maintenance/merge-fragmented-state-dbs.js, not wired into the egc CLI) that merges those fragments back in: additive-only, dry-run by default, source files opened strictly read-only.

Reported by Helal Ferrari Cabral (@helalferrari), same report as #1104.

5 new synthetic-data tests cover: dry-run makes zero changes, existing rows are never overwritten, missing tables (older schema) are skipped without crashing, source files are never modified on disk, and missing source paths are reported instead of throwing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual script to merge rows from fragmented per-harness SQLite state.db files into the canonical `~/.egc/egc/state.db`. It’s additive-only, dry-run by default, and helps repair data scattered by BUG-08.

- **New Features**
  - Adds `scripts/maintenance/merge-fragmented-state-dbs.js` (not wired into the `egc` CLI).
  - Supports multiple sources; writes only with `--apply`; prints a JSON report. Usage: node scripts/maintenance/merge-fragmented-state-dbs.js --source <path> [--source <path> ...] [--canonical <path>] [--apply]
  - Defaults `--canonical` to the real `resolveStateStorePath()` when omitted; on `--apply`, creates a timestamped backup of the canonical DB before writing.
  - Merges by primary key; never updates/deletes; skips `schema_migrations`; gracefully skips missing tables or PK columns; opens source DBs read-only.

- **Refactors**
  - Extracted `mergeOneTable` and SQL-fragment helpers to reduce complexity; behavior unchanged.

<sup>Written for commit 962c79d648f3e38175f2cb803d7f55b097c2a495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

