### PR TITLE
refactor: extract readExistingStateOrRecover in index.ts to cut cognitive complexity

### DIFF
--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -1238,6 +1238,26 @@ function readGlobalAppendix(projectContent: string): string | null {
   }
 }
 
+// Shared by both update_state paths (global and project-scoped): read the
+// existing doc, or -- only with force:true, and only when the file actually
+// exists -- quarantine an undecryptable one and continue from an empty doc.
+// Without force, an undecryptable file must abort the write rather than be
+// silently treated as empty, or a stale/rotated key would blank out memory
+// that is still there, just unreadable with the current key.
+function readExistingStateOrRecover(filePath: string, force: boolean | undefined, label: 'global' | 'project'): Record<string, string[]|string> {
+  try {
+    return readStateDoc(filePath);
+  } catch (err) {
+    if (force && fs.existsSync(filePath)) {
+      const backupPath = quarantineUndecryptableStateFile(filePath);
+      log('WARN', `update_state: force=true, undecryptable ${label} state backed up and replaced`, { file: filePath, backup: backupPath, error: String(err) });
+      return {};
+    }
+    log('ERROR', `[EGC encryption] Cannot read existing ${label} state, aborting update to prevent data loss`, { file: filePath, error: String(err) });
+    throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing ${label === 'global' ? 'global ' : ''}state file. The encryption key may have changed. Path: ${filePath}. Retry with force: true to back up the unreadable file and start fresh -- only do this after confirming the failure is persistent, not a transient lock from another process.`);
+  }
+}
+
 async function handleUpdateState(db: Database, toolArgs: unknown) {
   const args = UpdateStateSchema.parse(toolArgs || {});
   if (args.context) {
@@ -1270,18 +1290,7 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
   if (args.scope === 'global') {
     const globalFile = getGlobalStateFile();
     return withStateMergeLock(globalFile, async () => {
-      let existingGlobal: Record<string, string[]|string> = {};
-      try {
-        existingGlobal = readStateDoc(globalFile);
-      } catch (err) {
-        if (args.force && fs.existsSync(globalFile)) {
-          const backupPath = quarantineUndecryptableStateFile(globalFile);
-          log('WARN', 'update_state: force=true, undecryptable global state backed up and replaced', { file: globalFile, backup: backupPath, error: String(err) });
-        } else {
-          log('ERROR', '[EGC encryption] Cannot read existing global state, aborting update to prevent data loss', { file: globalFile, error: String(err) });
-          throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing global state file. The encryption key may have changed. Path: ${globalFile}. Retry with force: true to back up the unreadable file and start fresh.`);
-        }
-      }
+      const existingGlobal = readExistingStateOrRecover(globalFile, args.force, 'global');
       writeStateDoc(globalFile, 'global', args, existingGlobal, null);
       const writtenGlobal = readStateFile(globalFile, getEncKey());
       writeHmac(globalFile, writtenGlobal, getIntegrityKey());
@@ -1298,19 +1307,7 @@ async function handleUpdateState(db: Database, toolArgs: unknown) {
   // reintroduce the lost-update race between concurrent sessions.
   await withStateMergeLock(filePath, async () => {
     const resolved = resolveStateRead(getStateDir(), projPath, branch);
-    let existing: Record<string, string[]|string>;
-    try {
-      existing = readStateDoc(resolved.filePath);
-    } catch (err) {
-      if (args.force && fs.existsSync(resolved.filePath)) {
-        const backupPath = quarantineUndecryptableStateFile(resolved.filePath);
-        log('WARN', 'update_state: force=true, undecryptable state file backed up and replaced', { file: resolved.filePath, backup: backupPath, error: String(err) });
-        existing = {};
-      } else {
-        log('ERROR', '[EGC encryption] Cannot read existing state — aborting update to prevent data loss', { file: resolved.filePath, error: String(err) });
-        throw new McpError(ErrorCode.InternalError, `Failed to decrypt existing state file. The encryption key may have changed. Path: ${resolved.filePath}. Retry with force: true to back up the unreadable file and start fresh — only do this after confirming the failure is persistent, not a transient lock from another process.`);
-      }
-    }
+    const existing = readExistingStateOrRecover(resolved.filePath, args.force, 'project');
 
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     writeStateDoc(filePath, projPath, args, existing, branch);


### PR DESCRIPTION
## Summary
- Part of the SonarCloud CRITICAL cognitive-complexity cleanup campaign (last of the 17 flagged findings)
- `handleUpdateState` duplicated the same read/undecryptable-recovery try/catch/if for the global-scope and project-scope write paths
- Extracted a shared `readExistingStateOrRecover` helper; removes the duplication along with the nested branching from both call sites, no behavior change

## Test plan
- [x] `tsc --noEmit` clean
- [x] `node tests/egc-memory-multi-session.e2e.test.js` passes locally (16/16), including the sequential and concurrent `update_state` cases that exercise this exact code path
- [ ] CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `readExistingStateOrRecover` helper and used it in both global and project `update_state` paths. This removes duplicated read/recovery logic, reduces cognitive complexity, and keeps behavior unchanged.

- **Refactors**
  - Adds `readExistingStateOrRecover(filePath, force, label)` and calls it from both paths.
  - Unifies `force` handling and logging for undecryptable files; no behavior changes.

<sup>Written for commit 2c2b08c37272c6f388ec9d2f4195d9609f04b337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

