### PR TITLE
refactor(ci): extract shared frontmatter-block detector from 3 validators

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "imports": {
+    "#lib/*": "./scripts/lib/*.js"
+  },
   "main": "scripts/egc.js",
   "bin": {
     "egc": "scripts/egc.js",

--- a/scripts/ci/validate-agents.js
+++ b/scripts/ci/validate-agents.js
@@ -5,6 +5,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { extractFrontmatterBlock } = require('#lib/frontmatter-block');
 
 const AGENTS_DIR = path.join(__dirname, '../../agents');
 const REQUIRED_FIELDS = ['model', 'tools'];
@@ -16,14 +17,11 @@ const VALID_MODELS = [
 ];
 
 function extractFrontmatter(content) {
-  // Strip BOM if present (UTF-8 BOM: \uFEFF)
-  const cleanContent = content.replace(/^\uFEFF/, '');
-  // Support both LF and CRLF line endings
-  const match = cleanContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
+  const block = extractFrontmatterBlock(content);
+  if (block.error) return null;
 
   const frontmatter = {};
-  const lines = match[1].split(/\r?\n/);
+  const lines = block.raw.split(/\r?\n/);
   for (const line of lines) {
     const colonIdx = line.indexOf(':');
     if (colonIdx > 0) {

--- a/scripts/ci/validate-commands.js
+++ b/scripts/ci/validate-commands.js
@@ -6,6 +6,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { extractFrontmatterBlock } = require('#lib/frontmatter-block');
 
 const ROOT_DIR = path.join(__dirname, '../..');
 const COMMANDS_DIR = path.join(ROOT_DIR, 'commands');
@@ -13,19 +14,17 @@ const AGENTS_DIR = path.join(ROOT_DIR, 'agents');
 const SKILLS_DIR = path.join(ROOT_DIR, 'skills');
 
 function validateFrontmatter(file, content) {
-  if (!content.startsWith('---\n')) {
+  const block = extractFrontmatterBlock(content);
+  if (block.error === 'missing') {
     return [];
   }
-
-  const endIndex = content.indexOf('\n---\n', 4);
-  if (endIndex === -1) {
+  if (block.error === 'unterminated') {
     return [`${file} - frontmatter block is missing a closing --- delimiter`];
   }
 
-  const block = content.slice(4, endIndex);
   const errors = [];
 
-  for (const rawLine of block.split('\n')) {
+  for (const rawLine of block.raw.split('\n')) {
     const line = rawLine.trim();
     if (!line || line.startsWith('#')) {
       continue;

--- a/scripts/ci/validate-skill-frontmatter.js
+++ b/scripts/ci/validate-skill-frontmatter.js
@@ -11,6 +11,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { extractFrontmatterBlock } = require('#lib/frontmatter-block');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
@@ -63,24 +64,12 @@ function listSkillLeaves(root) {
   return leaves;
 }
 
-// Adapted from the frontmatter extractor in scripts/ci/validate-agents.js.
-// Distinguishes "no frontmatter block at all" from "frontmatter block opened
-// but never closed" so the error message points at the actual problem.
 function extractFrontmatter(content) {
-  const cleanContent = content.replace(/^\uFEFF/, '');
-  const opensFrontmatter = /^---\r?\n/.test(cleanContent);
-
-  if (!opensFrontmatter) {
-    return { error: 'missing' };
-  }
-
-  const match = cleanContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) {
-    return { error: 'unterminated' };
-  }
+  const block = extractFrontmatterBlock(content);
+  if (block.error) return { error: block.error };
 
   const frontmatter = {};
-  const lines = match[1].split(/\r?\n/);
+  const lines = block.raw.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     // Indented lines belong to a block scalar consumed below.

--- a/scripts/lib/frontmatter-block.js
+++ b/scripts/lib/frontmatter-block.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Shared frontmatter-block delimiter detection for scripts/ci/validate-agents.js,
+// scripts/ci/validate-skill-frontmatter.js, and scripts/ci/validate-commands.js.
+// All three used to reimplement the same "find the --- ... --- block" regex
+// independently (EGC-539 audit, Finding 5) -- this only locates the block; each
+// caller still parses its own contents (key:value pairs vs. syntax-only checks)
+// because their needs diverge past this point.
+
+const BOM = String.fromCharCode(0xFEFF);
+
+function extractFrontmatterBlock(content) {
+  const cleanContent = content.startsWith(BOM) ? content.slice(BOM.length) : content;
+
+  if (!/^---\r?\n/.test(cleanContent)) {
+    return { error: 'missing' };
+  }
+
+  const match = cleanContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) {
+    return { error: 'unterminated' };
+  }
+
+  return { raw: match[1] };
+}
+
+module.exports = { extractFrontmatterBlock };

--- a/tests/lib/frontmatter-block.test.js
+++ b/tests/lib/frontmatter-block.test.js
@@ -1,0 +1,72 @@
+/**
+ * Tests for scripts/lib/frontmatter-block.js -- the shared frontmatter-block
+ * delimiter detector extracted from validate-agents.js,
+ * validate-skill-frontmatter.js, and validate-commands.js (EGC-539 audit,
+ * Finding 5).
+ */
+
+const assert = require('assert');
+
+const { extractFrontmatterBlock } = require('../../scripts/lib/frontmatter-block');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/frontmatter-block.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('returns { error: "missing" } when content does not start with ---', () => {
+    assert.deepStrictEqual(extractFrontmatterBlock('# No frontmatter here\n'), { error: 'missing' });
+  })) passed++; else failed++;
+
+  if (test('returns { error: "unterminated" } when the closing --- is absent', () => {
+    assert.deepStrictEqual(extractFrontmatterBlock('---\nname: x\ndescription: x\n'), { error: 'unterminated' });
+  })) passed++; else failed++;
+
+  if (test('returns the raw block text between the delimiters on success', () => {
+    const result = extractFrontmatterBlock('---\nname: x\ndescription: y\n---\nbody');
+    assert.deepStrictEqual(result, { raw: 'name: x\ndescription: y' });
+  })) passed++; else failed++;
+
+  if (test('supports CRLF line endings', () => {
+    const result = extractFrontmatterBlock('---\r\nname: x\r\n---\r\nbody');
+    assert.deepStrictEqual(result, { raw: 'name: x' });
+  })) passed++; else failed++;
+
+  if (test('strips a leading UTF-8 BOM before detecting the opening delimiter', () => {
+    const result = extractFrontmatterBlock('﻿---\nname: x\n---\nbody');
+    assert.deepStrictEqual(result, { raw: 'name: x' });
+  })) passed++; else failed++;
+
+  if (test('treats an empty block (--- immediately followed by ---) as a valid empty raw string', () => {
+    const result = extractFrontmatterBlock('---\n\n---\nbody');
+    assert.deepStrictEqual(result, { raw: '' });
+  })) passed++; else failed++;
+
+  if (test('does not require trailing content after the closing --- (EOF right after)', () => {
+    const result = extractFrontmatterBlock('---\nname: x\n---');
+    assert.deepStrictEqual(result, { raw: 'name: x' });
+  })) passed++; else failed++;
+
+  if (test('matches the first closing --- non-greedily, not a later one', () => {
+    const result = extractFrontmatterBlock('---\nname: x\n---\nbody\n\n---\nnot part of frontmatter\n---');
+    assert.deepStrictEqual(result, { raw: 'name: x' });
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/frontmatter-block.test.js
+++ b/tests/lib/frontmatter-block.test.js
@@ -46,7 +46,8 @@ function runTests() {
   })) passed++; else failed++;
 
   if (test('strips a leading UTF-8 BOM before detecting the opening delimiter', () => {
-    const result = extractFrontmatterBlock('﻿---\nname: x\n---\nbody');
+    const bom = String.fromCharCode(0xFEFF);
+    const result = extractFrontmatterBlock(`${bom}---\nname: x\n---\nbody`);
     assert.deepStrictEqual(result, { raw: 'name: x' });
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
EGC-539 audit (Finding 5): `validate-agents.js`, `validate-skill-frontmatter.js`, and `validate-commands.js` each reimplemented the same `--- ... ---` block-detection regex independently. Extracted the shared piece into `scripts/lib/frontmatter-block.js`; each validator keeps its own logic past block detection (key:value split vs. YAML block-scalar folding vs. bracket/brace syntax checks).

Uses the same Node subpath-import fix (`package.json` `"imports"`) as the sibling PR #1138 (`skill-tree-walker.js`), for the same underlying reason -- `tests/ci/validators.test.js` copies validator source into a temp file elsewhere to test it, and a relative `require('../lib/...')` breaks from there.

One disclosed, verified-safe behavior change: `validate-commands.js` no longer requires a trailing newline after the closing `---` (matches the other two validators' already-tested behavior). No real command file hits this edge case.

## Test plan
- [x] `tests/ci/validators.test.js` 167/167
- [x] New `tests/lib/frontmatter-block.test.js` 8/8
- [x] All 3 validators unchanged baseline against real project files (63 agents, 77 commands, 230 skills)
- [x] `npx eslint` clean

Depends on nothing merging first; will rebase on top of #1138 if it merges first (both touch `package.json`'s `imports` field, trivial to resolve).

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated frontmatter `--- ... ---` block detection across CI validators by extracting a shared helper. Addresses EGC-539 (Finding 5) and keeps each validator’s parsing the same; `validate-commands.js` now accepts a closing `---` at EOF.

- **Refactors**
  - Added `scripts/lib/frontmatter-block.js`; updated the three validators to use it.
  - Added `#lib/*` in `package.json` for stable test paths; BOM test now builds the char via `String.fromCharCode(0xFEFF)` to pass Unicode-safety CI.

<sup>Written for commit 843c5772cd1760fd30850dcc47799bafe6451ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

