### PR TITLE
fix(guardian): close 2 real fail-open gaps found by EGC-537 audit

### DIFF
--- a/mcp/servers/egc-guardian/src/guardian-cli.ts
+++ b/mcp/servers/egc-guardian/src/guardian-cli.ts
@@ -26,8 +26,17 @@ function commandBatch(payload: string): unknown {
       if (typeof parsed.cwd === 'string') cwd = parsed.cwd;
     }
   } catch {
+    return [{ allowed: false, reason: 'malformed command-batch payload', trust_level: 'DANGEROUS' }];
+  }
+  if (commands.length === 0) {
     // Fail closed: an empty verdict array reads to the caller as "nothing to
-    // check", which allows the batch through instead of blocking it.
+    // check", which allows the batch through instead of blocking it. The
+    // only caller (pre-bash-guardian-validate.js) already short-circuits
+    // before ever sending an empty batch on purpose, so this is never a
+    // false positive -- it only fires for malformed JSON (caught above) or
+    // valid JSON in an unrecognized shape ({}, {"commands": "not an array"},
+    // a bare string/number, etc.), both of which used to fall through here
+    // silently.
     return [{ allowed: false, reason: 'malformed command-batch payload', trust_level: 'DANGEROUS' }];
   }
   return commands.map(c => validateCommand(c, cwd));

--- a/mcp/servers/egc-guardian/src/guardian-cli.ts
+++ b/mcp/servers/egc-guardian/src/guardian-cli.ts
@@ -25,7 +25,11 @@ function commandBatch(payload: string): unknown {
       commands = parsed.commands.filter((c: unknown): c is string => typeof c === 'string');
       if (typeof parsed.cwd === 'string') cwd = parsed.cwd;
     }
-  } catch { /* malformed batch payload: validate nothing, return empty */ }
+  } catch {
+    // Fail closed: an empty verdict array reads to the caller as "nothing to
+    // check", which allows the batch through instead of blocking it.
+    return [{ allowed: false, reason: 'malformed command-batch payload', trust_level: 'DANGEROUS' }];
+  }
   return commands.map(c => validateCommand(c, cwd));
 }
 

--- a/scripts/hooks/pre-bash-verification-gate.js
+++ b/scripts/hooks/pre-bash-verification-gate.js
@@ -79,7 +79,17 @@ function evaluate(rawInput) {
   let evaluation;
   try {
     evaluation = evaluateReceipt(process.cwd());
-  } catch {
+  } catch (err) {
+    if (mode === 'block') {
+      return {
+        output: rawInput,
+        stderr: [
+          `[Hook] BLOCKED by verification gate: could not evaluate the verification receipt (${err instanceof Error ? err.message : String(err)}).`,
+          `Set ${GATE_MODE_ENV}=off to disable this gate or ${GATE_MODE_ENV}=warn to allow through evaluation errors.`,
+        ].join('\n'),
+        exitCode: 2,
+      };
+    }
     return { output: rawInput, exitCode: 0 };
   }
 

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -282,6 +282,28 @@ function runTests() {
     assert.ok(result.stderr.includes('protected file'), `Expected the protected-file reason on stderr, got: ${result.stderr}`);
   })) passed++; else failed++;
 
+  if (!fs.existsSync(realGuardianCliPath)) {
+    console.log('  - skipped EGC-537 command-batch malformed-payload test; build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  } else if (test('EGC-537 guardian-cli command-batch fails closed on a malformed payload instead of returning an empty verdict list', () => {
+    // A malformed batch payload used to be swallowed into an empty commands
+    // array, so .map() produced []. Any caller treating an empty verdict
+    // list as "nothing to check" (pre-bash-guardian-validate.js's own loop
+    // does exactly that) would allow the batch through with no verdict at
+    // all. This drives the real built CLI directly, bypassing the hook,
+    // since the hook always JSON.stringifies its own well-formed payload --
+    // this is defense in depth for any other/future caller of command-batch.
+    const result = spawnSync('node', [realGuardianCliPath, 'command-batch'], {
+      input: '{not valid json',
+      encoding: 'utf8',
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    assert.strictEqual(result.status, 0, 'guardian-cli always exits 0; the caller reads the verdict from stdout');
+    const verdicts = JSON.parse(result.stdout);
+    assert.ok(Array.isArray(verdicts) && verdicts.length > 0, `Expected a non-empty verdict array, got: ${result.stdout}`);
+    assert.strictEqual(verdicts[0].allowed, false, `Expected a blocking verdict, got: ${result.stdout}`);
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/hooks/pre-bash-guardian-validate.test.js
+++ b/tests/hooks/pre-bash-guardian-validate.test.js
@@ -304,6 +304,30 @@ function runTests() {
     assert.strictEqual(verdicts[0].allowed, false, `Expected a blocking verdict, got: ${result.stdout}`);
   })) passed++; else failed++;
 
+  if (!fs.existsSync(realGuardianCliPath)) {
+    console.log('  - skipped EGC-537 command-batch wrong-shape payload test; build not found. Run npm run build in mcp/servers/egc-guardian first.');
+  } else if (test('EGC-537 guardian-cli command-batch fails closed on syntactically valid JSON in an unrecognized shape', () => {
+    // cubic review on PR #1134: the first fix only caught JSON.parse
+    // throwing. Valid JSON that isn't the expected {commands: [...]} or
+    // bare-array shape (an empty object, or commands as a non-array) parsed
+    // fine and fell through to the same empty-array fail-open. The only
+    // caller (pre-bash-guardian-validate.js) already short-circuits before
+    // ever sending an empty batch on purpose, so blocking on commands.length
+    // === 0 here is never a false positive for real traffic.
+    for (const payload of ['{}', '{"commands":"rm -rf /"}', 'null', '"just a string"']) {
+      const result = spawnSync('node', [realGuardianCliPath, 'command-batch'], {
+        input: payload,
+        encoding: 'utf8',
+        timeout: 15000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      assert.strictEqual(result.status, 0, `guardian-cli always exits 0 for payload ${payload}`);
+      const verdicts = JSON.parse(result.stdout);
+      assert.ok(Array.isArray(verdicts) && verdicts.length > 0, `Expected a non-empty verdict array for payload ${payload}, got: ${result.stdout}`);
+      assert.strictEqual(verdicts[0].allowed, false, `Expected a blocking verdict for payload ${payload}, got: ${result.stdout}`);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Context

Multica audit EGC-537 (silent failures / fallbacks that hide real breakage) had a complete report sitting in the issue's comments since this morning, never actioned. Verified all 3 findings against the current source on \`origin/main\` before touching anything.

## What's fixed

1. **\`guardian-cli.ts\` \`commandBatch\`**: a malformed batch payload was swallowed by the parse \`try/catch\`, returning an empty commands array. The caller (\`pre-bash-guardian-validate.js\`) treats an empty verdict array as "nothing to check" and allows the batch through. Now returns a blocking verdict on parse failure instead.
2. **\`pre-bash-verification-gate.js\`**: an exception from \`evaluateReceipt()\` always allowed the command through (exit 0), even in \`EGC_VERIFY_GATE=block\` mode. Now fails closed (exit 2) only in block mode; default warn mode unchanged.

## What's intentionally not changed

\`gateguard-fact-force.js\`'s parse-error fallthrough (the audit's 3rd finding) is marked \`// NOSONAR: parse failure allows the command through by design\` in the source -- an existing, deliberate decision for a friction/nudge gate, not the security boundary itself. Left alone.

## Test plan

- [x] New regression test for fix 1: spawns the real built \`guardian-cli.js\`, sends malformed JSON to \`command-batch\`, asserts a blocking verdict (\`tests/hooks/pre-bash-guardian-validate.test.js\`, 24/24 passing)
- [x] Existing \`tests/lib/verify-receipt.test.js\` (9/9) still passes unchanged for fix 2
- [x] Lint clean
- [ ] Coverage gap disclosed in the commit message: fix 2's exact catch block isn't independently exercised by a new test -- both of \`evaluateReceipt()\`'s internal calls already fail soft rather than throw, so this path may be unreachable through the current public API. Fix is still correct defensive code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes two fail-open paths from the EGC-537 audit. `command-batch` now blocks on malformed JSON and valid-but-wrong-shape payloads, and the verification gate fails closed in block mode on evaluation errors.

- **Bug Fixes**
  - `mcp/servers/egc-guardian/src/guardian-cli.ts`: `commandBatch` returns a blocking verdict if JSON parse fails or the payload yields no commands (e.g., `{}`, `{"commands":"..."}`, bare string/number) instead of `[]`, preventing bypass in `pre-bash-guardian-validate.js`.
  - `scripts/hooks/pre-bash-verification-gate.js`: when `evaluateReceipt()` throws and `EGC_VERIFY_GATE=block`, the hook blocks with exit 2 and an error message; warn/off modes unchanged.

<sup>Written for commit 9807d2911e5972898773a216120741bc83083491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

