### PR TITLE
fix(tests): eliminate macOS Node 20.x flake in crusher shim tests

### DIFF
--- a/scripts/crush-run.js
+++ b/scripts/crush-run.js
@@ -9,6 +9,7 @@
 // their exact semantics while their output still gets crushed.
 
 const { spawnSync } = require('node:child_process');
+const { writeSync } = require('node:fs');
 const { crushOutput } = require('./lib/crusher/engine');
 const { record } = require('./lib/crusher/metrics');
 
@@ -57,8 +58,14 @@ function main() {
   const commandLine = commandArgs.join(' ');
   const crushed = raw ? null : crushOutput(commandLine, stdout);
 
+  // fs.writeSync(1, ...), not process.stdout.write(), matters here: stdout to
+  // a pipe is asynchronous on POSIX, and the process.exit() a few lines below
+  // does not wait for a pending write to flush. That truncated the tail of
+  // large output non-deterministically by OS and Node version (confirmed as
+  // a real CI flake on macOS + Node 20.x, audit EGC-521). fs.writeSync is a
+  // genuine blocking syscall, so nothing is left pending when this exits.
   if (crushed) {
-    process.stdout.write(crushed.crushed + '\n');
+    writeSync(1, crushed.crushed + '\n');
     record({
       cmd: commandLine.trim().split(/\s+/)[0],
       kind: crushed.kind,
@@ -67,7 +74,7 @@ function main() {
       tokensSaved: crushed.tokensSaved,
     });
   } else if (stdout) {
-    process.stdout.write(stdout);
+    writeSync(1, stdout);
   }
 
   process.exit(typeof result.status === 'number' ? result.status : 1);

--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -20,6 +20,7 @@
 
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { writeSync } = require('node:fs');
 const { resolveRealBinary } = require('./shim-paths');
 
 const SPAWN_OPTIONS = {
@@ -110,8 +111,14 @@ function runShim(name, args) {
     crushed = null;
   }
 
+  // fs.writeSync(1, ...), not process.stdout.write(), matters here: stdout to
+  // a pipe is asynchronous on POSIX, and exitLikeChild() below can call
+  // process.exit() before a pending write flushes. That truncated the tail of
+  // large output non-deterministically by OS and Node version (confirmed as
+  // a real CI flake on macOS + Node 20.x, audit EGC-521). fs.writeSync is a
+  // genuine blocking syscall, so nothing is left pending when this exits.
   if (crushed) {
-    process.stdout.write(crushed.crushed + '\n');
+    writeSync(1, crushed.crushed + '\n');
     crusher.record({
       cmd: name,
       kind: crushed.kind,
@@ -120,7 +127,7 @@ function runShim(name, args) {
       tokensSaved: crushed.tokensSaved,
     });
   } else if (stdout) {
-    process.stdout.write(stdout);
+    writeSync(1, stdout);
   }
 
   exitLikeChild(result);

--- a/tests/crush-run-raw-shim.test.js
+++ b/tests/crush-run-raw-shim.test.js
@@ -44,7 +44,13 @@ function writeShimLauncher(binDir, name) {
 // its manifest.
 function writeRealBinary(dir, name, stdout) {
   const binPath = path.join(dir, name);
-  fs.writeFileSync(binPath, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(stdout)});\n`);
+  // Exiting only from the write callback, not right after the write() call,
+  // matters here: stdout to a pipe is asynchronous on POSIX, and a bare
+  // process.exit() does not wait for pending writes to flush -- it can
+  // truncate the tail of large output non-deterministically by OS and Node
+  // version (macOS's smaller default pipe buffer makes this bite harder than
+  // on Linux; seen as a real CI flake on macOS + Node 20.x).
+  fs.writeFileSync(binPath, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(stdout)}, () => process.exit(0));\n`);
   fs.chmodSync(binPath, 0o755);
   return binPath;
 }

--- a/tests/crush-run-raw-shim.test.js
+++ b/tests/crush-run-raw-shim.test.js
@@ -18,6 +18,29 @@ const { spawnSync } = require('node:child_process');
 const CRUSH_RUN = path.join(__dirname, '..', 'scripts', 'crush-run.js');
 const DISPATCH_MODULE = path.join(__dirname, '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
 
+// Built with String.fromCharCode/RegExp instead of typing the raw U+2028 and
+// U+2029 characters, so this file never carries invisible codepoints of its
+// own while implementing a fix for exactly that class of problem.
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
+const UNSAFE_CODE_CHARS = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  [LINE_SEPARATOR]: '\\u2028',
+  [PARAGRAPH_SEPARATOR]: '\\u2029',
+};
+const UNSAFE_CODE_CHARS_RE = new RegExp(`[<>${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`, 'g');
+
+// JSON.stringify alone is not a safe way to embed a value inside generated
+// source code: it leaves characters like < > and the U+2028/U+2029 line
+// separators untouched, which can still break out of the surrounding syntax
+// depending on context (flagged by CodeQL as js/bad-code-sanitization). These
+// fake binaries only ever receive fixed test fixtures, never external input,
+// but the construction itself should not rely on that.
+function jsStringLiteral(value) {
+  return JSON.stringify(value).replace(UNSAFE_CODE_CHARS_RE, (c) => UNSAFE_CODE_CHARS[c]);
+}
+
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
@@ -32,7 +55,7 @@ function writeShimLauncher(binDir, name) {
   const launcherPath = path.join(binDir, name);
   const source = [
     '#!/usr/bin/env node',
-    `require(${JSON.stringify(DISPATCH_MODULE)}).runShim(${JSON.stringify(name)}, process.argv.slice(2));`,
+    `require(${jsStringLiteral(DISPATCH_MODULE)}).runShim(${jsStringLiteral(name)}, process.argv.slice(2));`,
     '',
   ].join('\n');
   fs.writeFileSync(launcherPath, source);
@@ -53,7 +76,7 @@ function writeRealBinary(dir, name, stdout) {
   // macOS + Node 20.x even after waiting for that callback. fs.writeSync is a
   // genuine blocking syscall (loops internally until every byte is written),
   // so there is nothing left pending by the time this process exits.
-  fs.writeFileSync(binPath, `#!/usr/bin/env node\nrequire('fs').writeSync(1, ${JSON.stringify(stdout)});\nprocess.exit(0);\n`);
+  fs.writeFileSync(binPath, `#!/usr/bin/env node\nrequire('fs').writeSync(1, ${jsStringLiteral(stdout)});\nprocess.exit(0);\n`);
   fs.chmodSync(binPath, 0o755);
   return binPath;
 }

--- a/tests/crush-run-raw-shim.test.js
+++ b/tests/crush-run-raw-shim.test.js
@@ -44,13 +44,16 @@ function writeShimLauncher(binDir, name) {
 // its manifest.
 function writeRealBinary(dir, name, stdout) {
   const binPath = path.join(dir, name);
-  // Exiting only from the write callback, not right after the write() call,
-  // matters here: stdout to a pipe is asynchronous on POSIX, and a bare
-  // process.exit() does not wait for pending writes to flush -- it can
-  // truncate the tail of large output non-deterministically by OS and Node
-  // version (macOS's smaller default pipe buffer makes this bite harder than
-  // on Linux; seen as a real CI flake on macOS + Node 20.x).
-  fs.writeFileSync(binPath, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(stdout)}, () => process.exit(0));\n`);
+  // fs.writeSync(1, ...), not process.stdout.write(), matters here: this
+  // binary's stdout fd is inherited across two process hops (crush-run.js's
+  // own pipe, re-inherited by the shim launcher into this process), and
+  // process.stdout.write()'s callback firing does not reliably mean the data
+  // reached the OS pipe buffer across that many hops on every platform. This
+  // was seen as a real CI flake truncating the tail of large output on
+  // macOS + Node 20.x even after waiting for that callback. fs.writeSync is a
+  // genuine blocking syscall (loops internally until every byte is written),
+  // so there is nothing left pending by the time this process exits.
+  fs.writeFileSync(binPath, `#!/usr/bin/env node\nrequire('fs').writeSync(1, ${JSON.stringify(stdout)});\nprocess.exit(0);\n`);
   fs.chmodSync(binPath, 0o755);
   return binPath;
 }

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -44,7 +44,7 @@ function implBody({ stdout, exitCode = 0, echoStdin = false, selfSignal }) {
   // The write callback, not a bare statement after write(), is what makes this
   // reliable: stdout to a pipe is asynchronous on POSIX (smaller default pipe
   // buffers on macOS make this bite harder than on Linux), and process.exit()
-  // does not wait for pending writes to flush -- calling it before the write
+  // does not wait for pending writes to flush. Calling it before the write
   // callback fires can truncate the tail of large output non-deterministically
   // by OS and Node version (seen as a real CI flake on macOS + Node 20.x).
   return `process.stdout.write(${JSON.stringify(stdout ?? '')},()=>process.exit(${exitCode}));`;
@@ -221,8 +221,8 @@ function runTests() {
     const dir = createTempDir('egc-shim-dispatch-');
     try {
       // The manifest points at a path that does not exist, and a fresh PATH
-      // lookup for this nonsense name also fails -- must degrade to "command
-      // not found", not an uncaught throw or a hung process.
+      // lookup for this nonsense name also fails, so it must degrade to
+      // "command not found", not an uncaught throw or a hung process.
       seedManifest(dir, { 'totally-fake-binary-xyz-123': path.join(dir, 'does-not-exist') });
       const result = runShim(dir, 'totally-fake-binary-xyz-123', []);
       assert.strictEqual(result.status, 127);

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -34,14 +34,20 @@ function cleanup(dirPath) {
 // wrapper), matching how the real npm.cmd/npx.cmd wrappers work there.
 function implBody({ stdout, exitCode = 0, echoStdin = false, selfSignal }) {
   if (echoStdin) {
-    return "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{process.stdout.write(d);process.exit(0);});";
+    return "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{process.stdout.write(d,()=>process.exit(0));});";
   }
   if (selfSignal) {
     // Simulates a process killed by a signal (Ctrl+C/SIGINT, SIGTERM, ...):
     // spawnSync reports this as status=null, signal=<name> for the parent.
-    return `process.stdout.write(${JSON.stringify(stdout ?? '')});process.kill(process.pid, ${JSON.stringify(selfSignal)});setTimeout(()=>{},1000);`;
+    return `process.stdout.write(${JSON.stringify(stdout ?? '')},()=>{process.kill(process.pid, ${JSON.stringify(selfSignal)});});setTimeout(()=>{},1000);`;
   }
-  return `process.stdout.write(${JSON.stringify(stdout ?? '')});process.exit(${exitCode});`;
+  // The write callback, not a bare statement after write(), is what makes this
+  // reliable: stdout to a pipe is asynchronous on POSIX (smaller default pipe
+  // buffers on macOS make this bite harder than on Linux), and process.exit()
+  // does not wait for pending writes to flush -- calling it before the write
+  // callback fires can truncate the tail of large output non-deterministically
+  // by OS and Node version (seen as a real CI flake on macOS + Node 20.x).
+  return `process.stdout.write(${JSON.stringify(stdout ?? '')},()=>process.exit(${exitCode}));`;
 }
 
 function writeFakeBinary(dir, name, spec) {

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -9,6 +9,29 @@ const { spawnSync } = require('child_process');
 const DISPATCH_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
 const { needsShellOnWindows } = require('../../scripts/lib/crusher/shim-dispatch');
 
+// Built with String.fromCharCode/RegExp instead of typing the raw U+2028 and
+// U+2029 characters, so this file never carries invisible codepoints of its
+// own while implementing a fix for exactly that class of problem.
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
+const UNSAFE_CODE_CHARS = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  [LINE_SEPARATOR]: '\\u2028',
+  [PARAGRAPH_SEPARATOR]: '\\u2029',
+};
+const UNSAFE_CODE_CHARS_RE = new RegExp(`[<>${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`, 'g');
+
+// JSON.stringify alone is not a safe way to embed a value inside generated
+// source code: it leaves characters like < > and the U+2028/U+2029 line
+// separators untouched, which can still break out of the surrounding syntax
+// depending on context (flagged by CodeQL as js/bad-code-sanitization). These
+// fake binaries only ever receive fixed test fixtures, never external input,
+// but the construction itself should not rely on that.
+function jsStringLiteral(value) {
+  return JSON.stringify(value).replace(UNSAFE_CODE_CHARS_RE, (c) => UNSAFE_CODE_CHARS[c]);
+}
+
 function withPlatform(value, fn) {
   const original = Object.getOwnPropertyDescriptor(process, 'platform');
   Object.defineProperty(process, 'platform', { value, configurable: true });
@@ -39,7 +62,7 @@ function implBody({ stdout, exitCode = 0, echoStdin = false, selfSignal }) {
   if (selfSignal) {
     // Simulates a process killed by a signal (Ctrl+C/SIGINT, SIGTERM, ...):
     // spawnSync reports this as status=null, signal=<name> for the parent.
-    return `process.stdout.write(${JSON.stringify(stdout ?? '')},()=>{process.kill(process.pid, ${JSON.stringify(selfSignal)});});setTimeout(()=>{},1000);`;
+    return `process.stdout.write(${jsStringLiteral(stdout ?? '')},()=>{process.kill(process.pid, ${jsStringLiteral(selfSignal)});});setTimeout(()=>{},1000);`;
   }
   // The write callback, not a bare statement after write(), is what makes this
   // reliable: stdout to a pipe is asynchronous on POSIX (smaller default pipe
@@ -47,7 +70,7 @@ function implBody({ stdout, exitCode = 0, echoStdin = false, selfSignal }) {
   // does not wait for pending writes to flush. Calling it before the write
   // callback fires can truncate the tail of large output non-deterministically
   // by OS and Node version (seen as a real CI flake on macOS + Node 20.x).
-  return `process.stdout.write(${JSON.stringify(stdout ?? '')},()=>process.exit(${exitCode}));`;
+  return `process.stdout.write(${jsStringLiteral(stdout ?? '')},()=>process.exit(${exitCode}));`;
 }
 
 function writeFakeBinary(dir, name, spec) {
@@ -61,7 +84,7 @@ function writeFakeBinary(dir, name, spec) {
   }
 
   const binPath = path.join(dir, name);
-  fs.writeFileSync(binPath, `#!/usr/bin/env node\nrequire(${JSON.stringify(implPath)});\n`);
+  fs.writeFileSync(binPath, `#!/usr/bin/env node\nrequire(${jsStringLiteral(implPath)});\n`);
   fs.chmodSync(binPath, 0o755);
   return binPath;
 }


### PR DESCRIPTION
## Summary
- PR #1114 introduced two tests that write large output through a fake binary and immediately call process.exit(). Writes to a pipe are asynchronous on POSIX, so process.exit() right after write() can truncate the tail of the output before the OS-level write completes.
- Confirmed as the cause of the CI failure on main after #1114 merged: macOS + Node 20.x failed on npm, yarn, and bun (3/22 jobs), every other OS/Node combination passed.
- Fix: both fake-binary helpers now exit only from the write callback, guaranteeing the write has flushed first.

## Test plan
- [x] `node tests/lib/crusher-shim-dispatch.test.js` (10/10 passed)
- [x] `node tests/crush-run-raw-shim.test.js` (2/2 passed)
- [x] Root cause matches the exact failure signature from the main CI run (truncated tail of the last commit entry, both failures on macOS + Node 20.x only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS + Node 20.x CI flake by flushing stdout synchronously before exit in crusher scripts and tests to prevent truncated pipe output. Also sanitizes embedded values in generated test scripts to address CodeQL js/bad-code-sanitization.

- Bug Fixes
  - `scripts/crush-run.js` and `scripts/lib/crusher/shim-dispatch.js`: use `fs.writeSync(1, ...)` for stdout before `process.exit()` to avoid truncation.
  - Tests: fake binaries now exit from stdout write callbacks; the raw shim e2e fake binary uses `fs.writeSync(1, ...)`; generated scripts escape `<`, `>`, `U+2028`, and `U+2029` via a `jsStringLiteral` helper.

<sup>Written for commit 5ec24bd08898d2fe06a2541a1ffa739e814339da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

