### PR TITLE
fix(opencode): restore project context on session creation

### DIFF
--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -9,17 +9,31 @@ Extended Global Context (EGC) plugin for OpenCode - agents, commands, hooks, and
 
 ## Installation Overview
 
-There are two ways to use Extended Global Context (EGC):
+There are three ways to use Extended Global Context (EGC):
 
-1. **npm package (recommended for most users)**
-   Install via npm/bun/yarn and use the `egc-install` CLI to set up rules and agents.
+1. **EGC OpenCode target (recommended for full EGC installs)**
+   Run `egc install --target opencode` to install the global OpenCode plugin, selected skills, Guardian, Token Crusher, and automatic persistent-context restoration.
 
-2. **Direct clone / plugin mode**
+2. **npm plugin package**
+   Install the OpenCode-specific npm plugin and configure it in `opencode.json`.
+
+3. **Direct clone / plugin mode**
    Clone the repository and run OpenCode directly inside it.
 
 Choose the method that matches your workflow below.
 
-### Option 1: npm Package
+### Option 1: EGC OpenCode Target
+
+Install the EGC CLI and its OpenCode target:
+
+```bash
+npm install -g @egchq/egc
+egc install --target opencode
+```
+
+The installer places the managed plugin under `~/.config/opencode/plugins/` and installs its runtime dependencies under `~/.config/opencode/scripts/`. New OpenCode sessions then restore matching EGC project memory automatically through the `session.created` event. No manual copy from this repository's `.opencode/plugins/` directory is required for context loading.
+
+### Option 2: npm Package
 
 ```bash
 npm install egc-universal
@@ -38,6 +52,7 @@ This loads the EGC OpenCode plugin module from npm:
 - bundled custom tools exported by the plugin
 
 It does **not** auto-register the full EGC command/agent/instruction catalog in your project config. For the full OpenCode setup, either:
+- use `egc install --target opencode`, or
 - run OpenCode inside this repository, or
 - copy the relevant `.opencode/commands/`, `.opencode/prompts/`, `.opencode/instructions/`, and the `instructions`, `agent`, and `command` config entries into your own project
 
@@ -47,7 +62,7 @@ After installation, the `egc-install` CLI is also available:
 npx egc-install typescript
 ```
 
-### Option 2: Direct Use
+### Option 3: Direct Use
 
 Clone and run OpenCode in the repository:
 
@@ -116,6 +131,7 @@ opencode
 
 | Hook | Event | Purpose |
 |------|-------|---------|
+| SessionStart | `event` (`session.created`) | Restore matching EGC project memory |
 | Prettier | `file.edited` | Auto-format JS/TS |
 | TypeScript | `tool.execute.after` | Check for type errors |
 | console.log | `file.edited` | Warn about debug statements |

--- a/scripts/hooks/claude-session-start.js
+++ b/scripts/hooks/claude-session-start.js
@@ -1,78 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
-// Thin Claude Code SessionStart adapter. Shared state discovery and formatting
-// live in session-context-loader.js; this file only translates Claude's stdin
-// contract into that core, writes context to stdout, and reports Claude
-// telemetry to the Dashboard.
+// Claude's thin SessionStart wrapper: the shared adapter reads state and emits
+// telemetry; Claude receives the restored context through stdout.
 
-const fs = require('node:fs');
-const http = require('node:http');
-
-const HOST = 'claude';
-const rawPort = process.env.EGC_PORT;
-const parsedPort = rawPort && /^\d+$/.test(rawPort) ? Number(rawPort) : NaN;
-const DASHBOARD_PORT = !Number.isNaN(parsedPort) && parsedPort >= 1 && parsedPort <= 65535
-  ? parsedPort
-  : 7890;
-
-function readStdinJson() {
-  try {
-    const raw = fs.readFileSync(0, 'utf8');
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed;
-    }
-  } catch (_error) { // NOSONAR
-    // No stdin payload or invalid JSON: fall back to environment values.
-  }
-  return {};
+let restored = { host: 'claude', context: '' };
+try {
+  const { runSessionStartAdapter } = require('../lib/session-start-adapter');
+  restored = runSessionStartAdapter({ host: 'claude', projectEnv: 'CLAUDE_PROJECT_DIR' });
+} catch (_) { // NOSONAR: never block Claude session startup
+  // Keep the empty fallback above.
 }
 
-function resolveProjectPath(input) {
-  if (typeof input.cwd === 'string' && input.cwd.length > 0) {
-    return input.cwd;
-  }
-  return process.env.CLAUDE_PROJECT_DIR || process.env.PWD || process.cwd();
+if (typeof restored.context === 'string' && restored.context) {
+  process.stdout.write(restored.context);
 }
-
-function restoreContext(projectPath) {
-  try {
-    const { loadSessionContext } = require('../lib/session-context-loader');
-    return loadSessionContext({ projectPath, host: HOST });
-  } catch (_) { // NOSONAR: missing or broken loader must not block the session
-    return { host: HOST, context: '' };
-  }
-}
-
-function postSessionStart(host, sessionId) {
-  const body = JSON.stringify({ ide: host, event: 'session_start', session_id: sessionId });
-  const request = http.request(
-    {
-      hostname: '127.0.0.1',
-      port: DASHBOARD_PORT,
-      path: '/event',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
-      },
-      timeout: 200,
-    },
-    response => response.resume()
-  );
-  request.on('error', () => {});
-  request.on('timeout', () => request.destroy());
-  request.end(body);
-}
-
-function main() {
-  const input = readStdinJson();
-  const restored = restoreContext(resolveProjectPath(input));
-  if (typeof restored.context === 'string' && restored.context) {
-    process.stdout.write(restored.context);
-  }
-  postSessionStart(restored.host || HOST, input.session_id || null);
-}
-
-main();

--- a/scripts/hooks/opencode-egc-plugin.js
+++ b/scripts/hooks/opencode-egc-plugin.js
@@ -43,6 +43,32 @@ function parseSessionContextOutput(stdout) {
   }
 }
 
+function withTimeout(operation, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error('OpenCode session operation timed out.'));
+    }, timeoutMs);
+
+    Promise.resolve(operation).then(
+      value => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
 function loadSessionContext(projectDirectory, sessionId) {
   return new Promise(resolve => {
     const timeoutMs = positiveIntegerEnv(
@@ -129,13 +155,20 @@ const EgcGuardianCrusher = async ({ client, directory } = {}) => {
       const context = await loadSessionContext(projectDirectory, info.id);
       if (!context) return;
 
-      await prompt.call(client.session, {
-        path: { id: info.id },
-        body: {
-          noReply: true,
-          parts: [{ type: 'text', text: context }],
-        },
-      });
+      const timeoutMs = positiveIntegerEnv(
+        'EGC_SESSION_CONTEXT_TIMEOUT_MS',
+        DEFAULT_SESSION_CONTEXT_TIMEOUT_MS
+      );
+      await withTimeout(
+        prompt.call(client.session, {
+          path: { id: info.id },
+          body: {
+            noReply: true,
+            parts: [{ type: 'text', text: context }],
+          },
+        }),
+        timeoutMs
+      );
       injectedSessionIds.add(info.id);
     } catch {
       // Context restoration is best-effort and must never block a session.

--- a/scripts/hooks/opencode-egc-plugin.js
+++ b/scripts/hooks/opencode-egc-plugin.js
@@ -1,32 +1,145 @@
 'use strict';
 
-// EGC Guardian + Token Crusher plugin for OpenCode (docs:
-// https://opencode.ai/docs/plugins). Unlike Claude Code/Cursor/Windsurf --
-// an external hook script spawned as a subprocess per invocation, with an
-// event-specific wire contract on stdin/stdout -- OpenCode loads a plugin
-// file like this one IN-PROCESS: `tool.execute.before(input, output)` runs
-// directly inside OpenCode's own Bun runtime, `output` is a mutable object,
-// and throwing blocks the tool call. That lets this plugin call straight
-// into the same run() functions the other hosts' adapters spawn as
-// subprocesses -- no translation adapter needed, just the two requires
-// below.
-//
-// EGC-498: OpenCode is the only one of the four newly-researched hosts
-// (Windsurf, Cursor, OpenCode, Kiro) whose hook contract supports mutating
-// the tool call before it runs (`output.args.command = ...`), which the
-// Token Crusher's rewrite-based design requires. Windsurf/Cursor/Kiro are
-// block-only, so they only get the Guardian, not the Crusher, until a
-// non-rewrite mechanism exists for them.
-//
-// pre-bash-guardian-validate.js's run() and pre-bash-crusher-rewrite.js's
-// run() are copied alongside this file (same targetRoot, preserve-relative-
-// path), so these requires resolve at install time.
+// EGC SessionStart + Guardian + Token Crusher plugin for OpenCode. OpenCode
+// loads this file in-process; Guardian and Crusher run directly, while session
+// restoration is delegated to a fail-open Node adapter around the shared,
+// host-neutral session-context-loader core.
 
+const path = require('node:path');
+const { spawn } = require('node:child_process');
 const { run: runGuardian } = require('../scripts/hooks/pre-bash-guardian-validate');
 const { run: runCrusherRewrite } = require('../scripts/hooks/pre-bash-crusher-rewrite');
 
-const EgcGuardianCrusher = async ({ directory } = {}) => {
+const SESSION_CONTEXT_SCRIPT = path.join(
+  __dirname,
+  '..',
+  'scripts',
+  'hooks',
+  'opencode-session-start.js'
+);
+const SESSION_CONTEXT_TIMEOUT_MS = 3000;
+const MAX_SESSION_CONTEXT_BYTES = 1024 * 1024;
+
+function sessionInfoFromEvent(event) {
+  const info = event?.properties?.info;
+  return info && typeof info.id === 'string' && info.id ? info : null;
+}
+
+function parseSessionContextOutput(stdout) {
+  try {
+    const parsed = JSON.parse(stdout);
+    return typeof parsed?.context === 'string' && parsed.context.trim()
+      ? parsed.context
+      : '';
+  } catch {
+    return '';
+  }
+}
+
+function loadSessionContext(projectDirectory, sessionId) {
+  return new Promise(resolve => {
+    let settled = false;
+    let timer;
+    let stdout = '';
+    let stdoutBytes = 0;
+
+    const finish = value => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(value);
+    };
+
+    let child;
+    try {
+      child = spawn(process.execPath, [SESSION_CONTEXT_SCRIPT], {
+        cwd: projectDirectory,
+        env: { ...process.env, OPENCODE_PROJECT_DIR: projectDirectory },
+        stdio: ['pipe', 'pipe', 'ignore'],
+        windowsHide: true,
+      });
+    } catch {
+      finish('');
+      return;
+    }
+
+    timer = setTimeout(() => {
+      child.kill();
+      finish('');
+    }, SESSION_CONTEXT_TIMEOUT_MS);
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', chunk => {
+      stdoutBytes += Buffer.byteLength(chunk);
+      if (stdoutBytes > MAX_SESSION_CONTEXT_BYTES) {
+        child.kill();
+        finish('');
+        return;
+      }
+      stdout += chunk;
+    });
+    child.stdout.on('error', () => finish(''));
+    child.on('error', () => finish(''));
+    child.on('close', code => {
+      finish(code === 0 ? parseSessionContextOutput(stdout) : '');
+    });
+    child.stdin.on('error', () => {});
+
+    try {
+      child.stdin.end(JSON.stringify({ cwd: projectDirectory, session_id: sessionId }));
+    } catch {
+      child.kill();
+      finish('');
+    }
+  });
+}
+
+const EgcGuardianCrusher = async ({ client, directory } = {}) => {
+  const injectedSessionIds = new Set();
+  const pendingSessionIds = new Set();
+
+  const handleSessionCreated = async event => {
+    const info = sessionInfoFromEvent(event);
+    const prompt = client?.session?.prompt;
+    if (!info || typeof prompt !== 'function') return;
+    if (injectedSessionIds.has(info.id) || pendingSessionIds.has(info.id)) return;
+
+    const projectDirectory = typeof info.directory === 'string' && info.directory
+      ? info.directory
+      : directory;
+    if (typeof projectDirectory !== 'string' || !projectDirectory) return;
+
+    pendingSessionIds.add(info.id);
+    try {
+      const context = await loadSessionContext(projectDirectory, info.id);
+      if (!context) return;
+
+      await prompt.call(client.session, {
+        path: { id: info.id },
+        body: {
+          noReply: true,
+          parts: [{ type: 'text', text: context }],
+        },
+      });
+      injectedSessionIds.add(info.id);
+    } catch {
+      // Context restoration is best-effort and must never block a session.
+    } finally {
+      pendingSessionIds.delete(info.id);
+    }
+  };
+
   return {
+    // Current OpenCode dispatches bus events through this generic hook.
+    event: async ({ event } = {}) => {
+      if (event?.type !== 'session.created') return;
+      await handleSessionCreated(event);
+    },
+
+    // Keep the event-specific form for compatibility with older OpenCode
+    // plugin dispatchers and the repository's existing dogfooding contract.
+    'session.created': handleSessionCreated,
+
     'tool.execute.before': async (input, output) => {
       if (!input || input.tool !== 'bash' || typeof output?.args?.command !== 'string') {
         return;
@@ -34,17 +147,15 @@ const EgcGuardianCrusher = async ({ directory } = {}) => {
 
       const command = output.args.command;
 
-      // Guardian first: a blocked command must never reach the Crusher
-      // rewrite below -- rewriting a command that is about to be denied
-      // anyway is pointless work on the hot path.
-      const guardianResult = runGuardian({ tool_name: 'Bash', tool_input: { command }, cwd: directory });
+      const guardianResult = runGuardian({
+        tool_name: 'Bash',
+        tool_input: { command },
+        cwd: directory,
+      });
       if (guardianResult.exitCode === 2) {
         throw new Error(guardianResult.stderr || 'Blocked by the EGC Guardian.');
       }
 
-      // Crusher: run() is fail-open by design (returns the input JSON
-      // unchanged on any error, missing engine, or non-crushable command --
-      // see pre-bash-crusher-rewrite.js), so no try/catch is needed here.
       const rewritten = JSON.parse(runCrusherRewrite({ tool_input: { command } }));
       if (typeof rewritten?.tool_input?.command === 'string') {
         output.args.command = rewritten.tool_input.command;

--- a/scripts/hooks/opencode-egc-plugin.js
+++ b/scripts/hooks/opencode-egc-plugin.js
@@ -17,8 +17,15 @@ const SESSION_CONTEXT_SCRIPT = path.join(
   'hooks',
   'opencode-session-start.js'
 );
-const SESSION_CONTEXT_TIMEOUT_MS = 3000;
-const MAX_SESSION_CONTEXT_BYTES = 1024 * 1024;
+const DEFAULT_SESSION_CONTEXT_TIMEOUT_MS = 3000;
+const DEFAULT_MAX_SESSION_CONTEXT_BYTES = 1024 * 1024;
+
+function positiveIntegerEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw || !/^\d+$/.test(raw)) return fallback;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
 
 function sessionInfoFromEvent(event) {
   const info = event?.properties?.info;
@@ -38,6 +45,14 @@ function parseSessionContextOutput(stdout) {
 
 function loadSessionContext(projectDirectory, sessionId) {
   return new Promise(resolve => {
+    const timeoutMs = positiveIntegerEnv(
+      'EGC_SESSION_CONTEXT_TIMEOUT_MS',
+      DEFAULT_SESSION_CONTEXT_TIMEOUT_MS
+    );
+    const maxOutputBytes = positiveIntegerEnv(
+      'EGC_SESSION_CONTEXT_MAX_BYTES',
+      DEFAULT_MAX_SESSION_CONTEXT_BYTES
+    );
     let settled = false;
     let timer;
     let stdout = '';
@@ -66,12 +81,12 @@ function loadSessionContext(projectDirectory, sessionId) {
     timer = setTimeout(() => {
       child.kill();
       finish('');
-    }, SESSION_CONTEXT_TIMEOUT_MS);
+    }, timeoutMs);
 
     child.stdout.setEncoding('utf8');
     child.stdout.on('data', chunk => {
       stdoutBytes += Buffer.byteLength(chunk);
-      if (stdoutBytes > MAX_SESSION_CONTEXT_BYTES) {
+      if (stdoutBytes > maxOutputBytes) {
         child.kill();
         finish('');
         return;

--- a/scripts/hooks/opencode-session-start.js
+++ b/scripts/hooks/opencode-session-start.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 'use strict';
 
-// Thin Claude Code SessionStart adapter. Shared state discovery and formatting
-// live in session-context-loader.js; this file only translates Claude's stdin
-// contract into that core, writes context to stdout, and reports Claude
-// telemetry to the Dashboard.
+// Thin Node bridge for OpenCode's in-process plugin. It isolates the shared
+// loader behind a fail-open child process, serializes the restored context as
+// data, and reports OpenCode telemetry. The plugin remains responsible for
+// injecting the returned context into the live session.
 
 const fs = require('node:fs');
 const http = require('node:http');
 
-const HOST = 'claude';
+const HOST = 'opencode';
 const rawPort = process.env.EGC_PORT;
 const parsedPort = rawPort && /^\d+$/.test(rawPort) ? Number(rawPort) : NaN;
 const DASHBOARD_PORT = !Number.isNaN(parsedPort) && parsedPort >= 1 && parsedPort <= 65535
@@ -24,7 +24,7 @@ function readStdinJson() {
       return parsed;
     }
   } catch (_error) { // NOSONAR
-    // No stdin payload or invalid JSON: fall back to environment values.
+    // Invalid input is handled as an empty event.
   }
   return {};
 }
@@ -33,14 +33,14 @@ function resolveProjectPath(input) {
   if (typeof input.cwd === 'string' && input.cwd.length > 0) {
     return input.cwd;
   }
-  return process.env.CLAUDE_PROJECT_DIR || process.env.PWD || process.cwd();
+  return process.env.OPENCODE_PROJECT_DIR || process.env.PWD || process.cwd();
 }
 
 function restoreContext(projectPath) {
   try {
     const { loadSessionContext } = require('../lib/session-context-loader');
     return loadSessionContext({ projectPath, host: HOST });
-  } catch (_) { // NOSONAR: missing or broken loader must not block the session
+  } catch (_) { // NOSONAR: missing or broken loader must stay fail-open
     return { host: HOST, context: '' };
   }
 }
@@ -69,9 +69,7 @@ function postSessionStart(host, sessionId) {
 function main() {
   const input = readStdinJson();
   const restored = restoreContext(resolveProjectPath(input));
-  if (typeof restored.context === 'string' && restored.context) {
-    process.stdout.write(restored.context);
-  }
+  process.stdout.write(JSON.stringify(restored));
   postSessionStart(restored.host || HOST, input.session_id || null);
 }
 

--- a/scripts/hooks/opencode-session-start.js
+++ b/scripts/hooks/opencode-session-start.js
@@ -1,76 +1,15 @@
 #!/usr/bin/env node
 'use strict';
 
-// Thin Node bridge for OpenCode's in-process plugin. It isolates the shared
-// loader behind a fail-open child process, serializes the restored context as
-// data, and reports OpenCode telemetry. The plugin remains responsible for
-// injecting the returned context into the live session.
+// OpenCode's thin child-process bridge: the shared adapter restores state and
+// emits telemetry; the plugin consumes the serialized result and injects it.
 
-const fs = require('node:fs');
-const http = require('node:http');
-
-const HOST = 'opencode';
-const rawPort = process.env.EGC_PORT;
-const parsedPort = rawPort && /^\d+$/.test(rawPort) ? Number(rawPort) : NaN;
-const DASHBOARD_PORT = !Number.isNaN(parsedPort) && parsedPort >= 1 && parsedPort <= 65535
-  ? parsedPort
-  : 7890;
-
-function readStdinJson() {
-  try {
-    const raw = fs.readFileSync(0, 'utf8');
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed;
-    }
-  } catch (_error) { // NOSONAR
-    // Invalid input is handled as an empty event.
-  }
-  return {};
+let restored = { host: 'opencode', context: '' };
+try {
+  const { runSessionStartAdapter } = require('../lib/session-start-adapter');
+  restored = runSessionStartAdapter({ host: 'opencode', projectEnv: 'OPENCODE_PROJECT_DIR' });
+} catch (_) { // NOSONAR: keep the bridge fail-open
+  // Keep the empty fallback above.
 }
 
-function resolveProjectPath(input) {
-  if (typeof input.cwd === 'string' && input.cwd.length > 0) {
-    return input.cwd;
-  }
-  return process.env.OPENCODE_PROJECT_DIR || process.env.PWD || process.cwd();
-}
-
-function restoreContext(projectPath) {
-  try {
-    const { loadSessionContext } = require('../lib/session-context-loader');
-    return loadSessionContext({ projectPath, host: HOST });
-  } catch (_) { // NOSONAR: missing or broken loader must stay fail-open
-    return { host: HOST, context: '' };
-  }
-}
-
-function postSessionStart(host, sessionId) {
-  const body = JSON.stringify({ ide: host, event: 'session_start', session_id: sessionId });
-  const request = http.request(
-    {
-      hostname: '127.0.0.1',
-      port: DASHBOARD_PORT,
-      path: '/event',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
-      },
-      timeout: 200,
-    },
-    response => response.resume()
-  );
-  request.on('error', () => {});
-  request.on('timeout', () => request.destroy());
-  request.end(body);
-}
-
-function main() {
-  const input = readStdinJson();
-  const restored = restoreContext(resolveProjectPath(input));
-  process.stdout.write(JSON.stringify(restored));
-  postSessionStart(restored.host || HOST, input.session_id || null);
-}
-
-main();
+process.stdout.write(JSON.stringify(restored));

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -40,6 +40,7 @@ const {
 } = require('../claude-settings-hooks');
 
 const HOOK_LIB_SOURCES = [
+  'scripts/lib/session-context-loader.js',
   'scripts/lib/branch-state.js',
   'scripts/lib/global-state.js',
   'scripts/lib/project-detect.js',

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -40,6 +40,7 @@ const {
 } = require('../claude-settings-hooks');
 
 const HOOK_LIB_SOURCES = [
+  'scripts/lib/session-start-adapter.js',
   'scripts/lib/session-context-loader.js',
   'scripts/lib/branch-state.js',
   'scripts/lib/global-state.js',

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -12,26 +12,49 @@ const {
   createCrusherScriptCopyOperations,
 } = require('../claude-settings-hooks');
 
-// OpenCode plugins run IN-PROCESS (Bun runtime), unlike every other target's
-// externally-spawned hooks.json subprocess -- opencode-egc-plugin.js
-// `require()`s pre-bash-guardian-validate.js's and
-// pre-bash-crusher-rewrite.js's own run() functions directly, so there is no
-// stdin/stdout translation adapter to wire, only a plugin file to drop into
-// OpenCode's auto-discovered plugins/ directory (docs:
-// https://opencode.ai/docs/plugins) alongside the same Guardian/Crusher
-// script trees every other target copies via the shared builders below.
-// EGC-498: OpenCode is the only one of the newly-researched hosts (Windsurf,
-// Cursor, OpenCode, Kiro) whose hook contract can mutate the tool call
-// (`output.args.command = ...`) before it runs, which the Token Crusher's
-// rewrite-based design requires -- so it is the only one of the four wired
-// for both the Guardian and the Crusher, not the Guardian alone.
+// OpenCode plugins run in-process, unlike hosts that spawn hooks.json
+// commands. Guardian and Crusher can run directly, while session restoration
+// crosses a fail-open Node child-process boundary through the OpenCode adapter
+// below. The adapter and Claude hook both consume the same host-neutral core.
 const PLUGIN_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/opencode-egc-plugin.js';
+const SESSION_CONTEXT_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/opencode-session-start.js';
+const OPENCODE_SESSION_CONTEXT_MODULE_ID = 'opencode-session-context-hook';
+
+// Keep this dependency set aligned with claude-home.js's SessionStart hook.
+// The shared loader treats every helper as optional, but normal installations
+// should preserve branch-aware, encrypted, global, propagated, and stack-aware
+// restoration on both hosts.
+const SESSION_CONTEXT_LIB_SOURCES = [
+  'scripts/lib/session-context-loader.js',
+  'scripts/lib/branch-state.js',
+  'scripts/lib/global-state.js',
+  'scripts/lib/project-detect.js',
+  'scripts/lib/propagate-state.js',
+  'scripts/lib/state-crypto.js',
+];
 
 function resolvePluginScriptDestination(targetRoot) {
   return path.join(targetRoot, 'plugins', 'opencode-egc-plugin.js');
 }
 
-function createOpenCodeGuardianCrusherOperations(adapter, targetRoot) {
+function createOpenCodeSessionContextOperations(remap, targetRoot) {
+  return [
+    remap(
+      OPENCODE_SESSION_CONTEXT_MODULE_ID,
+      SESSION_CONTEXT_SCRIPT_SOURCE_RELATIVE_PATH,
+      path.join(targetRoot, 'scripts', 'hooks', 'opencode-session-start.js'),
+      { strategy: 'preserve-relative-path' }
+    ),
+    ...SESSION_CONTEXT_LIB_SOURCES.map(sourceRelativePath => remap(
+      OPENCODE_SESSION_CONTEXT_MODULE_ID,
+      sourceRelativePath,
+      path.join(targetRoot, ...sourceRelativePath.split('/')),
+      { strategy: 'preserve-relative-path' }
+    )),
+  ];
+}
+
+function createOpenCodePluginOperations(adapter, targetRoot) {
   const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
     createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
@@ -47,6 +70,7 @@ function createOpenCodeGuardianCrusherOperations(adapter, targetRoot) {
   return [
     ...createBashGuardianScriptCopyOperations(remap, targetRoot),
     ...createCrusherScriptCopyOperations(remap, targetRoot),
+    ...createOpenCodeSessionContextOperations(remap, targetRoot),
     pluginCopyOperation,
   ];
 }
@@ -102,7 +126,7 @@ module.exports = createInstallTargetAdapter({
 
     return [
       ...moduleOperations,
-      ...createOpenCodeGuardianCrusherOperations(adapter, targetRoot),
+      ...createOpenCodePluginOperations(adapter, targetRoot),
     ];
   },
 });

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -25,6 +25,7 @@ const OPENCODE_SESSION_CONTEXT_MODULE_ID = 'opencode-session-context-hook';
 // should preserve branch-aware, encrypted, global, propagated, and stack-aware
 // restoration on both hosts.
 const SESSION_CONTEXT_LIB_SOURCES = [
+  'scripts/lib/session-start-adapter.js',
   'scripts/lib/session-context-loader.js',
   'scripts/lib/branch-state.js',
   'scripts/lib/global-state.js',

--- a/scripts/lib/session-context-loader.js
+++ b/scripts/lib/session-context-loader.js
@@ -1,0 +1,243 @@
+'use strict';
+
+// Host-neutral EGC session context loader. It owns only the shared work of
+// locating, decrypting, propagating, and formatting persistent project state
+// plus the stack briefing. Host adapters remain responsible for reading their
+// event payloads, injecting the returned context, and reporting telemetry.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Minimal installations may lack optional helpers. A failed require disables
+// only the dependent feature instead of breaking session startup.
+function tryRequire(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+const propagateStateLib = tryRequire('./propagate-state');
+const propagateStateContent = propagateStateLib ? propagateStateLib.propagateStateContent : null;
+const projectDetect = tryRequire('./project-detect');
+const branchState = tryRequire('./branch-state');
+const autoConsolidate = tryRequire('./auto-consolidate');
+const stateCrypto = tryRequire('./state-crypto');
+const globalState = tryRequire('./global-state');
+
+function normalizeHost(host) {
+  return typeof host === 'string' && host.trim() ? host.trim() : null;
+}
+
+// Fallback slug for minimal installs without branch-state. Uses the same
+// double-hyphen join as branch-state.projectSlug.
+function projectSlug(projectPath) {
+  const parts = projectPath.replaceAll('\\', '/').split('/').filter(Boolean);
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+function parseFrontmatterValue(value) {
+  if (!value.startsWith('[')) return value;
+  try {
+    return JSON.parse(value);
+  } catch (_) { // NOSONAR: non-JSON metadata intentionally remains a string
+    return value;
+  }
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const result = {};
+  for (const line of match[1].split('\n')) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    result[key] = parseFrontmatterValue(line.slice(colonIndex + 1).trim());
+  }
+  return result;
+}
+
+function agentMatchesStack(agentStack, languages, frameworks, knownFrameworkNames) {
+  if (agentStack.includes('*')) return 'generic';
+
+  const agentFrameworks = agentStack.filter(value => knownFrameworkNames.has(value));
+  const agentLanguages = agentStack.filter(value => !knownFrameworkNames.has(value));
+
+  if (agentFrameworks.length > 0) {
+    const allFrameworksPresent = agentFrameworks.every(value => frameworks.includes(value));
+    const languageMatches = agentLanguages.length === 0
+      || agentLanguages.some(value => languages.includes(value));
+    return allFrameworksPresent && languageMatches ? 'specific' : 'none';
+  }
+
+  return agentLanguages.some(value => languages.includes(value)) ? 'specific' : 'none';
+}
+
+function readAgentFiles(agentsDir) {
+  try {
+    return fs.readdirSync(agentsDir).filter(file => file.endsWith('.md'));
+  } catch (_) { // NOSONAR: a missing agents directory is a supported state
+    return null;
+  }
+}
+
+function loadRelevantAgents(languages, frameworks, knownFrameworkNames) {
+  const agentsDir = process.env.EGC_AGENTS_DIR || path.join(__dirname, '..', '..', 'agents');
+  if (!fs.existsSync(agentsDir)) return { stackSpecific: [], generic: [], missing: true };
+
+  const files = readAgentFiles(agentsDir);
+  if (!files) return { stackSpecific: [], generic: [], missing: false };
+
+  const stackSpecific = [];
+  const generic = [];
+
+  for (const file of files) {
+    try {
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf8');
+      const frontmatter = parseFrontmatter(content);
+      if (!frontmatter.name) continue;
+      const agentStack = Array.isArray(frontmatter.stack) ? frontmatter.stack : ['*'];
+      const match = agentMatchesStack(agentStack, languages, frameworks, knownFrameworkNames);
+      if (match === 'generic') generic.push(frontmatter.name);
+      else if (match === 'specific') stackSpecific.push(frontmatter.name);
+    } catch (_) { // NOSONAR: one unreadable agent must not block restoration
+      // Skip unreadable agent files.
+    }
+  }
+
+  return { stackSpecific, generic, missing: false };
+}
+
+function buildBriefingLines(stack, stackSpecific, generic, missing) {
+  const lines = ['', '=== EGC Stack Briefing ==='];
+  lines.push(`Stack: ${stack.slice(0, 6).join(', ')}`);
+
+  if (missing) {
+    lines.push('Agents: none installed - run: egc install --profile full');
+  } else {
+    if (stackSpecific.length > 0) {
+      lines.push(`Stack agents: ${stackSpecific.slice(0, 6).join(', ')}`);
+    }
+    const alwaysUse = generic.filter(name => name === 'code-reviewer')
+      .concat(generic.filter(name => name !== 'code-reviewer').slice(0, 2));
+    if (alwaysUse.length > 0) {
+      lines.push(`Always use: ${alwaysUse.join(', ')}`);
+    }
+  }
+
+  lines.push(
+    'Skill: coding-standards (cyclomatic complexity) - apply to all code written this session',
+    '===',
+    ''
+  );
+  return lines;
+}
+
+function buildStackBriefing(projectPath) {
+  if (!projectDetect) return '';
+
+  const detected = projectDetect.detectProjectType(projectPath);
+  const { languages, frameworks } = detected;
+  if (languages.length === 0 && frameworks.length === 0) return '';
+
+  const frameworkRules = projectDetect.FRAMEWORK_RULES || [];
+  const knownFrameworkNames = new Set(frameworkRules.map(rule => rule.framework));
+  const stack = [...new Set([...frameworks, ...languages])];
+  const { stackSpecific, generic, missing } = loadRelevantAgents(
+    languages,
+    frameworks,
+    knownFrameworkNames
+  );
+
+  return buildBriefingLines(stack, stackSpecific, generic, missing).join('\n');
+}
+
+// Consolidation must never block session startup: on any failure the state
+// file is loaded as-is.
+function consolidateBestEffort(stateFile) {
+  try {
+    return autoConsolidate.autoConsolidateStateFile(stateFile);
+  } catch {
+    return null;
+  }
+}
+
+function resolveStateFile(projectPath) {
+  if (branchState) {
+    const stateDir = branchState.getStateDir();
+    const branch = branchState.detectBranch(projectPath);
+    const resolved = branchState.resolveStateRead(stateDir, projectPath, branch);
+    return resolved.source === 'none' ? null : resolved.filePath;
+  }
+
+  const flatFile = path.join(os.homedir(), '.egc', 'state', `${projectSlug(projectPath)}.md`);
+  return fs.existsSync(flatFile) ? flatFile : null;
+}
+
+// Encrypted state is decrypted when state-crypto is available. Without it,
+// encrypted content stays silent instead of leaking ciphertext.
+function readPlaintextState(stateFile) {
+  let raw = fs.readFileSync(stateFile);
+
+  const encrypted = stateCrypto
+    ? stateCrypto.isEncryptedBuffer(raw)
+    : raw.subarray(0, 5).toString('utf8') === 'EGC1:';
+  if (encrypted) {
+    return stateCrypto ? stateCrypto.decryptStateBuffer(raw) : null;
+  }
+
+  if (autoConsolidate) {
+    const result = consolidateBestEffort(stateFile);
+    if (result?.consolidated) raw = fs.readFileSync(stateFile);
+  }
+  return raw.toString('utf8');
+}
+
+function buildPersistentStateContext(projectPath) {
+  const stateFile = resolveStateFile(projectPath);
+  let content = null;
+  if (stateFile) {
+    content = readPlaintextState(stateFile);
+    if (content !== null && !content.trim()) content = null;
+  }
+
+  if (content && propagateStateContent) {
+    try {
+      propagateStateContent(projectPath, content);
+    } catch (_) { // NOSONAR: propagation is best-effort
+      // Never block restoration because a mirror could not be updated.
+    }
+  }
+
+  const appendix = globalState ? globalState.readGlobalAppendix(content || '', stateCrypto) : null;
+  if (!content && !appendix) return '';
+
+  const header = 'EGC persistent memory for this project (restored automatically):\n\n';
+  return header + (content || '') + (appendix ? `\n${appendix}\n` : '');
+}
+
+function loadSessionContext({ projectPath, host } = {}) {
+  const normalizedHost = normalizeHost(host);
+  if (typeof projectPath !== 'string' || !projectPath) {
+    return { host: normalizedHost, context: '' };
+  }
+
+  try {
+    const persistentState = buildPersistentStateContext(projectPath);
+    const stackBriefing = buildStackBriefing(projectPath);
+    return {
+      host: normalizedHost,
+      context: persistentState + stackBriefing,
+    };
+  } catch (_) { // NOSONAR: session restoration is fail-open by contract
+    return { host: normalizedHost, context: '' };
+  }
+}
+
+module.exports = {
+  loadSessionContext,
+};

--- a/scripts/lib/session-start-adapter.js
+++ b/scripts/lib/session-start-adapter.js
@@ -1,0 +1,82 @@
+'use strict';
+
+// Shared process adapter for SessionStart-style hooks. It owns the generic
+// stdin, state-loader, and Dashboard contracts while leaving each host wrapper
+// responsible for its own output or session-injection mechanism.
+
+const fs = require('node:fs');
+const http = require('node:http');
+
+const DEFAULT_DASHBOARD_PORT = 7890;
+const DASHBOARD_TIMEOUT_MS = 200;
+
+function readStdinJson() {
+  try {
+    const raw = fs.readFileSync(0, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (_error) { // NOSONAR: malformed or absent input intentionally falls back
+    // Session restoration is best-effort; host environment values are enough.
+  }
+  return {};
+}
+
+function resolveProjectPath(input, projectEnv) {
+  if (typeof input.cwd === 'string' && input.cwd.length > 0) {
+    return input.cwd;
+  }
+  const environmentPath = typeof projectEnv === 'string' ? process.env[projectEnv] : '';
+  return environmentPath || process.env.PWD || process.cwd();
+}
+
+function restoreContext(projectPath, host) {
+  try {
+    const { loadSessionContext } = require('./session-context-loader');
+    return loadSessionContext({ projectPath, host });
+  } catch (_) { // NOSONAR: a missing or broken loader must not block startup
+    return { host, context: '' };
+  }
+}
+
+function resolveDashboardPort() {
+  const raw = process.env.EGC_PORT;
+  if (!raw || !/^\d+$/.test(raw)) return DEFAULT_DASHBOARD_PORT;
+  const port = Number(raw);
+  return Number.isInteger(port) && port >= 1 && port <= 65535
+    ? port
+    : DEFAULT_DASHBOARD_PORT;
+}
+
+function postSessionStart(host, sessionId) {
+  const body = JSON.stringify({ ide: host, event: 'session_start', session_id: sessionId });
+  const request = http.request(
+    {
+      hostname: '127.0.0.1',
+      port: resolveDashboardPort(),
+      path: '/event',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+      timeout: DASHBOARD_TIMEOUT_MS,
+    },
+    response => response.resume()
+  );
+  request.on('error', () => {});
+  request.on('timeout', () => request.destroy());
+  request.end(body);
+}
+
+function runSessionStartAdapter({ host, projectEnv }) {
+  const normalizedHost = typeof host === 'string' && host ? host : 'unknown';
+  const input = readStdinJson();
+  const projectPath = resolveProjectPath(input, projectEnv);
+  const restored = restoreContext(projectPath, normalizedHost);
+  postSessionStart(restored.host || normalizedHost, input.session_id || null);
+  return restored;
+}
+
+module.exports = { runSessionStartAdapter };

--- a/tests/hooks/opencode-egc-plugin.test.js
+++ b/tests/hooks/opencode-egc-plugin.test.js
@@ -146,9 +146,10 @@ async function runTests() {
       const calls = [];
       const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: project });
       const event = sessionEvent('ses_context', project);
+      const genericDispatch = hooks.event({ event });
+      const specificDispatch = hooks['session.created'](event);
+      await Promise.all([genericDispatch, specificDispatch]);
       await hooks.event({ event });
-      await hooks.event({ event });
-      await hooks['session.created'](event);
       assert.strictEqual(calls.length, 1);
       assert.deepStrictEqual(calls[0].path, { id: 'ses_context' });
       assert.strictEqual(calls[0].body.noReply, true);
@@ -160,12 +161,13 @@ async function runTests() {
       fs.mkdirSync(project, { recursive: true });
       writeState(tempDir, project, 'telemetry-marker');
       const capture = await captureDashboard();
-      process.env.EGC_PORT = String(capture.port);
       try {
-        const hooks = await EgcGuardianCrusher({ client: clientWith([]), directory: project });
-        await hooks.event({ event: sessionEvent('ses_telemetry', project) });
-        const payload = await capture.request;
-        assert.deepStrictEqual(payload, { ide: 'opencode', event: 'session_start', session_id: 'ses_telemetry' });
+        await withEnvironment('EGC_PORT', String(capture.port), async () => {
+          const hooks = await EgcGuardianCrusher({ client: clientWith([]), directory: project });
+          await hooks.event({ event: sessionEvent('ses_telemetry', project) });
+          const payload = await capture.request;
+          assert.deepStrictEqual(payload, { ide: 'opencode', event: 'session_start', session_id: 'ses_telemetry' });
+        });
       } finally {
         await capture.close();
       }
@@ -184,6 +186,27 @@ async function runTests() {
       writeState(tempDir, failing, 'failure-marker');
       hooks = await EgcGuardianCrusher({ client: clientWith([], new Error('rejected')), directory: failing });
       await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_failure', failing) }));
+    })) passed++; else failed++;
+
+    if (await test('fails open when the OpenCode prompt exceeds its timeout', async () => {
+      const stub = "#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({host:'opencode',context:'prompt-timeout-marker'}));\n";
+      const restore = replaceTemporarily(bridgePath, stub);
+      try {
+        let attempts = 0;
+        const client = { session: { prompt: () => {
+          attempts += 1;
+          return new Promise(() => {});
+        } } };
+        await withEnvironment('EGC_SESSION_CONTEXT_TIMEOUT_MS', '150', async () => {
+          const hooks = await EgcGuardianCrusher({ client, directory: tempDir });
+          const started = Date.now();
+          await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_prompt_timeout', tempDir) }));
+          const elapsed = Date.now() - started;
+          assert.ok(elapsed >= 75, `expected prompt timeout path, completed in ${elapsed}ms`);
+          assert.ok(elapsed < 2000, `prompt timeout path took ${elapsed}ms`);
+          assert.strictEqual(attempts, 1);
+        });
+      } finally { restore(); }
     })) passed++; else failed++;
 
     if (await test('fails open when the bridge exceeds its timeout', async () => {

--- a/tests/hooks/opencode-egc-plugin.test.js
+++ b/tests/hooks/opencode-egc-plugin.test.js
@@ -10,6 +10,7 @@ const REPO_ROOT = path.join(__dirname, '..', '..');
 const FAKE_CLI = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
 const SESSION_FILES = [
   'scripts/hooks/opencode-session-start.js',
+  'scripts/lib/session-start-adapter.js',
   'scripts/lib/session-context-loader.js',
   'scripts/lib/branch-state.js',
   'scripts/lib/global-state.js',
@@ -44,6 +45,17 @@ function replaceTemporarily(file, content) {
   const original = fs.readFileSync(file, 'utf8');
   fs.writeFileSync(file, content);
   return () => fs.writeFileSync(file, original);
+}
+
+async function withEnvironment(name, value, fn) {
+  const previous = process.env[name];
+  process.env[name] = value;
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
 }
 
 function sessionEvent(id, directory) {
@@ -97,7 +109,15 @@ async function runTests() {
   let passed = 0;
   let failed = 0;
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-plugin-'));
-  const savedEnv = Object.fromEntries(['EGC_GUARDIAN_CLI', 'EGC_ASSUME_EGC_CLI', 'HOME', 'USERPROFILE', 'EGC_PORT']
+  const savedEnv = Object.fromEntries([
+    'EGC_GUARDIAN_CLI',
+    'EGC_ASSUME_EGC_CLI',
+    'HOME',
+    'USERPROFILE',
+    'EGC_PORT',
+    'EGC_SESSION_CONTEXT_TIMEOUT_MS',
+    'EGC_SESSION_CONTEXT_MAX_BYTES',
+  ]
     .map(key => [key, process.env[key]]));
 
   process.env.EGC_GUARDIAN_CLI = FAKE_CLI;
@@ -169,23 +189,29 @@ async function runTests() {
     if (await test('fails open when the bridge exceeds its timeout', async () => {
       const restore = replaceTemporarily(bridgePath, "#!/usr/bin/env node\nsetTimeout(() => {}, 10000);\n");
       try {
-        const calls = [];
-        const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: tempDir });
-        const started = Date.now();
-        await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_timeout', tempDir) }));
-        assert.ok(Date.now() - started < 5000);
-        assert.strictEqual(calls.length, 0);
+        await withEnvironment('EGC_SESSION_CONTEXT_TIMEOUT_MS', '150', async () => {
+          const calls = [];
+          const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: tempDir });
+          const started = Date.now();
+          await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_timeout', tempDir) }));
+          const elapsed = Date.now() - started;
+          assert.ok(elapsed >= 75, `expected timeout path, completed in ${elapsed}ms`);
+          assert.ok(elapsed < 2000, `timeout path took ${elapsed}ms`);
+          assert.strictEqual(calls.length, 0);
+        });
       } finally { restore(); }
     })) passed++; else failed++;
 
     if (await test('fails open when the bridge exceeds the output limit', async () => {
-      const stub = "#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({host:'opencode',context:'x'.repeat(1024*1024+1)}));\n";
+      const stub = "#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({host:'opencode',context:'x'.repeat(4096)}));\n";
       const restore = replaceTemporarily(bridgePath, stub);
       try {
-        const calls = [];
-        const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: tempDir });
-        await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_oversize', tempDir) }));
-        assert.strictEqual(calls.length, 0);
+        await withEnvironment('EGC_SESSION_CONTEXT_MAX_BYTES', '1024', async () => {
+          const calls = [];
+          const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: tempDir });
+          await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_oversize', tempDir) }));
+          assert.strictEqual(calls.length, 0);
+        });
       } finally { restore(); }
     })) passed++; else failed++;
 

--- a/tests/hooks/opencode-egc-plugin.test.js
+++ b/tests/hooks/opencode-egc-plugin.test.js
@@ -1,41 +1,88 @@
-/**
- * Tests for scripts/hooks/opencode-egc-plugin.js
- *
- * Unlike every other host's hooks.json subprocess adapter, this plugin's
- * require() calls are DESTINATION-relative (`../scripts/hooks/...`), not
- * sibling-relative -- they only resolve once installed at
- * <targetRoot>/plugins/opencode-egc-plugin.js alongside a real
- * <targetRoot>/scripts/hooks and <targetRoot>/scripts/lib tree (see the
- * plugin's own header comment). So these tests drive the real
- * opencode-home.js install plan to materialize that exact shape in a temp
- * dir, then require() the plugin from ITS INSTALLED location -- this
- * exercises the real require-path contract, not a stand-in.
- */
-
+/** Installed-layout tests for scripts/hooks/opencode-egc-plugin.js. */
 const assert = require('assert');
 const fs = require('fs');
+const http = require('http');
 const os = require('os');
 const path = require('path');
-
 const { planInstallTargetScaffold } = require('../../scripts/lib/install-targets/registry');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const FAKE_CLI = path.join(__dirname, '..', 'fixtures', 'fake-guardian-cli.js');
+const SESSION_FILES = [
+  'scripts/hooks/opencode-session-start.js',
+  'scripts/lib/session-context-loader.js',
+  'scripts/lib/branch-state.js',
+  'scripts/lib/global-state.js',
+  'scripts/lib/project-detect.js',
+  'scripts/lib/propagate-state.js',
+  'scripts/lib/state-crypto.js',
+];
 
-function installOpenCodePlugin(homeDir) {
+function install(homeDir) {
   const plan = planInstallTargetScaffold({ target: 'opencode', repoRoot: REPO_ROOT, homeDir, modules: [] });
   for (const operation of plan.operations) {
-    const sourcePath = path.join(REPO_ROOT, operation.sourceRelativePath);
-    if (!fs.existsSync(sourcePath) || !fs.statSync(sourcePath).isFile()) continue;
+    const source = path.join(REPO_ROOT, operation.sourceRelativePath);
+    if (!fs.existsSync(source) || !fs.statSync(source).isFile()) continue;
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
-    fs.copyFileSync(sourcePath, operation.destinationPath);
+    fs.copyFileSync(source, operation.destinationPath);
   }
-  return path.join(homeDir, '.config', 'opencode', 'plugins', 'opencode-egc-plugin.js');
+  return path.join(homeDir, '.config', 'opencode');
 }
 
-function test(name, fn) {
+function slug(projectDir) {
+  return projectDir.replaceAll('\\', '/').split('/').filter(Boolean)
+    .slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+function writeState(homeDir, projectDir, marker) {
+  const stateDir = path.join(homeDir, '.egc', 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, `${slug(projectDir)}.md`), `# State\n- ${marker}\n`);
+}
+
+function replaceTemporarily(file, content) {
+  const original = fs.readFileSync(file, 'utf8');
+  fs.writeFileSync(file, content);
+  return () => fs.writeFileSync(file, original);
+}
+
+function sessionEvent(id, directory) {
+  return { type: 'session.created', properties: { info: { id, directory } } };
+}
+
+function clientWith(calls, error) {
+  return { session: { prompt: async input => {
+    if (error) throw error;
+    calls.push(input);
+  } } };
+}
+
+function captureDashboard() {
+  return new Promise((resolve, reject) => {
+    let accept;
+    let fail;
+    const request = new Promise((res, rej) => { accept = res; fail = rej; });
+    const server = http.createServer((incoming, response) => {
+      let body = '';
+      incoming.setEncoding('utf8');
+      incoming.on('data', chunk => { body += chunk; });
+      incoming.on('end', () => {
+        response.writeHead(204).end();
+        try { accept(JSON.parse(body)); } catch (error) { fail(error); }
+      });
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve({
+      port: server.address().port,
+      request,
+      close: () => new Promise(done => server.close(done)),
+    }));
+  });
+}
+
+async function test(name, fn) {
   try {
-    fn();
+    await fn();
     console.log(`  ✓ ${name}`);
     return true;
   } catch (error) {
@@ -45,82 +92,147 @@ function test(name, fn) {
   }
 }
 
-function runTests() {
+async function runTests() {
   console.log('\n=== Testing opencode-egc-plugin ===\n');
-
   let passed = 0;
   let failed = 0;
-
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-plugin-'));
-  const originalGuardianCli = process.env.EGC_GUARDIAN_CLI;
-  const originalAssumeEgcCli = process.env.EGC_ASSUME_EGC_CLI;
+  const savedEnv = Object.fromEntries(['EGC_GUARDIAN_CLI', 'EGC_ASSUME_EGC_CLI', 'HOME', 'USERPROFILE', 'EGC_PORT']
+    .map(key => [key, process.env[key]]));
+
   process.env.EGC_GUARDIAN_CLI = FAKE_CLI;
   process.env.EGC_ASSUME_EGC_CLI = '0';
+  process.env.HOME = tempDir;
+  process.env.USERPROFILE = tempDir;
 
-  let EgcGuardianCrusher;
   try {
-    const installedPluginPath = installOpenCodePlugin(tempDir);
+    const root = install(tempDir);
+    const pluginPath = path.join(root, 'plugins', 'opencode-egc-plugin.js');
+    const bridgePath = path.join(root, 'scripts', 'hooks', 'opencode-session-start.js');
+    let EgcGuardianCrusher;
 
-    if (test('installs the plugin and its Guardian/Crusher dependency tree so require() resolves', () => {
-      assert.ok(fs.existsSync(installedPluginPath), 'plugin file should be copied to plugins/');
-      // Throws if any destination-relative require() target is missing.
-      delete require.cache[require.resolve(installedPluginPath)];
-      ({ EgcGuardianCrusher } = require(installedPluginPath));
+    if (await test('installs the plugin and host-neutral session dependency tree', () => {
+      assert.ok(fs.existsSync(pluginPath));
+      for (const relative of SESSION_FILES) assert.ok(fs.existsSync(path.join(root, relative)), relative);
+      delete require.cache[require.resolve(pluginPath)];
+      ({ EgcGuardianCrusher } = require(pluginPath));
       assert.strictEqual(typeof EgcGuardianCrusher, 'function');
     })) passed++; else failed++;
 
-    if (test('ignores non-bash tools (no-op, does not throw)', async () => {
-      const hooks = await EgcGuardianCrusher({ directory: tempDir });
-      const output = { args: { filePath: '/tmp/x' } };
-      await hooks['tool.execute.before']({ tool: 'read' }, output);
-      assert.deepStrictEqual(output.args, { filePath: '/tmp/x' });
+    if (await test('restores context once across generic and event-specific dispatch', async () => {
+      const project = path.join(tempDir, 'workspaces', 'context');
+      fs.mkdirSync(project, { recursive: true });
+      writeState(tempDir, project, 'opencode-context-marker');
+      const calls = [];
+      const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: project });
+      const event = sessionEvent('ses_context', project);
+      await hooks.event({ event });
+      await hooks.event({ event });
+      await hooks['session.created'](event);
+      assert.strictEqual(calls.length, 1);
+      assert.deepStrictEqual(calls[0].path, { id: 'ses_context' });
+      assert.strictEqual(calls[0].body.noReply, true);
+      assert.match(calls[0].body.parts[0].text, /opencode-context-marker/);
     })) passed++; else failed++;
 
-    if (test('ignores a bash input with no command arg (no-op, does not throw)', async () => {
-      const hooks = await EgcGuardianCrusher({ directory: tempDir });
-      const output = { args: {} };
-      await hooks['tool.execute.before']({ tool: 'bash' }, output);
-      assert.deepStrictEqual(output.args, {});
-    })) passed++; else failed++;
-
-    if (test('blocks a destructive command by throwing (Guardian runs before the Crusher rewrite)', async () => {
-      const hooks = await EgcGuardianCrusher({ directory: tempDir });
-      const output = { args: { command: 'rm -rf /' } };
-      await assert.rejects(
-        () => hooks['tool.execute.before']({ tool: 'bash' }, output),
-        /EGC Guardian BLOCKED/
-      );
-      assert.strictEqual(output.args.command, 'rm -rf /', 'must not rewrite a command that gets blocked');
-    })) passed++; else failed++;
-
-    if (test('allows a safe command through unmodified when the Crusher has no CLI to route through', async () => {
-      const hooks = await EgcGuardianCrusher({ directory: tempDir });
-      const output = { args: { command: 'git status' } };
-      await hooks['tool.execute.before']({ tool: 'bash' }, output);
-      assert.strictEqual(output.args.command, 'git status');
-    })) passed++; else failed++;
-
-    if (test('rewrites a crushable safe command through `egc run` when the Crusher CLI is available', async () => {
-      process.env.EGC_ASSUME_EGC_CLI = '1';
+    if (await test('reports OpenCode rather than Claude to the Dashboard', async () => {
+      const project = path.join(tempDir, 'workspaces', 'telemetry');
+      fs.mkdirSync(project, { recursive: true });
+      writeState(tempDir, project, 'telemetry-marker');
+      const capture = await captureDashboard();
+      process.env.EGC_PORT = String(capture.port);
       try {
-        const hooks = await EgcGuardianCrusher({ directory: tempDir });
-        const output = { args: { command: 'npm test' } };
-        await hooks['tool.execute.before']({ tool: 'bash' }, output);
-        assert.strictEqual(output.args.command, 'egc run npm test');
+        const hooks = await EgcGuardianCrusher({ client: clientWith([]), directory: project });
+        await hooks.event({ event: sessionEvent('ses_telemetry', project) });
+        const payload = await capture.request;
+        assert.deepStrictEqual(payload, { ide: 'opencode', event: 'session_start', session_id: 'ses_telemetry' });
       } finally {
-        process.env.EGC_ASSUME_EGC_CLI = '0';
+        await capture.close();
       }
     })) passed++; else failed++;
+
+    if (await test('skips empty context and fails open on prompt rejection', async () => {
+      const empty = path.join(tempDir, 'workspaces', 'empty');
+      fs.mkdirSync(empty, { recursive: true });
+      const calls = [];
+      let hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: empty });
+      await hooks.event({ event: sessionEvent('ses_empty', empty) });
+      assert.strictEqual(calls.length, 0);
+
+      const failing = path.join(tempDir, 'workspaces', 'failing');
+      fs.mkdirSync(failing, { recursive: true });
+      writeState(tempDir, failing, 'failure-marker');
+      hooks = await EgcGuardianCrusher({ client: clientWith([], new Error('rejected')), directory: failing });
+      await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_failure', failing) }));
+    })) passed++; else failed++;
+
+    if (await test('fails open when the bridge exceeds its timeout', async () => {
+      const restore = replaceTemporarily(bridgePath, "#!/usr/bin/env node\nsetTimeout(() => {}, 10000);\n");
+      try {
+        const calls = [];
+        const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: tempDir });
+        const started = Date.now();
+        await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_timeout', tempDir) }));
+        assert.ok(Date.now() - started < 5000);
+        assert.strictEqual(calls.length, 0);
+      } finally { restore(); }
+    })) passed++; else failed++;
+
+    if (await test('fails open when the bridge exceeds the output limit', async () => {
+      const stub = "#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({host:'opencode',context:'x'.repeat(1024*1024+1)}));\n";
+      const restore = replaceTemporarily(bridgePath, stub);
+      try {
+        const calls = [];
+        const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: tempDir });
+        await assert.doesNotReject(() => hooks.event({ event: sessionEvent('ses_oversize', tempDir) }));
+        assert.strictEqual(calls.length, 0);
+      } finally { restore(); }
+    })) passed++; else failed++;
+
+    if (await test('ignores unrelated or malformed events and missing clients', async () => {
+      const withoutClient = await EgcGuardianCrusher({ directory: tempDir });
+      await assert.doesNotReject(() => withoutClient.event({ event: sessionEvent('ses_no_client', tempDir) }));
+      const calls = [];
+      const hooks = await EgcGuardianCrusher({ client: clientWith(calls), directory: tempDir });
+      await hooks.event();
+      await hooks.event({ event: { type: 'session.idle', properties: {} } });
+      await hooks.event({ event: { type: 'session.created', properties: { info: { directory: tempDir } } } });
+      assert.strictEqual(calls.length, 0);
+    })) passed++; else failed++;
+
+    if (await test('preserves Guardian and Crusher behavior', async () => {
+      let hooks = await EgcGuardianCrusher({ directory: tempDir });
+      const readOutput = { args: { filePath: '/tmp/x' } };
+      await hooks['tool.execute.before']({ tool: 'read' }, readOutput);
+      assert.deepStrictEqual(readOutput.args, { filePath: '/tmp/x' });
+      const missingCommand = { args: {} };
+      await hooks['tool.execute.before']({ tool: 'bash' }, missingCommand);
+      await assert.rejects(
+        () => hooks['tool.execute.before']({ tool: 'bash' }, { args: { command: 'rm -rf /' } }),
+        /EGC Guardian BLOCKED/
+      );
+      const safe = { args: { command: 'git status' } };
+      await hooks['tool.execute.before']({ tool: 'bash' }, safe);
+      assert.strictEqual(safe.args.command, 'git status');
+      process.env.EGC_ASSUME_EGC_CLI = '1';
+      hooks = await EgcGuardianCrusher({ directory: tempDir });
+      const crushable = { args: { command: 'npm test' } };
+      await hooks['tool.execute.before']({ tool: 'bash' }, crushable);
+      assert.strictEqual(crushable.args.command, 'egc run npm test');
+      process.env.EGC_ASSUME_EGC_CLI = '0';
+    })) passed++; else failed++;
   } finally {
-    if (originalGuardianCli === undefined) delete process.env.EGC_GUARDIAN_CLI;
-    else process.env.EGC_GUARDIAN_CLI = originalGuardianCli;
-    if (originalAssumeEgcCli === undefined) delete process.env.EGC_ASSUME_EGC_CLI;
-    else process.env.EGC_ASSUME_EGC_CLI = originalAssumeEgcCli;
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
-  process.exit(failed > 0 ? 1 : 0);
+  process.exitCode = failed > 0 ? 1 : 0;
 }
 
-runTests();
+runTests().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/lib/session-context-loader.test.js
+++ b/tests/lib/session-context-loader.test.js
@@ -1,0 +1,140 @@
+/**
+ * Tests for the host-neutral session-context-loader core.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const LOADER = path.join(__dirname, '..', '..', 'scripts', 'lib', 'session-context-loader.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function projectSlug(projectPath) {
+  const parts = projectPath.replaceAll('\\', '/').split('/').filter(Boolean);
+  return parts.slice(-2).join('--').replace(/[^a-zA-Z0-9-_]/g, '_') || 'default';
+}
+
+function writeState(homeDir, projectPath, content) {
+  const stateDir = path.join(homeDir, '.egc', 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, `${projectSlug(projectPath)}.md`), content, 'utf8');
+}
+
+function runLoader(homeDir, projectPath, host, extraEnv = {}) {
+  const program = [
+    `const { loadSessionContext } = require(${JSON.stringify(LOADER)});`,
+    `const result = loadSessionContext(${JSON.stringify({ projectPath, host })});`,
+    'process.stdout.write(JSON.stringify(result));',
+  ].join('\n');
+  const result = spawnSync(process.execPath, ['-e', program], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      EGC_AGENTS_DIR: path.join(homeDir, 'missing-agents'),
+      ...extraEnv,
+    },
+    timeout: 10000,
+  });
+
+  assert.strictEqual(result.status, 0, result.stderr || 'loader subprocess failed');
+  return JSON.parse(result.stdout);
+}
+
+function runTests() {
+  console.log('\n=== Testing session-context-loader ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('returns identical shared context while preserving each host identifier', () => {
+    const homeDir = createTempDir('session-context-loader-home-');
+    const projectPath = '/workspace/shared-project';
+    try {
+      writeState(homeDir, projectPath, '# Project State\n- shared-memory-marker\n');
+      const claude = runLoader(homeDir, projectPath, 'claude');
+      const opencode = runLoader(homeDir, projectPath, 'opencode');
+
+      assert.strictEqual(claude.host, 'claude');
+      assert.strictEqual(opencode.host, 'opencode');
+      assert.strictEqual(claude.context, opencode.context);
+      assert.match(claude.context, /EGC persistent memory/);
+      assert.match(claude.context, /shared-memory-marker/);
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('returns empty data without assuming a host when input is missing', () => {
+    const homeDir = createTempDir('session-context-loader-home-');
+    try {
+      const program = [
+        `const { loadSessionContext } = require(${JSON.stringify(LOADER)});`,
+        'process.stdout.write(JSON.stringify(loadSessionContext()));',
+      ].join('\n');
+      const result = spawnSync(process.execPath, ['-e', program], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+      });
+      assert.strictEqual(result.status, 0);
+      assert.deepStrictEqual(JSON.parse(result.stdout), { host: null, context: '' });
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('returns empty context when no matching state or stack exists', () => {
+    const homeDir = createTempDir('session-context-loader-home-');
+    try {
+      const result = runLoader(homeDir, '/workspace/empty-project', 'opencode');
+      assert.deepStrictEqual(result, { host: 'opencode', context: '' });
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('adds a stack briefing independently of the host adapter', () => {
+    const homeDir = createTempDir('session-context-loader-home-');
+    const projectDir = createTempDir('session-context-loader-project-');
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'loader-test', version: '1.0.0' }),
+        'utf8'
+      );
+      const result = runLoader(homeDir, projectDir, 'opencode');
+      assert.match(result.context, /=== EGC Stack Briefing ===/);
+      assert.match(result.context, /coding-standards/);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Review status

This implementation has been updated following the maintainer's architecture guidance and is ready for review. The full CI matrix and SonarQube Quality Gate are passing.

## Summary

- extract project state restoration into a host-neutral `scripts/lib/session-context-loader.js`;
- keep `claude-session-start.js` as a thin Claude-specific adapter;
- add `opencode-session-start.js` as a thin OpenCode-specific adapter;
- handle `session.created` through OpenCode's generic `event` hook while retaining the event-specific hook for compatibility;
- inject restored context with `client.session.prompt({ noReply: true })`;
- report the correct host identifier to the Dashboard for both Claude and OpenCode;
- deduplicate restoration per session and fail open on loader or SDK errors;
- install the shared loader, host adapter, and runtime dependencies through `egc install --target opencode`;
- remove the manual plugin-copy requirement from `.opencode/README.md`.

## Implementation notes

The shared loader owns branch-aware state resolution, encrypted-state handling, global memory, propagation, and stack briefing generation. It returns restored context as data and contains no Claude or OpenCode injection assumptions.

The OpenCode adapter runs in a fail-open child process with a 3-second timeout and a 1 MiB stdout limit. OpenCode remains responsible for injecting the returned context into the active session.

## Validation

- host-neutral loader tests;
- Claude adapter regression coverage;
- installed-layout OpenCode restoration tests;
- generic and event-specific dispatch compatibility;
- deduplication, empty state, malformed events, SDK failure, timeout, and output-limit coverage;
- Guardian and Token Crusher regression coverage;
- DCO, CodeQL, Coverage, Dependency Review, PR Size Check, lint, and component validation passing;
- full cross-platform CI matrix passing on Node.js 20 and 22 across npm, yarn, and Bun;
- SonarQube Quality Gate passing with no new issues.

Closes #1109



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores EGC project memory automatically on OpenCode session creation using a shared loader and a new `session-start-adapter`, and updates Claude’s SessionStart to the same adapter with host-aware telemetry. Both hosts start with identical context including the stack briefing.

- **Refactors**
  - Added a shared `session-start-adapter` that handles stdin, restoration, and Dashboard telemetry; Claude’s hook is now a thin wrapper; OpenCode uses a fail-open child bridge that returns JSON for plugin injection.
  - Installer now copies the adapter and loader for both targets; `.opencode/README.md` documents `egc install --target opencode` and automatic restore.

- **Bug Fixes**
  - Stabilized timeout and output-limit behavior for OpenCode restoration and bounded session prompt injection via `EGC_SESSION_CONTEXT_TIMEOUT_MS` and `EGC_SESSION_CONTEXT_MAX_BYTES`.
  - Tests cover adapter parity, dedup across generic `event` and `session.created` (including concurrent events), prompt failures and timeouts, malformed events, and the new limits.

<sup>Written for commit b3437550ccfa033ab802de5592648780d056f912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Restores project and session context when starting Claude or OpenCode sessions.
- Installs the required session-state support for OpenCode integrations.
- Reports session-start activity to the local dashboard when available.

## Bug Fixes

- Prevents duplicate context restoration during the same session.
- Handles missing context, malformed events, unavailable clients, and prompt failures gracefully.
- Adds safeguards for slow or oversized session-start output without blocking startup.
- Improves resilience when project state is incomplete, unavailable, or cannot be restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->