### PR TITLE
refactor(guardian): unify Cline/Junie/Cursor adapter main() bodies

### DIFF
--- a/scripts/hooks/cline-guardian-adapter.js
+++ b/scripts/hooks/cline-guardian-adapter.js
@@ -24,7 +24,16 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
-const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+const { runJsonEnvelopeGuardianAdapter } = require('../lib/adapter-stdin-json');
+
+function buildGuardianInput(event) {
+  const toolName = event && typeof event === 'object' ? event.preToolUse?.toolName : undefined;
+  const command = toolName === 'execute_command' ? event.preToolUse?.parameters?.command : undefined;
+  if (!command || typeof command !== 'string') {
+    return null;
+  }
+  return { tool_name: 'Bash', tool_input: { command } };
+}
 
 function respond(cancel, errorMessage) {
   // process.exitCode (not process.exit()) so Node drains stdout naturally:
@@ -37,41 +46,11 @@ function respond(cancel, errorMessage) {
 }
 
 function main() {
-  readAdapterStdinJson(({ ok, truncated, value }) => {
-    // Same fail-closed-on-truncation guard as every other EGC translation
-    // adapter: a capped-length prefix can still happen to be syntactically
-    // valid JSON, so truncation is checked unconditionally, before `ok`.
-    if (truncated) {
-      respond(true, 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
-        'this validator can safely read, so it could not be parsed or validated. ' +
-        'Simplify the command.');
-      return;
-    }
-    if (!ok) {
-      respond(false);
-      return;
-    }
-
-    const event = value;
-    const toolName = event && typeof event === 'object' ? event.preToolUse?.toolName : undefined;
-    const command = toolName === 'execute_command' ? event.preToolUse?.parameters?.command : undefined;
-    if (!command || typeof command !== 'string') {
-      respond(false);
-      return;
-    }
-
-    const result = run({ tool_name: 'Bash', tool_input: { command } });
-    if (result.exitCode === 2) {
-      respond(true, result.stderr || 'Blocked by the EGC Guardian.');
-      return;
-    }
-
-    respond(false);
-  });
+  runJsonEnvelopeGuardianAdapter(buildGuardianInput, run, respond);
 }
 
 if (require.main === module) {
   main();
 }
 
-module.exports = {};
+module.exports = { buildGuardianInput };

--- a/scripts/hooks/cursor-guardian-adapter.js
+++ b/scripts/hooks/cursor-guardian-adapter.js
@@ -19,7 +19,7 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
-const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+const { runJsonEnvelopeGuardianAdapter } = require('../lib/adapter-stdin-json');
 
 function buildGuardianInput(cursorEvent) {
   if (!cursorEvent || typeof cursorEvent !== 'object') {
@@ -41,47 +41,21 @@ function buildGuardianInput(cursorEvent) {
   return input;
 }
 
-function respond(permission, message) {
+function respond(blocked, message) {
+  // process.exitCode (not process.exit()) so Node drains stdout naturally:
+  // on POSIX a forced exit can race the pipe write and truncate the
+  // response before Cursor reads it (same cubic-dev-ai finding already
+  // applied to the Cline/Junie translation adapters, PR #1081 -- this one
+  // was still on the older, race-prone process.exit() pattern until the
+  // EGC-539 audit's Finding 3 consolidation).
+  const permission = blocked ? 'deny' : 'allow';
   const payload = message ? { permission, user_message: message, agent_message: message } : { permission };
+  process.exitCode = blocked ? 2 : 0;
   process.stdout.write(JSON.stringify(payload));
-  process.exit(permission === 'deny' ? 2 : 0);
 }
 
 function main() {
-  readAdapterStdinJson(({ ok, truncated, value }) => {
-    // Checked before `ok`, unconditionally: a capped-length prefix can
-    // still happen to be syntactically valid JSON (e.g. the cut lands
-    // exactly at the end of a complete value, or JSON.parse's tolerance
-    // for trailing whitespace after a value), which previously reached the
-    // `ok: true` branch below with truncated data treated as trusted. Any
-    // truncated payload is unanalyzable -- some of what the caller sent
-    // was discarded -- so it always fails closed, regardless of whether
-    // JSON.parse happened to succeed on what remained.
-    if (truncated) {
-      respond('deny', 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
-        'this validator can safely read, so it could not be parsed or validated. ' +
-        'Simplify the command.');
-      return;
-    }
-    if (!ok) {
-      respond('allow');
-      return;
-    }
-
-    const guardianInput = buildGuardianInput(value);
-    if (!guardianInput) {
-      respond('allow');
-      return;
-    }
-
-    const result = run(guardianInput);
-    if (result.exitCode === 2) {
-      respond('deny', result.stderr || 'Blocked by the EGC Guardian.');
-      return;
-    }
-
-    respond('allow');
-  });
+  runJsonEnvelopeGuardianAdapter(buildGuardianInput, run, respond);
 }
 
 if (require.main === module) {

--- a/scripts/hooks/junie-guardian-adapter.js
+++ b/scripts/hooks/junie-guardian-adapter.js
@@ -17,60 +17,38 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
-const { readAdapterStdinJson } = require('../lib/adapter-stdin-json');
+const { runJsonEnvelopeGuardianAdapter } = require('../lib/adapter-stdin-json');
 
-function respond(decision, reason) {
+function buildGuardianInput(event) {
+  const command = event && typeof event === 'object' ? event.tool_input?.command : undefined;
+  if (!command) {
+    return null;
+  }
+  const guardianInput = { tool_name: 'Bash', tool_input: { command } };
+  if (event && typeof event.cwd === 'string') {
+    guardianInput.cwd = event.cwd;
+  }
+  return guardianInput;
+}
+
+function respond(blocked, reason) {
   // Sets exitCode and lets Node drain stdout naturally instead of forcing
   // process.exit() right after write(): on POSIX, stdout writes to a pipe
   // (which is what a hook subprocess always has) are asynchronous, so a
   // forced exit can race the write and truncate the response before Junie
   // reads it (cubic-dev-ai finding, PR #1081).
+  const decision = blocked ? 'deny' : 'allow';
   const payload = reason ? { decision, reason } : { decision };
-  process.exitCode = decision === 'deny' ? 2 : 0;
+  process.exitCode = blocked ? 2 : 0;
   process.stdout.write(JSON.stringify(payload));
 }
 
 function main() {
-  readAdapterStdinJson(({ ok, truncated, value }) => {
-    // Same fail-closed-on-truncation guard as the Cursor/Windsurf/Kiro
-    // adapters (cubic-dev-ai finding, PR #1073/#1074): a capped-length
-    // prefix can still happen to be syntactically valid JSON, so truncation
-    // is checked unconditionally, before `ok`.
-    if (truncated) {
-      respond('deny', 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
-        'this validator can safely read, so it could not be parsed or validated. ' +
-        'Simplify the command.');
-      return;
-    }
-    if (!ok) {
-      respond('allow');
-      return;
-    }
-
-    const event = value;
-    const command = event && typeof event === 'object' ? event.tool_input?.command : undefined;
-    if (!command) {
-      respond('allow');
-      return;
-    }
-
-    const guardianInput = { tool_name: 'Bash', tool_input: { command } };
-    if (event && typeof event.cwd === 'string') {
-      guardianInput.cwd = event.cwd;
-    }
-
-    const result = run(guardianInput);
-    if (result.exitCode === 2) {
-      respond('deny', result.stderr || 'Blocked by the EGC Guardian.');
-      return;
-    }
-
-    respond('allow');
-  });
+  runJsonEnvelopeGuardianAdapter(buildGuardianInput, run, respond);
 }
 
 if (require.main === module) {
   main();
 }
 
-module.exports = {};
+module.exports = { buildGuardianInput };

--- a/scripts/lib/adapter-stdin-json.js
+++ b/scripts/lib/adapter-stdin-json.js
@@ -119,6 +119,46 @@ function bootstrapPlainExitCodeAdapter({ isMain, buildGuardianInput, runGuardian
   return { buildGuardianInput };
 }
 
+// Shared main() body for host adapters that need a JSON envelope on stdout
+// (not a plain exit code) -- Cline ({cancel, errorMessage}), Junie
+// ({decision, reason}), Cursor ({permission, user_message, agent_message}).
+// Each host's own translation differs only in buildGuardianInput (event ->
+// Guardian input) and respond (blocked: boolean, message?: string) -> writes
+// its own envelope shape. The truncation/ok/blocked control flow itself was
+// duplicated three times before this (EGC-539 audit, Finding 3).
+function runJsonEnvelopeGuardianAdapter(buildGuardianInput, runGuardian, respond) {
+  readAdapterStdinJson(({ ok, truncated, value }) => {
+    // Checked before `ok`, unconditionally: a capped-length prefix can still
+    // happen to be syntactically valid JSON, so a truncated payload always
+    // fails closed regardless of whether JSON.parse happened to succeed on
+    // what remained.
+    if (truncated) {
+      respond(true, 'EGC Guardian BLOCKED this command: the event payload exceeded the size ' +
+        'this validator can safely read, so it could not be parsed or validated. ' +
+        'Simplify the command.');
+      return;
+    }
+    if (!ok) {
+      respond(false);
+      return;
+    }
+
+    const guardianInput = buildGuardianInput(value);
+    if (!guardianInput) {
+      respond(false);
+      return;
+    }
+
+    const result = runGuardian(guardianInput);
+    if (result.exitCode === 2) {
+      respond(true, result.stderr || 'Blocked by the EGC Guardian.');
+      return;
+    }
+
+    respond(false);
+  });
+}
+
 // Amazon Q, Goose, and OpenHands all deliver {tool_name, tool_input:
 // {command}, <cwdKey>} on stdin for their shell tool, differing only in
 // the shell tool's name and which top-level field carries the working
@@ -151,5 +191,6 @@ module.exports = {
   bootstrapPlainExitCodeAdapter,
   createBashToolGuardianInputMapper,
   readAdapterStdinJson,
+  runJsonEnvelopeGuardianAdapter,
   runPlainExitCodeGuardianAdapter,
 };

--- a/tests/hooks/cursor-guardian-adapter.test.js
+++ b/tests/hooks/cursor-guardian-adapter.test.js
@@ -48,6 +48,19 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
+  if (test('CLI: full stdout is present at exit (no truncation from exitCode-based exit)', () => {
+    // Regression guard for the cubic-dev-ai finding (PR #1081), applied to
+    // this adapter as part of the EGC-539 Finding 3 consolidation: this
+    // adapter used to call process.exit() right after stdout.write(),
+    // which can race the pipe flush on POSIX and truncate the response
+    // before the caller reads it. Now uses process.exitCode like the
+    // Cline/Junie adapters it shares runJsonEnvelopeGuardianAdapter with.
+    for (let i = 0; i < 20; i += 1) {
+      const result = runAdapterCli({ command: 'git status', cwd: '/tmp' });
+      assert.doesNotThrow(() => JSON.parse(result.stdout), `Run ${i}: stdout was not valid JSON: ${JSON.stringify(result.stdout)}`);
+    }
+  })) passed++; else failed++;
+
   if (test('maps a Cursor beforeShellExecution event to a Guardian Bash input', () => {
     const mapped = buildGuardianInput({ command: 'echo hi', cwd: '/Users/example/project' });
     assert.deepStrictEqual(mapped, { tool_name: 'Bash', tool_input: { command: 'echo hi' }, cwd: '/Users/example/project' });


### PR DESCRIPTION
## Context

EGC-539 audit (Finding 3): Cline, Junie, and Cursor each need a JSON envelope on stdout (not a plain exit code), so each independently reimplemented the same skeleton -- read stdin, check truncated (identical message copy-pasted 3x), check ok, build guardian input, run(), check exitCode, translate to the host's own envelope shape.

## Fix

Added \`runJsonEnvelopeGuardianAdapter\` to \`scripts/lib/adapter-stdin-json.js\`, parameterized by \`buildGuardianInput\` and a host-specific \`respond(blocked, message)\`. Each adapter now only supplies those two functions.

## Side effect fixed along the way

\`cursor-guardian-adapter.js\` was still calling \`process.exit()\` right after \`stdout.write()\` -- the exact POSIX pipe-race pattern already fixed for Cline/Junie in PR #1081. Consolidating onto the shared helper fixes this too; added the same "full stdout present" regression test Cline/Junie already had.

## Test plan

- [x] Full regression sweep: all 8 adapter test files + the shared module's tests (90 tests total, 0 failures)
- [x] No behavior change for any adapter's allow/deny decisions or output shape
- [x] Lint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the main flow for the Cline, Junie, and Cursor Guardian adapters into a shared helper to cut duplication and meet EGC-539 (Finding 3). Also fixes Cursor’s stdout truncation by using exitCode-based exits and adds a regression test.

- **Refactors**
  - Added `runJsonEnvelopeGuardianAdapter` in `scripts/lib/adapter-stdin-json.js`.
  - Updated Cline/Junie/Cursor adapters to supply `buildGuardianInput` and `respond`. No changes to decisions or envelope shapes.

- **Bug Fixes**
  - Cursor adapter now uses `process.exitCode` instead of `process.exit()` to avoid pipe-race truncation; added a test to verify full stdout is flushed.

<sup>Written for commit 80ab81c80cc1b9cc31455938e56d125f97352efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

