### PR TITLE
fix(cli): stop reassigning the for-loop counter in parseTargetArgs

### DIFF
--- a/scripts/lib/cli-target-args.js
+++ b/scripts/lib/cli-target-args.js
@@ -7,7 +7,8 @@ function takeValue(args, index, errorMessage) {
   return value;
 }
 
-// Returns the loop index to resume from (advanced past a consumed value, if any).
+// Returns the index of the last arg this call consumed (itself, or the value
+// after it for flags that take one) -- the caller resumes from +1 past that.
 function consumeArg(args, index, parsed, supportsDryRun) {
   const arg = args[index];
 
@@ -44,8 +45,9 @@ function parseTargetArgs(argv, { supportsDryRun = false } = {}) {
     help: false,
   };
 
-  for (let index = 0; index < args.length; index += 1) {
-    index = consumeArg(args, index, parsed, supportsDryRun);
+  let index = 0;
+  while (index < args.length) {
+    index = consumeArg(args, index, parsed, supportsDryRun) + 1;
   }
 
   if (parsed.repoRoot && !fs.existsSync(parsed.repoRoot)) {


### PR DESCRIPTION
## Summary
Follow-up to #1157. SonarCloud flagged a new finding (S2310, MAJOR) on the merged code: the `for` loop in `parseTargetArgs()` reassigned its own counter (`index`) inside the body.

Switched to a `while` loop with an explicit `+ 1` increment, which carries the same implicit `+1` the old `for` statement's increment clause contributed. No behavior change.

## Test plan
- [x] `node tests/lib/cli-target-args.test.js` -- 12/12 still passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the `for` loop in `parseTargetArgs()` with a `while` loop that uses an explicit increment to avoid reassigning the loop counter (SonarCloud S2310). No behavior change; index advances via `consumeArg(...) + 1` and existing tests still pass.

<sup>Written for commit 88328937e04d6c40edd4cf1a9f9bbcca317efccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

