### PR TITLE
refactor: extract processBlock/recordMissedOpportunity in discover.js to cut cognitive complexity

### DIFF
--- a/scripts/discover.js
+++ b/scripts/discover.js
@@ -64,6 +64,34 @@ function textOfResult(content) {
   return '';
 }
 
+function recordMissedOpportunity(cmd, output, opportunities) {
+  const alreadyCrushed = /(?:^|\s)egc\s+run\s/.test(cmd);
+  if (alreadyCrushed) return;
+  const kind = commandKind(cmd);
+  if (kind === 'generic') return;
+  const bytes = Buffer.byteLength(output, 'utf8');
+  if (bytes < MIN_BYTES_TO_CRUSH) return;
+  const tokens = estimateTokens(output);
+  const missed = Math.round(tokens * (CRUSH_RATIO[kind] || 0.7));
+  const agg = opportunities.get(kind) || { runs: 0, tokens: 0, missed: 0 };
+  agg.runs += 1;
+  agg.tokens += tokens;
+  agg.missed += missed;
+  opportunities.set(kind, agg);
+}
+
+function processBlock(block, pending, opportunities) {
+  if (block.type === 'tool_use' && block.name === 'Bash' && block.input && block.input.command) {
+    pending.set(block.id, block.input.command);
+    return;
+  }
+  if (block.type === 'tool_result' && pending.has(block.tool_use_id)) {
+    const cmd = pending.get(block.tool_use_id);
+    pending.delete(block.tool_use_id);
+    recordMissedOpportunity(cmd, textOfResult(block.content), opportunities);
+  }
+}
+
 function analyzeFile(file, opportunities) {
   let lines;
   try {
@@ -83,26 +111,7 @@ function analyzeFile(file, opportunities) {
     const content = obj && obj.message && obj.message.content;
     if (!Array.isArray(content)) continue;
     for (const block of content) {
-      if (block.type === 'tool_use' && block.name === 'Bash' && block.input && block.input.command) {
-        pending.set(block.id, block.input.command);
-      } else if (block.type === 'tool_result' && pending.has(block.tool_use_id)) {
-        const cmd = pending.get(block.tool_use_id);
-        pending.delete(block.tool_use_id);
-        const alreadyCrushed = /(?:^|\s)egc\s+run\s/.test(cmd);
-        if (alreadyCrushed) continue;
-        const kind = commandKind(cmd);
-        if (kind === 'generic') continue;
-        const output = textOfResult(block.content);
-        const bytes = Buffer.byteLength(output, 'utf8');
-        if (bytes < MIN_BYTES_TO_CRUSH) continue;
-        const tokens = estimateTokens(output);
-        const missed = Math.round(tokens * (CRUSH_RATIO[kind] || 0.7));
-        const agg = opportunities.get(kind) || { runs: 0, tokens: 0, missed: 0 };
-        agg.runs += 1;
-        agg.tokens += tokens;
-        agg.missed += missed;
-        opportunities.set(kind, agg);
-      }
+      processBlock(block, pending, opportunities);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Part of the SonarCloud CRITICAL cognitive-complexity cleanup campaign
- `analyzeFile`'s inner loop mixed tool_use/tool_result block classification with a 4-guard-clause opportunity aggregator
- Extracted `processBlock` and `recordMissedOpportunity`; the loop body is now a single call, no behavior change

## Test plan
- [x] `node tests/crusher-gain-discover.test.js` passes locally (4/4)
- [ ] CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `scripts/discover.js` by extracting `processBlock` and `recordMissedOpportunity` to cut cognitive complexity in the `analyzeFile` inner loop. No behavior change; the loop now delegates to a single `processBlock` call, supporting the SonarCloud critical cleanup.

<sup>Written for commit ef0bcbca18f51f5bf6c20cc2effb3ad8760a6a0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

