### PR TITLE
refactor(ci): extract shared CLI runner boilerplate from validate-*.js

### DIFF
--- a/scripts/ci/validate-agents.js
+++ b/scripts/ci/validate-agents.js
@@ -6,6 +6,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { extractFrontmatterBlock } = require('#lib/frontmatter-block');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const AGENTS_DIR = path.join(__dirname, '../../agents');
 const REQUIRED_FIELDS = ['model', 'tools'];
@@ -58,10 +59,7 @@ function validateAgentFrontmatter(file, frontmatter) {
 }
 
 function validateAgents() {
-  if (!fs.existsSync(AGENTS_DIR)) {
-    console.log('No agents directory found, skipping validation');
-    process.exit(0);
-  }
+  skipIfMissing(AGENTS_DIR, 'No agents directory found, skipping validation');
 
   const files = fs.readdirSync(AGENTS_DIR).filter(f => f.endsWith('.md'));
   let hasErrors = false;
@@ -80,11 +78,7 @@ function validateAgents() {
     if (validateAgentFrontmatter(file, frontmatter)) hasErrors = true;
   }
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(`Validated ${files.length} agent files`);
+  finishValidation(hasErrors, `Validated ${files.length} agent files`);
 }
 
 validateAgents();

--- a/scripts/ci/validate-commands.js
+++ b/scripts/ci/validate-commands.js
@@ -7,6 +7,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { extractFrontmatterBlock } = require('#lib/frontmatter-block');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const ROOT_DIR = path.join(__dirname, '../..');
 const COMMANDS_DIR = path.join(ROOT_DIR, 'commands');
@@ -173,10 +174,7 @@ function validateCommandFile(file, validCommands, validAgents, validSkills) {
 }
 
 function validateCommands() {
-  if (!fs.existsSync(COMMANDS_DIR)) {
-    console.log('No commands directory found, skipping validation');
-    process.exit(0);
-  }
+  skipIfMissing(COMMANDS_DIR, 'No commands directory found, skipping validation');
 
   const files = fs.readdirSync(COMMANDS_DIR).filter(f => f.endsWith('.md'));
   const validCommands = new Set(files.map(f => f.replace(/\.md$/, '')));
@@ -192,15 +190,11 @@ function validateCommands() {
     warnCount += result.warnCount;
   }
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
   let msg = `Validated ${files.length} command files`;
   if (warnCount > 0) {
     msg += ` (${warnCount} warnings)`;
   }
-  console.log(msg);
+  finishValidation(hasErrors, msg);
 }
 
 validateCommands();

--- a/scripts/ci/validate-hooks.js
+++ b/scripts/ci/validate-hooks.js
@@ -7,6 +7,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 const Ajv = require('ajv');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const HOOKS_FILE = path.join(__dirname, '../../hooks/hooks.json');
 const HOOKS_SCHEMA_PATH = path.join(__dirname, '../../schemas/hooks.schema.json');
@@ -254,10 +255,7 @@ function validateArrayFormat(hooks) {
 }
 
 function validateHooks() {
-  if (!fs.existsSync(HOOKS_FILE)) {
-    console.log('No hooks.json found, skipping validation');
-    process.exit(0);
-  }
+  skipIfMissing(HOOKS_FILE, 'No hooks.json found, skipping validation');
 
   let data;
   try {
@@ -292,11 +290,7 @@ function validateHooks() {
     process.exit(1);
   }
 
-  if (result.hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(`Validated ${result.totalMatchers} hook matchers`);
+  finishValidation(result.hasErrors, `Validated ${result.totalMatchers} hook matchers`);
 }
 
 validateHooks();

--- a/scripts/ci/validate-install-manifests.js
+++ b/scripts/ci/validate-install-manifests.js
@@ -8,6 +8,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const Ajv = require('ajv');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const REPO_ROOT = path.join(__dirname, '../..');
 const MODULES_MANIFEST_PATH = path.join(REPO_ROOT, 'manifests/install-modules.json');
@@ -227,10 +228,10 @@ function validateComponents(components, moduleIds) {
 }
 
 function validateInstallManifests() {
-  if (!fs.existsSync(MODULES_MANIFEST_PATH) || !fs.existsSync(PROFILES_MANIFEST_PATH)) {
-    console.log('Install manifests not found, skipping validation');
-    process.exit(0);
-  }
+  skipIfMissing(
+    [MODULES_MANIFEST_PATH, PROFILES_MANIFEST_PATH],
+    'Install manifests not found, skipping validation'
+  );
 
   let hasErrors = false;
   let modulesData;
@@ -269,11 +270,8 @@ function validateInstallManifests() {
   const components = Array.isArray(componentsData.components) ? componentsData.components : [];
   if (validateComponents(components, moduleIds)) hasErrors = true;
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(
+  finishValidation(
+    hasErrors,
     `Validated ${modules.length} install modules, ${components.length} install components, and ${Object.keys(profiles).length} profiles`
   );
 }

--- a/scripts/ci/validate-llm-providers.js
+++ b/scripts/ci/validate-llm-providers.js
@@ -12,6 +12,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { finishValidation } = require('#lib/validator-cli');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const README_PATH = path.join(REPO_ROOT, 'README.md');
@@ -67,11 +68,10 @@ function validate() {
   // separately as the fallback aggregator) are not checked here — only
   // the providers this script explicitly maps are in scope.
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(`Validated ${Object.keys(NATIVE_PROVIDER_FILES).length} native LLM providers named in README.md against src/llm/providers/`);
+  finishValidation(
+    hasErrors,
+    `Validated ${Object.keys(NATIVE_PROVIDER_FILES).length} native LLM providers named in README.md against src/llm/providers/`
+  );
 }
 
 validate();

--- a/scripts/ci/validate-rules.js
+++ b/scripts/ci/validate-rules.js
@@ -5,6 +5,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const RULES_DIR = path.join(__dirname, '../../rules');
 
@@ -43,10 +44,7 @@ function collectRuleFiles(dir) {
 }
 
 function validateRules() {
-  if (!fs.existsSync(RULES_DIR)) {
-    console.log('No rules directory found, skipping validation');
-    process.exit(0);
-  }
+  skipIfMissing(RULES_DIR, 'No rules directory found, skipping validation');
 
   const files = collectRuleFiles(RULES_DIR);
   let hasErrors = false;
@@ -71,11 +69,7 @@ function validateRules() {
     }
   }
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(`Validated ${validatedCount} rule files`);
+  finishValidation(hasErrors, `Validated ${validatedCount} rule files`);
 }
 
 validateRules();

--- a/scripts/ci/validate-skill-frontmatter.js
+++ b/scripts/ci/validate-skill-frontmatter.js
@@ -13,6 +13,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { listSkillLeaves } = require('#lib/skill-tree-walker');
 const { extractFrontmatterBlock } = require('#lib/frontmatter-block');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
@@ -109,10 +110,7 @@ function validateLeafFrontmatter(leaf) {
 }
 
 function validateSkillFrontmatter() {
-  if (!fs.existsSync(SKILLS_DIR)) {
-    console.log('No skills directory found, skipping validation');
-    process.exit(0);
-  }
+  skipIfMissing(SKILLS_DIR, 'No skills directory found, skipping validation');
 
   const leaves = listSkillLeaves(SKILLS_DIR);
   let hasErrors = false;
@@ -133,11 +131,7 @@ function validateSkillFrontmatter() {
     validCount++;
   }
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(`Validated frontmatter for ${validCount} skill files`);
+  finishValidation(hasErrors, `Validated frontmatter for ${validCount} skill files`);
 }
 
 if (require.main === module) {

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -3,14 +3,12 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { listSkillLeaves } = require('#lib/skill-tree-walker');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 
 function validateSkills() {
-  if (!fs.existsSync(SKILLS_DIR)) {
-    console.log('No curated skills directory (skills/), skipping');
-    process.exit(0);
-  }
+  skipIfMissing(SKILLS_DIR, 'No curated skills directory (skills/), skipping');
 
   const leaves = listSkillLeaves(SKILLS_DIR);
   let hasErrors = false;
@@ -41,11 +39,7 @@ function validateSkills() {
     validCount++;
   }
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(`Validated ${validCount} skill directories`);
+  finishValidation(hasErrors, `Validated ${validCount} skill directories`);
 }
 
 if (require.main === module) {

--- a/scripts/ci/validate-translation-structure.js
+++ b/scripts/ci/validate-translation-structure.js
@@ -12,6 +12,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { skipIfMissing, finishValidation } = require('#lib/validator-cli');
 
 const ROOT = path.join(__dirname, '../..');
 const README_PATH = path.join(ROOT, 'README.md');
@@ -139,10 +140,7 @@ function validateTranslationStructure() {
     process.exit(1);
   }
 
-  if (!fs.existsSync(TRANSLATIONS_DIR)) {
-    console.log('No translations directory found, skipping validation');
-    process.exit(0);
-  }
+  skipIfMissing(TRANSLATIONS_DIR, 'No translations directory found, skipping validation');
 
   const sourceContent = fs.readFileSync(README_PATH, 'utf-8');
   const sourceHeadings = extractHeadings(sourceContent);
@@ -164,11 +162,10 @@ function validateTranslationStructure() {
     }
   }
 
-  if (hasErrors) {
-    process.exit(1);
-  }
-
-  console.log(`Validated heading structure for ${validCount} translation files against README.md (${sourceHeadings.length} headings)`);
+  finishValidation(
+    hasErrors,
+    `Validated heading structure for ${validCount} translation files against README.md (${sourceHeadings.length} headings)`
+  );
 }
 
 if (require.main === module) {

--- a/scripts/lib/validator-cli.js
+++ b/scripts/lib/validator-cli.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Shared CLI runner boilerplate for scripts/ci/validate-*.js. Nine of the
+// eleven validate-*.js scripts independently reimplemented the same outer
+// shape: skip cleanly with a console.log + exit(0) when there is nothing to
+// validate, then, after each script's own file collection and per-item
+// checks accumulate their own errors, exit(1) on failure or print a success
+// summary (EGC-539 audit, scripts/ finding). This module centralizes only
+// that outer shape; each validator keeps its own item collection and
+// per-item validation, since those genuinely differ (recursive vs. flat
+// directory walk, single hasErrors accumulator vs. hasErrors+warnCount,
+// etc.) and forcing them through one generic loop would hide real
+// behavioral differences instead of removing duplicated ones.
+//
+// scripts/ci/check-unicode-safety.js and scripts/ci/validate-workflow-security.js
+// are deliberately NOT migrated to this module -- see the comments in those
+// files and the PR description for why forcing them in would distort
+// behavior that is genuinely different, not just duplicated.
+
+const fs = require('node:fs');
+
+/**
+ * Skip validation cleanly when a required input does not exist: prints
+ * `message` via console.log and exits 0. Accepts a single path or an array
+ * of paths that must ALL exist (skips if ANY is missing), matching
+ * validate-install-manifests.js's "either manifest missing" check.
+ *
+ * Returns without exiting when every path exists, so callers use it as a
+ * plain guard clause at the top of their validator's entry function.
+ *
+ * @param {string|string[]} requiredPaths
+ * @param {string} message
+ */
+function skipIfMissing(requiredPaths, message) {
+  const paths = Array.isArray(requiredPaths) ? requiredPaths : [requiredPaths];
+  if (paths.some(p => !fs.existsSync(p))) {
+    console.log(message);
+    process.exit(0);
+  }
+}
+
+/**
+ * Finish a validator run: exit 1 if the caller accumulated any errors,
+ * otherwise print the success summary. Falls through to a normal process
+ * end (exit code 0) when there are no errors, exactly like the
+ * hand-written `if (hasErrors) { process.exit(1); } console.log(...)` tail
+ * every validator used to repeat.
+ *
+ * @param {boolean} hasErrors
+ * @param {string} successMessage
+ */
+function finishValidation(hasErrors, successMessage) {
+  if (hasErrors) {
+    process.exit(1);
+  }
+  console.log(successMessage);
+}
+
+module.exports = { skipIfMissing, finishValidation };

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -12,6 +12,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { execFileSync } = require('child_process');
+const { runSourceInChildProcess } = require('../lib/run-source-in-child-process');
 
 const validatorsDir = path.join(__dirname, '..', '..', 'scripts', 'ci');
 const repoRoot = path.join(__dirname, '..', '..');
@@ -68,26 +69,7 @@ function stripShebang(source) {
  * @returns {{code: number, stdout: string, stderr: string}}
  */
 function runSourceViaTempFile(source, env = {}) {
-  const tmpFile = path.join(repoRoot, `.tmp-validator-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
-  try {
-    fs.writeFileSync(tmpFile, source, 'utf8');
-    const stdout = execFileSync('node', [tmpFile], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-      cwd: repoRoot,
-      env: { ...process.env, ...env },
-    });
-    return { code: 0, stdout, stderr: '' };
-  } catch (err) {
-    return {
-      code: err.status || 1,
-      stdout: err.stdout || '',
-      stderr: err.stderr || '',
-    };
-  } finally {
-    try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
-  }
+  return runSourceInChildProcess(source, { cwd: repoRoot, filePrefix: '.tmp-validator-', env });
 }
 
 /**

--- a/tests/lib/run-source-in-child-process.js
+++ b/tests/lib/run-source-in-child-process.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+/**
+ * Writes `source` to a throwaway .js file and runs it via `node` in a child
+ * process, so a process.exit() call inside the code under test doesn't kill
+ * the parent test runner. Shared by tests/ci/validators.test.js (validator
+ * scripts) and tests/lib/validator-cli.test.js (the shared
+ * skipIfMissing/finishValidation helpers those validators delegate to) --
+ * both previously kept their own copy of this same temp-file + execFileSync +
+ * error-code + finally-unlink scaffolding (cubic review, EGC-539 PR #1151).
+ * @param {string} source - full Node.js source to execute
+ * @param {object} [options]
+ * @param {string} [options.cwd] - directory to write the temp file into and run from; defaults to the repo root
+ * @param {string} [options.filePrefix] - temp filename prefix, so concurrent suites can't collide on the same name
+ * @param {Record<string,string>} [options.env] - extra environment variables merged over process.env
+ * @returns {{code: number, stdout: string, stderr: string}}
+ */
+function runSourceInChildProcess(source, options = {}) {
+  const cwd = options.cwd || path.join(__dirname, '..', '..');
+  const filePrefix = options.filePrefix || '.tmp-child-process-test-';
+  const tmpFile = path.join(cwd, `${filePrefix}${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
+  try {
+    fs.writeFileSync(tmpFile, source, 'utf8');
+    const stdout = execFileSync('node', [tmpFile], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+      cwd,
+      env: { ...process.env, ...(options.env || {}) },
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
+  }
+}
+
+module.exports = { runSourceInChildProcess };

--- a/tests/lib/validator-cli.test.js
+++ b/tests/lib/validator-cli.test.js
@@ -1,0 +1,134 @@
+/**
+ * Tests for scripts/lib/validator-cli.js -- the shared CLI runner boilerplate
+ * (skip-if-missing + finish-with-exit-code) extracted from nine of the
+ * scripts/ci/validate-*.js scripts (EGC-539 audit, scripts/ finding).
+ *
+ * skipIfMissing() and finishValidation() call process.exit() on some code
+ * paths, so those paths are exercised via a child process (like
+ * tests/ci/validators.test.js does for the validators themselves); the
+ * non-exiting paths are safe to call in-process.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const { skipIfMissing, finishValidation } = require('../../scripts/lib/validator-cli');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Run a snippet of source that requires #lib/validator-cli in a child
+ * process, so process.exit() calls inside skipIfMissing/finishValidation
+ * don't kill the test runner itself.
+ * @param {string} body - source appended after the require line
+ * @returns {{code: number, stdout: string, stderr: string}}
+ */
+function runInChildProcess(body) {
+  const source = `const { skipIfMissing, finishValidation } = require('#lib/validator-cli');\n${body}`;
+  const tmpFile = path.join(repoRoot, `.tmp-validator-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
+  try {
+    fs.writeFileSync(tmpFile, source, 'utf8');
+    const stdout = execFileSync('node', [tmpFile], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+      cwd: repoRoot,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing scripts/lib/validator-cli.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('skipIfMissing returns without exiting when the given path exists', () => {
+    let threw = false;
+    try {
+      skipIfMissing(__filename, 'should not print');
+    } catch (_err) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'skipIfMissing must not throw when the path exists');
+  })) passed++; else failed++;
+
+  if (test('skipIfMissing returns without exiting when every path in an array exists', () => {
+    let threw = false;
+    try {
+      skipIfMissing([__filename, repoRoot], 'should not print');
+    } catch (_err) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'skipIfMissing must not throw when all paths exist');
+  })) passed++; else failed++;
+
+  if (test('skipIfMissing prints the message and exits 0 when the path is missing', () => {
+    const missing = path.join(os.tmpdir(), `validator-cli-test-missing-${Date.now()}`);
+    const result = runInChildProcess(`skipIfMissing(${JSON.stringify(missing)}, 'skip message here');\nconsole.log('UNREACHABLE');`);
+    assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
+    assert.ok(result.stdout.includes('skip message here'), `Expected skip message in stdout, got: ${result.stdout}`);
+    assert.ok(!result.stdout.includes('UNREACHABLE'), 'Code after skipIfMissing must not run');
+  })) passed++; else failed++;
+
+  if (test('skipIfMissing exits 0 when any path in an array is missing (all-must-exist semantics)', () => {
+    const missing = path.join(os.tmpdir(), `validator-cli-test-missing-${Date.now()}`);
+    const result = runInChildProcess(
+      `skipIfMissing([${JSON.stringify(__filename)}, ${JSON.stringify(missing)}], 'partial skip');\nconsole.log('UNREACHABLE');`
+    );
+    assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
+    assert.ok(result.stdout.includes('partial skip'));
+    assert.ok(!result.stdout.includes('UNREACHABLE'));
+  })) passed++; else failed++;
+
+  if (test('finishValidation prints the success message and does not exit when hasErrors is false', () => {
+    let threw = false;
+    try {
+      finishValidation(false, 'all good');
+    } catch (_err) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'finishValidation must not throw when hasErrors is false');
+  })) passed++; else failed++;
+
+  if (test('finishValidation exits 1 without printing the success message when hasErrors is true', () => {
+    const result = runInChildProcess(`finishValidation(true, 'should not print');\nconsole.log('UNREACHABLE');`);
+    assert.strictEqual(result.code, 1, `Expected exit 1, got ${result.code}: ${result.stderr}`);
+    assert.ok(!result.stdout.includes('should not print'), 'Success message must not print when hasErrors is true');
+    assert.ok(!result.stdout.includes('UNREACHABLE'), 'Code after finishValidation must not run');
+  })) passed++; else failed++;
+
+  if (test('finishValidation exits 0 and prints the success message when hasErrors is false (child process)', () => {
+    const result = runInChildProcess(`finishValidation(false, 'validated N things');`);
+    assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
+    assert.ok(result.stdout.includes('validated N things'));
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/validator-cli.test.js
+++ b/tests/lib/validator-cli.test.js
@@ -10,13 +10,12 @@
  */
 
 const assert = require('assert');
-const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync } = require('child_process');
 
 const repoRoot = path.join(__dirname, '..', '..');
 const { skipIfMissing, finishValidation } = require('../../scripts/lib/validator-cli');
+const { runSourceInChildProcess } = require('./run-source-in-child-process');
 
 function test(name, fn) {
   try {
@@ -39,25 +38,7 @@ function test(name, fn) {
  */
 function runInChildProcess(body) {
   const source = `const { skipIfMissing, finishValidation } = require('#lib/validator-cli');\n${body}`;
-  const tmpFile = path.join(repoRoot, `.tmp-validator-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
-  try {
-    fs.writeFileSync(tmpFile, source, 'utf8');
-    const stdout = execFileSync('node', [tmpFile], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-      cwd: repoRoot,
-    });
-    return { code: 0, stdout, stderr: '' };
-  } catch (err) {
-    return {
-      code: err.status ?? 1,
-      stdout: err.stdout || '',
-      stderr: err.stderr || '',
-    };
-  } finally {
-    try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
-  }
+  return runSourceInChildProcess(source, { cwd: repoRoot, filePrefix: '.tmp-validator-cli-test-' });
 }
 
 function runTests() {
@@ -84,6 +65,23 @@ function runTests() {
       threw = true;
     }
     assert.strictEqual(threw, false, 'skipIfMissing must not throw when all paths exist');
+  })) passed++; else failed++;
+
+  // Deterministic child-process counterpart to the two in-process cases
+  // above (cubic review, EGC-539 PR #1151): those only prove skipIfMissing
+  // doesn't throw when called directly, but if a regression ever made it
+  // call process.exit() on the exists-path too, it would silently kill this
+  // whole test runner mid-suite -- reporting success with zero tests run,
+  // since finishValidation exits 0 -- rather than failing loudly. Running
+  // the same call in a child process makes that failure mode visible: a
+  // stray exit shows up as UNREACHABLE never printing.
+  if (test('skipIfMissing (child process): does not exit when the given path exists', () => {
+    const result = runInChildProcess(
+      `skipIfMissing(${JSON.stringify(__filename)}, 'should not print');\nconsole.log('REACHED');`
+    );
+    assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
+    assert.ok(!result.stdout.includes('should not print'), 'skipIfMissing must not print when the path exists');
+    assert.ok(result.stdout.includes('REACHED'), 'code after skipIfMissing must still run when the path exists');
   })) passed++; else failed++;
 
   if (test('skipIfMissing prints the message and exits 0 when the path is missing', () => {
@@ -121,10 +119,19 @@ function runTests() {
     assert.ok(!result.stdout.includes('UNREACHABLE'), 'Code after finishValidation must not run');
   })) passed++; else failed++;
 
+  // Deterministic child-process counterpart to the in-process case above
+  // (cubic review, EGC-539 PR #1151): an in-process-only happy-path
+  // assertion can't tell the difference between "never exits" and "the test
+  // process happened to survive" -- if this branch ever regressed into
+  // calling process.exit(), it would silently kill the whole suite mid-run
+  // (finishValidation's own exit(0) makes that look like success with fewer
+  // tests, not a failure) instead of failing loudly. Asserting REACHED
+  // printed makes that failure mode visible.
   if (test('finishValidation exits 0 and prints the success message when hasErrors is false (child process)', () => {
-    const result = runInChildProcess(`finishValidation(false, 'validated N things');`);
+    const result = runInChildProcess(`finishValidation(false, 'validated N things');\nconsole.log('REACHED');`);
     assert.strictEqual(result.code, 0, `Expected exit 0, got ${result.code}: ${result.stderr}`);
     assert.ok(result.stdout.includes('validated N things'));
+    assert.ok(result.stdout.includes('REACHED'), 'code after finishValidation must still run when hasErrors is false');
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Context

EGC-539 audit (scripts/ scope), high severity finding: the CLI boilerplate shape (parse files -> validate -> exit code) was duplicated across `scripts/ci/validate-*.js`: check existence -> `process.exit(0)` if not applicable -> loop accumulating errors -> `process.exit(1)` if any errors -> success message. No shared runner existed in `scripts/lib/`.

## Fix

Added `scripts/lib/validator-cli.js` with two focused helpers that capture only the boilerplate that was genuinely identical across validators:

- `skipIfMissing(pathOrPaths, message)` - the `if (!fs.existsSync(...)) { console.log(msg); process.exit(0); }` guard clause, accepting a single path or an array (skip if any is missing, matching `validate-install-manifests.js`'s two-manifest check).
- `finishValidation(hasErrors, successMessage)` - the `if (hasErrors) { process.exit(1); } console.log(msg);` tail.

Migrated 9 of the 11 candidate scripts to use these helpers, preserving every message, exit code, and skip condition exactly:

- `validate-hooks.js`
- `validate-install-manifests.js`
- `validate-llm-providers.js` (no skip check existed here - only `finishValidation` applies, and the helper naturally supports that since `skipIfMissing` is simply not called)
- `validate-rules.js`
- `validate-agents.js`
- `validate-commands.js` (kept its own `hasErrors` + `warnCount` accumulation and conditional warning-count suffix; only wrapped with the shared helpers)
- `validate-skills.js`
- `validate-skill-frontmatter.js`
- `validate-translation-structure.js` (partial adoption: only its one genuine skip case, the missing `translations/` directory, moved to `skipIfMissing`. Its two hard-fail preconditions - missing `README.md` and zero headings found - are `console.error` + `process.exit(1)`, not the soft-skip pattern, so they stay inline unchanged rather than being forced into the helper)

Each validator that had additional gates before its final accumulate-loop (e.g. `validate-hooks.js`'s JSON-parse and schema-validation exits, `validate-install-manifests.js`'s schema-validation exit) kept those exactly as-is; only the outermost skip-check and finish-tail were extracted.

### Deliberately left out (documented, not forced)

- **`check-unicode-safety.js`**: has no wrapping function at all (top-level script), an extra `--write` sanitize mode, and reports two different violation kinds (dangerous invisible chars vs. emoji) into an array rather than a boolean `hasErrors`. It's already tested via an env var override (`EGC_UNICODE_SCAN_ROOT`), not the source-substitution convention the other validators' tests use - confirming it was never part of this shape to begin with.
- **`validate-workflow-security.js`**: this is the file the audit finding calls out as the one outlier that `return`s an exit code instead of calling `process.exit()` directly. That's by design, not an oversight: the exported `validateWorkflowSecurity(workflowsDir)` function is parameterized (not reading a module-level directory constant like the others) and returns `0|1` so it stays composable/testable via direct `require()` without spawning a process - it has its own dedicated test file (`tests/ci/validate-workflow-security.test.js`) that already exercises it via `spawnSync`. Forcing it onto the shared exit()-based helpers would remove that composability for no behavioral gain, since nothing else in the repo currently consumes it as a library either way.

## Test plan

- `node tests/ci/validators.test.js` (isolated, RAM-safe): 167/167 passed, covering all 9 migrated validators' success and error paths against both the real project and temp fixtures.
- `node tests/lib/validator-cli.test.js` (new, isolated): 7/7 passed - unit coverage for `skipIfMissing` and `finishValidation`, including the `process.exit()` paths via a child process.
- `node tests/ci/validate-workflow-security.test.js` (isolated, unaffected file, sanity check): 4/4 passed.
- `node tests/lib/skill-tree-walker.test.js` and `node tests/lib/frontmatter-block.test.js` (isolated, unaffected files, sanity check): 8/8 and 8/8 passed.
- `node tests/scripts/check-unicode-safety.test.js` (isolated, unaffected file, sanity check): 5/5 passed.
- Manually ran all 9 migrated validators directly against the real repo (`node scripts/ci/validate-*.js`): all exit 0 with the same success messages as before the refactor.
- `npx eslint` on all changed/new files: clean, no errors or warnings.

Did not run the full test suite (`node tests/run-all.js`) locally to avoid a RAM-heavy process on this machine; relying on CI plus the isolated runs above, which cover every affected file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared CLI boilerplate into `scripts/lib/validator-cli.js` to remove duplication across validator scripts while keeping behavior identical. Addresses EGC-539 by standardizing skip and exit handling in CI validators.

- **Refactors**
  - Added `skipIfMissing()` and `finishValidation()` in `scripts/lib/validator-cli.js`.
  - Migrated 9 validator scripts to use the helpers; messages, exit codes, and custom logic (e.g., warnings in `validate-commands.js`) are unchanged. `validate-translation-structure.js` adopts only the skip guard; its hard-fail prechecks stay inline. Intentionally excluded `check-unicode-safety.js` and `validate-workflow-security.js`.
  - Testing: added `tests/lib/validator-cli.test.js`; extracted shared child-process runner to `tests/lib/run-source-in-child-process.js` and updated `tests/ci/validators.test.js` to use it; added child-process assertions to catch unintended exits on happy paths.

<sup>Written for commit 395fe589d83e5be18b95acc463aac4dac9dcac3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

