### PR TITLE
chore(context): sync AI tool context mirrors with canonical CLAUDE.md

### DIFF
--- a/.cursor/rules/egc-context.mdc
+++ b/.cursor/rules/egc-context.mdc
@@ -38,3 +38,8 @@ Detect user intent in any language and call the matching EGC tool — no keyword
 - User asks if a file path is safe to write → `validate_write`
 - User asks to organize a complex task → `orchestrate_task`
 - User asks AI to learn from session errors → `auto_learn`
+
+<!-- egc:start -->
+## EGC Project Memory
+
+<!-- egc:end -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,37 +46,4 @@ never reach the repository.
 <!-- egc:start -->
 ## EGC Project Memory
 
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/.trae/rules/egc-context.md
+++ b/.trae/rules/egc-context.md
@@ -24,37 +24,4 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,37 +62,4 @@ Skipping any of these breaks the EGC contract. There are no exceptions for "simp
 <!-- egc:start -->
 ## EGC Project Memory
 
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -93,37 +93,4 @@ Judge by the full conversation context, never by literal words. A remark to some
 <!-- egc:start -->
 ## EGC Project Memory
 
-## EGC Natural Language Interface
-
-Detect user intent in any language and call the matching EGC tool — no keywords required:
-
-**Session**
-- User resumes work (any language) → `get_state`
-- User ends session (any language) → `update_state`
-
-**Diagnosis — when AI seems confused or hallucinating**
-- User questions whether things are working → `get_project_state`
-- User asks what mistakes keep repeating → `detect_patterns`
-- User asks what was learned in past sessions → `lesson_recall`
-
-**Memory — user forces a save**
-- User asks to record a decision → `store_decision`
-- User asks AI not to repeat a mistake → `lesson_save`
-- User confirms a past lesson happened again → `lesson_reinforce`
-- User wants to store something temporarily → `working_memory_set`
-- User asks what is in temporary memory → `working_memory_get` / `working_memory_list`
-
-**Search — when AI forgot something**
-- User asks about past decisions on a topic → `search_history`
-- User asks for recent decisions chronologically → `query_history`
-
-**Context — when heavy**
-- User says context is full or heavy → `reduce_context`
-- User asks to compress session observations → `compress_observations`
-
-**Safety — when user is suspicious**
-- User asks if a shell command is safe → `validate_command`
-- User asks if a file path is safe to write → `validate_write`
-- User asks to organize a complex task → `orchestrate_task`
-- User asks AI to learn from session errors → `auto_learn`
 <!-- egc:end -->


### PR DESCRIPTION
Propaga a remoção da seção EGC Natural Language Interface (já fora do CLAUDE.md canônico) para os arquivos espelho de cada ferramenta (AGENTS.md, GEMINI.md, .github/copilot-instructions.md, .trae/rules/egc-context.md), e adiciona o bloco EGC Project Memory ao .cursor/rules/egc-context.mdc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync context mirrors with the canonical `CLAUDE.md` to keep guidance consistent. Removes the obsolete “EGC Natural Language Interface” and adds the “EGC Project Memory” block to `.cursor/rules/egc-context.mdc`.

- **Refactors**
  - Removed the “EGC Natural Language Interface” section from `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`, and `.trae/rules/egc-context.md`.
  - Added the “EGC Project Memory” block within the `egc:start`/`egc:end` anchors in `.cursor/rules/egc-context.mdc`.

<sup>Written for commit 9e407e575816039314527d9519b7c801a18482e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

