### PR TITLE
refactor(cli): extract consumeArg/takeValue to cut cognitive complexity

### DIFF
--- a/scripts/lib/cli-target-args.js
+++ b/scripts/lib/cli-target-args.js
@@ -1,6 +1,39 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+function takeValue(args, index, errorMessage) {
+  const value = args[index + 1];
+  if (!value) throw new Error(errorMessage);
+  return value;
+}
+
+// Returns the loop index to resume from (advanced past a consumed value, if any).
+function consumeArg(args, index, parsed, supportsDryRun) {
+  const arg = args[index];
+
+  if (arg === '--target') {
+    parsed.targets.push(takeValue(args, index, '--target requires a value'));
+    return index + 1;
+  }
+  if (arg === '--repo-root') {
+    parsed.repoRoot = path.resolve(takeValue(args, index, '--repo-root requires a path argument'));
+    return index + 1;
+  }
+  if (supportsDryRun && arg === '--dry-run') {
+    parsed.dryRun = true;
+    return index;
+  }
+  if (arg === '--json') {
+    parsed.json = true;
+    return index;
+  }
+  if (arg === '--help' || arg === '-h') {
+    parsed.help = true;
+    return index;
+  }
+  throw new Error(`Unknown argument: ${arg}`);
+}
+
 function parseTargetArgs(argv, { supportsDryRun = false } = {}) {
   const args = argv.slice(2);
   const parsed = {
@@ -12,31 +45,7 @@ function parseTargetArgs(argv, { supportsDryRun = false } = {}) {
   };
 
   for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-
-    if (arg === '--target') {
-      const rawTarget = args[index + 1];
-      if (!rawTarget) {
-        throw new Error('--target requires a value');
-      }
-      parsed.targets.push(rawTarget);
-      index += 1;
-    } else if (arg === '--repo-root') {
-      const rawRepoRoot = args[index + 1];
-      if (!rawRepoRoot) {
-        throw new Error('--repo-root requires a path argument');
-      }
-      parsed.repoRoot = path.resolve(rawRepoRoot);
-      index += 1;
-    } else if (supportsDryRun && arg === '--dry-run') {
-      parsed.dryRun = true;
-    } else if (arg === '--json') {
-      parsed.json = true;
-    } else if (arg === '--help' || arg === '-h') {
-      parsed.help = true;
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
+    index = consumeArg(args, index, parsed, supportsDryRun);
   }
 
   if (parsed.repoRoot && !fs.existsSync(parsed.repoRoot)) {

--- a/tests/lib/cli-target-args.test.js
+++ b/tests/lib/cli-target-args.test.js
@@ -1,0 +1,100 @@
+'use strict';
+/**
+ * Tests for scripts/lib/cli-target-args.js
+ *
+ * Run with: node tests/lib/cli-target-args.test.js
+ */
+const assert = require('node:assert');
+const path = require('node:path');
+const { parseTargetArgs } = require('../../scripts/lib/cli-target-args');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing cli-target-args ===\n');
+
+run('parses a single --target', () => {
+  const result = parseTargetArgs(['node', 'script.js', '--target', 'claude']);
+  assert.deepStrictEqual(result.targets, ['claude']);
+});
+
+run('parses multiple --target flags', () => {
+  const result = parseTargetArgs(['node', 'script.js', '--target', 'claude', '--target', 'cursor']);
+  assert.deepStrictEqual(result.targets, ['claude', 'cursor']);
+});
+
+run('--target with no value throws the exact original message', () => {
+  assert.throws(
+    () => parseTargetArgs(['node', 'script.js', '--target']),
+    /^Error: --target requires a value$/,
+  );
+});
+
+run('--repo-root resolves to an absolute path', () => {
+  const result = parseTargetArgs(['node', 'script.js', '--repo-root', '.']);
+  assert.strictEqual(result.repoRoot, path.resolve('.'));
+});
+
+run('--repo-root with no value throws the exact original message', () => {
+  assert.throws(
+    () => parseTargetArgs(['node', 'script.js', '--repo-root']),
+    /^Error: --repo-root requires a path argument$/,
+  );
+});
+
+run('--repo-root pointing at a nonexistent path throws', () => {
+  assert.throws(
+    () => parseTargetArgs(['node', 'script.js', '--repo-root', '/does/not/exist/xyz']),
+    /--repo-root path does not exist/,
+  );
+});
+
+run('--dry-run is ignored when supportsDryRun is false', () => {
+  assert.throws(
+    () => parseTargetArgs(['node', 'script.js', '--dry-run']),
+    /Unknown argument: --dry-run/,
+  );
+});
+
+run('--dry-run sets dryRun when supportsDryRun is true', () => {
+  const result = parseTargetArgs(['node', 'script.js', '--dry-run'], { supportsDryRun: true });
+  assert.strictEqual(result.dryRun, true);
+});
+
+run('--json sets json', () => {
+  const result = parseTargetArgs(['node', 'script.js', '--json']);
+  assert.strictEqual(result.json, true);
+});
+
+run('--help and -h both set help', () => {
+  assert.strictEqual(parseTargetArgs(['node', 'script.js', '--help']).help, true);
+  assert.strictEqual(parseTargetArgs(['node', 'script.js', '-h']).help, true);
+});
+
+run('unknown argument throws', () => {
+  assert.throws(
+    () => parseTargetArgs(['node', 'script.js', '--nope']),
+    /Unknown argument: --nope/,
+  );
+});
+
+run('no args returns all defaults', () => {
+  const result = parseTargetArgs(['node', 'script.js']);
+  assert.deepStrictEqual(result, { targets: [], repoRoot: null, dryRun: false, json: false, help: false });
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Part of the SonarCloud CRITICAL findings campaign (authorized by the project owner). `parseTargetArgs()` in `scripts/lib/cli-target-args.js` was at cognitive complexity 17 (limit 15): a 6-branch if/else chain with 2 nested value-taking branches.

Extracted:
- `takeValue(args, index, errorMessage)`: the repeated "grab the next arg or throw" pattern shared by `--target` and `--repo-root`.
- `consumeArg(args, index, parsed, supportsDryRun)`: the per-flag branching, returning the loop index to resume from.

No behavior change: every error message, default value, and the `--repo-root` existence check are identical to before.

## Test plan
- [x] New `tests/lib/cli-target-args.test.js` (this module had no test coverage before) -- 12/12 passing, covers every branch including exact error message text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored CLI target arg parsing by extracting `consumeArg` and `takeValue` to reduce cognitive complexity while keeping behavior identical. Added tests covering all branches in this module.

- **Refactors**
  - Extracted `takeValue(args, index, errorMessage)` to reuse “next arg or throw” logic.
  - Extracted `consumeArg(args, index, parsed, supportsDryRun)` to handle per-flag branching and index advancement.
  - Preserved all error messages, defaults, and the `--repo-root` existence check.
  - Lowered `parseTargetArgs()` cognitive complexity to meet Sonar S3776.
  - Added 12 tests for `cli-target-args` with full branch coverage.

<sup>Written for commit 646f7ff96f3ce3eedbf17cd50ae4644d45d6ba40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

