### PR TITLE
feat(crusher): wire the binary shim into the standard install flow

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -359,6 +359,21 @@ fs.writeFileSync(t,JSON.stringify(obj,null,2)+"\n");
         Remove-Item $propObsTmp -ErrorAction SilentlyContinue
     }
 
+    # Token Crusher PATH-level binary shim (git, npm, gh, ...). Best-effort:
+    # a failure here (permission, unsupported shell profile, ...) must never
+    # abort an otherwise successful install.
+    Write-Host ""
+    Write-Host "  installing Token Crusher binary shim..."
+    $CrusherShim = Join-Path (Join-Path $RootDir "scripts") "crusher-shim.js"
+    try {
+        node $CrusherShim install
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  note: crusher-shim install failed (non-fatal). Run 'node scripts\crusher-shim.js install' manually to retry." -ForegroundColor Yellow
+        }
+    } catch {
+        Write-Host "  note: crusher-shim install failed (non-fatal). Run 'node scripts\crusher-shim.js install' manually to retry." -ForegroundColor Yellow
+    }
+
     Write-Host ""
     Write-Host "Installation complete."
     if (-not $hasInstallArgs) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -458,7 +458,7 @@ fi
 # failure here (permission, unsupported shell config, ...) must never abort
 # an otherwise successful install. Skipped in --dry-run, same as the rest of
 # this section.
-if [ "$DRY_RUN" = false ]; then
+if [[ "$DRY_RUN" = false ]]; then
   echo ""
   echo "Installing Token Crusher binary shim..."
   node "$ROOT_DIR/scripts/crusher-shim.js" install || echo "  note: crusher-shim install failed (non-fatal). Run 'node scripts/crusher-shim.js install' manually to retry."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,8 +173,13 @@ if [ ! -f "$ROOT_DIR/mcp/servers/egc-memory/build/index.js" ]; then
 fi
 echo "  ✓ egc-memory build verified"
 
-# Final validation
-node scripts/egc.js doctor
+# Final validation. `egc doctor` exits 1 on warnings, not just errors (by
+# design, for standalone/CI use) -- under this script's `set -e`, an
+# untreated non-zero exit here would silently abort the rest of the install
+# (MCP registration, ecosystem install, the Token Crusher shim below) on any
+# warning, however minor. This is a status report, not a gate: never let it
+# be fatal to the install.
+node scripts/egc.js doctor || true
 
 # Interactive ecosystem install (skipped in CI/headless environments)
 if [ -t 0 ] && [ "$DRY_RUN" = false ]; then
@@ -447,6 +452,16 @@ if [ -d "$ROOT_DIR/.git" ] && [ "$DRY_RUN" = false ]; then
   else
     echo "  ✓ git pre-commit hook already installed"
   fi
+fi
+
+# Token Crusher PATH-level binary shim (git, npm, gh, ...). Best-effort: a
+# failure here (permission, unsupported shell config, ...) must never abort
+# an otherwise successful install. Skipped in --dry-run, same as the rest of
+# this section.
+if [ "$DRY_RUN" = false ]; then
+  echo ""
+  echo "Installing Token Crusher binary shim..."
+  node "$ROOT_DIR/scripts/crusher-shim.js" install || echo "  note: crusher-shim install failed (non-fatal). Run 'node scripts/crusher-shim.js install' manually to retry."
 fi
 
 echo ""

--- a/tests/scripts/install-ps1.test.js
+++ b/tests/scripts/install-ps1.test.js
@@ -147,6 +147,17 @@ function runTests() {
     assert.strictEqual(buildGuards.length, bashGuards.length, 'install.ps1 and install.sh should guard the same number of builds');
   })) passed++; else failed++;
 
+  if (test('installs the Token Crusher binary shim as a best-effort, non-fatal step', () => {
+    assert.ok(
+      scriptSource.includes('$CrusherShim = Join-Path (Join-Path $RootDir "scripts") "crusher-shim.js"'),
+      'install.ps1 must invoke crusher-shim.js install so future downloads get the shim automatically'
+    );
+    assert.ok(
+      /try\s*\{\s*node \$CrusherShim install/.test(scriptSource),
+      'the crusher-shim install call must be wrapped so a failure never aborts the install'
+    );
+  })) passed++; else failed++;
+
   if (!powerShellCommand) {
     console.log('  - skipped delegation test; PowerShell is not available in PATH');
   } else if (test('delegates to the Node installer and preserves dry-run output', () => {

--- a/tests/scripts/install-sh.test.js
+++ b/tests/scripts/install-sh.test.js
@@ -187,6 +187,19 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('installs the Token Crusher binary shim as a best-effort, non-fatal step', () => {
+    const script = fs.readFileSync(SCRIPT, 'utf8');
+
+    assert.ok(
+      /node "\$ROOT_DIR\/scripts\/crusher-shim\.js" install/.test(script),
+      'install.sh must invoke crusher-shim.js install so future downloads get the shim automatically'
+    );
+    assert.ok(
+      /crusher-shim\.js" install \|\|/.test(script),
+      'the crusher-shim install call must be wired with a || fallback so a failure never aborts the install'
+    );
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
`egc crusher-shim install` existed only as a separate, opt-in command. Anyone downloading a future release and running the normal `install.sh`/`install.ps1` would get the PreToolUse hook (which only helps harnesses that honor a command rewrite for the AI assistant itself, a gap Claude Code confirmed as "not planned") but never the shim, unless they already knew that command existed.

Both installers now run the shim install as a best-effort, non-fatal step near the end of the flow.

Also fixes a real bug found while verifying this end-to-end: `install.sh`'s final `egc doctor` call exits 1 on warnings (not just errors, by design for standalone/CI use), and under this script's `set -e`, that silently aborted the rest of the install (MCP registration, ecosystem install, and now the shim step) on any warning, however minor.

Verified end-to-end locally: ran `install.sh` for real in an isolated temp HOME and confirmed the shim binaries land in `~/.egc/bin` with a correct manifest, and that the doctor fix restores exit 0 with warnings present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the Token Crusher binary shim into the standard installers so running `install.sh` or `install.ps1` sets up PATH-level shims automatically. Also makes `install.sh` treat `egc doctor` warnings as non-fatal so the rest of the install completes.

- New Features
  - `install.sh` and `install.ps1` now run `node scripts/crusher-shim.js install` as a best-effort step near the end (non-fatal, skipped in `--dry-run`).

- Bug Fixes and Refactors
  - `install.sh`: treat `egc doctor` as non-fatal (`|| true`) to prevent aborts on warnings and allow MCP registration, ecosystem install, and the shim step to run.
  - `install.sh`: use `[[ ... ]]` conditionals to satisfy shell linting; no behavior change.

<sup>Written for commit 3d6cd735b61136b0b04137a1eb737b11a7873f8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

