### PR TITLE
fix(memory): configure commit-privacy filter automatically on first propagation

### DIFF
--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -31,15 +31,21 @@ function ensureCommitPrivacy(projectPath: string): void {
     const memoryFilters = tryRequireMemoryFilters();
     if (!memoryFilters) return;
     const scriptPath = path.join(__dirname, '..', '..', '..', '..', 'scripts', 'check-state-leak.js');
-    memoryFilters.configureMemoryFilters({ projectDir: projectPath, scriptPath, dryRun: false });
+    const result = memoryFilters.configureMemoryFilters({ projectDir: projectPath, scriptPath, dryRun: false });
+    // "not a git repository" is the normal, silent case (most MCP calls
+    // aren't rooted in a repo at all); any other configured:false reason
+    // (e.g. the fail-closed script-missing check) means privacy protection
+    // did NOT get set up and the user should know.
+    if (!result.configured && result.reason !== 'not a git repository') {
+      process.stderr.write(`[egc-memory] commit-privacy filter not configured for ${projectPath}: ${result.reason}\n`);
+    }
   } catch (err) {
     // Best-effort: never let commit-privacy setup block the memory write the
     // caller is waiting on. But silent failure here means a real git-config
     // error (permission denied, git binary crashed) leaves the user with no
     // signal that populated memory can still reach a commit -- a single
     // stderr line costs nothing (MCP servers speak MCP over stdout, stderr
-    // is free for diagnostics) and this is the one place that can ever know
-    // (cubic review, audit EGC-547).
+    // is free for diagnostics) and this is the one place that can ever know.
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`[egc-memory] commit-privacy filter setup failed for ${projectPath}: ${message}\n`);
   }

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -29,7 +29,13 @@ function tryRequireMemoryFilters(): typeof import('../../../../scripts/lib/memor
 function ensureCommitPrivacy(projectPath: string): void {
   try {
     const memoryFilters = tryRequireMemoryFilters();
-    if (!memoryFilters) return;
+    if (!memoryFilters) {
+      // Every other configured:false path below reports why via stderr;
+      // silently returning here would be the one way this function can
+      // leave memory unprotected with zero signal that anything went wrong.
+      process.stderr.write(`[egc-memory] commit-privacy filter module unavailable for ${projectPath}\n`);
+      return;
+    }
     const scriptPath = path.join(__dirname, '..', '..', '..', '..', 'scripts', 'check-state-leak.js');
     const result = memoryFilters.configureMemoryFilters({ projectDir: projectPath, scriptPath, dryRun: false });
     // "not a git repository" is the normal, silent case (most MCP calls

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -32,8 +32,16 @@ function ensureCommitPrivacy(projectPath: string): void {
     if (!memoryFilters) return;
     const scriptPath = path.join(__dirname, '..', '..', '..', '..', 'scripts', 'check-state-leak.js');
     memoryFilters.configureMemoryFilters({ projectDir: projectPath, scriptPath, dryRun: false });
-  } catch {
-    // best-effort: never let commit-privacy setup break memory propagation
+  } catch (err) {
+    // Best-effort: never let commit-privacy setup block the memory write the
+    // caller is waiting on. But silent failure here means a real git-config
+    // error (permission denied, git binary crashed) leaves the user with no
+    // signal that populated memory can still reach a commit -- a single
+    // stderr line costs nothing (MCP servers speak MCP over stdout, stderr
+    // is free for diagnostics) and this is the one place that can ever know
+    // (cubic review, audit EGC-547).
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[egc-memory] commit-privacy filter setup failed for ${projectPath}: ${message}\n`);
   }
 }
 

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -1,6 +1,42 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+// scripts/lib/memory-filters.js lives outside this package's src/ tree (tsconfig
+// rootDir is "src"), so a static import would break the build -- required at
+// runtime instead, mirroring the tryRequire pattern already used by
+// scripts/hooks/pre-bash-crusher-rewrite.js for the same kind of cross-package
+// reach. The npm package's "files" list ships scripts/ and
+// mcp/servers/egc-memory/build/ at the same relative depth as this repo, so the
+// path below resolves identically in a real `npm install -g` layout.
+function tryRequireMemoryFilters(): typeof import('../../../../scripts/lib/memory-filters') | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('../../../../scripts/lib/memory-filters');
+  } catch {
+    return null;
+  }
+}
+
+// Ensures populated memory can never reach a commit for this project, before
+// the first byte of real content is written to any propagation file.
+// Previously this only happened via the separate, manual `egc init` command
+// (scripts/init.js) -- a project that only ever ran `egc install` (the exact
+// command the README documents) never got this protection unless the user
+// also ran `egc init` by hand. Best-effort and silent: this is a privacy
+// convenience, not a correctness gate, so any failure here (no git binary, a
+// read-only filesystem, projectPath not a repo) must never block the actual
+// memory write that the caller is waiting on.
+function ensureCommitPrivacy(projectPath: string): void {
+  try {
+    const memoryFilters = tryRequireMemoryFilters();
+    if (!memoryFilters) return;
+    const scriptPath = path.join(__dirname, '..', '..', '..', '..', 'scripts', 'check-state-leak.js');
+    memoryFilters.configureMemoryFilters({ projectDir: projectPath, scriptPath, dryRun: false });
+  } catch {
+    // best-effort: never let commit-privacy setup break memory propagation
+  }
+}
+
 export interface PropagateArgs {
   projectPath: string;
   context?: string;
@@ -333,6 +369,7 @@ function writeLlmsTxt(projectPath: string, args: PropagateArgs): string | null {
 }
 
 export function propagateStateToTools(args: PropagateArgs): PropagateResult {
+  ensureCommitPrivacy(args.projectPath);
   const block = buildSummaryBlock(args);
   return {
     cursor: writeCursorContext(args.projectPath, block),

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -41,6 +41,7 @@ const NON_MARKDOWN_TARGETS = [
   '.rules',
   '.clinerules',
   '.cursorrules',
+  '.roorules',
   'CONVENTIONS.md',
   'llms.txt',
 ];

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -47,6 +47,11 @@ const HOOK_LIB_SOURCES = [
   'scripts/lib/project-detect.js',
   'scripts/lib/propagate-state.js',
   'scripts/lib/state-crypto.js',
+  // propagate-state.js's commit-privacy guard shells out to this script as
+  // the git clean-filter command -- it must land next to propagate-state.js
+  // (both flatten to the same libDestDir below), or the filter config points
+  // at a path that never existed on this machine (cubic review, audit EGC-547).
+  'scripts/check-state-leak.js',
 ];
 
 function createSessionStateHookOperations(adapter, targetRoot) {

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -32,6 +32,13 @@ const SESSION_CONTEXT_LIB_SOURCES = [
   'scripts/lib/project-detect.js',
   'scripts/lib/propagate-state.js',
   'scripts/lib/state-crypto.js',
+  // propagate-state.js's commit-privacy guard shells out to this script as
+  // the git clean-filter command -- must be present (this target preserves
+  // the scripts/ prefix, so it lands one level up from propagate-state.js,
+  // exactly where the runtime falls back to looking), or the filter config
+  // points at a path that never existed on this machine (cubic review,
+  // audit EGC-547).
+  'scripts/check-state-leak.js',
 ];
 
 function resolvePluginScriptDestination(targetRoot) {

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -45,16 +45,24 @@ const PROPAGATION_FILES = [
   'llms.txt',
   'CLAUDE.md',
   '.roo/rules/egc-context.md',
+  '.roorules',
   '.continue/rules/egc-context.md',
 ];
 
-function gitDir(projectDir) {
+// --git-path (not --git-dir + a manual join) resolves correctly for linked
+// worktrees too: git always reads info/attributes from the *common* git
+// directory, never the per-worktree one that --git-dir alone returns
+// (.git/worktrees/<name>) when run inside a linked worktree. Building the
+// path by hand from --git-dir would silently write bindings to a file git
+// never consults there, leaving worktree-based projects unprotected.
+function resolveAttributesFile(projectDir) {
   try {
-    return execFileSync(GIT_BIN, ['rev-parse', '--git-dir'], {
+    const raw = execFileSync(GIT_BIN, ['rev-parse', '--git-path', 'info/attributes'], {
       cwd: projectDir,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
+    return path.isAbsolute(raw) ? raw : path.join(projectDir, raw);
   } catch {
     return null;
   }
@@ -62,8 +70,8 @@ function gitDir(projectDir) {
 
 // Returns the action plan without touching anything when dryRun is true.
 function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
-  const resolvedGitDir = gitDir(projectDir);
-  if (!resolvedGitDir) {
+  const attributesFile = resolveAttributesFile(projectDir);
+  if (!attributesFile) {
     return { configured: false, reason: 'not a git repository', actions: [] };
   }
 
@@ -71,13 +79,26 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
   // filter anyway would silently commit unfiltered memory the moment git
   // tries (and fails) to run it -- fail closed instead: never configure.
   if (!fs.existsSync(scriptPath)) {
+    // A repo whose filter was set up before required=true existed would
+    // otherwise stay silently fail-open forever once the script goes
+    // missing, with no path back to fail-closed. Harden an already-present
+    // driver in place -- without touching its clean command or adding new
+    // bindings -- so a broken script at least blocks staging instead of
+    // silently falling back to unfiltered content.
+    if (!dryRun) {
+      let alreadyConfigured = true;
+      try {
+        execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.clean`], { cwd: projectDir, encoding: 'utf8' });
+      } catch {
+        alreadyConfigured = false;
+      }
+      if (alreadyConfigured) {
+        execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.required`, 'true'], { cwd: projectDir, encoding: 'utf8' });
+      }
+    }
     return { configured: false, reason: `clean-filter script not found at ${scriptPath}`, actions: [] };
   }
 
-  const absoluteGitDir = path.isAbsolute(resolvedGitDir)
-    ? resolvedGitDir
-    : path.join(projectDir, resolvedGitDir);
-  const attributesFile = path.join(absoluteGitDir, 'info', 'attributes');
   const cleanCommand = `node ${shSingleQuote(scriptPath)} --filter-clean`;
 
   const actions = [

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -26,7 +26,8 @@ const GIT_BIN = [
 // space, quote, `$`, or backtick could break the command or be interpreted
 // by the shell.
 function shSingleQuote(value) {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
+  const escaped = value.replaceAll("'", String.raw`'\''`);
+  return `'${escaped}'`;
 }
 
 const FILTER_NAME = 'egc-memory';

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -93,6 +93,11 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
         alreadyConfigured = false;
       }
       if (alreadyConfigured) {
+        // A driver configured before the smudge fix existed may have only
+        // `clean` set. Hardening straight to required=true here without also
+        // ensuring `smudge=cat` would turn every checkout/worktree/clone on
+        // this repo into a hard "smudge filter egc-memory failed" failure.
+        execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.smudge`, 'cat'], { cwd: projectDir, encoding: 'utf8' });
         execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.required`, 'true'], { cwd: projectDir, encoding: 'utf8' });
       }
     }

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -16,8 +16,18 @@ const path = require('node:path');
 const GIT_BIN = [
   '/usr/bin/git',
   '/usr/local/bin/git',
-  'C:\\Program Files\\Git\\cmd\\git.exe',
+  String.raw`C:\Program Files\Git\cmd\git.exe`,
 ].find(p => fs.existsSync(p)) || 'git';
+
+// POSIX single-quote escaping: git always resolves filter.<x>.clean through
+// its own bundled POSIX-like shell (sh on Linux/macOS, Git for Windows'
+// MSYS2 sh.exe on Windows -- never native cmd.exe), so single-quoting is
+// correct cross-platform here. Without this, a scriptPath containing a
+// space, quote, `$`, or backtick could break the command or be interpreted
+// by the shell.
+function shSingleQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 const FILTER_NAME = 'egc-memory';
 const PROPAGATION_FILES = [
@@ -56,14 +66,27 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
     return { configured: false, reason: 'not a git repository', actions: [] };
   }
 
+  // If the script this filter depends on isn't even on disk, configuring the
+  // filter anyway would silently commit unfiltered memory the moment git
+  // tries (and fails) to run it -- fail closed instead: never configure.
+  if (!fs.existsSync(scriptPath)) {
+    return { configured: false, reason: `clean-filter script not found at ${scriptPath}`, actions: [] };
+  }
+
   const absoluteGitDir = path.isAbsolute(resolvedGitDir)
     ? resolvedGitDir
     : path.join(projectDir, resolvedGitDir);
   const attributesFile = path.join(absoluteGitDir, 'info', 'attributes');
-  const cleanCommand = `node "${scriptPath}" --filter-clean`;
+  const cleanCommand = `node ${shSingleQuote(scriptPath)} --filter-clean`;
 
   const actions = [
     `git config filter.${FILTER_NAME}.clean '${cleanCommand}' (local repo config)`,
+    // required=true makes git refuse to stage a file through this filter if
+    // the clean command itself fails, instead of silently falling back to
+    // the original (unfiltered, still populated) content -- fail-closed
+    // matches the README's unconditional "never gets committed to git"
+    // promise.
+    `git config filter.${FILTER_NAME}.required true (local repo config)`,
   ];
 
   let existing = '';
@@ -71,8 +94,12 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
     existing = fs.readFileSync(attributesFile, 'utf8');
   } catch { /* first configuration: attributes file does not exist yet */ }
 
+  // Exact-line matching (not a raw substring test): a commented-out entry or
+  // a line with extra trailing content would still satisfy .includes(),
+  // silently skipping the real binding this project needs.
+  const existingLines = new Set(existing.split('\n').map(l => l.trim()));
   const missingBindings = PROPAGATION_FILES.filter(
-    file => !existing.includes(`${file} filter=${FILTER_NAME}`)
+    file => !existingLines.has(`${file} filter=${FILTER_NAME}`)
   );
   for (const file of missingBindings) {
     actions.push(`bind ${file} to filter=${FILTER_NAME} (.git/info/attributes)`);
@@ -80,6 +107,10 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
 
   if (!dryRun) {
     execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.clean`, cleanCommand], {
+      cwd: projectDir,
+      encoding: 'utf8',
+    });
+    execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.required`, 'true'], {
       cwd: projectDir,
       encoding: 'utf8',
     });

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -85,7 +85,14 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
     // the clean command itself fails, instead of silently falling back to
     // the original (unfiltered, still populated) content -- fail-closed
     // matches the README's unconditional "never gets committed to git"
-    // promise.
+    // promise. But required=true also turns an *unconfigured* smudge side
+    // into a hard failure instead of the passthru git defaults to when a
+    // filter driver is missing entirely (gitattributes(5)): once clean is
+    // set, checkout/worktree/clone on this repo starts failing with "smudge
+    // filter egc-memory failed" without an explicit smudge command. cat is
+    // configured as an identity smudge: the working tree keeps whatever
+    // content is checked out, only the staged blob gets cleaned.
+    `git config filter.${FILTER_NAME}.smudge cat (local repo config)`,
     `git config filter.${FILTER_NAME}.required true (local repo config)`,
   ];
 
@@ -107,6 +114,10 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
 
   if (!dryRun) {
     execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.clean`, cleanCommand], {
+      cwd: projectDir,
+      encoding: 'utf8',
+    });
+    execFileSync(GIT_BIN, ['config', `filter.${FILTER_NAME}.smudge`, 'cat'], {
       cwd: projectDir,
       encoding: 'utf8',
     });

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -57,7 +57,8 @@ const COMMIT_PRIVACY_FILES = [
 // username with an apostrophe, or a project cloned under a path a user
 // chose) could break the command or be interpreted by the shell.
 function shSingleQuote(value) {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
+  const escaped = value.replaceAll("'", String.raw`'\''`);
+  return `'${escaped}'`;
 }
 
 function ensureCommitPrivacy(projectPath) {

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -98,6 +98,17 @@ function ensureCommitPrivacy(projectPath) {
       cwd: projectPath,
       encoding: 'utf8',
     });
+    // required=true (below) also turns an *unconfigured* smudge side into a
+    // hard checkout failure instead of the passthru git defaults to when a
+    // filter driver is missing entirely (gitattributes(5)): once clean is
+    // set, checkout/worktree/clone on this repo starts failing with "smudge
+    // filter egc-memory failed" without an explicit smudge command. cat is
+    // configured as an identity smudge: the working tree keeps whatever
+    // content is checked out, only the staged blob gets cleaned.
+    execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.smudge`, 'cat'], {
+      cwd: projectPath,
+      encoding: 'utf8',
+    });
     // required=true makes git refuse to stage a file through this filter if
     // the clean command itself fails or is missing, instead of the git
     // default of silently falling back to the original (unfiltered, still

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -3,6 +3,23 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+// Ensures populated memory can never reach a commit for this project, before
+// the first byte of real content is written to any propagation file. See the
+// identical guard in mcp/servers/egc-memory/src/propagate.ts for why this
+// can't just be a one-time `egc init` step: a project that only ever ran
+// `egc install` (the README's own documented command) never got this
+// protection otherwise. Best-effort and silent -- never blocks the actual
+// memory write the caller is waiting on.
+function ensureCommitPrivacy(projectPath) {
+  try {
+    const { configureMemoryFilters } = require('./memory-filters');
+    const scriptPath = path.join(__dirname, '..', '..', 'scripts', 'check-state-leak.js');
+    configureMemoryFilters({ projectDir: projectPath, scriptPath, dryRun: false });
+  } catch {
+    // best-effort: never let commit-privacy setup break memory propagation
+  }
+}
+
 const EGC_START = '<!-- egc:start -->';
 const EGC_END = '<!-- egc:end -->';
 const MAX_ITEMS = 5;
@@ -326,6 +343,7 @@ function writeLlmsTxt(projectPath, parsed) {
 }
 
 function propagateStateContent(projectPath, stateContent) {
+  ensureCommitPrivacy(projectPath);
   const parsed = parseStateContent(stateContent);
   const block = buildSummaryBlock(parsed);
 

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -9,7 +9,7 @@ const path = require('node:path');
 const GIT_BIN = [
   '/usr/bin/git',
   '/usr/local/bin/git',
-  'C:\\Program Files\\Git\\cmd\\git.exe',
+  String.raw`C:\Program Files\Git\cmd\git.exe`,
 ].find(p => fs.existsSync(p)) || 'git';
 
 const COMMIT_PRIVACY_FILTER_NAME = 'egc-memory';
@@ -42,12 +42,24 @@ const COMMIT_PRIVACY_FILES = [
 // per-host install layouts (see scripts/lib/install-targets/claude-home.js
 // and opencode-home.js), and a sibling file that isn't also listed in that
 // same copy manifest is silently absent at the installed runtime -- exactly
-// the class of bug the commit-privacy fix itself was closing (cubic review,
-// audit EGC-547). Duplicated (not shared) with memory-filters.js/init.js on
-// purpose so this function has zero cross-file dependencies of its own.
+// the class of bug the commit-privacy fix itself was closing. Duplicated
+// (not shared) with memory-filters.js/init.js on purpose so this function
+// has zero cross-file dependencies of its own.
 //
 // Best-effort and silent -- never blocks the actual memory write the caller
 // is waiting on.
+// POSIX single-quote escaping: git always resolves filter.<x>.clean through
+// its own bundled POSIX-like shell (sh on Linux/macOS, Git for Windows'
+// MSYS2 sh.exe on Windows -- never native cmd.exe), so single-quoting is
+// correct cross-platform here, unlike the OS-native-shell case the Token
+// Crusher's --shell path has to special-case for Windows. Without this, a
+// scriptPath containing a space, quote, `$`, or backtick (e.g. a Windows
+// username with an apostrophe, or a project cloned under a path a user
+// chose) could break the command or be interpreted by the shell.
+function shSingleQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function ensureCommitPrivacy(projectPath) {
   try {
     let gitDir;
@@ -72,9 +84,26 @@ function ensureCommitPrivacy(projectPath) {
     const scriptPath = fs.existsSync(flattenedScriptPath)
       ? flattenedScriptPath
       : path.join(__dirname, '..', 'check-state-leak.js');
-    const cleanCommand = `node "${scriptPath}" --filter-clean`;
+    // If the script this filter depends on isn't even on disk, configuring
+    // the filter anyway would silently commit unfiltered memory the moment
+    // git tries (and fails) to run it -- fail closed here instead: skip
+    // configuration entirely and leave the loud stderr diagnostic to explain
+    // why.
+    if (!fs.existsSync(scriptPath)) {
+      throw new Error(`commit-privacy clean-filter script not found at ${scriptPath}`);
+    }
+    const cleanCommand = `node ${shSingleQuote(scriptPath)} --filter-clean`;
 
     execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.clean`, cleanCommand], {
+      cwd: projectPath,
+      encoding: 'utf8',
+    });
+    // required=true makes git refuse to stage a file through this filter if
+    // the clean command itself fails or is missing, instead of the git
+    // default of silently falling back to the original (unfiltered, still
+    // populated) content -- fail-closed matches the README's unconditional
+    // "never gets committed to git" promise.
+    execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.required`, 'true'], {
       cwd: projectPath,
       encoding: 'utf8',
     });
@@ -84,8 +113,13 @@ function ensureCommitPrivacy(projectPath) {
       existing = fs.readFileSync(attributesFile, 'utf8');
     } catch { /* first configuration: attributes file does not exist yet */ }
 
+    // Exact-line matching (not a raw substring test): a commented-out entry
+    // ("# AGENTS.md filter=egc-memory") or a line with extra trailing
+    // content would still satisfy .includes(), silently skipping the real
+    // binding this project needs.
+    const existingLines = new Set(existing.split('\n').map(l => l.trim()));
     const missingBindings = COMMIT_PRIVACY_FILES.filter(
-      file => !existing.includes(`${file} filter=${COMMIT_PRIVACY_FILTER_NAME}`)
+      file => !existingLines.has(`${file} filter=${COMMIT_PRIVACY_FILTER_NAME}`)
     );
     if (missingBindings.length > 0) {
       fs.mkdirSync(path.dirname(attributesFile), { recursive: true });
@@ -98,7 +132,7 @@ function ensureCommitPrivacy(projectPath) {
     // caller is waiting on. But silent failure here means a real git-config
     // error (permission denied, git binary crashed) leaves the user with no
     // signal that populated memory can still reach a commit -- a single
-    // stderr line costs nothing here either (cubic review, audit EGC-547).
+    // stderr line costs nothing here either.
     process.stderr.write(`[egc-memory] commit-privacy filter setup failed for ${projectPath}: ${err.message}\n`);
   }
 }

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -110,6 +110,11 @@ function ensureCommitPrivacy(projectPath) {
         alreadyConfigured = false;
       }
       if (alreadyConfigured) {
+        // A driver configured before the smudge fix existed may have only
+        // `clean` set. Hardening straight to required=true here without also
+        // ensuring `smudge=cat` would turn every checkout/worktree/clone on
+        // this repo into a hard "smudge filter egc-memory failed" failure.
+        execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.smudge`, 'cat'], { cwd: projectPath, encoding: 'utf8' });
         execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.required`, 'true'], { cwd: projectPath, encoding: 'utf8' });
       }
       throw new Error(`commit-privacy clean-filter script not found at ${scriptPath}`);

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -1,22 +1,105 @@
 'use strict';
 
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+
+// S4036: prefer fixed git locations over a PATH lookup; the bare name is the
+// last resort for layouts like nix or Windows portable installs.
+const GIT_BIN = [
+  '/usr/bin/git',
+  '/usr/local/bin/git',
+  'C:\\Program Files\\Git\\cmd\\git.exe',
+].find(p => fs.existsSync(p)) || 'git';
+
+const COMMIT_PRIVACY_FILTER_NAME = 'egc-memory';
+const COMMIT_PRIVACY_FILES = [
+  'AGENTS.md',
+  'GEMINI.md',
+  '.cursor/rules/egc-context.mdc',
+  '.trae/rules/egc-context.md',
+  '.github/copilot-instructions.md',
+  '.windsurf/rules/egc-context.md',
+  '.rules',
+  '.clinerules',
+  '.cursorrules',
+  'CONVENTIONS.md',
+  'llms.txt',
+  'CLAUDE.md',
+  '.roo/rules/egc-context.md',
+  '.continue/rules/egc-context.md',
+];
 
 // Ensures populated memory can never reach a commit for this project, before
 // the first byte of real content is written to any propagation file. See the
 // identical guard in mcp/servers/egc-memory/src/propagate.ts for why this
 // can't just be a one-time `egc init` step: a project that only ever ran
 // `egc install` (the README's own documented command) never got this
-// protection otherwise. Best-effort and silent -- never blocks the actual
-// memory write the caller is waiting on.
+// protection otherwise.
+//
+// Deliberately NOT a require('./memory-filters') call: this file is copied
+// individually (not as part of the whole scripts/lib/ tree) into several
+// per-host install layouts (see scripts/lib/install-targets/claude-home.js
+// and opencode-home.js), and a sibling file that isn't also listed in that
+// same copy manifest is silently absent at the installed runtime -- exactly
+// the class of bug the commit-privacy fix itself was closing (cubic review,
+// audit EGC-547). Duplicated (not shared) with memory-filters.js/init.js on
+// purpose so this function has zero cross-file dependencies of its own.
+//
+// Best-effort and silent -- never blocks the actual memory write the caller
+// is waiting on.
 function ensureCommitPrivacy(projectPath) {
   try {
-    const { configureMemoryFilters } = require('./memory-filters');
-    const scriptPath = path.join(__dirname, '..', '..', 'scripts', 'check-state-leak.js');
-    configureMemoryFilters({ projectDir: projectPath, scriptPath, dryRun: false });
-  } catch {
-    // best-effort: never let commit-privacy setup break memory propagation
+    let gitDir;
+    try {
+      gitDir = execFileSync(GIT_BIN, ['rev-parse', '--git-dir'], {
+        cwd: projectPath,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+    } catch {
+      return; // not a git repository
+    }
+
+    const absoluteGitDir = path.isAbsolute(gitDir) ? gitDir : path.join(projectPath, gitDir);
+    const attributesFile = path.join(absoluteGitDir, 'info', 'attributes');
+    // Installed layout flattens scripts/check-state-leak.js down into the
+    // same directory as this file (see HOOK_LIB_SOURCES in
+    // install-targets/claude-home.js and opencode-home.js); dev-repo layout
+    // keeps it one level up, in scripts/ proper. Check the flattened
+    // (installed) location first since that's the more common runtime.
+    const flattenedScriptPath = path.join(__dirname, 'check-state-leak.js');
+    const scriptPath = fs.existsSync(flattenedScriptPath)
+      ? flattenedScriptPath
+      : path.join(__dirname, '..', 'check-state-leak.js');
+    const cleanCommand = `node "${scriptPath}" --filter-clean`;
+
+    execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.clean`, cleanCommand], {
+      cwd: projectPath,
+      encoding: 'utf8',
+    });
+
+    let existing = '';
+    try {
+      existing = fs.readFileSync(attributesFile, 'utf8');
+    } catch { /* first configuration: attributes file does not exist yet */ }
+
+    const missingBindings = COMMIT_PRIVACY_FILES.filter(
+      file => !existing.includes(`${file} filter=${COMMIT_PRIVACY_FILTER_NAME}`)
+    );
+    if (missingBindings.length > 0) {
+      fs.mkdirSync(path.dirname(attributesFile), { recursive: true });
+      const header = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+      const lines = missingBindings.map(f => `${f} filter=${COMMIT_PRIVACY_FILTER_NAME}\n`).join('');
+      fs.appendFileSync(attributesFile, header + lines);
+    }
+  } catch (err) {
+    // Best-effort: never let commit-privacy setup block the memory write the
+    // caller is waiting on. But silent failure here means a real git-config
+    // error (permission denied, git binary crashed) leaves the user with no
+    // signal that populated memory can still reach a commit -- a single
+    // stderr line costs nothing here either (cubic review, audit EGC-547).
+    process.stderr.write(`[egc-memory] commit-privacy filter setup failed for ${projectPath}: ${err.message}\n`);
   }
 }
 

--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -27,6 +27,7 @@ const COMMIT_PRIVACY_FILES = [
   'llms.txt',
   'CLAUDE.md',
   '.roo/rules/egc-context.md',
+  '.roorules',
   '.continue/rules/egc-context.md',
 ];
 
@@ -63,19 +64,24 @@ function shSingleQuote(value) {
 
 function ensureCommitPrivacy(projectPath) {
   try {
-    let gitDir;
+    // --git-path (not --git-dir + a manual join) resolves correctly for
+    // linked worktrees too: git always reads info/attributes from the
+    // *common* git directory, never the per-worktree one that --git-dir
+    // alone returns (.git/worktrees/<name>) when run inside a linked
+    // worktree. Building the path by hand from --git-dir would silently
+    // write bindings to a file git never consults there, leaving
+    // worktree-based projects unprotected.
+    let attributesFile;
     try {
-      gitDir = execFileSync(GIT_BIN, ['rev-parse', '--git-dir'], {
+      const raw = execFileSync(GIT_BIN, ['rev-parse', '--git-path', 'info/attributes'], {
         cwd: projectPath,
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'ignore'],
       }).trim();
+      attributesFile = path.isAbsolute(raw) ? raw : path.join(projectPath, raw);
     } catch {
       return; // not a git repository
     }
-
-    const absoluteGitDir = path.isAbsolute(gitDir) ? gitDir : path.join(projectPath, gitDir);
-    const attributesFile = path.join(absoluteGitDir, 'info', 'attributes');
     // Installed layout flattens scripts/check-state-leak.js down into the
     // same directory as this file (see HOOK_LIB_SOURCES in
     // install-targets/claude-home.js and opencode-home.js); dev-repo layout
@@ -91,6 +97,21 @@ function ensureCommitPrivacy(projectPath) {
     // configuration entirely and leave the loud stderr diagnostic to explain
     // why.
     if (!fs.existsSync(scriptPath)) {
+      // A repo whose filter was set up before required=true existed would
+      // otherwise stay silently fail-open forever once the script goes
+      // missing, with no path back to fail-closed. Harden an already-present
+      // driver in place -- without touching its clean command or adding new
+      // bindings -- so a broken script at least blocks staging instead of
+      // silently falling back to unfiltered content.
+      let alreadyConfigured = true;
+      try {
+        execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.clean`], { cwd: projectPath, encoding: 'utf8' });
+      } catch {
+        alreadyConfigured = false;
+      }
+      if (alreadyConfigured) {
+        execFileSync(GIT_BIN, ['config', `filter.${COMMIT_PRIVACY_FILTER_NAME}.required`, 'true'], { cwd: projectPath, encoding: 'utf8' });
+      }
       throw new Error(`commit-privacy clean-filter script not found at ${scriptPath}`);
     }
     const cleanCommand = `node ${shSingleQuote(scriptPath)} --filter-clean`;

--- a/tests/memory-filters.test.js
+++ b/tests/memory-filters.test.js
@@ -120,5 +120,57 @@ run('non-git directory is skipped with a reason', () => {
   assert.ok(plan.reason.includes('not a git repository'));
 });
 
+run('fails closed (does not configure) when the clean-filter script is missing (audit EGC-547, P0)', () => {
+  const { dir, git } = makeRepo();
+  const missingScript = path.join(dir, 'this-script-does-not-exist.js');
+  const plan = configureMemoryFilters({ projectDir: dir, scriptPath: missingScript, dryRun: false });
+  assert.strictEqual(plan.configured, false, 'must not report success');
+  assert.ok(plan.reason.includes('not found'), 'reason explains why');
+  let cleanConfigured = true;
+  try {
+    git('config', `filter.${FILTER_NAME}.clean`);
+  } catch {
+    cleanConfigured = false;
+  }
+  assert.strictEqual(cleanConfigured, false, 'filter must never be configured to point at a script that is not on disk');
+});
+
+run('sets filter.required=true so git refuses to stage through a broken filter (audit EGC-547, P0)', () => {
+  const { dir, git } = makeRepo();
+  configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  const required = git('config', `filter.${FILTER_NAME}.required`).trim();
+  assert.strictEqual(required, 'true');
+});
+
+run('does not skip a real binding fooled by a commented-out or non-exact attributes line (audit EGC-547, P1)', () => {
+  const { dir } = makeRepo();
+  fs.mkdirSync(path.join(dir, '.git', 'info'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.git', 'info', 'attributes'),
+    `# AGENTS.md filter=${FILTER_NAME}\nAGENTS.md filter=${FILTER_NAME}-something-else\n`
+  );
+  const plan = configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  assert.strictEqual(plan.configured, true);
+  const attrs = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf8');
+  const realBindingCount = attrs.split('\n').filter(l => l.trim() === `AGENTS.md filter=${FILTER_NAME}`).length;
+  assert.strictEqual(realBindingCount, 1, 'the real exact binding must be added despite the lookalike lines');
+});
+
+run('configures and cleans correctly when the script path itself contains a space and a single quote (audit EGC-547, P2)', () => {
+  const { dir, git } = makeRepo();
+  const oddDir = path.join(dir, "a path with spaces and a ' quote");
+  fs.mkdirSync(oddDir, { recursive: true });
+  const oddScriptPath = path.join(oddDir, 'check-state-leak.js');
+  fs.copyFileSync(LEAK_SCRIPT, oddScriptPath);
+
+  const plan = configureMemoryFilters({ projectDir: dir, scriptPath: oddScriptPath, dryRun: false });
+  assert.strictEqual(plan.configured, true);
+
+  fs.writeFileSync(path.join(dir, 'AGENTS.md'), POPULATED);
+  git('add', 'AGENTS.md');
+  const staged = git('show', ':0:AGENTS.md');
+  assert.ok(!staged.includes('secret local context'), 'filter actually ran despite the odd path and stripped the content');
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/memory-filters.test.js
+++ b/tests/memory-filters.test.js
@@ -172,6 +172,21 @@ run('hardens an already-configured filter to required=true even when the script 
   assert.strictEqual(required, 'true', 'an already-configured driver must be hardened even when the script goes missing later');
 });
 
+run('hardening a pre-smudge-fix install adds smudge=cat, not just required=true (audit EGC-547, checkout regression)', () => {
+  const { dir, git } = makeRepo();
+  // Simulate an install from before the smudge fix existed: clean is
+  // configured, but smudge and required were never set.
+  git('config', `filter.${FILTER_NAME}.clean`, `node ${LEAK_SCRIPT} --filter-clean`);
+
+  const missingScript = path.join(dir, 'this-script-does-not-exist.js');
+  configureMemoryFilters({ projectDir: dir, scriptPath: missingScript, dryRun: false });
+
+  const required = git('config', `filter.${FILTER_NAME}.required`).trim();
+  assert.strictEqual(required, 'true');
+  const smudge = git('config', `filter.${FILTER_NAME}.smudge`).trim();
+  assert.strictEqual(smudge, 'cat', 'hardening to required=true must not skip smudge, or checkout breaks on this repo');
+});
+
 run('binds .roorules, the legacy Roo Code fallback, to the filter (audit EGC-547, privacy gap)', () => {
   const { dir } = makeRepo();
   const plan = configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });

--- a/tests/memory-filters.test.js
+++ b/tests/memory-filters.test.js
@@ -142,6 +142,44 @@ run('sets filter.required=true so git refuses to stage through a broken filter (
   assert.strictEqual(required, 'true');
 });
 
+run('protects a linked worktree by binding the common git dir, not the per-worktree one (audit EGC-547, worktree regression)', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'placeholder.txt'), 'x');
+  git('add', 'placeholder.txt');
+  git('commit', '-q', '-m', 'init');
+  const worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-worktree-'));
+  git('worktree', 'add', worktreeDir, '-b', 'egc-worktree-branch');
+  configureMemoryFilters({ projectDir: worktreeDir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  // git always reads info/attributes from the main worktree's .git, never
+  // from .git/worktrees/<name> -- the binding must land there regardless of
+  // which worktree configureMemoryFilters was run from.
+  const attrs = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf8');
+  assert.ok(attrs.includes(`AGENTS.md filter=${FILTER_NAME}`), 'binding lands in the common git dir, not the per-worktree one');
+});
+
+run('hardens an already-configured filter to required=true even when the script later goes missing (audit EGC-547, fail-open regression)', () => {
+  const { dir, git } = makeRepo();
+  configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  // Simulate a pre-required=true install: strip the hardening this same
+  // call just applied, as if the repo had been configured by an older
+  // version of this code.
+  git('config', `filter.${FILTER_NAME}.required`, 'false');
+
+  const missingScript = path.join(dir, 'this-script-does-not-exist.js');
+  const plan = configureMemoryFilters({ projectDir: dir, scriptPath: missingScript, dryRun: false });
+  assert.strictEqual(plan.configured, false, 'still must not report success without a real clean script');
+  const required = git('config', `filter.${FILTER_NAME}.required`).trim();
+  assert.strictEqual(required, 'true', 'an already-configured driver must be hardened even when the script goes missing later');
+});
+
+run('binds .roorules, the legacy Roo Code fallback, to the filter (audit EGC-547, privacy gap)', () => {
+  const { dir } = makeRepo();
+  const plan = configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  assert.strictEqual(plan.configured, true);
+  const attrs = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf8');
+  assert.ok(attrs.includes(`.roorules filter=${FILTER_NAME}`), '.roorules must be bound, not just .roo/rules/egc-context.md');
+});
+
 run('configures filter.smudge so required=true does not break checkout (audit EGC-547, smudge regression)', () => {
   const { dir, git } = makeRepo();
   configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });

--- a/tests/memory-filters.test.js
+++ b/tests/memory-filters.test.js
@@ -142,6 +142,23 @@ run('sets filter.required=true so git refuses to stage through a broken filter (
   assert.strictEqual(required, 'true');
 });
 
+run('configures filter.smudge so required=true does not break checkout (audit EGC-547, smudge regression)', () => {
+  const { dir, git } = makeRepo();
+  configureMemoryFilters({ projectDir: dir, scriptPath: LEAK_SCRIPT, dryRun: false });
+  const smudge = git('config', `filter.${FILTER_NAME}.smudge`).trim();
+  assert.strictEqual(smudge, 'cat');
+
+  // End-to-end: with required=true and clean configured but no smudge, git
+  // treats the undefined smudge side as a failed filter and aborts checkout
+  // ("smudge filter egc-memory failed") instead of the passthru it defaults
+  // to when a filter driver is missing entirely. Prove the real checkout
+  // path (not just the config value) survives once smudge is set.
+  fs.writeFileSync(path.join(dir, 'AGENTS.md'), POPULATED);
+  git('add', 'AGENTS.md');
+  git('commit', '-q', '-m', 'add AGENTS.md');
+  assert.doesNotThrow(() => git('checkout', '--', 'AGENTS.md'), 'checkout must not fail through the configured filter');
+});
+
 run('does not skip a real binding fooled by a commented-out or non-exact attributes line (audit EGC-547, P1)', () => {
   const { dir } = makeRepo();
   fs.mkdirSync(path.join(dir, '.git', 'info'), { recursive: true });

--- a/tests/scripts/egc-memory-propagate.test.js
+++ b/tests/scripts/egc-memory-propagate.test.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const SERVER_ROOT = path.join(__dirname, '../../mcp/servers/egc-memory');
 const PROPAGATE_PATH = path.join(SERVER_ROOT, 'build', 'propagate.js');
@@ -445,6 +446,35 @@ async function runTests() {
       assert.ok(result.cursor, 'cursor path should be returned');
       const mdc = fs.readFileSync(result.cursor, 'utf-8');
       assert.ok(mdc.includes('EGC Project Memory'), 'header present');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('configures the commit-privacy git filter automatically, without a separate egc init step (audit EGC-547)', () => {
+    const dir = mktemp();
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      propagateStateToTools({ projectPath: dir, ...args });
+      const attributesPath = path.join(dir, '.git', 'info', 'attributes');
+      const attributes = fs.readFileSync(attributesPath, 'utf-8');
+      assert.ok(attributes.includes('AGENTS.md filter=egc-memory'), 'AGENTS.md is bound to the filter');
+      assert.ok(attributes.includes('CLAUDE.md filter=egc-memory'), 'CLAUDE.md is bound to the filter');
+      const filterConfig = execFileSync('git', ['config', '--get', 'filter.egc-memory.clean'], {
+        cwd: dir,
+        encoding: 'utf-8',
+      }).trim();
+      assert.ok(filterConfig.includes('check-state-leak.js'), 'clean filter command is configured');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('does not throw when projectPath is not a git repository (audit EGC-547)', () => {
+    const dir = mktemp();
+    try {
+      const result = propagateStateToTools({ projectPath: dir, ...args });
+      assert.strictEqual(result.cursor, null, 'propagation still runs normally outside a git repo');
     } finally {
       cleanup(dir);
     }

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -589,6 +589,42 @@ function runFreshnessGuardTests() {
     }
   })) passed++; else failed++;
 
+  if (test('protects a linked worktree by binding the common git dir, not the per-worktree one (audit EGC-547, worktree regression)', () => {
+    const dir = mktemp();
+    let worktreeDir;
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+      fs.writeFileSync(path.join(dir, 'placeholder.txt'), 'x');
+      execFileSync('git', ['add', 'placeholder.txt'], { cwd: dir });
+      execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: dir });
+      worktreeDir = mktemp();
+      execFileSync('git', ['worktree', 'add', worktreeDir, '-b', 'egc-worktree-branch'], { cwd: dir });
+      propagateStateContent(worktreeDir, SAMPLE_STATE);
+      // git always reads info/attributes from the main worktree's .git,
+      // never from .git/worktrees/<name> -- the binding must land there
+      // regardless of which worktree propagateStateContent was run from.
+      const attrs = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf-8');
+      assert.ok(attrs.includes('AGENTS.md filter=egc-memory'), 'binding lands in the common git dir, not the per-worktree one');
+    } finally {
+      cleanup(dir);
+      if (worktreeDir) cleanup(worktreeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('binds .roorules, the legacy Roo Code fallback, to the filter (audit EGC-547, privacy gap)', () => {
+    const dir = mktemp();
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      propagateStateContent(dir, SAMPLE_STATE);
+      const attrs = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf-8');
+      assert.ok(attrs.includes('.roorules filter=egc-memory'), '.roorules must be bound, not just .roo/rules/egc-context.md');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('configures filter.smudge so required=true does not break checkout (audit EGC-547, smudge regression)', () => {
     const dir = mktemp();
     try {

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -574,6 +574,59 @@ function runFreshnessGuardTests() {
     }
   })) passed++; else failed++;
 
+  if (test('sets filter.required=true so git refuses to stage through a broken filter (audit EGC-547, P0)', () => {
+    const dir = mktemp();
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      propagateStateContent(dir, SAMPLE_STATE);
+      const required = execFileSync('git', ['config', '--get', 'filter.egc-memory.required'], {
+        cwd: dir,
+        encoding: 'utf-8',
+      }).trim();
+      assert.strictEqual(required, 'true');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not skip a real binding fooled by a commented-out or non-exact attributes line (audit EGC-547, P1)', () => {
+    const dir = mktemp();
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      fs.mkdirSync(path.join(dir, '.git', 'info'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, '.git', 'info', 'attributes'),
+        '# AGENTS.md filter=egc-memory\nAGENTS.md filter=egc-memory-something-else\n'
+      );
+      propagateStateContent(dir, SAMPLE_STATE);
+      const attributes = fs.readFileSync(path.join(dir, '.git', 'info', 'attributes'), 'utf-8');
+      const realBindingCount = attributes.split('\n').filter(l => l.trim() === 'AGENTS.md filter=egc-memory').length;
+      assert.strictEqual(realBindingCount, 1, 'the real exact binding must be added despite the lookalike lines');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('actually strips populated memory when a bound propagation file is staged (audit EGC-547, end-to-end)', () => {
+    const dir = mktemp();
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n');
+      propagateStateContent(dir, SAMPLE_STATE);
+
+      const populated = fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8');
+      assert.ok(populated.includes('EGC v1.1.1 stable'), 'sanity: file is actually populated before staging');
+
+      execFileSync('git', ['add', 'AGENTS.md'], { cwd: dir });
+      const staged = execFileSync('git', ['show', ':0:AGENTS.md'], { cwd: dir, encoding: 'utf-8' });
+      assert.ok(!staged.includes('EGC v1.1.1 stable'), 'clean filter must have run and stripped the populated memory before staging');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   return { passed, failed };
 }
 

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -589,6 +589,36 @@ function runFreshnessGuardTests() {
     }
   })) passed++; else failed++;
 
+  if (test('configures filter.smudge so required=true does not break checkout (audit EGC-547, smudge regression)', () => {
+    const dir = mktemp();
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n');
+      propagateStateContent(dir, SAMPLE_STATE);
+      const smudge = execFileSync('git', ['config', '--get', 'filter.egc-memory.smudge'], {
+        cwd: dir,
+        encoding: 'utf-8',
+      }).trim();
+      assert.strictEqual(smudge, 'cat');
+
+      // End-to-end: with required=true and clean configured but no smudge,
+      // git treats the undefined smudge side as a failed filter and aborts
+      // checkout ("smudge filter egc-memory failed") instead of the
+      // passthru it defaults to when a filter driver is missing entirely.
+      // Prove the real checkout path survives once smudge is set.
+      execFileSync('git', ['add', 'AGENTS.md'], { cwd: dir });
+      execFileSync('git', ['commit', '-q', '-m', 'add AGENTS.md'], { cwd: dir });
+      assert.doesNotThrow(
+        () => execFileSync('git', ['checkout', '--', 'AGENTS.md'], { cwd: dir }),
+        'checkout must not fail through the configured filter'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('does not skip a real binding fooled by a commented-out or non-exact attributes line (audit EGC-547, P1)', () => {
     const dir = mktemp();
     try {

--- a/tests/scripts/propagate-state.test.js
+++ b/tests/scripts/propagate-state.test.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const { propagateStateContent } = require('../../scripts/lib/propagate-state');
 
@@ -539,6 +540,35 @@ function runFreshnessGuardTests() {
         content.includes('<!-- egc:state-updated:2026-07-01T00:00:00.000Z -->'),
         'stamp advanced to the newer timestamp'
       );
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('configures the commit-privacy git filter automatically, without a separate egc init step (audit EGC-547)', () => {
+    const dir = mktemp();
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      propagateStateContent(dir, SAMPLE_STATE);
+      const attributesPath = path.join(dir, '.git', 'info', 'attributes');
+      const attributes = fs.readFileSync(attributesPath, 'utf-8');
+      assert.ok(attributes.includes('AGENTS.md filter=egc-memory'), 'AGENTS.md is bound to the filter');
+      const filterConfig = execFileSync('git', ['config', '--get', 'filter.egc-memory.clean'], {
+        cwd: dir,
+        encoding: 'utf-8',
+      }).trim();
+      assert.ok(filterConfig.includes('check-state-leak.js'), 'clean filter command is configured');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not throw when projectPath is not a git repository', () => {
+    const dir = mktemp();
+    try {
+      fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n');
+      const result = propagateStateContent(dir, SAMPLE_STATE);
+      assert.ok(result.agents, 'propagation still runs normally outside a git repo');
     } finally {
       cleanup(dir);
     }


### PR DESCRIPTION
## Summary
- Fixes the real gap found in the 2026-08-01 README-vs-code audit for the "never gets committed to git" claim.
- The git clean filter (`.git/info/attributes` + `filter.egc-memory.clean`) was only ever configured by the separate, manual `egc init` command — a project that only ran `egc install` (the README's own documented command) never got this protection.
- Both `propagate.ts` (MCP server) and `propagate-state.js` (CLI) now call `configureMemoryFilters` before writing any propagation file, best-effort and silent (never blocks the actual memory write if git is unavailable or the path isn't a repo).

## Test plan
- [x] 26/26 `tests/scripts/egc-memory-propagate.test.js` passing (2 new tests)
- [x] 35/35 `tests/scripts/propagate-state.test.js` passing (2 new tests)
- [x] Verified end-to-end in fresh temp git repos (both TS-compiled and CLI paths), not just unit tests: `.git/info/attributes` and the filter config are set without a separate `egc init` step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically installs and hardens the commit-privacy Git filter on first propagation (MCP and CLI), including linked worktrees, so `AGENTS.md`/`CLAUDE.md` never reach commits even if users only run `egc install`. Also configures `smudge=cat` with `required=true` to prevent checkout failures and extends the leak guard to `.roorules`; setup is best-effort and never blocks writes, with a single stderr hint on failure.

- **Bug Fixes**
  - Run commit-privacy setup before writing in both paths.
  - Inline filter logic in the CLI and ship `scripts/check-state-leak.js` in `claude-home`/`opencode-home` so installed layouts work; emit a one-line stderr when the module or script is unavailable.
  - Fail closed if the clean script is missing; harden existing setups to `filter.egc-memory.required=true` and `filter.egc-memory.smudge=cat`; no-op outside Git.
  - Escape the script path in git config and match `.git/info/attributes` by exact line.
  - Resolve attributes via `git rev-parse --git-path info/attributes` for linked worktrees; bind `.roorules` in addition to `.roo/rules/egc-context.md`. Addresses EGC-547.

- **Refactors**
  - Simplified single-quote escaping helper; no behavior change.

<sup>Written for commit 3bea01752159dc06a004e53c08660babd50ed7a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

