### PR TITLE
fix(guardian): also scan PR commit messages for internal-tool leaks

### DIFF
--- a/.github/workflows/pr-text-leak-check.yml
+++ b/.github/workflows/pr-text-leak-check.yml
@@ -36,4 +36,4 @@ jobs:
             ' > /tmp/pr-text.txt
 
       - name: Check for internal-tool leaks
-        run: node scripts/check-internal-tool-leak.js --text "$(cat /tmp/pr-text.txt)"
+        run: node scripts/check-internal-tool-leak.js --text-file /tmp/pr-text.txt

--- a/.github/workflows/pr-text-leak-check.yml
+++ b/.github/workflows/pr-text-leak-check.yml
@@ -24,13 +24,16 @@ jobs:
         with:
           node-version: 20
 
-      - name: Fetch PR title and body
+      - name: Fetch PR title, body, and every commit message
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr view ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --json title,body --jq '.title + "\n" + .body' > /tmp/pr-text.txt
+            --json title,body,commits --jq '
+              .title + "\n" + .body + "\n"
+              + ([.commits[] | .messageHeadline + "\n" + .messageBody] | join("\n"))
+            ' > /tmp/pr-text.txt
 
       - name: Check for internal-tool leaks
         run: node scripts/check-internal-tool-leak.js --text "$(cat /tmp/pr-text.txt)"

--- a/scripts/check-internal-tool-leak.js
+++ b/scripts/check-internal-tool-leak.js
@@ -7,9 +7,13 @@
 // have no legitimate reason to ever appear in this public codebase.
 //
 // Modes:
-//   --staged        check staged blobs (pre-commit hook)
-//   --tree          check tracked files on disk (CI guard)
-//   --text <string> check an arbitrary string (CI guard for PR title/body)
+//   --staged            check staged blobs (pre-commit hook)
+//   --tree              check tracked files on disk (CI guard)
+//   --text <string>     check an arbitrary string (small inputs only --
+//                        a shell argv element is capped around 128KB on
+//                        Linux; prefer --text-file for anything PR-sized)
+//   --text-file <path>  check the contents of a file (CI guard for PR
+//                        title/body/commit messages, no argv size limit)
 
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
@@ -84,19 +88,25 @@ function report(leaks, context) {
   return 1;
 }
 
+function checkText(text) {
+  const hits = findHits(text);
+  if (hits.length === 0) {
+    console.log('internal-tool leak check: clean');
+    return 0;
+  }
+  console.error(`BLOCKED: internal/personal tool reference found in PR title/body: ${hits.join(', ')}`);
+  return 1;
+}
+
 function main() {
   const args = process.argv.slice(2);
   const mode = args[0];
 
   if (mode === '--text') {
-    const text = args.slice(1).join(' ');
-    const hits = findHits(text);
-    if (hits.length === 0) {
-      console.log('internal-tool leak check: clean');
-      return;
-    }
-    console.error(`BLOCKED: internal/personal tool reference found in PR title/body: ${hits.join(', ')}`);
-    process.exit(1);
+    process.exit(checkText(args.slice(1).join(' ')));
+  }
+  if (mode === '--text-file') {
+    process.exit(checkText(fs.readFileSync(args[1], 'utf8')));
   }
 
   const leaks = mode === '--staged' ? checkStaged() : checkTree();

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -81,8 +81,8 @@ function cleanContent(content) {
 }
 
 function checkStaged() {
-  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACM'])
-    .split('\n').filter(Boolean).filter(isGuardedPath);
+  const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACMT', '-z'])
+    .split('\0').filter(Boolean).filter(isGuardedPath);
   const leaks = [];
   for (const file of staged) {
     let content;
@@ -97,7 +97,7 @@ function checkStaged() {
 }
 
 function checkTree() {
-  const tracked = git(['ls-files']).split('\n').filter(Boolean).filter(isGuardedPath);
+  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean).filter(isGuardedPath);
   const leaks = [];
   for (const file of tracked) {
     let content;

--- a/tests/check-internal-tool-leak.test.js
+++ b/tests/check-internal-tool-leak.test.js
@@ -99,5 +99,21 @@ run('--text mode passes clean text', () => {
   assert.strictEqual(res.status, 0, res.stderr);
 });
 
+run('--text-file mode blocks a leaking file (no argv size limit)', () => {
+  const { dir } = makeRepo();
+  const file = path.join(dir, 'pr-text.txt');
+  fs.writeFileSync(file, 'fix: bypasses found by Multica security audit');
+  const res = runScript(dir, '--text-file', file);
+  assert.strictEqual(res.status, 1);
+});
+
+run('--text-file mode passes a clean file', () => {
+  const { dir } = makeRepo();
+  const file = path.join(dir, 'pr-text.txt');
+  fs.writeFileSync(file, 'fix: bypasses found by an internal security audit');
+  const res = runScript(dir, '--text-file', file);
+  assert.strictEqual(res.status, 0, res.stderr);
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Reopens #1154 (closed automatically when its branch was deleted/recreated to rewrite a commit message).

Follow-up to #1153. Found a real gap in the new PR-text leak check: it only fetched the PR's current title+body, but `gh pr merge --squash` without an explicit `--body` builds the final commit message from the individual commit messages on the branch, not the PR body shown on GitHub. Those are two separate sources of text.

This is exactly how an internal-tool-name leak reached `main` before: a PR's body was already cleaned, but one of its underlying commits (never rewritten) still had the term in its message, and the squash picked that up instead.

Fix: `pr-text-leak-check.yml` now fetches every commit's `messageHeadline` + `messageBody` via `gh pr view --json commits` and checks those too, in addition to title+body.

Also hardened `check-state-leak.js` (the sibling script) against the same two git-plumbing gaps cubic found in `check-internal-tool-leak.js` in #1153: `--diff-filter=ACM` missing the `T` (type-change) status, and newline-splitting instead of NUL-splitting git's quoted output.

## Test plan
- [x] Ran the new jq query against a merged, clean PR -- no false positive
- [x] Ran the new jq query against an earlier merged PR known to have a leaking commit message -- confirmed it surfaces the term, proving the new check would have caught it
- [x] `node tests/check-state-leak.test.js` -- 5/5 still passing after the diff-filter/NUL-safety hardening
- [x] The new check itself caught a leak in this PR's own first draft commit message during review, confirming it works end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scan PR commit messages in the PR-text leak check to prevent internal-tool name leaks during squash merges. Also read PR text from a file to avoid argv size limits, and harden the state leak checker.

- **Bug Fixes**
  - `.github/workflows/pr-text-leak-check.yml`: fetches title, body, and each commit’s `messageHeadline` + `messageBody`; uses `--text-file /tmp/pr-text.txt` instead of `--text` to avoid E2BIG.
  - `scripts/check-internal-tool-leak.js`: adds `--text-file` mode (no argv size limit) while keeping `--text` for small inputs.
  - `scripts/check-state-leak.js`: adds `T` to `--diff-filter` and switches to `-z` NUL-safe parsing for `git diff` and `git ls-files`.

<sup>Written for commit 734c95d96a13af3be308f60d6c7afc4e01580369. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

