### PR TITLE
chore(deps): npm audit fix for brace-expansion and fast-uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,9 +1310,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2268,9 +2268,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Fixes two high-severity transitive dev advisories currently failing the `Security Scan / npm audit` check on every open PR (verified: also failing on `main`).
- `brace-expansion` 5.0.8 -> 5.0.9: DoS via unbounded intermediate arrays (GHSA-rgw5-rvv9-x895)
- `fast-uri` 3.1.4 -> 3.1.5: host confusion via backslash authority introducer (GHSA-7p8r-x3mc-p8w7)
- Both come in through eslint's dependency tree (dev-only), not the package's own dependencies. No `package.json` range changed, lockfile-only bump.

## Test plan
- [x] `npm audit --audit-level=high` reports 0 vulnerabilities after the fix
- [x] `npm ci` installs cleanly from the updated lockfile

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lockfile-only bump of `brace-expansion` to 5.0.9 and `fast-uri` to 3.1.5 to fix high-severity advisories and stop failing npm audit checks in CI. Dev-only via ESLint; no `package.json` changes or runtime impact.

- **Dependencies**
  - `brace-expansion` 5.0.8 → 5.0.9 (GHSA-rgw5-rvv9-x895)
  - `fast-uri` 3.1.4 → 3.1.5 (GHSA-7p8r-x3mc-p8w7)

<sup>Written for commit 97cb411e7afb2184aa4688594b5e0361957ca92f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

