### PR TITLE
fix(runtime): propagar falha de escrita do TRACER para acionar o fallback sincrono

### DIFF
--- a/scripts/runtime/session_bridge.py
+++ b/scripts/runtime/session_bridge.py
@@ -30,8 +30,7 @@ def _emit_via_tracer(workspace_root: str, event_type: str, execution_id: str, pa
     except Exception:
         return False
     try:
-        TRACER(workspace_root).trace_event(execution_id, event_type, payload)
-        return True
+        return bool(TRACER(workspace_root).trace_event(execution_id, event_type, payload))
     except Exception:
         return False
 

--- a/scripts/runtime/tracer.py
+++ b/scripts/runtime/tracer.py
@@ -41,7 +41,15 @@ class TRACER:
                 with open(self.log_file, "a", encoding="utf-8") as f:
                     f.write(json.dumps(event) + "\n")
                     f.flush()
-                    os.fsync(f.fileno())
+                    try:
+                        os.fsync(f.fileno())
+                    except OSError:
+                        # The record already reached the file (write + flush
+                        # succeeded); fsync only guarantees it survives a
+                        # crash before the OS's own flush. Do not report this
+                        # as a write failure -- callers with a fallback path
+                        # would re-append the same event, duplicating it.
+                        logger.warning("Trace event written but fsync failed (best-effort durability)")
             except Exception:
                 logger.exception("Failed to write trace event")
                 return False

--- a/scripts/runtime/tracer.py
+++ b/scripts/runtime/tracer.py
@@ -19,9 +19,15 @@ class TRACER:
         os.makedirs(os.path.dirname(self.log_file), exist_ok=True)
         self.lock = threading.Lock()
 
-    def trace_event(self, execution_id: str, event_type: str, data: Dict[str, Any]):
+    def trace_event(self, execution_id: str, event_type: str, data: Dict[str, Any]) -> bool:
         """
         Logs a structured trace event safely across threads.
+
+        Returns True only if the event was actually persisted to disk.
+        Callers must not assume success just because no exception propagated:
+        write failures are caught here (so a single bad trace never crashes
+        the caller) but must still be reported via the return value so
+        callers with a fallback persistence path know to use it.
         """
         event = {
             "timestamp": time.time(),
@@ -29,13 +35,18 @@ class TRACER:
             "type": event_type,
             "data": data
         }
-        
+
         with self.lock:
             try:
                 with open(self.log_file, "a", encoding="utf-8") as f:
                     f.write(json.dumps(event) + "\n")
+                    f.flush()
+                    os.fsync(f.fileno())
             except Exception:
                 logger.exception("Failed to write trace event")
+                return False
+
+        return True
 
     def get_traces(self, execution_id: Optional[str] = None) -> list:
         """


### PR DESCRIPTION
## Resumo

O job de CI `Test (windows-latest, Node 22.x, npm)` falhava (run [30756693094](https://github.com/Fmarzochi/EGC/actions/runs/30756693094), commit `051e2d17`) em `tests/scripts/egc-session-bridge.test.js`, caso `SessionStart emits session.sessionstart trace event`: o array de eventos lido de `.sessions/execution_log.jsonl` vinha vazio mesmo com o processo Python encerrando com codigo 0.

## Causa raiz

`TRACER.trace_event` (`scripts/runtime/tracer.py`) captura qualquer excecao ao escrever no arquivo, registra via `logger.exception` e retorna sem sinalizar a falha (retorno implicito `None` tanto no sucesso quanto na falha). Em `_emit_via_tracer` (`scripts/runtime/session_bridge.py`) esse retorno era descartado: bastava a chamada nao lancar excecao para o helper devolver `True`, mesmo que a escrita real tivesse falhado silenciosamente. Como consequencia, `session_bridge.py` nunca chamava `_emit_via_fallback`, que e o unico caminho ja comprovado sincrono e correto.

Investigacao feita antes de aplicar o fix:
- Reproduzi localmente (Linux) o caminho feliz do TRACER: a escrita e sincrona (`open`/`write`/close dentro do mesmo `with`, sem threads nem I/O pendente), o que descarta a hipotese inicial de buffer assincrono nao sendo flushado antes do processo encerrar.
- Descartei diferenca de quebra de linha CRLF como causa de falha de parse no lado Node (`JSON.parse` tolera `\r` final, testado isoladamente).
- Forcei a escrita do TRACER a falhar (substitui o arquivo de log por um diretorio) e confirmei que, antes desta mudanca, `_emit_via_tracer` reportava sucesso mesmo assim, reproduzindo exatamente o sintoma do CI: processo encerra com sucesso, mas nenhum evento e persistido.

Isso explica por que so o Windows falha: alguma falha de I/O pontual e especifica da plataforma (padrao conhecido em runners `windows-latest`, ex. bloqueio transitorio de antivirus/Defender em arquivo recem-criado) faz a escrita do TRACER falhar silenciosamente, e o bug de propagacao de erro impede que o fallback sincrono assuma. Linux/macOS passam porque a escrita do TRACER simplesmente nao falha la.

## Mudanca

- `scripts/runtime/tracer.py`: `trace_event` agora retorna `bool` (`True` somente se o evento foi de fato persistido) e adiciona `flush()` + `os.fsync()` sincronos antes de fechar o arquivo, como camada extra de garantia.
- `scripts/runtime/session_bridge.py`: `_emit_via_tracer` agora propaga o retorno real de `trace_event` em vez de assumir sucesso apenas pela ausencia de excecao.

Com isso o fallback sincrono passa a ser acionado sempre que a escrita do TRACER falhar, por qualquer motivo, em qualquer plataforma, sem depender de identificar a causa exata da falha pontual no runner Windows.

Nenhum outro chamador de `trace_event` depende do valor de retorno (`scripts/orchestration/orchestrator.py` ignora o retorno em todas as chamadas), entao a mudanca de assinatura e segura.

## Teste

Rodei apenas o arquivo isolado (sem suite completa, por restricao de RAM local):

```
node tests/scripts/egc-session-bridge.test.js
```

Resultado local (Linux/WSL): 6/6 passando, incluindo os dois casos que dependem de Python (`SessionStart emits session.sessionstart trace event` e `SessionEnd emits session.sessionend trace event`).

Nao foi possivel reproduzir 100% o ambiente `windows-latest` localmente (esta maquina e Linux); o fix corrige a falha de design (erro engolido sem propagacao) que explica o sintoma observado, independente da causa exata do erro de I/O pontual do Windows. Fica para o CI do PR confirmar o job Windows verde.

## Nao fazer merge

Abrindo apenas para revisao, sem merge automatico.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates tracer write failures to trigger the synchronous fallback, fixing intermittent Windows CI trace test failures. `trace_event` now returns a boolean, uses `flush()` with best‑effort `fsync()`, and avoids duplicates when only `fsync()` fails.

- **Bug Fixes**
  - `trace_event` returns True only when open/write/flush succeed; `fsync()` failures are logged and do not trigger fallback.
  - `_emit_via_tracer` returns the `trace_event` result instead of assuming success.
  - Fixes Windows CI flakiness where no events were persisted in `egc-session-bridge.test.js`.

<sup>Written for commit 95b2a9b9a149e35f1fe3efa6380dc62f53c68452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

