### PR TITLE
test(hooks): add coverage for desktop-notify.js and run-with-flags.js (EGC-539)

### DIFF
--- a/tests/hooks/desktop-notify.test.js
+++ b/tests/hooks/desktop-notify.test.js
@@ -1,0 +1,358 @@
+/**
+ * Tests for scripts/hooks/desktop-notify.js
+ *
+ * desktop-notify.js fingerprints the host OS (macOS via process.platform,
+ * WSL via reading /proc/version at module load) and shells out to
+ * osascript (macOS) or PowerShell/BurntToast (WSL) to show a native
+ * notification. Both paths build a script/command string that embeds
+ * untrusted text (the last assistant message) inside a quoted literal, so
+ * the escaping in notifyMacOS()/notifyWindows() is a real injection
+ * boundary even though spawnSync() itself never goes through a shell.
+ *
+ * Neither run() export nor its OS-fingerprinting is exercised by any
+ * existing test file (EGC-539). run() and log() are the only functions the
+ * module exports or imports, so the OS-specific branches below are driven
+ * by controlled module-load conditions rather than by calling private
+ * helpers directly:
+ *   - process.platform is faked with Object.defineProperty (configurable
+ *     on Node) before a cache-cleared re-require, which is what isMacOS
+ *     captures at require time in both desktop-notify.js and lib/utils.js.
+ *   - fs.readFileSync is monkeypatched to fake /proc/version content
+ *     ONLY for that exact path (all other calls delegate to the real
+ *     implementation, since Node's own module loader also calls
+ *     readFileSync while we re-require the module).
+ *   - child_process.spawnSync is monkeypatched to capture the exact
+ *     script/command string that would have been handed to
+ *     osascript/PowerShell, instead of actually invoking them (neither
+ *     binary exists on the Linux CI host this runs on).
+ * All monkeypatches are restored in try/finally so they cannot leak into
+ * other test files run in the same process.
+ *
+ * Run with: node tests/hooks/desktop-notify.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const cp = require('child_process');
+const fs = require('fs');
+
+const desktopNotifyPath = require.resolve(path.join('..', '..', 'scripts', 'hooks', 'desktop-notify.js'));
+// lib/utils.js also captures isMacOS/isWindows/isLinux as module-load-time
+// constants from process.platform. desktop-notify.js imports isMacOS from
+// there, so any test that fakes process.platform must evict THIS cache
+// entry too (both when entering and when leaving the fake), or a later
+// test would keep reusing the previous test's stale, already-evaluated
+// isMacOS value instead of re-deriving it from the real platform.
+const utilsPath = require.resolve(path.join('..', '..', 'scripts', 'lib', 'utils.js'));
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function resetModuleCaches() {
+  delete require.cache[desktopNotifyPath];
+  delete require.cache[utilsPath];
+}
+
+function withFakePlatform(platform, fn) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  resetModuleCaches();
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, 'platform', descriptor);
+    resetModuleCaches();
+  }
+}
+
+function withFakeWSL(fn) {
+  const originalReadFileSync = fs.readFileSync;
+  fs.readFileSync = function patchedReadFileSync(filePath, ...rest) {
+    if (filePath === '/proc/version') {
+      return 'Linux version 5.15.0-microsoft-standard-WSL2 (Microsoft@Microsoft.com)';
+    }
+    return originalReadFileSync.call(fs, filePath, ...rest);
+  };
+  resetModuleCaches();
+  try {
+    return fn();
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+    resetModuleCaches();
+  }
+}
+
+function withFakeSpawnSync(handler, fn) {
+  const original = cp.spawnSync;
+  const calls = [];
+  cp.spawnSync = (...args) => {
+    calls.push(args);
+    return handler(...args);
+  };
+  try {
+    return fn(calls);
+  } finally {
+    cp.spawnSync = original;
+  }
+}
+
+/** Counts literal double-quote (U+0022) characters -- proof AppleScript
+ * string boundaries were not smuggled through unescaped. */
+function countDoubleQuotes(str) {
+  return (str.match(/"/g) || []).length;
+}
+
+function runTests() {
+  console.log('\n=== Testing desktop-notify.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  console.log('OS detection - macOS:');
+
+  if (test('process.platform === darwin makes lib/utils.isMacOS (and desktop-notify\'s copy) true', () => {
+    withFakePlatform('darwin', () => {
+      const utils = require(utilsPath);
+      assert.strictEqual(utils.isMacOS, true);
+    });
+  })) passed++; else failed++;
+
+  if (test('on macOS, run() invokes osascript exactly once via spawnSync', () => {
+    withFakePlatform('darwin', () => {
+      withFakeSpawnSync(() => ({ status: 0, error: null }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        const raw = JSON.stringify({ last_assistant_message: 'All tests passed' });
+        const out = run(raw);
+        assert.strictEqual(out, raw, 'run() always returns raw unchanged');
+        assert.strictEqual(calls.length, 1, `Expected exactly one spawnSync call, got ${calls.length}`);
+        const [cmd, args] = calls[0];
+        assert.strictEqual(cmd, 'osascript');
+        assert.deepStrictEqual(args.slice(0, 1), ['-e']);
+      });
+    });
+  })) passed++; else failed++;
+
+  console.log('\nOS detection - WSL:');
+
+  if (test('a /proc/version containing "microsoft" makes desktop-notify treat the host as WSL', () => {
+    withFakeWSL(() => {
+      withFakeSpawnSync(() => ({ status: 1, error: null }), (calls) => {
+        // Every PowerShell candidate probe fails: run() should log a tip
+        // and never attempt notifyWindows(), proving isWSL flipped true
+        // (on a non-WSL host with the real /proc/version this branch is
+        // never entered at all, so zero calls would also be zero on a
+        // non-WSL fs.readFileSync, which is exactly what the "plain Linux"
+        // test below asserts by contrast).
+        const { run } = require(desktopNotifyPath);
+        const raw = JSON.stringify({ last_assistant_message: 'ok' });
+        run(raw);
+        assert.ok(calls.length >= 1, 'Expected at least one PowerShell candidate probe via spawnSync');
+        for (const [, probeArgs] of calls) {
+          assert.deepStrictEqual(probeArgs, ['-Command', 'exit 0']);
+        }
+      });
+    });
+  })) passed++; else failed++;
+
+  if (test('on WSL with a resolvable PowerShell, run() sends a BurntToast command via spawnSync', () => {
+    withFakeWSL(() => {
+      withFakeSpawnSync((execPath, args) => {
+        if (args[1] === 'exit 0') {
+          return execPath === 'pwsh.exe' ? { status: 0 } : { status: 1 };
+        }
+        return { status: 0 };
+      }, (calls) => {
+        const { run } = require(desktopNotifyPath);
+        const raw = JSON.stringify({ last_assistant_message: 'Build succeeded' });
+        run(raw);
+        const notifyCall = calls.find(([, args]) => args[0] === '-Command' && args[1] !== 'exit 0');
+        assert.ok(notifyCall, `Expected a BurntToast notify call, got calls: ${JSON.stringify(calls)}`);
+        const [execPath, args] = notifyCall;
+        assert.strictEqual(execPath, 'pwsh.exe');
+        assert.ok(args[1].includes('BurntToastNotification'));
+        assert.ok(args[1].includes('Build succeeded'));
+      });
+    });
+  })) passed++; else failed++;
+
+  console.log('\nHappy path - plain Linux (non-WSL, non-macOS):');
+
+  if (test('on a plain Linux host, run() never calls spawnSync and returns raw unchanged', () => {
+    // No platform/fs faking: this repo's CI runs on plain Linux (see
+    // tests/hooks/detect-project-worktree.test.js's win32 skip guard for
+    // the same host assumption elsewhere in this suite), so isMacOS and
+    // isWSL are both naturally false here already.
+    resetModuleCaches();
+    withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+      const { run } = require(desktopNotifyPath);
+      const raw = JSON.stringify({ last_assistant_message: 'Nothing to notify' });
+      const out = run(raw);
+      assert.strictEqual(out, raw);
+      assert.strictEqual(calls.length, 0, `Expected no subprocess spawned on plain Linux, got: ${JSON.stringify(calls)}`);
+    });
+  })) passed++; else failed++;
+
+  console.log('\nDangerous input escaping - macOS (AppleScript injection):');
+
+  if (test('a double-quote-breakout payload is fully neutralized before reaching osascript', () => {
+    withFakePlatform('darwin', () => {
+      withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        // Classic AppleScript command-injection shape: close the string
+        // literal early with an unescaped quote, then chain a `do shell
+        // script` call. If notifyMacOS() failed to escape this, the
+        // resulting -e script would contain a syntactically valid
+        // "foo" & (do shell script "...") & "bar" expression.
+        const payload = 'foo" & (do shell script "touch /tmp/pwned") & "bar';
+        const raw = JSON.stringify({ last_assistant_message: payload });
+        run(raw);
+        assert.strictEqual(calls.length, 1);
+        const script = calls[0][1][1];
+        assert.strictEqual(countDoubleQuotes(script), 4, `Expected exactly 4 literal double quotes (title+body wrappers only), got ${countDoubleQuotes(script)} in: ${script}`);
+        assert.ok(script.includes('\u201C'), 'Expected curly quotes substituted in for the payload\'s double quotes');
+        assert.ok(!script.includes('foo" &'), 'The payload must not be able to close the AppleScript string literal early');
+      });
+    });
+  })) passed++; else failed++;
+
+  if (test('backslashes are stripped (AppleScript has no backslash-escape support)', () => {
+    withFakePlatform('darwin', () => {
+      withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        const raw = JSON.stringify({ last_assistant_message: 'C:\\Users\\evil\\payload.exe' });
+        run(raw);
+        const script = calls[0][1][1];
+        assert.ok(!script.includes('\\'), `Expected all backslashes stripped, got: ${script}`);
+      });
+    });
+  })) passed++; else failed++;
+
+  if (test('shell metacharacters (; & ` $()) survive verbatim but cannot execute (spawnSync never invokes a shell)', () => {
+    withFakePlatform('darwin', () => {
+      withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        const payload = 'done; rm -rf ~ && `id` $(whoami)';
+        const raw = JSON.stringify({ last_assistant_message: payload });
+        run(raw);
+        const [cmd, args, opts] = calls[0];
+        assert.strictEqual(cmd, 'osascript');
+        assert.ok(!opts || opts.shell !== true, 'spawnSync must not be invoked with shell:true');
+        assert.ok(args[1].includes('rm -rf'), 'The literal text is embedded as inert AppleScript string content, not stripped');
+      });
+    });
+  })) passed++; else failed++;
+
+  console.log('\nDangerous input escaping - WSL (PowerShell injection):');
+
+  if (test('a single-quote-breakout payload is doubled before reaching PowerShell', () => {
+    withFakeWSL(() => {
+      withFakeSpawnSync((execPath, args) => {
+        if (args[1] === 'exit 0') return execPath === 'pwsh.exe' ? { status: 0 } : { status: 1 };
+        return { status: 0 };
+      }, (calls) => {
+        const { run } = require(desktopNotifyPath);
+        // PowerShell single-quoted string injection shape: close the
+        // literal early, then chain a destructive cmdlet.
+        const payload = "it's done'; Remove-Item C:\\ -Recurse -Force #";
+        const raw = JSON.stringify({ last_assistant_message: payload });
+        run(raw);
+        const notifyCall = calls.find(([, args2]) => args2[0] === '-Command' && args2[1] !== 'exit 0');
+        assert.ok(notifyCall, 'Expected a BurntToast notify call');
+        const command = notifyCall[1][1];
+        // Every single quote from the payload must appear doubled ('') --
+        // a lone, unescaped ' would let the payload terminate the
+        // PowerShell string literal early.
+        const bodyMatch = command.match(/New-BurntToastNotification -Text '[^']*(?:''[^']*)*', '([^']*(?:''[^']*)*)'/);
+        assert.ok(bodyMatch, `Expected to locate the escaped body argument in: ${command}`);
+        const rawBody = bodyMatch[1];
+        assert.ok(rawBody.includes("it''s done''; Remove-Item"), `Expected doubled single quotes, got: ${rawBody}`);
+      });
+    });
+  })) passed++; else failed++;
+
+  console.log('\nextractSummary behavior (observed indirectly via the escaped notification body):');
+
+  if (test('uses the first non-empty line, trimmed, skipping leading blank lines', () => {
+    withFakePlatform('darwin', () => {
+      withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        const raw = JSON.stringify({ last_assistant_message: '\n\n   First real line here   \nSecond line ignored' });
+        run(raw);
+        const script = calls[0][1][1];
+        assert.ok(script.includes('First real line here'), `Expected trimmed first line in: ${script}`);
+        assert.ok(!script.includes('Second line ignored'), `Did not expect the second line in: ${script}`);
+      });
+    });
+  })) passed++; else failed++;
+
+  if (test('truncates a first line longer than 100 chars and appends an ellipsis', () => {
+    withFakePlatform('darwin', () => {
+      withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        const longLine = 'x'.repeat(150);
+        const raw = JSON.stringify({ last_assistant_message: longLine });
+        run(raw);
+        const script = calls[0][1][1];
+        assert.ok(script.includes(`${'x'.repeat(100)}...`), `Expected a 100-char truncation plus ellipsis in: ${script}`);
+        assert.ok(!script.includes('x'.repeat(101)), 'Body must not contain the untruncated 101st x');
+      });
+    });
+  })) passed++; else failed++;
+
+  if (test('falls back to "Done" when last_assistant_message is missing or not a string', () => {
+    withFakePlatform('darwin', () => {
+      withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        run(JSON.stringify({}));
+        const script = calls[0][1][1];
+        assert.ok(script.includes('Done'), `Expected the "Done" fallback in: ${script}`);
+      });
+    });
+  })) passed++; else failed++;
+
+  console.log('\nError handling:');
+
+  if (test('malformed JSON on stdin is caught and raw is still returned unchanged', () => {
+    resetModuleCaches();
+    const { run } = require(desktopNotifyPath);
+    const raw = '{not valid json';
+    const out = run(raw);
+    assert.strictEqual(out, raw);
+  })) passed++; else failed++;
+
+  if (test('empty stdin does not throw and returns the empty string unchanged', () => {
+    resetModuleCaches();
+    const { run } = require(desktopNotifyPath);
+    const out = run('');
+    assert.strictEqual(out, '');
+  })) passed++; else failed++;
+
+  console.log('\nStandalone entrypoint (require.main === module stdin path):');
+
+  if (test('runs standalone via node and echoes stdin back to stdout', () => {
+    const { spawnSync } = require('child_process');
+    const raw = JSON.stringify({ last_assistant_message: 'Standalone run' });
+    const result = spawnSync('node', [desktopNotifyPath], {
+      input: raw,
+      encoding: 'utf8',
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    assert.strictEqual(result.status, 0, `Expected clean exit, got status ${result.status}, stderr: ${result.stderr}`);
+    assert.strictEqual(result.stdout, raw, 'Expected raw stdin echoed back to stdout');
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/desktop-notify.test.js
+++ b/tests/hooks/desktop-notify.test.js
@@ -75,20 +75,27 @@ function withFakePlatform(platform, fn) {
 }
 
 function withFakeWSL(fn) {
-  const originalReadFileSync = fs.readFileSync;
-  fs.readFileSync = function patchedReadFileSync(filePath, ...rest) {
-    if (filePath === '/proc/version') {
-      return 'Linux version 5.15.0-microsoft-standard-WSL2 (Microsoft@Microsoft.com)';
-    }
-    return originalReadFileSync.call(fs, filePath, ...rest);
-  };
-  resetModuleCaches();
-  try {
-    return fn();
-  } finally {
-    fs.readFileSync = originalReadFileSync;
+  // desktop-notify.js only reads /proc/version at all when
+  // process.platform === 'linux' (it skips the read entirely on darwin/
+  // win32 CI runners), so faking the file content alone is not enough --
+  // this must also force the platform, or the WSL branch is never reached
+  // on macOS/Windows CI hosts.
+  return withFakePlatform('linux', () => {
+    const originalReadFileSync = fs.readFileSync;
+    fs.readFileSync = function patchedReadFileSync(filePath, ...rest) {
+      if (filePath === '/proc/version') {
+        return 'Linux version 5.15.0-microsoft-standard-WSL2 (Microsoft@Microsoft.com)';
+      }
+      return originalReadFileSync.call(fs, filePath, ...rest);
+    };
     resetModuleCaches();
-  }
+    try {
+      return fn();
+    } finally {
+      fs.readFileSync = originalReadFileSync;
+      resetModuleCaches();
+    }
+  });
 }
 
 function withFakeSpawnSync(handler, fn) {
@@ -187,17 +194,19 @@ function runTests() {
   console.log('\nHappy path - plain Linux (non-WSL, non-macOS):');
 
   if (test('on a plain Linux host, run() never calls spawnSync and returns raw unchanged', () => {
-    // No platform/fs faking: this repo's CI runs on plain Linux (see
-    // tests/hooks/detect-project-worktree.test.js's win32 skip guard for
-    // the same host assumption elsewhere in this suite), so isMacOS and
-    // isWSL are both naturally false here already.
-    resetModuleCaches();
-    withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
-      const { run } = require(desktopNotifyPath);
-      const raw = JSON.stringify({ last_assistant_message: 'Nothing to notify' });
-      const out = run(raw);
-      assert.strictEqual(out, raw);
-      assert.strictEqual(calls.length, 0, `Expected no subprocess spawned on plain Linux, got: ${JSON.stringify(calls)}`);
+    // Force platform to 'linux' explicitly (this suite's CI matrix also
+    // runs on macos-latest/windows-latest, where isMacOS would be true or
+    // the /proc/version read would be skipped entirely -- see the
+    // withFakeWSL comment above for why the platform must be pinned
+    // rather than relying on the real CI host).
+    withFakePlatform('linux', () => {
+      withFakeSpawnSync(() => ({ status: 0 }), (calls) => {
+        const { run } = require(desktopNotifyPath);
+        const raw = JSON.stringify({ last_assistant_message: 'Nothing to notify' });
+        const out = run(raw);
+        assert.strictEqual(out, raw);
+        assert.strictEqual(calls.length, 0, `Expected no subprocess spawned on plain Linux, got: ${JSON.stringify(calls)}`);
+      });
     });
   })) passed++; else failed++;
 

--- a/tests/hooks/run-with-flags.test.js
+++ b/tests/hooks/run-with-flags.test.js
@@ -39,14 +39,26 @@ function test(name, fn) {
  * script path, feeding `input` on stdin. profilesCsv defaults to
  * 'minimal,standard,strict' so the hook always passes the isHookEnabled()
  * gate regardless of the ambient EGC_HOOK_PROFILE.
+ *
+ * EGC_HOOK_PROFILE and EGC_DISABLED_HOOKS are pinned to fixed, known-safe
+ * values here rather than left to inherit from the developer's shell
+ * (cubic review, EGC-539 PR #1143): isHookEnabled() reads both from
+ * process.env, so an ambient EGC_HOOK_PROFILE=strict would make the
+ * profile-gating test below spuriously enable should-not-run.js, and an
+ * ambient EGC_DISABLED_HOOKS containing 'test-hook'/'evil-hook'/
+ * 'symlink-hook' would silently skip the path-safety assertions these
+ * tests exist to exercise. Callers may still override either via `env`.
  */
-function runDispatcher({ pluginRoot, hookId = 'test-hook', relScriptPath, profilesCsv = 'minimal,standard,strict', input = 'raw-input' }) {
+function runDispatcher({ pluginRoot, hookId = 'test-hook', relScriptPath, profilesCsv = 'minimal,standard,strict', input = 'raw-input', env = {} }) {
   const result = spawnSync('node', [runner, hookId, relScriptPath, profilesCsv], {
     input,
     encoding: 'utf8',
     env: {
       ...process.env,
+      EGC_HOOK_PROFILE: 'standard',
+      EGC_DISABLED_HOOKS: '',
       EGC_PLUGIN_ROOT: pluginRoot,
+      ...env,
     },
     timeout: 15000,
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/hooks/run-with-flags.test.js
+++ b/tests/hooks/run-with-flags.test.js
@@ -1,0 +1,260 @@
+/**
+ * Tests for scripts/hooks/run-with-flags.js
+ *
+ * run-with-flags.js is the central dispatcher every hook in hooks/hooks.json
+ * is wired through (EGC-539): it resolves EGC_PLUGIN_ROOT, gates execution
+ * via isHookEnabled(), then requires the target hook and calls run(raw).
+ * Before doing any of that it calls assertSafeScriptPath() to reject a
+ * scriptPath that escapes the resolved plugin root, either via a literal
+ * '../' traversal or via a symlink whose real target lives outside the
+ * root. Until now it was only exercised indirectly through other hooks'
+ * test files (e.g. tests/hooks/pre-bash-guardian-validate.test.js), never
+ * directly against its own path-safety and dispatch logic.
+ *
+ * Run with: node tests/hooks/run-with-flags.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Spawns run-with-flags.js against a given plugin root / hookId / relative
+ * script path, feeding `input` on stdin. profilesCsv defaults to
+ * 'minimal,standard,strict' so the hook always passes the isHookEnabled()
+ * gate regardless of the ambient EGC_HOOK_PROFILE.
+ */
+function runDispatcher({ pluginRoot, hookId = 'test-hook', relScriptPath, profilesCsv = 'minimal,standard,strict', input = 'raw-input' }) {
+  const result = spawnSync('node', [runner, hookId, relScriptPath, profilesCsv], {
+    input,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      EGC_PLUGIN_ROOT: pluginRoot,
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function makeTempPluginRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egc-539-run-with-flags-'));
+}
+
+function runTests() {
+  console.log('\n=== Testing run-with-flags.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  console.log('assertSafeScriptPath - valid path:');
+
+  if (test('a script inside the plugin root that exports run() is required and executed', () => {
+    const pluginRoot = makeTempPluginRoot();
+    try {
+      fs.writeFileSync(
+        path.join(pluginRoot, 'good-hook.js'),
+        "module.exports = { run: (raw) => `PROCESSED:${raw}` };\n"
+      );
+      const result = runDispatcher({ pluginRoot, relScriptPath: 'good-hook.js', input: 'hello' });
+      assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
+      assert.strictEqual(result.stdout, 'PROCESSED:hello');
+      assert.strictEqual(result.stderr, '', `Expected no stderr, got: ${result.stderr}`);
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('a nested valid path (subdirectory) inside the plugin root is accepted', () => {
+    const pluginRoot = makeTempPluginRoot();
+    try {
+      fs.mkdirSync(path.join(pluginRoot, 'nested', 'dir'), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, 'nested', 'dir', 'good-hook.js'),
+        "module.exports = { run: (raw) => `NESTED:${raw}` };\n"
+      );
+      const result = runDispatcher({ pluginRoot, relScriptPath: path.join('nested', 'dir', 'good-hook.js'), input: 'hi' });
+      assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
+      assert.strictEqual(result.stdout, 'NESTED:hi');
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log('\nassertSafeScriptPath - path traversal:');
+
+  if (test('rejects a relative path that escapes the plugin root via ../', () => {
+    const pluginRoot = makeTempPluginRoot();
+    try {
+      // Outside pluginRoot, one level up, so '../secret.js' resolves to a
+      // real file -- proving the rejection is the traversal guard itself,
+      // not just a missing-file fallthrough.
+      const outsideFile = path.join(pluginRoot, '..', `egc-539-secret-${path.basename(pluginRoot)}.js`);
+      fs.writeFileSync(outsideFile, "module.exports = { run: () => 'LEAKED' };\n");
+      try {
+        const result = runDispatcher({ pluginRoot, hookId: 'evil-hook', relScriptPath: `../${path.basename(outsideFile)}`, input: 'stdin-passthrough' });
+        assert.strictEqual(result.code, 0, 'run-with-flags always fails open with exit 0 after rejecting a path');
+        assert.ok(result.stderr.includes('Path traversal rejected'), `Expected traversal rejection on stderr, got: ${result.stderr}`);
+        assert.ok(result.stderr.includes('evil-hook'), `Expected hookId in the error, got: ${result.stderr}`);
+        assert.strictEqual(result.stdout, 'stdin-passthrough', 'Expected raw stdin passed through unchanged, not the leaked hook output');
+      } finally {
+        fs.rmSync(outsideFile, { force: true });
+      }
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('rejects an absolute scriptPath outside the plugin root', () => {
+    const pluginRoot = makeTempPluginRoot();
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-539-outside-'));
+    try {
+      const outsideFile = path.join(outsideDir, 'absolute-secret.js');
+      fs.writeFileSync(outsideFile, "module.exports = { run: () => 'LEAKED' };\n");
+      const result = runDispatcher({ pluginRoot, relScriptPath: outsideFile, input: 'stdin-passthrough' });
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stderr.includes('Path traversal rejected'), `Expected traversal rejection on stderr, got: ${result.stderr}`);
+      assert.strictEqual(result.stdout, 'stdin-passthrough');
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('rejects a scriptPath that resolves to the plugin root itself (empty relative path)', () => {
+    const pluginRoot = makeTempPluginRoot();
+    try {
+      const result = runDispatcher({ pluginRoot, relScriptPath: '.', input: 'stdin-passthrough' });
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stderr.includes('Path traversal rejected'), `Expected traversal rejection on stderr, got: ${result.stderr}`);
+      assert.strictEqual(result.stdout, 'stdin-passthrough');
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log('\nassertSafeScriptPath - missing script:');
+
+  if (test('rejects a relative path inside the root that does not exist', () => {
+    const pluginRoot = makeTempPluginRoot();
+    try {
+      const result = runDispatcher({ pluginRoot, relScriptPath: 'does-not-exist.js', input: 'stdin-passthrough' });
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stderr.includes('Script not found'), `Expected not-found rejection on stderr, got: ${result.stderr}`);
+      assert.strictEqual(result.stdout, 'stdin-passthrough');
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log('\nassertSafeScriptPath - symlink traversal:');
+
+  const canSymlink = (() => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-539-symlink-probe-'));
+    try {
+      const target = path.join(dir, 'target.txt');
+      fs.writeFileSync(target, 'x');
+      fs.symlinkSync(target, path.join(dir, 'link.txt'));
+      return true;
+    } catch {
+      return false;
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  })();
+
+  if (!canSymlink) {
+    console.log('  - skipped symlink traversal tests; this environment cannot create symlinks (no permission).');
+  } else {
+    if (test('rejects a symlink inside the plugin root whose real target lives outside it', () => {
+      const pluginRoot = makeTempPluginRoot();
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-539-symlink-target-'));
+      try {
+        const outsideFile = path.join(outsideDir, 'secret.js');
+        fs.writeFileSync(outsideFile, "module.exports = { run: () => 'LEAKED' };\n");
+        fs.symlinkSync(outsideFile, path.join(pluginRoot, 'link-hook.js'));
+
+        const result = runDispatcher({ pluginRoot, hookId: 'symlink-hook', relScriptPath: 'link-hook.js', input: 'stdin-passthrough' });
+        assert.strictEqual(result.code, 0);
+        assert.ok(result.stderr.includes('Symlink traversal rejected'), `Expected symlink rejection on stderr, got: ${result.stderr}`);
+        assert.ok(result.stderr.includes('symlink-hook'), `Expected hookId in the error, got: ${result.stderr}`);
+        assert.strictEqual(result.stdout, 'stdin-passthrough', 'Expected raw stdin passed through unchanged, not the leaked hook output');
+      } finally {
+        fs.rmSync(pluginRoot, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    })) passed++; else failed++;
+
+    if (test('accepts a symlink inside the plugin root whose real target also lives inside it', () => {
+      const pluginRoot = makeTempPluginRoot();
+      try {
+        fs.mkdirSync(path.join(pluginRoot, 'real'));
+        const realFile = path.join(pluginRoot, 'real', 'hook.js');
+        fs.writeFileSync(realFile, "module.exports = { run: (raw) => `LINKED:${raw}` };\n");
+        fs.symlinkSync(realFile, path.join(pluginRoot, 'link-hook.js'));
+
+        const result = runDispatcher({ pluginRoot, relScriptPath: 'link-hook.js', input: 'hi' });
+        assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
+        assert.strictEqual(result.stdout, 'LINKED:hi');
+        assert.strictEqual(result.stderr, '');
+      } finally {
+        fs.rmSync(pluginRoot, { recursive: true, force: true });
+      }
+    })) passed++; else failed++;
+  }
+
+  console.log('\nHook profile gating:');
+
+  if (test('passes stdin through unchanged without requiring the script when the hook is disabled for the active profile', () => {
+    const pluginRoot = makeTempPluginRoot();
+    try {
+      // A script that would blow up if it were ever required, so the test
+      // fails loudly if the profile gate is bypassed.
+      fs.writeFileSync(path.join(pluginRoot, 'should-not-run.js'), "throw new Error('should never be required');\n");
+      const result = runDispatcher({ pluginRoot, relScriptPath: 'should-not-run.js', profilesCsv: 'strict', input: 'stdin-passthrough' });
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(result.stdout, 'stdin-passthrough');
+      assert.strictEqual(result.stderr, '');
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('passes stdin through unchanged when hookId or scriptPath argv is missing', () => {
+    const result = spawnSync('node', [runner], {
+      input: 'stdin-passthrough',
+      encoding: 'utf8',
+      env: { ...process.env },
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout, 'stdin-passthrough');
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/hooks/run-with-flags.test.js
+++ b/tests/hooks/run-with-flags.test.js
@@ -40,14 +40,21 @@ function test(name, fn) {
  * 'minimal,standard,strict' so the hook always passes the isHookEnabled()
  * gate regardless of the ambient EGC_HOOK_PROFILE.
  *
- * EGC_HOOK_PROFILE and EGC_DISABLED_HOOKS are pinned to fixed, known-safe
- * values here rather than left to inherit from the developer's shell
- * (cubic review, EGC-539 PR #1143): isHookEnabled() reads both from
- * process.env, so an ambient EGC_HOOK_PROFILE=strict would make the
- * profile-gating test below spuriously enable should-not-run.js, and an
- * ambient EGC_DISABLED_HOOKS containing 'test-hook'/'evil-hook'/
- * 'symlink-hook' would silently skip the path-safety assertions these
- * tests exist to exercise. Callers may still override either via `env`.
+ * EGC_HOOK_PROFILE and EGC_DISABLED_HOOKS (and their legacy ECC_ aliases)
+ * are pinned to fixed, known-safe values here rather than left to inherit
+ * from the developer's shell (cubic review, EGC-539 PR #1143):
+ * isHookEnabled() reads `EGC_HOOK_PROFILE || ECC_HOOK_PROFILE` and
+ * `EGC_DISABLED_HOOKS || ECC_DISABLED_HOOKS`, so pinning only the EGC_
+ * variant does NOT neutralize an ambient ECC_ one -- the first fix here
+ * pinned EGC_DISABLED_HOOKS: '' alone, which is falsy and falls through to
+ * ECC_DISABLED_HOOKS if that's set in the shell, reintroducing the exact
+ * non-determinism this diff aims to remove (cubic caught this as a P3 on
+ * re-review). An ambient EGC_HOOK_PROFILE/ECC_HOOK_PROFILE=strict would
+ * make the profile-gating test below spuriously enable should-not-run.js,
+ * and an ambient EGC_DISABLED_HOOKS/ECC_DISABLED_HOOKS containing
+ * 'test-hook'/'evil-hook'/'symlink-hook' would silently skip the
+ * path-safety assertions these tests exist to exercise. Callers may still
+ * override any of the four via `env`.
  */
 function runDispatcher({ pluginRoot, hookId = 'test-hook', relScriptPath, profilesCsv = 'minimal,standard,strict', input = 'raw-input', env = {} }) {
   const result = spawnSync('node', [runner, hookId, relScriptPath, profilesCsv], {
@@ -56,7 +63,9 @@ function runDispatcher({ pluginRoot, hookId = 'test-hook', relScriptPath, profil
     env: {
       ...process.env,
       EGC_HOOK_PROFILE: 'standard',
+      ECC_HOOK_PROFILE: 'standard',
       EGC_DISABLED_HOOKS: '',
+      ECC_DISABLED_HOOKS: '',
       EGC_PLUGIN_ROOT: pluginRoot,
       ...env,
     },


### PR DESCRIPTION
## Context

EGC-539 audit (`scripts/` engineering health) flagged two hooks with no dedicated test coverage: `scripts/hooks/desktop-notify.js` (OS fingerprinting via `/proc/version`, subprocess probing, manual shell/AppleScript escaping) and `scripts/hooks/run-with-flags.js` (the central dispatcher every hook in `hooks/hooks.json` runs through; its `assertSafeScriptPath` rejects path-traversal/symlink-escape attempts). Confirmed by grep across `tests/hooks/`: no file exercised either module directly. `run-with-flags.js` was only exercised indirectly, as the harness other hooks' own test files spawn to test *their* hook, never its own dispatch/path-safety logic.

This is coverage-only, no behavior change.

## Fix

Added:
- `tests/hooks/desktop-notify.test.js` (15 cases): macOS/WSL OS detection (faking `process.platform` and `/proc/version` content, both restored via try/finally), the plain-Linux happy path (no subprocess spawned), an AppleScript double-quote-breakout injection payload (asserts the escaped script contains exactly 4 literal `"` characters -- the title/body wrapper quotes only -- so the payload can never close the string literal early), backslash-stripping, a PowerShell single-quote-breakout injection payload (asserts every `'` in the payload is doubled), `extractSummary` truncation/fallback behavior, malformed/empty stdin, and the standalone `require.main === module` entrypoint.
- `tests/hooks/run-with-flags.test.js` (10 cases): `assertSafeScriptPath` accepting a valid path (including a nested subdirectory) inside the plugin root, rejecting a `../` traversal and an absolute path outside the root, rejecting a missing script, rejecting a symlink whose real target resolves outside the root while accepting one that resolves back inside it, and the hook-profile gate skipping `require()` of a disabled hook entirely (a script that throws if ever required proves it wasn't).

No production code touched.

## Additional finding (not fixed in this PR)

While reading `run-with-flags.js`, `hasRunExport` (line 141) detects whether a hook exports `run()` with `/\bmodule\.exports\b/.test(src) && /\brun\b/.test(src)` -- a text-heuristic that only checks the *word* "run" appears somewhere in the file, not that `module.exports` actually has a `run` property. The code's own comment above it warns that requiring a legacy hook without going through the intended `run()` fast-path "would interfere with the parent process or cause double execution." This is out of scope for `assertSafeScriptPath`/desktop-notify escaping (the two areas this PR was asked to cover), and I did not find any current file in `scripts/hooks/` that actually trips the false positive, so it is not reproduced or fixed here -- flagging it for a follow-up look.

## Test plan

- [x] `node tests/hooks/desktop-notify.test.js` -- 15/15 passing
- [x] `node tests/hooks/run-with-flags.test.js` -- 10/10 passing
- [x] `npx eslint tests/hooks/desktop-notify.test.js tests/hooks/run-with-flags.test.js` -- clean
- [x] Both `assertSafeScriptPath` and the desktop-notify escaping behaved correctly under test; no real bug found in either (only the coverage gap itself)

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add dedicated test coverage for `scripts/hooks/desktop-notify.js` and `scripts/hooks/run-with-flags.js` to satisfy Linear EGC-539, validating OS detection, escaping, and path-safety. Tests only; no production code changes.

- **New Features**
  - `desktop-notify`: tests macOS/WSL detection (`process.platform`, `/proc/version`), AppleScript/PowerShell escaping, summary truncation, stdin handling, and standalone entrypoint.
  - `run-with-flags`: tests `assertSafeScriptPath` (accepts in-root/nested; rejects `../`, absolute, missing, and out-of-root symlink; accepts in-root symlink) and hook profile gating (disabled hooks are skipped; stdin is passed through).

- **Bug Fixes**
  - Pin `process.platform` to `linux` in WSL and plain-Linux tests so `/proc/version` checks run on macOS/Windows CI; `withFakeWSL()` composes the platform pin.
  - Pin `EGC_HOOK_PROFILE`/`EGC_DISABLED_HOOKS` and legacy `ECC_HOOK_PROFILE`/`ECC_DISABLED_HOOKS` in `run-with-flags` spawns to avoid ambient env interference; `runDispatcher()` sets safe defaults with per-test overrides.

<sup>Written for commit ec3f09ac3627963949a50fb8626365baed5a215a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


