### PR TITLE
fix(guardian): resolve DENIED_PATHS entries at comparison time, not load time

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,8 @@ module.exports = [
             '.claude/**',
             'dashboard/**',
             'node_modules/**',
-            'mcp/servers/*/build/**'
+            'mcp/servers/*/build/**',
+            'fuzz/validator.cjs'
         ]
     },
     js.configs.recommended,

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -702,25 +702,31 @@ export function buildDeniedPaths(): string[] {
     );
   }
 
-  // isProtectedPath() resolves the incoming path through fs.realpathSync()
-  // before comparing it against this list, so an entry that is itself a
-  // symlink must be resolved here too, or the comparison never matches.
-  // Concretely: on macOS /etc is a symlink to /private/etc, so a write to
-  // /etc/hosts or /etc/shadow resolves to /private/etc/hosts, which never
-  // starts with the literal '/etc' string below, silently defeating this
-  // protection on macOS only (audit EGC-538 sub-part 1, caught by CI).
-  const resolved = paths.map(p => {
-    try {
-      return fs.realpathSync(p);
-    } catch {
-      return p;
-    }
-  });
-
-  return [...new Set([...paths, ...resolved])].filter(Boolean);
+  return paths.filter(Boolean);
 }
 
 export const DENIED_PATHS: string[] = buildDeniedPaths();
+
+// Shared by both the incoming path and each DENIED_PATHS entry in
+// isProtectedPath(): resolve through fs.realpathSync(), falling back to
+// resolving just the parent directory (then the lexical path unchanged) when
+// the target doesn't exist yet. A denied entry resolved once at DENIED_PATHS'
+// module-load time would go stale for a directory that becomes a symlink (or
+// whose symlink target starts existing) after the guardian process starts --
+// the same shape as the macOS /etc bug, just materializing later instead of
+// always being present (cubic review, PR #1129). Resolving both sides fresh
+// on every isProtectedPath() call removes that staleness window entirely.
+export function resolveRealOrLexical(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    try {
+      return path.join(fs.realpathSync(path.dirname(p)), path.basename(p));
+    } catch {
+      return p;
+    }
+  }
+}
 
 // baseDir defaults to process.cwd() (path.resolve's own implicit behavior
 // when given one argument) so existing callers are unaffected. Callers that
@@ -742,20 +748,14 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
     ? path.join(os.homedir(), p.slice(1))
     : p;
 
-  let normalizedP = path.resolve(baseDir, expanded);
   // Resolve symlinks so a link inside an allowed directory cannot point past
   // this check into a denied path. Fall back to the lexical path (then the
   // parent) when the target does not exist yet, e.g. a write being created.
-  try {
-    normalizedP = fs.realpathSync(normalizedP);
-  } catch {
-    try {
-      normalizedP = path.join(fs.realpathSync(path.dirname(normalizedP)), path.basename(normalizedP));
-    } catch { /* keep the lexical resolution */ }
-  }
+  const normalizedP = resolveRealOrLexical(path.resolve(baseDir, expanded));
 
   for (const denied of DENIED_PATHS) {
-    if (normalizedP === denied || normalizedP.startsWith(denied + path.sep)) {
+    const resolvedDenied = resolveRealOrLexical(denied);
+    if (normalizedP === resolvedDenied || normalizedP.startsWith(resolvedDenied + path.sep)) {
       return true;
     }
   }

--- a/mcp/servers/egc-memory/node_modules
+++ b/mcp/servers/egc-memory/node_modules
@@ -1,1 +1,0 @@
-/home/felipe/Projetos/EGC/mcp/servers/egc-memory/node_modules

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -19,7 +19,7 @@ const VALIDATOR_PATH = path.join(
   '../../mcp/servers/egc-guardian/build/validator.js'
 );
 
-let validateCommand, validateWrite, isProtectedPath, buildDeniedPaths, resolveRealOrLexical;
+let validateCommand, validateWrite, isProtectedPath, buildDeniedPaths, resolveRealOrLexical, DENIED_PATHS;
 
 try {
   // ESM build: we use dynamic import wrapped in an async IIFE then run tests
@@ -46,6 +46,7 @@ async function runTests() {
   isProtectedPath = mod.isProtectedPath;
   buildDeniedPaths = mod.buildDeniedPaths;
   resolveRealOrLexical = mod.resolveRealOrLexical;
+  DENIED_PATHS = mod.DENIED_PATHS;
 
   const home = os.homedir();
 
@@ -266,6 +267,38 @@ async function runTests() {
         'a symlink retargeted after the first check must resolve fresh, not use a stale cached target'
       );
     } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+  run(`isProtectedPath blocks a write under a symlinked DENIED_PATHS entry end-to-end (macOS /etc regression, EGC-538)`, () => {
+    // cubic review on PR #1130: the resolveRealOrLexical() unit test above
+    // proves the helper resolves symlinks correctly, but does not exercise
+    // isProtectedPath()'s own DENIED_PATHS loop, so a regression there (e.g.
+    // reverting to load-time resolution) would still pass every other test.
+    // DENIED_PATHS is a mutable array bound to a const reference (not
+    // reassigned), so temporarily appending a symlinked entry here drives the
+    // exact real-world shape -- a denied directory that is itself a symlink --
+    // through the real isProtectedPath() comparison, then removes it.
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-guardian-e2e-symlink-'));
+    const realTarget = path.join(tmpBase, 'real-denied-target');
+    const linkPath = path.join(tmpBase, 'denied-link');
+    fs.mkdirSync(realTarget, { recursive: true });
+    fs.symlinkSync(realTarget, linkPath, 'dir');
+
+    DENIED_PATHS.push(linkPath);
+    try {
+      assert.strictEqual(
+        isProtectedPath(path.join(realTarget, 'secret.txt')),
+        true,
+        'a write under the real target of a symlinked DENIED_PATHS entry must be blocked'
+      );
+      assert.strictEqual(
+        isProtectedPath(path.join(linkPath, 'secret.txt')),
+        true,
+        'a write under the symlink path itself must also be blocked'
+      );
+    } finally {
+      DENIED_PATHS.pop();
       fs.rmSync(tmpBase, { recursive: true, force: true });
     }
   });

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -19,7 +19,7 @@ const VALIDATOR_PATH = path.join(
   '../../mcp/servers/egc-guardian/build/validator.js'
 );
 
-let validateCommand, validateWrite, isProtectedPath, buildDeniedPaths;
+let validateCommand, validateWrite, isProtectedPath, buildDeniedPaths, resolveRealOrLexical;
 
 try {
   // ESM build: we use dynamic import wrapped in an async IIFE then run tests
@@ -45,6 +45,7 @@ async function runTests() {
   validateWrite = mod.validateWrite;
   isProtectedPath = mod.isProtectedPath;
   buildDeniedPaths = mod.buildDeniedPaths;
+  resolveRealOrLexical = mod.resolveRealOrLexical;
 
   const home = os.homedir();
 
@@ -226,33 +227,56 @@ async function runTests() {
   run(`protected: ~/.aws/config`,   () => assert.strictEqual(isProtectedPath(`${home}/.aws/config`), true));
   run(`protected: ~/.gnupg/`,       () => assert.strictEqual(isProtectedPath(`${home}/.gnupg/trustdb.gpg`), true));
   run(`protected: /etc/shadow`,     () => assert.strictEqual(isProtectedPath('/etc/shadow'), true));
-  run(`buildDeniedPaths resolves a symlinked entry (macOS /etc regression, EGC-538)`, () => {
-    // isProtectedPath() resolves the incoming path via fs.realpathSync()
-    // before comparing it against DENIED_PATHS. On macOS, /etc is a symlink
-    // to /private/etc, so /etc/hosts resolves to /private/etc/hosts and
-    // silently bypassed protection until DENIED_PATHS itself was also
-    // resolved through realpath. This reproduces that shape with a real
-    // symlink instead of requiring macOS itself.
+  run(`resolveRealOrLexical resolves a symlinked DENIED_PATHS-shaped entry (macOS /etc regression, EGC-538)`, () => {
+    // isProtectedPath() resolves both the incoming path and each DENIED_PATHS
+    // entry through resolveRealOrLexical() at comparison time (not once at
+    // module load). On macOS, /etc is a symlink to /private/etc, so /etc/hosts
+    // resolves to /private/etc/hosts and silently bypassed protection until
+    // the denied entry was also resolved through realpath (cubic review, PR
+    // #1129: a denied directory that becomes a symlink, or whose target
+    // starts existing, after the process already started would go stale
+    // under load-time resolution -- module-level DENIED_PATHS is itself
+    // fixed at import time, so this exercises the shared resolver directly
+    // rather than fighting that fact with an os.homedir() mock that can
+    // never reach an already-computed constant).
     const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-guardian-symlink-'));
     const realTarget = path.join(tmpBase, 'real-ssh-target');
-    const symlinkHome = path.join(tmpBase, 'home');
+    const linkPath = path.join(tmpBase, '.ssh');
     fs.mkdirSync(realTarget, { recursive: true });
-    fs.mkdirSync(symlinkHome, { recursive: true });
-    fs.symlinkSync(realTarget, path.join(symlinkHome, '.ssh'), 'dir');
+    fs.symlinkSync(realTarget, linkPath, 'dir');
 
-    const originalHomedir = os.homedir;
-    os.homedir = () => symlinkHome;
     try {
-      const denied = buildDeniedPaths();
-      const resolvedTarget = fs.realpathSync(realTarget);
-      assert.ok(
-        denied.includes(resolvedTarget),
-        'buildDeniedPaths must include the symlink-resolved real path, not just the lexical one'
+      assert.strictEqual(
+        resolveRealOrLexical(linkPath),
+        fs.realpathSync(realTarget),
+        'a symlinked denied entry must resolve to its real target'
+      );
+
+      // Retarget the same symlink after the first check above, proving
+      // resolution is not cached/stale between calls (the exact staleness
+      // cubic flagged): a second, different real directory must also
+      // resolve immediately, with no re-import or process restart needed.
+      const secondTarget = path.join(tmpBase, 'retargeted-ssh');
+      fs.mkdirSync(secondTarget, { recursive: true });
+      fs.rmSync(linkPath);
+      fs.symlinkSync(secondTarget, linkPath, 'dir');
+      assert.strictEqual(
+        resolveRealOrLexical(linkPath),
+        fs.realpathSync(secondTarget),
+        'a symlink retargeted after the first check must resolve fresh, not use a stale cached target'
       );
     } finally {
-      os.homedir = originalHomedir;
       fs.rmSync(tmpBase, { recursive: true, force: true });
     }
+  });
+  run(`isProtectedPath still catches a write under a real (non-symlinked) DENIED_PATHS entry`, () => {
+    // Sanity check that buildDeniedPaths()'s lexical entries still flow
+    // through isProtectedPath()'s comparison-time resolution for the common,
+    // non-symlinked case -- resolveRealOrLexical() must fall back to the
+    // lexical path unchanged when there is nothing to resolve.
+    const denied = buildDeniedPaths();
+    assert.ok(denied.includes(path.join(home, '.ssh')));
+    assert.strictEqual(isProtectedPath(path.join(home, '.ssh', 'id_rsa')), true);
   });
   run(`protected: .env`,            () => assert.strictEqual(isProtectedPath('.env'), true));
   run(`protected: secret.pem`,      () => assert.strictEqual(isProtectedPath('secret.pem'), true));


### PR DESCRIPTION
## Summary
- buildDeniedPaths() resolved symlinks once at module load, creating a staleness window: a denied directory that becomes a symlink (or whose target starts existing) after the guardian process starts would bypass protection until a restart.
- Both the incoming path and each DENIED_PATHS entry now resolve through the shared resolveRealOrLexical() helper on every isProtectedPath() call, so there is no staleness window.
- Excludes fuzz/validator.cjs from ESLint (generated fuzz harness, not hand-written source).

Flagged in cubic review on PR #1129 as a follow-up to the EGC-538 macOS /etc symlink bug.

## Test plan
- [x] npm run build (egc-guardian package)
- [x] node tests/scripts/egc-guardian.test.js -- 125/125 passed locally
- [x] npx eslint on touched files -- 0 errors
- [ ] Full CI matrix (cloud)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve denied paths at comparison time in `egc-guardian` to remove the staleness window where new or retargeted symlinks could bypass protection (EGC-538/macOS /etc). Also remove a circular `node_modules` symlink from `egc-memory` and ignore a generated fuzz harness in ESLint.

- **Bug Fixes**
  - Guardian: Both input and denied paths now resolve via `resolveRealOrLexical()` on every check, preventing stale `DENIED_PATHS` and blocking symlink escapes (EGC-538).
  - Memory: Untracked circular `node_modules` symlink in `mcp/servers/egc-memory` to avoid broken clones.

- **Misc**
  - Tests now include end-to-end coverage for symlinked `DENIED_PATHS` and mid-run symlink retargets.
  - ESLint now ignores `fuzz/validator.cjs` (generated).

<sup>Written for commit f6348975ab6b08b4647e6692e2cded39982358fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

