### PR TITLE
refactor(memory): dedup 9 near-identical context writers in propagate-state.js

### DIFF
--- a/scripts/lib/propagate-state.js
+++ b/scripts/lib/propagate-state.js
@@ -337,8 +337,14 @@ function writeCursorContext(projectPath, block, stateUpdated) {
   return filePath;
 }
 
-function writeCopilotContext(projectPath, block, stateUpdated) {
-  const filePath = path.join(projectPath, '.github', 'copilot-instructions.md');
+// Shared by every writer whose target is a single flat file that this
+// function neither creates nor makes a directory for: the file (and its
+// parent dir, e.g. .github/) must already exist, or propagation is skipped
+// entirely. This is the common shape behind Copilot, Gemini, Zed, Cline,
+// Aider, legacy Cursor, and AGENTS.md -- they differ only in which relative
+// path they point at.
+function writeSimpleContext(projectPath, relativePathParts, block, stateUpdated) {
+  const filePath = path.join(projectPath, ...relativePathParts);
   try {
     if (!fs.existsSync(filePath)) return null;
   } catch {
@@ -351,124 +357,62 @@ function writeCopilotContext(projectPath, block, stateUpdated) {
   return filePath;
 }
 
+function writeCopilotContext(projectPath, block, stateUpdated) {
+  return writeSimpleContext(projectPath, ['.github', 'copilot-instructions.md'], block, stateUpdated);
+}
+
 function writeGeminiContext(projectPath, block, stateUpdated) {
-  const filePath = path.join(projectPath, 'GEMINI.md');
+  return writeSimpleContext(projectPath, ['GEMINI.md'], block, stateUpdated);
+}
+
+// Shared by Windsurf and Trae: unlike writeSimpleContext, the gate is on the
+// tool's top-level dir (e.g. .windsurf/) rather than the target file itself,
+// and a rules/ subfolder is created under it on demand before the shared
+// egc-context.md is written there.
+function writeToolRulesContext(projectPath, toolDirName, block, stateUpdated) {
+  const toolDir = path.join(projectPath, toolDirName);
   try {
-    if (!fs.existsSync(filePath)) return null;
+    if (!fs.existsSync(toolDir) || !fs.statSync(toolDir).isDirectory()) return null;
   } catch {
     return null;
   }
 
-  const existing = fs.readFileSync(filePath, 'utf-8');
+  const rulesDir = path.join(toolDir, 'rules');
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const filePath = path.join(rulesDir, 'egc-context.md');
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
   if (isStaleWrite(existing, stateUpdated)) return filePath;
   fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
   return filePath;
 }
 
 function writeWindsurfContext(projectPath, block, stateUpdated) {
-  const windsurfDir = path.join(projectPath, '.windsurf');
-  try {
-    if (!fs.existsSync(windsurfDir) || !fs.statSync(windsurfDir).isDirectory()) return null;
-  } catch {
-    return null;
-  }
-
-  const rulesDir = path.join(windsurfDir, 'rules');
-  fs.mkdirSync(rulesDir, { recursive: true });
-
-  const filePath = path.join(rulesDir, 'egc-context.md');
-  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return writeToolRulesContext(projectPath, '.windsurf', block, stateUpdated);
 }
 
 function writeTraeContext(projectPath, block, stateUpdated) {
-  const traeDir = path.join(projectPath, '.trae');
-  try {
-    if (!fs.existsSync(traeDir) || !fs.statSync(traeDir).isDirectory()) return null;
-  } catch {
-    return null;
-  }
-
-  const rulesDir = path.join(traeDir, 'rules');
-  fs.mkdirSync(rulesDir, { recursive: true });
-
-  const filePath = path.join(rulesDir, 'egc-context.md');
-  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return writeToolRulesContext(projectPath, '.trae', block, stateUpdated);
 }
 
 function writeZedContext(projectPath, block, stateUpdated) {
-  const filePath = path.join(projectPath, '.rules');
-  try {
-    if (!fs.existsSync(filePath)) return null;
-  } catch {
-    return null;
-  }
-
-  const existing = fs.readFileSync(filePath, 'utf-8');
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return writeSimpleContext(projectPath, ['.rules'], block, stateUpdated);
 }
 
 function writeClineContext(projectPath, block, stateUpdated) {
-  const filePath = path.join(projectPath, '.clinerules');
-  try {
-    if (!fs.existsSync(filePath)) return null;
-  } catch {
-    return null;
-  }
-
-  const existing = fs.readFileSync(filePath, 'utf-8');
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return writeSimpleContext(projectPath, ['.clinerules'], block, stateUpdated);
 }
 
 function writeAiderContext(projectPath, block, stateUpdated) {
-  const filePath = path.join(projectPath, 'CONVENTIONS.md');
-  try {
-    if (!fs.existsSync(filePath)) return null;
-  } catch {
-    return null;
-  }
-
-  const existing = fs.readFileSync(filePath, 'utf-8');
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return writeSimpleContext(projectPath, ['CONVENTIONS.md'], block, stateUpdated);
 }
 
 function writeLegacyCursorRules(projectPath, block, stateUpdated) {
-  const filePath = path.join(projectPath, '.cursorrules');
-  try {
-    if (!fs.existsSync(filePath)) return null;
-  } catch {
-    return null;
-  }
-
-  const existing = fs.readFileSync(filePath, 'utf-8');
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return writeSimpleContext(projectPath, ['.cursorrules'], block, stateUpdated);
 }
 
 function writeAgentsContext(projectPath, block, stateUpdated) {
-  const filePath = path.join(projectPath, 'AGENTS.md');
-  try {
-    if (!fs.existsSync(filePath)) return null;
-  } catch {
-    return null;
-  }
-
-  const existing = fs.readFileSync(filePath, 'utf-8');
-  if (isStaleWrite(existing, stateUpdated)) return filePath;
-  fs.writeFileSync(filePath, upsertEgcSection(existing, block), 'utf-8');
-  return filePath;
+  return writeSimpleContext(projectPath, ['AGENTS.md'], block, stateUpdated);
 }
 
 function writeLlmsTxt(projectPath, parsed) {


### PR DESCRIPTION
## Summary
EGC-539 audit (scripts/ scope): `writeCopilotContext`, `writeGeminiContext`, `writeZedContext`, `writeClineContext`, `writeAiderContext`, `writeLegacyCursorRules`, and `writeAgentsContext` in `scripts/lib/propagate-state.js` were byte-for-byte identical except for the literal target file path. `writeWindsurfContext`/`writeTraeContext` were a second near-identical pair (same body plus an extra `mkdirSync` for a `rules/` subfolder).

## Fix
Extracted two shared helpers:
- `writeSimpleContext(projectPath, relativePathParts, block, stateUpdated)` -- the flat-file case: target file (and its parent dir) must already exist, or propagation is skipped.
- `writeToolRulesContext(projectPath, toolDirName, block, stateUpdated)` -- the Windsurf/Trae case: gate on the tool's top-level dir, create a `rules/` subfolder on demand, write `egc-context.md` there.

All 9 original functions are now one-line wrappers delegating to one of the two helpers. Same file paths written, same content, same return values -- structural refactor only, no behavior change.

## Test plan
- [x] `tests/scripts/propagate-state.test.js`: 41/41 passing before and after the refactor (isolated run, not full suite)
- [x] `npx eslint scripts/lib/propagate-state.js` clean

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated nine near-identical context writers in scripts/lib/propagate-state.js for EGC-539. Extracted two shared helpers; behavior is unchanged.

- **Refactors**
  - Added writeSimpleContext(projectPath, relativePathParts, block, stateUpdated) for flat-file targets that must already exist.
  - Added writeToolRulesContext(projectPath, toolDirName, block, stateUpdated) for `.windsurf`/`.trae` with `rules/` creation and `egc-context.md`.
  - Converted writeCopilotContext, writeGeminiContext, writeZedContext, writeClineContext, writeAiderContext, writeLegacyCursorRules, writeAgentsContext to one-line wrappers.
  - Converted writeWindsurfContext and writeTraeContext to wrappers.
  - Same file paths, content, and return values.

<sup>Written for commit df3d8e92d4ea0dcceb17cf48029d273f3facd7ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

