### PR TITLE
refactor: extract comment-stripping char handler in roocode-guardian-denylist to cut cognitive complexity

### DIFF
--- a/scripts/lib/roocode-guardian-denylist.js
+++ b/scripts/lib/roocode-guardian-denylist.js
@@ -59,38 +59,45 @@ function isPlainObject(value) {
 // realistic file. Strip comments and trailing commas first (string-aware,
 // so `"a // not a comment"` survives intact), matching JSONC's actual
 // grammar without pulling in a parser dependency for this one call site.
+// Consumes one character starting at `text[i]` of the comment-stripping scan,
+// mutating `state` in place, and returns the index to resume from.
+function consumeCommentStrippingChar(text, i, state) {
+  const ch = text[i];
+  const next = text[i + 1];
+
+  if (state.inLineComment) {
+    if (ch === '\n') { state.inLineComment = false; state.out += ch; }
+    return i + 1;
+  }
+  if (state.inBlockComment) {
+    if (ch === '*' && next === '/') { state.inBlockComment = false; return i + 2; }
+    return i + 1;
+  }
+  if (state.inString) {
+    state.out += ch;
+    if (ch === '\\') { state.out += next; return i + 2; }
+    if (ch === '"') state.inString = false;
+    return i + 1;
+  }
+  if (ch === '"') { state.inString = true; state.out += ch; return i + 1; }
+  if (ch === '/' && next === '/') { state.inLineComment = true; return i + 2; }
+  if (ch === '/' && next === '*') { state.inBlockComment = true; return i + 2; }
+
+  state.out += ch;
+  return i + 1;
+}
+
 function stripJsonComments(text) {
-  let out = '';
-  let inString = false;
-  let inLineComment = false;
-  let inBlockComment = false;
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    const next = text[i + 1];
-    if (inLineComment) {
-      if (ch === '\n') { inLineComment = false; out += ch; }
-      continue;
-    }
-    if (inBlockComment) {
-      if (ch === '*' && next === '/') { inBlockComment = false; i++; }
-      continue;
-    }
-    if (inString) {
-      out += ch;
-      if (ch === '\\') { out += next; i++; continue; }
-      if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') { inString = true; out += ch; continue; }
-    if (ch === '/' && next === '/') { inLineComment = true; i++; continue; }
-    if (ch === '/' && next === '*') { inBlockComment = true; i++; continue; }
-    out += ch;
+  const state = { out: '', inString: false, inLineComment: false, inBlockComment: false };
+  let i = 0;
+  while (i < text.length) {
+    i = consumeCommentStrippingChar(text, i, state);
   }
   // String-aware: a string value containing a literal ",]" or ",}" (e.g. a
   // user's note field quoting JSON syntax) must not be mistaken for an
   // actual trailing comma. Alternates between skipping whole string
   // literals untouched and collapsing a real trailing comma.
-  return out.replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (match, trailing) => (
+  return state.out.replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (match, trailing) => (
     trailing === undefined ? match : trailing
   ));
 }


### PR DESCRIPTION
## Summary
- SonarCloud CRITICAL cleanup: \`stripJsonComments\` (cognitive complexity 28) mixed line-comment, block-comment, string, and quote/comment-start handling into one loop body.
- Extracted the per-character decision into \`consumeCommentStrippingChar\`, called from a thin \`while\` loop. No behavior change.

## Test plan
- [x] \`tests/lib/roocode-guardian-denylist.test.js\`: 19/19 passing
- [x] \`tests/lib/claude-settings-hooks.test.js\` (importer): 68/68 passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a per-character handler to simplify JSONC comment stripping in the denylist. Reduces SonarCloud cognitive complexity with no behavior change.

- **Refactors**
  - Added `consumeCommentStrippingChar(text, i, state)` to handle string/line/block comment states.
  - Simplified `stripJsonComments` to a small `while` loop calling the new handler.
  - Preserves trailing-comma removal and string-escape handling; existing tests pass.

<sup>Written for commit f3577b1ddcc0dea3514a5b22dac41bc8203961d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

