### PR TITLE
fix(guardian): skip stale-file pruning scan when GateGuard is disabled

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -230,28 +230,33 @@ function isChecked(key) {
   return found;
 }
 
-// Prune stale session files older than 1 hour
-(function pruneStaleFiles() {
-  try {
-    const files = fs.readdirSync(STATE_DIR);
-    const now = Date.now();
-    for (const f of files) {
-      const isStateFile = f.startsWith('state-') && (f.endsWith('.json') || f.includes('.json.tmp.'));
-      if (!isStateFile) continue;
-      const fp = path.join(STATE_DIR, f);
-      try {
-        const stat = fs.statSync(fp);
-        if (now - stat.mtimeMs > SESSION_TIMEOUT_MS * 2) {
-          fs.unlinkSync(fp);
+// Prune stale session files older than 1 hour. Every other piece of work in
+// this module checks isGateGuardDisabled() first; this module-load-time scan
+// used to run unconditionally, so a disabled GateGuard still paid the
+// synchronous readdir/stat/unlink cost on every process start (EGC-539 audit).
+if (!isGateGuardDisabled()) {
+  (function pruneStaleFiles() {
+    try {
+      const files = fs.readdirSync(STATE_DIR);
+      const now = Date.now();
+      for (const f of files) {
+        const isStateFile = f.startsWith('state-') && (f.endsWith('.json') || f.includes('.json.tmp.'));
+        if (!isStateFile) continue;
+        const fp = path.join(STATE_DIR, f);
+        try {
+          const stat = fs.statSync(fp);
+          if (now - stat.mtimeMs > SESSION_TIMEOUT_MS * 2) {
+            fs.unlinkSync(fp);
+          }
+        } catch (_) { // NOSONAR
+          // Ignore files that disappear between readdir/stat/unlink.
         }
-      } catch (_) { // NOSONAR
-        // Ignore files that disappear between readdir/stat/unlink.
       }
+    } catch (_) { // NOSONAR
+      /* ignore */
     }
-  } catch (_) { // NOSONAR
-    /* ignore */
-  }
-})();
+  })();
+}
 
 // --- Sanitize file path against injection ---
 

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -17,6 +17,7 @@ const stateDir = fs.mkdtempSync(path.join(baseStateDir, 'gateguard-test-'));
 const TEST_SESSION_ID = 'gateguard-test-session';
 const stateFile = path.join(stateDir, `state-${TEST_SESSION_ID}.json`);
 const READ_HEARTBEAT_MS = 60 * 1000;
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // must match gateguard-fact-force.js
 
 function test(name, fn) {
   try {
@@ -1140,6 +1141,40 @@ function runTests() {
     const result = runDirectHook(input);
     assert.strictEqual(result.code, 0);
     assert.deepStrictEqual(JSON.parse(result.stdout), input);
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('EGC-539: stale-file pruning is skipped when GateGuard is disabled (module-load-time scan)', () => {
+    // Module-load-time pruneStaleFiles() used to run unconditionally,
+    // regardless of isGateGuardDisabled() -- so a disabled GateGuard still
+    // paid the sync readdir/stat/unlink cost, and the fix must not remove
+    // the pruning behavior itself, only gate it. A separate stale file (not
+    // the session's own stateFile, to avoid racing runDirectHook's own
+    // writes to it) is used so pruning is unambiguously the only thing that
+    // could remove it.
+    const staleFile = path.join(stateDir, 'state-stale-disabled-test.json');
+    fs.writeFileSync(staleFile, JSON.stringify({ checked: [], last_active: 0 }), 'utf8');
+    const oldTime = (Date.now() - (SESSION_TIMEOUT_MS * 3)) / 1000;
+    fs.utimesSync(staleFile, oldTime, oldTime);
+
+    runDirectHook(
+      { tool_name: 'Edit', tool_input: { file_path: '/src/gateguard-disabled-scan.js', old_string: 'a', new_string: 'b' } },
+      { EGC_GATEGUARD: 'off' }
+    );
+
+    assert.ok(fs.existsSync(staleFile), 'a disabled GateGuard must not run the module-load-time pruning scan at all');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('EGC-539: stale-file pruning still runs normally when GateGuard is enabled', () => {
+    const staleFile = path.join(stateDir, 'state-stale-enabled-test.json');
+    fs.writeFileSync(staleFile, JSON.stringify({ checked: [], last_active: 0 }), 'utf8');
+    const oldTime = (Date.now() - (SESSION_TIMEOUT_MS * 3)) / 1000;
+    fs.utimesSync(staleFile, oldTime, oldTime);
+
+    runDirectHook({ tool_name: 'Edit', tool_input: { file_path: '/src/gateguard-enabled-scan.js', old_string: 'a', new_string: 'b' } });
+
+    assert.ok(!fs.existsSync(staleFile), 'an enabled GateGuard must still prune files older than 2x SESSION_TIMEOUT_MS');
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.


### PR DESCRIPTION
## Context

EGC-539 audit (Finding 8): every other piece of work in \`gateguard-fact-force.js\` checks \`isGateGuardDisabled()\` first, but the module-load-time \`pruneStaleFiles()\` IIFE ran unconditionally. Since this module is required on every Bash pre-hook invocation through \`bash-hook-dispatcher.js\` (and every host adapter that wires GateGuard), a disabled GateGuard still paid the synchronous \`readdir\`/\`stat\`/\`unlink\` cost on every process start.

## Fix

Gated the scan behind the same \`isGateGuardDisabled()\` check already used everywhere else in the file.

## Test plan

- [x] New test: a disabled GateGuard does not prune a stale state file at all
- [x] New test: an enabled GateGuard still prunes files older than 2x SESSION_TIMEOUT_MS (no regression)
- [x] Full file: 49/49 passing
- [x] Lint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the module-load-time stale-file pruning when GateGuard is disabled to avoid unnecessary sync FS work on every pre-hook start. Behavior when enabled is unchanged (files older than 2× `SESSION_TIMEOUT_MS` are still pruned). Related to EGC-539.

- **Bug Fixes**
  - Gated `pruneStaleFiles()` behind `isGateGuardDisabled()` in `scripts/hooks/gateguard-fact-force.js`.
  - Added tests ensuring the scan is skipped when disabled and still runs when enabled in `tests/hooks/gateguard-fact-force.test.js`.

<sup>Written for commit 4a45dcb207cb22f845504e913f8377ceaa42fb18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

