### PR TITLE
fix(guardian): also scan PR commit messages for internal-tool leaks

### DIFF
--- a/.github/workflows/pr-text-leak-check.yml
+++ b/.github/workflows/pr-text-leak-check.yml
@@ -24,13 +24,16 @@ jobs:
         with:
           node-version: 20
 
-      - name: Fetch PR title and body
+      - name: Fetch PR title, body, and every commit message
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr view ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --json title,body --jq '.title + "\n" + .body' > /tmp/pr-text.txt
+            --json title,body,commits --jq '
+              .title + "\n" + .body + "\n"
+              + ([.commits[] | .messageHeadline + "\n" + .messageBody] | join("\n"))
+            ' > /tmp/pr-text.txt
 
       - name: Check for internal-tool leaks
         run: node scripts/check-internal-tool-leak.js --text "$(cat /tmp/pr-text.txt)"

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -81,8 +81,8 @@ function cleanContent(content) {
 }
 
 function checkStaged() {
-  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACM'])
-    .split('\n').filter(Boolean).filter(isGuardedPath);
+  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACMT', '-z'])
+    .split('\0').filter(Boolean).filter(isGuardedPath);
   const leaks = [];
   for (const file of staged) {
     let content;
@@ -97,7 +97,7 @@ function checkStaged() {
 }
 
 function checkTree() {
-  const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(isGuardedPath);
+  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean).filter(isGuardedPath);
   const leaks = [];
   for (const file of tracked) {
     let content;


### PR DESCRIPTION
## Summary
Follow-up to #1153. Found a real gap in the new PR-text leak check: it only fetched the PR's current title+body, but `gh pr merge --squash` without an explicit `--body` builds the final commit message from the individual commit messages on the branch, not the PR body shown on GitHub. Those are two separate sources of text.

This is exactly how an internal-tool-name leak reached `main` before: a PR's body was already cleaned via `gh pr edit`, but one of its underlying commits (never rewritten) still had the term in its message, and the squash picked that up instead.

Fix: `pr-text-leak-check.yml` now fetches every commit's `messageHeadline` + `messageBody` via `gh pr view --json commits` and checks those too, in addition to title+body.

Also hardened `check-state-leak.js` (the sibling script) against the same two git-plumbing gaps cubic found in `check-internal-tool-leak.js` in #1153: `--diff-filter=ACM` missing the `T` (type-change) status, and newline-splitting instead of NUL-splitting git's quoted output.

## Test plan
- [x] Ran the new jq query against PR #1153 (merged, clean) -- no false positive
- [x] Ran the new jq query against PR #1143 (merged before this campaign, known to have a leaking commit message) -- confirmed it surfaces the term, proving the new check would have caught it
- [x] `node tests/check-state-leak.test.js` -- 5/5 still passing after the diff-filter/NUL-safety hardening