### PR TITLE
fix(docs): remove dangling runtime/ reference, add missing security/+spec/ (EGC-540)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,9 @@ for the formal classification of every subsystem.
 | `architecture/` | Long-form architecture, current and target | `architecture/README.md` |
 | `governance/` | Subsystem classification, skill/agent policies | `governance/README.md` |
 | `guides/` | Operational and contributor walk-throughs | `guides/README.md` |
-| `installation/` | Setup playbooks for downstream stacks | direct files |
-| `runtime/` | Runtime contracts (command/agent map, session adapter) | direct files |
+| `security/` | Threat model, SCA policy, release verification | `security/THREAT-MODEL.md` |
+| `spec/` | Formal specs (integration tiers, agent memory interchange) | `spec/README.md` |
+| `installation.md` | Setup playbook for downstream stacks | direct file |
 
 ## Cross-references
 

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -11,6 +11,5 @@ selected. Read `SUBSYSTEM-MAP.md` first.
 | `skill-adaptation-policy.md` | When and how to adapt or fork an existing skill |
 | `capability-surface-selection.md` | Criteria for surfacing a skill into a harness install profile |
 
-For runtime contracts (command/agent map, session adapter), see
-`../runtime/`. For onboarding contributor process, see the root
-`CONTRIBUTING.md` and `../README.md`.
+For onboarding contributor process, see the root `CONTRIBUTING.md` and
+`../README.md`.

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -11,5 +11,5 @@ selected. Read `SUBSYSTEM-MAP.md` first.
 | `skill-adaptation-policy.md` | When and how to adapt or fork an existing skill |
 | `capability-surface-selection.md` | Criteria for surfacing a skill into a harness install profile |
 
-For onboarding contributor process, see the root `CONTRIBUTING.md` and
+For onboarding contributor process, see `.github/CONTRIBUTING.md` and
 `../README.md`.


### PR DESCRIPTION
## Summary
Part of the EGC-540 catalog audit. `docs/README.md`'s Layout table and `docs/governance/README.md` both pointed to `../runtime/` for "runtime contracts (command/agent map, session adapter)" -- that directory does not exist anywhere in the repo. A repo-wide grep for the referenced content found no real destination to redirect to instead, so the dangling pointer is removed rather than patched with an invented target.

Also:
- `installation/` was listed as a folder in the Layout table but is actually a flat file (`installation.md`).
- The table omitted `security/` (4 files: threat model, SCA policy, release verification, security assessment) and `spec/` (3 files: integration tiers, agent memory interchange, README), both of which exist and are current.

## Test plan
- [x] Confirmed `security/` and `spec/` directories and their referenced start-here files exist
- [x] Confirmed no test references `docs/README.md`'s content directly (doc-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken docs links from the EGC-540 audit. Removes dangling `runtime/` refs, adds missing `security/` and `spec/`, corrects `installation.md`, and fixes the `CONTRIBUTING.md` path.

- **Bug Fixes**
  - Removed `../runtime/` references from `docs/README.md` and `docs/governance/README.md`.
  - Added `security/` and `spec/` to the layout table with `security/THREAT-MODEL.md` and `spec/README.md` as entry points.
  - Corrected `installation/` to `installation.md` in the layout table.
  - Updated `CONTRIBUTING.md` link in `docs/governance/README.md` to `.github/CONTRIBUTING.md`.

<sup>Written for commit fecc83fbb5a5a5d43d82696d68d0f93c42bc8498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

