### PR TITLE
refactor(ci): extract shared skill-tree walker from validate-skills.js

### DIFF
--- a/scripts/ci/validate-skill-frontmatter.js
+++ b/scripts/ci/validate-skill-frontmatter.js
@@ -11,58 +11,11 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { listSkillLeaves } = require('#lib/skill-tree-walker');
 const { extractFrontmatterBlock } = require('#lib/frontmatter-block');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-
-function hasSkillMd(dir) {
-  return fs.existsSync(path.join(dir, 'SKILL.md'));
-}
-
-function isCategoryRoot(dir) {
-  if (hasSkillMd(dir)) return false;
-  try {
-    const children = fs.readdirSync(dir, { withFileTypes: true });
-    return children.some(c => c.isDirectory() && hasSkillMd(path.join(dir, c.name)));
-  } catch (_) { /* ignore: unreadable directory safely means it is not a category root */ // NOSONAR
-    return false;
-  }
-}
-
-// Mirrors scripts/ci/validate-skills.js: skills live either directly under
-// skills/<name>/SKILL.md or nested one level under a category directory
-// (skills/<category>/<name>/SKILL.md).
-function listSkillLeaves(root) {
-  const leaves = [];
-  const entries = fs.readdirSync(root, { withFileTypes: true });
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const entryPath = path.join(root, entry.name);
-
-    if (hasSkillMd(entryPath)) {
-      leaves.push({ relPath: entry.name, dirName: entry.name, fullPath: entryPath });
-      continue;
-    }
-
-    if (isCategoryRoot(entryPath)) {
-      const skillEntries = fs.readdirSync(entryPath, { withFileTypes: true });
-      for (const skill of skillEntries) {
-        if (!skill.isDirectory()) continue;
-        const skillPath = path.join(entryPath, skill.name);
-        leaves.push({
-          relPath: path.join(entry.name, skill.name),
-          dirName: skill.name,
-          fullPath: skillPath,
-          missing: !hasSkillMd(skillPath),
-        });
-      }
-    }
-  }
-
-  return leaves;
-}
 
 function extractFrontmatter(content) {
   const block = extractFrontmatterBlock(content);

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { hasSkillMd, isCategoryRoot, listSkillLeaves } = require('../lib/skill-tree-walker');
+const { hasSkillMd, isCategoryRoot, listSkillLeaves } = require('#lib/skill-tree-walker');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { hasSkillMd, isCategoryRoot, listSkillLeaves } = require('#lib/skill-tree-walker');
+const { listSkillLeaves } = require('#lib/skill-tree-walker');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 
@@ -52,4 +52,4 @@ if (require.main === module) {
   validateSkills();
 }
 
-module.exports = { listSkillLeaves, hasSkillMd, isCategoryRoot };
+module.exports = { listSkillLeaves };

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -2,62 +2,9 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { hasSkillMd, isCategoryRoot, listSkillLeaves } = require('../lib/skill-tree-walker');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
-
-function hasSkillMd(dir) {
-  return fs.existsSync(path.join(dir, 'SKILL.md'));
-}
-
-function isCategoryRoot(dir) {
-  if (hasSkillMd(dir)) return false;
-  try {
-    const children = fs.readdirSync(dir, { withFileTypes: true });
-    return children.some(c => c.isDirectory() && hasSkillMd(path.join(dir, c.name)));
-  } catch (_err) { // NOSONAR: unreadable dir cannot contain a skill
-    return false;
-  }
-}
-
-function collectSkillEntriesFromCategory(entryPath, entryName) {
-  const leaves = [];
-  const skillEntries = fs.readdirSync(entryPath, { withFileTypes: true });
-  for (const skill of skillEntries) {
-    if (!skill.isDirectory()) continue;
-    const skillPath = path.join(entryPath, skill.name);
-    const relPath = path.join(entryName, skill.name);
-    if (hasSkillMd(skillPath)) {
-      leaves.push({ relPath, fullPath: skillPath });
-    } else {
-      leaves.push({ relPath, fullPath: skillPath, missing: true });
-    }
-  }
-  return leaves;
-}
-
-function listSkillLeaves(root) {
-  const leaves = [];
-  const entries = fs.readdirSync(root, { withFileTypes: true });
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const entryPath = path.join(root, entry.name);
-
-    if (hasSkillMd(entryPath)) {
-      leaves.push({ relPath: entry.name, fullPath: entryPath });
-      continue;
-    }
-
-    if (isCategoryRoot(entryPath)) {
-      leaves.push(...collectSkillEntriesFromCategory(entryPath, entry.name));
-      continue;
-    }
-
-    leaves.push({ relPath: entry.name, fullPath: entryPath, missing: true });
-  }
-
-  return leaves;
-}
 
 function validateSkills() {
   if (!fs.existsSync(SKILLS_DIR)) {

--- a/scripts/lib/skill-tree-walker.js
+++ b/scripts/lib/skill-tree-walker.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// Shared skill-directory tree walker for scripts/ci/validate-skills.js and
+// scripts/ci/validate-skill-frontmatter.js. Both used to reimplement this
+// identically (EGC-539 audit, Finding 4) -- the convention is that a skill
+// lives either directly under skills/<name>/SKILL.md, or nested one level
+// under a category directory (skills/<category>/<name>/SKILL.md).
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function hasSkillMd(dir) {
+  return fs.existsSync(path.join(dir, 'SKILL.md'));
+}
+
+function isCategoryRoot(dir) {
+  if (hasSkillMd(dir)) return false;
+  try {
+    const children = fs.readdirSync(dir, { withFileTypes: true });
+    return children.some(c => c.isDirectory() && hasSkillMd(path.join(dir, c.name)));
+  } catch (_err) { // NOSONAR: unreadable dir cannot contain a skill
+    return false;
+  }
+}
+
+// Each leaf is { relPath, dirName, fullPath, missing? }. relPath is
+// category/name for nested skills, or just name for top-level ones; dirName
+// is always the leaf directory's own name, used by validate-skill-
+// frontmatter.js to check the frontmatter `name` field against it.
+function listSkillLeaves(root) {
+  const leaves = [];
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const entryPath = path.join(root, entry.name);
+
+    if (hasSkillMd(entryPath)) {
+      leaves.push({ relPath: entry.name, dirName: entry.name, fullPath: entryPath });
+      continue;
+    }
+
+    if (isCategoryRoot(entryPath)) {
+      const skillEntries = fs.readdirSync(entryPath, { withFileTypes: true });
+      for (const skill of skillEntries) {
+        if (!skill.isDirectory()) continue;
+        const skillPath = path.join(entryPath, skill.name);
+        leaves.push({
+          relPath: path.join(entry.name, skill.name),
+          dirName: skill.name,
+          fullPath: skillPath,
+          missing: !hasSkillMd(skillPath),
+        });
+      }
+      continue;
+    }
+
+    leaves.push({ relPath: entry.name, dirName: entry.name, fullPath: entryPath, missing: true });
+  }
+
+  return leaves;
+}
+
+module.exports = { hasSkillMd, isCategoryRoot, listSkillLeaves };

--- a/tests/lib/skill-tree-walker.test.js
+++ b/tests/lib/skill-tree-walker.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for scripts/lib/skill-tree-walker.js -- the shared skill-directory
+ * tree walker extracted from scripts/ci/validate-skills.js and
+ * scripts/ci/validate-skill-frontmatter.js (EGC-539 audit, Finding 4).
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { hasSkillMd, isCategoryRoot, listSkillLeaves } = require('../../scripts/lib/skill-tree-walker');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function makeSkill(root, ...segments) {
+  const dir = path.join(root, ...segments);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: x\ndescription: x\n---\n');
+  return dir;
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/skill-tree-walker.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('hasSkillMd is true for a directory with SKILL.md, false otherwise', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-walker-'));
+    try {
+      const withSkill = makeSkill(root, 'has-one');
+      const without = path.join(root, 'no-skill');
+      fs.mkdirSync(without);
+      assert.strictEqual(hasSkillMd(withSkill), true);
+      assert.strictEqual(hasSkillMd(without), false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('isCategoryRoot is true only for a directory whose children (not itself) have SKILL.md', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-walker-'));
+    try {
+      const category = path.join(root, 'category');
+      fs.mkdirSync(category);
+      makeSkill(category, 'child-skill');
+      assert.strictEqual(isCategoryRoot(category), true);
+
+      const leafSkill = makeSkill(root, 'leaf-skill');
+      assert.strictEqual(isCategoryRoot(leafSkill), false, 'a directory with its own SKILL.md is a leaf, not a category root');
+
+      const empty = path.join(root, 'empty');
+      fs.mkdirSync(empty);
+      assert.strictEqual(isCategoryRoot(empty), false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('isCategoryRoot does not throw on an unreadable directory', () => {
+    assert.strictEqual(isCategoryRoot(path.join(os.tmpdir(), 'skill-walker-does-not-exist')), false);
+  })) passed++; else failed++;
+
+  if (test('listSkillLeaves finds top-level skills directly', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-walker-'));
+    try {
+      makeSkill(root, 'top-level-skill');
+      const leaves = listSkillLeaves(root);
+      assert.strictEqual(leaves.length, 1);
+      assert.strictEqual(leaves[0].relPath, 'top-level-skill');
+      assert.strictEqual(leaves[0].dirName, 'top-level-skill');
+      assert.strictEqual(leaves[0].missing, undefined);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('listSkillLeaves finds skills nested one level under a category directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-walker-'));
+    try {
+      makeSkill(root, 'docs', 'nested-skill');
+      const leaves = listSkillLeaves(root);
+      assert.strictEqual(leaves.length, 1);
+      assert.strictEqual(leaves[0].relPath, path.join('docs', 'nested-skill'));
+      assert.strictEqual(leaves[0].dirName, 'nested-skill');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('listSkillLeaves flags a directory with no SKILL.md and no valid children as missing', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-walker-'));
+    try {
+      fs.mkdirSync(path.join(root, 'broken-skill'));
+      const leaves = listSkillLeaves(root);
+      assert.strictEqual(leaves.length, 1);
+      assert.strictEqual(leaves[0].missing, true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('listSkillLeaves flags a skill missing under an otherwise-valid category', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-walker-'));
+    try {
+      const category = path.join(root, 'category');
+      makeSkill(category, 'real-skill');
+      fs.mkdirSync(path.join(category, 'broken-skill'));
+      const leaves = listSkillLeaves(root);
+      assert.strictEqual(leaves.length, 2);
+      const broken = leaves.find(l => l.dirName === 'broken-skill');
+      assert.strictEqual(broken.missing, true);
+      const real = leaves.find(l => l.dirName === 'real-skill');
+      // A found nested skill explicitly gets missing: false (from
+      // !hasSkillMd(...)); a found top-level skill never sets the key at
+      // all (undefined). Both are falsy for every real consumer's `if
+      // (leaf.missing)` check -- pre-existing, harmless asymmetry inherited
+      // from the two original implementations, not introduced here.
+      assert.ok(!real.missing);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('listSkillLeaves ignores non-directory entries at the root', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-walker-'));
+    try {
+      fs.writeFileSync(path.join(root, 'README.md'), 'not a skill');
+      makeSkill(root, 'real-skill');
+      const leaves = listSkillLeaves(root);
+      assert.strictEqual(leaves.length, 1);
+      assert.strictEqual(leaves[0].dirName, 'real-skill');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary
EGC-539 audit (Finding 4): `hasSkillMd`/`isCategoryRoot` were byte-for-byte identical between `validate-skills.js` and `validate-skill-frontmatter.js`, and `listSkillLeaves` reimplemented the same directory walk a second time. Extracted into `scripts/lib/skill-tree-walker.js`.

## Test plan
- [x] New `tests/lib/skill-tree-walker.test.js` (8/8 passing)
- [x] Both validators produce identical baseline against the real `skills/` directory before/after (230/230 in both)
- [x] `npx eslint` clean on all 4 changed files

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the shared skill-tree walker into `scripts/lib/skill-tree-walker.js` and updated both validators to import it via `#lib/skill-tree-walker`. Fixed test harness module resolution and removed unused re-exports; behavior unchanged (EGC-539, Finding 4).

- **Refactors**
  - Added `hasSkillMd`, `isCategoryRoot`, and `listSkillLeaves` in `scripts/lib/skill-tree-walker.js`; replaced duplicate logic in both validators; dropped unused re-exports in `scripts/ci/validate-skills.js`. Added `tests/lib/skill-tree-walker.test.js` (8 tests).

- **Bug Fixes**
  - Added `imports` map in `package.json` and switched validators to `require('#lib/skill-tree-walker')` to fix MODULE_NOT_FOUND in the test harness.
  - CI restored: validators tests pass (167/167); validators still match baseline results (230/230).

<sup>Written for commit 415fbaea5e1521703b62c6c62bc3b2946d1b461a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

