### PR TITLE
docs(installation): document the Crusher shim, fix stale example counts

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,7 @@ sh scripts/install.sh
 > **Note:** Gemini CLI free tier was discontinued on June 18, 2026 for individual users. The `~/.gemini/GEMINI.md` target still works for paid Google accounts. For free-tier users, [Antigravity CLI](https://antigravity.dev) is the recommended alternative: EGC supports it via `egc install --target antigravity`.
 4. Registers both MCP servers in every detected tool's config file
 5. Asks interactively whether to install the prompt library (63 agents, 230 skills, 77 commands): skipped automatically in CI
+6. Installs the Token Crusher binary shim (`~/.egc/bin`): a best-effort, non-fatal step, see [Token Crusher](#token-crusher) below
 
 ### Example output
 
@@ -130,7 +131,11 @@ EGC install
   ✓ registered in Cursor
   ✓ registered in Gemini CLI  ← paid accounts only; see note above
 
-Install prompt library? (63 agents, 229 skills, 76 commands) [y/N]:
+Install prompt library? (63 agents, 230 skills, 77 commands) [y/N]:
+
+Installing Token Crusher binary shim...
+Shim directory: ~/.egc/bin
+Installed: git, npm, gh, ...
 
 Installation complete.
 Run 'egc doctor' to verify.
@@ -252,6 +257,16 @@ egc discover           # scan recent session transcripts for crushable output th
 ```
 
 On hook-capable harnesses the bash dispatcher routes eligible simple commands through `egc run` automatically. The rewrite is strictly fail-open: pipelines, chaining, redirection, already-wrapped commands, or a missing `egc` CLI all pass through untouched. Opt out anytime with `EGC_DISABLED_HOOKS=pre:bash:crusher-rewrite`.
+
+**Known limitation:** on Claude Code, that hook rewrite does not fire for commands the AI assistant itself runs through the Bash tool -- only for a human typing directly into the terminal. This is a confirmed, permanent gap in how Claude Code's `PreToolUse` hook applies to assistant-issued commands, not an EGC bug.
+
+To cover that gap, `egc install` and `egc auto-update` also install a PATH-level binary shim under `~/.egc/bin`, covering `git`, `npm`, `pnpm`, `yarn`, `bun`, `pip`, `pip3`, `poetry`, `pipenv`, `uv`, `composer`, `bundle`, and `gh`: small launcher files that sit ahead of the real binaries on `PATH` and route through the same compression engine. Because it works via normal shell `PATH` resolution, it compresses output for any caller -- a human, this AI, or another tool entirely -- regardless of hook support. It requires a new shell session after install to pick up the `PATH` change. Manage it directly with:
+
+```bash
+egc crusher-shim install    # add the shim to ~/.egc/bin and your shell's PATH
+egc crusher-shim status     # check whether it's installed and active in this shell
+egc crusher-shim uninstall  # remove it
+```
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,7 +179,7 @@ echo "  ✓ egc-memory build verified"
 # (MCP registration, ecosystem install, the Token Crusher shim below) on any
 # warning, however minor. This is a status report, not a gate: never let it
 # be fatal to the install.
-node scripts/egc.js doctor || true
+node scripts/egc.js doctor --repo-root "$ROOT_DIR" || true
 
 # Interactive ecosystem install (skipped in CI/headless environments)
 if [ -t 0 ] && [ "$DRY_RUN" = false ]; then


### PR DESCRIPTION
The installer example output and the "what the installer does" list never mentioned the Token Crusher binary shim added in PR #1112, and the Token Crusher section only documented the PreToolUse hook path -- not the known gap where that hook never fires for commands Claude Code's own assistant issues, nor the shim that covers it.

Also fixes two component counts inside the example output that had drifted from the real catalog (229/76 -> 230/77, matching the description one line above), and adds `--repo-root` to `install.sh`'s own `doctor` call so it compares against the checkout that was just installed instead of the published npm package, per the guidance already documented lower in this same file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the installation guide to document the Token Crusher binary shim (`~/.egc/bin`) and the Claude Code `PreToolUse` gap it covers, and corrected example counts (230 skills, 77 commands). Also updated `scripts/install.sh` to run `egc doctor` with `--repo-root` so it verifies the checked-out repo instead of the published package.

<sup>Written for commit a8a3d9fd579bfee848e4dfd57f5a06f6e5048e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

