### PR TITLE
fix(install): add default case to install-args detection switch

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,6 +51,7 @@ _has_install_args=false
 for _arg in "$@"; do
   case "$_arg" in
     --target|--profile|--modules|--config|--with|--without|--dry-run|--json) _has_install_args=true; break ;;
+    *) ;;
   esac
   # positional arg = language/component
   case "$_arg" in -*) ;; *) _has_install_args=true; break ;; esac


### PR DESCRIPTION
## Summary
Part of a broader campaign fixing pre-existing SonarCloud CRITICAL findings on `main` (authorized by the project owner). This one: shelldre:S131 flags a `case` statement in `scripts/install.sh` scanning argv for known install flags with no default branch.

No behavior change: a non-matching arg already fell through to the loop's next iteration; the added `*) ;;` just makes that explicit.

## Test plan
- [x] `bash -n scripts/install.sh` -- syntax valid

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a default case to the install-args `case` in `scripts/install.sh` to clear a SonarCloud CRITICAL (shelldre:S131). No behavior change; it just makes the fall-through explicit.

<sup>Written for commit 3f75428eedc572b0398e48e45111af2600e35535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

