### PR TITLE
fix(crusher): keep PascalCase exceptions, assertion detail, Spanish past tense

### DIFF
--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -42,7 +42,7 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 // built from them correctly treats accented letters as word characters.
 const KEEP_WORD_EN_RE = /(?<![\p{L}\p{N}_])(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception|panic)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_PT_RE = /(?<![\p{L}\p{N}_])(erro|falha|aviso|negado|recusado|exceção|pânico)(?![\p{L}\p{N}_])/iu;
-const KEEP_WORD_ES_RE = /(?<![\p{L}\p{N}_])(fallo|falló|falla|fallé|fallando|fallado|advertencia|denegado|rechazado|excepción)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_ES_RE = /(?<![\p{L}\p{N}_])(fallo|falló|falla|fallé|fallando|fallado|fallaron|advertencia|denegado|rechazado|excepción)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_FR_DE_IT_RE = /(?<![\p{L}\p{N}_])(erreur|échec|panne|avertissement|warnung|fehler|errore|avviso)(?![\p{L}\p{N}_])/iu;
 
 // The boundary regexes above require a NON-word character on both sides,
@@ -95,13 +95,23 @@ function isStackFrame(line) {
 // indentation measurably narrows (without a whole-output failure-context
 // state machine, out of scope here) the odds of matching an unrelated
 // line of normal column-0 output that happens to start with the same
-// word (cubic review, audit EGC-547).
+// word, audit EGC-547.
+//
+// The pytest pattern can't require indentation the same way: a real
+// pytest detail line ("E       assert 1 == 2") is itself column-0, and so
+// is npm's own "> pkg@version script-name" banner line that `npm run
+// <script>`/`npm test` always prints first -- both start with `>`/`E` at
+// the same indentation, so an indentation requirement would just trade
+// one false positive for a false negative on real pytest output. Exclude
+// the npm banner shape explicitly instead.
 const ASSERT_DETAIL_PYTEST_RE = /^\s*[>E]\s+\S/;
+const NPM_SCRIPT_BANNER_RE = /^>\s+\S+@\S+\s/;
 const ASSERT_DETAIL_GO_RE = /^\s+(expected|actual|got|want)\s*:/i;
 const ASSERT_DETAIL_RUST_RE = /^\s+(left|right)\s*:\s/;
 const ASSERT_DETAIL_CARET_RE = /^\s*\^[\^~]*\s*$/;
 
 function isAssertionDetail(line) {
+  if (NPM_SCRIPT_BANNER_RE.test(line)) return false;
   return ASSERT_DETAIL_PYTEST_RE.test(line)
     || ASSERT_DETAIL_GO_RE.test(line)
     || ASSERT_DETAIL_RUST_RE.test(line)

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -42,14 +42,26 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 // built from them correctly treats accented letters as word characters.
 const KEEP_WORD_EN_RE = /(?<![\p{L}\p{N}_])(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception|panic)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_PT_RE = /(?<![\p{L}\p{N}_])(erro|falha|aviso|negado|recusado|exceção|pânico)(?![\p{L}\p{N}_])/iu;
-const KEEP_WORD_ES_RE = /(?<![\p{L}\p{N}_])(fallo|advertencia|denegado|rechazado|excepción)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_ES_RE = /(?<![\p{L}\p{N}_])(fallo|falló|falla|fallé|fallando|fallado|advertencia|denegado|rechazado|excepción)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_FR_DE_IT_RE = /(?<![\p{L}\p{N}_])(erreur|échec|panne|avertissement|warnung|fehler|errore|avviso)(?![\p{L}\p{N}_])/iu;
+
+// The boundary regexes above require a NON-word character on both sides,
+// which is correct for a standalone word ("error: x") but wrongly rejects
+// the same keyword used as a PascalCase compound-identifier suffix
+// (TypeError, AssertionError, NullPointerException): the letter immediately
+// before the capitalized keyword ("...e" in "TypeError") fails the negative
+// lookbehind, so the exception class name was silently dropped from every
+// language's test/traceback output. Case-sensitive on purpose -- this only
+// needs to catch the capitalized suffix form; the lowercase standalone form
+// is already covered by KEEP_WORD_EN_RE above.
+const KEEP_WORD_PASCAL_SUFFIX_RE = /(?<=[\p{L}\p{N}_])(Error|Exception|Fatal|Warning|Failure|Panic)(?![\p{L}\p{N}_])/u;
 
 function matchesKeepWord(line) {
   return KEEP_WORD_EN_RE.test(line)
     || KEEP_WORD_PT_RE.test(line)
     || KEEP_WORD_ES_RE.test(line)
-    || KEEP_WORD_FR_DE_IT_RE.test(line);
+    || KEEP_WORD_FR_DE_IT_RE.test(line)
+    || KEEP_WORD_PASCAL_SUFFIX_RE.test(line);
 }
 
 // Stack-trace frame lines carry no keep-word of their own (a Python
@@ -71,6 +83,24 @@ function isStackFrame(line) {
     || STACK_FRAME_CAUSE_RE.test(line);
 }
 
+// Assertion-detail continuation lines: the summary line ("assertion failed",
+// "AssertionError") already contains a keep-word, but the actual expected/
+// actual values a debugger needs are printed on separate lines that never
+// repeat that word, so they were silently stripped even though they are the
+// entire point of keeping the failure. One pattern per shape (rather than one
+// alternation) to keep cyclomatic complexity within SonarCloud's limit.
+const ASSERT_DETAIL_PYTEST_RE = /^\s*[>E]\s+\S/;
+const ASSERT_DETAIL_GO_RE = /^\s*(expected|actual|got|want)\s*:/i;
+const ASSERT_DETAIL_RUST_RE = /^\s+(left|right)\s*:\s/;
+const ASSERT_DETAIL_CARET_RE = /^\s*\^[\^~]*\s*$/;
+
+function isAssertionDetail(line) {
+  return ASSERT_DETAIL_PYTEST_RE.test(line)
+    || ASSERT_DETAIL_GO_RE.test(line)
+    || ASSERT_DETAIL_RUST_RE.test(line)
+    || ASSERT_DETAIL_CARET_RE.test(line);
+}
+
 // System-level failure signals that never contain the word "error": a
 // killed or crashed process, or an HTTP status line/code carrying a
 // standard reason phrase. The HTTP pattern requires a known reason phrase
@@ -82,6 +112,7 @@ const HTTP_ERROR_RE = /\b(?:HTTP\/[\d.]+\s+)?[45]\d{2}\s+(Bad Request|Unauthoriz
 function shouldKeepLine(line) {
   return matchesKeepWord(line)
     || isStackFrame(line)
+    || isAssertionDetail(line)
     || SYSTEM_FAILURE_RE.test(line)
     || HTTP_ERROR_RE.test(line);
 }

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -89,8 +89,15 @@ function isStackFrame(line) {
 // repeat that word, so they were silently stripped even though they are the
 // entire point of keeping the failure. One pattern per shape (rather than one
 // alternation) to keep cyclomatic complexity within SonarCloud's limit.
+// Both Go and Rust patterns require at least one leading space: real
+// assertion-detail lines are always indented under a failure header
+// (--- FAIL:, assertion `left == right` failed), while requiring
+// indentation measurably narrows (without a whole-output failure-context
+// state machine, out of scope here) the odds of matching an unrelated
+// line of normal column-0 output that happens to start with the same
+// word (cubic review, audit EGC-547).
 const ASSERT_DETAIL_PYTEST_RE = /^\s*[>E]\s+\S/;
-const ASSERT_DETAIL_GO_RE = /^\s*(expected|actual|got|want)\s*:/i;
+const ASSERT_DETAIL_GO_RE = /^\s+(expected|actual|got|want)\s*:/i;
 const ASSERT_DETAIL_RUST_RE = /^\s+(left|right)\s*:\s/;
 const ASSERT_DETAIL_CARET_RE = /^\s*\^[\^~]*\s*$/;
 

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -102,20 +102,39 @@ function isStackFrame(line) {
 // is npm's own "> pkg@version script-name" banner line that `npm run
 // <script>`/`npm test` always prints first -- both start with `>`/`E` at
 // the same indentation, so an indentation requirement would just trade
-// one false positive for a false negative on real pytest output. Exclude
-// the npm banner shape explicitly instead.
+// one false positive for a false negative on real pytest output. The npm
+// banner is excluded by position instead (see npmScriptBannerLineCount
+// below), not by shape, since its second line ("> resolved-command") has
+// no shape of its own to exclude.
 const ASSERT_DETAIL_PYTEST_RE = /^\s*[>E]\s+\S/;
-const NPM_SCRIPT_BANNER_RE = /^>\s+\S+@\S+\s/;
 const ASSERT_DETAIL_GO_RE = /^\s+(expected|actual|got|want)\s*:/i;
 const ASSERT_DETAIL_RUST_RE = /^\s+(left|right)\s*:\s/;
 const ASSERT_DETAIL_CARET_RE = /^\s*\^[\^~]*\s*$/;
 
 function isAssertionDetail(line) {
-  if (NPM_SCRIPT_BANNER_RE.test(line)) return false;
   return ASSERT_DETAIL_PYTEST_RE.test(line)
     || ASSERT_DETAIL_GO_RE.test(line)
     || ASSERT_DETAIL_RUST_RE.test(line)
     || ASSERT_DETAIL_CARET_RE.test(line);
+}
+
+// npm's own two-line banner -- "> pkg@version script-name" followed by
+// "> resolved-command" -- is always printed together at the very start of
+// `npm run <script>`/`npm test`, before any of the script's own output.
+// Both lines share the same column-0 "> " shape as a real pytest detail
+// line, so isAssertionDetail() can't tell them apart by shape alone: the
+// first line has a recognizable pkg@version marker, but the second is just
+// whatever command package.json resolved to, with no shape of its own.
+// Recognized by position instead -- this banner can only ever be the first
+// two lines of the whole output.
+const NPM_SCRIPT_BANNER_RE = /^>\s+\S+@\S+\s/;
+const NPM_BANNER_CONTINUATION_RE = /^>\s+\S/;
+
+function npmScriptBannerLineCount(lines) {
+  if (NPM_SCRIPT_BANNER_RE.test(lines[0] || '') && NPM_BANNER_CONTINUATION_RE.test(lines[1] || '')) {
+    return 2;
+  }
+  return 0;
 }
 
 // System-level failure signals that never contain the word "error": a
@@ -273,7 +292,9 @@ function crushGitDiff(output) {
 
 function crushTestRunner(output) {
   const lines = output.split('\n');
-  const kept = lines.filter(raw => {
+  const bannerLineCount = npmScriptBannerLineCount(lines);
+  const kept = lines.filter((raw, i) => {
+    if (i < bannerLineCount) return false;
     const l = stripAnsi(raw);
     return shouldKeepLine(l)
       || /^\s*(Tests|Test Suites|Snapshots|Time|Ran all|passed|failed|\u2715|\u2717|\u2716|FAIL|PASS:?\s*$)/i.test(l.trim())

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -160,9 +160,13 @@ run('crushed output preserves PascalCase exception class names with no separate 
 run('crushed output preserves multi-line assertion detail from pytest, Go, Rust, and compiler caret lines (audit EGC-547)', () => {
   // The summary line ("assertion failed", "AssertionError") already
   // contains a keep-word, but the expected/actual values a debugger needs
-  // are printed on separate lines that never repeat that word.
+  // are printed on separate lines that never repeat that word. The detail
+  // block sits far from both ends of the output (150 filler lines on each
+  // side) so it survives only via isAssertionDetail(), not because it
+  // happens to land inside the always-kept 5-line summary tail (cubic
+  // review, audit EGC-547).
   const lines = [];
-  for (let i = 0; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
+  for (let i = 0; i < 150; i++) lines.push(`  ok test case number ${i} does something fine`);
   lines.push('FAILED test_math.py::test_add - assert 1 == 2');
   lines.push('>       assert 1 == 2');
   lines.push('E       assert 1 == 2');
@@ -174,6 +178,7 @@ run('crushed output preserves multi-line assertion detail from pytest, Go, Rust,
   lines.push(' right: 2');
   lines.push('      x + 1');
   lines.push('      ^~~~~');
+  for (let i = 150; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
   lines.push('done');
   const result = crushOutput('npm test', lines.join('\n'));
   assert.ok(result);

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -138,6 +138,67 @@ run('crushed output preserves localized failures that start with an accented let
   assert.ok(result.crushed.includes('Pânico: estado inválido'), 'Portuguese panic line starting with an accented letter survives');
 });
 
+run('crushed output preserves PascalCase exception class names with no separate keep-word (audit EGC-547)', () => {
+  // KEEP_WORD_EN_RE required a non-word character on both sides of "error"/
+  // "exception", so the same keyword used as a compound-identifier suffix
+  // (TypeError, AssertionError, NullPointerException) was rejected: the
+  // letter right before it ("...e" in "TypeError") is a word character, not
+  // a boundary.
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
+  lines.push('    throw new TypeError("not a function")');
+  lines.push('    raise AssertionError("expected 1 got 2")');
+  lines.push('    throws java.lang.NullPointerException');
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('TypeError'), 'TypeError survives with no separate "error" word');
+  assert.ok(result.crushed.includes('AssertionError'), 'AssertionError survives with no separate "error" word');
+  assert.ok(result.crushed.includes('NullPointerException'), 'NullPointerException survives with no separate "exception" word');
+});
+
+run('crushed output preserves multi-line assertion detail from pytest, Go, Rust, and compiler caret lines (audit EGC-547)', () => {
+  // The summary line ("assertion failed", "AssertionError") already
+  // contains a keep-word, but the expected/actual values a debugger needs
+  // are printed on separate lines that never repeat that word.
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
+  lines.push('FAILED test_math.py::test_add - assert 1 == 2');
+  lines.push('>       assert 1 == 2');
+  lines.push('E       assert 1 == 2');
+  lines.push('--- FAIL: TestAdd (0.00s)');
+  lines.push('    expected: 1');
+  lines.push('    actual: 2');
+  lines.push('assertion `left == right` failed');
+  lines.push('  left: 1');
+  lines.push(' right: 2');
+  lines.push('      x + 1');
+  lines.push('      ^~~~~');
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('>       assert 1 == 2'), 'pytest ">" detail line survives');
+  assert.ok(result.crushed.includes('E       assert 1 == 2'), 'pytest "E" detail line survives');
+  assert.ok(result.crushed.includes('expected: 1'), 'Go "expected:" detail line survives');
+  assert.ok(result.crushed.includes('actual: 2'), 'Go "actual:" detail line survives');
+  assert.ok(result.crushed.includes('left: 1'), 'Rust "left:" detail line survives');
+  assert.ok(result.crushed.includes('right: 2'), 'Rust "right:" detail line survives');
+  assert.ok(result.crushed.includes('^~~~~'), 'compiler caret line survives');
+});
+
+run('crushed output preserves the Spanish past-tense verb "falló" (audit EGC-547)', () => {
+  // "fallo" (noun/1st person) and "falló" (3rd person past tense) are
+  // different words -- "falló" is not a substring of "fallo", so it was
+  // simply never in the keyword list at all, not a boundary bug.
+  const lines = [];
+  for (let i = 0; i < 300; i++) lines.push(`  ok caso de prueba ${i} paso normalmente`);
+  lines.push('La conexión falló después de 3 intentos');
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(result.crushed.includes('La conexión falló después de 3 intentos'), 'Spanish past-tense failure line survives');
+});
+
 run('mvn/gradle test detection stays scoped to the first line, ignoring "test" on later lines of a compound command (cubic review, audit EGC-490)', () => {
   assert.strictEqual(commandKind('mvn clean\necho "just a test message, unrelated to mvn goals"'), 'generic');
   assert.strictEqual(commandKind('mvn clean test'), 'test-runner');

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -119,7 +119,7 @@ run('crushed output preserves localized (non-English) error/warning terms (audit
   assert.ok(result.crushed.includes('Erreur système'), 'French error line survives');
 });
 
-run('crushed output preserves localized failures that start with an accented letter (cubic review, audit EGC-490)', () => {
+run('crushed output preserves localized failures that start with an accented letter (audit EGC-490)', () => {
   // \b in JS regex is ASCII-only, so a standalone word beginning with an
   // accented letter (no preceding word-character to form a real boundary)
   // could sit between two "non-word" positions and never match \b at all.
@@ -143,12 +143,15 @@ run('crushed output preserves PascalCase exception class names with no separate 
   // "exception", so the same keyword used as a compound-identifier suffix
   // (TypeError, AssertionError, NullPointerException) was rejected: the
   // letter right before it ("...e" in "TypeError") is a word character, not
-  // a boundary.
+  // a boundary. The exception lines sit 150 filler lines from both ends of
+  // the output, so they survive only via KEEP_WORD_PASCAL_SUFFIX_RE, not
+  // because they happen to land inside the always-kept 5-line summary tail.
   const lines = [];
-  for (let i = 0; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
+  for (let i = 0; i < 150; i++) lines.push(`  ok test case number ${i} does something fine`);
   lines.push('    throw new TypeError("not a function")');
   lines.push('    raise AssertionError("expected 1 got 2")');
   lines.push('    throws java.lang.NullPointerException');
+  for (let i = 150; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
   lines.push('done');
   const result = crushOutput('npm test', lines.join('\n'));
   assert.ok(result);
@@ -163,8 +166,7 @@ run('crushed output preserves multi-line assertion detail from pytest, Go, Rust,
   // are printed on separate lines that never repeat that word. The detail
   // block sits far from both ends of the output (150 filler lines on each
   // side) so it survives only via isAssertionDetail(), not because it
-  // happens to land inside the always-kept 5-line summary tail (cubic
-  // review, audit EGC-547).
+  // happens to land inside the always-kept 5-line summary tail.
   const lines = [];
   for (let i = 0; i < 150; i++) lines.push(`  ok test case number ${i} does something fine`);
   lines.push('FAILED test_math.py::test_add - assert 1 == 2');
@@ -191,26 +193,53 @@ run('crushed output preserves multi-line assertion detail from pytest, Go, Rust,
   assert.ok(result.crushed.includes('^~~~~'), 'compiler caret line survives');
 });
 
-run('crushed output preserves the Spanish past-tense verb "falló" (audit EGC-547)', () => {
-  // "fallo" (noun/1st person) and "falló" (3rd person past tense) are
-  // different words -- "falló" is not a substring of "fallo", so it was
-  // simply never in the keyword list at all, not a boundary bug.
+run('crushed output preserves the Spanish past-tense verbs "falló" and "fallaron"', () => {
+  // "fallo" (noun/1st person), "falló" (3rd person singular past), and
+  // "fallaron" (3rd person plural past) are all distinct words -- none is
+  // reachable from another by substring, so each had to be listed
+  // explicitly, not a boundary bug. Both lines sit 150 filler lines from
+  // both ends of the output, so they survive only via KEEP_WORD_ES_RE, not
+  // because they happen to land inside the always-kept 5-line summary tail.
   const lines = [];
-  for (let i = 0; i < 300; i++) lines.push(`  ok caso de prueba ${i} paso normalmente`);
+  for (let i = 0; i < 150; i++) lines.push(`  ok caso de prueba ${i} paso normalmente`);
   lines.push('La conexión falló después de 3 intentos');
+  lines.push('3 pruebas fallaron en el último intento');
+  for (let i = 150; i < 300; i++) lines.push(`  ok caso de prueba ${i} paso normalmente`);
   lines.push('done');
   const result = crushOutput('npm test', lines.join('\n'));
   assert.ok(result);
-  assert.ok(result.crushed.includes('La conexión falló después de 3 intentos'), 'Spanish past-tense failure line survives');
+  assert.ok(result.crushed.includes('La conexión falló después de 3 intentos'), 'Spanish past-tense singular failure line survives');
+  assert.ok(result.crushed.includes('3 pruebas fallaron en el último intento'), 'Spanish past-tense plural failure line survives');
 });
 
-run('mvn/gradle test detection stays scoped to the first line, ignoring "test" on later lines of a compound command (cubic review, audit EGC-490)', () => {
+run('crusher does not mistake the npm run-script banner for pytest assertion detail', () => {
+  // `npm run <script>`/`npm test` always prints "> pkg@version script-name"
+  // (and a second "> resolved-command" line) before the script's own
+  // output. Both start with "> " at column 0, the same shape as a real
+  // pytest detail line ("E       assert ..."), so without an explicit
+  // exclusion the banner would be misclassified as assertion detail.
+  const lines = [];
+  lines.push('> my-app@1.0.0 test');
+  lines.push('> jest --ci');
+  lines.push('');
+  for (let i = 0; i < 150; i++) lines.push(`  ok test case number ${i} does something fine`);
+  lines.push('FAIL src/foo.test.js');
+  lines.push('  ● the thing fails');
+  lines.push('    expect(received).toBe(expected)');
+  for (let i = 150; i < 300; i++) lines.push(`  ok test case number ${i} does something fine`);
+  lines.push('done');
+  const result = crushOutput('npm test', lines.join('\n'));
+  assert.ok(result);
+  assert.ok(!result.crushed.includes('> my-app@1.0.0 test'), 'npm script banner line is not kept as assertion detail');
+});
+
+run('mvn/gradle test detection stays scoped to the first line, ignoring "test" on later lines of a compound command (audit EGC-490)', () => {
   assert.strictEqual(commandKind('mvn clean\necho "just a test message, unrelated to mvn goals"'), 'generic');
   assert.strictEqual(commandKind('mvn clean test'), 'test-runner');
   assert.strictEqual(commandKind('./gradlew clean test'), 'test-runner');
 });
 
-run('mvn/gradle test detection joins shell line-continuations into one logical line (cubic review, audit EGC-490)', () => {
+run('mvn/gradle test detection joins shell line-continuations into one logical line (audit EGC-490)', () => {
   // A backslash right before the newline is a shell line continuation --
   // `mvn clean \` + newline + `test` is one logical command, not two.
   assert.strictEqual(commandKind('mvn clean \\\ntest'), 'test-runner');

--- a/tests/crusher-engine.test.js
+++ b/tests/crusher-engine.test.js
@@ -230,7 +230,8 @@ run('crusher does not mistake the npm run-script banner for pytest assertion det
   lines.push('done');
   const result = crushOutput('npm test', lines.join('\n'));
   assert.ok(result);
-  assert.ok(!result.crushed.includes('> my-app@1.0.0 test'), 'npm script banner line is not kept as assertion detail');
+  assert.ok(!result.crushed.includes('> my-app@1.0.0 test'), 'npm script banner line 1 is not kept as assertion detail');
+  assert.ok(!result.crushed.includes('> jest --ci'), 'npm script banner line 2 (resolved command) is not kept as assertion detail either');
 });
 
 run('mvn/gradle test detection stays scoped to the first line, ignoring "test" on later lines of a compound command (audit EGC-490)', () => {


### PR DESCRIPTION
## Summary
- Fixes 3 of the real gaps found in the 2026-08-01 README-vs-code audit for the "preserving every error and warning" claim.
- `KEEP_WORD_EN_RE` required a non-word character before/after the keyword, so PascalCase compound identifiers (`TypeError`, `AssertionError`, `NullPointerException`) never matched. Added a dedicated suffix check.
- Assertion-detail continuation lines (pytest `>`/`E`, Go `expected:`/`actual:`, Rust `left:`/`right:`, compiler caret lines) never repeat the summary line's keep-word and were silently stripped.
- `falló` (Spanish past tense) is a different word from `fallo`, not a boundary bug — it was simply missing.

## Test plan
- [x] 27/27 `tests/crusher-engine.test.js` passing (3 new tests, one per fixed case)
- [x] 17/17 `tests/hooks/pre-bash-crusher-rewrite.test.js` passing (zero regressions in the consumer)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves key failure info in `crusher` output and avoids false positives: PascalCase exception names, assertion detail lines, and Spanish past‑tense failures now survive filtering. Also skips both lines of the npm run‑script banner so they don’t look like pytest output. Addresses audit EGC-547 gaps to keep more useful error context in logs.

- **Bug Fixes**
  - Keep PascalCase exceptions via `KEEP_WORD_PASCAL_SUFFIX_RE` (e.g., `TypeError`, `AssertionError`, `NullPointerException`).
  - Keep assertion detail lines and reduce false positives: pytest `>`/`E`, Go `expected:`/`actual:`/`got:`/`want:` (requires indentation), Rust `left:`/`right:`, compiler caret lines; exclude both npm run‑script banner lines at the start (e.g., `> pkg@version script-name`, `> resolved-command`).
  - Expand Spanish keep‑words in `KEEP_WORD_ES_RE` to include `falló`, `fallaron`, and related forms (`falla`, `fallé`, `fallando`, `fallado`).

<sup>Written for commit 105bae69314165c8c01bf105e2c09ba044d98ac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

