### PR TITLE
feat(crusher): add scoped savings breakdown to egc gain

### DIFF
--- a/scripts/gain.js
+++ b/scripts/gain.js
@@ -5,7 +5,7 @@
 // ledger only and prints to the terminal, so the report itself costs zero
 // tokens. `egc saved` stays as the short summary; gain is the detailed view.
 
-const { readAll, aggregate, metricsFilePath } = require('./lib/crusher/metrics');
+const { readAll, aggregateBreakdown, metricsFilePath } = require('./lib/crusher/metrics');
 
 const BAR_WIDTH = 24;
 
@@ -38,19 +38,25 @@ function printHistory(entries) {
   if (entries.length > recent.length) {
     console.log(`  ... ${entries.length - recent.length} earlier run(s) omitted`);
   }
-  for (const e of recent) {
-    const when = (e.ts || '').replace('T', ' ').slice(0, 16);
+  for (const entry of recent) {
+    const when = (entry.ts || '').replace('T', ' ').slice(0, 16);
     console.log(
-      `  ${when}  ${String(e.kind || '?').padEnd(12)} ` +
-      `~${formatTokens(e.tokensSaved || 0).padStart(7)} saved  ${e.cmd || ''}`
+      `  ${when}  ${String(entry.kind || '?').padEnd(12)} ` +
+      `~${formatTokens(entry.tokensSaved || 0).padStart(7)} saved  ${entry.cmd || ''}`
     );
   }
+}
+
+function printScopedTokens(label, totals, unavailableMessage) {
+  const value = totals?.available === false
+    ? unavailableMessage
+    : `~${formatTokens(totals?.tokensSaved || 0)} tokens`;
+  console.log(`  ${label.padEnd(20)} ${value}`);
 }
 
 function main() {
   const json = process.argv.includes('--json');
   const entries = readAll();
-  const totals = aggregate(entries);
 
   if (process.argv.includes('--history')) {
     if (json) {
@@ -61,8 +67,13 @@ function main() {
     return;
   }
 
+  const report = aggregateBreakdown(entries);
+  const totals = report.sinceInstall;
+
   if (json) {
-    console.log(JSON.stringify({ ...totals, entries: entries.length }, null, 2));
+    // Preserve the existing top-level lifetime fields while adding the scoped
+    // report, so scripts consuming runs/bytes/tokens/byKind keep working.
+    console.log(JSON.stringify({ ...totals, ...report, entries: entries.length }, null, 2));
     return;
   }
 
@@ -73,23 +84,24 @@ function main() {
   }
 
   const pct = totals.bytesIn > 0 ? (1 - totals.bytesOut / totals.bytesIn) : 0;
-  const avg = Math.round(totals.tokensSaved / totals.runs);
-  const biggest = entries.reduce(
-    (top, e) => ((e.tokensSaved || 0) > (top.tokensSaved || 0) ? e : top),
-    entries[0]
-  );
 
   console.log('EGC Token Gain (local ledger, zero token cost)');
   console.log('═'.repeat(52));
   console.log('');
-  console.log(`  Crushed runs:     ${totals.runs}`);
-  console.log(`  Output size:      ${formatBytes(totals.bytesIn)} -> ${formatBytes(totals.bytesOut)}`);
-  console.log(`  Tokens saved:     ~${formatTokens(totals.tokensSaved)}`);
-  console.log(`  Avg per run:      ~${formatTokens(avg)} tokens`);
-  if (biggest && biggest.cmd) {
-    console.log(`  Biggest crush:    ~${formatTokens(biggest.tokensSaved || 0)} tokens (${biggest.cmd})`);
+  printScopedTokens('Today', report.today);
+  printScopedTokens('Current session', report.currentSession, 'unavailable (no EGC_SESSION_ID)');
+  printScopedTokens('Current project', report.currentProject, 'unavailable');
+  printScopedTokens('Since install', report.sinceInstall);
+  printScopedTokens('Last 7 days', report.last7Days);
+  printScopedTokens('Last 30 days', report.last30Days);
+  console.log('');
+  console.log(`  Crushed runs:         ${report.runs}`);
+  console.log(`  Average per run:      ~${formatTokens(report.averagePerRun)} tokens`);
+  if (report.biggest?.cmd) {
+    console.log(`  Biggest crush:        ~${formatTokens(report.biggest.tokensSaved)} tokens (${report.biggest.cmd})`);
   }
-  console.log(`  Efficiency:       ${bar(pct)} ${(pct * 100).toFixed(1)}%`);
+  console.log(`  Output size:          ${formatBytes(totals.bytesIn)} -> ${formatBytes(totals.bytesOut)}`);
+  console.log(`  Efficiency:           ${bar(pct)} ${(pct * 100).toFixed(1)}%`);
   console.log('');
 
   const kinds = Object.entries(totals.byKind).sort((a, b) => b[1].tokensSaved - a[1].tokensSaved);
@@ -97,10 +109,10 @@ function main() {
     console.log('  By command kind');
     console.log('  ' + '─'.repeat(50));
     const top = kinds[0][1].tokensSaved || 1;
-    for (const [kind, k] of kinds) {
+    for (const [kind, kindTotals] of kinds) {
       console.log(
-        `  ${kind.padEnd(14)} ${String(k.runs).padStart(4)} runs  ` +
-        `~${formatTokens(k.tokensSaved).padStart(7)}  ${bar(k.tokensSaved / top, 10)}`
+        `  ${kind.padEnd(14)} ${String(kindTotals.runs).padStart(4)} runs  ` +
+        `~${formatTokens(kindTotals.tokensSaved).padStart(7)}  ${bar(kindTotals.tokensSaved / top, 10)}`
       );
     }
     console.log('');

--- a/scripts/lib/crusher/metrics.js
+++ b/scripts/lib/crusher/metrics.js
@@ -150,7 +150,7 @@ function aggregateBreakdown(entries, options = {}) {
     ? []
     : normalizedEntries.filter(entry => entry.session === session);
   const biggestEntry = normalizedEntries.reduce((biggest, entry) => (
-    finiteNumber(entry.tokensSaved) > finiteNumber(biggest?.tokensSaved) ? entry : biggest
+    biggest === null || finiteNumber(entry.tokensSaved) > finiteNumber(biggest.tokensSaved) ? entry : biggest
   ), null);
   const firstTimestamp = timestampedEntries.reduce((earliest, item) => (
     earliest === null || item.timestamp < earliest ? item.timestamp : earliest

--- a/scripts/lib/crusher/metrics.js
+++ b/scripts/lib/crusher/metrics.js
@@ -9,26 +9,77 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const UNKNOWN_SCOPE = 'unknown';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Return the machine-local Crusher ledger path. */
 function metricsFilePath() {
   return path.join(os.homedir(), '.egc', 'metrics', 'crusher.jsonl');
 }
 
+/** Normalize a session-like scope label while preserving legacy unknowns. */
+function normalizeScope(value) {
+  if (typeof value !== 'string') return UNKNOWN_SCOPE;
+  const normalized = value.trim();
+  return normalized && normalized !== UNKNOWN_SCOPE ? normalized : UNKNOWN_SCOPE;
+}
+
+/** Normalize a project path into a stable absolute machine-local identifier. */
+function normalizeProject(value) {
+  const normalized = normalizeScope(value);
+  if (normalized === UNKNOWN_SCOPE) return UNKNOWN_SCOPE;
+  try {
+    return path.resolve(normalized);
+  } catch {
+    return normalized;
+  }
+}
+
+/** Attach backward-compatible project/session buckets to one ledger entry. */
+function normalizeEntry(entry) {
+  const source = entry && typeof entry === 'object' ? entry : {};
+  return {
+    ...source,
+    project: normalizeProject(source.project),
+    session: normalizeScope(source.session),
+  };
+}
+
+/** Resolve the attribution available to a Crusher child process. */
+function resolveMetricContext({ cwd = process.cwd(), env = process.env } = {}) {
+  const project = env.EGC_PROJECT_DIR || env.PROJECT_ROOT || cwd;
+  const session = env.EGC_SESSION_ID || env.ECC_SESSION_ID;
+  return {
+    project: normalizeProject(project),
+    session: normalizeScope(session),
+  };
+}
+
+/** Append one best-effort ledger row without ever breaking the wrapped command. */
 function record(entry) {
   try {
     const file = metricsFilePath();
+    const context = resolveMetricContext();
+    const row = normalizeEntry({
+      ts: new Date().toISOString(),
+      ...entry,
+      project: entry?.project ?? context.project,
+      session: entry?.session ?? context.session,
+    });
     fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-    fs.appendFileSync(file, JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n');
+    fs.appendFileSync(file, JSON.stringify(row) + '\n');
   } catch { // NOSONAR: accounting must never break the command being run
     // ignore: savings accounting is best-effort
   }
 }
 
+/** Read every valid JSONL row and normalize legacy scope fields. */
 function readAll() {
   try {
     const raw = fs.readFileSync(metricsFilePath(), 'utf8');
     return raw.split('\n').filter(Boolean).map(line => {
       try {
-        return JSON.parse(line);
+        return normalizeEntry(JSON.parse(line));
       } catch {
         return null;
       }
@@ -38,19 +89,113 @@ function readAll() {
   }
 }
 
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+/** Aggregate totals and command-kind savings for a set of ledger rows. */
 function aggregate(entries) {
   const totals = { runs: 0, bytesIn: 0, bytesOut: 0, tokensSaved: 0, byKind: {} };
-  for (const e of entries) {
+  for (const rawEntry of entries) {
+    const entry = normalizeEntry(rawEntry);
     totals.runs += 1;
-    totals.bytesIn += e.bytesIn || 0;
-    totals.bytesOut += e.bytesOut || 0;
-    totals.tokensSaved += e.tokensSaved || 0;
-    const kind = e.kind || 'generic';
+    totals.bytesIn += finiteNumber(entry.bytesIn);
+    totals.bytesOut += finiteNumber(entry.bytesOut);
+    totals.tokensSaved += finiteNumber(entry.tokensSaved);
+    const kind = typeof entry.kind === 'string' && entry.kind ? entry.kind : 'generic';
     totals.byKind[kind] = totals.byKind[kind] || { runs: 0, tokensSaved: 0 };
     totals.byKind[kind].runs += 1;
-    totals.byKind[kind].tokensSaved += e.tokensSaved || 0;
+    totals.byKind[kind].tokensSaved += finiteNumber(entry.tokensSaved);
   }
   return totals;
 }
 
-module.exports = { metricsFilePath, record, readAll, aggregate };
+function timestampMs(entry) {
+  const value = Date.parse(entry?.ts);
+  return Number.isFinite(value) ? value : null;
+}
+
+function aggregateWindow(timestampedEntries, startMs, endMs) {
+  return aggregate(timestampedEntries
+    .filter(({ timestamp }) => timestamp >= startMs && timestamp <= endMs)
+    .map(({ entry }) => entry));
+}
+
+/**
+ * Build the time-, project-, and session-scoped statistics used by `egc gain`.
+ * Today follows the user's local calendar day; 7d/30d are exact rolling spans.
+ */
+function aggregateBreakdown(entries, options = {}) {
+  const parsedNow = options.now instanceof Date
+    ? new Date(options.now.getTime())
+    : new Date(options.now ?? Date.now());
+  const now = Number.isFinite(parsedNow.getTime()) ? parsedNow : new Date();
+  const context = resolveMetricContext(options.context || {});
+  const project = normalizeProject(options.project ?? context.project);
+  const session = normalizeScope(options.session ?? context.session);
+  const normalizedEntries = entries.map(normalizeEntry);
+  const timestampedEntries = normalizedEntries
+    .map(entry => ({ entry, timestamp: timestampMs(entry) }))
+    .filter(item => item.timestamp !== null);
+  const nowMs = now.getTime();
+  const localDayStart = new Date(now.getTime());
+  localDayStart.setHours(0, 0, 0, 0);
+
+  const sinceInstall = aggregate(normalizedEntries);
+  const projectEntries = project === UNKNOWN_SCOPE
+    ? []
+    : normalizedEntries.filter(entry => entry.project === project);
+  const sessionEntries = session === UNKNOWN_SCOPE
+    ? []
+    : normalizedEntries.filter(entry => entry.session === session);
+  const biggestEntry = normalizedEntries.reduce((biggest, entry) => (
+    finiteNumber(entry.tokensSaved) > finiteNumber(biggest?.tokensSaved) ? entry : biggest
+  ), null);
+  const firstTimestamp = timestampedEntries.reduce((earliest, item) => (
+    earliest === null || item.timestamp < earliest ? item.timestamp : earliest
+  ), null);
+
+  return {
+    generatedAt: now.toISOString(),
+    scopes: { project, session },
+    today: aggregateWindow(timestampedEntries, localDayStart.getTime(), nowMs),
+    currentSession: {
+      available: session !== UNKNOWN_SCOPE,
+      ...aggregate(sessionEntries),
+    },
+    currentProject: {
+      available: project !== UNKNOWN_SCOPE,
+      ...aggregate(projectEntries),
+    },
+    sinceInstall: {
+      startedAt: firstTimestamp === null ? null : new Date(firstTimestamp).toISOString(),
+      ...sinceInstall,
+    },
+    last7Days: aggregateWindow(timestampedEntries, nowMs - (7 * DAY_MS), nowMs),
+    last30Days: aggregateWindow(timestampedEntries, nowMs - (30 * DAY_MS), nowMs),
+    runs: sinceInstall.runs,
+    averagePerRun: sinceInstall.runs > 0
+      ? Math.round(sinceInstall.tokensSaved / sinceInstall.runs)
+      : 0,
+    biggest: biggestEntry ? {
+      ts: biggestEntry.ts || null,
+      cmd: biggestEntry.cmd || '',
+      kind: biggestEntry.kind || 'generic',
+      tokensSaved: finiteNumber(biggestEntry.tokensSaved),
+      project: biggestEntry.project,
+      session: biggestEntry.session,
+    } : null,
+  };
+}
+
+module.exports = {
+  UNKNOWN_SCOPE,
+  metricsFilePath,
+  normalizeEntry,
+  resolveMetricContext,
+  record,
+  readAll,
+  aggregate,
+  aggregateBreakdown,
+};

--- a/scripts/lib/crusher/metrics.js
+++ b/scripts/lib/crusher/metrics.js
@@ -47,7 +47,7 @@ function normalizeEntry(entry) {
 
 /** Resolve the attribution available to a Crusher child process. */
 function resolveMetricContext({ cwd = process.cwd(), env = process.env } = {}) {
-  const project = env.EGC_PROJECT_DIR || env.PROJECT_ROOT || cwd;
+  const project = env.EGC_PROJECT_ROOT || env.EGC_PROJECT_DIR || env.PROJECT_ROOT || cwd;
   const session = env.EGC_SESSION_ID || env.ECC_SESSION_ID;
   return {
     project: normalizeProject(project),

--- a/tests/crusher-metrics.test.js
+++ b/tests/crusher-metrics.test.js
@@ -1,0 +1,192 @@
+'use strict';
+/**
+ * Tests for Token Crusher ledger attribution and scoped gain aggregates.
+ *
+ * Run with: node tests/crusher-metrics.test.js
+ */
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  UNKNOWN_SCOPE,
+  normalizeEntry,
+  resolveMetricContext,
+  record,
+  readAll,
+  aggregateBreakdown,
+} = require('../scripts/lib/crusher/metrics');
+
+const ROOT = path.join(__dirname, '..');
+const GAIN = path.join(ROOT, 'scripts', 'gain.js');
+
+let passed = 0;
+let failed = 0;
+function run(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${error.message}`);
+    failed++;
+  }
+}
+
+function withProcessContext({ home, cwd, session }, fn) {
+  const previous = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    EGC_SESSION_ID: process.env.EGC_SESSION_ID,
+    cwd: process.cwd(),
+  };
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  if (session === undefined) delete process.env.EGC_SESSION_ID;
+  else process.env.EGC_SESSION_ID = session;
+  process.chdir(cwd);
+  try {
+    return fn();
+  } finally {
+    process.chdir(previous.cwd);
+    for (const key of ['HOME', 'USERPROFILE', 'EGC_SESSION_ID']) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+    }
+  }
+}
+
+console.log('\n=== Testing Token Crusher scoped metrics ===\n');
+
+run('resolves project and existing EGC session conventions', () => {
+  const cwd = path.join(os.tmpdir(), 'egc-project-context');
+  const context = resolveMetricContext({
+    cwd,
+    env: { EGC_SESSION_ID: 'ses_test' },
+  });
+  assert.strictEqual(context.project, path.resolve(cwd));
+  assert.strictEqual(context.session, 'ses_test');
+
+  const fallback = resolveMetricContext({ cwd, env: {} });
+  assert.strictEqual(fallback.session, UNKNOWN_SCOPE);
+});
+
+run('normalizes legacy rows into unknown attribution buckets', () => {
+  const legacy = normalizeEntry({ ts: '2026-07-31T00:00:00Z', tokensSaved: 10 });
+  assert.strictEqual(legacy.project, UNKNOWN_SCOPE);
+  assert.strictEqual(legacy.session, UNKNOWN_SCOPE);
+});
+
+run('computes project, session, rolling-window, average, and biggest totals', () => {
+  const projectA = path.resolve(path.join(os.tmpdir(), 'egc-project-a'));
+  const projectB = path.resolve(path.join(os.tmpdir(), 'egc-project-b'));
+  const entries = [
+    { ts: '2026-07-31T10:00:00Z', project: projectA, session: 'ses_a', kind: 'git-log', cmd: 'git', tokensSaved: 100, bytesIn: 1000, bytesOut: 100 },
+    { ts: '2026-07-30T12:00:00Z', project: projectA, session: 'ses_b', kind: 'tests', cmd: 'npm', tokensSaved: 300, bytesIn: 3000, bytesOut: 300 },
+    { ts: '2026-07-20T12:00:00Z', project: projectB, session: 'ses_a', kind: 'diff', cmd: 'git', tokensSaved: 700, bytesIn: 7000, bytesOut: 700 },
+    { ts: '2026-07-31T11:00:00Z', kind: 'generic', cmd: 'legacy', tokensSaved: 50, bytesIn: 500, bytesOut: 50 },
+  ];
+  const report = aggregateBreakdown(entries, {
+    now: '2026-07-31T12:00:00Z',
+    project: projectA,
+    session: 'ses_a',
+  });
+
+  assert.strictEqual(report.runs, 4);
+  assert.strictEqual(report.sinceInstall.tokensSaved, 1150);
+  assert.strictEqual(report.averagePerRun, 288);
+  assert.strictEqual(report.biggest.tokensSaved, 700);
+  assert.strictEqual(report.biggest.cmd, 'git');
+  assert.strictEqual(report.currentProject.tokensSaved, 400);
+  assert.strictEqual(report.currentSession.tokensSaved, 800);
+  assert.strictEqual(report.last7Days.tokensSaved, 450);
+  assert.strictEqual(report.last30Days.tokensSaved, 1150);
+});
+
+run('uses the local calendar boundary instead of the UTC date boundary', () => {
+  const previousTZ = process.env.TZ;
+  process.env.TZ = 'America/Los_Angeles';
+  try {
+    const report = aggregateBreakdown([
+      { ts: '2026-07-31T07:30:00Z', tokensSaved: 100 },
+      { ts: '2026-07-31T06:30:00Z', tokensSaved: 200 },
+    ], {
+      now: '2026-07-31T08:30:00Z',
+      project: UNKNOWN_SCOPE,
+      session: UNKNOWN_SCOPE,
+    });
+    assert.strictEqual(report.today.runs, 1);
+    assert.strictEqual(report.today.tokensSaved, 100);
+  } finally {
+    if (previousTZ === undefined) delete process.env.TZ;
+    else process.env.TZ = previousTZ;
+  }
+});
+
+run('records attribution and exposes the scoped gain panel without breaking legacy JSON', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-scoped-gain-home-'));
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-scoped-gain-project-'));
+
+  withProcessContext({ home, cwd: project, session: 'ses_cli' }, () => {
+    record({ cmd: 'git', kind: 'git-log', bytesIn: 1000, bytesOut: 100, tokensSaved: 225 });
+    const first = readAll()[0];
+    assert.strictEqual(first.project, path.resolve(project));
+    assert.strictEqual(first.session, 'ses_cli');
+  });
+
+  const ledger = path.join(home, '.egc', 'metrics', 'crusher.jsonl');
+  fs.appendFileSync(ledger, `${JSON.stringify({
+    ts: new Date().toISOString(),
+    cmd: 'legacy',
+    kind: 'generic',
+    bytesIn: 500,
+    bytesOut: 100,
+    tokensSaved: 75,
+  })}\n`);
+
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    EGC_SESSION_ID: 'ses_cli',
+  };
+  const jsonResult = spawnSync(process.execPath, [GAIN, '--json'], {
+    cwd: project,
+    env,
+    encoding: 'utf8',
+  });
+  assert.strictEqual(jsonResult.status, 0, jsonResult.stderr);
+  const report = JSON.parse(jsonResult.stdout);
+  assert.strictEqual(report.tokensSaved, 300, 'legacy top-level lifetime total remains available');
+  assert.strictEqual(report.currentProject.tokensSaved, 225);
+  assert.strictEqual(report.currentSession.tokensSaved, 225);
+  assert.strictEqual(report.sinceInstall.tokensSaved, 300);
+
+  const historyResult = spawnSync(process.execPath, [GAIN, '--history', '--json'], {
+    cwd: project,
+    env,
+    encoding: 'utf8',
+  });
+  assert.strictEqual(historyResult.status, 0, historyResult.stderr);
+  const history = JSON.parse(historyResult.stdout);
+  assert.strictEqual(history[1].project, UNKNOWN_SCOPE);
+  assert.strictEqual(history[1].session, UNKNOWN_SCOPE);
+
+  const panel = spawnSync(process.execPath, [GAIN], {
+    cwd: project,
+    env,
+    encoding: 'utf8',
+  });
+  assert.strictEqual(panel.status, 0, panel.stderr);
+  assert.match(panel.stdout, /Today/);
+  assert.match(panel.stdout, /Current session/);
+  assert.match(panel.stdout, /Current project/);
+  assert.match(panel.stdout, /Last 7 days/);
+  assert.match(panel.stdout, /Last 30 days/);
+  assert.match(panel.stdout, /Biggest crush:.*git/);
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/crusher-metrics.test.js
+++ b/tests/crusher-metrics.test.js
@@ -125,7 +125,7 @@ run('records attribution and exposes the scoped gain panel without breaking lega
 
     const ledger = path.join(home, '.egc', 'metrics', 'crusher.jsonl');
     const first = JSON.parse(fs.readFileSync(ledger, 'utf8').trim());
-    assert.strictEqual(first.project, path.resolve(project));
+    assert.strictEqual(fs.realpathSync(first.project), fs.realpathSync(project));
     assert.strictEqual(first.session, 'ses_cli');
 
     fs.appendFileSync(ledger, `${JSON.stringify({

--- a/tests/crusher-metrics.test.js
+++ b/tests/crusher-metrics.test.js
@@ -13,13 +13,12 @@ const {
   UNKNOWN_SCOPE,
   normalizeEntry,
   resolveMetricContext,
-  record,
-  readAll,
   aggregateBreakdown,
 } = require('../scripts/lib/crusher/metrics');
 
 const ROOT = path.join(__dirname, '..');
 const GAIN = path.join(ROOT, 'scripts', 'gain.js');
+const METRICS = path.join(ROOT, 'scripts', 'lib', 'crusher', 'metrics.js');
 
 let passed = 0;
 let failed = 0;
@@ -35,27 +34,13 @@ function run(name, fn) {
   }
 }
 
-function withProcessContext({ home, cwd, session }, fn) {
-  const previous = {
-    HOME: process.env.HOME,
-    USERPROFILE: process.env.USERPROFILE,
-    EGC_SESSION_ID: process.env.EGC_SESSION_ID,
-    cwd: process.cwd(),
-  };
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  if (session === undefined) delete process.env.EGC_SESSION_ID;
-  else process.env.EGC_SESSION_ID = session;
-  process.chdir(cwd);
-  try {
-    return fn();
-  } finally {
-    process.chdir(previous.cwd);
-    for (const key of ['HOME', 'USERPROFILE', 'EGC_SESSION_ID']) {
-      if (previous[key] === undefined) delete process.env[key];
-      else process.env[key] = previous[key];
-    }
-  }
+function runNode(script, options = {}) {
+  const result = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8',
+    ...options,
+  });
+  assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  return result;
 }
 
 console.log('\n=== Testing Token Crusher scoped metrics ===\n');
@@ -106,86 +91,90 @@ run('computes project, session, rolling-window, average, and biggest totals', ()
 });
 
 run('uses the local calendar boundary instead of the UTC date boundary', () => {
-  const previousTZ = process.env.TZ;
-  process.env.TZ = 'America/Los_Angeles';
-  try {
-    const report = aggregateBreakdown([
-      { ts: '2026-07-31T07:30:00Z', tokensSaved: 100 },
-      { ts: '2026-07-31T06:30:00Z', tokensSaved: 200 },
-    ], {
-      now: '2026-07-31T08:30:00Z',
-      project: UNKNOWN_SCOPE,
-      session: UNKNOWN_SCOPE,
-    });
-    assert.strictEqual(report.today.runs, 1);
-    assert.strictEqual(report.today.tokensSaved, 100);
-  } finally {
-    if (previousTZ === undefined) delete process.env.TZ;
-    else process.env.TZ = previousTZ;
-  }
+  const now = new Date(2026, 6, 31, 1, 30);
+  const today = new Date(2026, 6, 31, 0, 30);
+  const previousDay = new Date(2026, 6, 30, 23, 30);
+  const report = aggregateBreakdown([
+    { ts: today.toISOString(), tokensSaved: 100 },
+    { ts: previousDay.toISOString(), tokensSaved: 200 },
+  ], {
+    now,
+    project: UNKNOWN_SCOPE,
+    session: UNKNOWN_SCOPE,
+  });
+  assert.strictEqual(report.today.runs, 1);
+  assert.strictEqual(report.today.tokensSaved, 100);
 });
 
 run('records attribution and exposes the scoped gain panel without breaking legacy JSON', () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-scoped-gain-home-'));
   const project = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-scoped-gain-project-'));
-
-  withProcessContext({ home, cwd: project, session: 'ses_cli' }, () => {
-    record({ cmd: 'git', kind: 'git-log', bytesIn: 1000, bytesOut: 100, tokensSaved: 225 });
-    const first = readAll()[0];
-    assert.strictEqual(first.project, path.resolve(project));
-    assert.strictEqual(first.session, 'ses_cli');
-  });
-
-  const ledger = path.join(home, '.egc', 'metrics', 'crusher.jsonl');
-  fs.appendFileSync(ledger, `${JSON.stringify({
-    ts: new Date().toISOString(),
-    cmd: 'legacy',
-    kind: 'generic',
-    bytesIn: 500,
-    bytesOut: 100,
-    tokensSaved: 75,
-  })}\n`);
-
   const env = {
     ...process.env,
     HOME: home,
     USERPROFILE: home,
     EGC_SESSION_ID: 'ses_cli',
+    EGC_TEST_METRICS_MODULE: METRICS,
   };
-  const jsonResult = spawnSync(process.execPath, [GAIN, '--json'], {
-    cwd: project,
-    env,
-    encoding: 'utf8',
-  });
-  assert.strictEqual(jsonResult.status, 0, jsonResult.stderr);
-  const report = JSON.parse(jsonResult.stdout);
-  assert.strictEqual(report.tokensSaved, 300, 'legacy top-level lifetime total remains available');
-  assert.strictEqual(report.currentProject.tokensSaved, 225);
-  assert.strictEqual(report.currentSession.tokensSaved, 225);
-  assert.strictEqual(report.sinceInstall.tokensSaved, 300);
 
-  const historyResult = spawnSync(process.execPath, [GAIN, '--history', '--json'], {
-    cwd: project,
-    env,
-    encoding: 'utf8',
-  });
-  assert.strictEqual(historyResult.status, 0, historyResult.stderr);
-  const history = JSON.parse(historyResult.stdout);
-  assert.strictEqual(history[1].project, UNKNOWN_SCOPE);
-  assert.strictEqual(history[1].session, UNKNOWN_SCOPE);
+  try {
+    runNode(
+      "const { record } = require(process.env.EGC_TEST_METRICS_MODULE); record({ cmd: 'git', kind: 'git-log', bytesIn: 1000, bytesOut: 100, tokensSaved: 225 });",
+      { cwd: project, env }
+    );
 
-  const panel = spawnSync(process.execPath, [GAIN], {
-    cwd: project,
-    env,
-    encoding: 'utf8',
-  });
-  assert.strictEqual(panel.status, 0, panel.stderr);
-  assert.match(panel.stdout, /Today/);
-  assert.match(panel.stdout, /Current session/);
-  assert.match(panel.stdout, /Current project/);
-  assert.match(panel.stdout, /Last 7 days/);
-  assert.match(panel.stdout, /Last 30 days/);
-  assert.match(panel.stdout, /Biggest crush:.*git/);
+    const ledger = path.join(home, '.egc', 'metrics', 'crusher.jsonl');
+    const first = JSON.parse(fs.readFileSync(ledger, 'utf8').trim());
+    assert.strictEqual(first.project, path.resolve(project));
+    assert.strictEqual(first.session, 'ses_cli');
+
+    fs.appendFileSync(ledger, `${JSON.stringify({
+      ts: new Date().toISOString(),
+      cmd: 'legacy',
+      kind: 'generic',
+      bytesIn: 500,
+      bytesOut: 100,
+      tokensSaved: 75,
+    })}\n`);
+
+    const jsonResult = spawnSync(process.execPath, [GAIN, '--json'], {
+      cwd: project,
+      env,
+      encoding: 'utf8',
+    });
+    assert.strictEqual(jsonResult.status, 0, jsonResult.stderr);
+    const report = JSON.parse(jsonResult.stdout);
+    assert.strictEqual(report.tokensSaved, 300, 'legacy top-level lifetime total remains available');
+    assert.strictEqual(report.currentProject.tokensSaved, 225);
+    assert.strictEqual(report.currentSession.tokensSaved, 225);
+    assert.strictEqual(report.sinceInstall.tokensSaved, 300);
+
+    const historyResult = spawnSync(process.execPath, [GAIN, '--history', '--json'], {
+      cwd: project,
+      env,
+      encoding: 'utf8',
+    });
+    assert.strictEqual(historyResult.status, 0, historyResult.stderr);
+    const history = JSON.parse(historyResult.stdout);
+    assert.strictEqual(history[1].project, UNKNOWN_SCOPE);
+    assert.strictEqual(history[1].session, UNKNOWN_SCOPE);
+
+    const panel = spawnSync(process.execPath, [GAIN], {
+      cwd: project,
+      env,
+      encoding: 'utf8',
+    });
+    assert.strictEqual(panel.status, 0, panel.stderr);
+    assert.match(panel.stdout, /Today/);
+    assert.match(panel.stdout, /Current session/);
+    assert.match(panel.stdout, /Current project/);
+    assert.match(panel.stdout, /Last 7 days/);
+    assert.match(panel.stdout, /Last 30 days/);
+    assert.match(panel.stdout, /Biggest crush:.*git/);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(project, { recursive: true, force: true });
+  }
 });
 
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/tests/crusher-metrics.test.js
+++ b/tests/crusher-metrics.test.js
@@ -45,16 +45,36 @@ function runNode(script, options = {}) {
 
 console.log('\n=== Testing Token Crusher scoped metrics ===\n');
 
-run('resolves project and existing EGC session conventions', () => {
+run('resolves canonical project and session conventions with legacy fallbacks', () => {
   const cwd = path.join(os.tmpdir(), 'egc-project-context');
+  const canonicalRoot = path.join(os.tmpdir(), 'egc-project-root');
+  const compatibleRoot = path.join(os.tmpdir(), 'egc-project-dir');
+  const legacyRoot = path.join(os.tmpdir(), 'project-root');
   const context = resolveMetricContext({
     cwd,
-    env: { EGC_SESSION_ID: 'ses_test' },
+    env: {
+      EGC_PROJECT_ROOT: canonicalRoot,
+      EGC_PROJECT_DIR: compatibleRoot,
+      PROJECT_ROOT: legacyRoot,
+      EGC_SESSION_ID: 'ses_test',
+      ECC_SESSION_ID: 'ses_legacy',
+    },
   });
-  assert.strictEqual(context.project, path.resolve(cwd));
+  assert.strictEqual(context.project, path.resolve(canonicalRoot));
   assert.strictEqual(context.session, 'ses_test');
 
+  const compatible = resolveMetricContext({
+    cwd,
+    env: { EGC_PROJECT_DIR: compatibleRoot, PROJECT_ROOT: legacyRoot, ECC_SESSION_ID: 'ses_legacy' },
+  });
+  assert.strictEqual(compatible.project, path.resolve(compatibleRoot));
+  assert.strictEqual(compatible.session, 'ses_legacy');
+
+  const legacy = resolveMetricContext({ cwd, env: { PROJECT_ROOT: legacyRoot } });
+  assert.strictEqual(legacy.project, path.resolve(legacyRoot));
+
   const fallback = resolveMetricContext({ cwd, env: {} });
+  assert.strictEqual(fallback.project, path.resolve(cwd));
   assert.strictEqual(fallback.session, UNKNOWN_SCOPE);
 });
 
@@ -109,10 +129,13 @@ run('uses the local calendar boundary instead of the UTC date boundary', () => {
 run('records attribution and exposes the scoped gain panel without breaking legacy JSON', () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-scoped-gain-home-'));
   const project = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-scoped-gain-project-'));
+  const nestedCwd = path.join(project, 'nested');
+  fs.mkdirSync(nestedCwd);
   const env = {
     ...process.env,
     HOME: home,
     USERPROFILE: home,
+    EGC_PROJECT_ROOT: project,
     EGC_SESSION_ID: 'ses_cli',
     EGC_TEST_METRICS_MODULE: METRICS,
   };
@@ -120,7 +143,7 @@ run('records attribution and exposes the scoped gain panel without breaking lega
   try {
     runNode(
       "const { record } = require(process.env.EGC_TEST_METRICS_MODULE); record({ cmd: 'git', kind: 'git-log', bytesIn: 1000, bytesOut: 100, tokensSaved: 225 });",
-      { cwd: project, env }
+      { cwd: nestedCwd, env }
     );
 
     const ledger = path.join(home, '.egc', 'metrics', 'crusher.jsonl');
@@ -138,7 +161,7 @@ run('records attribution and exposes the scoped gain panel without breaking lega
     })}\n`);
 
     const jsonResult = spawnSync(process.execPath, [GAIN, '--json'], {
-      cwd: project,
+      cwd: nestedCwd,
       env,
       encoding: 'utf8',
     });
@@ -150,7 +173,7 @@ run('records attribution and exposes the scoped gain panel without breaking lega
     assert.strictEqual(report.sinceInstall.tokensSaved, 300);
 
     const historyResult = spawnSync(process.execPath, [GAIN, '--history', '--json'], {
-      cwd: project,
+      cwd: nestedCwd,
       env,
       encoding: 'utf8',
     });
@@ -160,7 +183,7 @@ run('records attribution and exposes the scoped gain panel without breaking lega
     assert.strictEqual(history[1].session, UNKNOWN_SCOPE);
 
     const panel = spawnSync(process.execPath, [GAIN], {
-      cwd: project,
+      cwd: nestedCwd,
       env,
       encoding: 'utf8',
     });


### PR DESCRIPTION
## Status

This implementation follows the canonical EGC attribution conventions confirmed in #1117 and is ready for review.

## Summary

The Token Crusher ledger now records attribution for new entries while remaining backward-compatible with existing JSONL data.

New entries record the current project from `EGC_PROJECT_ROOT`, with `EGC_PROJECT_DIR`, `PROJECT_ROOT`, and the current working directory retained as compatibility fallbacks. Session attribution uses `EGC_SESSION_ID`, falls back to `ECC_SESSION_ID`, and records `unknown` when neither is available.

`egc gain` now reports:

- Today
- Current session
- Current project
- Since install
- Runs
- Average per run
- Biggest single-run saving
- Last 7 days
- Last 30 days

The existing lifetime totals, efficiency panel, command-kind breakdown, `--history`, and top-level `--json` fields remain available.

## Time-window behavior

“Today” uses the local calendar-day boundary rather than the UTC date boundary.

The 7-day and 30-day values are rolling windows based on the current time.

Malformed timestamps are ignored by time-scoped windows without preventing the entries from contributing to lifetime totals.

## Compatibility

Existing ledger rows without `project` or `session` fields continue to load and are attributed to `unknown`.

The JSONL ledger does not require migration.

The existing `egc gain --json` lifetime fields remain compatible, with the scoped aggregates added alongside them.

## Tests

Added coverage for:

- local-day filtering across a UTC/local-time boundary;
- canonical `EGC_PROJECT_ROOT` precedence and compatibility fallbacks;
- project and session attribution;
- legacy entries without attribution fields;
- average and biggest-run calculations;
- rolling 7-day and 30-day windows;
- scoped CLI and JSON output.

Closes #1117


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds time-, session-, and project-scoped savings to `egc gain` with a clear breakdown and stable JSON/CLI output, addressing #1117. Fixes biggest-crush reporting when all entries save zero tokens.

- **New Features**
  - Ledger records `project` from `EGC_PROJECT_ROOT` > `EGC_PROJECT_DIR`/`PROJECT_ROOT` > `cwd`, and `session` from `EGC_SESSION_ID`/`ECC_SESSION_ID`; missing values normalize to `unknown`.
  - Scoped report: Today (local day), Current session, Current project, Since install (with `startedAt`), Last 7 days, Last 30 days; plus Runs, Average per run, Biggest crush. JSON adds `generatedAt`, `scopes`, and `available`, preserves lifetime fields; `egc gain` shows the panel; `egc gain --json` includes the scoped report; `egc gain --history` returns normalized entries.

- **Bug Fixes**
  - Cross-platform Crusher tests: run homedir writes in child processes, use local-day boundaries, compare canonical project realpaths.
  - Prefer `EGC_PROJECT_ROOT` for attribution with alias and `cwd` fallbacks.
  - Biggest crush now selects the first valid entry even when all savings are zero; JSON no longer reports `biggest: null` in all-zero ledgers.

<sup>Written for commit 55cea125f415ff81864f75f0eb96b295707a5185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token savings reports by time period, project, and session.
  * Added average savings, largest savings event, output metrics, and command-type breakdowns.
  * Preserved lifetime totals alongside scoped report data.
  * Added clearer handling for unavailable scope information.

* **Bug Fixes**
  * Improved compatibility with legacy metrics data and environment settings.
  * Filtered malformed history entries more safely.

* **Tests**
  * Added coverage for scoped reporting, legacy data, calendar boundaries, and report output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->