### PR TITLE
fix(guardian,memory): wire ESLint TypeScript coverage, fix 17 real findings (EGC-538)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
         run: npm ci
 
       - name: Run ESLint
-        run: npx eslint "scripts/**/*.js" "tests/**/*.js"
+        run: npx eslint "scripts/**/*.js" "tests/**/*.js" "mcp/servers/*/src/**/*.ts"
 
       - name: Run markdownlint
         run: npx markdownlint --config .github/.markdownlint.json "agents/**/*.md" "skills/**/*.md" "commands/**/*.md" "rules/**/*.md"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 const js = require('@eslint/js');
 const globals = require('globals');
+const tseslint = require('typescript-eslint');
 
 module.exports = [
     {
@@ -37,6 +38,34 @@ module.exports = [
         files: ['**/*.mjs'],
         languageOptions: {
             sourceType: 'module'
+        }
+    },
+    // mcp/servers/**/*.ts had zero ESLint coverage: no TS parser was
+    // configured anywhere in the tree, and this file's default file
+    // matching never selects .ts (engineering audit, EGC-538).
+    ...tseslint.configs.recommended.map(config => ({
+        ...config,
+        files: ['mcp/servers/*/src/**/*.ts']
+    })),
+    {
+        files: ['mcp/servers/*/src/**/*.ts'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: {
+                ...globals.node,
+                ...globals.es2022
+            }
+        },
+        rules: {
+            'no-unused-vars': 'off',
+            '@typescript-eslint/no-unused-vars': ['error', {
+                argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
+                caughtErrorsIgnorePattern: '^_'
+            }],
+            'eqeqeq': 'warn',
+            'complexity': ['warn', { max: 20 }]
         }
     }
 ];

--- a/mcp/servers/egc-guardian/src/guardian-cli.ts
+++ b/mcp/servers/egc-guardian/src/guardian-cli.ts
@@ -45,7 +45,7 @@ async function route(payload: string): Promise<unknown> {
 }
 
 async function mine(payload: string): Promise<unknown> {
-  let jsonl = '';
+  let jsonl: string;
   try {
     jsonl = fs.readFileSync(payload, 'utf8'); // NOSONAR tssecurity:S8707
   } catch {

--- a/mcp/servers/egc-guardian/src/prompt-injection-scanner.ts
+++ b/mcp/servers/egc-guardian/src/prompt-injection-scanner.ts
@@ -42,9 +42,13 @@ const PATTERNS: Array<{ category: string; pattern: RegExp; reason: string }> = [
   { category: 'hidden_comment_directive', pattern: /<!--\s*(ignore|system|instructions?)[\s\S]{0,200}-->/i, reason: 'directive hidden inside an HTML comment' },
 ];
 
+// These are 4 deliberately distinct zero-width codepoints (ZWSP/ZWNJ/ZWJ/BOM),
+// not an accidental combining sequence; the rule can't tell the two apart.
 const ZERO_WIDTH_CHARS = '\u200B\u200C\u200D\uFEFF';
+// eslint-disable-next-line no-misleading-character-class
 const ZERO_WIDTH_RE = new RegExp(`[${ZERO_WIDTH_CHARS}]`);
 const ZERO_WIDTH_NEAR_KEYWORD_RE = new RegExp(
+  // eslint-disable-next-line no-misleading-character-class
   String.raw`[${ZERO_WIDTH_CHARS}][\s\S]{0,40}(?:ignore|system|instructions?)|(?:ignore|system|instructions?)[\s\S]{0,40}[${ZERO_WIDTH_CHARS}]`,
   'i',
 );

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -702,7 +702,22 @@ export function buildDeniedPaths(): string[] {
     );
   }
 
-  return paths.filter(Boolean);
+  // isProtectedPath() resolves the incoming path through fs.realpathSync()
+  // before comparing it against this list, so an entry that is itself a
+  // symlink must be resolved here too, or the comparison never matches.
+  // Concretely: on macOS /etc is a symlink to /private/etc, so a write to
+  // /etc/hosts or /etc/shadow resolves to /private/etc/hosts, which never
+  // starts with the literal '/etc' string below, silently defeating this
+  // protection on macOS only (audit EGC-538 sub-part 1, caught by CI).
+  const resolved = paths.map(p => {
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return p;
+    }
+  });
+
+  return [...new Set([...paths, ...resolved])].filter(Boolean);
 }
 
 export const DENIED_PATHS: string[] = buildDeniedPaths();

--- a/mcp/servers/egc-memory/src/compress.ts
+++ b/mcp/servers/egc-memory/src/compress.ts
@@ -190,7 +190,7 @@ async function loadRawObservationsFromStateDb(
       .map((row: EventRow) => {
         const payload = JSON.parse(row.payload);
         return {
-          id: row.id,
+          id: String(row.id),
           tool: payload.tool,
           output: payload.output ?? payload.result ?? "",
           content: payload.input ?? payload.output ?? payload.result ?? "",

--- a/mcp/servers/egc-memory/src/compress.ts
+++ b/mcp/servers/egc-memory/src/compress.ts
@@ -13,6 +13,14 @@ import { open } from "sqlite";
 
 export type ObservationType = "tool_failure" | "tool_success" | "file_edit" | "generic";
 
+// Minimal shape of a row from the `events` table, matching the SELECT/UPDATE
+// queries in this file -- the `sqlite` package's own types are loose (any[]).
+interface EventRow {
+  id: number;
+  payload: string;
+  timestamp: string;
+}
+
 export interface RawObservation {
   id?: string;
   tool?: string;
@@ -168,10 +176,10 @@ async function loadRawObservationsFromStateDb(
       LIMIT ?
     `;
 
-    const rows = await db.all(query, [projectRoot, sinceFilter, sinceFilter, limit]);
+    const rows: EventRow[] = await db.all(query, [projectRoot, sinceFilter, sinceFilter, limit]);
 
     return rows
-      .filter((row: any) => {
+      .filter((row: EventRow) => {
         try {
           const p = JSON.parse(row.payload);
           return p !== null && typeof p === "object" && (p.tool || p.output || p.result || p.input);
@@ -179,7 +187,7 @@ async function loadRawObservationsFromStateDb(
           return false;
         }
       })
-      .map((row: any) => {
+      .map((row: EventRow) => {
         const payload = JSON.parse(row.payload);
         return {
           id: row.id,
@@ -289,7 +297,7 @@ export async function replaceObservation(projectPath: string, id: string, compre
         [compressed.compressed_at, id]
       );
 
-      if ((result as any)?.changes > 0) {
+      if (((result as { changes?: number } | undefined)?.changes ?? 0) > 0) {
         return;
       }
     } finally {

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -102,7 +102,7 @@ export function loadOrCreateEncKey(keyPath: string = defaultEncKeyPath()): Buffe
       if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
         return readExistingKey();
       }
-      throw new Error(`[EGC encryption] Failed to persist encryption key to ${keyPath}: ${String(e)}. Remove the file or fix permissions and restart.`);
+      throw new Error(`[EGC encryption] Failed to persist encryption key to ${keyPath}: ${String(e)}. Remove the file or fix permissions and restart.`, { cause: e });
     }
   } finally {
     try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -248,7 +248,7 @@ async function acquireMigrationLock(lockFile: string): Promise<void> {
     try {
       fs.writeFileSync(lockFile, process.pid.toString(), { flag: 'wx' });
       locked = true;
-    } catch (e) { // NOSONAR: lock contention is handled by the retry loop below
+    } catch { // NOSONAR: lock contention is handled by the retry loop below
       retries--;
       await new Promise(r => setTimeout(r, 100));
     }
@@ -806,10 +806,6 @@ const TeamInitSchema = z.object({
   remote: z.string().min(1),
   branch: z.string().min(1).default('main')
 });
-
-const TeamSyncSchema = z.object({});
-
-const TeamStatusSchema = z.object({});
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -50,7 +50,8 @@ export function loadOrCreateKey(): Buffer {
       hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
     } catch (readErr: unknown) {
       throw new Error(
-        `HMAC key file at ${KEY_PATH} exists but could not be read: ${(readErr as Error).message}`
+        `HMAC key file at ${KEY_PATH} exists but could not be read: ${(readErr as Error).message}`,
+        { cause: readErr }
       );
     }
 

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 // path below resolves identically in a real `npm install -g` layout.
 function tryRequireMemoryFilters(): typeof import('../../../../scripts/lib/memory-filters') | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require('../../../../scripts/lib/memory-filters');
   } catch {
     return null;
@@ -192,14 +192,14 @@ function writeClaudeContext(projectPath: string, block: string): string | null {
 function writeRooCodeContext(projectPath: string, block: string): string | null {
   const rooDir = path.join(projectPath, '.roo');
   const rulesDir = path.join(rooDir, 'rules');
-  let rulesDirHasContent = false;
+  let rulesDirHasContent: boolean;
   try {
     rulesDirHasContent = fs.existsSync(rulesDir) && fs.statSync(rulesDir).isDirectory() && fs.readdirSync(rulesDir).length > 0;
   } catch {
     rulesDirHasContent = false;
   }
 
-  let rooRulesExists = false;
+  let rooRulesExists: boolean;
   const rooRulesPath = path.join(projectPath, '.roorules');
   try {
     rooRulesExists = fs.existsSync(rooRulesPath);

--- a/mcp/servers/egc-memory/src/sync/GitBackend.ts
+++ b/mcp/servers/egc-memory/src/sync/GitBackend.ts
@@ -110,7 +110,7 @@ export class GitBackend extends SyncBackend {
       try {
         await this.git.push(['--set-upstream', 'origin', this.config.branch]);
       } catch (error_) {
-        throw new Error(`Push failed after setting upstream: ${String(error_)}`);
+        throw new Error(`Push failed after setting upstream: ${String(error_)}`, { cause: error_ });
       }
     }
     return true;
@@ -139,7 +139,7 @@ export class GitBackend extends SyncBackend {
       // No commits yet.
     }
 
-    let hasUncommittedChanges = false;
+    let hasUncommittedChanges: boolean;
     try {
       const gitStatus = await this.git.status();
       hasUncommittedChanges = gitStatus.files.length > 0;
@@ -147,7 +147,7 @@ export class GitBackend extends SyncBackend {
       hasUncommittedChanges = false;
     }
 
-    let conflictCount = 0;
+    let conflictCount: number;
     try {
       const gitStatus = await this.git.status();
       conflictCount = gitStatus.conflicted.length;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "@types/node": "^26.0.0",
         "eslint": "^10.0.0",
         "globals": "^17.6.0",
-        "markdownlint-cli": "^0.49.0"
+        "markdownlint-cli": "^0.49.0",
+        "typescript-eslint": "^8.65.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -850,6 +851,226 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/abbrev": {
       "version": "4.0.0",
@@ -4712,6 +4933,19 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4766,6 +5000,45 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     "@types/node": "^26.0.0",
     "eslint": "^10.0.0",
     "globals": "^17.6.0",
-    "markdownlint-cli": "^0.49.0"
+    "markdownlint-cli": "^0.49.0",
+    "typescript-eslint": "^8.65.0"
   },
   "overrides": {
     "js-yaml": "^4.2.0",

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const assert = require('assert');
+const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
@@ -18,7 +19,7 @@ const VALIDATOR_PATH = path.join(
   '../../mcp/servers/egc-guardian/build/validator.js'
 );
 
-let validateCommand, validateWrite, isProtectedPath;
+let validateCommand, validateWrite, isProtectedPath, buildDeniedPaths;
 
 try {
   // ESM build: we use dynamic import wrapped in an async IIFE then run tests
@@ -43,6 +44,7 @@ async function runTests() {
   validateCommand = mod.validateCommand;
   validateWrite = mod.validateWrite;
   isProtectedPath = mod.isProtectedPath;
+  buildDeniedPaths = mod.buildDeniedPaths;
 
   const home = os.homedir();
 
@@ -224,6 +226,34 @@ async function runTests() {
   run(`protected: ~/.aws/config`,   () => assert.strictEqual(isProtectedPath(`${home}/.aws/config`), true));
   run(`protected: ~/.gnupg/`,       () => assert.strictEqual(isProtectedPath(`${home}/.gnupg/trustdb.gpg`), true));
   run(`protected: /etc/shadow`,     () => assert.strictEqual(isProtectedPath('/etc/shadow'), true));
+  run(`buildDeniedPaths resolves a symlinked entry (macOS /etc regression, EGC-538)`, () => {
+    // isProtectedPath() resolves the incoming path via fs.realpathSync()
+    // before comparing it against DENIED_PATHS. On macOS, /etc is a symlink
+    // to /private/etc, so /etc/hosts resolves to /private/etc/hosts and
+    // silently bypassed protection until DENIED_PATHS itself was also
+    // resolved through realpath. This reproduces that shape with a real
+    // symlink instead of requiring macOS itself.
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-guardian-symlink-'));
+    const realTarget = path.join(tmpBase, 'real-ssh-target');
+    const symlinkHome = path.join(tmpBase, 'home');
+    fs.mkdirSync(realTarget, { recursive: true });
+    fs.mkdirSync(symlinkHome, { recursive: true });
+    fs.symlinkSync(realTarget, path.join(symlinkHome, '.ssh'), 'dir');
+
+    const originalHomedir = os.homedir;
+    os.homedir = () => symlinkHome;
+    try {
+      const denied = buildDeniedPaths();
+      const resolvedTarget = fs.realpathSync(realTarget);
+      assert.ok(
+        denied.includes(resolvedTarget),
+        'buildDeniedPaths must include the symlink-resolved real path, not just the lexical one'
+      );
+    } finally {
+      os.homedir = originalHomedir;
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
   run(`protected: .env`,            () => assert.strictEqual(isProtectedPath('.env'), true));
   run(`protected: secret.pem`,      () => assert.strictEqual(isProtectedPath('secret.pem'), true));
   run(`not protected: src/index.ts`,() => assert.strictEqual(isProtectedPath('src/index.ts'), false));


### PR DESCRIPTION
## Summary
Engineering audit (EGC-538, sub-part of EGC-536 after the full-repo scope stalled twice) found `mcp/servers/**/*.ts` had zero ESLint coverage: no TypeScript parser configured anywhere, and CI's lint step (`eslint "scripts/**/*.js" "tests/**/*.js"`) never touched these two MCP servers that gate command/write execution and encrypt state for the whole project.

- Adds `typescript-eslint` and a `files: ['mcp/servers/*/src/**/*.ts']` block.
- Running it surfaced **17 real, previously-invisible errors**, all fixed — see commit message for the per-file breakdown (useless assignments, missing `cause` on rethrown errors, `any` narrowed to concrete types, orphaned dead code, a stale eslint-disable comment targeting a renamed rule, and one documented false-positive suppression for an intentional 4-codepoint zero-width character class).
- 6 pre-existing complexity warnings (validator.ts, index.ts, patterns.ts) are left untouched — refactoring security-critical validation logic isn't a mechanical fix and deserves its own review, not bundled here.

## Test plan
- [x] `npx eslint mcp/servers/egc-guardian/src mcp/servers/egc-memory/src` — 0 errors (was 17), 6 pre-existing complexity warnings unchanged
- [x] `tsc --noEmit` clean on both packages
- [x] 224 real tests passing across the 6 touched test suites (`egc-guardian-bypass-hardening`, `egc-guardian-destructive-cli`, `egc-memory-encryption`, `post-webfetch-injection-scan`, `guardian-content-scanner`, `egc-memory-propagate`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TypeScript ESLint coverage for `mcp/servers/*/src/**/*.ts` to address EGC-538, fixes 17 real issues in `egc-guardian` and `egc-memory`, resolves a TypeScript build break in `egc-memory/compress.ts`, enforces coverage in CI, and closes a macOS-only path protection gap in `egc-guardian`. Complexity warnings remain unchanged for a follow-up refactor.

- **Bug Fixes**
  - Hardened error handling by adding `cause` on rethrows in encryption, integrity, and Git sync paths.
  - Tightened types and cleaned dead code: typed `EventRow` and `db.run` result; removed orphaned Zod schemas and an unused catch binding; fixed stale rule suppression; documented the intentional zero-width character class false-positive; dropped useless initial assignments.
  - Fixed `tsc` failure by converting numeric `EventRow.id` to string at the boundary to match `RawObservation.id`.
  - Fixed a macOS-only protection bypass by resolving symlinked entries in `buildDeniedPaths()`; added a regression test to prevent future regressions.

- **Dependencies**
  - Added `typescript-eslint` and configured `eslint.config.js` to lint `mcp/servers/*/src/**/*.ts`.
  - Updated CI lint step to include the new glob so TypeScript ESLint coverage is enforced.

<sup>Written for commit 194b52bd9f33a08128b3343e37ebd87ffddeac52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

