### PR TITLE
refactor: extract shell-syntax char scanner in pre-bash-crusher-rewrite to cut cognitive complexity

### DIFF
--- a/scripts/hooks/pre-bash-crusher-rewrite.js
+++ b/scripts/hooks/pre-bash-crusher-rewrite.js
@@ -55,25 +55,37 @@ function wrappedRe() {
 // assertions on Windows CI and was reverted; if a host that actually
 // shells out via cmd.exe is ever wired to this hook, that needs its own
 // dedicated handling, not a blanket win32 check here.
+const COMPLEX_SHELL_CHARS = new Set(['\n', '|', '&', ';', '<', '>', '$', '`', '(', ')']);
+
+// Scans one character of hasComplexShellSyntax's quote-tracking pass.
+// Returns `{ complex: true }` to short-circuit the whole scan, otherwise
+// `{ nextIndex, quote }` for the caller to resume from.
+function scanShellSyntaxChar(cmd, i, quote) {
+  const ch = cmd[i];
+
+  if (quote === "'") {
+    return { nextIndex: i + 1, quote: ch === "'" ? null : quote };
+  }
+  if (quote === '"') {
+    if (ch === '\\') return { nextIndex: i + 2, quote };
+    if (ch === '"') return { nextIndex: i + 1, quote: null };
+    if (ch === '$' || ch === '`') return { complex: true };
+    return { nextIndex: i + 1, quote };
+  }
+  if (ch === '\\') return { nextIndex: i + 2, quote };
+  if (ch === "'" || ch === '"') return { nextIndex: i + 1, quote: ch };
+  if (COMPLEX_SHELL_CHARS.has(ch)) return { complex: true };
+  return { nextIndex: i + 1, quote };
+}
+
 function hasComplexShellSyntax(cmd) {
   let quote = null;
-  for (let i = 0; i < cmd.length; i++) {
-    const ch = cmd[i];
-    if (quote === "'") {
-      if (ch === "'") quote = null;
-      continue;
-    }
-    if (quote === '"') {
-      if (ch === '\\') { i++; continue; }
-      if (ch === '"') { quote = null; continue; }
-      if (ch === '$' || ch === '`') return true;
-      continue;
-    }
-    if (ch === '\\') { i++; continue; }
-    if (ch === "'" || ch === '"') { quote = ch; continue; }
-    if (ch === '\n' || ch === '|' || ch === '&' || ch === ';' || ch === '<' || ch === '>' || ch === '$' || ch === '`' || ch === '(' || ch === ')') {
-      return true;
-    }
+  let i = 0;
+  while (i < cmd.length) {
+    const step = scanShellSyntaxChar(cmd, i, quote);
+    if (step.complex) return true;
+    i = step.nextIndex;
+    quote = step.quote;
   }
   // An unterminated quote masks whatever follows it from this scan; treat
   // that as complex rather than silently trusting the no-shell fast path.


### PR DESCRIPTION
## Summary
- SonarCloud CRITICAL cleanup: \`hasComplexShellSyntax\` (cognitive complexity 23) mixed quote-state tracking with a long OR chain of shell metacharacters in one loop body.
- Extracted the per-character decision into \`scanShellSyntaxChar\` and the metacharacter set into a \`COMPLEX_SHELL_CHARS\` Set, called from a thin \`while\` loop. No behavior change.

## Test plan
- [x] \`tests/hooks/pre-bash-crusher-rewrite.test.js\`: 23/23 passing
- [x] \`tests/lib/install-targets.test.js\` (importer): 158/158 passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut cognitive complexity in `hasComplexShellSyntax` by extracting a per-character scanner and a metacharacter set. No behavior change; resolves the SonarCloud CRITICAL in the pre-bash-crusher-rewrite hook.

- **Refactors**
  - Added `scanShellSyntaxChar(cmd, i, quote)` and rewrote `hasComplexShellSyntax` to a simple while loop.
  - Centralized metacharacters in `COMPLEX_SHELL_CHARS` for clarity.

<sup>Written for commit 63a6a04872eb17981bb5305dc53572d87d56e059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

