### PR TITLE
refactor(install-targets): extract shared modules-input normalization

### DIFF
--- a/scripts/lib/install-targets/aider-project.js
+++ b/scripts/lib/install-targets/aider-project.js
@@ -19,6 +19,17 @@ const { MERGE_YAML_READ_LIST_KIND } = require('../aider-config-merge');
 // user's own existing keys (model settings, lint commands, etc).
 
 function createAiderPlanOperations(input, adapter) {
+  // Deliberately NOT using helpers.js's normalizeModulesInput() here (EGC-539
+  // audit): that shared helper also falls back to a singular `input.module`,
+  // which this adapter has never supported -- registry.js's
+  // planInstallTargetScaffold always normalizes to a `modules` array before
+  // calling in, but adapter.planOperations() can also be invoked directly
+  // with a singular `module` (see the equivalent trae-project.js test
+  // coverage in install-targets.test.js), and no such direct caller or test
+  // exists for this adapter today. Adopting the shared helper here would
+  // silently add fallback support for a shape this adapter's own tests never
+  // exercise, changing its observable contract rather than only its
+  // implementation. Left as the array-only variant on purpose.
   const modules = Array.isArray(input.modules) ? input.modules : [];
   const planningInput = {
     repoRoot: input.repoRoot,

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -5,6 +5,7 @@ const {
   createInstallTargetAdapter,
   createManagedScaffoldOperation,
   createRemappedOperation,
+  normalizeModulesInput,
   normalizeRelativePath,
   planFlatSkillOperation,
 } = require('./helpers');
@@ -98,14 +99,7 @@ module.exports = createInstallTargetAdapter({
     return paths.length > 0;
   },
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
     const {
       repoRoot,
       projectRoot,

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -4,9 +4,9 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
-  normalizeModulesInput,
   normalizeRelativePath,
   planFlatSkillOperation,
+  resolveModulesPlan,
 } = require('./helpers');
 
 const CLAUDE_EXCLUDED_SOURCE_PREFIXES = [
@@ -125,13 +125,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.claude',
   planOperations(input, adapter) {
-    const modules = normalizeModulesInput(input);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
+    const { modules, planningInput, targetRoot } = resolveModulesPlan(input, adapter);
 
     const moduleOperations = modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -4,6 +4,7 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
   normalizeRelativePath,
   planFlatSkillOperation,
 } = require('./helpers');
@@ -124,14 +125,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.claude',
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/cline-project.js
+++ b/scripts/lib/install-targets/cline-project.js
@@ -5,6 +5,7 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
 } = require('./helpers');
 const {
   createAdapterStdinJsonCopyOperation,
@@ -111,14 +112,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.clinerules',
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
 
     const {
       repoRoot,

--- a/scripts/lib/install-targets/codebuddy-project.js
+++ b/scripts/lib/install-targets/codebuddy-project.js
@@ -5,6 +5,7 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
   planFlatSkillOperation,
 } = require('./helpers');
 const {
@@ -128,14 +129,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.codebuddy',
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
     const {
       repoRoot,
       projectRoot,

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -5,6 +5,7 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
   planFlatSkillOperation,
 } = require('./helpers');
 const {
@@ -154,14 +155,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'codex-install-state.json'],
   nativeRootRelativePath: '.agents',
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -5,8 +5,8 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
-  normalizeModulesInput,
   planFlatSkillOperation,
+  resolveModulesPlan,
 } = require('./helpers');
 const {
   GATEGUARD_HOOK_MODULE_ID,
@@ -155,13 +155,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'codex-install-state.json'],
   nativeRootRelativePath: '.agents',
   planOperations(input, adapter) {
-    const modules = normalizeModulesInput(input);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
+    const { modules, planningInput, targetRoot } = resolveModulesPlan(input, adapter);
 
     const moduleOperations = modules.flatMap(module => {
       const paths = (Array.isArray(module.paths) ? module.paths : [])

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -9,6 +9,7 @@ const {
   createManagedOperation,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
 } = require('./helpers');
 const {
   HOOK_OPERATION_KIND,
@@ -281,14 +282,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc-install-state.json'],
   nativeRootRelativePath: '.cursor',
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
     const seenDestinationPaths = new Set();
     const {
       repoRoot,

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -5,8 +5,8 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
-  normalizeModulesInput,
   normalizeRelativePath,
+  resolveModulesPlan,
 } = require('./helpers');
 const {
   createGlobalGateGuardHookMergeOperation,
@@ -177,13 +177,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.gemini-plugin',
   planOperations(input, adapter) {
-    const modules = normalizeModulesInput(input);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
+    const { modules, planningInput, targetRoot } = resolveModulesPlan(input, adapter);
     const homeDir = input.homeDir || os.homedir();
 
     const moduleOperations = modules.flatMap(module => {

--- a/scripts/lib/install-targets/gemini-home.js
+++ b/scripts/lib/install-targets/gemini-home.js
@@ -5,6 +5,7 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
   normalizeRelativePath,
 } = require('./helpers');
 const {
@@ -176,14 +177,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.gemini-plugin',
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -67,6 +67,29 @@ function normalizeModulesInput(input = {}) {
   return [];
 }
 
+// The normalizeModulesInput() call plus the repoRoot/projectRoot/homeDir
+// planningInput shape plus the adapter.resolveRoot(planningInput) call were
+// identical across claude-home.js, codex-home.js, gemini-home.js, and
+// opencode-home.js's planOperations -- each rebuilding the same 3-value
+// lookup before diverging into its own module-to-operation mapping.
+// Collapsing normalizeModulesInput() alone (above) into a 1-line call
+// elsewhere in this same audit round made this remaining prefix contiguous
+// enough to cross SonarCloud's cross-file duplication threshold (EGC-539
+// audit, PR #1150). Only these three values are pulled out -- adapters that
+// need extra planningInput fields (e.g. cursor-project.js's
+// seenDestinationPaths) or a different root-resolution path keep their own
+// inline version rather than being forced through this.
+function resolveModulesPlan(input, adapter) {
+  const modules = normalizeModulesInput(input);
+  const planningInput = {
+    repoRoot: input.repoRoot,
+    projectRoot: input.projectRoot,
+    homeDir: input.homeDir,
+  };
+  const targetRoot = adapter.resolveRoot(planningInput);
+  return { modules, planningInput, targetRoot };
+}
+
 function buildValidationIssue(severity, code, message, extra = {}) {
   return {
     severity,
@@ -307,13 +330,7 @@ function planFlatSkillOperation(adapter, moduleId, sourceRelativePath, planningI
  */
 function createFlatSkillPlanOperations(rawInput, adapter) {
   const input = rawInput ?? {};
-  const modules = normalizeModulesInput(input);
-  const planningInput = {
-    repoRoot: input.repoRoot,
-    projectRoot: input.projectRoot,
-    homeDir: input.homeDir,
-  };
-  const targetRoot = adapter.resolveRoot(planningInput);
+  const { modules, planningInput, targetRoot } = resolveModulesPlan(input, adapter);
 
   return modules.flatMap(module => {
     const paths = Array.isArray(module.paths) ? module.paths : [];
@@ -442,4 +459,5 @@ module.exports = {
   normalizeModulesInput,
   normalizeRelativePath,
   planFlatSkillOperation,
+  resolveModulesPlan,
 };

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -46,6 +46,27 @@ function resolveBaseRoot(scope, input = {}) {
   throw new Error(`Unsupported install target scope: ${scope}`);
 }
 
+// Every adapter's planOperations(input, adapter) accepts either a `modules`
+// array (the shape registry.js's planInstallTargetScaffold always normalizes
+// to before calling in) or a single `module` object (the shape a caller that
+// invokes adapter.planOperations() directly, bypassing the registry, may
+// still pass -- see the "singular input.module" test coverage in
+// install-targets.test.js). This normalization was duplicated verbatim
+// across nine adapter files plus twice more inside this file itself
+// (createFlatSkillPlanOperations and createDefaultScaffoldOperations) before
+// being consolidated here (EGC-539 audit).
+function normalizeModulesInput(input = {}) {
+  if (Array.isArray(input.modules)) {
+    return input.modules;
+  }
+
+  if (input.module) {
+    return [input.module];
+  }
+
+  return [];
+}
+
 function buildValidationIssue(severity, code, message, extra = {}) {
   return {
     severity,
@@ -286,14 +307,7 @@ function planFlatSkillOperation(adapter, moduleId, sourceRelativePath, planningI
  */
 function createFlatSkillPlanOperations(rawInput, adapter) {
   const input = rawInput ?? {};
-  let modules;
-  if (Array.isArray(input.modules)) {
-    modules = input.modules;
-  } else if (input.module) {
-    modules = [input.module];
-  } else {
-    modules = [];
-  }
+  const modules = normalizeModulesInput(input);
   const planningInput = {
     repoRoot: input.repoRoot,
     projectRoot: input.projectRoot,
@@ -318,20 +332,12 @@ function createFlatSkillPlanOperations(rawInput, adapter) {
 // roocode-project.js before this (SonarCloud new-code duplication finding
 // on PR #1122); consolidated here as the single source of truth.
 function createDefaultScaffoldOperations(input, adapter) {
-  if (Array.isArray(input.modules)) {
-    return input.modules.flatMap(module => {
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, adapter.target))
-        .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
-    });
-  }
-
-  const module = input.module || {};
-  const paths = Array.isArray(module.paths) ? module.paths : [];
-  return paths
-    .filter(p => !isForeignPlatformPath(p, adapter.target))
-    .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
+  return normalizeModulesInput(input).flatMap(module => {
+    const paths = Array.isArray(module.paths) ? module.paths : [];
+    return paths
+      .filter(p => !isForeignPlatformPath(p, adapter.target))
+      .map(sourceRelativePath => adapter.createScaffoldOperation(module.id, sourceRelativePath, input));
+  });
 }
 
 function createInstallTargetAdapter(config) {
@@ -390,28 +396,11 @@ function createInstallTargetAdapter(config) {
         return config.planOperations(input, adapter);
       }
 
-      if (Array.isArray(input.modules)) {
-        return input.modules.flatMap(module => {
-          const paths = Array.isArray(module.paths) ? module.paths : [];
-          return paths
-            .filter(p => !isForeignPlatformPath(p, config.target))
-            .map(sourceRelativePath => adapter.createScaffoldOperation(
-              module.id,
-              sourceRelativePath,
-              input
-            ));
-        });
-      }
-
-      const module = input.module || {};
-      const paths = Array.isArray(module.paths) ? module.paths : [];
-      return paths
-        .filter(p => !isForeignPlatformPath(p, config.target))
-        .map(sourceRelativePath => adapter.createScaffoldOperation(
-          module.id,
-          sourceRelativePath,
-          input
-        ));
+      // Same body createDefaultScaffoldOperations exposes for adapters that
+      // define a custom planOperations of their own -- this default branch
+      // used to keep an unreduced copy of the exact same logic (EGC-539
+      // audit) instead of calling that already-extracted helper.
+      return createDefaultScaffoldOperations(input, adapter);
     },
     supportsModule(module, input = {}) {
       if (typeof config.supportsModule === 'function') {
@@ -450,6 +439,7 @@ module.exports = {
   ),
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
   normalizeRelativePath,
   planFlatSkillOperation,
 };

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -4,8 +4,8 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
-  normalizeModulesInput,
   normalizeRelativePath,
+  resolveModulesPlan,
 } = require('./helpers');
 const {
   BASH_GUARDIAN_HOOK_MODULE_ID,
@@ -92,13 +92,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.opencode',
   planOperations(input, adapter) {
-    const modules = normalizeModulesInput(input);
-    const planningInput = {
-      repoRoot: input.repoRoot,
-      projectRoot: input.projectRoot,
-      homeDir: input.homeDir,
-    };
-    const targetRoot = adapter.resolveRoot(planningInput);
+    const { modules, planningInput, targetRoot } = resolveModulesPlan(input, adapter);
 
     const moduleOperations = modules.flatMap(module => {
       const paths = (Array.isArray(module.paths) ? module.paths : [])

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -4,6 +4,7 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
   normalizeRelativePath,
 } = require('./helpers');
 const {
@@ -91,14 +92,7 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['egc', 'install-state.json'],
   nativeRootRelativePath: '.opencode',
   planOperations(input, adapter) {
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
     const planningInput = {
       repoRoot: input.repoRoot,
       projectRoot: input.projectRoot,

--- a/scripts/lib/install-targets/trae-project.js
+++ b/scripts/lib/install-targets/trae-project.js
@@ -4,6 +4,7 @@ const {
   createInstallTargetAdapter,
   createRemappedOperation,
   isForeignPlatformPath,
+  normalizeModulesInput,
 } = require('./helpers');
 const {
   createBashGuardianHookMergeOperationForDestination,
@@ -88,14 +89,7 @@ module.exports = createInstallTargetAdapter({
     // when planOperations is omitted (this file's previous behavior) --
     // preserved verbatim here only because a custom planOperations is now
     // needed to also append the Guardian/Crusher operations below.
-    let modules;
-    if (Array.isArray(input.modules)) {
-      modules = input.modules;
-    } else if (input.module) {
-      modules = [input.module];
-    } else {
-      modules = [];
-    }
+    const modules = normalizeModulesInput(input);
 
     const moduleOperations = modules.flatMap(module => {
       const paths = Array.isArray(module.paths) ? module.paths : [];

--- a/scripts/lib/install-targets/warp-project.js
+++ b/scripts/lib/install-targets/warp-project.js
@@ -62,6 +62,13 @@ function readSkillDescription(sourcePath) {
 }
 
 function createWarpPlanOperations(input, adapter) {
+  // Deliberately NOT using helpers.js's normalizeModulesInput() here (EGC-539
+  // audit): same reasoning as aider-project.js's createAiderPlanOperations --
+  // that shared helper also falls back to a singular `input.module`, which
+  // this adapter has never supported and has no test coverage exercising
+  // (unlike trae-project.js's direct-call fallback test). Left as the
+  // array-only variant on purpose rather than silently widening this
+  // adapter's observable contract.
   const modules = Array.isArray(input.modules) ? input.modules : [];
   const planningInput = {
     repoRoot: input.repoRoot,


### PR DESCRIPTION
## Context

EGC-539 audit (scripts/ scope) flagged a MEDIA-severity finding: the same
~8-line modules-input normalization block

```js
Array.isArray(input.modules) ? input.modules : input.module ? [input.module] : []
```

appeared duplicated verbatim across nine `scripts/lib/install-targets/*.js`
adapters (`codebuddy-project.js`, `claude-home.js`, `antigravity-project.js`,
`codex-home.js`, `cline-project.js`, `opencode-home.js`, `cursor-project.js`,
`gemini-home.js`, `trae-project.js`), plus two more copies inside
`helpers.js` itself (`createFlatSkillPlanOperations` and
`createDefaultScaffoldOperations`). None of the adapter copies called the
shared infrastructure `helpers.js` already provides for other pieces of the
same `planOperations` contract.

## Fix

- Added `normalizeModulesInput(input)` to `helpers.js` as the single source
  of truth for this normalization (array `input.modules`, or a fallback to a
  singular `input.module`, or `[]`).
- Migrated all nine listed adapters to call it, removing their own inline
  copy of the block.
- Refactored `createFlatSkillPlanOperations` and `createDefaultScaffoldOperations`
  in `helpers.js` to use the same shared function instead of their own
  duplicated logic.
- Found and fixed a **third**, previously unnoticed copy of the exact same
  logic: the earlier extraction of `createDefaultScaffoldOperations` (PR
  #1122) never actually replaced the inline duplicate still sitting inside
  `createInstallTargetAdapter`'s own default `planOperations()` method. That
  default branch now delegates to `createDefaultScaffoldOperations` too, so
  there is exactly one implementation of this logic left in the codebase.

### `aider-project.js` and `warp-project.js` deliberately left untouched

Both already used a simplified array-only variant
(`Array.isArray(input.modules) ? input.modules : []`) with no `input.module`
fallback. Investigated whether this is truly dead code before deciding
whether to fold them into the same helper:

- `registry.js`'s `planInstallTargetScaffold` always normalizes `modules` to
  an array before calling `adapter.planOperations()`, so through that one
  production entry point the fallback is never exercised for any adapter.
- However, `adapter.planOperations()` can also be called directly, bypassing
  the registry -- exactly the shape `install-targets.test.js`'s "trae
  adapter accepts a singular `input.module`" test exercises today for
  `trae-project.js`.
- No equivalent direct-call test exists for `aider-project.js` or
  `warp-project.js`.

Since adopting the shared helper there would silently add fallback support
for an input shape neither adapter's own tests exercise -- widening their
observable contract rather than only their implementation -- both were left
as-is, with a comment explaining the decision in place of the change.

## Test plan

- `node tests/lib/install-targets.test.js`: 158/158 passed, both before any
  change (baseline) and after every migration step.
- `node tests/hooks/opencode-egc-plugin.test.js`: 9/9 passed (exercises
  `opencode-home.js` transitively through `registry.js`).
- `npx eslint` on all 12 changed files: clean, exit 0.
- No behavior change for any migrated adapter: same inputs produce the same
  `operations` output before and after, verified by the unchanged test
  suite above.

Ref: EGC-539 audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated modules-input handling across install-target adapters by adding `normalizeModulesInput` and a new `resolveModulesPlan` in `helpers.js`. Addresses EGC-539, fixes SonarCloud duplication, and keeps behavior unchanged.

- **Refactors**
  - Added `normalizeModulesInput(input)` and used it in `createDefaultScaffoldOperations` and adapters that only need the modules list (`codebuddy-project.js`, `antigravity-project.js`, `cline-project.js`, `cursor-project.js`, `trae-project.js`).
  - Added `resolveModulesPlan(input, adapter)` to return `{ modules, planningInput, targetRoot }`; migrated `claude-home.js`, `codex-home.js`, `gemini-home.js`, `opencode-home.js`, and `createFlatSkillPlanOperations` to use it.
  - Default `planOperations()` in `createInstallTargetAdapter` now delegates to `createDefaultScaffoldOperations` instead of inlining the logic.
  - Left `aider-project.js` and `warp-project.js` as array-only on purpose; added comments explaining the decision.

<sup>Written for commit 3f34a2cb8b686d502406bef6d14c0b12a271ffaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

