### PR TITLE
docs(readme): add hook-coverage caveat to the Guardian bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install -g @egchq/egc && egc install
 ```
 
 - **Reduce context waste by up to 90%, cut token costs, and keep every AI perfectly aligned across sessions.**
-- **Guardian: validate every command before execution and block dangerous writes. Every shared brain comes with a built-in safety layer.**
+- **Guardian: validate every command before execution and block dangerous writes. Every shared brain comes with a built-in safety layer.** ([coverage depends on each tool's hook support](docs/security/SECURITY-ASSESSMENT.md#known-limitations))
 - **One command, zero config: memory stays local and encrypted on your machine, and never gets committed to git.**
 
 <div align="center">


### PR DESCRIPTION
## Summary
- Follow-up to the 2026-08-01 README-vs-code audit. The detailed Guardian section already links to the Security Assessment's known-limitations (tools without hook support), but the short install-page bullet was still an unqualified "validate every command" claim.
- Adds the same caveat inline so the summary at the top of the README matches the detailed section instead of overstating coverage.
- Note: the other flagged claim ("detect prompt injection") and the EGC-512 regex gap were already fixed in earlier sessions this week -- verified against current code, not re-fixed here.

## Test plan
- [x] `node scripts/ci/catalog.js` -- all counts still `ok: true`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Guardian claim in the README by adding an inline caveat that coverage depends on each tool’s hook support, with a link to the known limitations. This aligns the install-page summary with the detailed Security Assessment and avoids overstating coverage.

<sup>Written for commit be0de1945677578b4264adeeb639a23d2539252e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

