### PR TITLE
fix(crusher): egc run --raw now bypasses the PATH shim's own compression

### DIFF
--- a/scripts/crush-run.js
+++ b/scripts/crush-run.js
@@ -18,15 +18,21 @@ const SPAWN_OPTIONS = {
   maxBuffer: 64 * 1024 * 1024,
 };
 
-function runCommand(commandArgs, shell) {
+function runCommand(commandArgs, shell, raw) {
+  // A command covered by the PATH-level binary shim (git, npm, ...) resolves
+  // to the shim, not the real binary, regardless of this flag: the shim runs
+  // as an independent child process and would compress the output itself
+  // before crush-run.js ever sees it. EGC_CRUSHER_RAW tells the shim to
+  // passthrough instead, so --raw actually reaches stdout raw end-to-end.
+  const options = raw ? { ...SPAWN_OPTIONS, env: { ...process.env, EGC_CRUSHER_RAW: '1' } } : SPAWN_OPTIONS;
   if (shell) {
     // The rewrite hook passes the full command line as a single argument, so the
     // platform shell (/bin/sh on POSIX, cmd.exe on Windows) re-parses it exactly
     // as the caller's shell would have. shell: true keeps this portable instead
     // of hardcoding a bash path that does not exist on every OS.
-    return spawnSync(commandArgs.join(' '), { ...SPAWN_OPTIONS, shell: true });
+    return spawnSync(commandArgs.join(' '), { ...options, shell: true });
   }
-  return spawnSync(commandArgs[0], commandArgs.slice(1), { ...SPAWN_OPTIONS, shell: false });
+  return spawnSync(commandArgs[0], commandArgs.slice(1), { ...options, shell: false });
 }
 
 function main() {
@@ -40,7 +46,7 @@ function main() {
     process.exit(commandArgs.length === 0 ? 1 : 0);
   }
 
-  const result = runCommand(commandArgs, shell);
+  const result = runCommand(commandArgs, shell, raw);
 
   if (result.error) {
     console.error(`egc run: ${result.error.message}`);

--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -75,7 +75,11 @@ function runShim(name, args) {
     process.exit(127);
   }
 
-  if (process.stdout.isTTY) {
+  // Set by crush-run.js when the caller asked for `egc run --raw`: the outer
+  // process already decided to skip compression, but the shim would resolve
+  // and compress on its own otherwise, since it runs as an independent child
+  // with no other visibility into that intent.
+  if (process.env.EGC_CRUSHER_RAW === '1' || process.stdout.isTTY) {
     return passthrough(realBinary, args);
   }
 

--- a/tests/crush-run-raw-shim.test.js
+++ b/tests/crush-run-raw-shim.test.js
@@ -1,0 +1,126 @@
+'use strict';
+/**
+ * End-to-end regression test for EGC-521: `egc run --raw <cmd>` must return
+ * the real raw output even when <cmd> resolves through the Token Crusher
+ * PATH shim (git, npm, ...) instead of the real binary. Before this fix, the
+ * shim ran as an independent child process with no visibility into --raw and
+ * compressed the output anyway, so crush-run.js's own "skip compression"
+ * path just forwarded output that was already crushed.
+ *
+ * Run with: node tests/crush-run-raw-shim.test.js
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CRUSH_RUN = path.join(__dirname, '..', 'scripts', 'crush-run.js');
+const DISPATCH_MODULE = path.join(__dirname, '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(...dirs) {
+  for (const dir of dirs) fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// Mirrors shim-install.js's posixLauncherSource(): the exact launcher shape
+// `egc crusher-shim install` writes to ~/.egc/bin/<name>.
+function writeShimLauncher(binDir, name) {
+  const launcherPath = path.join(binDir, name);
+  const source = [
+    '#!/usr/bin/env node',
+    `require(${JSON.stringify(DISPATCH_MODULE)}).runShim(${JSON.stringify(name)}, process.argv.slice(2));`,
+    '',
+  ].join('\n');
+  fs.writeFileSync(launcherPath, source);
+  fs.chmodSync(launcherPath, 0o755);
+  return launcherPath;
+}
+
+// Stands in for the real /usr/bin/git that the shim launcher resolves to via
+// its manifest.
+function writeRealBinary(dir, name, stdout) {
+  const binPath = path.join(dir, name);
+  fs.writeFileSync(binPath, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(stdout)});\n`);
+  fs.chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+function setUpShimmedGit(home, bigBody) {
+  const shimBin = path.join(home, '.egc', 'bin');
+  fs.mkdirSync(shimBin, { recursive: true });
+  const realBinDir = createTempDir('egc-crush-run-raw-real-');
+  const realGit = writeRealBinary(realBinDir, 'git', bigBody);
+  writeShimLauncher(shimBin, 'git');
+  fs.writeFileSync(path.join(shimBin, 'manifest.json'), JSON.stringify({ git: realGit }));
+  return { shimBin, realBinDir };
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.stack || err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const runCase = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing egc run --raw against the PATH-level Token Crusher shim (EGC-521) ===\n');
+
+// The shim ships as a POSIX shebang launcher; Windows uses a separate .cmd
+// mechanism not exercised here (see needsShellOnWindows coverage instead).
+if (process.platform !== 'win32') {
+  const bigBody = Array.from({ length: 100 }, (_, i) => `commit ${'a'.repeat(40)}\nAuthor: x\nDate: y\n\n    message ${i}\n`).join('\n');
+
+  runCase('egc run --raw returns the true raw output, not the shim\'s compressed form', () => {
+    const home = createTempDir('egc-crush-run-raw-');
+    const { shimBin, realBinDir } = setUpShimmedGit(home, bigBody);
+    try {
+      const env = {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        PATH: `${shimBin}${path.delimiter}${process.env.PATH}`,
+      };
+
+      const result = spawnSync(process.execPath, [CRUSH_RUN, '--raw', 'git', 'log', '--stat'], { encoding: 'utf8', env });
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.strictEqual(result.stdout, bigBody, 'expected the exact raw output through egc run --raw, even though "git" on PATH resolves to the shim');
+      assert.ok(!result.stdout.includes('[egc-crusher]'), '--raw must never show the compression marker');
+    } finally {
+      cleanup(home, realBinDir);
+    }
+  });
+
+  runCase('without --raw, the same setup still compresses through the shim (sanity check)', () => {
+    const home = createTempDir('egc-crush-run-raw-');
+    const { shimBin, realBinDir } = setUpShimmedGit(home, bigBody);
+    try {
+      const env = {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        PATH: `${shimBin}${path.delimiter}${process.env.PATH}`,
+      };
+
+      const result = spawnSync(process.execPath, [CRUSH_RUN, 'git', 'log', '--stat'], { encoding: 'utf8', env });
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('[egc-crusher] saved'), 'expected the crusher marker when --raw is not passed');
+    } finally {
+      cleanup(home, realBinDir);
+    }
+  });
+}
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -109,6 +109,24 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('EGC_CRUSHER_RAW=1 bypasses compression for a large non-generic command (egc run --raw escape hatch, audit EGC-521)', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      const bigBody = Array.from({ length: 100 }, (_, i) => `commit ${'a'.repeat(40)}\nAuthor: x\nDate: y\n\n    message ${i}\n`).join('\n');
+      const fakeGit = writeFakeBinary(dir, 'git', { stdout: bigBody });
+      seedManifest(dir, { git: fakeGit });
+
+      const result = runShim(dir, 'git', ['log', '--stat'], {
+        env: { ...process.env, HOME: dir, USERPROFILE: dir, EGC_CRUSHER_RAW: '1' },
+      });
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, bigBody, 'expected the exact raw output, not the compressed form');
+      assert.ok(!result.stdout.includes('[egc-crusher]'));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('a generic command (git status) never gets captured or compressed, even with large output', () => {
     const dir = createTempDir('egc-shim-dispatch-');
     try {


### PR DESCRIPTION
## Summary
- The PATH-level binary shim (git, npm, ...) runs as an independent child process with no visibility into `egc run --raw`, so it compressed output on its own even when the caller asked to skip compression.
- `crush-run.js` now sets `EGC_CRUSHER_RAW=1` for the child when `--raw` is passed; the shim passes through untouched whenever that env var is set.

## Test plan
- [x] `node tests/lib/crusher-shim-dispatch.test.js` (10/10 passed, includes new case for the raw escape hatch)
- [x] `node tests/crush-run-raw-shim.test.js` (new end-to-end regression test, 2/2 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `egc run --raw` so shimmed commands like `git` and `npm` return true raw output. We pass `EGC_CRUSHER_RAW=1` to child processes and make the shim skip compression, addressing EGC-521.

- **Bug Fixes**
  - In `scripts/crush-run.js`, set `EGC_CRUSHER_RAW=1` when `--raw` is used.
  - In `scripts/lib/crusher/shim-dispatch.js`, bypass compression when `EGC_CRUSHER_RAW` is set, ensuring passthrough for PATH-level shims.

<sup>Written for commit c128554db6a985e963f25e1c89acc3d11f4923be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

