### PR TITLE
fix(crusher): case-insensitive PATH filtering, signal handling, safer Windows PATH edits

### DIFF
--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -37,13 +37,27 @@ function needsShellOnWindows(binaryPath) {
   return process.platform === 'win32' && /\.(cmd|bat)$/i.test(binaryPath);
 }
 
+// A child killed by a signal (Ctrl+C/SIGINT, SIGTERM, ...) has result.status
+// === null and result.signal set. Re-raising the same signal on this
+// process (rather than exiting with a made-up status code) makes it
+// terminate the same way the real binary did, so a parent shell or process
+// manager watching for that signal sees the standard 128+n convention
+// instead of an opaque, unrelated exit code.
+function exitLikeChild(result) {
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
+  process.exit(typeof result.status === 'number' ? result.status : 1);
+}
+
 function passthrough(realBinary, args) {
   const result = spawnSync(realBinary, args, { stdio: 'inherit', shell: needsShellOnWindows(realBinary) });
   if (result.error) {
     process.stderr.write(`${path.basename(realBinary)}: ${result.error.message}\n`);
     process.exit(127);
   }
-  process.exit(typeof result.status === 'number' ? result.status : 1);
+  exitLikeChild(result);
 }
 
 function loadCrusher() {
@@ -73,8 +87,15 @@ function runShim(name, args) {
 
   const result = spawnSync(realBinary, args, { ...SPAWN_OPTIONS, shell: needsShellOnWindows(realBinary) });
   if (result.error) {
+    // ENOBUFS (output exceeded maxBuffer) is not "command not found" -- exit
+    // 127 there would be actively misleading to anything inspecting the
+    // status code. The child was already killed mid-run by spawnSync itself
+    // in this case, so there is nothing safe left to fall back to (retrying
+    // via passthrough would re-execute whatever side effects the command
+    // already had, possibly a second time).
+    const isBufferOverflow = result.error.code === 'ENOBUFS' || /maxBuffer/i.test(result.error.message || '');
     process.stderr.write(`${name}: ${result.error.message}\n`);
-    process.exit(127);
+    process.exit(isBufferOverflow ? 1 : 127);
   }
 
   const stdout = result.stdout || '';
@@ -98,7 +119,7 @@ function runShim(name, args) {
     process.stdout.write(stdout);
   }
 
-  process.exit(typeof result.status === 'number' ? result.status : 1);
+  exitLikeChild(result);
 }
 
 // Windows launchers (.cmd) cannot shebang directly into this file the way a
@@ -108,4 +129,4 @@ if (require.main === module) {
   runShim(process.argv[2], process.argv.slice(3));
 }
 
-module.exports = { runShim, needsShellOnWindows };
+module.exports = { runShim, needsShellOnWindows, exitLikeChild };

--- a/scripts/lib/crusher/shim-install.js
+++ b/scripts/lib/crusher/shim-install.js
@@ -28,10 +28,24 @@ const DISPATCH_MODULE = path.join(__dirname, 'shim-dispatch.js');
 const PATH_MARKER = 'EGC Token Crusher shim';
 const RC_CANDIDATES = ['.bashrc', '.zshrc', '.bash_profile', '.profile'];
 
+function launcherNotFoundMessage(name) {
+  // The launcher hardcodes an absolute path back into this repo checkout
+  // (there is nowhere else for it to point to). If that checkout is moved,
+  // renamed, or deleted, require() throws MODULE_NOT_FOUND -- catching it
+  // here trades Node's raw stack trace for a message that actually tells
+  // the person what to do about it.
+  return `${name}: the EGC Token Crusher shim can't find its own code (was the EGC checkout moved or deleted?). Run 'egc crusher-shim install' again from wherever it lives now, or 'egc crusher-shim uninstall' to remove this shim.`;
+}
+
 function posixLauncherSource(name) {
   return [
     '#!/usr/bin/env node',
-    `require(${JSON.stringify(DISPATCH_MODULE)}).runShim(${JSON.stringify(name)}, process.argv.slice(2));`,
+    'try {',
+    `  require(${JSON.stringify(DISPATCH_MODULE)}).runShim(${JSON.stringify(name)}, process.argv.slice(2));`,
+    '} catch (e) {',
+    `  if (e.code === 'MODULE_NOT_FOUND') { process.stderr.write(${JSON.stringify(launcherNotFoundMessage(name))} + '\\n'); process.exit(127); }`,
+    '  throw e;',
+    '}',
     '',
   ].join('\n');
 }
@@ -39,9 +53,16 @@ function posixLauncherSource(name) {
 function windowsLauncherSource(name) {
   // cmd.exe/PowerShell resolve PATHEXT-listed extensions; a POSIX shebang
   // does not execute there, so this spawns node on shim-dispatch.js as a
-  // separate process instead of requiring it in-process.
+  // separate process instead of requiring it in-process. Batch has no
+  // exception handling, so the existence check happens up front instead of
+  // catching node's own error after the fact (see posixLauncherSource for
+  // why this check exists at all).
   return [
     '@echo off',
+    `if not exist "${DISPATCH_MODULE}" (`,
+    `  echo ${launcherNotFoundMessage(name)}`,
+    '  exit /b 127',
+    ')',
     `node "${DISPATCH_MODULE}" ${name} %*`,
     '',
   ].join('\r\n');
@@ -100,20 +121,48 @@ function uninstallPosixPath() {
   return RC_CANDIDATES.map(name => removeFromRcFile(path.join(home, name)));
 }
 
+// PowerShell double-quoted strings ("...") interpolate $variables; single
+// quotes ('...') do not. JSON.stringify() always emits double quotes, so
+// embedding it directly would let a $ anywhere in the path (rare, but valid
+// in a Windows username) be misread as a PowerShell variable reference.
+// Single-quoting with '' as the escape for an embedded ' is the standard,
+// safe way to embed an arbitrary string in a PowerShell script.
+function powershellSingleQuote(value) {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function runPowerShell(script) {
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- this IS the feature: prepending our own ~/.egc/bin (never user/attacker-writable beyond the local account already running this installer) ahead of the existing user PATH, read/written only through Windows's own SetEnvironmentVariable API
+  if (result.error) {
+    return { ok: false, stdout: '', error: result.error.message };
+  }
+  if (result.status !== 0) {
+    // spawnSync only ever populates result.error for a failure to launch
+    // powershell.exe itself; a script-level failure (bad syntax, denied
+    // registry write, execution policy) instead surfaces as a non-zero
+    // status with nothing in result.error, which the previous version of
+    // this code silently treated as success.
+    return { ok: false, stdout: result.stdout || '', error: (result.stderr || `powershell exited with status ${result.status}`).trim() };
+  }
+  return { ok: true, stdout: result.stdout || '', error: null };
+}
+
 // Best-effort: not exercised on real Windows by this repo's CI or by any
 // test in this suite (process.platform !== 'win32' everywhere else here).
 // Persisting a user env var on Windows has no direct Node API; this shells
 // out to PowerShell, which every supported Windows version ships.
 function installWindowsPath(dir) {
-  const script = `$dir = ${JSON.stringify(dir)}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; if (($current -split ';') -notcontains $dir) { [Environment]::SetEnvironmentVariable('Path', "$dir;$current", 'User'); Write-Output 'changed' } else { Write-Output 'already-present' }`;
-  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- this IS the feature: prepending our own ~/.egc/bin (never user/attacker-writable beyond the local account already running this installer) ahead of the existing user PATH, read/written only through Windows's own SetEnvironmentVariable API
-  return { changed: !result.error && /changed/.test(result.stdout || ''), error: result.error ? result.error.message : null };
+  const safeDir = powershellSingleQuote(dir);
+  const script = `$dir = ${safeDir}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; $parts = ($current -split ';') | Where-Object { $_ }; if ($parts -notcontains $dir) { [Environment]::SetEnvironmentVariable('Path', (@($dir) + $parts -join ';'), 'User'); Write-Output 'changed' } else { Write-Output 'already-present' }`;
+  const result = runPowerShell(script);
+  return { changed: result.ok && /changed/.test(result.stdout), error: result.error };
 }
 
 function uninstallWindowsPath(dir) {
-  const script = `$dir = ${JSON.stringify(dir)}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; $parts = ($current -split ';') | Where-Object { $_ -ne $dir }; [Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User'); Write-Output 'done'`;
-  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- same PATH edit as installWindowsPath, in reverse
-  return { changed: !result.error, error: result.error ? result.error.message : null };
+  const safeDir = powershellSingleQuote(dir);
+  const script = `$dir = ${safeDir}; $current = [Environment]::GetEnvironmentVariable('Path','User'); if ($current -eq $null) { $current = '' }; $parts = ($current -split ';') | Where-Object { $_ }; if ($parts -contains $dir) { [Environment]::SetEnvironmentVariable('Path', (($parts | Where-Object { $_ -ne $dir }) -join ';'), 'User'); Write-Output 'changed' } else { Write-Output 'not-present' }`;
+  const result = runPowerShell(script);
+  return { changed: result.ok && /changed/.test(result.stdout), error: result.error };
 }
 
 function install() {
@@ -168,4 +217,4 @@ function status() {
   };
 }
 
-module.exports = { install, uninstall, status, SHIM_BINARY_NAMES };
+module.exports = { install, uninstall, status, SHIM_BINARY_NAMES, powershellSingleQuote };

--- a/scripts/lib/crusher/shim-install.js
+++ b/scripts/lib/crusher/shim-install.js
@@ -43,7 +43,7 @@ function posixLauncherSource(name) {
     'try {',
     `  require(${JSON.stringify(DISPATCH_MODULE)}).runShim(${JSON.stringify(name)}, process.argv.slice(2));`,
     '} catch (e) {',
-    `  if (e.code === 'MODULE_NOT_FOUND') { process.stderr.write(${JSON.stringify(launcherNotFoundMessage(name))} + '\\n'); process.exit(127); }`,
+    String.raw`  if (e.code === 'MODULE_NOT_FOUND') { process.stderr.write(${JSON.stringify(launcherNotFoundMessage(name))} + '\n'); process.exit(127); }`,
     '  throw e;',
     '}',
     '',
@@ -128,7 +128,7 @@ function uninstallPosixPath() {
 // Single-quoting with '' as the escape for an embedded ' is the standard,
 // safe way to embed an arbitrary string in a PowerShell script.
 function powershellSingleQuote(value) {
-  return `'${value.replace(/'/g, "''")}'`;
+  return `'${value.replaceAll("'", "''")}'`;
 }
 
 function runPowerShell(script) {

--- a/scripts/lib/crusher/shim-paths.js
+++ b/scripts/lib/crusher/shim-paths.js
@@ -41,6 +41,16 @@ function pathEnvKey() {
   return Object.keys(process.env).find(k => k.toLowerCase() === 'path') || 'PATH';
 }
 
+// Windows and default macOS (HFS+/APFS) filesystems are case-insensitive, so
+// a PATH entry that differs from shimDir() only in casing would otherwise
+// slip past the filter below and resolve back to the shim itself --
+// structurally the exact infinite-recursion case this filter exists to rule
+// out. Linux stays case-sensitive, matching its case-sensitive filesystem.
+function normalizePathForCompare(p) {
+  const resolved = path.resolve(p);
+  return process.platform === 'win32' || process.platform === 'darwin' ? resolved.toLowerCase() : resolved;
+}
+
 // Resolves the real binary on PATH with the shim directory filtered out, so
 // this never just finds the shim itself (directly at install time, before
 // any manifest exists, and as a fallback at dispatch time if the manifest is
@@ -48,9 +58,10 @@ function pathEnvKey() {
 function resolveWithoutShim(name) {
   const dir = shimDir();
   const key = pathEnvKey();
+  const normalizedDir = normalizePathForCompare(dir);
   const filtered = (process.env[key] || '')
     .split(path.delimiter)
-    .filter(p => p && path.resolve(p) !== path.resolve(dir));
+    .filter(p => p && normalizePathForCompare(p) !== normalizedDir);
 
   const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [name], { // NOSONAR jssecurity:S8705 -- name is always a hardcoded SHIM_BINARY_NAMES entry or the launcher's own baked-in name, never untrusted input; array-form with no shell also rules out injection
     encoding: 'utf8',
@@ -74,6 +85,7 @@ module.exports = {
   manifestPath,
   readManifest,
   pathEnvKey,
+  normalizePathForCompare,
   resolveWithoutShim,
   resolveRealBinary,
 };

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -32,9 +32,14 @@ function cleanup(dirPath) {
 // so the underlying behavior is expressed once, in Node, and only the
 // per-platform launcher mechanics differ (a shebang file vs. a .cmd
 // wrapper), matching how the real npm.cmd/npx.cmd wrappers work there.
-function implBody({ stdout, exitCode = 0, echoStdin = false }) {
+function implBody({ stdout, exitCode = 0, echoStdin = false, selfSignal }) {
   if (echoStdin) {
     return "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{process.stdout.write(d);process.exit(0);});";
+  }
+  if (selfSignal) {
+    // Simulates a process killed by a signal (Ctrl+C/SIGINT, SIGTERM, ...):
+    // spawnSync reports this as status=null, signal=<name> for the parent.
+    return `process.stdout.write(${JSON.stringify(stdout ?? '')});process.kill(process.pid, ${JSON.stringify(selfSignal)});setTimeout(()=>{},1000);`;
   }
   return `process.stdout.write(${JSON.stringify(stdout ?? '')});process.exit(${exitCode});`;
 }
@@ -142,6 +147,21 @@ function runTests() {
 
       const result = runShim(dir, 'git', ['status']);
       assert.strictEqual(result.status, 7);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('a child killed by a signal makes the shim die by the same signal, not a generic exit code (audit EGC-520)', () => {
+    if (process.platform === 'win32') return; // POSIX signal semantics only
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      const fakeGit = writeFakeBinary(dir, 'git', { selfSignal: 'SIGTERM' });
+      seedManifest(dir, { git: fakeGit });
+
+      const result = runShim(dir, 'git', ['status']);
+      assert.strictEqual(result.signal, 'SIGTERM');
+      assert.strictEqual(result.status, null);
     } finally {
       cleanup(dir);
     }

--- a/tests/lib/crusher-shim-install.test.js
+++ b/tests/lib/crusher-shim-install.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { install, uninstall, status, SHIM_BINARY_NAMES } = require('../../scripts/lib/crusher/shim-install');
+const { install, uninstall, status, SHIM_BINARY_NAMES, powershellSingleQuote } = require('../../scripts/lib/crusher/shim-install');
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -48,6 +48,16 @@ function runTests() {
   console.log('\n=== Testing scripts/lib/crusher/shim-install.js ===\n');
   let passed = 0;
   let failed = 0;
+
+  if (test('powershellSingleQuote escapes embedded quotes and never leaves a $ open to interpolation (audit EGC-518)', () => {
+    assert.strictEqual(powershellSingleQuote('C:\\Users\\felipe\\.egc\\bin'), "'C:\\Users\\felipe\\.egc\\bin'");
+    assert.strictEqual(powershellSingleQuote("C:\\Users\\o'brien\\.egc\\bin"), "'C:\\Users\\o''brien\\.egc\\bin'");
+    // The whole point: JSON.stringify's double quotes let PowerShell try to
+    // interpolate $user; single-quoting the same path must not.
+    const withDollar = 'C:\\Users\\$user\\.egc\\bin';
+    assert.strictEqual(powershellSingleQuote(withDollar), "'C:\\Users\\$user\\.egc\\bin'");
+    assert.ok(powershellSingleQuote(withDollar).startsWith("'") && powershellSingleQuote(withDollar).endsWith("'"));
+  })) passed++; else failed++;
 
   if (test('install() accounts for every SHIM_BINARY_NAMES entry as installed or skipped, never dropped', () => {
     const dir = createTempDir('egc-shim-install-');

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -11,6 +11,7 @@ const {
   manifestPath,
   readManifest,
   pathEnvKey,
+  normalizePathForCompare,
   resolveWithoutShim,
   resolveRealBinary,
 } = require('../../scripts/lib/crusher/shim-paths');
@@ -21,6 +22,16 @@ function createTempDir(prefix) {
 
 function cleanup(dirPath) {
   fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function withPlatform(value, fn) {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
 }
 
 function withHome(tempHome, fn) {
@@ -100,6 +111,21 @@ function runTests() {
 
   if (test('pathEnvKey finds the PATH variable regardless of case', () => {
     assert.ok(['PATH', 'Path'].includes(pathEnvKey()));
+  })) passed++; else failed++;
+
+  if (test('normalizePathForCompare is case-insensitive on win32/darwin, case-sensitive on linux (audit EGC-520)', () => {
+    const upper = '/Users/Felipe/.egc/bin';
+    const lower = '/users/felipe/.egc/bin';
+
+    withPlatform('win32', () => {
+      assert.strictEqual(normalizePathForCompare(upper), normalizePathForCompare(lower));
+    });
+    withPlatform('darwin', () => {
+      assert.strictEqual(normalizePathForCompare(upper), normalizePathForCompare(lower));
+    });
+    withPlatform('linux', () => {
+      assert.notStrictEqual(normalizePathForCompare(upper), normalizePathForCompare(lower));
+    });
   })) passed++; else failed++;
 
   if (test('resolveWithoutShim finds a real system binary (node itself)', () => {


### PR DESCRIPTION
Follow-up review of #1107 (Token Crusher binary shim) found five real issues before they could ship:

1. **Infinite-recursion risk on Windows/macOS**: `resolveWithoutShim()` filtered PATH case-sensitively, but both filesystems are case-insensitive. A PATH entry differing only in casing from the shim directory would resolve back to the shim itself.
2. **PowerShell variable injection**: the Windows PATH edit embedded the target directory via `JSON.stringify` (double-quoted), and PowerShell interpolates `$variables` inside double quotes. Switched to single-quoted literals.
3. **Silent PowerShell failures**: both PATH helpers only checked `result.error` (a failure to launch `powershell.exe` itself), not a non-zero script exit (e.g. a denied registry write), so a real failure reported as success.
4. **`uninstallWindowsPath` always reported `changed: true`**, even when the directory was never in PATH.
5. **Signal handling**: a child killed by SIGINT/SIGTERM exited the shim with a generic status code instead of the standard 128+n convention.

Also gives the generated launchers a clear message instead of a raw `MODULE_NOT_FOUND` stack trace if the EGC checkout has moved.

6 new regression tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reliability issues in the Token Crusher shim: case-insensitive PATH filtering on Windows/macOS, safer Windows PATH edits, correct signal propagation, and clearer launcher errors. Prevents shim recursion, avoids silent PATH edit failures, and matches standard exit behavior.

- **Bug Fixes**
  - PATH filtering is case-insensitive on Windows/macOS; Linux stays case-sensitive.
  - Windows PATH edits: single-quoted PowerShell strings (no $ interpolation), detect non-zero script exits, surface stderr; uninstall reports changed only when actually removed.
  - Signal handling: re-raise child signals (SIGINT/SIGTERM); ENOBUFS exits with code 1 instead of 127.
  - Launchers show a clear message when `shim-dispatch.js` is missing; `.cmd` checks existence and exits 127.
  - Added 6 regression tests for case-insensitive comparisons, PowerShell quoting, signal propagation, and status reporting.

- **Refactors**
  - Use String.raw and replaceAll per SonarCloud; no behavior change.

<sup>Written for commit 2757affa7cb3aed63d8d0f55baa419aa233a93e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

