### PR TITLE
chore(deps): npm audit fix across fuzz/ and MCP server lockfiles

### DIFF
--- a/fuzz/package-lock.json
+++ b/fuzz/package-lock.json
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/fuzz/package.json
+++ b/fuzz/package.json
@@ -16,6 +16,6 @@
     "cross-spawn": "^7.0.6",
     "uuid": "^11.1.1",
     "js-yaml": "^4.2.0",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }

--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -882,9 +882,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1903,9 +1903,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -1101,7 +1101,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -20,6 +20,7 @@
   },
   "overrides": {
     "undici": "^6.27.0",
-    "@hono/node-server": "^2.0.5"
+    "@hono/node-server": "^2.0.5",
+    "ip-address": "^10.4.0"
   }
 }

--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -21,6 +21,6 @@
   "overrides": {
     "undici": "^6.27.0",
     "@hono/node-server": "^2.0.5",
-    "ip-address": "^10.4.0"
+    "ip-address": "10.4.0"
   }
 }

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -1255,9 +1255,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -998,9 +998,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2221,9 +2221,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -23,6 +23,7 @@
   },
   "overrides": {
     "undici": "^6.27.0",
-    "@hono/node-server": "^2.0.5"
+    "@hono/node-server": "^2.0.5",
+    "ip-address": "^10.4.0"
   }
 }

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -24,6 +24,6 @@
   "overrides": {
     "undici": "^6.27.0",
     "@hono/node-server": "^2.0.5",
-    "ip-address": "^10.4.0"
+    "ip-address": "10.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #1175, which only fixed the root lockfile. A sweep of all 7 lockfiles in the monorepo found 3 more with open high-severity advisories:
  - `fuzz/`: `brace-expansion` was pinned to 5.0.8 via an `overrides` entry from an earlier advisory fix -- that exact pin is now the vulnerable version (GHSA-rgw5-rvv9-x895). Bumped the override to 5.0.9.
  - `mcp/servers/egc-memory/`, `mcp/servers/egc-guardian/`: `fast-uri` host confusion (GHSA-7p8r-x3mc-p8w7) + a moderate `undici` advisory, both cleared by `npm audit fix`.
- Verified `npm audit --audit-level=high` reports 0 vulnerabilities across all 7 lockfiles (`.`, `dashboard/`, `docker/`, `fuzz/`, `.opencode/`, `mcp/servers/egc-memory/`, `mcp/servers/egc-guardian/`).

## Test plan
- [x] `npm audit --audit-level=high --package-lock-only` -> 0 vulnerabilities in all 7 lockfiles
- [x] `mcp/servers/egc-memory`: `npm ci && npm run build` (tsc) clean
- [x] `mcp/servers/egc-guardian`: `npm ci && npm run build` (tsc) clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes high-severity advisories in non-root lockfiles by updating `brace-expansion`, `fast-uri`, `undici`, and pinning `ip-address` to exact 10.4.0. `npm audit --audit-level=high` now reports 0 vulnerabilities across all 7 lockfiles; both MCP servers build clean.

- **Dependencies**
  - fuzz/: `brace-expansion` 5.0.8 → 5.0.9 (fix GHSA-rgw5-rvv9-x895).
  - mcp/servers/egc-memory and mcp/servers/egc-guardian: `fast-uri` 3.1.4 → 3.1.5 (fix GHSA-7p8r-x3mc-p8w7); `undici` 6.27.0 → 6.28.0.
  - mcp/servers/egc-memory and mcp/servers/egc-guardian: override `ip-address` to 10.4.0 to clear SSRF advisories and prevent drift.

<sup>Written for commit 7ff31d02f7bbd3f49bd3804627cd659ad34ebebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

