### PR TITLE
fix(guardian): make splitShellSegments comment-aware (EGC-539)

### DIFF
--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -13,6 +13,15 @@ function handleInsideQuotes(ch, i, command, quote) {
 
 function handleEscape(ch, i, command) {
   if (ch === '\\' && i + 1 < command.length) {
+    // A backslash escaping a CRLF line-continuation ('\' followed by '\r\n')
+    // must swallow all three characters as one unit, not just the '\r' --
+    // otherwise the lone '\n' left behind falls through to the newline
+    // handling further down the main loop and spuriously ends the current
+    // segment, even though bash removes the whole three-character sequence
+    // as a single continuation (cubic review, EGC-539 PR #1147).
+    if (command[i + 1] === '\r' && command[i + 2] === '\n') {
+      return { chars: ch + command[i + 1] + command[i + 2], advance: 2, handled: true };
+    }
     return { chars: ch + command[i + 1], advance: 1, handled: true };
   }
   return { handled: false };
@@ -248,15 +257,18 @@ const COMMENT_WORD_START_RE = /[\s;&|(]/;
 // backslash and cancels out; the escaping power passes to the newline only
 // off the single unpaired backslash left when the count is odd).
 function skipLineContinuations(command, i) {
-  while (i >= 0) {
-    const isBareLf = command[i] === '\n';
-    const isCrLf = command[i] === '\r' && command[i + 1] === '\n';
-    if (!isBareLf && !isCrLf) break;
-    // Either way (bare '\n' or the '\r' that starts a '\r\n' pair), i is
-    // already the index the newline run starts at -- the backslash count
-    // is checked immediately before that index in both cases.
+  while (i >= 0 && command[i] === '\n') {
+    // Cubic review (EGC-539, PR #1147): the caller always passes the index
+    // of the LAST character of the newline run (i.e. the '\n', never the
+    // '\r' that may precede it in a '\r\n' pair), so a '\r\n' continuation
+    // must have its backslash count start two characters back -- one
+    // earlier version of this check tested command[i] === '\r' here, which
+    // can never be true given how the caller invokes this function, so the
+    // CRLF branch silently never fired and a backslash-CRLF continuation
+    // was miscounted as a real, unescaped newline.
+    const j0 = command[i - 1] === '\r' ? i - 2 : i - 1;
     let backslashes = 0;
-    let j = i - 1;
+    let j = j0;
     while (j >= 0 && command[j] === '\\') { backslashes += 1; j -= 1; }
     if (backslashes % 2 === 0) break; // even (incl. zero): a real, unescaped newline
     i = j; // odd: backslash-newline continuation, keep walking back from before it

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -13,15 +13,11 @@ function handleInsideQuotes(ch, i, command, quote) {
 
 function handleEscape(ch, i, command) {
   if (ch === '\\' && i + 1 < command.length) {
-    // A backslash escaping a CRLF line-continuation ('\' followed by '\r\n')
-    // must swallow all three characters as one unit, not just the '\r' --
-    // otherwise the lone '\n' left behind falls through to the newline
-    // handling further down the main loop and spuriously ends the current
-    // segment, even though bash removes the whole three-character sequence
-    // as a single continuation (cubic review, EGC-539 PR #1147).
-    if (command[i + 1] === '\r' && command[i + 2] === '\n') {
-      return { chars: ch + command[i + 1] + command[i + 2], advance: 2, handled: true };
-    }
+    // A backslash before '\r\n' escapes only the '\r' (bash has no special
+    // treatment of CR), leaving the '\n' unescaped to end the line normally
+    // and a following '#' to start a real comment -- confirmed against a
+    // real bash shell (cubic review, EGC-539 PR #1147, correcting an earlier
+    // change that wrongly swallowed all three characters as one unit).
     return { chars: ch + command[i + 1], advance: 1, handled: true };
   }
   return { handled: false };
@@ -256,19 +252,17 @@ const COMMENT_WORD_START_RE = /[\s;&|(]/;
 // N is odd (each adjacent pair of backslashes is itself an escaped literal
 // backslash and cancels out; the escaping power passes to the newline only
 // off the single unpaired backslash left when the count is odd).
+//
+// A backslash before '\r\n' does NOT continue the line -- it escapes only
+// the '\r' (bash has no special handling of a lone CR), so the '\n' right
+// after it still ends the line for real, and this function must not walk
+// past it. Confirmed against a real bash shell (cubic review, EGC-539 PR
+// #1147, correcting an earlier change that treated '\'+'\r'+'\n' as one
+// continuation unit).
 function skipLineContinuations(command, i) {
   while (i >= 0 && command[i] === '\n') {
-    // Cubic review (EGC-539, PR #1147): the caller always passes the index
-    // of the LAST character of the newline run (i.e. the '\n', never the
-    // '\r' that may precede it in a '\r\n' pair), so a '\r\n' continuation
-    // must have its backslash count start two characters back -- one
-    // earlier version of this check tested command[i] === '\r' here, which
-    // can never be true given how the caller invokes this function, so the
-    // CRLF branch silently never fired and a backslash-CRLF continuation
-    // was miscounted as a real, unescaped newline.
-    const j0 = command[i - 1] === '\r' ? i - 2 : i - 1;
     let backslashes = 0;
-    let j = j0;
+    let j = i - 1;
     while (j >= 0 && command[j] === '\\') { backslashes += 1; j -= 1; }
     if (backslashes % 2 === 0) break; // even (incl. zero): a real, unescaped newline
     i = j; // odd: backslash-newline continuation, keep walking back from before it

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -223,14 +223,55 @@ function matchHeredocTerminator(command, i, hd) {
   return { matched: true, rawLine };
 }
 
+// Word-start characters for comment detection specifically -- deliberately
+// narrower than HEREDOC_WORD_STOP_RE. `)`, `<`, and `>` are NOT reliable
+// word-start cues here: bash concatenates $(...)/`<(...)`/`>(...)` with
+// whatever literal text immediately follows into a single word (`$(date)#c`
+// is the one word `$(date)#c`, not a command substitution followed by a
+// comment), and `>`/`<` are redirection operators where a following `#` is
+// part of a filename (`echo hi >#x` redirects into a file literally named
+// `#x`). Cubic review (EGC-539, PR #1147) caught that reusing
+// HEREDOC_WORD_STOP_RE here made splitShellSegments silently fold a live
+// `&&`/`;`/`|` separator into what it mistook for a comment, hiding a
+// destructive command from Guardian's per-segment validation -- exactly
+// the class of divergence this file exists to prevent.
+const COMMENT_WORD_START_RE = /[\s;&|(]/;
+
+// Bash removes an unescaped-backslash-then-newline pair entirely before
+// tokenizing (a line continuation), so 'foo\<newline>#bar' is the single
+// word 'foo#bar', not 'foo' followed by a comment starting at '#'. Walking
+// back from `i` (the position of a candidate word-start character, usually
+// a newline) over any such continuations finds the character bash would
+// actually treat as preceding the current position. A run of N consecutive
+// backslashes immediately before the newline continues the line only when
+// N is odd (each adjacent pair of backslashes is itself an escaped literal
+// backslash and cancels out; the escaping power passes to the newline only
+// off the single unpaired backslash left when the count is odd).
+function skipLineContinuations(command, i) {
+  while (i >= 0) {
+    const isBareLf = command[i] === '\n';
+    const isCrLf = command[i] === '\r' && command[i + 1] === '\n';
+    if (!isBareLf && !isCrLf) break;
+    const nlStart = isCrLf ? i : i; // the newline run itself starts at i either way
+    let backslashes = 0;
+    let j = nlStart - 1;
+    while (j >= 0 && command[j] === '\\') { backslashes += 1; j -= 1; }
+    if (backslashes % 2 === 0) break; // even (incl. zero): a real, unescaped newline
+    i = j; // odd: backslash-newline continuation, keep walking back from before it
+  }
+  return i;
+}
+
 // A `#` starts a comment (running to the end of the line, never split on or
 // scanned for substitutions) only when it is not inside a quote or an
 // already-open heredoc body, and only when it begins a new word — `foo#bar`
 // is one identifier, not a comment, matching bash's own rule that `#` is
 // only special in a word-start position.
 function isCommentStart(command, i, quote, heredocState) {
-  return heredocState !== 'in-body' && !quote && command[i] === '#'
-    && (i === 0 || HEREDOC_WORD_STOP_RE.test(command[i - 1]));
+  if (heredocState === 'in-body' || quote || command[i] !== '#') return false;
+  if (i === 0) return true;
+  const precedingIndex = skipLineContinuations(command, i - 1);
+  return precedingIndex < 0 || COMMENT_WORD_START_RE.test(command[precedingIndex]);
 }
 
 /**

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -252,9 +252,11 @@ function skipLineContinuations(command, i) {
     const isBareLf = command[i] === '\n';
     const isCrLf = command[i] === '\r' && command[i + 1] === '\n';
     if (!isBareLf && !isCrLf) break;
-    const nlStart = isCrLf ? i : i; // the newline run itself starts at i either way
+    // Either way (bare '\n' or the '\r' that starts a '\r\n' pair), i is
+    // already the index the newline run starts at -- the backslash count
+    // is checked immediately before that index in both cases.
     let backslashes = 0;
-    let j = nlStart - 1;
+    let j = i - 1;
     while (j >= 0 && command[j] === '\\') { backslashes += 1; j -= 1; }
     if (backslashes % 2 === 0) break; // even (incl. zero): a real, unescaped newline
     i = j; // odd: backslash-newline continuation, keep walking back from before it

--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -155,6 +155,84 @@ function parseHeredocOperator(command, i) {
   };
 }
 
+// Shared heredoc tracking used by both splitShellSegments and
+// extractSubstitutionBodies. A heredoc redirect (<<EOF, <<-EOF, <<'EOF', ...)
+// suspends normal scanning until a line consisting of exactly the delimiter
+// is found; everything up to that line is body text, not further shell
+// syntax to split on or scan for substitutions/comments in. Keeping this
+// state machine in one place means a fix to it (like the EOF-1/v1.0
+// delimiter-parsing fixes documented above parseHeredocDelimiterWord)
+// automatically applies to both consumers instead of needing to be
+// hand-ported to each — which is exactly how splitShellSegments ended up
+// without # comment support in the first place: extractSubstitutionBodies
+// gained it in a later audit round and the sibling parser was never updated
+// to match, so a `#`-prefixed remark like `echo hi # note: rm -rf / &&
+// something` had its trailing `&&` read as a real separator and produced a
+// spurious extra segment ("something") that was never live shell syntax.
+function createHeredocState() {
+  return {
+    state: null, // null | 'awaiting-body' | 'in-body'
+    delimiter: null,
+    stripLeadingTabs: false,
+    literal: false,
+    queue: [],
+    atLineStart: false,
+  };
+}
+
+// Applies a heredoc operator just parsed by parseHeredocOperator: starts
+// waiting for the first heredoc's body, or queues a later one on the same
+// command line (`cmd <<A <<B`) to be consumed once the first one's body
+// closes.
+function applyHeredocOperator(hd, op) {
+  if (hd.state === null) {
+    hd.delimiter = op.delimiter;
+    hd.stripLeadingTabs = op.stripLeadingTabs;
+    hd.literal = op.literal;
+    hd.state = 'awaiting-body';
+  } else {
+    hd.queue.push({ delimiter: op.delimiter, stripLeadingTabs: op.stripLeadingTabs, literal: op.literal });
+  }
+}
+
+// Checks whether the line starting at command[i] (only called when hd.state
+// is 'in-body' and hd.atLineStart is true) is the heredoc's terminator line.
+// If it is, advances to the next queued heredoc (or clears hd back to no
+// active heredoc) and returns the raw terminator line so the caller can fold
+// it into whatever it is building; otherwise clears atLineStart and reports
+// no match so the caller keeps scanning this line as ordinary body text.
+function matchHeredocTerminator(command, i, hd) {
+  const lineEnd = command.indexOf('\n', i);
+  const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
+  const line = rawLine.replace(/\r$/, '');
+  const candidate = hd.stripLeadingTabs ? line.replace(/^\t+/, '') : line;
+  if (candidate !== hd.delimiter) {
+    hd.atLineStart = false;
+    return { matched: false };
+  }
+  const next = hd.queue.shift();
+  if (next) {
+    hd.delimiter = next.delimiter;
+    hd.stripLeadingTabs = next.stripLeadingTabs;
+    hd.literal = next.literal;
+  } else {
+    hd.state = null;
+    hd.delimiter = null;
+    hd.atLineStart = false;
+  }
+  return { matched: true, rawLine };
+}
+
+// A `#` starts a comment (running to the end of the line, never split on or
+// scanned for substitutions) only when it is not inside a quote or an
+// already-open heredoc body, and only when it begins a new word — `foo#bar`
+// is one identifier, not a comment, matching bash's own rule that `#` is
+// only special in a word-start position.
+function isCommentStart(command, i, quote, heredocState) {
+  return heredocState !== 'in-body' && !quote && command[i] === '#'
+    && (i === 0 || HEREDOC_WORD_STOP_RE.test(command[i - 1]));
+}
+
 /**
  * Split a shell command into segments by operators (&&, ||, ;, &)
  * while respecting quoting (single/double) and escaped characters.
@@ -177,6 +255,15 @@ function parseHeredocOperator(command, i) {
  * segment; the guardian command validator opts in, since a pipeline stage
  * can itself be a wrapper/destructive command (`echo x | xargs rm -rf`)
  * that needs to be judged as its own segment.
+ *
+ * A `# comment` runs to the end of its line and is folded into the current
+ * segment as inert text, not scanned for operators — `echo hi # note: rm -rf
+ * / && something` is one segment, the same way a real shell never treats the
+ * `&&` after a `#` as a live separator. (Security fix, EGC-539: this parser
+ * previously had no comment awareness at all, so that `&&` was read as a
+ * real separator and produced a spurious extra segment, "something", that
+ * was never live shell syntax — a parsing divergence from
+ * extractSubstitutionBodies below, which already handled comments.)
  */
 function splitShellSegments(command, options = {}) { // NOSONAR: shell segment parser state machine kept inline for auditability
   const splitOnPipe = Boolean(options.splitOnPipe);
@@ -190,50 +277,30 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
   // flag plus a separate "seen delimiter" flag) is deliberate: two
   // independently-updated flags previously went out of sync exactly at this
   // transition, causing the terminator's own trailing newline to be
-  // swallowed into the body instead of ending the segment.
-  let heredocState = null;
-  let heredocDelimiter = null;
-  let heredocStripLeadingTabs = false;
-  // Heredocs queued on the same operator line after the first (e.g. the `B`
-  // in `cmd <<A <<B`), consumed in order as each preceding body closes.
-  const heredocQueue = [];
-  // True only for the first character of a body line -- the terminator can
-  // only ever be a whole line, so the expensive indexOf('\n')+slice+compare
-  // below only needs to run there. Re-running it at every character of a
-  // long single-line body was O(line length) work per character, i.e.
-  // O(n^2) for one long line, before Guardian even validated anything.
-  let heredocAtLineStart = false;
+  // swallowed into the body instead of ending the segment. See
+  // createHeredocState()'s doc comment for why this tracking is shared with
+  // extractSubstitutionBodies below.
+  const hd = createHeredocState();
+  // True from an unquoted, word-starting `#` until (not including) the next
+  // newline -- reset unconditionally on every newline below, same as
+  // extractSubstitutionBodies's inComment tracking.
+  let inComment = false;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
 
-    if (heredocState === 'in-body') {
-      if (heredocAtLineStart) {
-        const lineEnd = command.indexOf('\n', i);
-        const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
-        const line = rawLine.replace(/\r$/, '');
-        const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
-        if (candidate === heredocDelimiter) {
-          current += rawLine;
-          i += rawLine.length - 1;
-          const next = heredocQueue.shift();
-          if (next) {
-            heredocDelimiter = next.delimiter;
-            heredocStripLeadingTabs = next.stripLeadingTabs;
-            // Stay in 'in-body' and at a (new) line start: the newline
-            // right after this terminator line is also the first character
-            // of the next queued heredoc's body, not a fresh
-            // 'awaiting-body' gap.
-          } else {
-            heredocState = null;
-            heredocDelimiter = null;
-            heredocAtLineStart = false;
-          }
+    if (ch === '\n') inComment = false;
+
+    if (hd.state === 'in-body') {
+      if (hd.atLineStart) {
+        const term = matchHeredocTerminator(command, i, hd);
+        if (term.matched) {
+          current += term.rawLine;
+          i += term.rawLine.length - 1;
           continue;
         }
-        heredocAtLineStart = false;
       }
-      if (ch === '\n') heredocAtLineStart = true;
+      if (ch === '\n') hd.atLineStart = true;
       current += ch;
       continue;
     }
@@ -259,26 +326,28 @@ function splitShellSegments(command, options = {}) { // NOSONAR: shell segment p
       continue;
     }
 
-    if (heredocState === 'awaiting-body' && ch === '\n') {
+    if (!inComment && isCommentStart(command, i, quote, hd.state)) {
+      inComment = true;
       current += ch;
-      heredocState = 'in-body';
-      heredocAtLineStart = true;
       continue;
     }
 
-    if (heredocState !== 'in-body' && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
+    if (inComment) {
+      current += ch;
+      continue;
+    }
+
+    if (hd.state === 'awaiting-body' && ch === '\n') {
+      current += ch;
+      hd.state = 'in-body';
+      hd.atLineStart = true;
+      continue;
+    }
+
+    if (hd.state !== 'in-body' && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
       const op = parseHeredocOperator(command, i);
       if (op) {
-        if (heredocState === null) {
-          heredocDelimiter = op.delimiter;
-          heredocStripLeadingTabs = op.stripLeadingTabs;
-          heredocState = 'awaiting-body';
-        } else {
-          // Already awaiting the first heredoc's body on this same command
-          // line — this is a second (or later) chained heredoc; its body
-          // comes after the first one's, so only queue it for now.
-          heredocQueue.push({ delimiter: op.delimiter, stripLeadingTabs: op.stripLeadingTabs });
-        }
+        applyHeredocOperator(hd, op);
         current += command.slice(i, i + op.length);
         i += op.length - 1;
         continue;
@@ -449,101 +518,72 @@ function pushSubstitutionAt(command, i, bodies) {
 function extractSubstitutionBodies(command) { // NOSONAR: shell scanner state machine kept inline for auditability
   const bodies = [];
   let quote = null;
-  let heredocState = null;
-  let heredocDelimiter = null;
-  let heredocStripLeadingTabs = false;
-  let heredocLiteral = false;
-  const heredocQueue = [];
+  // See createHeredocState()'s doc comment: this tracking is shared with
+  // splitShellSegments above.
+  const hd = createHeredocState();
   let inComment = false;
-  // True only for the first character of a body line -- see the identical
-  // field in splitShellSegments for why re-checking the terminator at every
-  // character (not just line starts) was an O(n^2) cost on one long body
-  // line.
-  let heredocAtLineStart = false;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
 
     if (ch === '\n') inComment = false;
 
-    if (heredocState === 'in-body') {
-      if (heredocAtLineStart) {
-        const lineEnd = command.indexOf('\n', i);
-        const rawLine = lineEnd === -1 ? command.slice(i) : command.slice(i, lineEnd);
-        const line = rawLine.replace(/\r$/, '');
-        const candidate = heredocStripLeadingTabs ? line.replace(/^\t+/, '') : line;
-        if (candidate === heredocDelimiter) {
-          i += rawLine.length - 1;
-          const next = heredocQueue.shift();
-          if (next) {
-            heredocDelimiter = next.delimiter;
-            heredocStripLeadingTabs = next.stripLeadingTabs;
-            heredocLiteral = next.literal;
-          } else {
-            heredocState = null;
-            heredocDelimiter = null;
-            heredocAtLineStart = false;
-          }
+    if (hd.state === 'in-body') {
+      if (hd.atLineStart) {
+        const term = matchHeredocTerminator(command, i, hd);
+        if (term.matched) {
+          i += term.rawLine.length - 1;
           continue;
         }
-        heredocAtLineStart = false;
       }
-      if (ch === '\n') heredocAtLineStart = true;
-      if (heredocLiteral) continue;
+      if (ch === '\n') hd.atLineStart = true;
+      if (hd.literal) continue;
       // Bare/unquoted-delimiter heredoc body: falls through to the normal
       // scan below, since bash still expands $(...) here.
     }
 
-    if (heredocState !== 'in-body' && quote === "'") {
+    if (hd.state !== 'in-body' && quote === "'") {
       if (ch === quote) quote = null;
       continue;
     }
 
-    if (heredocState !== 'in-body' && quote === '"' && ch === '\\' && i + 1 < command.length) {
+    if (hd.state !== 'in-body' && quote === '"' && ch === '\\' && i + 1 < command.length) {
       i += 1;
       continue;
     }
 
-    if (heredocState !== 'in-body' && quote === '"' && ch === quote) {
+    if (hd.state !== 'in-body' && quote === '"' && ch === quote) {
       quote = null;
       continue;
     }
 
-    if (heredocState !== 'in-body' && !quote && ch === '\\' && i + 1 < command.length) {
+    if (hd.state !== 'in-body' && !quote && ch === '\\' && i + 1 < command.length) {
       i += 1;
       continue;
     }
 
-    if (heredocState !== 'in-body' && !quote && (ch === '"' || ch === "'")) {
+    if (hd.state !== 'in-body' && !quote && (ch === '"' || ch === "'")) {
       quote = ch;
       continue;
     }
 
-    if (heredocState !== 'in-body' && !quote && !inComment && ch === '#'
-        && (i === 0 || HEREDOC_WORD_STOP_RE.test(command[i - 1]))) {
+    if (!inComment && isCommentStart(command, i, quote, hd.state)) {
       inComment = true;
       continue;
     }
 
     if (inComment) continue;
 
-    if (heredocState === 'awaiting-body' && ch === '\n') {
-      heredocState = 'in-body';
-      heredocAtLineStart = true;
+    if (hd.state === 'awaiting-body' && ch === '\n') {
+      hd.state = 'in-body';
+      hd.atLineStart = true;
       continue;
     }
 
-    if (heredocState !== 'in-body' && !quote && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
+    if (hd.state !== 'in-body' && !quote && ch === '<' && command[i + 1] === '<' && command[i + 2] !== '<') {
       const op = parseHeredocOperator(command, i);
       if (op) {
-        if (heredocState === null) {
-          heredocDelimiter = op.delimiter;
-          heredocStripLeadingTabs = op.stripLeadingTabs;
-          heredocLiteral = op.literal;
-          heredocState = 'awaiting-body';
-        } else {
-          heredocQueue.push({ delimiter: op.delimiter, stripLeadingTabs: op.stripLeadingTabs, literal: op.literal });
-        }
+        applyHeredocOperator(hd, op);
         i += op.length - 1;
         continue;
       }

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -264,6 +264,45 @@ test('# inside a heredoc body is literal body text, not a comment (no change fro
   assert.deepStrictEqual(segs, ['cat <<EOF\n# not a comment && rm -rf /\nEOF', 'echo done']);
 });
 
+// Cubic review (EGC-539, PR #1147): the first comment-detection fix above
+// introduced its own two false-comment regressions -- a live && hidden
+// behind a # that only LOOKS like a comment start. Both are real bash
+// tokenization behavior, verified against a real bash shell.
+test('a backslash-newline continuation glues the next line onto the current word, so a following # is mid-word, not a comment start', () => {
+  // Bash removes the unescaped backslash+newline pair entirely before
+  // tokenizing, so 'echo hi\<newline>#c && rm -rf /' is really the single
+  // token line 'echo hi#c && rm -rf /' -- '#c' is glued onto 'hi' (not a
+  // comment), and the && after it is a live, real separator. The segment
+  // text itself is preserved verbatim (backslash and newline included, same
+  // as every other test in this file) -- only the split *decision* changes.
+  assert.deepStrictEqual(
+    splitShellSegments('echo hi\\\n#c && rm -rf /'),
+    ['echo hi\\\n#c', 'rm -rf /'],
+  );
+});
+test('a space before the backslash-newline continuation keeps # as a real comment start on the next line', () => {
+  // Contrast with the case above: a space before the escaped newline means
+  // bash sees 'hi ' (trailing space preserved) followed by '#c ...', so #
+  // genuinely starts a word here and is a real comment that absorbs the
+  // trailing && into the same (single) segment, verbatim text preserved.
+  assert.deepStrictEqual(
+    splitShellSegments('echo hi \\\n#c && rm -rf /'),
+    ['echo hi \\\n#c && rm -rf /'],
+  );
+});
+test('# immediately after a closing paren from $(...) is mid-word, not a comment start (bash concatenates the following text onto the same word)', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo $(date)#c && echo AFTER'),
+    ['echo $(date)#c', 'echo AFTER'],
+  );
+});
+test('# immediately after a redirection target character is part of the filename, not a comment start', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo hi >#x && rm -rf /'),
+    ['echo hi >#x', 'rm -rf /'],
+  );
+});
+
 // extractSubstitutionBodies (cubic-dev-ai P0: $(...)/`...`/<(...)/>(...) content
 // must be recoverable so a hidden command can be validated, not just skipped)
 console.log('\nextractSubstitutionBodies:');

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -290,17 +290,23 @@ test('a space before the backslash-newline continuation keeps # as a real commen
     ['echo hi \\\n#c && rm -rf /'],
   );
 });
-test('a backslash-CRLF continuation glues the next line onto the current word too, not just backslash-LF', () => {
-  // Cubic review, second pass (EGC-539, PR #1147): the caller always passes
-  // the index of the newline run's LAST character (the '\n', never a
-  // leading '\r'), so a '\r\n' continuation needs its backslash count to
-  // start two characters back, not one. A prior fix here tested
-  // command[i] === '\r' inside skipLineContinuations, which could never be
-  // true given how it's actually invoked, so the CRLF branch silently never
-  // fired and this exact case was miscounted as a real, unescaped newline.
+test('a backslash before CRLF escapes only the CR, not the whole line ending, so the following # is still a real comment', () => {
+  // Cubic review, third pass (EGC-539, PR #1147): confirmed against a real
+  // bash shell that '\' + '\r' + '\n' is NOT a line continuation. Bash has
+  // no special handling of a lone CR, so the backslash escapes only the
+  // '\r' (kept literally in the word), and the unescaped '\n' right after
+  // it still ends the line for real. A prior fix here wrongly swallowed all
+  // three characters as one continuation unit, which caused the '#' on the
+  // next line to be read as mid-word instead of a real comment start -- that
+  // silently pulled '&& rm -rf /' inside what bash treats as inert comment
+  // text out as its own live segment, defeating the whole point of this PR.
+  // The two segments below match real bash: the first ends at the escaped
+  // CR (trimmed, same as the plain-newline-splitting tests above), and the
+  // '#' on the next line starts a real comment that absorbs the rest of the
+  // line, including '&& rm -rf /', as inert text -- never its own segment.
   assert.deepStrictEqual(
     splitShellSegments('echo hi\\\r\n#c && rm -rf /'),
-    ['echo hi\\\r\n#c', 'rm -rf /'],
+    ['echo hi\\', '#c && rm -rf /'],
   );
 });
 test('# immediately after a closing paren from $(...) is mid-word, not a comment start (bash concatenates the following text onto the same word)', () => {

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -290,6 +290,19 @@ test('a space before the backslash-newline continuation keeps # as a real commen
     ['echo hi \\\n#c && rm -rf /'],
   );
 });
+test('a backslash-CRLF continuation glues the next line onto the current word too, not just backslash-LF', () => {
+  // Cubic review, second pass (EGC-539, PR #1147): the caller always passes
+  // the index of the newline run's LAST character (the '\n', never a
+  // leading '\r'), so a '\r\n' continuation needs its backslash count to
+  // start two characters back, not one. A prior fix here tested
+  // command[i] === '\r' inside skipLineContinuations, which could never be
+  // true given how it's actually invoked, so the CRLF branch silently never
+  // fired and this exact case was miscounted as a real, unescaped newline.
+  assert.deepStrictEqual(
+    splitShellSegments('echo hi\\\r\n#c && rm -rf /'),
+    ['echo hi\\\r\n#c', 'rm -rf /'],
+  );
+});
 test('# immediately after a closing paren from $(...) is mid-word, not a comment start (bash concatenates the following text onto the same word)', () => {
   assert.deepStrictEqual(
     splitShellSegments('echo $(date)#c && echo AFTER'),

--- a/tests/lib/shell-split.test.js
+++ b/tests/lib/shell-split.test.js
@@ -221,6 +221,49 @@ test('multiple heredocs on one line are consumed in order, not mixed with ordina
   ]);
 });
 
+// Comments (EGC-539 audit, security fix: splitShellSegments previously had no
+// # comment awareness at all, unlike extractSubstitutionBodies below -- a
+// real parsing divergence in a module that feeds the Guardian bash validator.
+// echo hi # note: rm -rf / && something used to split into ["echo hi # note:
+// rm -rf /", "something"], treating the && inside the comment as a live
+// separator and manufacturing a segment ("something") that was never live
+// shell syntax.)
+console.log('\nComments (EGC-539):');
+test('a # comment absorbs a trailing && instead of producing a spurious extra segment', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo hi # note: rm -rf / && something'),
+    ['echo hi # note: rm -rf / && something'],
+  );
+});
+test('a # comment absorbs trailing ; and | operators too, not just &&', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo hi # rm -rf /; also | this', { splitOnPipe: true }),
+    ['echo hi # rm -rf /; also | this'],
+  );
+});
+test('# appearing mid-word does not start a comment (foo#bar is one identifier)', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo foo#bar && something'),
+    ['echo foo#bar', 'something'],
+  );
+});
+test('a comment only runs to end of line: operators on the next line still split normally', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo hi # comment\necho bye && echo baz'),
+    ['echo hi # comment', 'echo bye', 'echo baz'],
+  );
+});
+test('a quoted # does not start a comment', () => {
+  assert.deepStrictEqual(
+    splitShellSegments('echo "a # b" && echo c'),
+    ['echo "a # b"', 'echo c'],
+  );
+});
+test('# inside a heredoc body is literal body text, not a comment (no change from prior behavior)', () => {
+  const segs = splitShellSegments('cat <<EOF\n# not a comment && rm -rf /\nEOF\necho done');
+  assert.deepStrictEqual(segs, ['cat <<EOF\n# not a comment && rm -rf /\nEOF', 'echo done']);
+});
+
 // extractSubstitutionBodies (cubic-dev-ai P0: $(...)/`...`/<(...)/>(...) content
 // must be recoverable so a hidden command can be validated, not just skipped)
 console.log('\nextractSubstitutionBodies:');


### PR DESCRIPTION
## Context

EGC-539 audit (Finding 2, `scripts/` scope), confirmed by runtime reproduction: `splitShellSegments` and `extractSubstitutionBodies` in `scripts/lib/shell-split.js` each reimplement their own heredoc/quote state machine, and only `extractSubstitutionBodies` had ever been taught to recognize `#` comments (added in a later cubic-dev-ai audit round without being ported to its sibling). Both functions feed `scripts/hooks/pre-bash-guardian-validate.js`, the hook that decides which Bash commands the Guardian security gate blocks.

This is a real parsing divergence, not a cosmetic inconsistency:

```js
splitShellSegments('echo hi # note: rm -rf / && something')
// before: ["echo hi # note: rm -rf /", "something"]
```

The `&&` inside the `#` comment was read as a live separator, manufacturing a spurious extra segment (`"something"`) that was never live shell syntax and got validated by the Guardian as if it were its own command.

## Fix

Extracted the shared heredoc-tracking state machine (`createHeredocState` / `applyHeredocOperator` / `matchHeredocTerminator`) and the comment-start predicate (`isCommentStart`) into internal helpers consumed by **both** public functions, then wired `splitShellSegments` up to the same comment tracking `extractSubstitutionBodies` already had.

This is a security-relevant behavior fix, not just a refactor: a `#` comment now runs to end of line and is folded into the current segment as inert text in **both** parsers, matching real shell semantics and closing the divergence between them:

```js
splitShellSegments('echo hi # note: rm -rf / && something')
// after: ["echo hi # note: rm -rf / && something"]
```

As a side effect of the dedup, `extractSubstitutionBodies`'s own reported cyclomatic complexity drops from 46 to 38 (eslint `complexity` warning, non-blocking both before and after). `splitShellSegments`'s stays at 32. Behavior for every pre-existing test case is unchanged — only the new comment-awareness in `splitShellSegments` is new behavior.

## Test plan

- Baseline captured before any change: `node tests/lib/shell-split.test.js` → 72/72, `node tests/hooks/pre-bash-guardian-validate.test.js` → 22/22, `node tests/hooks/pre-bash-dev-server-block.test.js` → 10/10.
- 6 new regression tests added to `tests/lib/shell-split.test.js` under a "Comments (EGC-539)" section:
  - a `#` comment absorbs a trailing `&&` instead of producing a spurious extra segment (the exact finding reproduction)
  - a `#` comment absorbs trailing `;`/`|` too, not just `&&`
  - `#` appearing mid-word does not start a comment (`foo#bar` stays one identifier)
  - a comment only runs to end of line — operators on the next line still split normally
  - a quoted `#` does not start a comment
  - `#` inside a heredoc body stays literal body text (no behavior change there)
- After the change, run in isolation (never the full suite):
  - `node tests/lib/shell-split.test.js` → **78/78 passing** (72 pre-existing + 6 new)
  - `node tests/hooks/pre-bash-guardian-validate.test.js` → **22/22, unchanged**
  - `node tests/hooks/pre-bash-dev-server-block.test.js` → **10/10, unchanged**
- `npx eslint scripts/lib/shell-split.js tests/lib/shell-split.test.js` → 0 errors (2 pre-existing complexity warnings, one of which improved).

Not merging this PR — opening for review only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `splitShellSegments` comment-aware and correct line-continuation handling so `#` only starts a comment at true word starts. Prevents spurious segments and aligns with `extractSubstitutionBodies` (EGC-539).

- **Bug Fixes**
  - `#` comments run to EOL; operators inside no longer split segments.
  - Narrowed word-start rules; `$(date)#c` and `>#x` are mid-word, not comments.
  - Line continuations: backslash-LF continues a line; backslash-CRLF does not. `#` after CRLF starts a real comment. `skipLineContinuations` walks over LF only; `handleEscape` no longer swallows `\r\n` as one unit.
  - Unified heredoc/comment handling across both parsers to stop Guardian from validating non-existent commands.

- **Refactors**
  - Shared helpers for heredoc tracking and comment-start detection; reduced `extractSubstitutionBodies` complexity (46 → 38). Removed a dead conditional in `skipLineContinuations`.
  - Tests added/updated for mid-word `#` and continuation edges; all passing. Guardian hooks unchanged.

<sup>Written for commit fb4f440acef876042b193390a46beb9e38103ee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

