### PR TITLE
fix(guardian): close truncation fail-open in windsurf-gateguard-adapter

### DIFF
--- a/scripts/hooks/windsurf-gateguard-adapter.js
+++ b/scripts/hooks/windsurf-gateguard-adapter.js
@@ -20,6 +20,7 @@
 
 const fs = require('node:fs');
 const { run } = require('./gateguard-fact-force');
+const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
 
 function buildGateGuardInput(windsurfEvent) {
   const actionName = windsurfEvent.agent_action_name || '';
@@ -78,24 +79,26 @@ function extractDenyReason(result) {
 }
 
 function main() {
-  const MAX_STDIN = 1024 * 1024;
-  let raw = '';
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', chunk => {
-    if (raw.length < MAX_STDIN) {
-      raw += chunk.substring(0, MAX_STDIN - raw.length);
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    // Checked before ok, unconditionally: a capped-length prefix can still
+    // happen to be syntactically valid JSON, which would otherwise reach
+    // the ok:true branch below with truncated data treated as trusted. The
+    // hand-rolled reader this replaced had no truncation tracking at all
+    // and silently allowed on any payload past the 1MB cap (EGC-539 audit).
+    if (truncated) {
+      process.stderr.write(
+        'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+        'this validator can safely read, so it could not be parsed or validated. ' +
+        'Simplify the command.\n'
+      );
+      process.exit(2);
     }
-  });
-  process.stdin.on('end', () => {
-    let windsurfEvent;
-    try {
-      windsurfEvent = JSON.parse(raw);
-    } catch {
+    if (!ok) {
       // Allow on parse error: same fail-open policy as gateguard-fact-force.js.
       process.exit(0);
     }
 
-    const gateguardInput = buildGateGuardInput(windsurfEvent);
+    const gateguardInput = buildGateGuardInput(value);
     if (!gateguardInput) {
       process.exit(0);
     }

--- a/scripts/lib/adapter-stdin-json.js
+++ b/scripts/lib/adapter-stdin-json.js
@@ -12,7 +12,16 @@
 const MAX_STDIN = 1024 * 1024;
 
 function readAdapterStdinJson(onComplete) {
-  let raw = '';
+  // Buffered as raw bytes (no setEncoding) and only decoded to a UTF-8
+  // string once, in the 'end' handler. String.prototype.length counts
+  // UTF-16 code units, not bytes, so accumulating into a string and
+  // capping on .length let multibyte payloads exceed the stated 1 MiB byte
+  // cap without ever being marked truncated (EGC-539 / cubic review on
+  // PR #1135). truncated is only set when a chunk is actually cut short or
+  // more data arrives after the cap is already reached -- a payload that
+  // lands exactly at MAX_STDIN bytes with nothing discarded stays untruncated.
+  const chunks = [];
+  let totalBytes = 0;
   let truncated = false;
   let done = false;
   const complete = result => {
@@ -21,12 +30,18 @@ function readAdapterStdinJson(onComplete) {
     onComplete(result);
   };
 
-  process.stdin.setEncoding('utf8');
   process.stdin.on('data', chunk => {
-    if (raw.length < MAX_STDIN) {
-      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    if (totalBytes >= MAX_STDIN) {
+      truncated = true;
+      return;
     }
-    if (raw.length >= MAX_STDIN) {
+    const remaining = MAX_STDIN - totalBytes;
+    if (chunk.length <= remaining) {
+      chunks.push(chunk);
+      totalBytes += chunk.length;
+    } else {
+      chunks.push(chunk.subarray(0, remaining));
+      totalBytes += remaining;
       truncated = true;
     }
   });
@@ -37,6 +52,7 @@ function readAdapterStdinJson(onComplete) {
   // other unreadable-input path this reader already has.
   process.stdin.on('error', () => complete({ ok: false, truncated }));
   process.stdin.on('end', () => {
+    const raw = Buffer.concat(chunks).toString('utf8');
     let value;
     try {
       value = JSON.parse(raw);

--- a/tests/hooks/windsurf-gateguard-adapter.test.js
+++ b/tests/hooks/windsurf-gateguard-adapter.test.js
@@ -189,6 +189,24 @@ function runTests() {
     assert.strictEqual(result.code, 0);
   })) passed++; else failed++;
 
+  if (test('CLI: a truncated oversized payload fails CLOSED (exit 2), matching every other adapter on this same threat model', () => {
+    // EGC-539 audit: this adapter used to hand-roll its own stdin reader
+    // with no truncation tracking at all, so an oversized-but-still-
+    // parseable payload silently allowed through (exit 0) -- reproduced
+    // live before this fix. It now shares readAdapterStdinJson with
+    // windsurf-guardian-adapter.js and the Cursor/Junie/Cline adapters,
+    // which all correctly fail closed on this exact input shape.
+    const oversizedPadding = 'A'.repeat(2 * 1024 * 1024);
+    const result = runAdapterCli(JSON.stringify({
+      agent_action_name: 'pre_run_command',
+      trajectory_id: `traj-cli-truncated-${Date.now()}`,
+      tool_info: { command_line: 'ls', cwd: '/tmp' },
+      padding: oversizedPadding,
+    }));
+    assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
+    assert.ok(result.stderr.includes('exceeded the size'), `Expected the truncation reason on stderr, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/adapter-stdin-json.test.js
+++ b/tests/lib/adapter-stdin-json.test.js
@@ -1,0 +1,109 @@
+/**
+ * Tests for scripts/lib/adapter-stdin-json.js -- the shared truncation-aware
+ * stdin JSON reader used by 12+ host adapters (Windsurf, Cursor, Junie,
+ * Cline, Amazon Q, Goose, OpenHands).
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const MODULE_PATH = path.join(__dirname, '..', '..', 'scripts', 'lib', 'adapter-stdin-json.js');
+const { MAX_STDIN } = require(MODULE_PATH);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+// Runs readAdapterStdinJson in a real subprocess (it reads process.stdin
+// directly, so it cannot be driven in-process without hijacking stdin for
+// the whole test file) and prints the result as JSON on stdout.
+const driverPath = path.join(os.tmpdir(), `egc-adapter-stdin-json-driver-${process.pid}.js`);
+fs.writeFileSync(driverPath, `
+  const { readAdapterStdinJson } = require(${JSON.stringify(MODULE_PATH)});
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    process.stdout.write(JSON.stringify({ ok, truncated, hasValue: value !== undefined }));
+  });
+`);
+process.on('exit', () => { try { fs.rmSync(driverPath, { force: true }); } catch { /* best-effort cleanup */ } });
+
+function readViaSubprocess(input) {
+  const result = spawnSync(process.execPath, [driverPath], {
+    input,
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return JSON.parse(result.stdout.toString('utf8'));
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/adapter-stdin-json.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('a payload of exactly MAX_STDIN bytes (ASCII) is not marked truncated', () => {
+    const prefix = '{"padding":"';
+    const suffix = '"}';
+    const padLen = MAX_STDIN - prefix.length - suffix.length;
+    const payload = prefix + 'A'.repeat(padLen) + suffix;
+    assert.strictEqual(Buffer.byteLength(payload, 'utf8'), MAX_STDIN, 'test payload must be exactly at the cap');
+    const result = readViaSubprocess(payload);
+    assert.strictEqual(result.truncated, false, 'a boundary-exact payload with nothing discarded must not be flagged truncated');
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.hasValue, true);
+  })) passed++; else failed++;
+
+  if (test('a payload one byte over MAX_STDIN is marked truncated', () => {
+    const prefix = '{"padding":"';
+    const suffix = 'X"}';
+    const padLen = MAX_STDIN - prefix.length - suffix.length + 1;
+    const payload = prefix + 'A'.repeat(padLen) + suffix;
+    assert.strictEqual(Buffer.byteLength(payload, 'utf8'), MAX_STDIN + 1, 'test payload must be exactly one byte over the cap');
+    const result = readViaSubprocess(payload);
+    assert.strictEqual(result.truncated, true);
+  })) passed++; else failed++;
+
+  if (test('a multibyte (emoji) payload is capped by real UTF-8 bytes, not UTF-16 code units', () => {
+    // Each emoji is a surrogate pair: 2 UTF-16 code units but 4 UTF-8 bytes.
+    // Before the fix, accumulating into a JS string and capping on
+    // .length used code units, so this payload (600K units, under the old
+    // buggy cap) sailed through even though it is 1.2MB of real bytes.
+    const emoji = '\u{1F600}'.repeat(300000);
+    const payload = JSON.stringify({ padding: emoji });
+    const byteLength = Buffer.byteLength(payload, 'utf8');
+    const codeUnitLength = payload.length;
+    assert.ok(byteLength > MAX_STDIN, 'test payload must exceed the byte cap');
+    assert.ok(codeUnitLength < MAX_STDIN, 'test payload must stay under the old (buggy) code-unit cap, or this test proves nothing');
+    const result = readViaSubprocess(payload);
+    assert.strictEqual(result.truncated, true, `expected truncated=true for a ${byteLength}-byte payload (cap ${MAX_STDIN}), got ${JSON.stringify(result)}`);
+  })) passed++; else failed++;
+
+  if (test('a small well-formed payload is read correctly, not truncated', () => {
+    const result = readViaSubprocess(JSON.stringify({ hello: 'world' }));
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.truncated, false);
+    assert.strictEqual(result.hasValue, true);
+  })) passed++; else failed++;
+
+  if (test('malformed (non-truncated) JSON fails open with ok:false, truncated:false', () => {
+    const result = readViaSubprocess('{not valid json');
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.truncated, false);
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Context

Multica audit EGC-539 (\`scripts/\` engineering health -- hooks, ci, lib, install-targets) found and live-reproduced a fail-open gap: \`windsurf-gateguard-adapter.js\` hand-rolled its own stdin reader with no truncation tracking, unlike every other adapter on the same threat model.

## Reproduction (before the fix)

\`\`\`
$ node scripts/hooks/windsurf-gateguard-adapter.js < 2mb-padded-payload.json
$ echo \$?
0
\`\`\`

Its sibling \`windsurf-guardian-adapter.js\`, which already uses the shared \`readAdapterStdinJson()\`, correctly exits 2 on the identical payload shape.

## Fix

Swapped the hand-rolled reader for \`readAdapterStdinJson\` from \`scripts/lib/adapter-stdin-json.js\`. Kept this file's own \`main()\` body (it needs the custom \`hookSpecificOutput\` -> exit-code/stderr translation that \`gateguard-fact-force.js\`'s \`run()\` doesn't produce directly -- same reason Cursor keeps its own \`main()\` instead of the shared \`bootstrapPlainExitCodeAdapter\` helper).

## Test plan

- [x] Reproduced the bypass before the fix, confirmed exit 2 after (manual verification)
- [x] New regression test in \`tests/hooks/windsurf-gateguard-adapter.test.js\` (14/14 passing)
- [x] Well-formed payload still allows correctly (no regression)
- [x] Lint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the fail-open truncation gap in `scripts/hooks/windsurf-gateguard-adapter.js` and hardens the shared stdin JSON reader. Oversized or truncated stdin now fails closed (exit 2) with truncation computed by real UTF‑8 bytes; addresses EGC-539.

- **Bug Fixes**
  - Replace the adapter’s hand-rolled reader with `readAdapterStdinJson`; keep its custom `main()` and add a CLI regression test asserting exit 2 and the truncation message.
  - Update `scripts/lib/adapter-stdin-json.js` to buffer raw bytes and mark `truncated` only when bytes are actually discarded; add `tests/lib/adapter-stdin-json.test.js` covering exact-cap, over-cap, multibyte, and malformed JSON cases.

<sup>Written for commit c4b5cbe733b50d45a3144875a76089766c619706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

