### PR TITLE
fix: make build chmod cross-platform

### DIFF
--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -5,7 +5,7 @@
   "description": "EGC Guardian MCP Server: validation, context reduction, and task orchestration",
   "main": "build/index.js",
   "scripts": {
-    "build": "node ../../../scripts/build-skill-index.js && tsc && chmod +x build/index.js",
+    "build": "node ../../../scripts/build-skill-index.js && tsc && node -e \"require('node:fs').chmodSync('build/index.js', 0o755)\"",
     "start": "node build/index.js"
   },
   "dependencies": {

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -4,7 +4,7 @@
   "description": "EGC Memory MCP Server: persistent cross-session project state and decision history",
   "main": "build/index.js",
   "scripts": {
-    "build": "tsc && chmod +x build/index.js",
+    "build": "tsc && node -e \"require('node:fs').chmodSync('build/index.js', 0o755)\"",
     "start": "node build/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
## O que a branch entrega

Torna o `npm run build` dos dois servidores MCP cross-platform. Hoje a chain termina em `chmod +x build/index.js`, comando que nao existe no Windows.

## O problema

O `tsc` ja compilou quando a chain quebra, entao o build sai **integro mas com exit 1**. O artefato esta bom e o comando reporta falha.

Esse e o risco real, e nao e o build: um build que falha vermelho com artefato bom ensina todo mundo a ignorar o exit code, e a proxima falha de verdade passa batido. Em CI, significa que o job so nao quebra por sorte de plataforma.

## A correcao

`chmod +x build/index.js` vira `node -e "require('node:fs').chmodSync('build/index.js', 0o755)"`.

- **Sem dependencia nova.** `fs.chmodSync` e stdlib. Descartei `shx` justamente por isso.
- **Seguro no Windows.** Nao lanca, apenas nao tem efeito util, que e exatamente o comportamento desejado ali.
- **Preserva o Unix.** Os dois fontes tem `#!/usr/bin/env node` no topo, entao o bit de execucao e intencional. Simplesmente remover o `chmod` teria trocado um bug barulhento por um silencioso.

## Escopo

Corrigido nos **dois** servidores, `egc-guardian` e `egc-memory`, nao so onde o problema apareceu. O memory tinha a mesma linha e teria continuado quebrado.

## Verificacao

`npm run build` com **exit 0** nos dois servidores, no Windows, em cima desta base. Um diff de 2 linhas.

## Fora de escopo, de proposito

Durante a investigacao o `egc-memory` falhava tambem com `TS5108: moduleResolution=node10 has been removed`. Confirmei que era staleness da base antiga: apos rebase na `main` atual, com a migracao do TypeScript 7 (#689) ja integrada, o erro nao ocorre mais. Nada a fazer aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the MCP server build scripts cross-platform by replacing `chmod +x` with a Node `fs.chmodSync` call. Fixes Windows builds that compiled but exited with code 1.

- **Bug Fixes**
  - Replaced `chmod +x build/index.js` with `node -e "require('node:fs').chmodSync('build/index.js', 0o755)"` in `egc-guardian` and `egc-memory`.
  - No new deps; uses Node stdlib.
  - Windows: no error, benign no-op. Unix: keeps exec bit for shebang.
  - Builds now exit 0 when `tsc` succeeds, avoiding false CI failures.

<sup>Written for commit 6d90c5986ab5c20664ecf3f21507cebb1fc0997e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the build process to set executable permissions consistently across supported platforms.
  * Reduced reliance on platform-specific command-line utilities during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->