### PR TITLE
fix(guardian): fix exitCode race and dedupe wiring in plain adapters (EGC-539)

### DIFF
--- a/scripts/hooks/kiro-guardian-adapter.js
+++ b/scripts/hooks/kiro-guardian-adapter.js
@@ -27,7 +27,7 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
-const { runPlainExitCodeGuardianAdapter } = require('../lib/adapter-stdin-json');
+const { bootstrapPlainExitCodeAdapter } = require('../lib/adapter-stdin-json');
 
 const BASH_TOOL_NAMES = new Set(['execute_bash', 'shell', 'execute_cmd']);
 
@@ -49,12 +49,8 @@ function buildGuardianInput(kiroEvent) {
   return input;
 }
 
-function main() {
-  runPlainExitCodeGuardianAdapter(buildGuardianInput, run);
-}
-
-if (require.main === module) {
-  main();
-}
-
-module.exports = { buildGuardianInput };
+module.exports = bootstrapPlainExitCodeAdapter({
+  isMain: require.main === module,
+  buildGuardianInput,
+  runGuardian: run,
+});

--- a/scripts/hooks/windsurf-guardian-adapter.js
+++ b/scripts/hooks/windsurf-guardian-adapter.js
@@ -21,7 +21,7 @@
 'use strict';
 
 const { run } = require('./pre-bash-guardian-validate');
-const { runPlainExitCodeGuardianAdapter } = require('../lib/adapter-stdin-json');
+const { bootstrapPlainExitCodeAdapter } = require('../lib/adapter-stdin-json');
 
 function buildGuardianInput(windsurfEvent) {
   if (!windsurfEvent || typeof windsurfEvent !== 'object') {
@@ -48,12 +48,8 @@ function buildGuardianInput(windsurfEvent) {
   return input;
 }
 
-function main() {
-  runPlainExitCodeGuardianAdapter(buildGuardianInput, run);
-}
-
-if (require.main === module) {
-  main();
-}
-
-module.exports = { buildGuardianInput };
+module.exports = bootstrapPlainExitCodeAdapter({
+  isMain: require.main === module,
+  buildGuardianInput,
+  runGuardian: run,
+});

--- a/scripts/lib/adapter-stdin-json.js
+++ b/scripts/lib/adapter-stdin-json.js
@@ -85,33 +85,47 @@ function runPlainExitCodeGuardianAdapter(buildGuardianInput, runGuardian) {
         'this validator can safely read, so it could not be parsed or validated. ' +
         'Simplify the command.\n'
       );
-      process.exit(2);
+      // process.exitCode (not process.exit()) so Node drains stderr
+      // naturally: on POSIX a forced exit can race the pipe write and
+      // truncate the diagnostic message before the host reads it -- the
+      // same cubic-dev-ai finding already applied to the JSON-envelope
+      // contract (see cursor-guardian-adapter.js's respond()), now applied
+      // here for the plain-exit-code contract's 5 hosts (EGC-539 audit).
+      // The exit code (the actual security decision) was never at risk --
+      // Node still delivers it synchronously either way -- only the
+      // stderr diagnostic could race and truncate under process.exit().
+      process.exitCode = 2;
+      return;
     }
     if (!ok) {
-      process.exit(0);
+      process.exitCode = 0;
+      return;
     }
 
     const guardianInput = buildGuardianInput(value);
     if (!guardianInput) {
-      process.exit(0);
+      process.exitCode = 0;
+      return;
     }
 
     const result = runGuardian(guardianInput);
     if (result.exitCode === 2) {
       const reason = result.stderr || 'Blocked by the EGC Guardian.';
       process.stderr.write(reason.endsWith('\n') ? reason : `${reason}\n`);
-      process.exit(2);
+      process.exitCode = 2;
+      return;
     }
 
-    process.exit(0);
+    process.exitCode = 0;
   });
 }
 
 // Shared entrypoint for the plain-exit-code adapters (Amazon Q, Goose,
-// OpenHands -- Kiro predates this helper and keeps its own inline copy):
-// collapses each adapter's identical "run when invoked directly, always
-// export buildGuardianInput for tests" boilerplate into one call, so those
-// three near-identical translation scripts stop duplicating it verbatim.
+// OpenHands, Kiro, Windsurf): collapses each adapter's identical "run when
+// invoked directly, always export buildGuardianInput for tests" boilerplate
+// into one call, so those near-identical translation scripts stop
+// duplicating it verbatim. Each host keeps its own buildGuardianInput (their
+// wire contracts differ), only the wiring around it is shared.
 function bootstrapPlainExitCodeAdapter({ isMain, buildGuardianInput, runGuardian }) {
   if (isMain) {
     runPlainExitCodeGuardianAdapter(buildGuardianInput, runGuardian);

--- a/tests/hooks/guardian-adapter-test-harness.js
+++ b/tests/hooks/guardian-adapter-test-harness.js
@@ -117,6 +117,20 @@ function runGuardianAdapterTests({
     assert.strictEqual(result.code, 2, `Expected fail-closed on truncated oversized input, got exit ${result.code}`);
   }));
 
+  record(test('CLI: full stderr reason is present at exit (no truncation from exitCode-based exit)', () => {
+    // Regression guard for the race fixed in runPlainExitCodeGuardianAdapter
+    // (EGC-539 audit, Finding A): the shared helper used to call
+    // process.exit(2) right after stderr.write(), which can race the pipe
+    // flush on POSIX and truncate the diagnostic message before the host
+    // reads it. Now uses process.exitCode, the same fix already applied to
+    // the JSON-envelope contract's Cline/Junie/Cursor adapters.
+    for (let i = 0; i < 20; i += 1) {
+      const result = runAdapterCli(buildEvent(shellToolName, { command: 'rm -rf /' }, {}));
+      assert.strictEqual(result.code, 2, `Run ${i}: expected exit 2`);
+      assert.ok(result.stderr.length > 0, `Run ${i}: expected non-empty stderr`);
+    }
+  }));
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   return failed === 0;
 }

--- a/tests/hooks/kiro-guardian-adapter.test.js
+++ b/tests/hooks/kiro-guardian-adapter.test.js
@@ -156,6 +156,24 @@ function runTests() {
     assert.strictEqual(result.code, 2, `Expected fail-closed on a truncated-but-parseable payload, got exit ${result.code}`);
   })) passed++; else failed++;
 
+  if (test('CLI: full stderr reason is present at exit (no truncation from exitCode-based exit)', () => {
+    // Regression guard for the race fixed in runPlainExitCodeGuardianAdapter
+    // (EGC-539 audit, Finding A): the shared helper used to call
+    // process.exit(2) right after stderr.write(), which can race the pipe
+    // flush on POSIX and truncate the diagnostic message before the host
+    // reads it. Now uses process.exitCode, the same fix already applied to
+    // the JSON-envelope contract's Cline/Junie/Cursor adapters.
+    for (let i = 0; i < 20; i += 1) {
+      const result = runAdapterCli({
+        hook_event_name: 'preToolUse',
+        tool_name: 'execute_bash',
+        tool_input: { command: 'rm -rf /' },
+      });
+      assert.strictEqual(result.code, 2, `Run ${i}: expected exit 2`);
+      assert.ok(result.stderr.length > 0, `Run ${i}: expected non-empty stderr`);
+    }
+  })) passed++; else failed++;
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/hooks/windsurf-guardian-adapter.test.js
+++ b/tests/hooks/windsurf-guardian-adapter.test.js
@@ -162,6 +162,23 @@ function runTests() {
     assert.strictEqual(result.code, 2, `Expected fail-closed on a truncated-but-parseable payload, got exit ${result.code}`);
   })) passed++; else failed++;
 
+  if (test('CLI: full stderr reason is present at exit (no truncation from exitCode-based exit)', () => {
+    // Regression guard for the race fixed in runPlainExitCodeGuardianAdapter
+    // (EGC-539 audit, Finding A): the shared helper used to call
+    // process.exit(2) right after stderr.write(), which can race the pipe
+    // flush on POSIX and truncate the diagnostic message before the host
+    // reads it. Now uses process.exitCode, the same fix already applied to
+    // the JSON-envelope contract's Cline/Junie/Cursor adapters.
+    for (let i = 0; i < 20; i += 1) {
+      const result = runAdapterCli({
+        agent_action_name: 'pre_run_command',
+        tool_info: { command_line: 'rm -rf /' },
+      });
+      assert.strictEqual(result.code, 2, `Run ${i}: expected exit 2`);
+      assert.ok(result.stderr.length > 0, `Run ${i}: expected non-empty stderr`);
+    }
+  })) passed++; else failed++;
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/adapter-stdin-json.test.js
+++ b/tests/lib/adapter-stdin-json.test.js
@@ -46,6 +46,39 @@ function readViaSubprocess(input) {
   return JSON.parse(result.stdout.toString('utf8'));
 }
 
+// Deterministic counterpart to the repeated-spawn timing race test in
+// kiro-/windsurf-guardian-adapter.test.js (cubic review, EGC-539 PR #1148,
+// P3): that test's 20 real-node-spawn loop can only ever catch a
+// process.exit()-vs-process.exitCode regression probabilistically, since
+// the truncation it guards against depends on OS pipe-flush timing. This
+// driver instead overrides process.exit to prove -- unconditionally, not
+// just "usually" -- that runPlainExitCodeGuardianAdapter's blocked path
+// never calls it: if it ever does, the override itself reports that fact
+// on stderr before forcing a real exit, and the assertion below fails
+// every single run rather than only when timing happens to expose it.
+const blockedExitDriverPath = path.join(os.tmpdir(), `egc-adapter-stdin-json-blocked-exit-driver-${process.pid}.js`);
+fs.writeFileSync(blockedExitDriverPath, `
+  process.exit = (code) => {
+    process.stderr.write('__PROCESS_EXIT_CALLED__:' + code);
+    process.reallyExit(code === undefined ? 1 : code);
+  };
+  const { runPlainExitCodeGuardianAdapter } = require(${JSON.stringify(MODULE_PATH)});
+  runPlainExitCodeGuardianAdapter(
+    () => ({ command: 'ignored' }),
+    () => ({ exitCode: 2, stderr: 'blocked reason\\n' }),
+  );
+`);
+process.on('exit', () => { try { fs.rmSync(blockedExitDriverPath, { force: true }); } catch { /* best-effort cleanup */ } });
+
+function readBlockedExitViaSubprocess() {
+  const result = spawnSync(process.execPath, [blockedExitDriverPath], {
+    input: JSON.stringify({ some: 'event' }),
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return { code: result.status, stderr: result.stderr.toString('utf8') };
+}
+
 function runTests() {
   console.log('\n=== Testing scripts/lib/adapter-stdin-json.js ===\n');
 
@@ -100,6 +133,16 @@ function runTests() {
     const result = readViaSubprocess('{not valid json');
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.truncated, false);
+  })) passed++; else failed++;
+
+  if (test('runPlainExitCodeGuardianAdapter never calls process.exit() on a blocked result -- uses process.exitCode instead', () => {
+    const result = readBlockedExitViaSubprocess();
+    assert.ok(
+      !result.stderr.includes('__PROCESS_EXIT_CALLED__'),
+      `process.exit() must never be called (it can race and truncate the stderr diagnostic on POSIX); ` +
+      `runPlainExitCodeGuardianAdapter must set process.exitCode instead. stderr was: ${result.stderr}`,
+    );
+    assert.strictEqual(result.code, 2, 'the process must still exit with code 2 via process.exitCode');
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);

--- a/tests/lib/adapter-stdin-json.test.js
+++ b/tests/lib/adapter-stdin-json.test.js
@@ -56,10 +56,19 @@ function readViaSubprocess(input) {
 // never calls it: if it ever does, the override itself reports that fact
 // on stderr before forcing a real exit, and the assertion below fails
 // every single run rather than only when timing happens to expose it.
+//
+// The marker write itself must be synchronous (cubic review, second pass,
+// P2): process.stderr.write() on a pipe is async, and process.reallyExit()
+// does not drain pending pipe writes, so a plain .write() call here would
+// have the exact same truncation race this test exists to make
+// deterministic -- a regression could lose the marker and this guard would
+// pass regardless. fs.writeSync(2, ...) (fd 2 is stderr) is a real
+// synchronous syscall with no such race.
 const blockedExitDriverPath = path.join(os.tmpdir(), `egc-adapter-stdin-json-blocked-exit-driver-${process.pid}.js`);
 fs.writeFileSync(blockedExitDriverPath, `
+  const fs = require('fs');
   process.exit = (code) => {
-    process.stderr.write('__PROCESS_EXIT_CALLED__:' + code);
+    fs.writeSync(2, '__PROCESS_EXIT_CALLED__:' + code);
     process.reallyExit(code === undefined ? 1 : code);
   };
   const { runPlainExitCodeGuardianAdapter } = require(${JSON.stringify(MODULE_PATH)});


### PR DESCRIPTION
## Context

EGC-539 audit (`scripts/` engineering health -- hooks, ci, lib, install-targets) found two related findings in the same area of code (host adapters), both in the "plain exit code" contract used by `amazonq-`, `goose-`, `openhands-`, `kiro-`, and `windsurf-guardian-adapter.js`.

**Finding A (race, MEDIUM):** `runPlainExitCodeGuardianAdapter` in `scripts/lib/adapter-stdin-json.js` called `process.exit(2)`/`process.exit(0)` directly, right after `process.stderr.write(...)`. On POSIX a forced exit can race the pipe flush and truncate the stderr diagnostic before the host reads it -- the exact class of bug already fixed on the sibling JSON-envelope contract (`runJsonEnvelopeGuardianAdapter`), where `cursor-guardian-adapter.js`'s `respond()` already documents switching to `process.exitCode` for this reason. That fix never reached the plain-exit-code contract's 5 consumers. The exit code itself (the actual security decision) was always delivered synchronously either way, so there was no validation bypass -- only the diagnostic message on stderr was at risk of truncation when the hook is invoked via a pipe.

**Finding B (duplication, LOW-MEDIUM):** `kiro-guardian-adapter.js` and `windsurf-guardian-adapter.js` still reimplemented the "run when invoked directly, always export `buildGuardianInput` for tests" `main()`/`module.exports` boilerplate that `bootstrapPlainExitCodeAdapter` (also in `adapter-stdin-json.js`) already exists to eliminate -- `amazonq-`, `goose-`, and `openhands-guardian-adapter.js` already use it for the identical purpose. Kiro genuinely needs its own `buildGuardianInput` (its wire contract differs from the others), but that doesn't require duplicating the wiring around it, and Windsurf was never covered by the helper's own doc comment despite being an obvious candidate.

## Fix

- `runPlainExitCodeGuardianAdapter` now sets `process.exitCode` instead of calling `process.exit()`, with an explicit `return` after each branch to preserve the exact original control flow (each branch was previously terminal because `process.exit()` never returns).
- `kiro-guardian-adapter.js` and `windsurf-guardian-adapter.js` now call `bootstrapPlainExitCodeAdapter`, keeping their own `buildGuardianInput` translation and dropping the duplicated `main()`/`module.exports` wiring, matching `amazonq-`/`goose-`/`openhands-guardian-adapter.js`.
- Updated the stale doc comment above `bootstrapPlainExitCodeAdapter` (previously said "Kiro predates this helper and keeps its own inline copy," no longer true).
- No behavior change for any host: same allow/deny decisions, same exit codes, same stderr content, same `buildGuardianInput` exports for tests.

## Test plan

- [x] New regression test (`kiro-guardian-adapter.test.js`, `windsurf-guardian-adapter.test.js`, and the shared `guardian-adapter-test-harness.js` used by amazonq/goose/openhands): repeats a blocked run 20x and asserts `stderr` is never empty, mirroring the existing "full stdout is present at exit" regression tests that already cover the identical fix on the JSON-envelope contract (Cline/Junie/Cursor).
- [x] Isolated run: `node tests/lib/adapter-stdin-json.test.js` -- 5/5 passing
- [x] Isolated run: `node tests/hooks/kiro-guardian-adapter.test.js` -- 14/14 passing
- [x] Isolated run: `node tests/hooks/windsurf-guardian-adapter.test.js` -- 14/14 passing
- [x] Isolated run: `node tests/hooks/amazonq-guardian-adapter.test.js` -- 12/12 passing
- [x] Isolated run: `node tests/hooks/goose-guardian-adapter.test.js` -- 12/12 passing
- [x] Isolated run: `node tests/hooks/openhands-guardian-adapter.test.js` -- 12/12 passing
- [x] Sanity (unmodified, shares `adapter-stdin-json.js`): `node tests/hooks/cursor-guardian-adapter.test.js` -- 12/12, `node tests/hooks/cline-guardian-adapter.test.js` -- 7/7, `node tests/hooks/junie-guardian-adapter.test.js` -- 7/7
- [x] `npx eslint` on all 6 touched files -- clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stderr truncation in plain exit-code guardian adapters by using process.exitCode and dedupes Kiro/Windsurf wiring via bootstrapPlainExitCodeAdapter. Addresses EGC-539 with stronger, deterministic tests.

- **Bug Fixes**
  - Use process.exitCode with early returns in runPlainExitCodeGuardianAdapter to prevent POSIX pipe races that truncate stderr.
  - Strengthened coverage: repeated blocked-run checks across adapters and a deterministic test that asserts process.exit is never called, now using fs.writeSync(2, ...) for the exit marker to avoid async pipe races.

- **Refactors**
  - Kiro and Windsurf now use bootstrapPlainExitCodeAdapter, keeping their own buildGuardianInput; behavior unchanged.
  - Updated the helper’s doc comment to include Kiro and Windsurf.

<sup>Written for commit c189e481aaa420d2d64f7a246613ab318ed1d367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

