### PR TITLE
feat(guardian): add automated guard against internal/personal tool leaks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,4 +2,5 @@
 # Blocks commits that would leak populated EGC memory from propagation files.
 if command -v node >/dev/null 2>&1; then
   node "$(git rev-parse --show-toplevel)/scripts/check-state-leak.js" --staged || exit 1
+  node "$(git rev-parse --show-toplevel)/scripts/check-internal-tool-leak.js" --staged || exit 1
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,10 @@ jobs:
         run: node scripts/check-state-leak.js --tree
         continue-on-error: false
 
+      - name: Check for internal-tool leaks
+        run: node scripts/check-internal-tool-leak.js --tree
+        continue-on-error: false
+
   security:
     name: Security Scan
     uses: ./.github/workflows/reusable-security-audit.yml

--- a/.github/workflows/pr-text-leak-check.yml
+++ b/.github/workflows/pr-text-leak-check.yml
@@ -17,10 +17,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/pr-text-leak-check.yml
+++ b/.github/workflows/pr-text-leak-check.yml
@@ -1,0 +1,36 @@
+name: PR Text Leak Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-pr-text:
+    name: Check PR title/body for internal-tool leaks
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Fetch PR title and body
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json title,body --jq '.title + "\n" + .body' > /tmp/pr-text.txt
+
+      - name: Check for internal-tool leaks
+        run: node scripts/check-internal-tool-leak.js --text "$(cat /tmp/pr-text.txt)"

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -607,7 +607,7 @@ export const PROTECTED_FILE_PATTERNS: RegExp[] = [
   /\.gemini[\\/]config[\\/]mcp_config\.json$/,
   // Antigravity CLI's own MCP server registration file — a separate file
   // from Gemini CLI's above despite sharing the ~/.gemini home root
-  // (scripts/lib/mcp-register.js's "Antigravity CLI" target). Multica squad
+  // (scripts/lib/mcp-register.js's "Antigravity CLI" target). Internal
   // audit (EGC-460/461, 2026-07-27) found guardian-bin.js now also trusts
   // this file, for the same reasoning as the Gemini CLI entry above.
   /\.gemini[\\/]antigravity-cli[\\/]mcp_config\.json$/,
@@ -626,7 +626,7 @@ export const PROTECTED_FILE_PATTERNS: RegExp[] = [
   // validator treat it as authoritative.
   /\.codex[\\/]config\.toml$/,
   // Home-scoped install marker (scripts/lib/install/apply.js's
-  // writeGuardianCliMarker(), 2026-07-27 Multica design review EGC-465).
+  // writeGuardianCliMarker(), 2026-07-27 internal design review EGC-465).
   // guardian-bin.js's fromEgcHomeMarker() trusts this file's packageRoot
   // value to resolve the guardian CLI on installs with no MCP config of
   // their own (Copilot, CodeBuddy). Same reasoning as the other resolution

--- a/scripts/check-internal-tool-leak.js
+++ b/scripts/check-internal-tool-leak.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+'use strict';
+
+// Guards against internal/personal tool names leaking into the public repo:
+// tracked files, staged commits, and PR titles/bodies. The denylist covers
+// codenames and setups that have leaked before (see EGC-539 follow-up) and
+// have no legitimate reason to ever appear in this public codebase.
+//
+// Modes:
+//   --staged        check staged blobs (pre-commit hook)
+//   --tree          check tracked files on disk (CI guard)
+//   --text <string> check an arbitrary string (CI guard for PR title/body)
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+
+const DENYLIST = ['multica'];
+
+// The checker's own source and test fixtures legitimately contain the
+// denylisted terms; never treat them as a leak.
+const SELF_PATHS = new Set([
+  'scripts/check-internal-tool-leak.js',
+  'tests/check-internal-tool-leak.test.js',
+]);
+
+const GIT_BIN = [
+  '/usr/bin/git',
+  '/usr/local/bin/git',
+  'C:\\Program Files\\Git\\cmd\\git.exe',
+].find(p => fs.existsSync(p)) || 'git';
+
+function git(args, options) {
+  return execFileSync(GIT_BIN, args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64, ...options });
+}
+
+function findHits(content) {
+  const lower = content.toLowerCase();
+  return DENYLIST.filter(term => lower.includes(term));
+}
+
+function checkStaged() {
+  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACM'])
+    .split('\n').filter(Boolean).filter(f => !SELF_PATHS.has(f));
+  const leaks = [];
+  for (const file of staged) {
+    let content;
+    try {
+      content = git(['show', `:0:${file}`]);
+    } catch {
+      continue;
+    }
+    const hits = findHits(content);
+    if (hits.length > 0) leaks.push({ file, hits });
+  }
+  return leaks;
+}
+
+function checkTree() {
+  const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(f => !SELF_PATHS.has(f));
+  const leaks = [];
+  for (const file of tracked) {
+    let content;
+    try {
+      content = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const hits = findHits(content);
+    if (hits.length > 0) leaks.push({ file, hits });
+  }
+  return leaks;
+}
+
+function report(leaks, context) {
+  if (leaks.length === 0) {
+    console.log('internal-tool leak check: clean');
+    return 0;
+  }
+  console.error(`BLOCKED: internal/personal tool references must never be public. Found in ${context}:`);
+  for (const leak of leaks) {
+    console.error(`  - ${leak.file}: ${leak.hits.join(', ')}`);
+  }
+  console.error('\nRemove the reference and reword generically before committing/merging.');
+  return 1;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const mode = args[0];
+
+  if (mode === '--text') {
+    const text = args.slice(1).join(' ');
+    const hits = findHits(text);
+    if (hits.length === 0) {
+      console.log('internal-tool leak check: clean');
+      return;
+    }
+    console.error(`BLOCKED: internal/personal tool reference found in PR title/body: ${hits.join(', ')}`);
+    process.exit(1);
+  }
+
+  const leaks = mode === '--staged' ? checkStaged() : checkTree();
+  process.exit(report(leaks, mode === '--staged' ? 'staged files' : 'tracked files'));
+}
+
+main();

--- a/scripts/check-internal-tool-leak.js
+++ b/scripts/check-internal-tool-leak.js
@@ -26,7 +26,7 @@ const SELF_PATHS = new Set([
 const GIT_BIN = [
   '/usr/bin/git',
   '/usr/local/bin/git',
-  'C:\\Program Files\\Git\\cmd\\git.exe',
+  String.raw`C:\Program Files\Git\cmd\git.exe`,
 ].find(p => fs.existsSync(p)) || 'git';
 
 function git(args, options) {
@@ -39,8 +39,8 @@ function findHits(content) {
 }
 
 function checkStaged() {
-  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACM'])
-    .split('\n').filter(Boolean).filter(f => !SELF_PATHS.has(f));
+  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACMT', '-z'])
+    .split('\0').filter(Boolean).filter(f => !SELF_PATHS.has(f));
   const leaks = [];
   for (const file of staged) {
     let content;
@@ -56,7 +56,7 @@ function checkStaged() {
 }
 
 function checkTree() {
-  const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(f => !SELF_PATHS.has(f));
+  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean).filter(f => !SELF_PATHS.has(f));
   const leaks = [];
   for (const file of tracked) {
     let content;

--- a/scripts/lib/amazonq-guardian-operations.js
+++ b/scripts/lib/amazonq-guardian-operations.js
@@ -2,7 +2,7 @@
 
 // EGC-498 (corrected): Amazon Q Developer CLI has a real preToolUse hook
 // (verified against aws/amazon-q-developer-cli's own docs, not the earlier
-// Multica report which incorrectly classified it as prompt-only). Shared
+// earlier internal report which incorrectly classified it as prompt-only). Shared
 // between amazonq-project.js and amazonq-home.js: both roots use this
 // identical operation shape, differing only in rootSegments/
 // installStatePathSegments.

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -982,8 +982,8 @@ function createEgcMemorySaveScriptCopyOperations(createRemappedOperation, target
 // falls back to CLAUDE_PROJECT_DIR/PWD/cwd() when input.cwd is absent, so the
 // exact same tested, proven state-load-and-print logic that opens every
 // session also re-injects state right after a compaction finishes -- closes
-// EGC-495 without inventing new untested logic. Confirmed real by the
-// Multica squad (EGC-497) via Claude Code binary inspection: PostCompact is
+// EGC-495 without inventing new untested logic. Confirmed real by an
+// internal audit (EGC-497) via Claude Code binary inspection: PostCompact is
 // an actual hook event (executePostCompactHooks, markPostCompaction).
 function createPostCompactHookMergeOperation(targetRoot) {
   const hookScriptPath = resolveHookScriptDestination(targetRoot);

--- a/scripts/lib/guardian-bin.js
+++ b/scripts/lib/guardian-bin.js
@@ -45,8 +45,8 @@ function fromMcpConfigs() {
     path.join(os.homedir(), '.gemini', 'config', 'mcp_config.json'),
     // Antigravity CLI's own MCP registration file — a SEPARATE file from
     // Gemini CLI's above despite sharing the ~/.gemini home root (see
-    // scripts/lib/mcp-register.js's "Antigravity CLI" target). Multica
-    // squad audit (EGC-460/461, 2026-07-27) confirmed a pure-Antigravity
+    // scripts/lib/mcp-register.js's "Antigravity CLI" target). Internal
+    // audit (EGC-460/461, 2026-07-27) confirmed a pure-Antigravity
     // install (no Claude Code, no Gemini CLI alongside it) had no working
     // fallback here either, for the same fail-open reason as Gemini CLI
     // above.
@@ -270,7 +270,7 @@ function fromCodexToml() {
 // apply.js's writeGuardianCliMarker() records the real package root here on
 // every install/repair, so any standalone copy can read it back.
 //
-// 2026-07-27 Multica design review (EGC-465): deliberately does NOT require
+// 2026-07-27 internal design review (EGC-465): deliberately does NOT require
 // the resolved candidate to live under the user's home directory, unlike
 // fromMcpConfigs()/fromCodexToml() above. Those two guard against a
 // synced/tampered CONFIG FILE pointing resolution somewhere attacker-

--- a/scripts/lib/install-targets/amazonq-project.js
+++ b/scripts/lib/install-targets/amazonq-project.js
@@ -4,7 +4,7 @@ const { createAmazonQGuardianOperations } = require('../amazonq-guardian-operati
 
 // EGC-498 (corrected): Amazon Q Developer CLI's preToolUse hook is real
 // (confirmed against aws/amazon-q-developer-cli's own docs -- the earlier
-// Multica report classifying it as prompt-only was wrong). The custom-agent
+// earlier internal report classifying it as prompt-only was wrong). The custom-agent
 // config lives at .amazonq/cli-agents/*.json, a sibling of the rules/ root
 // this adapter already scaffolds, not nested inside it -- so the Guardian
 // operations resolve their own root from the .amazonq parent directory

--- a/scripts/lib/install-targets/amp-home.js
+++ b/scripts/lib/install-targets/amp-home.js
@@ -15,7 +15,7 @@ const {
 // concern, out of scope for this pass (EGC-507).
 //
 // Guardian + Token Crusher via Amp's Plugin API (EGC-507, design reviewed
-// with the Multica squad before implementing, 2026-07-29): the hooks doc
+// with an internal audit before implementing, 2026-07-29): the hooks doc
 // this file used to cite (ampcode.com/manual?internal#hooks,
 // Sourcegraph-internal only, "Preview" since May 2025) now 404s. In its
 // place, Amp ships a PUBLIC Plugin API (ampcode.com/manual/plugin-api, no

--- a/scripts/lib/install-targets/amp-project.js
+++ b/scripts/lib/install-targets/amp-project.js
@@ -15,7 +15,7 @@ const {
 // pass (EGC-507).
 //
 // Guardian + Token Crusher via Amp's Plugin API (EGC-507, design reviewed
-// with the Multica squad before implementing): reconfirmed 2026-07-29 that
+// with an internal audit before implementing): reconfirmed 2026-07-29 that
 // the old hooks doc this file used to cite (ampcode.com/manual?internal#
 // hooks, Sourcegraph-internal only) now 404s -- Amp replaced it with a
 // PUBLIC Plugin API (ampcode.com/manual/plugin-api). Plugins run IN-PROCESS

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -200,7 +200,7 @@ function resolvePackageRoot() {
 }
 
 // Home-scoped, tool-agnostic anchor for guardian-bin.js's
-// fromEgcHomeMarker() resolution strategy (2026-07-27 Multica design
+// fromEgcHomeMarker() resolution strategy (2026-07-27 internal design
 // review, EGC-465): a Copilot- or CodeBuddy-only install has no MCP config
 // file of its own to trust, so this records the real package root at the
 // one moment it is actually known -- install time -- for any standalone

--- a/scripts/lib/openhands-guardian-operations.js
+++ b/scripts/lib/openhands-guardian-operations.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // EGC-498 (corrected): OpenHands has a real pre_tool_use hook (verified
-// against OpenHands/docs' own hooks.mdx, not the earlier Multica report
+// against OpenHands/docs' own hooks.mdx, not an earlier internal report
 // which incorrectly classified it as prompt-only). Project-only --
 // confirmed no global/home hooks.json path exists.
 

--- a/tests/check-internal-tool-leak.test.js
+++ b/tests/check-internal-tool-leak.test.js
@@ -1,0 +1,103 @@
+'use strict';
+/**
+ * Tests for scripts/check-internal-tool-leak.js
+ *
+ * Covers the internal/personal tool name guard: a denylisted term must be
+ * caught in staged blobs (--staged), the tracked tree (--tree), and
+ * arbitrary text (--text, used for PR title/body in CI).
+ *
+ * Run with: node tests/check-internal-tool-leak.test.js
+ */
+const assert = require('node:assert');
+const { execFileSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'check-internal-tool-leak.js');
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-tool-leak-test-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(dir, 'scripts', 'check-internal-tool-leak.js'));
+  return { dir, git };
+}
+
+function runScript(dir, ...args) {
+  return spawnSync('node', [path.join(dir, 'scripts', 'check-internal-tool-leak.js'), ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+  });
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing check-internal-tool-leak ===\n');
+
+run('staged file mentioning the denylisted term is blocked', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'NOTES.md'), 'An independent Multica audit found 3 bugs.\n');
+  git('add', 'NOTES.md');
+  const res = runScript(dir, '--staged');
+  assert.strictEqual(res.status, 1, `expected exit 1, got ${res.status}: ${res.stderr}`);
+  assert.ok(res.stderr.includes('multica'));
+});
+
+run('case-insensitive match is caught', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'NOTES.md'), 'Found by MULTICA security review.\n');
+  git('add', 'NOTES.md');
+  const res = runScript(dir, '--staged');
+  assert.strictEqual(res.status, 1);
+});
+
+run('tree mode flags a committed file', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'NOTES.md'), 'multica pass found 3 bugs\n');
+  git('add', 'NOTES.md');
+  git('commit', '-q', '-m', 'seed', '--no-verify');
+  const res = runScript(dir, '--tree');
+  assert.strictEqual(res.status, 1);
+  assert.ok(res.stderr.includes('NOTES.md'));
+});
+
+run('clean staged content passes', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'NOTES.md'), 'An independent security audit found 3 bugs.\n');
+  git('add', 'NOTES.md');
+  const res = runScript(dir, '--staged');
+  assert.strictEqual(res.status, 0, res.stderr);
+});
+
+run('--text mode blocks a leaking string', () => {
+  const { dir } = makeRepo();
+  const res = runScript(dir, '--text', 'fix: bypasses found by Multica security audit');
+  assert.strictEqual(res.status, 1);
+});
+
+run('--text mode passes clean text', () => {
+  const { dir } = makeRepo();
+  const res = runScript(dir, '--text', 'fix: bypasses found by an internal security audit');
+  assert.strictEqual(res.status, 0, res.stderr);
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -175,7 +175,7 @@ run('.gemini/GEMINI.md write stays allowed (functional file, not a credential/tr
   assert.strictEqual(v.allowed, true, `expected .gemini/GEMINI.md to stay allowed, got: ${v.reason}`);
 });
 
-console.log('\nAntigravity/OpenCode cross-CLI fail-open fix (Multica audit EGC-460/461, 2026-07-27):');
+console.log('\nAntigravity/OpenCode cross-CLI fail-open fix (internal audit EGC-460/461, 2026-07-27):');
 run('.gemini/antigravity-cli/mcp_config.json write is blocked (guardian-bin.js now trusts this file too)', () => {
   const v = validateWrite('.gemini/antigravity-cli/mcp_config.json');
   assert.strictEqual(v.allowed, false, 'expected .gemini/antigravity-cli/mcp_config.json write to be blocked');
@@ -199,7 +199,7 @@ run('.egc/guardian-cli-path.json write is blocked (guardian-bin.js now trusts th
   assert.strictEqual(v.allowed, false, 'expected .egc/guardian-cli-path.json write to be blocked');
 });
 
-// Multica audit EGC-533 findings (2026-08-02): trailing-whitespace path
+// Internal audit EGC-533 findings (2026-08-02): trailing-whitespace path
 // bypass and git includeIf bypass.
 run('.env write with a trailing newline is still blocked (audit EGC-533, Finding 1)', () => {
   const v = validateWrite('.env\n');

--- a/tests/hooks/amp-guardian-crusher-plugin.test.js
+++ b/tests/hooks/amp-guardian-crusher-plugin.test.js
@@ -4,7 +4,7 @@
  * Amp (Sourcegraph) loads this plugin IN-PROCESS from .amp/plugins/*.ts
  * (project) or ~/.config/amp/plugins/*.ts (home), executed by Amp's own
  * Bun runtime (confirmed against https://ampcode.com/manual/plugin-api,
- * design reviewed with the Multica squad -- EGC-507). Same in-process
+ * design reviewed with an internal audit -- EGC-507). Same in-process
  * pattern as OpenCode's plugin: no stdin/stdout translation adapter, this
  * file requires the shared run() functions directly.
  *

--- a/tests/lib/guardian-bin.test.js
+++ b/tests/lib/guardian-bin.test.js
@@ -257,7 +257,7 @@ function main() {
   });
 
   run('resolves via ~/.gemini/antigravity-cli/mcp_config.json on an Antigravity-only install', () => {
-    // Multica squad audit (EGC-460/461, 2026-07-27): this is a SEPARATE file
+    // Internal audit (EGC-460/461, 2026-07-27): this is a SEPARATE file
     // from ~/.gemini/config/mcp_config.json above despite sharing the
     // ~/.gemini home root -- a pure-Antigravity install (no Claude Code, no
     // Gemini CLI alongside it) had no working config-based fallback here


### PR DESCRIPTION
## Summary
Follow-up to #1152: found that PRs #1127/#1128 (merged before this cleanup) leaked an internal auditor-tool name in their title, body, commit message, and in `docs/ROADMAP.md`. Nothing in the repo automatically catches this class of leak today, so it can happen again.

Adds a denylist-based scanner with three entry points:
- `--staged`: wired into `.githooks/pre-commit`, blocks a local commit that stages a file mentioning a denylisted term.
- `--tree`: wired into CI (`ci.yml`), catches anything committed through a path that bypassed local hooks.
- `--text`: new `pr-text-leak-check.yml` workflow, fetches the PR's title+body via `gh pr view` and fails the check if a denylisted term appears. This is the gap the other two modes can't close: PR title/body is GitHub metadata, not a git object, so no local hook or tree scan ever sees it.

The denylist currently has one entry; add more as needed the same way `check-state-leak.js`'s signature list grows.

## Test plan
- [x] `node tests/check-internal-tool-leak.test.js` -- 6/6 passing
- [x] Confirmed the checker doesn't flag its own source or test fixtures (both excluded explicitly)
- [x] Ran `--staged` against this PR's own diff -- clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a denylist guard to block internal/personal tool names in code, commits, and PR text. Follow-up to EGC-539; closes the PR-title/body gap and cleans up existing comment references.

- **New Features**
  - New scanner `scripts/check-internal-tool-leak.js` with `--staged`, `--tree`, and `--text` modes (case-insensitive); wired into `.githooks/pre-commit`, CI, and a PR title/body check via `gh pr view` in `.github/workflows/pr-text-leak-check.yml`.
  - Initial denylist has one entry; self-files excluded; 6 tests cover all modes and clean paths.

- **Bug Fixes**
  - Removed the internal tool name from comments across validator, scripts, and tests; plus scanner hardening: Windows `git` path via `String.raw`, `--diff-filter=ACMT`, NUL-safe `git` listings, and pinned `actions/checkout`/`actions/setup-node` by SHA.

<sup>Written for commit 7822788f7e31e9dc316c0a673fcd0900f0d6194f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

