### PR TITLE
refactor: extract heredoc quoted-span parser in shell-split.js to cut cognitive complexity

### DIFF
--- a/scripts/lib/shell-split.js
+++ b/scripts/lib/shell-split.js
@@ -59,6 +59,40 @@ const HEREDOC_WORD_STOP_RE = /[\s;&|()<>]/;
 // be concatenated (`EO"F"1` is the word `EOF1`). Returns null on an
 // unterminated quote (malformed input — the caller must not guess a
 // delimiter out of it) or if no word is present at all.
+// Parses a single quoted span (`'...'` or `"..."`) inside a heredoc
+// delimiter word, starting right after the opening quote at `start`.
+// Bash only strips the backslash inside "..." when it precedes one of
+// these five characters; before anything else the backslash is kept
+// literally in the string. Always stripping it (as this used to) computed
+// a too-short delimiter value for forms like <<"EO\NF" (backslash-N is not
+// special), so the real terminator line — which bash resolves to the
+// correct, longer value including the literal backslash — never matched,
+// and the heredoc body never closed. Returns `closed: false` if the
+// command ends before the closing quote is found.
+function parseHeredocQuotedSpan(command, quoteChar, start) {
+  let j = start;
+  let inner = '';
+  let closed = false;
+  while (j < command.length) {
+    const c = command[j];
+    if (quoteChar === '"' && c === '\\' && j + 1 < command.length) {
+      const escaped = command[j + 1];
+      if (escaped === '$' || escaped === '`' || escaped === '"' || escaped === '\\' || escaped === '\n') {
+        inner += escaped;
+        j += 2;
+      } else {
+        inner += c;
+        j += 1;
+      }
+      continue;
+    }
+    if (c === quoteChar) { closed = true; j += 1; break; }
+    inner += c;
+    j += 1;
+  }
+  return { inner, closed, nextIndex: j };
+}
+
 function parseHeredocDelimiterWord(command, start) {
   let i = start;
   let value = '';
@@ -84,39 +118,11 @@ function parseHeredocDelimiterWord(command, start) {
       // EOF-1 truncation bug above, just via escaping instead of a
       // narrow character class). Single quotes have no escape mechanism in
       // bash (the first `'` always closes), so only `"` needs this.
-      const quoteChar = ch;
-      let j = i + 1;
-      let inner = '';
-      let closed = false;
-      while (j < command.length) {
-        const c = command[j];
-        if (quoteChar === '"' && c === '\\' && j + 1 < command.length) {
-          const escaped = command[j + 1];
-          // Bash only strips the backslash inside "..." when it precedes
-          // one of these five characters; before anything else the
-          // backslash is kept literally in the string. Always stripping it
-          // (as this used to) computed a too-short delimiter value for
-          // forms like <<"EO\NF" (backslash-N is not special), so the real
-          // terminator line — which bash resolves to the correct, longer
-          // value including the literal backslash — never matched, and the
-          // heredoc body never closed.
-          if (escaped === '$' || escaped === '`' || escaped === '"' || escaped === '\\' || escaped === '\n') {
-            inner += escaped;
-            j += 2;
-          } else {
-            inner += c;
-            j += 1;
-          }
-          continue;
-        }
-        if (c === quoteChar) { closed = true; j += 1; break; }
-        inner += c;
-        j += 1;
-      }
-      if (!closed) return null;
-      value += inner;
+      const span = parseHeredocQuotedSpan(command, ch, i + 1);
+      if (!span.closed) return null;
+      value += span.inner;
       literal = true;
-      i = j;
+      i = span.nextIndex;
       consumedAny = true;
       continue;
     }


### PR DESCRIPTION
## Summary
- SonarCloud CRITICAL cleanup: \`parseHeredocDelimiterWord\` (cognitive complexity 30) nested a full quote-scan loop inside its own word-scan loop. Unlike \`splitShellSegments\` and \`extractSubstitutionBodies\` in the same file, this function is not \`// NOSONAR\`-suppressed, so it's the actual flagged finding.
- Extracted the quoted-span scan into \`parseHeredocQuotedSpan\`. No behavior change -- every escaping/quoting comment from the original is preserved verbatim on the extracted function.

## Test plan
- [x] \`tests/lib/shell-split.test.js\`: 83/83 passing
- [x] \`tests/hooks/pre-bash-guardian-validate.test.js\` (the main Guardian command validator, imports this module): 22/22 passing (3 pre-existing skips, unrelated -- missing egc-guardian build)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored heredoc delimiter parsing by extracting the quoted-span scan into `parseHeredocQuotedSpan` to cut cognitive complexity in `parseHeredocDelimiterWord`. No behavior changes; all tests pass.

- **Refactors**
  - Added `parseHeredocQuotedSpan` in `scripts/lib/shell-split.js` to parse `'...'` and `"..."` spans with Bash-accurate escape handling inside double quotes.
  - `parseHeredocDelimiterWord` now delegates quoted spans to the helper and continues to return `null` for unterminated quotes.

<sup>Written for commit b2f5a293f7b268217091695dedbf77836421d593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

