### PR TITLE
refactor(install-targets): remove dead createNamespacedFlatRuleOperations (EGC-539)

### DIFF
--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -182,49 +182,6 @@ function createRemappedOperation(adapter, moduleId, sourceRelativePath, destinat
   });
 }
 
-function createNamespacedFlatRuleOperations(adapter, moduleId, sourceRelativePath, input = {}) {
-  const normalizedSourcePath = normalizeRelativePath(sourceRelativePath);
-  const sourceRoot = path.join(input.repoRoot || '', normalizedSourcePath);
-
-  if (!input.repoRoot || !fs.existsSync(sourceRoot) || !fs.statSync(sourceRoot).isDirectory()) {
-    return [];
-  }
-
-  const targetRulesDir = path.join(adapter.resolveRoot(input), 'rules');
-  const operations = [];
-  const entries = fs.readdirSync(sourceRoot, { withFileTypes: true }).sort((left, right) => (
-    left.name.localeCompare(right.name)
-  ));
-
-  for (const entry of entries) {
-    const namespace = entry.name;
-    const entryPath = path.join(sourceRoot, entry.name);
-
-    if (entry.isDirectory()) {
-      const relativeFiles = listRelativeFiles(entryPath);
-      for (const relativeFile of relativeFiles) {
-        const flattenedFileName = `${namespace}-${normalizeRelativePath(relativeFile).replaceAll('/', '-')}`;
-        const sourceRelativeFile = path.join(normalizedSourcePath, namespace, relativeFile);
-        operations.push(createManagedOperation({
-          moduleId,
-          sourceRelativePath: sourceRelativeFile,
-          destinationPath: path.join(targetRulesDir, flattenedFileName),
-          strategy: 'flatten-copy',
-        }));
-      }
-    } else if (entry.isFile()) {
-      operations.push(createManagedOperation({
-        moduleId,
-        sourceRelativePath: path.join(normalizedSourcePath, entry.name),
-        destinationPath: path.join(targetRulesDir, entry.name),
-        strategy: 'flatten-copy',
-      }));
-    }
-  }
-
-  return operations;
-}
-
 function createFlatFileOperations({ // NOSONAR: directory walk building install operations kept inline; branches mirror the layout rules
   moduleId,
   repoRoot,
@@ -491,7 +448,6 @@ module.exports = {
       strategy,
     })
   ),
-  createNamespacedFlatRuleOperations,
   createRemappedOperation,
   isForeignPlatformPath,
   normalizeRelativePath,


### PR DESCRIPTION
## Context

Multica audit EGC-539 (`scripts/` engineering health -- hooks, ci, lib, install-targets) flagged `createNamespacedFlatRuleOperations` in `scripts/lib/install-targets/helpers.js` (~lines 185-226, exported at ~line 494) as dead code: a repo-wide grep for the symbol only matches its own definition and its own `module.exports` entry, with zero real callers.

Verified independently before touching anything:

```
$ grep -rn "createNamespacedFlatRuleOperations" . | grep -v "/.git/"
scripts/lib/install-targets/helpers.js:185:function createNamespacedFlatRuleOperations(adapter, moduleId, sourceRelativePath, input = {}) {
scripts/lib/install-targets/helpers.js:494:  createNamespacedFlatRuleOperations,
```

Also checked every consumer of `helpers.js` individually: all 30 files under `scripts/lib/install-targets/` that `require('./helpers')` were inspected for their destructured import lists, and none import `createNamespacedFlatRuleOperations`. Only `createFlatRuleOperations` (an alias for the separate `createFlatFileOperations`) is used in production, by `cursor-project.js`, `codebuddy-project.js`, and `cline-project.js`. `tests/lib/install-targets.test.js` -- the only test file that exercises this module -- was also checked and never references the symbol.

The dead function duplicated ~90% of `createFlatFileOperations` (same directory walk, same flatten-copy strategy for namespaced rule files), so removing it also removes the duplication risk of the two implementations drifting apart.

## Fix

Removed `createNamespacedFlatRuleOperations` and its `module.exports` entry from `scripts/lib/install-targets/helpers.js`. No other export or call site changed. `listRelativeFiles`, the helper the removed function shared with `createFlatFileOperations`, is still used by the latter and was left untouched.

## Test plan

- [x] Isolated run: `node tests/lib/install-targets.test.js` -- 154/154 passing
- [x] `npx eslint scripts/lib/install-targets/helpers.js` -- clean

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead `createNamespacedFlatRuleOperations` from `scripts/lib/install-targets/helpers.js` to reduce duplication and keep the install-targets code clean. No behavior change; the function had no callers (EGC-539).

- **Refactors**
  - Removed the function and its `module.exports` entry; kept `listRelativeFiles`.
  - Verified all consumers use `createFlatRuleOperations`; tests still pass.

<sup>Written for commit 18d2e0a0f7dd30d5c94a1fef141872c99db49128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

