### PR TITLE
docs(skills): remove nonexistent v1.8 version references in loop-skill deprecation note

### DIFF
--- a/skills/ai/autonomous-loops/SKILL.md
+++ b/skills/ai/autonomous-loops/SKILL.md
@@ -6,8 +6,8 @@ origin: EGC
 
 # Autonomous Loops Skill
 
-> Compatibility note (v1.8.0): `autonomous-loops` is retained for one release.
-> The canonical skill name is now `continuous-agent-loop`. New loop guidance
+> Compatibility note: `autonomous-loops` is kept as a legacy alias. The
+> canonical skill name is `continuous-agent-loop`. New loop guidance
 > should be authored there, while this skill remains available to avoid
 > breaking existing workflows.
 

--- a/skills/devops/continuous-agent-loop/SKILL.md
+++ b/skills/devops/continuous-agent-loop/SKILL.md
@@ -6,7 +6,7 @@ origin: EGC
 
 # Continuous Agent Loop
 
-This is the v1.8+ canonical loop skill name. It supersedes `autonomous-loops` while keeping compatibility for one release.
+This is the canonical loop skill name. It supersedes `autonomous-loops`, which is kept as a legacy alias for compatibility.
 
 ## Loop Selection Flow
 


### PR DESCRIPTION
## Summary
- Part of the EGC-540 catalog audit backlog
- `autonomous-loops` and `continuous-agent-loop` both cited a "v1.8.0" one-release compatibility window for the alias
- EGC has never shipped a 1.8.x release (current: 1.1.17); the promised removal trigger never had a version to fire on, so the alias silently became permanent while the docs kept citing a nonexistent release
- Reworded both notes to describe the alias as an ongoing legacy shim instead of a broken time-boxed promise

## Test plan
- [x] `node tests/ci/catalog.test.js` passes locally (7/7)
- [x] `node tests/ci/skill-index-integrity.test.js` passes locally (3/3)
- [ ] CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies loop-skill docs by removing the nonexistent v1.8 reference and stating that `autonomous-loops` is a legacy alias for `continuous-agent-loop` (not time-boxed). Addresses Linear EGC-540 by aligning the deprecation note with actual releases.

<sup>Written for commit 48a2b45e90c36f80638c5895b66e757cb9febd54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

