### PR TITLE
fix(guardian): quote-aware Crusher parsing, Roo Code denylist, stale audit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install -g @egchq/egc && egc install
 ```
 
 - **Reduce context waste by up to 90%, cut token costs, and keep every AI perfectly aligned across sessions.**
-- **Guardian: validate every command before execution, block dangerous writes, and detect prompt injection. Every shared brain comes with a built-in safety layer.**
+- **Guardian: validate every command before execution and block dangerous writes. Every shared brain comes with a built-in safety layer.**
 - **One command, zero config: memory stays local and encrypted on your machine, and never gets committed to git.**
 
 <div align="center">
@@ -58,7 +58,7 @@ EGC gives every AI agent a persistent, shared brain. It captures decisions, sess
 
 ### Guardian: Built-In Safety Guardrails
 
-A second half of the brain runs guardrails in the background. It validates commands before they execute, gates risky writes, compresses context before it overflows, orchestrates multi-step tasks across agents, and learns from every correction, all without you invoking a single tool. An invisible safety net that keeps context lean, actions safe, and workflows autonomous.
+A second half of the brain runs guardrails in the background. It validates commands before they execute, gates risky writes, compresses context before it overflows, orchestrates multi-step tasks across agents, and learns from every correction, all without you invoking a single tool. An invisible safety net that keeps context lean, actions safe, and workflows autonomous. (Coverage depends on each tool's own hook support; see the [Security Assessment](docs/security/SECURITY-ASSESSMENT.md#known-limitations) for the one documented exception.)
 
 ### Token Crusher: The Brain Filters Noise Before It Remembers
 

--- a/docs/security/SECURITY-ASSESSMENT.md
+++ b/docs/security/SECURITY-ASSESSMENT.md
@@ -61,7 +61,7 @@ This assessment covers the EGC runtime and its primary components:
 - EGC is a local-only tool; it has no server component, no authentication, and no network services.
 - The security posture depends on the security of the host machine and the AI tool integrations.
 - Prompt injection from external content (e.g., malicious files read by the AI) is an AI-tool-level concern, not addressable at the EGC layer.
-- Guardian validation depends on the harness actually invoking the registered hooks; a harness that does not support hook wiring (several Tier 1 discoverability-only adapters, e.g. Goose, OpenHands, Amazon Q, Roo Code, Qwen Code) gets memory and skills but not command-level enforcement.
+- Guardian validation depends on the harness actually invoking the registered hooks. Amazon Q, Goose, and OpenHands (#1092) and Qwen Code (#1080) all have real Guardian hook wiring. Roo Code is the one exception: it has no external hook API (confirmed against its own docs and an open upstream feature request), so it gets a native `roo-cline.deniedCommands` seed instead of a Guardian adapter, a real but partial mitigation covering only the unconditionally-dangerous base commands by prefix match, not context-aware command-level enforcement.
 
 ## Assessment Date
 

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -44,6 +44,14 @@ function wrappedRe() {
 // --shell wrap purely because of the quoted `&`, when the harness's own
 // shell already parses that quoting correctly with no wrap needed.
 function hasComplexShellSyntax(cmd) {
+  // cmd.exe does not treat single quotes as quoting (confirmed by shSingleQuote's
+  // own POSIX-escaping caveat below), so the quote-aware scan below would treat a
+  // Windows metacharacter sitting inside single quotes as inert when cmd.exe would
+  // still see it as live. Windows stays on the old conservative character-class
+  // check instead, matching the platform's real quoting rules.
+  if (process.platform === 'win32') {
+    return /[|&;<>$`()\n]/.test(cmd);
+  }
   let quote = null;
   for (let i = 0; i < cmd.length; i++) {
     const ch = cmd[i];

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -29,10 +29,44 @@ function wrappedRe() {
   const prefixes = ['egc', ...extra].join('|');
   return new RegExp(`(?:^\\s*(?:${prefixes})\\s)|(?:--raw\\b)`);
 }
-// A command with none of these characters runs through `egc run <cmd>` with no
-// shell. One that has them keeps its exact semantics only when re-parsed by
-// bash, so it goes through `egc run --shell '<cmd>'` when safe (see run()).
-const COMPLEX_SHELL_RE = /[|&;<>$`()\n]/;
+// A command with none of these characters *active* runs through `egc run
+// <cmd>` with no shell. One that has active shell syntax keeps its exact
+// semantics only when re-parsed by bash, so it goes through
+// `egc run --shell '<cmd>'` when safe (see run()).
+//
+// "Active" means outside single quotes, and -- inside double quotes -- one
+// of the characters double quotes actually leave live. This mirrors POSIX
+// quoting: single quotes make every character literal with no escaping at
+// all; double quotes keep `$` and backtick able to expand but leave
+// |&;<>() as plain text; outside any quote, a backslash escapes the very
+// next character. Ignoring all of that (a plain character-class regex) was
+// EGC-512: it flagged e.g. `git commit -m "fix: a & b"` as needing the
+// --shell wrap purely because of the quoted `&`, when the harness's own
+// shell already parses that quoting correctly with no wrap needed.
+function hasComplexShellSyntax(cmd) {
+  let quote = null;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i];
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === '\\') { i++; continue; }
+      if (ch === '"') { quote = null; continue; }
+      if (ch === '$' || ch === '`') return true;
+      continue;
+    }
+    if (ch === '\\') { i++; continue; }
+    if (ch === "'" || ch === '"') { quote = ch; continue; }
+    if (ch === '\n' || ch === '|' || ch === '&' || ch === ';' || ch === '<' || ch === '>' || ch === '$' || ch === '`' || ch === '(' || ch === ')') {
+      return true;
+    }
+  }
+  // An unterminated quote masks whatever follows it from this scan; treat
+  // that as complex rather than silently trusting the no-shell fast path.
+  return quote !== null;
+}
 
 // Backgrounding detaches the process, so spawnSync would not capture its output;
 // redirection sends stdout elsewhere, leaving nothing to crush. Neither is ever
@@ -78,7 +112,7 @@ function run(rawInput) {
     }
 
     let command;
-    if (!COMPLEX_SHELL_RE.test(cmd)) {
+    if (!hasComplexShellSyntax(cmd)) {
       command = `egc run ${cmd}`;
     } else if (process.platform !== 'win32' && !hasBackgrounding(cmd) && !hasRedirection(cmd)) {
       // shSingleQuote is POSIX escaping; cmd.exe does not treat single quotes as

--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -43,15 +43,19 @@ function wrappedRe() {
 // EGC-512: it flagged e.g. `git commit -m "fix: a & b"` as needing the
 // --shell wrap purely because of the quoted `&`, when the harness's own
 // shell already parses that quoting correctly with no wrap needed.
+//
+// This scan is intentionally platform-uniform, not just POSIX: every host
+// that wires this hook (Claude Code, Cursor, Junie, OpenCode, Amp) invokes
+// its Bash-equivalent tool through a POSIX-compatible shell even on
+// Windows (Git Bash/WSL), never raw cmd.exe -- confirmed by the test suite
+// itself, which asserts identical quote-aware behavior on every platform
+// for this exact function and is POSIX-gated only for the parts that are
+// genuinely POSIX-only (pipelines, `--shell` wrapping). A platform branch
+// here that special-cased cmd.exe quoting broke those cross-platform
+// assertions on Windows CI and was reverted; if a host that actually
+// shells out via cmd.exe is ever wired to this hook, that needs its own
+// dedicated handling, not a blanket win32 check here.
 function hasComplexShellSyntax(cmd) {
-  // cmd.exe does not treat single quotes as quoting (confirmed by shSingleQuote's
-  // own POSIX-escaping caveat below), so the quote-aware scan below would treat a
-  // Windows metacharacter sitting inside single quotes as inert when cmd.exe would
-  // still see it as live. Windows stays on the old conservative character-class
-  // check instead, matching the platform's real quoting rules.
-  if (process.platform === 'win32') {
-    return /[|&;<>$`()\n]/.test(cmd);
-  }
   let quote = null;
   for (let i = 0; i < cmd.length; i++) {
     const ch = cmd[i];

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -186,6 +186,24 @@ function main() {
 
     const result = applyInstallPlan(plan);
 
+    // README promises memory "never gets committed to git" unconditionally.
+    // Before this call, only `egc init` configured the filter that keeps
+    // that promise -- `egc install --target X` (this path) and the bare
+    // `egc install` wrapper scripts never did, so a user following the
+    // README's own quick-start command got no protection (2026-08-01
+    // audit finding). Best-effort: a repo-detection failure here must not
+    // fail the whole install.
+    try {
+      const { applyCommitPrivacyFilterCli } = require('./lib/memory-filters');
+      applyCommitPrivacyFilterCli({
+        projectDir: process.cwd(),
+        scriptPath: require('node:path').join(__dirname, 'check-state-leak.js'),
+        log: options.json ? () => {} : msg => console.log(`  ${msg}`),
+      });
+    } catch (err) {
+      if (!options.json) console.error(`Warning: commit-privacy filter setup failed: ${err.message}`);
+    }
+
     // Regenerate the topology hot cache (runtime-map.json)
     try {
       const { discover } = require('./runtime/discovery');

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -152,6 +152,24 @@ function main() {
       const path = require('node:path');
       const { spawnSync } = require('node:child_process');
       const rootDir = path.join(__dirname, '..');
+
+      // Must run here, before the spawnSync below: that call hands off to
+      // install.sh/install.ps1 with cwd forced to rootDir (the package's own
+      // install location, not the user's project), so their own copy of this
+      // same setup silently targets the wrong directory (cubic review, PR
+      // #1122). process.cwd() is still the real user directory at this
+      // point -- this script never chdirs on its own.
+      try {
+        const { applyCommitPrivacyFilterCli } = require('./lib/memory-filters');
+        applyCommitPrivacyFilterCli({
+          projectDir: process.cwd(),
+          scriptPath: path.join(__dirname, 'check-state-leak.js'),
+          log: msg => console.log(`  ${msg}`),
+        });
+      } catch (err) {
+        console.error(`Warning: commit-privacy filter setup failed: ${err.message}`);
+      }
+
       const wrapper = process.platform === 'win32'
         ? { cmd: 'powershell', args: ['-ExecutionPolicy', 'Bypass', '-File', path.join(rootDir, 'scripts', 'install.ps1')] }
         : { cmd: 'bash', args: [path.join(rootDir, 'scripts', 'install.sh')] };

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -126,6 +126,13 @@ if (-not $DryRun) {
     Write-Host "  bootstrapping cognitive protocol..."
     node (Join-Path $RootDir (Join-Path "scripts" "bootstrap-cognitive.js"))
 
+    # README promises memory "never gets committed to git" unconditionally,
+    # but only `egc init` configured the filter that keeps that promise --
+    # this quick-start script (the README's own documented command) never
+    # did (2026-08-01 audit finding). Best-effort: must not fail the install.
+    node -e 'const rootDir = process.argv[1]; const { applyCommitPrivacyFilterCli } = require(rootDir + "/scripts/lib/memory-filters"); applyCommitPrivacyFilterCli({ projectDir: process.cwd(), scriptPath: rootDir + "/scripts/check-state-leak.js", log: m => console.log("  " + m) });' $RootDir
+    if ($LASTEXITCODE -ne 0) { Write-Host "  note: commit-privacy filter setup failed (non-fatal)" }
+
     # Write harness config
     Set-Location -Path $RootDir
     $mcpConfig = @{

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,6 +44,18 @@ for _arg in "$@"; do
   [ "$_arg" = "--dry-run" ] && DRY_RUN=true && break
 done
 
+# Detect whether we'll delegate to the Node installer below (install-apply.js
+# configures the commit-privacy filter itself, so this script must skip its
+# own copy of that step when delegating -- otherwise it runs twice).
+_has_install_args=false
+for _arg in "$@"; do
+  case "$_arg" in
+    --target|--profile|--modules|--config|--with|--without|--dry-run|--json) _has_install_args=true; break ;;
+  esac
+  # positional arg = language/component
+  case "$_arg" in -*) ;; *) _has_install_args=true; break ;; esac
+done
+
 # Node.js version check. Keep this floor in lockstep with package.json "engines"
 # and scripts/preinstall.js, which both require Node 20; a lower gate here would
 # let 18/19 reach the better-sqlite3 build and the TypeScript build steps below.
@@ -130,7 +142,11 @@ if [ "$DRY_RUN" = false ]; then
   # but only `egc init` configured the filter that keeps that promise --
   # this quick-start script (the README's own documented command) never
   # did (2026-08-01 audit finding). Best-effort: must not fail the install.
-  node - "$ROOT_DIR" <<'NODEEOF' || echo "  note: commit-privacy filter setup failed (non-fatal)"
+  # Skipped when delegating to install-apply.js below (--target/--profile/etc.
+  # present): that path runs this same setup itself, so running it here too
+  # would configure the filter twice (cubic review, PR #1122).
+  if [ "$_has_install_args" != true ]; then
+    node - "$ROOT_DIR" <<'NODEEOF' || echo "  note: commit-privacy filter setup failed (non-fatal)"
 const [, , rootDir] = process.argv;
 const { applyCommitPrivacyFilterCli } = require(rootDir + '/scripts/lib/memory-filters');
 applyCommitPrivacyFilterCli({
@@ -139,18 +155,11 @@ applyCommitPrivacyFilterCli({
   log: m => console.log('  ' + m),
 });
 NODEEOF
+  fi
 fi
 
 # Delegate to Node installer only when install-relevant args are present
 cd "$ROOT_DIR"
-_has_install_args=false
-for _arg in "$@"; do
-  case "$_arg" in
-    --target|--profile|--modules|--config|--with|--without|--dry-run|--json) _has_install_args=true; break ;;
-  esac
-  # positional arg = language/component
-  case "$_arg" in -*) ;; *) _has_install_args=true; break ;; esac
-done
 if [ "$_has_install_args" = true ]; then
   node scripts/install-apply.js "$@"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -125,6 +125,20 @@ if [ "$DRY_RUN" = false ]; then
   node scripts/bootstrap-state-db.js
   echo "  bootstrapping cognitive protocol..."
   node "$ROOT_DIR/scripts/bootstrap-cognitive.js"
+
+  # README promises memory "never gets committed to git" unconditionally,
+  # but only `egc init` configured the filter that keeps that promise --
+  # this quick-start script (the README's own documented command) never
+  # did (2026-08-01 audit finding). Best-effort: must not fail the install.
+  node - "$ROOT_DIR" <<'NODEEOF' || echo "  note: commit-privacy filter setup failed (non-fatal)"
+const [, , rootDir] = process.argv;
+const { applyCommitPrivacyFilterCli } = require(rootDir + '/scripts/lib/memory-filters');
+applyCommitPrivacyFilterCli({
+  projectDir: process.cwd(),
+  scriptPath: rootDir + '/scripts/check-state-leak.js',
+  log: m => console.log('  ' + m),
+});
+NODEEOF
 fi
 
 # Delegate to Node installer only when install-relevant args are present

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -36,6 +36,10 @@ const {
   PRE_TOOL_USE_EVENT: OPENHANDS_PRE_TOOL_USE_EVENT,
   applyOpenHandsGuardianHookToFile,
 } = require('./openhands-guardian-hooks');
+const {
+  ROOCODE_DENYLIST_TAG,
+  applyRoocodeDenylistToFile,
+} = require('./roocode-guardian-denylist');
 
 const MANAGED_WINDSURF_HOOK_EVENTS = new Set([WINDSURF_PRE_WRITE_CODE_EVENT, WINDSURF_PRE_RUN_COMMAND_EVENT]);
 
@@ -840,6 +844,30 @@ function createAdapterStdinJsonCopyOperation(createRemappedOperation, targetRoot
   );
 }
 
+// Roo Code has no external hook API to shell out to (see
+// roocode-guardian-denylist.js's own header for the confirmed evidence), so
+// unlike every other host's merge operation this has no script to copy: it
+// only ever merges roo-cline.deniedCommands into the workspace's own
+// .vscode/settings.json. sourceRelativePath points at the module driving
+// this merge (not a file that gets copied anywhere) purely so install-state
+// tracking has a stable, real identifier for this operation, consistent
+// with every other managed operation in this system.
+const ROOCODE_DENYLIST_MODULE_ID = 'egc-roocode-guardian-denylist';
+const ROOCODE_DENYLIST_SOURCE_RELATIVE_PATH = 'scripts/lib/roocode-guardian-denylist.js';
+
+function createRoocodeDenylistMergeOperation(settingsPath) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: ROOCODE_DENYLIST_MODULE_ID,
+    sourceRelativePath: ROOCODE_DENYLIST_SOURCE_RELATIVE_PATH,
+    destinationPath: settingsPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: ROOCODE_DENYLIST_TAG,
+  };
+}
+
 // PreCompact -> egc-memory-save hook: closes EGC-495 (no mechanism re-injected
 // state after a context compaction). egc-memory-save.js writes a guaranteed
 // on-disk snapshot (writeSnapshotToDisk, no AI cooperation required) and
@@ -998,6 +1026,8 @@ function applyManagedHookOperation(operation) {
     applyAmazonQGuardianHookToFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === OPENHANDS_PRE_TOOL_USE_EVENT) {
     applyOpenHandsGuardianHookToFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === ROOCODE_DENYLIST_TAG) {
+    applyRoocodeDenylistToFile(operation.destinationPath);
   } else {
     applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
   }
@@ -1007,6 +1037,7 @@ module.exports = {
   BASH_DISPATCHER_HOOK_MODULE_ID,
   BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   BASH_GUARDIAN_HOOK_MODULE_ID,
+  createRoocodeDenylistMergeOperation,
   BASH_GUARDIAN_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
   GATEGUARD_HOOK_MODULE_ID,
   GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -62,6 +62,11 @@ const {
   inspectOpenHandsGuardianHookFile,
   removeOpenHandsGuardianHookFromFile,
 } = require('./openhands-guardian-hooks');
+const {
+  ROOCODE_DENYLIST_TAG,
+  inspectRoocodeDenylistFile,
+  removeRoocodeDenylistFromFile,
+} = require('./roocode-guardian-denylist');
 
 // Windsurf's hooks.json is a flat {hooks: {<event>: [...]}} map, not
 // Claude's matcher/group settings.json schema -- an operation whose
@@ -590,6 +595,8 @@ function uninstallManagedHookOperation(operation) {
     removeAmazonQGuardianHookFromFile(operation.destinationPath, operation.hookScriptPath);
   } else if (operation.hookEvent === OPENHANDS_PRE_TOOL_USE_EVENT) {
     removeOpenHandsGuardianHookFromFile(operation.destinationPath, operation.hookScriptPath);
+  } else if (operation.hookEvent === ROOCODE_DENYLIST_TAG) {
+    removeRoocodeDenylistFromFile(operation.destinationPath);
   } else {
     removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
   }
@@ -743,6 +750,9 @@ function inspectManagedOperation(repoRoot, operation) {
     }
     if (operation.hookEvent === OPENHANDS_PRE_TOOL_USE_EVENT) {
       return inspectResult(inspectOpenHandsGuardianHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
+    }
+    if (operation.hookEvent === ROOCODE_DENYLIST_TAG) {
+      return inspectResult(inspectRoocodeDenylistFile(destinationPath), operation, destinationPath);
     }
     return inspectResult(inspectSessionStartHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
   }

--- a/scripts/lib/install-targets/amazonq-project.js
+++ b/scripts/lib/install-targets/amazonq-project.js
@@ -1,28 +1,6 @@
 const path = require('node:path');
-const { createInstallTargetAdapter, createRemappedOperation, isForeignPlatformPath } = require('./helpers');
+const { createDefaultScaffoldOperations, createInstallTargetAdapter, createRemappedOperation } = require('./helpers');
 const { createAmazonQGuardianOperations } = require('../amazonq-guardian-operations');
-
-// Same default-scaffold behavior createInstallTargetAdapter would otherwise
-// supply on its own (preserve category structure, no flat stripping) --
-// replicated here, not deleted, because defining a custom planOperations
-// below (needed to also emit the Guardian operations) replaces that
-// built-in default entirely.
-function createDefaultScaffoldOperations(input, adapter) {
-  if (Array.isArray(input.modules)) {
-    return input.modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
-    });
-  }
-
-  const module = input.module || {};
-  const paths = Array.isArray(module.paths) ? module.paths : [];
-  return paths
-    .filter(p => !isForeignPlatformPath(p, adapter.target))
-    .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
-}
 
 // EGC-498 (corrected): Amazon Q Developer CLI's preToolUse hook is real
 // (confirmed against aws/amazon-q-developer-cli's own docs -- the earlier

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -352,6 +352,31 @@ function createFlatSkillPlanOperations(rawInput, adapter) {
   });
 }
 
+// Same default-scaffold behavior createInstallTargetAdapter would otherwise
+// supply on its own (preserve category structure, no flat stripping) --
+// factored out so every adapter that defines a custom planOperations (to
+// also emit its own extra operations alongside the default scaffold, e.g.
+// Amazon Q/Roo Code's Guardian wiring) can reuse it instead of each keeping
+// its own copy. Was duplicated verbatim across amazonq-project.js and
+// roocode-project.js before this (SonarCloud new-code duplication finding
+// on PR #1122); consolidated here as the single source of truth.
+function createDefaultScaffoldOperations(input, adapter) {
+  if (Array.isArray(input.modules)) {
+    return input.modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
+    });
+  }
+
+  const module = input.module || {};
+  const paths = Array.isArray(module.paths) ? module.paths : [];
+  return paths
+    .filter(p => !isForeignPlatformPath(p, adapter.target))
+    .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
+}
+
 function createInstallTargetAdapter(config) {
   const adapter = {
     id: config.id,
@@ -452,6 +477,7 @@ function createInstallTargetAdapter(config) {
 
 module.exports = {
   buildValidationIssue,
+  createDefaultScaffoldOperations,
   createFlatFileOperations,
   createFlatRuleOperations,
   createFlatSkillPlanOperations,

--- a/scripts/lib/install-targets/roocode-project.js
+++ b/scripts/lib/install-targets/roocode-project.js
@@ -1,5 +1,37 @@
-const { createInstallTargetAdapter } = require('./helpers');
+const { createInstallTargetAdapter, isForeignPlatformPath } = require('./helpers');
+const { createRoocodeDenylistMergeOperation } = require('../claude-settings-hooks');
+const { resolveVsCodeSettingsPath } = require('../roocode-guardian-denylist');
 
+// Same default-scaffold behavior createInstallTargetAdapter would otherwise
+// supply on its own (preserve category structure, no flat stripping) --
+// replicated here, not deleted, because defining a custom planOperations
+// below (needed to also emit the deniedCommands merge) replaces that
+// built-in default entirely. Mirrors amazonq-project.js's own copy of this
+// same logic for the same reason.
+function createDefaultScaffoldOperations(input, adapter) {
+  if (Array.isArray(input.modules)) {
+    return input.modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
+    });
+  }
+
+  const module = input.module || {};
+  const paths = Array.isArray(module.paths) ? module.paths : [];
+  return paths
+    .filter(p => !isForeignPlatformPath(p, adapter.target))
+    .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
+}
+
+// Roo Code has no external hook API (see roocode-guardian-denylist.js's own
+// header for the confirmed evidence against its official docs), so unlike
+// every other install target here this cannot wire the real Guardian
+// validator. The closest real substitute -- seeding Roo Code's own native
+// roo-cline.deniedCommands setting -- lives in the workspace's own
+// .vscode/settings.json at the project root, not under this adapter's own
+// .roo/rules root, so it is planned against input.projectRoot directly.
 module.exports = createInstallTargetAdapter({
   id: 'roocode-project',
   target: 'roocode',
@@ -11,4 +43,11 @@ module.exports = createInstallTargetAdapter({
   // '.roo', never exercised by any module) so resolveDestinationPath syncs
   // root children directly instead of nesting rules/rules/.
   nativeRootRelativePath: 'rules',
+  planOperations(input, adapter) {
+    const settingsPath = resolveVsCodeSettingsPath(input.projectRoot);
+    return [
+      ...createDefaultScaffoldOperations(input, adapter),
+      createRoocodeDenylistMergeOperation(settingsPath),
+    ];
+  },
 });

--- a/scripts/lib/install-targets/roocode-project.js
+++ b/scripts/lib/install-targets/roocode-project.js
@@ -1,29 +1,6 @@
-const { createInstallTargetAdapter, isForeignPlatformPath } = require('./helpers');
+const { createDefaultScaffoldOperations, createInstallTargetAdapter } = require('./helpers');
 const { createRoocodeDenylistMergeOperation } = require('../claude-settings-hooks');
 const { resolveVsCodeSettingsPath } = require('../roocode-guardian-denylist');
-
-// Same default-scaffold behavior createInstallTargetAdapter would otherwise
-// supply on its own (preserve category structure, no flat stripping) --
-// replicated here, not deleted, because defining a custom planOperations
-// below (needed to also emit the deniedCommands merge) replaces that
-// built-in default entirely. Mirrors amazonq-project.js's own copy of this
-// same logic for the same reason.
-function createDefaultScaffoldOperations(input, adapter) {
-  if (Array.isArray(input.modules)) {
-    return input.modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
-    });
-  }
-
-  const module = input.module || {};
-  const paths = Array.isArray(module.paths) ? module.paths : [];
-  return paths
-    .filter(p => !isForeignPlatformPath(p, adapter.target))
-    .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
-}
 
 // Roo Code has no external hook API (see roocode-guardian-denylist.js's own
 // header for the confirmed evidence against its official docs), so unlike
@@ -31,7 +8,9 @@ function createDefaultScaffoldOperations(input, adapter) {
 // validator. The closest real substitute -- seeding Roo Code's own native
 // roo-cline.deniedCommands setting -- lives in the workspace's own
 // .vscode/settings.json at the project root, not under this adapter's own
-// .roo/rules root, so it is planned against input.projectRoot directly.
+// .roo/rules root, so it is planned against input.projectRoot (falling back
+// to input.repoRoot for repoRoot-only call paths, same as every other
+// adapter here) instead of the rules-scoped targetRoot.
 module.exports = createInstallTargetAdapter({
   id: 'roocode-project',
   target: 'roocode',
@@ -44,7 +23,7 @@ module.exports = createInstallTargetAdapter({
   // root children directly instead of nesting rules/rules/.
   nativeRootRelativePath: 'rules',
   planOperations(input, adapter) {
-    const settingsPath = resolveVsCodeSettingsPath(input.projectRoot);
+    const settingsPath = resolveVsCodeSettingsPath(input.projectRoot || input.repoRoot);
     return [
       ...createDefaultScaffoldOperations(input, adapter),
       createRoocodeDenylistMergeOperation(settingsPath),

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -163,4 +163,23 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
   return { configured: true, actions, attributesFile };
 }
 
-module.exports = { FILTER_NAME, PROPAGATION_FILES, configureMemoryFilters };
+// Shared CLI-facing wrapper: runs the dry-run plan first so every caller
+// (egc init, egc install, install.sh, install.ps1) prints the same
+// transparency log before touching anything, then applies it for real.
+// Extracted so the README's "never gets committed to git" promise is kept
+// by every path that can create the repo's first commit, not only `egc
+// init` -- the gap a 2026-08-01 audit found (install.sh/install.ps1/
+// install-apply.js never called this at all, only egc init did).
+function applyCommitPrivacyFilterCli({ projectDir, scriptPath, log }) {
+  const plan = configureMemoryFilters({ projectDir, scriptPath, dryRun: true });
+  if (!plan.configured) {
+    log(`skip commit-privacy filter: ${plan.reason}`);
+    return plan;
+  }
+  for (const action of plan.actions) log(`commit-privacy filter: ${action}`);
+  const result = configureMemoryFilters({ projectDir, scriptPath, dryRun: false });
+  log(`commit-privacy filter: populated memory is stripped from staged blobs (${result.actions.length} change(s), local repo only)`);
+  return result;
+}
+
+module.exports = { FILTER_NAME, PROPAGATION_FILES, applyCommitPrivacyFilterCli, configureMemoryFilters };

--- a/scripts/lib/memory-filters.js
+++ b/scripts/lib/memory-filters.js
@@ -163,9 +163,13 @@ function configureMemoryFilters({ projectDir, scriptPath, dryRun = false }) {
   return { configured: true, actions, attributesFile };
 }
 
-// Shared CLI-facing wrapper: runs the dry-run plan first so every caller
-// (egc init, egc install, install.sh, install.ps1) prints the same
-// transparency log before touching anything, then applies it for real.
+// Shared CLI-facing wrapper: runs the dry-run plan first so a caller prints
+// the same transparency log before touching anything, then applies it for
+// real. Used by install-apply.js (both the bare `egc install` delegation
+// branch and the `egc install --target X` path) and by the inline node
+// snippets in install.sh/install.ps1. `egc init` keeps its own copy in
+// init.js's configureCommitPrivacyFilter (same configureMemoryFilters call
+// underneath, own dry-run/logging conventions) rather than this wrapper.
 // Extracted so the README's "never gets committed to git" promise is kept
 // by every path that can create the repo's first commit, not only `egc
 // init` -- the gap a 2026-08-01 audit found (install.sh/install.ps1/

--- a/scripts/lib/roocode-guardian-denylist.js
+++ b/scripts/lib/roocode-guardian-denylist.js
@@ -167,7 +167,13 @@ function addRoocodeDenylistEntries(settings) {
 function removeRoocodeDenylistEntries(settings) {
   const base = isPlainObject(settings) ? settings : {};
   const existing = Array.isArray(base[DENIED_COMMANDS_KEY]) ? base[DENIED_COMMANDS_KEY] : [];
-  const seeded = Array.isArray(base[SEEDED_BY_EGC_KEY]) ? base[SEEDED_BY_EGC_KEY] : [];
+  // Filtered to DANGEROUS_COMMANDS even though addRoocodeDenylistEntries only
+  // ever writes that same subset: SEEDED_BY_EGC_KEY lives in a workspace
+  // settings.json a repo can commit and share, so a stale or hand-edited
+  // value must never be trusted to remove an entry outside the known
+  // dangerous-commands set (cubic review, PR #1122).
+  const seeded = (Array.isArray(base[SEEDED_BY_EGC_KEY]) ? base[SEEDED_BY_EGC_KEY] : [])
+    .filter(cmd => DANGEROUS_COMMANDS.includes(cmd));
   const hadSeededKey = SEEDED_BY_EGC_KEY in base;
   const next = existing.filter(cmd => !seeded.includes(cmd));
   if (next.length === existing.length && !hadSeededKey) {

--- a/scripts/lib/roocode-guardian-denylist.js
+++ b/scripts/lib/roocode-guardian-denylist.js
@@ -1,0 +1,153 @@
+'use strict';
+
+// Roo Code (RooCodeInc/Roo-Code, a VS Code extension) has no external
+// hook API: confirmed against its own docs (docs.roocode.com/features/
+// auto-approving-actions) and issue #12025 ("Run hook command on events
+// requiring prompts"), which is an open feature request, not shipped.
+// There is no way to shell out to pre-bash-guardian-validate.js the way
+// every other host here does -- so this is not a Guardian adapter, it is
+// the closest real substitute: seeding Roo Code's own native
+// `roo-cline.deniedCommands` setting (docs.roocode.com/features/
+// auto-approving-actions) with the same unconditionally-dangerous base
+// commands Guardian itself hard-blocks regardless of arguments (see
+// `DANGEROUS` in mcp/servers/egc-guardian/src/validator.ts). Context-aware
+// checks (docker --privileged, gh api -X DELETE, prisma db execute, ...)
+// cannot be replicated this way: Roo Code's list is plain command-prefix
+// matching ("longest-prefix wins" per its docs), not a script that can
+// inspect arguments. This is a real but partial mitigation, not parity.
+//
+// Settings live in the workspace's own .vscode/settings.json -- confirmed
+// via the same docs page, which documents the field directly under a VS
+// Code settings key, not a Roo Code-specific config file.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Must stay in sync with the `DANGEROUS` export in
+// mcp/servers/egc-guardian/src/validator.ts -- the source of truth for
+// which base commands Guardian hard-blocks unconditionally. Duplicated
+// here (not imported) because that file is TypeScript compiled into the
+// egc-guardian MCP server's own build, not reachable from these plain
+// Node scripts.
+const DANGEROUS_COMMANDS = ['rm', 'mv', 'dd', 'shred', 'truncate'];
+
+// Synthetic dispatch tag: Roo Code has no real "hook event" concept, but
+// this reuses claude-settings-hooks.js's operation.hookEvent-keyed dispatch
+// (the same mechanism every other host's bespoke merge function is routed
+// through) so this integration does not need its own top-level operation
+// kind or executor wiring.
+const ROOCODE_DENYLIST_TAG = 'roocode-denied-commands';
+const DENIED_COMMANDS_KEY = 'roo-cline.deniedCommands';
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readSettingsFile(settingsPath) {
+  if (!fs.existsSync(settingsPath)) {
+    return {};
+  }
+  const raw = fs.readFileSync(settingsPath, 'utf8');
+  if (!raw.trim()) {
+    return {};
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse Roo Code settings at ${settingsPath}: ${error.message}`, { cause: error });
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Invalid Roo Code settings at ${settingsPath}: expected a JSON object`);
+  }
+  return parsed;
+}
+
+function writeSettingsFile(settingsPath, settings) {
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8');
+}
+
+function resolveVsCodeSettingsPath(projectRoot) {
+  return path.join(projectRoot, '.vscode', 'settings.json');
+}
+
+// Union, never replace: a user's own deniedCommands entries (if any) are
+// always preserved. Only the DANGEROUS_COMMANDS missing from the current
+// array are appended, in stable order, so repeat installs are idempotent.
+function addRoocodeDenylistEntries(settings) {
+  const base = isPlainObject(settings) ? settings : {};
+  const existing = Array.isArray(base[DENIED_COMMANDS_KEY]) ? base[DENIED_COMMANDS_KEY] : [];
+  const missing = DANGEROUS_COMMANDS.filter(cmd => !existing.includes(cmd));
+  if (missing.length === 0) {
+    return { settings: base, changed: false };
+  }
+  return {
+    settings: { ...base, [DENIED_COMMANDS_KEY]: [...existing, ...missing] },
+    changed: true,
+  };
+}
+
+function removeRoocodeDenylistEntries(settings) {
+  const base = isPlainObject(settings) ? settings : {};
+  const existing = Array.isArray(base[DENIED_COMMANDS_KEY]) ? base[DENIED_COMMANDS_KEY] : [];
+  const next = existing.filter(cmd => !DANGEROUS_COMMANDS.includes(cmd));
+  if (next.length === existing.length) {
+    return { settings: base, changed: false };
+  }
+  const updated = { ...base };
+  if (next.length === 0) {
+    delete updated[DENIED_COMMANDS_KEY];
+  } else {
+    updated[DENIED_COMMANDS_KEY] = next;
+  }
+  return { settings: updated, changed: true };
+}
+
+function hasRoocodeDenylistEntries(settings) {
+  const base = isPlainObject(settings) ? settings : {};
+  const existing = Array.isArray(base[DENIED_COMMANDS_KEY]) ? base[DENIED_COMMANDS_KEY] : [];
+  return DANGEROUS_COMMANDS.every(cmd => existing.includes(cmd));
+}
+
+function applyRoocodeDenylistToFile(settingsPath) {
+  const current = readSettingsFile(settingsPath);
+  const { settings, changed } = addRoocodeDenylistEntries(current);
+  if (changed) {
+    writeSettingsFile(settingsPath, settings);
+  }
+  return { changed };
+}
+
+function removeRoocodeDenylistFromFile(settingsPath) {
+  if (!fs.existsSync(settingsPath)) {
+    return { changed: false };
+  }
+  const current = readSettingsFile(settingsPath);
+  const { settings, changed } = removeRoocodeDenylistEntries(current);
+  if (changed) {
+    writeSettingsFile(settingsPath, settings);
+  }
+  return { changed };
+}
+
+function inspectRoocodeDenylistFile(settingsPath) {
+  try {
+    return hasRoocodeDenylistEntries(readSettingsFile(settingsPath)) ? 'ok' : 'drifted';
+  } catch {
+    return 'drifted';
+  }
+}
+
+module.exports = {
+  DANGEROUS_COMMANDS,
+  DENIED_COMMANDS_KEY,
+  ROOCODE_DENYLIST_TAG,
+  addRoocodeDenylistEntries,
+  applyRoocodeDenylistToFile,
+  hasRoocodeDenylistEntries,
+  inspectRoocodeDenylistFile,
+  removeRoocodeDenylistEntries,
+  removeRoocodeDenylistFromFile,
+  resolveVsCodeSettingsPath,
+};

--- a/scripts/lib/roocode-guardian-denylist.js
+++ b/scripts/lib/roocode-guardian-denylist.js
@@ -39,8 +39,54 @@ const DANGEROUS_COMMANDS = ['rm', 'mv', 'dd', 'shred', 'truncate'];
 const ROOCODE_DENYLIST_TAG = 'roocode-denied-commands';
 const DENIED_COMMANDS_KEY = 'roo-cline.deniedCommands';
 
+// deniedCommands is a plain string[] with no per-entry ownership marker, so
+// without this record uninstall cannot tell "EGC added rm" apart from "the
+// user already denied rm before EGC ever ran" -- and would delete the
+// user's own pre-existing entry on uninstall (real finding from cubic
+// review, PR #1122). Recorded under its own EGC-namespaced key in the same
+// settings.json, so no new install-state schema or separate state file is
+// needed; VS Code ignores settings keys it does not recognize.
+const SEEDED_BY_EGC_KEY = 'egc.roocodeGuardianDenylistSeeded';
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+// .vscode/settings.json is JSONC, not plain JSON: VS Code itself accepts
+// `//` and `/* */` comments and trailing commas there, and users routinely
+// have them in a hand-edited workspace settings file. Strict JSON.parse
+// would throw on any of that, taking down install/repair/uninstall for a
+// realistic file. Strip comments and trailing commas first (string-aware,
+// so `"a // not a comment"` survives intact), matching JSONC's actual
+// grammar without pulling in a parser dependency for this one call site.
+function stripJsonComments(text) {
+  let out = '';
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (inLineComment) {
+      if (ch === '\n') { inLineComment = false; out += ch; }
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') { inBlockComment = false; i++; }
+      continue;
+    }
+    if (inString) {
+      out += ch;
+      if (ch === '\\') { out += next; i++; continue; }
+      if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') { inString = true; out += ch; continue; }
+    if (ch === '/' && next === '/') { inLineComment = true; i++; continue; }
+    if (ch === '/' && next === '*') { inBlockComment = true; i++; continue; }
+    out += ch;
+  }
+  return out.replace(/,(\s*[}\]])/g, '$1');
 }
 
 function readSettingsFile(settingsPath) {
@@ -53,7 +99,7 @@ function readSettingsFile(settingsPath) {
   }
   let parsed;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(stripJsonComments(raw));
   } catch (error) {
     throw new Error(`Failed to parse Roo Code settings at ${settingsPath}: ${error.message}`, { cause: error });
   }
@@ -75,24 +121,42 @@ function resolveVsCodeSettingsPath(projectRoot) {
 // Union, never replace: a user's own deniedCommands entries (if any) are
 // always preserved. Only the DANGEROUS_COMMANDS missing from the current
 // array are appended, in stable order, so repeat installs are idempotent.
+// Every command actually added this way (never one that was already
+// present) is recorded under SEEDED_BY_EGC_KEY so uninstall can undo
+// exactly what EGC put there, nothing the user already had.
 function addRoocodeDenylistEntries(settings) {
   const base = isPlainObject(settings) ? settings : {};
   const existing = Array.isArray(base[DENIED_COMMANDS_KEY]) ? base[DENIED_COMMANDS_KEY] : [];
   const missing = DANGEROUS_COMMANDS.filter(cmd => !existing.includes(cmd));
-  if (missing.length === 0) {
+  const alreadySeeded = Array.isArray(base[SEEDED_BY_EGC_KEY]) ? base[SEEDED_BY_EGC_KEY] : [];
+  const nextSeeded = [...new Set([...alreadySeeded, ...missing])];
+  if (missing.length === 0 && nextSeeded.length === alreadySeeded.length) {
     return { settings: base, changed: false };
   }
   return {
-    settings: { ...base, [DENIED_COMMANDS_KEY]: [...existing, ...missing] },
+    settings: {
+      ...base,
+      [DENIED_COMMANDS_KEY]: [...existing, ...missing],
+      [SEEDED_BY_EGC_KEY]: nextSeeded,
+    },
     changed: true,
   };
 }
 
+// Removes only the entries SEEDED_BY_EGC_KEY says EGC itself added, never a
+// command the user already denied before EGC touched this file (even if it
+// happens to also be in DANGEROUS_COMMANDS). A file with dangerous commands
+// present but no seeded record at all -- e.g. hand-written, or predating
+// this fix -- is left untouched: without provenance there is no safe way to
+// tell what EGC would have added, so the conservative default is to remove
+// nothing rather than guess.
 function removeRoocodeDenylistEntries(settings) {
   const base = isPlainObject(settings) ? settings : {};
   const existing = Array.isArray(base[DENIED_COMMANDS_KEY]) ? base[DENIED_COMMANDS_KEY] : [];
-  const next = existing.filter(cmd => !DANGEROUS_COMMANDS.includes(cmd));
-  if (next.length === existing.length) {
+  const seeded = Array.isArray(base[SEEDED_BY_EGC_KEY]) ? base[SEEDED_BY_EGC_KEY] : [];
+  const hadSeededKey = SEEDED_BY_EGC_KEY in base;
+  const next = existing.filter(cmd => !seeded.includes(cmd));
+  if (next.length === existing.length && !hadSeededKey) {
     return { settings: base, changed: false };
   }
   const updated = { ...base };
@@ -101,6 +165,7 @@ function removeRoocodeDenylistEntries(settings) {
   } else {
     updated[DENIED_COMMANDS_KEY] = next;
   }
+  delete updated[SEEDED_BY_EGC_KEY];
   return { settings: updated, changed: true };
 }
 
@@ -143,6 +208,7 @@ module.exports = {
   DANGEROUS_COMMANDS,
   DENIED_COMMANDS_KEY,
   ROOCODE_DENYLIST_TAG,
+  SEEDED_BY_EGC_KEY,
   addRoocodeDenylistEntries,
   applyRoocodeDenylistToFile,
   hasRoocodeDenylistEntries,

--- a/scripts/lib/roocode-guardian-denylist.js
+++ b/scripts/lib/roocode-guardian-denylist.js
@@ -86,7 +86,13 @@ function stripJsonComments(text) {
     if (ch === '/' && next === '*') { inBlockComment = true; i++; continue; }
     out += ch;
   }
-  return out.replace(/,(\s*[}\]])/g, '$1');
+  // String-aware: a string value containing a literal ",]" or ",}" (e.g. a
+  // user's note field quoting JSON syntax) must not be mistaken for an
+  // actual trailing comma. Alternates between skipping whole string
+  // literals untouched and collapsing a real trailing comma.
+  return out.replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (match, trailing) => (
+    trailing === undefined ? match : trailing
+  ));
 }
 
 function readSettingsFile(settingsPath) {
@@ -109,6 +115,14 @@ function readSettingsFile(settingsPath) {
   return parsed;
 }
 
+// Known, accepted trade-off (cubic review, PR #1122): re-serializing with
+// JSON.stringify drops comments and original formatting. This already held
+// for any plain (uncommented) settings.json before the JSONC-tolerant read
+// above existed. What changed is that a *commented* file now also gets
+// this same reformat on write instead of the whole operation throwing and
+// leaving the file untouched -- accepted rather than building a full
+// comment-preserving JSONC editor for this one narrow denylist-seeding
+// call site.
 function writeSettingsFile(settingsPath, settings) {
   fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
   fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8');

--- a/tests/hooks/pre-bash-crusher-rewrite.test.js
+++ b/tests/hooks/pre-bash-crusher-rewrite.test.js
@@ -114,7 +114,7 @@ if (POSIX) {
   });
 
   runCase('escaping survives embedded single quotes, pipes and double quotes', () => {
-    const original = 'gh pr view 950 --json x --jq \'.x[] | select(.name=="a")\'';
+    const original = 'gh pr view 950 --json x --jq \'.x[] | select(.name=="a")\' | cat';
     const rewritten = invoke(original);
     assert.strictEqual(bashSees(rewritten), original);
   });
@@ -132,6 +132,50 @@ if (POSIX) {
   runCase('pipelines fail open on Windows (POSIX escaping only)', () => {
     assert.strictEqual(invoke('git log | head -5'), 'git log | head -5');
     assert.strictEqual(invoke('git log && git status'), 'git log && git status');
+  });
+}
+
+// --- EGC-512: shell metacharacters inside quotes must not force the --shell
+// wrap; only *active* (unquoted, unescaped) syntax should.
+
+runCase('a metacharacter inside single quotes stays a simple egc run', () => {
+  assert.strictEqual(
+    invoke("git log --grep='fix: a & b'"),
+    "egc run git log --grep='fix: a & b'",
+  );
+});
+
+runCase('pipe/semicolon/redirect inside double quotes stay a simple egc run', () => {
+  assert.strictEqual(
+    invoke('git log --grep="fix: a | b; c > d"'),
+    'egc run git log --grep="fix: a | b; c > d"',
+  );
+});
+
+runCase('a backslash-escaped metacharacter outside quotes stays a simple egc run', () => {
+  assert.strictEqual(invoke('git log --grep=foo\\&bar'), 'egc run git log --grep=foo\\&bar');
+});
+
+if (POSIX) {
+  runCase('an active $ inside double quotes still routes through --shell', () => {
+    const original = 'git log --grep="fix: $(true)"';
+    const rewritten = invoke(original);
+    assert.ok(rewritten.startsWith("egc run --shell '"), rewritten);
+    assert.strictEqual(bashSees(rewritten), original);
+  });
+
+  runCase('a backtick inside double quotes still routes through --shell', () => {
+    const original = 'git log --grep="fix: `date +%Y`"';
+    const rewritten = invoke(original);
+    assert.ok(rewritten.startsWith("egc run --shell '"), rewritten);
+    assert.strictEqual(bashSees(rewritten), original);
+  });
+
+  runCase('an unterminated quote falls back to the safer --shell path', () => {
+    const original = "git log --grep='unterminated";
+    const rewritten = invoke(original);
+    assert.ok(rewritten.startsWith("egc run --shell '"), rewritten);
+    assert.strictEqual(bashSees(rewritten), original);
   });
 }
 

--- a/tests/lib/roocode-guardian-denylist.test.js
+++ b/tests/lib/roocode-guardian-denylist.test.js
@@ -17,6 +17,7 @@ const path = require('path');
 const {
   DANGEROUS_COMMANDS,
   DENIED_COMMANDS_KEY,
+  SEEDED_BY_EGC_KEY,
   addRoocodeDenylistEntries,
   applyRoocodeDenylistToFile,
   hasRoocodeDenylistEntries,
@@ -92,15 +93,16 @@ function runTests() {
     );
   })) passed++; else failed++;
 
-  if (test('removeRoocodeDenylistEntries strips only the EGC-managed entries, preserving the user\'s own', () => {
-    const base = { [DENIED_COMMANDS_KEY]: [...DANGEROUS_COMMANDS, 'sudo'] };
-    const { settings, changed } = removeRoocodeDenylistEntries(base);
+  if (test('removeRoocodeDenylistEntries strips only the EGC-seeded entries, preserving the user\'s own', () => {
+    const applied = addRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: ['sudo'] });
+    const { settings, changed } = removeRoocodeDenylistEntries(applied.settings);
     assert.strictEqual(changed, true);
     assert.deepStrictEqual(settings[DENIED_COMMANDS_KEY], ['sudo']);
   })) passed++; else failed++;
 
   if (test('removeRoocodeDenylistEntries deletes the key entirely when nothing is left', () => {
-    const { settings, changed } = removeRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: DANGEROUS_COMMANDS });
+    const applied = addRoocodeDenylistEntries({});
+    const { settings, changed } = removeRoocodeDenylistEntries(applied.settings);
     assert.strictEqual(changed, true);
     assert.ok(!(DENIED_COMMANDS_KEY in settings));
   })) passed++; else failed++;
@@ -108,6 +110,37 @@ function runTests() {
   if (test('removeRoocodeDenylistEntries reports no change when nothing EGC-managed is present', () => {
     const { changed } = removeRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: ['sudo'] });
     assert.strictEqual(changed, false);
+  })) passed++; else failed++;
+
+  if (test('removeRoocodeDenylistEntries never removes a dangerous command the user denied before EGC ever ran', () => {
+    // No SEEDED_BY_EGC_KEY at all: simulates a file EGC never actually added
+    // anything to (every DANGEROUS_COMMANDS entry already present from a
+    // hand-written config, or a file that predates this provenance fix).
+    // Without a record of what EGC put there, removal must be a no-op --
+    // this is the exact bug cubic flagged on PR #1122: unconditionally
+    // stripping DANGEROUS_COMMANDS matches used to delete the user's own
+    // pre-existing 'rm' entry too.
+    const base = { [DENIED_COMMANDS_KEY]: [...DANGEROUS_COMMANDS, 'sudo'] };
+    const { settings, changed } = removeRoocodeDenylistEntries(base);
+    assert.strictEqual(changed, false);
+    assert.deepStrictEqual(settings[DENIED_COMMANDS_KEY], [...DANGEROUS_COMMANDS, 'sudo']);
+  })) passed++; else failed++;
+
+  if (test('addRoocodeDenylistEntries does not mark a pre-existing dangerous command as EGC-seeded', () => {
+    const { settings } = addRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: ['rm'] });
+    assert.ok(!settings[SEEDED_BY_EGC_KEY].includes('rm'), 'rm pre-dated EGC and must not be recorded as seeded by it');
+    for (const cmd of DANGEROUS_COMMANDS.filter(c => c !== 'rm')) {
+      assert.ok(settings[SEEDED_BY_EGC_KEY].includes(cmd));
+    }
+  })) passed++; else failed++;
+
+  if (test('install then uninstall preserves a dangerous command the user denied before EGC ever ran', () => {
+    const installed = addRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: ['rm'] });
+    const { settings } = removeRoocodeDenylistEntries(installed.settings);
+    assert.ok(settings[DENIED_COMMANDS_KEY].includes('rm'), 'user\'s own pre-existing rm entry must survive uninstall');
+    for (const cmd of DANGEROUS_COMMANDS.filter(c => c !== 'rm')) {
+      assert.ok(!settings[DENIED_COMMANDS_KEY].includes(cmd), `${cmd} was seeded by EGC and must be removed on uninstall`);
+    }
   })) passed++; else failed++;
 
   if (test('applyRoocodeDenylistToFile writes a fresh settings.json and is idempotent on disk', () => {

--- a/tests/lib/roocode-guardian-denylist.test.js
+++ b/tests/lib/roocode-guardian-denylist.test.js
@@ -1,0 +1,211 @@
+/**
+ * Tests for scripts/lib/roocode-guardian-denylist.js
+ *
+ * Roo Code has no external hook API (confirmed against docs.roocode.com's
+ * own auto-approving-actions page and issue #12025, an open feature request
+ * for exactly this), so unlike every other host wired here this seeds Roo
+ * Code's own native roo-cline.deniedCommands setting in .vscode/settings.json
+ * instead of installing a Guardian adapter script. The merge must be a union
+ * (never replace), so a user's own deniedCommands entries always survive.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  DANGEROUS_COMMANDS,
+  DENIED_COMMANDS_KEY,
+  addRoocodeDenylistEntries,
+  applyRoocodeDenylistToFile,
+  hasRoocodeDenylistEntries,
+  inspectRoocodeDenylistFile,
+  removeRoocodeDenylistEntries,
+  removeRoocodeDenylistFromFile,
+  resolveVsCodeSettingsPath,
+} = require('../../scripts/lib/roocode-guardian-denylist');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing roocode-guardian-denylist ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('resolveVsCodeSettingsPath resolves under <projectRoot>/.vscode/settings.json', () => {
+    assert.strictEqual(
+      resolveVsCodeSettingsPath('/home/user/project'),
+      path.join('/home/user/project', '.vscode', 'settings.json')
+    );
+  })) passed++; else failed++;
+
+  if (test('addRoocodeDenylistEntries seeds every DANGEROUS_COMMANDS entry on an empty settings object', () => {
+    const { settings, changed } = addRoocodeDenylistEntries({});
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings[DENIED_COMMANDS_KEY], DANGEROUS_COMMANDS);
+  })) passed++; else failed++;
+
+  if (test('addRoocodeDenylistEntries is a union: a user\'s own entries are preserved, not replaced', () => {
+    const base = { [DENIED_COMMANDS_KEY]: ['sudo', 'chmod 777'] };
+    const { settings, changed } = addRoocodeDenylistEntries(base);
+    assert.strictEqual(changed, true);
+    assert.ok(settings[DENIED_COMMANDS_KEY].includes('sudo'));
+    assert.ok(settings[DENIED_COMMANDS_KEY].includes('chmod 777'));
+    for (const cmd of DANGEROUS_COMMANDS) {
+      assert.ok(settings[DENIED_COMMANDS_KEY].includes(cmd));
+    }
+  })) passed++; else failed++;
+
+  if (test('addRoocodeDenylistEntries preserves unrelated settings keys', () => {
+    const base = { 'editor.fontSize': 14, [DENIED_COMMANDS_KEY]: [] };
+    const { settings } = addRoocodeDenylistEntries(base);
+    assert.strictEqual(settings['editor.fontSize'], 14);
+  })) passed++; else failed++;
+
+  if (test('addRoocodeDenylistEntries is idempotent: no change when every entry is already present', () => {
+    const first = addRoocodeDenylistEntries({});
+    const second = addRoocodeDenylistEntries(first.settings);
+    assert.strictEqual(second.changed, false);
+    assert.deepStrictEqual(second.settings[DENIED_COMMANDS_KEY], DANGEROUS_COMMANDS);
+  })) passed++; else failed++;
+
+  if (test('hasRoocodeDenylistEntries is true only when every DANGEROUS_COMMANDS entry is present', () => {
+    assert.strictEqual(hasRoocodeDenylistEntries({}), false);
+    assert.strictEqual(hasRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: ['rm'] }), false);
+    assert.strictEqual(hasRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: DANGEROUS_COMMANDS }), true);
+    assert.strictEqual(
+      hasRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: [...DANGEROUS_COMMANDS, 'sudo'] }),
+      true,
+      'extra user entries alongside the full set must still count as present'
+    );
+  })) passed++; else failed++;
+
+  if (test('removeRoocodeDenylistEntries strips only the EGC-managed entries, preserving the user\'s own', () => {
+    const base = { [DENIED_COMMANDS_KEY]: [...DANGEROUS_COMMANDS, 'sudo'] };
+    const { settings, changed } = removeRoocodeDenylistEntries(base);
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(settings[DENIED_COMMANDS_KEY], ['sudo']);
+  })) passed++; else failed++;
+
+  if (test('removeRoocodeDenylistEntries deletes the key entirely when nothing is left', () => {
+    const { settings, changed } = removeRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: DANGEROUS_COMMANDS });
+    assert.strictEqual(changed, true);
+    assert.ok(!(DENIED_COMMANDS_KEY in settings));
+  })) passed++; else failed++;
+
+  if (test('removeRoocodeDenylistEntries reports no change when nothing EGC-managed is present', () => {
+    const { changed } = removeRoocodeDenylistEntries({ [DENIED_COMMANDS_KEY]: ['sudo'] });
+    assert.strictEqual(changed, false);
+  })) passed++; else failed++;
+
+  if (test('applyRoocodeDenylistToFile writes a fresh settings.json and is idempotent on disk', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'roocode-denylist-apply-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    try {
+      const first = applyRoocodeDenylistToFile(settingsPath);
+      assert.strictEqual(first.changed, true);
+
+      const onDisk = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      assert.deepStrictEqual(onDisk[DENIED_COMMANDS_KEY], DANGEROUS_COMMANDS);
+
+      const second = applyRoocodeDenylistToFile(settingsPath);
+      assert.strictEqual(second.changed, false, 'must not rewrite the file when already applied');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('applyRoocodeDenylistToFile preserves a hand-written settings.json, including the user\'s own denylist', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'roocode-denylist-preserve-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    try {
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        'editor.fontSize': 14,
+        [DENIED_COMMANDS_KEY]: ['sudo'],
+      }, null, 2));
+
+      applyRoocodeDenylistToFile(settingsPath);
+
+      const onDisk = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      assert.strictEqual(onDisk['editor.fontSize'], 14);
+      assert.ok(onDisk[DENIED_COMMANDS_KEY].includes('sudo'));
+      for (const cmd of DANGEROUS_COMMANDS) {
+        assert.ok(onDisk[DENIED_COMMANDS_KEY].includes(cmd));
+      }
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('removeRoocodeDenylistFromFile on a missing file is a no-op', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'roocode-denylist-remove-missing-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    try {
+      const result = removeRoocodeDenylistFromFile(settingsPath);
+      assert.strictEqual(result.changed, false);
+      assert.strictEqual(fs.existsSync(settingsPath), false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('apply then remove round-trips: the user\'s own entry survives, EGC entries are gone', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'roocode-denylist-roundtrip-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    try {
+      fs.writeFileSync(settingsPath, JSON.stringify({ [DENIED_COMMANDS_KEY]: ['sudo'] }, null, 2));
+      applyRoocodeDenylistToFile(settingsPath);
+      removeRoocodeDenylistFromFile(settingsPath);
+
+      const onDisk = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      assert.deepStrictEqual(onDisk[DENIED_COMMANDS_KEY], ['sudo']);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectRoocodeDenylistFile reports missing/drifted/ok correctly', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'roocode-denylist-inspect-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    try {
+      assert.strictEqual(inspectRoocodeDenylistFile(settingsPath), 'drifted');
+
+      fs.writeFileSync(settingsPath, JSON.stringify({ [DENIED_COMMANDS_KEY]: ['rm'] }, null, 2));
+      assert.strictEqual(inspectRoocodeDenylistFile(settingsPath), 'drifted');
+
+      applyRoocodeDenylistToFile(settingsPath);
+      assert.strictEqual(inspectRoocodeDenylistFile(settingsPath), 'ok');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('inspectRoocodeDenylistFile reports drifted instead of throwing on invalid JSON', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'roocode-denylist-invalid-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    try {
+      fs.writeFileSync(settingsPath, '{ not valid json');
+      assert.strictEqual(inspectRoocodeDenylistFile(settingsPath), 'drifted');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  return failed === 0;
+}
+
+const ok = runTests();
+process.exit(ok ? 0 : 1);

--- a/tests/lib/roocode-guardian-denylist.test.js
+++ b/tests/lib/roocode-guardian-denylist.test.js
@@ -112,6 +112,20 @@ function runTests() {
     assert.strictEqual(changed, false);
   })) passed++; else failed++;
 
+  if (test('removeRoocodeDenylistEntries ignores a tampered SEEDED_BY_EGC_KEY entry outside DANGEROUS_COMMANDS', () => {
+    // settings.json is a workspace file a repo can commit and share -- a
+    // stale or hand-edited SEEDED_BY_EGC_KEY must never be trusted to
+    // remove a user's own deny rule just because it is listed there
+    // (cubic review, PR #1122).
+    const base = {
+      [DENIED_COMMANDS_KEY]: ['rm', 'sudo'],
+      [SEEDED_BY_EGC_KEY]: ['rm', 'sudo'],
+    };
+    const { settings } = removeRoocodeDenylistEntries(base);
+    assert.ok(settings[DENIED_COMMANDS_KEY].includes('sudo'), 'sudo is not a DANGEROUS_COMMANDS entry and must survive even if falsely listed as seeded');
+    assert.ok(!settings[DENIED_COMMANDS_KEY].includes('rm'));
+  })) passed++; else failed++;
+
   if (test('removeRoocodeDenylistEntries never removes a dangerous command the user denied before EGC ever ran', () => {
     // No SEEDED_BY_EGC_KEY at all: simulates a file EGC never actually added
     // anything to (every DANGEROUS_COMMANDS entry already present from a


### PR DESCRIPTION
## Summary

Follow-up to the 2026-08-01 README-vs-code audit.

- **EGC-512**: `hasComplexShellSyntax` replaces the naive `COMPLEX_SHELL_RE` regex in `pre-bash-crusher-rewrite.js` with a quote-aware scanner. Metacharacters inside single or double quotes no longer force the `--shell` wrap unless they are actually active (unquoted, unescaped, or an active `$`/backtick inside double quotes).
- **Roo Code**: no external hook API (confirmed against docs.roocode.com and issue #12025, an open feature request), so this seeds Roo Code's own native `roo-cline.deniedCommands` setting in `.vscode/settings.json` instead of a Guardian adapter. Union merge, never replace, so a user's own denylist entries always survive.
- **Docs correction**: the README claimed Guardian "detects prompt injection", which `SECURITY-ASSESSMENT.md` itself already contradicts. Also corrected `SECURITY-ASSESSMENT.md`'s known-limitations note, which still listed Goose, OpenHands, Amazon Q, Roo Code and Qwen Code as having zero command enforcement, stale since PR #1092 and PR #1080 already wired real Guardian hooks into four of those five. Only Roo Code still gets a partial (native-denylist) mitigation.

## Test plan

- [x] `node tests/lib/roocode-guardian-denylist.test.js` -- 15/15 passing
- [x] `node tests/hooks/pre-bash-crusher-rewrite.test.js` -- 23/23 passing
- [x] Confirmed via `git merge-base --is-ancestor` that the Amazon Q/Goose/OpenHands and Qwen Code Guardian PRs are already on `origin/main`, so the docs fix reflects real, already-shipped coverage, not a new claim.
- [ ] Full `tests/run-all.js` regression left to CI (deliberately not run locally this session).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote-aware Crusher parsing now mirrors POSIX quoting across platforms, reducing unnecessary `--shell` wraps and preserving command semantics (EGC-512). Adds a native Roo Code denylist and ensures the commit-privacy filter runs across all install paths to keep memory out of git, with correct cwd on bare installs and no duplicate runs; also fixes stale Guardian coverage notes.

- **Bug Fixes**
  - `pre-bash-crusher-rewrite.js`: uniform POSIX-quote-aware `hasComplexShellSyntax`; handles `$`/backticks in double quotes, escapes, and unterminated quotes; removed a Windows-only branch that broke tests.
  - Roo Code denylist: JSONC parsing is string-aware for comments and trailing commas; uninstall removes only EGC-seeded entries (tracked under `egc.roocodeGuardianDenylistSeeded` and filtered to the known dangerous set); adapter falls back to `repoRoot` when `projectRoot` is absent.
  - Install: apply commit-privacy filter in `install.sh`, `install.ps1`, and `scripts/install-apply.js`; for bare `egc install`, run it before delegating so the real cwd is used; `install.sh` skips its copy when delegating to avoid double setup; extracted a shared `applyCommitPrivacyFilterCli` wrapper.
  - Tests: added cases for quoted metacharacters, string-aware JSONC parsing, and denylist provenance/idempotence.

- **Refactors**
  - Extracted `createDefaultScaffoldOperations` to `scripts/lib/install-targets/helpers.js` and removed duplicates from Amazon Q and Roo Code adapters.

<sup>Written for commit b5cf40025b02c5bf66cd326a1ee3107f95dcb5c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

