### PR TITLE
fix(doctor): CRLF/LF-only differences are not drift

### DIFF
--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -141,7 +141,19 @@ function areFilesEqual(leftPath, rightPath) {
       return false;
     }
 
-    return fs.readFileSync(leftPath).equals(fs.readFileSync(rightPath));
+    const left = fs.readFileSync(leftPath);
+    const right = fs.readFileSync(rightPath);
+    if (left.equals(right)) {
+      return true;
+    }
+
+    // A byte mismatch that disappears once CRLF/LF are normalized is a
+    // line-ending artifact of the install pipeline (e.g. Windows
+    // core.autocrlf rewriting the repo's LF source on checkout, or a
+    // rewrite step like buildResolvedClaudeHooks() that always emits LF via
+    // JSON.stringify), not a real edit to the managed file -- never flag it
+    // as drift.
+    return left.toString('utf8').replace(/\r\n/g, '\n') === right.toString('utf8').replace(/\r\n/g, '\n');
   } catch (_error) { // NOSONAR: unreadable files are treated as different
     return false;
   }

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -153,7 +153,7 @@ function areFilesEqual(leftPath, rightPath) {
     // rewrite step like buildResolvedClaudeHooks() that always emits LF via
     // JSON.stringify), not a real edit to the managed file -- never flag it
     // as drift.
-    return left.toString('utf8').replace(/\r\n/g, '\n') === right.toString('utf8').replace(/\r\n/g, '\n');
+    return left.toString('utf8').replaceAll('\r\n', '\n') === right.toString('utf8').replaceAll('\r\n', '\n');
   } catch (_error) { // NOSONAR: unreadable files are treated as different
     return false;
   }

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -283,6 +283,113 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('a CRLF-only difference (Windows checkout vs. a rewrite that always emits LF) is not drift (audit issue #1049)', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+    const altRepoRoot = createTempDir('doctor-altrepo-');
+
+    try {
+      fs.cpSync(path.join(REPO_ROOT, 'manifests'), path.join(altRepoRoot, 'manifests'), { recursive: true });
+      const altSourcePath = path.join(altRepoRoot, 'hooks', 'hooks.json');
+      fs.mkdirSync(path.dirname(altSourcePath), { recursive: true });
+      // The repo's own copy is LF, as git stores it (git ls-files --eol).
+      fs.writeFileSync(altSourcePath, '{\n  "hooks": {}\n}\n');
+
+      const targetRoot = path.join(homeDir, '.gemini');
+      const statePath = path.join(targetRoot, 'egc', 'install-state.json');
+      const managedFile = path.join(targetRoot, 'hooks', 'hooks.json');
+      fs.mkdirSync(path.dirname(managedFile), { recursive: true });
+      // Same content, CRLF line endings -- what a Windows checkout with
+      // core.autocrlf=true (no .gitattributes forcing LF) actually produces
+      // on disk, or what a rewrite step re-emitting the file via
+      // JSON.stringify(...) would differ by in the other direction. Either
+      // way this is not a real edit to the managed file.
+      fs.writeFileSync(managedFile, '{\r\n  "hooks": {}\r\n}\r\n');
+
+      writeState(statePath, {
+        adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+        targetRoot,
+        installStatePath: statePath,
+        request: { profile: null, modules: [], legacyLanguages: ['typescript'], legacyMode: true },
+        resolution: { selectedModules: ['hooks-runtime'], skippedModules: [] },
+        operations: [
+          {
+            kind: 'copy-file',
+            moduleId: 'hooks-runtime',
+            sourceRelativePath: 'hooks/hooks.json',
+            destinationPath: managedFile,
+            strategy: 'preserve-relative-path',
+            ownership: 'managed',
+            scaffoldOnly: false,
+          },
+        ],
+        source: { repoVersion: CURRENT_PACKAGE_VERSION, repoCommit: 'abc123', manifestVersion: CURRENT_MANIFEST_VERSION },
+      });
+
+      const result = run(['--target', 'egc', '--repo-root', altRepoRoot, '--json'], { cwd: projectRoot, homeDir });
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.strictEqual(parsed.results[0].status, 'ok', 'a CRLF/LF-only difference must not be reported as drift');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(altRepoRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('a real content difference is still reported as drift even when both files use CRLF', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+    const altRepoRoot = createTempDir('doctor-altrepo-');
+
+    try {
+      fs.cpSync(path.join(REPO_ROOT, 'manifests'), path.join(altRepoRoot, 'manifests'), { recursive: true });
+      const altSourcePath = path.join(altRepoRoot, 'hooks', 'hooks.json');
+      fs.mkdirSync(path.dirname(altSourcePath), { recursive: true });
+      fs.writeFileSync(altSourcePath, '{\r\n  "hooks": {}\r\n}\r\n');
+
+      const targetRoot = path.join(homeDir, '.gemini');
+      const statePath = path.join(targetRoot, 'egc', 'install-state.json');
+      const managedFile = path.join(targetRoot, 'hooks', 'hooks.json');
+      fs.mkdirSync(path.dirname(managedFile), { recursive: true });
+      // Genuinely different content (not just line endings) -- must still
+      // be caught as drift so the CRLF normalization does not mask real edits.
+      fs.writeFileSync(managedFile, '{\r\n  "hooks": { "edited": true }\r\n}\r\n');
+
+      writeState(statePath, {
+        adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+        targetRoot,
+        installStatePath: statePath,
+        request: { profile: null, modules: [], legacyLanguages: ['typescript'], legacyMode: true },
+        resolution: { selectedModules: ['hooks-runtime'], skippedModules: [] },
+        operations: [
+          {
+            kind: 'copy-file',
+            moduleId: 'hooks-runtime',
+            sourceRelativePath: 'hooks/hooks.json',
+            destinationPath: managedFile,
+            strategy: 'preserve-relative-path',
+            ownership: 'managed',
+            scaffoldOnly: false,
+          },
+        ],
+        source: { repoVersion: CURRENT_PACKAGE_VERSION, repoCommit: 'abc123', manifestVersion: CURRENT_MANIFEST_VERSION },
+      });
+
+      const result = run(['--target', 'egc', '--repo-root', altRepoRoot, '--json'], { cwd: projectRoot, homeDir });
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(result.code, 1);
+      assert.ok(
+        parsed.results[0].issues.some(issue => issue.code === 'drifted-managed-files'),
+        'a real content edit must still be reported as drift, CRLF normalization must not mask it'
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+      cleanup(altRepoRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('--repo-root rejects a path that does not exist with a clear error', () => {
     const homeDir = createTempDir('doctor-home-');
     const projectRoot = createTempDir('doctor-project-');


### PR DESCRIPTION
Reported by Aki-new (issue #1049): egc doctor showed "1 managed file(s) differ from the source repo" right after a clean install on Windows, reproduced twice with identical results.

Root cause: hooks/hooks.json is copied byte-for-byte like every other managed file, but applyInstallPlan() rewrites that one file a second time via JSON.stringify(...) + '\n', which always emits LF. On a Windows checkout with core.autocrlf enabled (this repo has no .gitattributes forcing LF), the repo's own copy on disk is CRLF, so areFilesEqual()'s byte comparison against the LF-rewritten destination reports drift on a file nothing actually touched.

areFilesEqual() now falls back to a CRLF-normalized comparison only when the raw bytes differ, matching the same normalization already used in propagate-state.js. Two new regression tests cover both directions: a line-ending-only difference is healthy, and a genuine content edit under CRLF is still correctly reported as drift.

Closes the open half of #1049.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false “drifted managed files” reports on Windows by treating CRLF/LF-only differences as not drift. Aligns file comparison with existing normalization and still flags real edits; fixes #1049.

- **Bug Fixes**
  - areFilesEqual() falls back to CRLF-normalized compare only when raw bytes differ (uses replaceAll).
  - Prevents drift when `hooks/hooks.json` is LF-rewritten but the repo copy is CRLF.
  - Adds tests: CRLF-only diff passes; real edit under CRLF fails.

<sup>Written for commit ef4cb8de7a367932c1198eb8bcf5922fc703ca69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

