### PR TITLE
fix(deps): pin hono to 4.12.34 to close a ReDoS advisory

### DIFF
--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -1034,9 +1034,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -21,6 +21,7 @@
   "overrides": {
     "undici": "^6.27.0",
     "@hono/node-server": "^2.0.5",
-    "ip-address": "10.4.0"
+    "ip-address": "10.4.0",
+    "hono": "4.12.34"
   }
 }

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -1178,9 +1178,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -24,6 +24,7 @@
   "overrides": {
     "undici": "^6.27.0",
     "@hono/node-server": "^2.0.5",
-    "ip-address": "10.4.0"
+    "ip-address": "10.4.0",
+    "hono": "4.12.34"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2583,9 +2583,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "js-yaml": "^4.2.0",
     "markdown-it": "^14.2.0",
     "undici": "^6.27.0",
-    "@hono/node-server": "^2.0.5"
+    "@hono/node-server": "^2.0.5",
+    "hono": "4.12.34"
   },
   "pnpm": {
     "overrides": {
@@ -139,7 +140,8 @@
       "markdownlint-cli>js-yaml": "^4.2.0",
       "markdown-it": "^14.2.0",
       "undici": "^6.27.0",
-      "@hono/node-server": "^2.0.5"
+      "@hono/node-server": "^2.0.5",
+      "hono": "4.12.34"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #1180. Dependabot surfaced a new advisory right after that PR merged: `hono` 4.12.32 (transitive via `@modelcontextprotocol/sdk` -> `@hono/node-server`, plus a direct entry in the root lockfile) has a ReDoS in its CORS middleware via `Access-Control-Request-Headers` (medium severity).
- Pinned to `4.12.34` (first patched version) via `overrides`, same style already used for `ip-address` in these three lockfiles: root `package.json`, `mcp/servers/egc-memory/package.json`, `mcp/servers/egc-guardian/package.json`.

## Test plan
- [x] `npm audit --audit-level=high --package-lock-only` -> 0 vulnerabilities in all 3 lockfiles
- [x] `mcp/servers/egc-memory`: `npm ci && npm run build` (tsc) clean
- [x] `mcp/servers/egc-guardian`: `npm ci && npm run build` (tsc) clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `hono` to `4.12.34` via `overrides` to fix a ReDoS in the CORS middleware and clear the advisory. This removes the vuln and keeps both MCP servers building clean.

- **Dependencies**
  - Added `hono: 4.12.34` to `overrides` in `package.json`, `mcp/servers/egc-memory/package.json`, and `mcp/servers/egc-guardian/package.json`; updated lockfiles.
  - Verified `npm audit --audit-level=high` shows 0 vulns; `npm ci && npm run build` passes for both servers.

<sup>Written for commit 546958ecc7f5eef7aa6043631378f5822d7635d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

