### PR TITLE
feat(crusher): add PATH-level binary shim for the Token Crusher

### DIFF
--- a/scripts/crusher-shim.js
+++ b/scripts/crusher-shim.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+
+// egc crusher-shim install|uninstall|status
+//
+// Installs a PATH-level binary shim (git, npm, ...) that compresses noisy
+// output for any tool that shells out to run them -- not just the harnesses
+// whose hooks support a PreToolUse command rewrite. See
+// scripts/lib/crusher/shim-install.js for the implementation.
+
+const { install, uninstall, status } = require('./lib/crusher/shim-install');
+
+function printInstallResult(result) {
+  console.log(`Shim directory: ${result.dir}`);
+  if (result.installed.length) console.log(`Installed: ${result.installed.join(', ')}`);
+  if (result.skipped.length) console.log(`Not found on this machine (skipped): ${result.skipped.join(', ')}`);
+  const changed = result.pathResult.filter(r => r.changed);
+  if (changed.length) {
+    console.log(`PATH updated in: ${changed.map(r => r.path).join(', ')}`);
+    console.log('Open a new terminal (or `source` the file above) for it to take effect.');
+  } else {
+    console.log('PATH already configured, or no shell config file found to update.');
+  }
+}
+
+function printUninstallResult(result) {
+  console.log(`Shim directory: ${result.dir}`);
+  console.log(result.removed.length ? `Removed: ${result.removed.join(', ')}` : 'Nothing to remove.');
+  const changed = result.pathResult.filter(r => r.changed);
+  if (changed.length) console.log(`PATH entry removed from: ${changed.map(r => r.path).join(', ')}`);
+}
+
+function printStatus(result) {
+  console.log(`Shim directory: ${result.dir} (${result.dirExists ? 'exists' : 'not created'})`);
+  console.log(result.shimmed.length ? `Shimmed binaries: ${result.shimmed.join(', ')}` : 'No binaries shimmed.');
+  console.log(`Active in this shell's PATH right now: ${result.activeInCurrentShell ? 'yes' : 'no'}`);
+}
+
+function main() {
+  const action = process.argv[2];
+
+  if (action === 'install') return printInstallResult(install());
+  if (action === 'uninstall') return printUninstallResult(uninstall());
+  if (action === 'status') return printStatus(status());
+
+  console.log('Usage: egc crusher-shim <install|uninstall|status>');
+  console.log('\nInstalls a PATH-level binary shim (git, npm, pip, gh, ...) that compresses');
+  console.log('noisy output for any tool that shells out to run them, independent of any');
+  console.log('AI harness\'s hook support. Requires a new shell session after install.');
+  process.exit(action ? 1 : 0);
+}
+
+main();

--- a/scripts/egc.js
+++ b/scripts/egc.js
@@ -137,6 +137,10 @@ const COMMANDS = {
     script: 'discover.js',
     description: 'Scan recent session transcripts for crushable output that skipped the Token Crusher',
   },
+  'crusher-shim': {
+    script: 'crusher-shim.js',
+    description: 'Install/uninstall a PATH-level Token Crusher binary shim (works for any tool that shells out, not just harnesses with hook rewrite support)',
+  },
   claw: {
     script: 'claw.js',
     description: 'NanoClaw REPL: persistent session-aware agent loop with Markdown history',
@@ -176,6 +180,7 @@ const PRIMARY_COMMANDS = [
   'saved',
   'gain',
   'discover',
+  'crusher-shim',
   'claw',
   'harness-audit',
 ];

--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -28,8 +28,17 @@ const SPAWN_OPTIONS = {
   maxBuffer: 64 * 1024 * 1024,
 };
 
+// npm, yarn, pnpm, corepack-shimmed bun etc. ship as .cmd/.bat wrappers on
+// Windows, not native .exe binaries. Node's spawn/spawnSync cannot launch a
+// .cmd/.bat directly without a shell (a well-documented Windows-only
+// child_process gotcha) -- shell: true is the standard fix, same as the
+// cross-spawn package uses for the same reason.
+function needsShellOnWindows(binaryPath) {
+  return process.platform === 'win32' && /\.(cmd|bat)$/i.test(binaryPath);
+}
+
 function passthrough(realBinary, args) {
-  const result = spawnSync(realBinary, args, { stdio: 'inherit' });
+  const result = spawnSync(realBinary, args, { stdio: 'inherit', shell: needsShellOnWindows(realBinary) });
   if (result.error) {
     process.stderr.write(`${path.basename(realBinary)}: ${result.error.message}\n`);
     process.exit(127);
@@ -62,7 +71,7 @@ function runShim(name, args) {
     return passthrough(realBinary, args);
   }
 
-  const result = spawnSync(realBinary, args, SPAWN_OPTIONS);
+  const result = spawnSync(realBinary, args, { ...SPAWN_OPTIONS, shell: needsShellOnWindows(realBinary) });
   if (result.error) {
     process.stderr.write(`${name}: ${result.error.message}\n`);
     process.exit(127);
@@ -99,4 +108,4 @@ if (require.main === module) {
   runShim(process.argv[2], process.argv.slice(3));
 }
 
-module.exports = { runShim };
+module.exports = { runShim, needsShellOnWindows };

--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// Token Crusher binary shim dispatcher. A tiny per-binary launcher file
+// (e.g. ~/.egc/bin/git) calls runShim(name, args) with its own hardcoded
+// name. This runs completely independently of any AI harness's hook
+// contract: it IS the binary that gets exec'd, via normal shell PATH
+// resolution, so it works for a human's terminal, an AI tool's subprocess
+// capture, a CI script, or anything else that shells out -- the exact gap
+// left by the PreToolUse rewrite being silently ignored for assistant-issued
+// Bash calls in Claude Code (see bootstrap-cognitive.js).
+//
+// Fails open at every step:
+//   - Real binary not resolvable -> "command not found", same as no shim.
+//   - stdout is a TTY (a human at an interactive terminal) -> full
+//     passthrough, untouched. There is no model context to save there, and
+//     buffering instead of streaming would break progress bars/prompts.
+//   - Engine/metrics modules unavailable, or the command kind is 'generic'
+//     -> full passthrough, zero capture, zero behavior change.
+//   - Any unexpected error at any point -> full passthrough.
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { resolveRealBinary } = require('./shim-paths');
+
+const SPAWN_OPTIONS = {
+  encoding: 'utf8',
+  stdio: ['inherit', 'pipe', 'inherit'],
+  maxBuffer: 64 * 1024 * 1024,
+};
+
+function passthrough(realBinary, args) {
+  const result = spawnSync(realBinary, args, { stdio: 'inherit' });
+  if (result.error) {
+    process.stderr.write(`${path.basename(realBinary)}: ${result.error.message}\n`);
+    process.exit(127);
+  }
+  process.exit(typeof result.status === 'number' ? result.status : 1);
+}
+
+function loadCrusher() {
+  try {
+    return { ...require('./engine'), ...require('./metrics') };
+  } catch {
+    return null;
+  }
+}
+
+function runShim(name, args) {
+  const realBinary = resolveRealBinary(name);
+  if (!realBinary) {
+    process.stderr.write(`${name}: command not found\n`);
+    process.exit(127);
+  }
+
+  if (process.stdout.isTTY) {
+    return passthrough(realBinary, args);
+  }
+
+  const crusher = loadCrusher();
+  const commandLine = [name, ...args].join(' ');
+  if (!crusher || crusher.commandKind(commandLine) === 'generic') {
+    return passthrough(realBinary, args);
+  }
+
+  const result = spawnSync(realBinary, args, SPAWN_OPTIONS);
+  if (result.error) {
+    process.stderr.write(`${name}: ${result.error.message}\n`);
+    process.exit(127);
+  }
+
+  const stdout = result.stdout || '';
+  let crushed;
+  try {
+    crushed = crusher.crushOutput(commandLine, stdout);
+  } catch {
+    crushed = null;
+  }
+
+  if (crushed) {
+    process.stdout.write(crushed.crushed + '\n');
+    crusher.record({
+      cmd: name,
+      kind: crushed.kind,
+      bytesIn: crushed.bytesIn,
+      bytesOut: crushed.bytesOut,
+      tokensSaved: crushed.tokensSaved,
+    });
+  } else if (stdout) {
+    process.stdout.write(stdout);
+  }
+
+  process.exit(typeof result.status === 'number' ? result.status : 1);
+}
+
+// Windows launchers (.cmd) cannot shebang directly into this file the way a
+// POSIX launcher does, so they spawn `node shim-dispatch.js <name> <args...>`
+// as a separate process instead of requiring runShim() in-process.
+if (require.main === module) {
+  runShim(process.argv[2], process.argv.slice(3));
+}
+
+module.exports = { runShim };

--- a/scripts/lib/crusher/shim-install.js
+++ b/scripts/lib/crusher/shim-install.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// Installs/removes the Token Crusher binary shim: a small launcher file per
+// binary in ~/.egc/bin (git, npm, ...), a manifest recording each binary's
+// real underlying path, and a PATH entry so the shim directory is found
+// before the real binaries. This works for any tool that shells out --
+// unlike the PreToolUse hook rewrite, it does not depend on any AI harness
+// honoring a rewritten command.
+//
+// A new shell session is required for the PATH change to take effect; this
+// module only edits config, it cannot change the PATH of the process that
+// invoked it (or any already-running shell).
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  SHIM_BINARY_NAMES,
+  shimDir,
+  manifestPath,
+  readManifest,
+  pathEnvKey,
+  resolveWithoutShim,
+} = require('./shim-paths');
+
+const DISPATCH_MODULE = path.join(__dirname, 'shim-dispatch.js');
+const PATH_MARKER = 'EGC Token Crusher shim';
+const RC_CANDIDATES = ['.bashrc', '.zshrc', '.bash_profile', '.profile'];
+
+function posixLauncherSource(name) {
+  return [
+    '#!/usr/bin/env node',
+    `require(${JSON.stringify(DISPATCH_MODULE)}).runShim(${JSON.stringify(name)}, process.argv.slice(2));`,
+    '',
+  ].join('\n');
+}
+
+function windowsLauncherSource(name) {
+  // cmd.exe/PowerShell resolve PATHEXT-listed extensions; a POSIX shebang
+  // does not execute there, so this spawns node on shim-dispatch.js as a
+  // separate process instead of requiring it in-process.
+  return [
+    '@echo off',
+    `node "${DISPATCH_MODULE}" ${name} %*`,
+    '',
+  ].join('\r\n');
+}
+
+function writeLauncher(dir, name) {
+  if (process.platform === 'win32') {
+    fs.writeFileSync(path.join(dir, `${name}.cmd`), windowsLauncherSource(name));
+    return;
+  }
+  const launcherPath = path.join(dir, name);
+  fs.writeFileSync(launcherPath, posixLauncherSource(name));
+  fs.chmodSync(launcherPath, 0o755);
+}
+
+function removeLauncher(dir, name) {
+  const launcherPath = process.platform === 'win32' ? path.join(dir, `${name}.cmd`) : path.join(dir, name);
+  if (fs.existsSync(launcherPath)) {
+    fs.unlinkSync(launcherPath);
+    return true;
+  }
+  return false;
+}
+
+function addToRcFile(rcPath, dir) {
+  if (!fs.existsSync(rcPath)) return { path: rcPath, changed: false, reason: 'does not exist' };
+  const content = fs.readFileSync(rcPath, 'utf8');
+  if (content.includes(PATH_MARKER)) return { path: rcPath, changed: false, reason: 'already installed' };
+  const block = `\n# ${PATH_MARKER} (added by egc crusher-shim install)\nexport PATH="${dir}:$PATH"\n`;
+  fs.appendFileSync(rcPath, block);
+  return { path: rcPath, changed: true };
+}
+
+function removeFromRcFile(rcPath) {
+  if (!fs.existsSync(rcPath)) return { path: rcPath, changed: false };
+  const lines = fs.readFileSync(rcPath, 'utf8').split('\n');
+  const markerIdx = lines.findIndex(l => l.includes(PATH_MARKER));
+  if (markerIdx === -1) return { path: rcPath, changed: false };
+
+  const toRemove = new Set([markerIdx]);
+  if ((lines[markerIdx + 1] || '').trim().startsWith('export PATH=')) toRemove.add(markerIdx + 1);
+  if (markerIdx > 0 && lines[markerIdx - 1].trim() === '') toRemove.add(markerIdx - 1);
+
+  const kept = lines.filter((_, i) => !toRemove.has(i));
+  fs.writeFileSync(rcPath, kept.join('\n'));
+  return { path: rcPath, changed: true };
+}
+
+function installPosixPath(dir) {
+  const home = os.homedir();
+  return RC_CANDIDATES.map(name => addToRcFile(path.join(home, name), dir));
+}
+
+function uninstallPosixPath() {
+  const home = os.homedir();
+  return RC_CANDIDATES.map(name => removeFromRcFile(path.join(home, name)));
+}
+
+// Best-effort: not exercised on real Windows by this repo's CI or by any
+// test in this suite (process.platform !== 'win32' everywhere else here).
+// Persisting a user env var on Windows has no direct Node API; this shells
+// out to PowerShell, which every supported Windows version ships.
+function installWindowsPath(dir) {
+  const script = `$dir = ${JSON.stringify(dir)}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; if (($current -split ';') -notcontains $dir) { [Environment]::SetEnvironmentVariable('Path', "$dir;$current", 'User'); Write-Output 'changed' } else { Write-Output 'already-present' }`;
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' });
+  return { changed: !result.error && /changed/.test(result.stdout || ''), error: result.error ? result.error.message : null };
+}
+
+function uninstallWindowsPath(dir) {
+  const script = `$dir = ${JSON.stringify(dir)}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; $parts = ($current -split ';') | Where-Object { $_ -ne $dir }; [Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User'); Write-Output 'done'`;
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' });
+  return { changed: !result.error, error: result.error ? result.error.message : null };
+}
+
+function install() {
+  const dir = shimDir();
+  fs.mkdirSync(dir, { recursive: true });
+
+  const manifest = {};
+  const installed = [];
+  const skipped = [];
+
+  for (const name of SHIM_BINARY_NAMES) {
+    const realPath = resolveWithoutShim(name);
+    if (!realPath) {
+      skipped.push(name);
+      continue;
+    }
+    manifest[name] = realPath;
+    writeLauncher(dir, name);
+    installed.push(name);
+  }
+
+  fs.writeFileSync(manifestPath(), JSON.stringify(manifest, null, 2));
+  const pathResult = process.platform === 'win32' ? installWindowsPath(dir) : installPosixPath(dir);
+
+  return { dir, installed, skipped, pathResult };
+}
+
+function uninstall() {
+  const dir = shimDir();
+  const manifest = readManifest();
+  const removed = Object.keys(manifest).filter(name => removeLauncher(dir, name));
+
+  if (fs.existsSync(manifestPath())) fs.unlinkSync(manifestPath());
+  const pathResult = process.platform === 'win32' ? uninstallWindowsPath(dir) : uninstallPosixPath();
+
+  return { dir, removed, pathResult };
+}
+
+function status() {
+  const dir = shimDir();
+  const manifest = readManifest();
+  const key = pathEnvKey();
+  const activeInCurrentShell = (process.env[key] || '')
+    .split(path.delimiter)
+    .some(p => p && path.resolve(p) === path.resolve(dir));
+
+  return {
+    dir,
+    dirExists: fs.existsSync(dir),
+    shimmed: Object.keys(manifest),
+    activeInCurrentShell,
+  };
+}
+
+module.exports = { install, uninstall, status, SHIM_BINARY_NAMES };

--- a/scripts/lib/crusher/shim-install.js
+++ b/scripts/lib/crusher/shim-install.js
@@ -54,7 +54,7 @@ function writeLauncher(dir, name) {
   }
   const launcherPath = path.join(dir, name);
   fs.writeFileSync(launcherPath, posixLauncherSource(name));
-  fs.chmodSync(launcherPath, 0o755);
+  fs.chmodSync(launcherPath, 0o755); // NOSONAR javascript:S2612 -- rwxr-xr-x, the minimum needed to make this launcher executable; not group/other-writable
 }
 
 function removeLauncher(dir, name) {
@@ -106,13 +106,13 @@ function uninstallPosixPath() {
 // out to PowerShell, which every supported Windows version ships.
 function installWindowsPath(dir) {
   const script = `$dir = ${JSON.stringify(dir)}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; if (($current -split ';') -notcontains $dir) { [Environment]::SetEnvironmentVariable('Path', "$dir;$current", 'User'); Write-Output 'changed' } else { Write-Output 'already-present' }`;
-  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' });
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- this IS the feature: prepending our own ~/.egc/bin (never user/attacker-writable beyond the local account already running this installer) ahead of the existing user PATH, read/written only through Windows's own SetEnvironmentVariable API
   return { changed: !result.error && /changed/.test(result.stdout || ''), error: result.error ? result.error.message : null };
 }
 
 function uninstallWindowsPath(dir) {
   const script = `$dir = ${JSON.stringify(dir)}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; $parts = ($current -split ';') | Where-Object { $_ -ne $dir }; [Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User'); Write-Output 'done'`;
-  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' });
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- same PATH edit as installWindowsPath, in reverse
   return { changed: !result.error, error: result.error ? result.error.message : null };
 }
 

--- a/scripts/lib/crusher/shim-paths.js
+++ b/scripts/lib/crusher/shim-paths.js
@@ -52,7 +52,7 @@ function resolveWithoutShim(name) {
     .split(path.delimiter)
     .filter(p => p && path.resolve(p) !== path.resolve(dir));
 
-  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [name], {
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [name], { // NOSONAR jssecurity:S8705 -- name is always a hardcoded SHIM_BINARY_NAMES entry or the launcher's own baked-in name, never untrusted input; array-form with no shell also rules out injection
     encoding: 'utf8',
     env: { ...process.env, [key]: filtered.join(path.delimiter) },
   });

--- a/scripts/lib/crusher/shim-paths.js
+++ b/scripts/lib/crusher/shim-paths.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// Shared paths and PATH-resolution helpers for the Token Crusher binary shim.
+// Used by both shim-dispatch.js (runs on every shimmed invocation) and
+// shim-install.js (install/uninstall/status), so the two never disagree on
+// where things live or how a "real" binary is found.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+// Conservative v1 list: binaries whose subcommands the engine already
+// classifies (see engine.js commandKind()) and that are not invoked so
+// pervasively that a bug in resolution would be catastrophic. Deliberately
+// excludes node, go, cargo, dotnet, mvn/gradle: each is either the runtime
+// this very shim runs on, or invoked too broadly for a v1 blast radius.
+const SHIM_BINARY_NAMES = [
+  'git', 'npm', 'pnpm', 'yarn', 'bun',
+  'pip', 'pip3', 'poetry', 'pipenv', 'uv',
+  'composer', 'bundle', 'gh',
+];
+
+function shimDir() {
+  return path.join(os.homedir(), '.egc', 'bin');
+}
+
+function manifestPath() {
+  return path.join(shimDir(), 'manifest.json');
+}
+
+function readManifest() {
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath(), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function pathEnvKey() {
+  return Object.keys(process.env).find(k => k.toLowerCase() === 'path') || 'PATH';
+}
+
+// Resolves the real binary on PATH with the shim directory filtered out, so
+// this never just finds the shim itself (directly at install time, before
+// any manifest exists, and as a fallback at dispatch time if the manifest is
+// missing, stale, or its target no longer exists).
+function resolveWithoutShim(name) {
+  const dir = shimDir();
+  const key = pathEnvKey();
+  const filtered = (process.env[key] || '')
+    .split(path.delimiter)
+    .filter(p => p && path.resolve(p) !== path.resolve(dir));
+
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [name], {
+    encoding: 'utf8',
+    env: { ...process.env, [key]: filtered.join(path.delimiter) },
+  });
+  if (probe.status !== 0 || !probe.stdout) return null;
+  const first = probe.stdout.split(/\r?\n/).map(l => l.trim()).find(Boolean);
+  return first || null;
+}
+
+function resolveRealBinary(name) {
+  const manifest = readManifest();
+  const fromManifest = manifest[name];
+  if (fromManifest && fs.existsSync(fromManifest)) return fromManifest;
+  return resolveWithoutShim(name);
+}
+
+module.exports = {
+  SHIM_BINARY_NAMES,
+  shimDir,
+  manifestPath,
+  readManifest,
+  pathEnvKey,
+  resolveWithoutShim,
+  resolveRealBinary,
+};

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -28,9 +28,11 @@ function seedManifest(homeDir, entries) {
 }
 
 function runShim(homeDir, name, args, options = {}) {
+  // os.homedir() reads USERPROFILE on Windows, HOME everywhere else -- both
+  // must be set or the real runner/user home leaks into the child process.
   return spawnSync(process.execPath, [DISPATCH_SCRIPT, name, ...args], {
     encoding: 'utf8',
-    env: { ...process.env, HOME: homeDir },
+    env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
     ...options,
   });
 }

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -7,6 +7,17 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const DISPATCH_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
+const { needsShellOnWindows } = require('../../scripts/lib/crusher/shim-dispatch');
+
+function withPlatform(value, fn) {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+}
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -16,9 +27,32 @@ function cleanup(dirPath) {
   fs.rmSync(dirPath, { recursive: true, force: true });
 }
 
-function writeFakeBinary(filePath, scriptBody) {
-  fs.writeFileSync(filePath, `#!/bin/sh\n${scriptBody}\n`, 'utf8');
-  fs.chmodSync(filePath, 0o755);
+// Fake binaries are small Node scripts, not shell scripts: a POSIX shebang
+// script does not execute at all on Windows (no shell, no chmod semantics),
+// so the underlying behavior is expressed once, in Node, and only the
+// per-platform launcher mechanics differ (a shebang file vs. a .cmd
+// wrapper), matching how the real npm.cmd/npx.cmd wrappers work there.
+function implBody({ stdout, exitCode = 0, echoStdin = false }) {
+  if (echoStdin) {
+    return "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{process.stdout.write(d);process.exit(0);});";
+  }
+  return `process.stdout.write(${JSON.stringify(stdout ?? '')});process.exit(${exitCode});`;
+}
+
+function writeFakeBinary(dir, name, spec) {
+  const implPath = path.join(dir, `${name}.impl.js`);
+  fs.writeFileSync(implPath, implBody(spec), 'utf8');
+
+  if (process.platform === 'win32') {
+    const binPath = path.join(dir, `${name}.cmd`);
+    fs.writeFileSync(binPath, `@echo off\r\nnode "${implPath}" %*\r\n`);
+    return binPath;
+  }
+
+  const binPath = path.join(dir, name);
+  fs.writeFileSync(binPath, `#!/usr/bin/env node\nrequire(${JSON.stringify(implPath)});\n`);
+  fs.chmodSync(binPath, 0o755);
+  return binPath;
 }
 
 function seedManifest(homeDir, entries) {
@@ -57,9 +91,8 @@ function runTests() {
   if (test('a non-generic command with large output gets compressed with the crusher marker', () => {
     const dir = createTempDir('egc-shim-dispatch-');
     try {
-      const fakeGit = path.join(dir, 'fake-git');
       const bigBody = Array.from({ length: 100 }, (_, i) => `commit ${'a'.repeat(40)}\nAuthor: x\nDate: y\n\n    message ${i}\n`).join('\n');
-      writeFakeBinary(fakeGit, `cat <<'EOF'\n${bigBody}\nEOF`);
+      const fakeGit = writeFakeBinary(dir, 'git', { stdout: bigBody });
       seedManifest(dir, { git: fakeGit });
 
       const result = runShim(dir, 'git', ['log', '--stat']);
@@ -74,9 +107,8 @@ function runTests() {
   if (test('a generic command (git status) never gets captured or compressed, even with large output', () => {
     const dir = createTempDir('egc-shim-dispatch-');
     try {
-      const fakeGit = path.join(dir, 'fake-git');
       const bigBody = 'x'.repeat(5000);
-      writeFakeBinary(fakeGit, `printf '%s' '${bigBody}'`);
+      const fakeGit = writeFakeBinary(dir, 'git', { stdout: bigBody });
       seedManifest(dir, { git: fakeGit });
 
       const result = runShim(dir, 'git', ['status']);
@@ -91,8 +123,7 @@ function runTests() {
   if (test('small non-generic output (below the crush threshold) passes through unchanged', () => {
     const dir = createTempDir('egc-shim-dispatch-');
     try {
-      const fakeGit = path.join(dir, 'fake-git');
-      writeFakeBinary(fakeGit, `echo 'commit abc123'`);
+      const fakeGit = writeFakeBinary(dir, 'git', { stdout: 'commit abc123\n' });
       seedManifest(dir, { git: fakeGit });
 
       const result = runShim(dir, 'git', ['log']);
@@ -106,8 +137,7 @@ function runTests() {
   if (test('the real exit code is preserved through the shim', () => {
     const dir = createTempDir('egc-shim-dispatch-');
     try {
-      const fakeGit = path.join(dir, 'fake-git');
-      writeFakeBinary(fakeGit, `echo 'failure'\nexit 7`);
+      const fakeGit = writeFakeBinary(dir, 'git', { stdout: 'failure\n', exitCode: 7 });
       seedManifest(dir, { git: fakeGit });
 
       const result = runShim(dir, 'git', ['status']);
@@ -120,9 +150,8 @@ function runTests() {
   if (test('stdin is passed through to the real binary untouched', () => {
     const dir = createTempDir('egc-shim-dispatch-');
     try {
-      const fakeCat = path.join(dir, 'fake-npm');
-      writeFakeBinary(fakeCat, 'cat');
-      seedManifest(dir, { npm: fakeCat });
+      const fakeNpm = writeFakeBinary(dir, 'npm', { echoStdin: true });
+      seedManifest(dir, { npm: fakeNpm });
 
       const result = runShim(dir, 'npm', ['status'], { input: 'hello from stdin' });
       assert.strictEqual(result.status, 0);
@@ -157,6 +186,18 @@ function runTests() {
     } finally {
       cleanup(dir);
     }
+  })) passed++; else failed++;
+
+  if (test('needsShellOnWindows requires shell only for .cmd/.bat on win32, never on POSIX', () => {
+    withPlatform('win32', () => {
+      assert.strictEqual(needsShellOnWindows('C:\\Program Files\\nodejs\\npm.cmd'), true);
+      assert.strictEqual(needsShellOnWindows('C:\\Program Files\\nodejs\\npm.CMD'), true);
+      assert.strictEqual(needsShellOnWindows('C:\\tools\\ruby\\bundle.bat'), true);
+      assert.strictEqual(needsShellOnWindows('C:\\Program Files\\Git\\bin\\git.exe'), false);
+    });
+    withPlatform('linux', () => {
+      assert.strictEqual(needsShellOnWindows('/usr/local/bin/npm.cmd'), false, 'never true off win32, regardless of extension');
+    });
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const DISPATCH_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function writeFakeBinary(filePath, scriptBody) {
+  fs.writeFileSync(filePath, `#!/bin/sh\n${scriptBody}\n`, 'utf8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+function seedManifest(homeDir, entries) {
+  const binDir = path.join(homeDir, '.egc', 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'manifest.json'), JSON.stringify(entries));
+}
+
+function runShim(homeDir, name, args, options = {}) {
+  return spawnSync(process.execPath, [DISPATCH_SCRIPT, name, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: homeDir },
+    ...options,
+  });
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.stack || err.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/crusher/shim-dispatch.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (test('a non-generic command with large output gets compressed with the crusher marker', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      const fakeGit = path.join(dir, 'fake-git');
+      const bigBody = Array.from({ length: 100 }, (_, i) => `commit ${'a'.repeat(40)}\nAuthor: x\nDate: y\n\n    message ${i}\n`).join('\n');
+      writeFakeBinary(fakeGit, `cat <<'EOF'\n${bigBody}\nEOF`);
+      seedManifest(dir, { git: fakeGit });
+
+      const result = runShim(dir, 'git', ['log', '--stat']);
+      assert.strictEqual(result.status, 0);
+      assert.ok(result.stdout.includes('[egc-crusher] saved'), 'expected the crusher marker in output');
+      assert.ok(result.stdout.length < bigBody.length, 'expected compressed output to be smaller than the original');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('a generic command (git status) never gets captured or compressed, even with large output', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      const fakeGit = path.join(dir, 'fake-git');
+      const bigBody = 'x'.repeat(5000);
+      writeFakeBinary(fakeGit, `printf '%s' '${bigBody}'`);
+      seedManifest(dir, { git: fakeGit });
+
+      const result = runShim(dir, 'git', ['status']);
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, bigBody);
+      assert.ok(!result.stdout.includes('[egc-crusher]'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('small non-generic output (below the crush threshold) passes through unchanged', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      const fakeGit = path.join(dir, 'fake-git');
+      writeFakeBinary(fakeGit, `echo 'commit abc123'`);
+      seedManifest(dir, { git: fakeGit });
+
+      const result = runShim(dir, 'git', ['log']);
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout.trim(), 'commit abc123');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('the real exit code is preserved through the shim', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      const fakeGit = path.join(dir, 'fake-git');
+      writeFakeBinary(fakeGit, `echo 'failure'\nexit 7`);
+      seedManifest(dir, { git: fakeGit });
+
+      const result = runShim(dir, 'git', ['status']);
+      assert.strictEqual(result.status, 7);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('stdin is passed through to the real binary untouched', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      const fakeCat = path.join(dir, 'fake-npm');
+      writeFakeBinary(fakeCat, 'cat');
+      seedManifest(dir, { npm: fakeCat });
+
+      const result = runShim(dir, 'npm', ['status'], { input: 'hello from stdin' });
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, 'hello from stdin');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('an unresolvable binary name exits 127 with "command not found"', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      seedManifest(dir, {});
+      const result = runShim(dir, 'totally-fake-binary-xyz-123', ['--version']);
+      assert.strictEqual(result.status, 127);
+      assert.ok(result.stderr.includes('command not found'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('a stale manifest entry pointing nowhere degrades to "command not found", never crashes', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      // The manifest points at a path that does not exist, and a fresh PATH
+      // lookup for this nonsense name also fails -- must degrade to "command
+      // not found", not an uncaught throw or a hung process.
+      seedManifest(dir, { 'totally-fake-binary-xyz-123': path.join(dir, 'does-not-exist') });
+      const result = runShim(dir, 'totally-fake-binary-xyz-123', []);
+      assert.strictEqual(result.status, 127);
+      assert.strictEqual(result.signal, null, 'must exit cleanly, not crash/signal');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/crusher-shim-install.test.js
+++ b/tests/lib/crusher-shim-install.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { install, uninstall, status, SHIM_BINARY_NAMES } = require('../../scripts/lib/crusher/shim-install');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function withHome(tempHome, fn) {
+  const saved = process.env.HOME;
+  process.env.HOME = tempHome;
+  try {
+    return fn();
+  } finally {
+    if (saved === undefined) delete process.env.HOME;
+    else process.env.HOME = saved;
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.stack || err.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/crusher/shim-install.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (test('install() accounts for every SHIM_BINARY_NAMES entry as installed or skipped, never dropped', () => {
+    const dir = createTempDir('egc-shim-install-');
+    try {
+      withHome(dir, () => {
+        const result = install();
+        const all = new Set([...result.installed, ...result.skipped]);
+        assert.strictEqual(all.size, SHIM_BINARY_NAMES.length);
+        for (const name of SHIM_BINARY_NAMES) assert.ok(all.has(name), `${name} missing from installed+skipped`);
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('install() writes an executable launcher and a real manifest path for every installed binary', () => {
+    const dir = createTempDir('egc-shim-install-');
+    try {
+      withHome(dir, () => {
+        const result = install();
+        assert.ok(result.installed.length > 0, 'expected at least one binary (e.g. git) to be found on this machine');
+
+        const manifest = JSON.parse(fs.readFileSync(path.join(result.dir, 'manifest.json'), 'utf8'));
+        for (const name of result.installed) {
+          const launcherPath = process.platform === 'win32' ? path.join(result.dir, `${name}.cmd`) : path.join(result.dir, name);
+          assert.ok(fs.existsSync(launcherPath), `launcher missing for ${name}`);
+          if (process.platform !== 'win32') {
+            const mode = fs.statSync(launcherPath).mode & 0o777;
+            assert.ok(mode & 0o100, `${name} launcher must be executable`);
+          }
+          assert.ok(manifest[name] && fs.existsSync(manifest[name]), `manifest entry for ${name} must point at a real file`);
+        }
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('installing twice appends the PATH block to an existing rc file exactly once', () => {
+    if (process.platform === 'win32') return; // rc-file logic is POSIX-only
+    const dir = createTempDir('egc-shim-install-');
+    try {
+      withHome(dir, () => {
+        const rcPath = path.join(dir, '.bashrc');
+        fs.writeFileSync(rcPath, '# pre-existing bashrc content\n');
+
+        install();
+        install();
+
+        const content = fs.readFileSync(rcPath, 'utf8');
+        const occurrences = content.split('EGC Token Crusher shim').length - 1;
+        assert.strictEqual(occurrences, 1, 'PATH block must be idempotent across repeated installs');
+        assert.ok(content.includes('# pre-existing bashrc content'), 'must not clobber existing rc content');
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('install() never throws when no rc file candidates exist at all', () => {
+    const dir = createTempDir('egc-shim-install-');
+    try {
+      withHome(dir, () => {
+        assert.doesNotThrow(() => install());
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('uninstall() removes every launcher, the manifest, and the PATH block cleanly', () => {
+    if (process.platform === 'win32') return; // rc-file logic is POSIX-only
+    const dir = createTempDir('egc-shim-install-');
+    try {
+      withHome(dir, () => {
+        const rcPath = path.join(dir, '.bashrc');
+        fs.writeFileSync(rcPath, '# original line one\n# original line two\n');
+
+        const installed = install();
+        const removed = uninstall();
+
+        assert.deepStrictEqual(new Set(removed.removed), new Set(installed.installed));
+        assert.ok(!fs.existsSync(path.join(installed.dir, 'manifest.json')));
+        for (const name of installed.installed) {
+          assert.ok(!fs.existsSync(path.join(installed.dir, name)));
+        }
+
+        const content = fs.readFileSync(rcPath, 'utf8');
+        assert.ok(!content.includes('EGC Token Crusher shim'));
+        assert.ok(content.includes('# original line one'));
+        assert.ok(content.includes('# original line two'));
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('status() reports the shimmed list and whether the dir is active on the current PATH', () => {
+    const dir = createTempDir('egc-shim-install-');
+    try {
+      withHome(dir, () => {
+        const before = status();
+        assert.strictEqual(before.dirExists, false);
+        assert.deepStrictEqual(before.shimmed, []);
+
+        const installed = install();
+        const afterInstall = status();
+        assert.strictEqual(afterInstall.dirExists, true);
+        assert.deepStrictEqual(new Set(afterInstall.shimmed), new Set(installed.installed));
+        assert.strictEqual(afterInstall.activeInCurrentShell, false, 'installing does not change this process\'s own PATH');
+
+        const savedPath = process.env.PATH;
+        process.env.PATH = `${installed.dir}${path.delimiter}${savedPath}`;
+        try {
+          assert.strictEqual(status().activeInCurrentShell, true);
+        } finally {
+          process.env.PATH = savedPath;
+        }
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/crusher-shim-install.test.js
+++ b/tests/lib/crusher-shim-install.test.js
@@ -16,13 +16,19 @@ function cleanup(dirPath) {
 }
 
 function withHome(tempHome, fn) {
-  const saved = process.env.HOME;
+  // os.homedir() reads USERPROFILE on Windows, HOME everywhere else -- both
+  // must be overridden or the real runner/user home leaks into the test.
+  const savedHome = process.env.HOME;
+  const savedUserProfile = process.env.USERPROFILE;
   process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
   try {
     return fn();
   } finally {
-    if (saved === undefined) delete process.env.HOME;
-    else process.env.HOME = saved;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
   }
 }
 

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  SHIM_BINARY_NAMES,
+  shimDir,
+  manifestPath,
+  readManifest,
+  pathEnvKey,
+  resolveWithoutShim,
+  resolveRealBinary,
+} = require('../../scripts/lib/crusher/shim-paths');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function withHome(tempHome, fn) {
+  const saved = process.env.HOME;
+  process.env.HOME = tempHome;
+  try {
+    return fn();
+  } finally {
+    if (saved === undefined) delete process.env.HOME;
+    else process.env.HOME = saved;
+  }
+}
+
+function writeFakeExecutable(filePath) {
+  fs.writeFileSync(filePath, '#!/bin/sh\necho fake\n', 'utf8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.stack || err.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/crusher/shim-paths.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (test('shimDir/manifestPath resolve under the current HOME', () => {
+    const dir = createTempDir('egc-shim-paths-');
+    try {
+      withHome(dir, () => {
+        assert.strictEqual(shimDir(), path.join(dir, '.egc', 'bin'));
+        assert.strictEqual(manifestPath(), path.join(dir, '.egc', 'bin', 'manifest.json'));
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('readManifest returns {} when the manifest file does not exist', () => {
+    const dir = createTempDir('egc-shim-paths-');
+    try {
+      withHome(dir, () => {
+        assert.deepStrictEqual(readManifest(), {});
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('readManifest returns {} instead of throwing on corrupt JSON', () => {
+    const dir = createTempDir('egc-shim-paths-');
+    try {
+      withHome(dir, () => {
+        fs.mkdirSync(path.join(dir, '.egc', 'bin'), { recursive: true });
+        fs.writeFileSync(manifestPath(), '{not valid json');
+        assert.deepStrictEqual(readManifest(), {});
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('pathEnvKey finds the PATH variable regardless of case', () => {
+    assert.ok(['PATH', 'Path'].includes(pathEnvKey()));
+  })) passed++; else failed++;
+
+  if (test('resolveWithoutShim finds a real system binary (node itself)', () => {
+    const found = resolveWithoutShim('node');
+    assert.ok(found, 'expected node to resolve on PATH');
+    assert.ok(fs.existsSync(found));
+  })) passed++; else failed++;
+
+  if (test('resolveWithoutShim returns null for a name that does not exist anywhere', () => {
+    assert.strictEqual(resolveWithoutShim('totally-fake-binary-xyz-123'), null);
+  })) passed++; else failed++;
+
+  if (test('resolveWithoutShim never resolves to something inside the shim directory itself', () => {
+    const dir = createTempDir('egc-shim-paths-');
+    try {
+      withHome(dir, () => {
+        const shimBinDir = shimDir();
+        fs.mkdirSync(shimBinDir, { recursive: true });
+        const decoy = path.join(shimBinDir, 'node');
+        writeFakeExecutable(decoy);
+
+        const savedPath = process.env.PATH;
+        process.env.PATH = `${shimBinDir}${path.delimiter}${savedPath}`;
+        try {
+          const found = resolveWithoutShim('node');
+          assert.notStrictEqual(path.resolve(found), path.resolve(decoy), 'must not resolve back to the shim decoy');
+        } finally {
+          process.env.PATH = savedPath;
+        }
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('resolveRealBinary prefers a valid manifest entry over a fresh PATH lookup', () => {
+    const dir = createTempDir('egc-shim-paths-');
+    try {
+      withHome(dir, () => {
+        fs.mkdirSync(shimDir(), { recursive: true });
+        const fakeGit = path.join(dir, 'fake-git');
+        writeFakeExecutable(fakeGit);
+        fs.writeFileSync(manifestPath(), JSON.stringify({ git: fakeGit }));
+
+        assert.strictEqual(resolveRealBinary('git'), fakeGit);
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('resolveRealBinary falls back to a fresh lookup when the manifest entry no longer exists on disk', () => {
+    const dir = createTempDir('egc-shim-paths-');
+    try {
+      withHome(dir, () => {
+        fs.mkdirSync(shimDir(), { recursive: true });
+        fs.writeFileSync(manifestPath(), JSON.stringify({ node: path.join(dir, 'deleted-node') }));
+
+        const found = resolveRealBinary('node');
+        assert.ok(found && fs.existsSync(found), 'must recover via a fresh PATH lookup');
+        assert.notStrictEqual(found, path.join(dir, 'deleted-node'));
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('SHIM_BINARY_NAMES excludes node, go, cargo, dotnet and mvn/gradle (deliberate v1 scope)', () => {
+    for (const excluded of ['node', 'go', 'cargo', 'dotnet', 'mvn', 'gradle']) {
+      assert.ok(!SHIM_BINARY_NAMES.includes(excluded), `${excluded} must not be in the v1 shim list`);
+    }
+    assert.ok(SHIM_BINARY_NAMES.includes('git'));
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -24,13 +24,19 @@ function cleanup(dirPath) {
 }
 
 function withHome(tempHome, fn) {
-  const saved = process.env.HOME;
+  // os.homedir() reads USERPROFILE on Windows, HOME everywhere else -- both
+  // must be overridden or the real runner/user home leaks into the test.
+  const savedHome = process.env.HOME;
+  const savedUserProfile = process.env.USERPROFILE;
   process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
   try {
     return fn();
   } finally {
-    if (saved === undefined) delete process.env.HOME;
-    else process.env.HOME = saved;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
   }
 }
 


### PR DESCRIPTION
The PreToolUse hook rewrite is silently ignored when the Bash call is issued by the assistant itself in Claude Code (a confirmed, not-planned Anthropic limitation). This adds a second delivery mechanism for the Token Crusher that does not depend on any harness's hook contract: a small launcher per binary (git, npm, pip, gh, ...) in `~/.egc/bin` ahead of the real binaries on PATH, reusing the existing `commandKind`/`crushOutput` engine.

- Full untouched passthrough whenever stdout is a TTY (no context window to save, and buffering would break progress bars/prompts).
- Only already-recognized non-generic command kinds capture output; everything else is a zero-overhead exec of the real binary.
- Any resolution failure degrades to "command not found", matching no-shim behavior.
- `egc crusher-shim install|uninstall|status` manages it.
- v1 list: git, npm, pnpm, yarn, bun, pip, pip3, poetry, pipenv, uv, composer, bundle, gh. Deliberately excludes node/go/cargo/dotnet/mvn/gradle (broader invocation surface, out of scope for v1).

Verified end to end on this machine: a real `git log --stat` through the installed shim crushed with the same marker/savings format as `egc run`, and `git status` (generic) is byte-identical with/without the shim.

23 new synthetic tests across 3 files (paths resolution, dispatch behavior via subprocess with fake binaries, install/uninstall/status idempotency).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PATH-level Token Crusher shim that compresses noisy CLI output even when hook-based rewrites are ignored. Manage via `egc crusher-shim install|uninstall|status`; open a new shell to activate.

- **New Features**
  - Installs small launchers in `~/.egc/bin` ahead of real binaries, with passthrough for interactive TTYs and generic commands.
  - Captures stdout only for recognized non-generic commands; preserves exit codes/stderr; on resolution failure, returns “command not found”.
  - v1 binaries: `git`, `npm`, `pnpm`, `yarn`, `bun`, `pip`, `pip3`, `poetry`, `pipenv`, `uv`, `composer`, `bundle`, `gh`.

- **Bug Fixes**
  - Windows: spawn `.cmd`/`.bat` real binaries with `shell: true`; updated test fixtures to Node-based wrappers and set `USERPROFILE` with `HOME` for stable CI.
  - Added comments to silence Sonar hotspots for PATH edits, launcher chmod, and command resolution.

<sup>Written for commit 5ec0171f91afe166ccf3f95037fcea4ca1df9fb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

