### PR TITLE
fix(guardian): scaffold GateGuard script for codebuddy installs (EGC-539)

### DIFF
--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -8,7 +8,10 @@ const {
   planFlatSkillOperation,
 } = require('./helpers');
 const {
-  createGateGuardScriptCopyOperations,
+  GATEGUARD_HOOK_MODULE_ID,
+  GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+  GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
+  resolveGateGuardHookScriptDestination,
   createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseCrusherHookMergeOperation,
   createCrusherScriptCopyOperations,
@@ -21,16 +24,52 @@ const {
 // foreign-platform paths, so a module selection that explicitly includes
 // 'hooks-runtime' (whose paths cover scripts/hooks and scripts/lib) already
 // scaffolds gateguard-fact-force.js and utils.js via moduleOperations below.
-// Cubic review (EGC-539, PR #1142) caught that the unconditional copy here
-// would double-copy those same two files in that case. Only add the
-// explicit copy when no selected module's paths already cover scripts/hooks
-// or scripts/lib.
-function selectedModulesCoverGateGuardScripts(modules) {
+// Cubic review (EGC-539, PR #1142) caught two real gaps in earlier versions
+// of this guard: (1) an `.some()`-based check treated covering EITHER
+// scripts/hooks or scripts/lib as proof BOTH GateGuard files were already
+// scaffolded, so a module selection covering only one of the two directories
+// would skip copying the other file entirely, leaving it missing; (2) even
+// after requiring both directories, the guard still worked at the whole-pair
+// level (createGateGuardScriptCopyOperations copies both files together),
+// so a selection covering only scripts/hooks (not scripts/lib) had no way to
+// copy just the missing file without also re-copying the one already
+// covered. Each of the two GateGuard files is therefore checked and copied
+// independently below: skip a given file's explicit copy only when the
+// selected modules cover its own exact path or its whole containing
+// directory (which scaffolds recursively); a module pinning some other,
+// unrelated file in that directory does not count as covering it.
+function isPathCovered(modules, directoryPath, exactFilePath) {
   return modules.some(module => {
     const paths = Array.isArray(module.paths) ? module.paths : [];
-    return paths.some(p => p === 'scripts/hooks' || p === 'scripts/lib'
-      || p.startsWith('scripts/hooks/') || p.startsWith('scripts/lib/'));
+    return paths.some(p => p === directoryPath || p === exactFilePath);
   });
+}
+
+function createGateGuardScriptCopyOperationsIfMissing(adapter, targetRoot, modules) {
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+  );
+  const operations = [];
+
+  if (!isPathCovered(modules, 'scripts/hooks', GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH)) {
+    operations.push(remap(
+      GATEGUARD_HOOK_MODULE_ID,
+      GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveGateGuardHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ));
+  }
+
+  if (!isPathCovered(modules, 'scripts/lib', GATEGUARD_LIB_SOURCE_RELATIVE_PATH)) {
+    operations.push(remap(
+      GATEGUARD_HOOK_MODULE_ID,
+      GATEGUARD_LIB_SOURCE_RELATIVE_PATH,
+      path.join(targetRoot, 'scripts', 'lib', 'utils.js'),
+      { strategy: 'preserve-relative-path' }
+    ));
+  }
+
+  return operations;
 }
 
 // CodeBuddy's PreToolUse hooks read from <project>/.codebuddy/settings.json
@@ -51,12 +90,7 @@ function selectedModulesCoverGateGuardScripts(modules) {
 // when the selected modules already scaffold those same two files.
 function createHookOperations(adapter, targetRoot, modules) {
   return [
-    ...(selectedModulesCoverGateGuardScripts(modules) ? [] : createGateGuardScriptCopyOperations(
-      (moduleId, sourceRelativePath, destinationPath, options) => (
-        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-      ),
-      targetRoot
-    )),
+    ...createGateGuardScriptCopyOperationsIfMissing(adapter, targetRoot, modules),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'MultiEdit'),

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -8,6 +8,7 @@ const {
   planFlatSkillOperation,
 } = require('./helpers');
 const {
+  createGateGuardScriptCopyOperations,
   createPreToolUseGateGuardHookMergeOperation,
   createPreToolUseCrusherHookMergeOperation,
   createCrusherScriptCopyOperations,
@@ -18,12 +19,26 @@ const {
 // CodeBuddy's PreToolUse hooks read from <project>/.codebuddy/settings.json
 // using the same {"hooks": {"PreToolUse": [{"matcher", "hooks"}]}} shape
 // Claude Code uses (https://www.codebuddy.ai/docs/cli/hooks), and this
-// adapter's own targetRoot already resolves to <project>/.codebuddy -- the
-// same root the hooks-runtime module scaffolds scripts/hooks/
-// gateguard-fact-force.js and scripts/lib/utils.js into. So the generic
-// Claude merge helper is reusable here without modification.
+// adapter's own targetRoot already resolves to <project>/.codebuddy. The
+// generic Claude merge helper is reusable here without modification, but
+// 'hooks-runtime' is not a default legacy module for the codebuddy target
+// (see LEGACY_COMPAT_BASE_MODULE_IDS_BY_TARGET in install-manifests.js), so
+// a module selection that omits it never scaffolds gateguard-fact-force.js
+// or utils.js on its own. EGC-539 found the merge operations below were
+// registered unconditionally while the script copy was not, so an install
+// whose selected modules did not include scripts/hooks/scripts/lib wrote a
+// PreToolUse hook pointing at a file that was never copied, breaking every
+// Edit/Write/MultiEdit/Bash call with ENOENT. Copy the script and its
+// utils.js dependency explicitly and unconditionally here, mirroring the
+// same fix already applied to antigravity-project.js and copilot-home.js.
 function createHookOperations(adapter, targetRoot) {
   return [
+    ...createGateGuardScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) => (
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
+      ),
+      targetRoot
+    ),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'MultiEdit'),

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -16,6 +16,23 @@ const {
   createBashGuardianScriptCopyOperations,
 } = require('../claude-settings-hooks');
 
+// Unlike antigravity-project.js (whose SUPPORTED_SOURCE_PREFIXES excludes
+// 'scripts/**' entirely), CodeBuddy's module path filter only excludes
+// foreign-platform paths, so a module selection that explicitly includes
+// 'hooks-runtime' (whose paths cover scripts/hooks and scripts/lib) already
+// scaffolds gateguard-fact-force.js and utils.js via moduleOperations below.
+// Cubic review (EGC-539, PR #1142) caught that the unconditional copy here
+// would double-copy those same two files in that case. Only add the
+// explicit copy when no selected module's paths already cover scripts/hooks
+// or scripts/lib.
+function selectedModulesCoverGateGuardScripts(modules) {
+  return modules.some(module => {
+    const paths = Array.isArray(module.paths) ? module.paths : [];
+    return paths.some(p => p === 'scripts/hooks' || p === 'scripts/lib'
+      || p.startsWith('scripts/hooks/') || p.startsWith('scripts/lib/'));
+  });
+}
+
 // CodeBuddy's PreToolUse hooks read from <project>/.codebuddy/settings.json
 // using the same {"hooks": {"PreToolUse": [{"matcher", "hooks"}]}} shape
 // Claude Code uses (https://www.codebuddy.ai/docs/cli/hooks), and this
@@ -29,16 +46,17 @@ const {
 // whose selected modules did not include scripts/hooks/scripts/lib wrote a
 // PreToolUse hook pointing at a file that was never copied, breaking every
 // Edit/Write/MultiEdit/Bash call with ENOENT. Copy the script and its
-// utils.js dependency explicitly and unconditionally here, mirroring the
-// same fix already applied to antigravity-project.js and copilot-home.js.
-function createHookOperations(adapter, targetRoot) {
+// utils.js dependency explicitly here, mirroring the same fix already
+// applied to antigravity-project.js and copilot-home.js, but skip the copy
+// when the selected modules already scaffold those same two files.
+function createHookOperations(adapter, targetRoot, modules) {
   return [
-    ...createGateGuardScriptCopyOperations(
+    ...(selectedModulesCoverGateGuardScripts(modules) ? [] : createGateGuardScriptCopyOperations(
       (moduleId, sourceRelativePath, destinationPath, options) => (
         createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
       ),
       targetRoot
-    ),
+    )),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseGateGuardHookMergeOperation(targetRoot, 'MultiEdit'),
@@ -122,7 +140,7 @@ module.exports = createInstallTargetAdapter({
     // mirroring Claude Code's always-on hook registration.
     return [
       ...moduleOperations,
-      ...createHookOperations(adapter, targetRoot),
+      ...createHookOperations(adapter, targetRoot, modules),
     ];
   },
 });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2236,19 +2236,89 @@ function runTests() {
     // each for Edit/Write/MultiEdit/Bash) legitimately carry
     // sourceRelativePath: 'scripts/hooks/gateguard-fact-force.js' too --
     // they reference the script path to build the hook command, they don't
-    // copy it. Only 'copy-path' operations represent an actual file copy,
-    // so the double-copy check must scope to that operation type.
+    // copy it. createManagedOperation sets `kind`, not `type` (every other
+    // assertion in this file uses operation.kind); an earlier version of
+    // this test asserted on operation.type, which is always undefined, so
+    // these two checks passed trivially regardless of whether the
+    // double-copy regression was actually present (cubic review caught
+    // this). Only 'copy-path' operations represent an actual file copy, so
+    // the double-copy check must scope to that operation kind.
     const explicitFileLevelScriptOp = plan.operations.find(operation => (
-      operation.type === 'copy-path'
+      operation.kind === 'copy-path'
       && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
     ));
     assert.strictEqual(explicitFileLevelScriptOp, undefined, 'createGateGuardScriptCopyOperations\' explicit file-level copy should be skipped when the module already covers scripts/hooks');
 
     const explicitFileLevelUtilsOp = plan.operations.find(operation => (
-      operation.type === 'copy-path'
+      operation.kind === 'copy-path'
       && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
     ));
     assert.strictEqual(explicitFileLevelUtilsOp, undefined, 'createGateGuardScriptCopyOperations\' explicit file-level copy of utils.js should be skipped when the module already covers scripts/lib');
+  })) passed++; else failed++;
+
+  // Cubic review (EGC-539, PR #1142), violation 1: a module selection that
+  // covers only ONE of scripts/hooks or scripts/lib (not both) must still
+  // get the explicit copy for the file it does NOT already cover -- an
+  // earlier `.some()`-based guard treated covering either one as proof both
+  // were scaffolded, silently dropping utils.js in this scenario and
+  // reintroducing the ENOENT fail-open this PR exists to fix.
+  if (test('codebuddy adapter still copies utils.js when a selected module covers only scripts/hooks, not scripts/lib', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codebuddy',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'hooks-only', paths: ['scripts/hooks'] }],
+    });
+
+    // scripts/hooks is covered by the module (no duplicate expected), but
+    // scripts/lib is not, so utils.js must still be copied explicitly.
+    const explicitFileLevelScriptOp = plan.operations.find(operation => (
+      operation.kind === 'copy-path'
+      && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+    ));
+    assert.strictEqual(explicitFileLevelScriptOp, undefined, 'gateguard-fact-force.js is already covered by the scripts/hooks module, the explicit copy should still be skipped');
+
+    const explicitFileLevelUtilsOp = plan.operations.find(operation => (
+      operation.kind === 'copy-path'
+      && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
+      && operation.destinationPath === path.join(projectRoot, '.codebuddy', 'scripts', 'lib', 'utils.js')
+    ));
+    assert.ok(explicitFileLevelUtilsOp, 'utils.js must still be explicitly copied: the selected module does not cover scripts/lib at all');
+  })) passed++; else failed++;
+
+  // Cubic review (EGC-539, PR #1142), violation 2: a module selection that
+  // pins a single unrelated file inside scripts/hooks or scripts/lib (not
+  // the whole directory, not the GateGuard files themselves) must not be
+  // mistaken for coverage of gateguard-fact-force.js/utils.js -- an earlier
+  // `startsWith('scripts/hooks/')` guard matched any file in that
+  // directory, wrongly skipping the explicit copy.
+  if (test('codebuddy adapter still copies the GateGuard script when a selected module only pins an unrelated file in scripts/hooks/scripts/lib', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codebuddy',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'unrelated-files', paths: ['scripts/hooks/pretooluse-output.js', 'scripts/lib/crusher/engine.js'] }],
+    });
+
+    const explicitFileLevelScriptOp = plan.operations.find(operation => (
+      operation.kind === 'copy-path'
+      && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+      && operation.destinationPath === path.join(projectRoot, '.codebuddy', 'scripts', 'hooks', 'gateguard-fact-force.js')
+    ));
+    assert.ok(explicitFileLevelScriptOp, 'gateguard-fact-force.js must still be explicitly copied: the selected module only pins an unrelated file in scripts/hooks, not the directory or the GateGuard script itself');
+
+    const explicitFileLevelUtilsOp = plan.operations.find(operation => (
+      operation.kind === 'copy-path'
+      && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
+      && operation.destinationPath === path.join(projectRoot, '.codebuddy', 'scripts', 'lib', 'utils.js')
+    ));
+    assert.ok(explicitFileLevelUtilsOp, 'utils.js must still be explicitly copied: the selected module only pins an unrelated file in scripts/lib, not the directory or utils.js itself');
   })) passed++; else failed++;
 
   if (test('codebuddy adapter also registers the Token Crusher on Bash at .codebuddy/settings.json', () => {

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2197,6 +2197,60 @@ function runTests() {
     assert.ok(utilsOp, 'Should scaffold gateguard-fact-force.js\'s utils.js dependency alongside it');
   })) passed++; else failed++;
 
+  // Cubic review (EGC-539, PR #1142): a codebuddy install that explicitly
+  // selects a module whose paths already cover scripts/hooks/scripts/lib
+  // (e.g. 'hooks-runtime') must not double-copy gateguard-fact-force.js and
+  // utils.js -- once via moduleOperations, once via the unconditional copy
+  // the test above exercises.
+  if (test('codebuddy adapter does not double-copy the GateGuard script when a selected module already covers scripts/hooks and scripts/lib', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codebuddy',
+      repoRoot,
+      projectRoot,
+      modules: [{ id: 'hooks-runtime', paths: ['scripts/hooks', 'scripts/lib'] }],
+    });
+
+    // A module path of 'scripts/hooks' (a directory, not a single file)
+    // scaffolds via moduleOperations as one directory-level copy operation
+    // whose recursive copy already includes gateguard-fact-force.js -- it
+    // does not appear as a per-file operation. The explicit file-level copy
+    // this test guards against would come only from createHookOperations's
+    // own createGateGuardScriptCopyOperations call, which should have been
+    // skipped here since the module already covers it.
+    const moduleLevelHooksOp = plan.operations.find(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks'
+      && operation.destinationPath === path.join(projectRoot, '.codebuddy', 'scripts', 'hooks')
+    ));
+    assert.ok(moduleLevelHooksOp, 'Expected the selected hooks-runtime module to scaffold scripts/hooks as a directory-level operation');
+
+    const moduleLevelLibOp = plan.operations.find(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib'
+      && operation.destinationPath === path.join(projectRoot, '.codebuddy', 'scripts', 'lib')
+    ));
+    assert.ok(moduleLevelLibOp, 'Expected the selected hooks-runtime module to scaffold scripts/lib as a directory-level operation');
+
+    // Merge operations (createPreToolUseGateGuardHookMergeOperation, one
+    // each for Edit/Write/MultiEdit/Bash) legitimately carry
+    // sourceRelativePath: 'scripts/hooks/gateguard-fact-force.js' too --
+    // they reference the script path to build the hook command, they don't
+    // copy it. Only 'copy-path' operations represent an actual file copy,
+    // so the double-copy check must scope to that operation type.
+    const explicitFileLevelScriptOp = plan.operations.find(operation => (
+      operation.type === 'copy-path'
+      && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+    ));
+    assert.strictEqual(explicitFileLevelScriptOp, undefined, 'createGateGuardScriptCopyOperations\' explicit file-level copy should be skipped when the module already covers scripts/hooks');
+
+    const explicitFileLevelUtilsOp = plan.operations.find(operation => (
+      operation.type === 'copy-path'
+      && normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
+    ));
+    assert.strictEqual(explicitFileLevelUtilsOp, undefined, 'createGateGuardScriptCopyOperations\' explicit file-level copy of utils.js should be skipped when the module already covers scripts/lib');
+  })) passed++; else failed++;
+
   if (test('codebuddy adapter also registers the Token Crusher on Bash at .codebuddy/settings.json', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2165,6 +2165,38 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  // EGC-539: the GateGuard PreToolUse merge operations above were registered
+  // unconditionally (test above), but the script the hooks point at was
+  // never actually copied -- so a codebuddy install whose selected modules
+  // did not include scripts/hooks/scripts/lib wrote a hooks.json entry
+  // pointing at a file that never existed on disk. Same pattern the sibling
+  // Crusher/Guardian tests below already guard for their own scripts.
+  if (test('codebuddy adapter also scaffolds the GateGuard script and its utils.js dependency, unconditional of module selection', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codebuddy',
+      repoRoot,
+      projectRoot,
+      modules: [],
+    });
+
+    const scriptOp = plan.operations.find(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/gateguard-fact-force.js'
+      && operation.destinationPath === path.join(
+        projectRoot, '.codebuddy', 'scripts', 'hooks', 'gateguard-fact-force.js'
+      )
+    ));
+    assert.ok(scriptOp, 'Should scaffold gateguard-fact-force.js into .codebuddy even with no modules selected');
+
+    const utilsOp = plan.operations.find(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/lib/utils.js'
+      && operation.destinationPath === path.join(projectRoot, '.codebuddy', 'scripts', 'lib', 'utils.js')
+    ));
+    assert.ok(utilsOp, 'Should scaffold gateguard-fact-force.js\'s utils.js dependency alongside it');
+  })) passed++; else failed++;
+
   if (test('codebuddy adapter also registers the Token Crusher on Bash at .codebuddy/settings.json', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';


### PR DESCRIPTION
## Context

EGC-539 audit (`scripts/` engineering health -- hooks, ci, lib, install-targets) found and confirmed a fail-open gap in `scripts/lib/install-targets/codebuddy-project.js`: `createHookOperations` registers 4 GateGuard `PreToolUse` merge entries in `.codebuddy/settings.json` (Edit/Write/MultiEdit/Bash), all pointing at `.codebuddy/scripts/hooks/gateguard-fact-force.js`, but it never called `createGateGuardScriptCopyOperations` (from `scripts/lib/claude-settings-hooks.js`) to actually copy that script and its `utils.js` dependency onto disk.

`hooks-runtime` is not a default legacy module for the `codebuddy` target (see `LEGACY_COMPAT_BASE_MODULE_IDS_BY_TARGET` in `scripts/lib/install-manifests.js` -- it only lists `egc` and `cursor`), so a CodeBuddy install whose selected modules don't happen to include `scripts/hooks`/`scripts/lib` writes a `PreToolUse` hook entry pointing at a file that was never scaffolded. Every subsequent Edit/Write/MultiEdit/Bash call in that project then fails trying to launch a nonexistent hook script (ENOENT).

The existing test at `tests/lib/install-targets.test.js` (`codebuddy adapter registers the GateGuard fact-force hook...`) only asserted the settings.json merge entries existed, never that the script itself was copied -- unlike its sibling Token Crusher and EGC Guardian tests for the same adapter, which both assert `assert.ok(op, ...)` that their scripts are scaffolded. That gap is why CI stayed green.

## Fix

`createHookOperations` now calls `createGateGuardScriptCopyOperations` unconditionally, before registering the merge operations, mirroring the identical fix already shipped in `scripts/lib/install-targets/antigravity-project.js` and `scripts/lib/install-targets/copilot-home.js` for the same class of bug.

## Test plan

- [x] New test: `codebuddy adapter also scaffolds the GateGuard script and its utils.js dependency, unconditional of module selection` (`modules: []`, same style as the sibling Crusher/Guardian tests)
- [x] Isolated run: `node tests/lib/install-targets.test.js` -- 155/155 passing
- [x] `npx eslint scripts/lib/install-targets/codebuddy-project.js tests/lib/install-targets.test.js` -- clean (pre-existing `runTests` complexity warning only, unrelated to this change, present on `main` as well)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fail-open in CodeBuddy by always scaffolding the GateGuard hook script and its `utils.js`, with per-file coverage checks to avoid double-copy and to never skip needed files. Addresses EGC-539.

- **Bug Fixes**
  - Copy `scripts/hooks/gateguard-fact-force.js` and `scripts/lib/utils.js` before registering PreToolUse merges (Edit, Write, MultiEdit, Bash); skip each file only if a selected module covers that exact file or its containing directory.
  - Tests: add cases for no modules, no double-copy when `hooks-runtime` covers both dirs, ensure `utils.js` is copied when only `scripts/hooks` is covered, and still copy when unrelated files are pinned; fix assertions to use `operation.kind` for copy checks.

<sup>Written for commit ad274fbd2e8551e732b39edb980822132cfb4ba2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


