### PR TITLE
refactor(hooks): centralize hookEvent apply/remove/inspect dispatch in a lookup table (EGC-539)

### DIFF
--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -15,33 +15,45 @@ const {
   PRE_RUN_COMMAND_EVENT: WINDSURF_PRE_RUN_COMMAND_EVENT,
   PRE_WRITE_CODE_EVENT: WINDSURF_PRE_WRITE_CODE_EVENT,
   applyWindsurfGateGuardHookToFile,
+  inspectWindsurfGateGuardHookFile,
+  removeWindsurfGateGuardHookFromFile,
 } = require('./windsurf-gateguard-hooks');
 const {
   BEFORE_SHELL_EXECUTION_EVENT: CURSOR_BEFORE_SHELL_EXECUTION_EVENT,
   applyCursorGuardianHookToFile,
+  inspectCursorGuardianHookFile,
+  removeCursorGuardianHookFromFile,
 } = require('./cursor-guardian-hooks');
 const {
   CRUSHER_HOOK_DISPATCH_EVENT: CURSOR_CRUSHER_HOOK_DISPATCH_EVENT,
   applyCursorCrusherHookToFile,
+  inspectCursorCrusherHookFile,
+  removeCursorCrusherHookFromFile,
 } = require('./cursor-crusher-hooks');
 const {
   PRE_TOOL_USE_EVENT: KIRO_PRE_TOOL_USE_EVENT,
   applyKiroGuardianHookToFile,
+  inspectKiroGuardianHookFile,
+  removeKiroGuardianHookFromFile,
 } = require('./kiro-guardian-hooks');
 const {
   OPERATION_DISPATCH_TAG: AMAZONQ_OPERATION_DISPATCH_TAG,
   applyAmazonQGuardianHookToFile,
+  inspectAmazonQGuardianHookFile,
+  removeAmazonQGuardianHookFromFile,
 } = require('./amazonq-guardian-hooks');
 const {
   PRE_TOOL_USE_EVENT: OPENHANDS_PRE_TOOL_USE_EVENT,
   applyOpenHandsGuardianHookToFile,
+  inspectOpenHandsGuardianHookFile,
+  removeOpenHandsGuardianHookFromFile,
 } = require('./openhands-guardian-hooks');
 const {
   ROOCODE_DENYLIST_TAG,
   applyRoocodeDenylistToFile,
+  inspectRoocodeDenylistFile,
+  removeRoocodeDenylistFromFile,
 } = require('./roocode-guardian-denylist');
-
-const MANAGED_WINDSURF_HOOK_EVENTS = new Set([WINDSURF_PRE_WRITE_CODE_EVENT, WINDSURF_PRE_RUN_COMMAND_EVENT]);
 
 const SESSION_START_EVENT = 'SessionStart';
 const STOP_EVENT = 'Stop';
@@ -989,16 +1001,108 @@ function createPostCompactHookMergeOperation(targetRoot) {
   };
 }
 
-function applyCompactHookOperation(operation) {
-  if (operation.hookEvent === PRE_COMPACT_EVENT) {
-    applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath);
-    return true;
-  }
-  if (operation.hookEvent === POST_COMPACT_EVENT) {
-    applyHookEntryToFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
-    return true;
-  }
-  return false;
+// Windsurf's two managed events (pre_write_code, pre_run_command) both go
+// through the same flat-hooks.json helpers, just forwarding whichever of the
+// two the operation actually carries -- one handler trio, two table keys,
+// equivalent to the old `MANAGED_WINDSURF_HOOK_EVENTS.has(...)` Set check.
+const WINDSURF_HOOK_OPERATION_HANDLERS = {
+  apply: operation => applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+  remove: operation => removeWindsurfGateGuardHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+  inspect: operation => inspectWindsurfGateGuardHookFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+};
+
+// Single source of truth for "given this operation's hookEvent, which
+// apply/remove/inspect functions handle it". Shared by applyManagedHookOperation
+// below, and by install-lifecycle.js's uninstallManagedHookOperation and
+// inspectManagedOperation (via resolveHookOperationHandlers) -- previously
+// each of those three call sites re-enumerated this same ~11-event chain
+// independently, so adding a new host meant remembering to update 2-3 places
+// by hand (EGC-539 audit finding). SessionStart is deliberately absent: it is
+// the fallback for any hookEvent not listed here, matching every original
+// chain's trailing `else` branch (see resolveHookOperationHandlers).
+const HOOK_EVENT_OPERATION_HANDLERS = {
+  [STOP_EVENT]: {
+    apply: operation => applyStopHookToFile(operation.destinationPath, operation.hookScriptPath),
+    remove: operation => removeStopHookFromFile(operation.destinationPath, operation.hookScriptPath),
+    inspect: operation => inspectStopHookFile(operation.destinationPath, operation.hookScriptPath),
+  },
+  [USER_PROMPT_SUBMIT_EVENT]: {
+    apply: operation => applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath),
+    remove: operation => removeIntuitionHookFromFile(operation.destinationPath, operation.hookScriptPath),
+    inspect: operation => inspectIntuitionHookFile(operation.destinationPath, operation.hookScriptPath),
+  },
+  [PRE_TOOL_USE_EVENT]: {
+    // Apply/inspect scope to the operation's matcher, since several distinct
+    // PreToolUse hooks (Bash dispatcher, write validator, GateGuard, Crusher)
+    // share this event under different matchers. Remove does not: a given
+    // EGC hook script path is only ever registered once per event regardless
+    // of matcher, and removeHookEntry() already strips it from every group.
+    apply: operation => applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher }),
+    remove: operation => removeHookEntryFromFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath),
+    inspect: operation => inspectHookEntryFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, operation.hookMatcher),
+  },
+  [PRE_COMPACT_EVENT]: {
+    apply: operation => applyPreCompactHookToFile(operation.destinationPath, operation.hookScriptPath),
+    remove: operation => removePreCompactHookFromFile(operation.destinationPath, operation.hookScriptPath),
+    inspect: operation => inspectPreCompactHookFile(operation.destinationPath, operation.hookScriptPath),
+  },
+  [POST_COMPACT_EVENT]: {
+    // PostCompact reuses claude-session-start.js (see
+    // createPostCompactHookMergeOperation above) but is still merged/removed/
+    // inspected under its own event key via the generic entry helpers, not
+    // the SessionStart-specific ones.
+    apply: operation => applyHookEntryToFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath),
+    remove: operation => removeHookEntryFromFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath),
+    inspect: operation => inspectHookEntryFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath),
+  },
+  [WINDSURF_PRE_WRITE_CODE_EVENT]: WINDSURF_HOOK_OPERATION_HANDLERS,
+  [WINDSURF_PRE_RUN_COMMAND_EVENT]: WINDSURF_HOOK_OPERATION_HANDLERS,
+  [CURSOR_BEFORE_SHELL_EXECUTION_EVENT]: {
+    // Only apply threads seedPath through: it seeds a freshly scaffolded
+    // hooks.json on first install and has no meaning for remove/inspect,
+    // which only ever read or strip an already-existing entry.
+    apply: operation => applyCursorGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath, { seedPath: operation.seedPath }),
+    remove: operation => removeCursorGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+    inspect: operation => inspectCursorGuardianHookFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+  },
+  [CURSOR_CRUSHER_HOOK_DISPATCH_EVENT]: {
+    apply: operation => applyCursorCrusherHookToFile(operation.destinationPath, operation.hookScriptPath),
+    remove: operation => removeCursorCrusherHookFromFile(operation.destinationPath, operation.hookScriptPath),
+    inspect: operation => inspectCursorCrusherHookFile(operation.destinationPath, operation.hookScriptPath),
+  },
+  [KIRO_PRE_TOOL_USE_EVENT]: {
+    apply: operation => applyKiroGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+    remove: operation => removeKiroGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+    inspect: operation => inspectKiroGuardianHookFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath),
+  },
+  [AMAZONQ_OPERATION_DISPATCH_TAG]: {
+    apply: operation => applyAmazonQGuardianHookToFile(operation.destinationPath, operation.hookScriptPath),
+    remove: operation => removeAmazonQGuardianHookFromFile(operation.destinationPath, operation.hookScriptPath),
+    inspect: operation => inspectAmazonQGuardianHookFile(operation.destinationPath, operation.hookScriptPath),
+  },
+  [OPENHANDS_PRE_TOOL_USE_EVENT]: {
+    apply: operation => applyOpenHandsGuardianHookToFile(operation.destinationPath, operation.hookScriptPath),
+    remove: operation => removeOpenHandsGuardianHookFromFile(operation.destinationPath, operation.hookScriptPath),
+    inspect: operation => inspectOpenHandsGuardianHookFile(operation.destinationPath, operation.hookScriptPath),
+  },
+  [ROOCODE_DENYLIST_TAG]: {
+    apply: operation => applyRoocodeDenylistToFile(operation.destinationPath),
+    remove: operation => removeRoocodeDenylistFromFile(operation.destinationPath),
+    inspect: operation => inspectRoocodeDenylistFile(operation.destinationPath),
+  },
+};
+
+const SESSION_START_HOOK_OPERATION_HANDLERS = {
+  apply: operation => applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath),
+  remove: operation => removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath),
+  inspect: operation => inspectSessionStartHookFile(operation.destinationPath, operation.hookScriptPath),
+};
+
+// Any hookEvent not present in HOOK_EVENT_OPERATION_HANDLERS (currently just
+// SessionStart itself) falls back to the SessionStart handler trio -- this is
+// the trailing `else` branch every original dispatch chain ended with.
+function resolveHookOperationHandlers(hookEvent) {
+  return HOOK_EVENT_OPERATION_HANDLERS[hookEvent] || SESSION_START_HOOK_OPERATION_HANDLERS;
 }
 
 // Shared by install/apply.js and install-lifecycle.js's repair path: both
@@ -1006,31 +1110,7 @@ function applyCompactHookOperation(operation) {
 // fallback for any event not explicitly handled above it), so it lives here
 // once instead of being duplicated per caller.
 function applyManagedHookOperation(operation) {
-  if (operation.hookEvent === STOP_EVENT) {
-    applyStopHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
-    applyIntuitionHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
-    applyHookEntryToFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, { matcher: operation.hookMatcher });
-  } else if (applyCompactHookOperation(operation)) {
-    // handled above
-  } else if (MANAGED_WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
-    applyWindsurfGateGuardHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-  } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
-    applyCursorGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath, { seedPath: operation.seedPath });
-  } else if (operation.hookEvent === CURSOR_CRUSHER_HOOK_DISPATCH_EVENT) {
-    applyCursorCrusherHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
-    applyKiroGuardianHookToFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-  } else if (operation.hookEvent === AMAZONQ_OPERATION_DISPATCH_TAG) {
-    applyAmazonQGuardianHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === OPENHANDS_PRE_TOOL_USE_EVENT) {
-    applyOpenHandsGuardianHookToFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === ROOCODE_DENYLIST_TAG) {
-    applyRoocodeDenylistToFile(operation.destinationPath);
-  } else {
-    applySessionStartHookToFile(operation.destinationPath, operation.hookScriptPath);
-  }
+  resolveHookOperationHandlers(operation.hookEvent).apply(operation);
 }
 
 module.exports = {
@@ -1146,6 +1226,7 @@ module.exports = {
   removeWriteValidatorHookFromFile,
   resolveBashDispatcherHookScriptDestination,
   resolveGateGuardHookScriptDestination,
+  resolveHookOperationHandlers,
   resolveHookScriptDestination,
   resolveIntuitionHookScriptDestination,
   resolveRouterHookScriptDestination,

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -14,66 +14,9 @@ const {
 } = require('./install-targets/registry');
 const {
   HOOK_OPERATION_KIND,
-  PRE_TOOL_USE_EVENT,
-  PRE_COMPACT_EVENT,
-  POST_COMPACT_EVENT,
-  STOP_EVENT,
-  USER_PROMPT_SUBMIT_EVENT,
   applyManagedHookOperation,
-  inspectHookEntryFile,
-  inspectIntuitionHookFile,
-  inspectPreCompactHookFile,
-  inspectSessionStartHookFile,
-  inspectStopHookFile,
-  removeHookEntryFromFile,
-  removeIntuitionHookFromFile,
-  removePreCompactHookFromFile,
-  removeSessionStartHookFromFile,
-  removeStopHookFromFile,
+  resolveHookOperationHandlers,
 } = require('./claude-settings-hooks');
-const {
-  PRE_RUN_COMMAND_EVENT: WINDSURF_PRE_RUN_COMMAND_EVENT,
-  PRE_WRITE_CODE_EVENT: WINDSURF_PRE_WRITE_CODE_EVENT,
-  inspectWindsurfGateGuardHookFile,
-  removeWindsurfGateGuardHookFromFile,
-} = require('./windsurf-gateguard-hooks');
-const {
-  BEFORE_SHELL_EXECUTION_EVENT: CURSOR_BEFORE_SHELL_EXECUTION_EVENT,
-  inspectCursorGuardianHookFile,
-  removeCursorGuardianHookFromFile,
-} = require('./cursor-guardian-hooks');
-const {
-  CRUSHER_HOOK_DISPATCH_EVENT: CURSOR_CRUSHER_HOOK_DISPATCH_EVENT,
-  inspectCursorCrusherHookFile,
-  removeCursorCrusherHookFromFile,
-} = require('./cursor-crusher-hooks');
-const {
-  PRE_TOOL_USE_EVENT: KIRO_PRE_TOOL_USE_EVENT,
-  inspectKiroGuardianHookFile,
-  removeKiroGuardianHookFromFile,
-} = require('./kiro-guardian-hooks');
-const {
-  OPERATION_DISPATCH_TAG: AMAZONQ_OPERATION_DISPATCH_TAG,
-  inspectAmazonQGuardianHookFile,
-  removeAmazonQGuardianHookFromFile,
-} = require('./amazonq-guardian-hooks');
-const {
-  PRE_TOOL_USE_EVENT: OPENHANDS_PRE_TOOL_USE_EVENT,
-  inspectOpenHandsGuardianHookFile,
-  removeOpenHandsGuardianHookFromFile,
-} = require('./openhands-guardian-hooks');
-const {
-  ROOCODE_DENYLIST_TAG,
-  inspectRoocodeDenylistFile,
-  removeRoocodeDenylistFromFile,
-} = require('./roocode-guardian-denylist');
-
-// Windsurf's hooks.json is a flat {hooks: {<event>: [...]}} map, not
-// Claude's matcher/group settings.json schema -- an operation whose
-// hookEvent is one of these two needs the Windsurf-specific
-// apply/inspect/remove helpers above, not the Claude ones the rest of this
-// file's HOOK_OPERATION_KIND branches fall back to.
-const WINDSURF_HOOK_EVENTS = new Set([WINDSURF_PRE_WRITE_CODE_EVENT, WINDSURF_PRE_RUN_COMMAND_EVENT]);
 const {
   MERGE_YAML_READ_LIST_KIND,
   REMOVE_SENTINEL: AIDER_REMOVE_SENTINEL,
@@ -572,34 +515,12 @@ function uninstallWarpAgentsIndexEntry(operation) {
 
 function uninstallManagedHookOperation(operation) {
   // Strips only the EGC-managed hook entry. The settings file itself is never
-  // deleted because Claude Code and the user own its other keys.
-  if (operation.hookEvent === STOP_EVENT) {
-    removeStopHookFromFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
-    removeIntuitionHookFromFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
-    removeHookEntryFromFile(operation.destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath);
-  } else if (operation.hookEvent === PRE_COMPACT_EVENT) {
-    removePreCompactHookFromFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === POST_COMPACT_EVENT) {
-    removeHookEntryFromFile(operation.destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath);
-  } else if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
-    removeWindsurfGateGuardHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-  } else if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
-    removeCursorGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-  } else if (operation.hookEvent === CURSOR_CRUSHER_HOOK_DISPATCH_EVENT) {
-    removeCursorCrusherHookFromFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
-    removeKiroGuardianHookFromFile(operation.destinationPath, operation.hookEvent, operation.hookScriptPath);
-  } else if (operation.hookEvent === AMAZONQ_OPERATION_DISPATCH_TAG) {
-    removeAmazonQGuardianHookFromFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === OPENHANDS_PRE_TOOL_USE_EVENT) {
-    removeOpenHandsGuardianHookFromFile(operation.destinationPath, operation.hookScriptPath);
-  } else if (operation.hookEvent === ROOCODE_DENYLIST_TAG) {
-    removeRoocodeDenylistFromFile(operation.destinationPath);
-  } else {
-    removeSessionStartHookFromFile(operation.destinationPath, operation.hookScriptPath);
-  }
+  // deleted because Claude Code and the user own its other keys. Which
+  // remove function handles a given hookEvent is looked up from the same
+  // apply/remove/inspect table claude-settings-hooks.js's
+  // applyManagedHookOperation uses, instead of re-enumerating the same
+  // ~11 events here (EGC-539 audit finding).
+  resolveHookOperationHandlers(operation.hookEvent).remove(operation);
   return { removedPaths: [], cleanupTargets: [] };
 }
 
@@ -718,43 +639,13 @@ function inspectManagedOperation(repoRoot, operation) {
   }
 
   if (operation.kind === HOOK_OPERATION_KIND) {
-    if (operation.hookEvent === STOP_EVENT) {
-      return inspectResult(inspectStopHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === USER_PROMPT_SUBMIT_EVENT) {
-      return inspectResult(inspectIntuitionHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === PRE_TOOL_USE_EVENT) {
-      return inspectResult(inspectHookEntryFile(destinationPath, PRE_TOOL_USE_EVENT, operation.hookScriptPath, operation.hookMatcher), operation, destinationPath);
-    }
-    if (operation.hookEvent === PRE_COMPACT_EVENT) {
-      return inspectResult(inspectPreCompactHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === POST_COMPACT_EVENT) {
-      return inspectResult(inspectHookEntryFile(destinationPath, POST_COMPACT_EVENT, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (WINDSURF_HOOK_EVENTS.has(operation.hookEvent)) {
-      return inspectResult(inspectWindsurfGateGuardHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === CURSOR_BEFORE_SHELL_EXECUTION_EVENT) {
-      return inspectResult(inspectCursorGuardianHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === CURSOR_CRUSHER_HOOK_DISPATCH_EVENT) {
-      return inspectResult(inspectCursorCrusherHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === KIRO_PRE_TOOL_USE_EVENT) {
-      return inspectResult(inspectKiroGuardianHookFile(destinationPath, operation.hookEvent, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === AMAZONQ_OPERATION_DISPATCH_TAG) {
-      return inspectResult(inspectAmazonQGuardianHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === OPENHANDS_PRE_TOOL_USE_EVENT) {
-      return inspectResult(inspectOpenHandsGuardianHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
-    }
-    if (operation.hookEvent === ROOCODE_DENYLIST_TAG) {
-      return inspectResult(inspectRoocodeDenylistFile(destinationPath), operation, destinationPath);
-    }
-    return inspectResult(inspectSessionStartHookFile(destinationPath, operation.hookScriptPath), operation, destinationPath);
+    // Same lookup table uninstallManagedHookOperation and
+    // applyManagedHookOperation use: which inspect function handles a given
+    // hookEvent is resolved once, centrally, in claude-settings-hooks.js
+    // (EGC-539 audit finding -- this file no longer re-enumerates all ~11
+    // events on its own).
+    const status = resolveHookOperationHandlers(operation.hookEvent).inspect(operation);
+    return inspectResult(status, operation, destinationPath);
   }
 
   if (operation.kind === MERGE_YAML_READ_LIST_KIND) {


### PR DESCRIPTION
## Summary
EGC-539 audit (scripts/ scope, medium severity): the hookEvent dispatch chain was triplicated across `scripts/lib/claude-settings-hooks.js` and `scripts/lib/install-lifecycle.js`. `applyManagedHookOperation` (already shared between callers, per its own comment), `uninstallManagedHookOperation`, and the `HOOK_OPERATION_KIND` branch of `inspectManagedOperation` each independently enumerated the same ~11 `hookEvent` values (Stop, UserPromptSubmit, PreToolUse, PreCompact/PostCompact, Windsurf's two events, Cursor shell-execution/crusher, Kiro, AmazonQ, OpenHands, RooCode, SessionStart fallback) in the same order, across three separate if/else-if chains. Adding a new host meant remembering to update 2-3 chains by hand, with nothing forcing the point if one was missed.

**High-impact change, treated with extra care**: `claude-settings-hooks.js` is `require()`d by ~25 files, essentially every install-target adapter in the project (Claude, Cursor, Antigravity, Codex, Kiro, AmazonQ, OpenHands, RooCode, Windsurf, Copilot, CodeBuddy, Goose, Amp, Continue, and more). A mistake here could break install/uninstall/repair for many hosts at once, so this PR is a pure internal-dispatch swap only — no exported function signature changed, every observable asymmetry between the three original chains was read line-by-line and preserved verbatim, and it was verified against every isolated test file that exercises this code path (including the broader `install-targets.test.js` as an end-to-end cross-host check) before and after.

## Fix
- Added `HOOK_EVENT_OPERATION_HANDLERS`, a lookup table in `claude-settings-hooks.js` keyed by `hookEvent`/tag, each entry holding `{ apply, remove, inspect }` functions that wrap the same per-host helper calls the original chains made.
- Added `resolveHookOperationHandlers(hookEvent)`, exported from `claude-settings-hooks.js`: returns the matching table entry, or the SessionStart handler trio as fallback — exactly mirroring every original chain's trailing `else` branch.
- `applyManagedHookOperation` now just calls `resolveHookOperationHandlers(operation.hookEvent).apply(operation)`.
- `install-lifecycle.js`'s `uninstallManagedHookOperation` and the `HOOK_OPERATION_KIND` branch of `inspectManagedOperation` now call the same resolver's `.remove`/`.inspect` instead of re-implementing the dispatch, and no longer need direct imports of the seven per-host `remove*`/`inspect*` functions those handlers wrap internally (moved into `claude-settings-hooks.js`'s own imports instead).
- Preserved every subtle behavioral asymmetry found while reading the three original chains line-by-line:
  - `PreToolUse`'s `remove` ignores the operation's matcher (a script path is only ever registered once per event, and `removeHookEntry` already strips it from every matcher group) while `apply`/`inspect` do scope to `operation.hookMatcher`.
  - Cursor's `apply` is the only one that threads `{ seedPath: operation.seedPath }` through — `remove`/`inspect` never did.
  - Windsurf's two managed events (`pre_write_code`, `pre_run_command`) share one handler trio across two table keys, equivalent to the original `Set.has(...)` check.
  - Every per-host helper's exact argument shape (2-arg, 3-arg with `hookEvent` forwarded, or 1-arg for RooCode) is preserved unchanged.
- Removed now-dead code made redundant by the table: `applyCompactHookOperation` and the `MANAGED_WINDSURF_HOOK_EVENTS`/`WINDSURF_HOOK_EVENTS` Sets (both were file-private, confirmed via grep to have no other callers).

No behavior change for any install target: this is a structural refactor of dispatch plumbing only.

## Test plan
- [x] Baseline (before refactor) captured for all three relevant suites: `node tests/lib/claude-settings-hooks.test.js` (68/68), `node tests/lib/install-lifecycle.test.js` (36/36), `node tests/lib/install-targets.test.js` (158/158, cross-host end-to-end layer, confirmed identical pass count via `git stash`/`git stash pop` before and after)
- [x] After refactor: same three suites, same pass counts, 0 failures, identical output — 262/262 total
- [x] Confirmed via `grep` that every symbol removed from `install-lifecycle.js`'s imports (7 per-host `remove*`/`inspect*` pairs, 5 Claude-generic `remove*`/`inspect*` functions, the Windsurf event constants, and the derived `Set`) had no other call sites in the file
- [x] Confirmed via `grep` that all ~13 hookEvent/tag string constants used as table keys are pairwise distinct (no accidental key collisions from two different hosts sharing a literal event string)
- [x] `npx eslint scripts/lib/claude-settings-hooks.js scripts/lib/install-lifecycle.js` clean
- [x] Ran each test file in isolation (never the full suite) per this repo's RAM-safety convention

Signed-off-by: Felipe Marzochi <fmarzochi@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized hookEvent dispatch into a single lookup table to remove three duplicated chains and cut missed-update risk when adding new hosts. No behavior changes; addresses EGC-539.

- **Refactors**
  - Added `HOOK_EVENT_OPERATION_HANDLERS` in `claude-settings-hooks.js` with per-event `apply/remove/inspect`.
  - Exported `resolveHookOperationHandlers(hookEvent)` with `SessionStart` fallback.
  - Updated `applyManagedHookOperation`, `uninstallManagedHookOperation`, and `inspectManagedOperation` to use the resolver; removed per-host imports from `install-lifecycle.js`.
  - Preserved existing nuances: `PreToolUse` remove ignores matcher; Cursor apply threads `seedPath`; Windsurf’s two events share one handler; argument shapes unchanged.
  - Removed dead code: `applyCompactHookOperation` and Windsurf event sets.
  - Tests unchanged (same pass counts).

<sup>Written for commit 41c56110eb2f50d240443de36418cee9acc797cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

