### PR TITLE
refactor(guardian): split cursor-project planOperations into per-branch helpers

### DIFF
--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -29,6 +29,23 @@ const {
   resolveCrusherAdapterScriptDestination,
 } = require('../cursor-crusher-hooks');
 
+// Shared by createCursorGuardianOperations and createCursorCrusherOperations
+// below: hooks-runtime already scaffolds the whole scripts/hooks and
+// scripts/lib trees (install-modules.json), which includes every file each
+// function's own copy operations would otherwise duplicate -- drop the
+// redundant per-file copies when that module is selected, keeping only the
+// merge operation (never redundant: it is the sole writer of hooks.json's
+// entry for that hook). EGC-539 audit (Finding 9): this closure used to be
+// defined identically in both functions below.
+function createAlreadyScaffoldedChecker(modules) {
+  const selectedPaths = new Set(modules.flatMap(module => (Array.isArray(module.paths) ? module.paths : [])));
+  const alreadyScaffolded = sourceRelativePath => (
+    (selectedPaths.has('scripts/hooks') && sourceRelativePath.startsWith('scripts/hooks/'))
+    || (selectedPaths.has('scripts/lib') && sourceRelativePath.startsWith('scripts/lib/'))
+  );
+  return { selectedPaths, alreadyScaffolded };
+}
+
 // EGC-494/EGC-498: every Cursor install registers the Guardian Bash
 // validator on beforeShellExecution, even when no content modules are
 // selected -- the same "deterministic, unconditional" pattern
@@ -39,17 +56,7 @@ function createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot) 
     createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
 
-  // hooks-runtime already scaffolds the whole scripts/hooks and scripts/lib
-  // trees (install-modules.json), which includes every file the Guardian
-  // copy operations below would otherwise duplicate -- drop the redundant
-  // per-file copies when that module is selected, keeping only the merge
-  // operation (never redundant: it is the sole writer of hooks.json's
-  // Guardian entry).
-  const selectedPaths = new Set(modules.flatMap(module => (Array.isArray(module.paths) ? module.paths : [])));
-  const alreadyScaffolded = sourceRelativePath => (
-    (selectedPaths.has('scripts/hooks') && sourceRelativePath.startsWith('scripts/hooks/'))
-    || (selectedPaths.has('scripts/lib') && sourceRelativePath.startsWith('scripts/lib/'))
-  );
+  const { selectedPaths, alreadyScaffolded } = createAlreadyScaffoldedChecker(modules);
 
   const guardianScriptCopyOperations = createBashGuardianScriptCopyOperations(remap, targetRoot)
     .filter(operation => !alreadyScaffolded(operation.sourceRelativePath));
@@ -110,11 +117,7 @@ function createCursorCrusherOperations(adapter, targetRoot, modules) {
     createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
 
-  const selectedPaths = new Set(modules.flatMap(module => (Array.isArray(module.paths) ? module.paths : [])));
-  const alreadyScaffolded = sourceRelativePath => (
-    (selectedPaths.has('scripts/hooks') && sourceRelativePath.startsWith('scripts/hooks/'))
-    || (selectedPaths.has('scripts/lib') && sourceRelativePath.startsWith('scripts/lib/'))
-  );
+  const { alreadyScaffolded } = createAlreadyScaffoldedChecker(modules);
 
   const adapterModuleId = 'egc-cursor-crusher-hook';
   const adapterScriptDestination = resolveCrusherAdapterScriptDestination(targetRoot);
@@ -193,6 +196,81 @@ function createJsonMergeOperation({ moduleId, repoRoot, sourceRelativePath, dest
     scaffoldOnly: false,
     mergePayload: readJsonObject(sourcePath, sourceRelativePath),
   });
+}
+
+// Cursor treats nested AGENTS.md files as directory context; do not install
+// EGC's root project identity into a host project's .cursor/.
+function planAgentsMdOperations() {
+  return [];
+}
+
+function planRulesOperations({ module, repoRoot, sourceRelativePath, targetRoot, takeUniqueOperations }) {
+  return takeUniqueOperations(createFlatRuleOperations({
+    moduleId: module.id,
+    repoRoot,
+    sourceRelativePath,
+    destinationDir: path.join(targetRoot, 'rules'),
+    destinationNameTransform: toCursorRuleFileName,
+  }));
+}
+
+function planAgentsOperations({ module, repoRoot, sourceRelativePath, targetRoot, takeUniqueOperations }) {
+  return takeUniqueOperations(createFlatFileOperations({
+    moduleId: module.id,
+    repoRoot,
+    sourceRelativePath,
+    destinationDir: path.join(targetRoot, 'agents'),
+    destinationNameTransform: toCursorAgentFileName,
+  }));
+}
+
+function planCursorDirOperations({ module, repoRoot, targetRoot, cursorMcpOperation, takeUniqueOperations }) {
+  const cursorRoot = path.join(repoRoot, '.cursor');
+  if (!fs.existsSync(cursorRoot) || !fs.statSync(cursorRoot).isDirectory()) {
+    return [];
+  }
+
+  const childOperations = fs.readdirSync(cursorRoot, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .filter(entry => entry.name !== 'rules' && entry.name !== 'hooks.json')
+    .map(entry => createManagedOperation({
+      moduleId: module.id,
+      sourceRelativePath: path.join('.cursor', entry.name),
+      destinationPath: path.join(targetRoot, entry.name),
+      strategy: 'preserve-relative-path',
+    }));
+
+  const ruleOperations = createFlatRuleOperations({
+    moduleId: module.id,
+    repoRoot,
+    sourceRelativePath: '.cursor/rules',
+    destinationDir: path.join(targetRoot, 'rules'),
+    destinationNameTransform: toCursorRuleFileName,
+  });
+
+  return takeUniqueOperations([
+    ...childOperations,
+    ...(cursorMcpOperation ? [cursorMcpOperation] : []),
+    ...ruleOperations,
+  ]);
+}
+
+function planMcpConfigsOperations({
+  module, sourceRelativePath, planningInput, adapter, cursorMcpOperation, takeUniqueOperations,
+}) {
+  const operations = [
+    adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput),
+  ];
+  if (cursorMcpOperation) {
+    operations.push(cursorMcpOperation);
+  }
+  return takeUniqueOperations(operations);
+}
+
+function planDefaultOperations({ module, sourceRelativePath, planningInput, adapter, takeUniqueOperations }) {
+  return takeUniqueOperations([
+    adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput),
+  ]);
 }
 
 module.exports = createInstallTargetAdapter({
@@ -274,6 +352,10 @@ module.exports = createInstallTargetAdapter({
       });
     }
 
+    // EGC-539 audit (Finding 9): dispatches each module path to its own
+    // planXOperations helper above instead of inlining all six branches'
+    // logic here -- same operations, same order, same dedup as before, just
+    // no longer all flattened into one ~150-line closure.
     return [...entries.flatMap(({ module, sourceRelativePath }) => {
       const cursorMcpOperation = createJsonMergeOperation({
         moduleId: module.id,
@@ -283,75 +365,28 @@ module.exports = createInstallTargetAdapter({
       });
 
       if (sourceRelativePath === 'AGENTS.md') {
-        // Cursor treats nested AGENTS.md files as directory context; do not
-        // install EGC's root project identity into a host project's .cursor/.
-        return [];
+        return planAgentsMdOperations();
       }
 
       if (sourceRelativePath === 'rules') {
-        return takeUniqueOperations(createFlatRuleOperations({
-          moduleId: module.id,
-          repoRoot,
-          sourceRelativePath,
-          destinationDir: path.join(targetRoot, 'rules'),
-          destinationNameTransform: toCursorRuleFileName,
-        }));
+        return planRulesOperations({ module, repoRoot, sourceRelativePath, targetRoot, takeUniqueOperations });
       }
 
       if (sourceRelativePath === 'agents') {
-        return takeUniqueOperations(createFlatFileOperations({
-          moduleId: module.id,
-          repoRoot,
-          sourceRelativePath,
-          destinationDir: path.join(targetRoot, 'agents'),
-          destinationNameTransform: toCursorAgentFileName,
-        }));
+        return planAgentsOperations({ module, repoRoot, sourceRelativePath, targetRoot, takeUniqueOperations });
       }
 
       if (sourceRelativePath === '.cursor') {
-        const cursorRoot = path.join(repoRoot, '.cursor');
-        if (!fs.existsSync(cursorRoot) || !fs.statSync(cursorRoot).isDirectory()) {
-          return [];
-        }
-
-        const childOperations = fs.readdirSync(cursorRoot, { withFileTypes: true })
-          .sort((left, right) => left.name.localeCompare(right.name))
-          .filter(entry => entry.name !== 'rules' && entry.name !== 'hooks.json')
-          .map(entry => createManagedOperation({
-            moduleId: module.id,
-            sourceRelativePath: path.join('.cursor', entry.name),
-            destinationPath: path.join(targetRoot, entry.name),
-            strategy: 'preserve-relative-path',
-          }));
-
-        const ruleOperations = createFlatRuleOperations({
-          moduleId: module.id,
-          repoRoot,
-          sourceRelativePath: '.cursor/rules',
-          destinationDir: path.join(targetRoot, 'rules'),
-          destinationNameTransform: toCursorRuleFileName,
-        });
-
-        return takeUniqueOperations([
-          ...childOperations,
-          ...(cursorMcpOperation ? [cursorMcpOperation] : []),
-          ...ruleOperations,
-        ]);
+        return planCursorDirOperations({ module, repoRoot, targetRoot, cursorMcpOperation, takeUniqueOperations });
       }
 
       if (sourceRelativePath === 'mcp-configs') {
-        const operations = [
-          adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput),
-        ];
-        if (cursorMcpOperation) {
-          operations.push(cursorMcpOperation);
-        }
-        return takeUniqueOperations(operations);
+        return planMcpConfigsOperations({
+          module, sourceRelativePath, planningInput, adapter, cursorMcpOperation, takeUniqueOperations,
+        });
       }
 
-      return takeUniqueOperations([
-        adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput),
-      ]);
+      return planDefaultOperations({ module, sourceRelativePath, planningInput, adapter, takeUniqueOperations });
     }), ...createCursorGuardianOperations(adapter, targetRoot, modules, repoRoot),
     ...createCursorCrusherOperations(adapter, targetRoot, modules)];
   },


### PR DESCRIPTION
## Summary
EGC-539 audit (Finding 9, `scripts/`): `planOperations` in `scripts/lib/install-targets/cursor-project.js` was a single ~150-line function with a 6-branch `flatMap` (`AGENTS.md`/`rules`/`agents`/`.cursor`/`mcp-configs`/default), mixing a sort comparator, dedup, and per-branch operation-building logic in one closure. The same `alreadyScaffolded` closure (skips `scripts/hooks`/`scripts/lib` copies already covered by hooks-runtime's directory scaffold) was also copied verbatim between `createCursorGuardianOperations` and `createCursorCrusherOperations` in the same file.

## Fix
- Extracted the duplicated closure into a shared `createAlreadyScaffoldedChecker(modules)`, used by both functions. It also exposes `selectedPaths`, which `createCursorGuardianOperations` still needs separately for its own `seedPath` check.
- Split `planOperations`'s `flatMap` body into one `planXOperations` helper per branch: `planAgentsMdOperations`, `planRulesOperations`, `planAgentsOperations`, `planCursorDirOperations`, `planMcpConfigsOperations`, `planDefaultOperations`. `planOperations` is now a thin dispatcher over the already-sorted entries.
- Structural refactor only: same operations generated, same order, same dedup behavior as before.

## Test plan
- [x] `node tests/lib/install-targets.test.js` -- 154/154 (baseline before this change was also 154/154, no change in pass count)
- [x] `node tests/lib/install-executor.test.js` -- 10/10
- [x] `node tests/lib/install-lifecycle.test.js` -- 36/36
- [x] `npx eslint scripts/lib/install-targets/cursor-project.js` -- clean

No new test file -- structural split of already-tested code, not new behavior.

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor to split `planOperations` in `scripts/lib/install-targets/cursor-project.js` into small helpers and remove duplicated scaffold checks. Addresses EGC-539 (Finding 9). Logic and output are unchanged.

- **Refactors**
  - Added `createAlreadyScaffoldedChecker(modules)` shared by `createCursorGuardianOperations` and `createCursorCrusherOperations`.
  - Broke `planOperations` into helpers: `planAgentsMdOperations`, `planRulesOperations`, `planAgentsOperations`, `planCursorDirOperations`, `planMcpConfigsOperations`, `planDefaultOperations`.
  - Preserved operation order, deduping, and generated operations.

<sup>Written for commit 6b041d31408ef15d67e263cc1fbf185e35354e5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

