### PR TITLE
feat: add lazy-code ladder to rules and a routed lazy-code skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The brain doesn't just remember: it filters. Before any shell output reaches the
 
 ## Prompt Library
 
-As a bonus, EGC gives you access to 61 agents, 230 skills, and 77 commands, plus 109 rules: specialists that review your code on their own, best-practice guides for every language and situation, shortcuts that run a whole sequence of tasks for you, and style rules that keep your code consistent. All written from real engineering sessions, not theory. Don't want to use any of it? Fine: EGC's persistent memory works exactly the same.
+As a bonus, EGC gives you access to 61 agents, 231 skills, and 77 commands, plus 109 rules: specialists that review your code on their own, best-practice guides for every language and situation, shortcuts that run a whole sequence of tasks for you, and style rules that keep your code consistent. All written from real engineering sessions, not theory. Don't want to use any of it? Fine: EGC's persistent memory works exactly the same.
 
 ---
 

--- a/mcp/servers/egc-guardian/src/catalog-index.ts
+++ b/mcp/servers/egc-guardian/src/catalog-index.ts
@@ -712,6 +712,11 @@ export const CATALOG: ReadonlyArray<{ kind: 'agent' | 'skill' | 'rule'; name: st
   },
   {
     "kind": "skill",
+    "name": "lazy-code",
+    "description": "Use this skill when writing, adding, refactoring, fixing, or reviewing code, and when choosing a library or dependency. Forces the smallest solution that actually works: question whether the task needs to exist (YAGNI), reuse what the codebase already has, reach for the standard library and native platform features before custom code and before new dependencies, one line before fifty. Also use when the user says \"be lazy\", \"simplest solution\", \"minimal solution\", \"do less\", \"shortest path\", or complains about over-engineering, bloat, boilerplate, or unnecessary dependencies. Supports intensity levels lite, full, and ultra. Do NOT use for non-coding requests such as research, investigation, documentation, prose, translation, or summaries, where the ruleset is pure token cost with no code to shrink."
+  },
+  {
+    "kind": "skill",
     "name": "healthcare-emr-patterns",
     "description": "EMR/EHR development patterns for healthcare applications. Clinical safety, encounter workflows, prescription generation, clinical decision support integration, and accessibility-first UI for medical data entry."
   },

--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -12,6 +12,40 @@ CORRECT: update(original, field, value) → returns new copy with change
 
 Rationale: Immutable data prevents hidden side effects, makes debugging easier, and enables safe concurrency.
 
+## The Ladder (decide BEFORE writing)
+
+KISS, DRY, and YAGNI below say *what* to value. The ladder says *when to stop*. Run it
+before writing code, and stop at the first rung that holds:
+
+1. Does this need to be built at all? Speculative need means skip it, and say so in one line.
+2. Does it already exist in this codebase? A helper, util, type, or pattern already here gets
+   reused, not re-written. Re-implementing what lives a few files over is the most common waste.
+3. Does the standard library do this? Use it.
+4. Does a native platform feature cover it? A native input control over a component library,
+   a declarative style rule over scripting, a database constraint over application code.
+5. Does an already-installed dependency solve it? Use it. Never add a new dependency for what
+   a few lines can do.
+6. Can it be one line? Make it one line.
+7. Only then: write the minimum code that works.
+
+The ladder runs **after** you understand the problem, never instead of it. Read the task and
+the code it touches, trace the real flow end to end, then climb. The smallest change in the
+wrong place is not efficient, it is a second bug.
+
+**Precedence:** the ladder decides *whether and how much* code gets written. Every other rule
+in this file decides *what that code looks like once it exists*. They do not compete: a rung
+that says "do not build it" ends the question, and once you are writing, the style rules below
+are binding in full.
+
+**Bug fix means root cause, not symptom.** A report names a symptom. Before editing, find every
+caller of the function you are about to touch. One guard in the shared function is a smaller
+diff than one guard per caller, and patching only the path the ticket names leaves sibling
+callers broken.
+
+**Mark deliberate shortcuts.** A simplification that cuts a real corner with a known ceiling
+(a global lock, a quadratic scan, a naive heuristic) gets a comment naming the ceiling and the
+upgrade path, so the next reader inherits the decision instead of the mystery.
+
 ## Core Principles
 
 ### KISS (Keep It Simple)
@@ -40,6 +74,12 @@ MANY SMALL FILES > FEW LARGE FILES:
 - Extract utilities from large modules
 - Organize by feature/domain, not by type
 
+**This governs existing structure, not new work.** The two are easy to read as contradictory,
+so the split is explicit: a change adds the fewest files it can, and an existing file is split
+once it actually crosses the threshold above. Scattering a small change across several new
+files to look modular is the failure mode this rule does not license. Splitting an 800-line
+module that genuinely grew is the one it requires.
+
 ## Error Handling
 
 ALWAYS handle errors comprehensively:
@@ -55,6 +95,29 @@ ALWAYS validate at system boundaries:
 - Use schema-based validation where available
 - Fail fast with clear error messages
 - Never trust external data (API responses, user input, file content)
+
+## Never Simplified Away
+
+The ladder shortens the solution. It never shortens this list, and "it was one line" is not a
+defence for anything below:
+
+- Input validation at trust boundaries (see Input Validation above)
+- Error handling that prevents data loss (see Error Handling above)
+- Security controls and authorization checks
+- Accessibility basics
+- Calibration that real hardware needs, because a physical clock drifts and a physical sensor
+  reads off, and a minimal model cannot see that
+- Anything the user explicitly asked to keep. If the user wants the full version, build it and
+  do not re-argue.
+
+Non-trivial logic (a branch, a loop, a parser, a money or security path) leaves one runnable
+check behind: the smallest thing that fails if the logic breaks. Trivial one-liners need none,
+YAGNI applies to tests too.
+
+This list exists because "prefer shorter code" without it measurably drops guards: in the
+benchmark this ladder is derived from, the arm given only "prefer one-liner solutions" wrote
+the fewest lines and was the only one to let a path-traversal input escape its base directory.
+The lines it saved were the check.
 
 ## Naming Conventions
 

--- a/scripts/lib/skill-index.json
+++ b/scripts/lib/skill-index.json
@@ -712,6 +712,11 @@
     },
     {
       "kind": "skill",
+      "name": "lazy-code",
+      "description": "Use this skill when writing, adding, refactoring, fixing, or reviewing code, and when choosing a library or dependency. Forces the smallest solution that actually works: question whether the task needs to exist (YAGNI), reuse what the codebase already has, reach for the standard library and native platform features before custom code and before new dependencies, one line before fifty. Also use when the user says \"be lazy\", \"simplest solution\", \"minimal solution\", \"do less\", \"shortest path\", or complains about over-engineering, bloat, boilerplate, or unnecessary dependencies. Supports intensity levels lite, full, and ultra. Do NOT use for non-coding requests such as research, investigation, documentation, prose, translation, or summaries, where the ruleset is pure token cost with no code to shrink."
+    },
+    {
+      "kind": "skill",
       "name": "healthcare-emr-patterns",
       "description": "EMR/EHR development patterns for healthcare applications. Clinical safety, encounter workflows, prescription generation, clinical decision support integration, and accessibility-first UI for medical data entry."
     },

--- a/skills/general/lazy-code/SKILL.md
+++ b/skills/general/lazy-code/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: lazy-code
+description: Use this skill when writing, adding, refactoring, fixing, or reviewing code, and when choosing a library or dependency. Forces the smallest solution that actually works: question whether the task needs to exist (YAGNI), reuse what the codebase already has, reach for the standard library and native platform features before custom code and before new dependencies, one line before fifty. Also use when the user says "be lazy", "simplest solution", "minimal solution", "do less", "shortest path", or complains about over-engineering, bloat, boilerplate, or unnecessary dependencies. Supports intensity levels lite, full, and ultra. Do NOT use for non-coding requests such as research, investigation, documentation, prose, translation, or summaries, where the ruleset is pure token cost with no code to shrink.
+origin: EGC
+---
+
+# Lazy Code: the smallest solution that actually works
+
+Lazy means efficient, not careless. The best code is the code never written.
+
+This is the deep version of the ladder in `rules/common/coding-style.md`. The rules file carries
+the ladder always-on because it is short. This skill carries what does not earn always-on space:
+intensity levels, the output contract, and worked examples.
+
+## When this skill pays, and when it costs
+
+It pays on tasks with room to over-build, where a custom component competes with a native
+platform feature. Measured on real agent sessions against a real repository: 54% fewer lines in
+aggregate, 22% fewer tokens, 20% lower cost, 27% less time.
+
+The aggregate hides the shape, and the shape is the useful part. On irreducible work such as a
+plain CRUD endpoint, every arm converged and the saving was roughly zero. On over-build traps it
+reached 94%, because the alternative to hand-building a date picker is one native input. It never
+produced more code than the baseline.
+
+It costs, with no return, on requests that are not code. That is why this is a routed skill and
+not a permanent instruction.
+
+**Provider note that decides whether to load this at all:** the saving is not universal. On
+reasoning models whose baseline output is already terse, an always-on ruleset is re-sent as input
+on every call and the input overhead outweighs the lines saved, turning a 20% saving into a
+26-39% loss. Load this per task, never as a standing preamble, and the inversion does not happen.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need means skip it, and say so in one line.
+2. **Already in this codebase?** Reuse the helper, util, type, or pattern that already lives
+   here. Look before you write. Re-implementing what sits a few files over is the most common waste.
+3. **Standard library does it?** Use it.
+4. **Native platform feature covers it?** A native input control over a component library, a
+   declarative style rule over scripting, a database constraint over application code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+Two rungs work, take the higher one and move on. The ladder is a reflex, not a research project.
+
+**It runs after comprehension, never instead of it.** Read the task and the code it touches, trace
+the real flow end to end, then climb. A small diff you do not understand is not efficiency, it is
+a confident wrong fix wearing efficiency as a costume.
+
+**Bug fix means root cause.** A report names a symptom. Find every caller of the function you are
+about to touch before editing. One guard in the shared function is a smaller diff than one guard
+per caller, and fixing only the path the ticket names leaves sibling callers broken.
+
+## Intensity
+
+| Level | Behaviour |
+|-------|-----------|
+| lite  | Build what was asked, then name the lazier alternative in one line. The user picks. |
+| full  | The ladder enforced. Standard library and native features first. Shortest diff, shortest explanation. Default. |
+| ultra | Deletion before addition. Ship the minimal version and challenge the rest of the requirement in the same response. |
+
+Worked example, for the request "add a cache for these API responses":
+
+- **lite:** ships the cache, then notes that the standard library's memoization decorator covers
+  this in one line if owning a cache class is not wanted.
+- **full:** applies the standard library memoization decorator with a size bound. Skips the custom
+  cache class, and says to add one when the built-in measurably falls short.
+- **ultra:** no cache until a profiler asks for one. When it does, the built-in decorator. A
+  hand-rolled expiry cache is a bug farm with a hit rate.
+
+## Output contract
+
+Code first. Then at most three short lines: what was skipped, and when to add it.
+
+If the explanation runs longer than the code, delete the explanation. Every paragraph defending a
+simplification is complexity smuggled back in as prose.
+
+Explanation the user explicitly asked for, such as a report, a walkthrough, or per-phase notes, is
+not debt. Give it in full. The rule is only against unrequested prose.
+
+A complex request gets the lazy version and the question in the same response, never a stall:
+build the smaller thing, then ask whether the larger thing is actually needed.
+
+## Never simplified away
+
+Input validation at trust boundaries, error handling that prevents data loss, security controls,
+authorization checks, accessibility basics, the calibration real hardware needs, and anything the
+user explicitly asked to keep. If the user insists on the full version, build it without re-arguing.
+
+Non-trivial logic leaves one runnable check behind: the smallest thing that fails if the logic
+breaks. No frameworks, no fixtures, no per-function suites unless asked. Trivial one-liners need
+no test, YAGNI applies to tests too.
+
+This list is not decoration. In the benchmark this skill derives from, the arm given only "prefer
+one-liner solutions" wrote the fewest lines and was the only arm to let a path-traversal input
+escape its base directory. The three lines it saved were the check. That is the entire difference
+between lazy and careless.
+
+## Attribution
+
+The ladder, the intensity levels, and the never-simplify list are adapted from
+[ponytail](https://github.com/DietrichGebert/ponytail) by Dietrich Gebert, MIT licensed. The
+benchmark figures cited here are from that project's published agentic evaluation. Adapted for
+EGC to be routed per task rather than always-on, which is what keeps the saving from inverting on
+non-Claude reasoning models.


### PR DESCRIPTION
## O que a branch entrega

Traz pro EGC a disciplina de "menor solucao que funciona" em **duas camadas**, para que ela valha em qualquer LLM que consuma o EGC, nao so no Claude.

Adaptado de [ponytail](https://github.com/DietrichGebert/ponytail) (MIT), com atribuicao nos dois arquivos.

## Por que duas camadas, e nao um ruleset unico

Essa e a decisao central da branch.

O ganho medido do ruleset original **nao e universal**. No benchmark publicado pelo proprio projeto de origem, em modelos de raciocinio cuja saida base ja e enxuta ele **inverte**: de ~20% mais barato para **26-39% mais caro**. A causa e estrutural e vale para qualquer LLM com esse perfil: um ruleset sempre-ligado e reenviado como input a cada chamada, e o overhead de input supera as linhas economizadas.

Portar como instrucao permanente teria feito o EGC custar mais caro exatamente nas LLMs que a branch pretende cobrir. Dai a separacao:

**Camada 1, sempre-ligada e curta** (`rules/common/coding-style.md`): a escada de decisao de 7 degraus e a lista "Never Simplified Away". Sao ~400 tokens marginais num arquivo que ja era carregado, e se distribuem sozinhos para Gemini, Cursor, Codex, opencode, trae e kiro pelo caminho que `rules/common/` ja tem.

**Camada 2, roteada** (`skills/general/lazy-code/`): intensidade, contrato de saida e exemplos, que e o volume. A `description` do frontmatter exclui request nao-codigo de proposito, porque e o texto que o `orchestrate_task` usa para rotear. Carregado por tarefa, a inversao nao acontece.

## Conflitos resolvidos, nao empilhados

A escada colide com regras que o `coding-style.md` ja tinha. Resolver isso foi o trabalho real da branch; empilhar sem resolver faz o agente obedecer a regra que vier por ultimo no contexto.

1. **"MANY SMALL FILES" contra "menor numero de arquivos"**: separados por escopo explicito. A regra de organizacao governa **estrutura existente**; a escada governa **trabalho novo**. Espalhar uma mudanca pequena em varios arquivos novos deixa de ser licenciado; dividir um modulo que cresceu de verdade continua exigido.
2. **Escada contra as regras de estilo**: precedencia declarada no proprio arquivo. A escada decide **se e quanto** codigo existe; o resto do `coding-style.md` decide **como** ele e escrito. Nao competem.

## Por que a lista "Never Simplified Away" nao e enfeite

No benchmark de origem, o braco que recebeu apenas "prefira solucoes de uma linha" escreveu **menos** linhas e foi o **unico** a deixar um input de path traversal escapar do diretorio base. As linhas que ele economizou eram a checagem. A lista e o que separa preguicoso de descuidado.

## Arquivos

- `rules/common/coding-style.md`: escada, precedencia, lista de nao-negociaveis
- `skills/general/lazy-code/SKILL.md`: skill roteada
- `catalog-index.ts` e `skills-index.json`: regerados por `scripts/build-skill-index.js`

## Verificacao

`tsc --noEmit` limpo e `npm run build` com exit 0 no `egc-guardian`; entrada `lazy-code` presente no catalogo compilado e no `skill-index.json`.

**Nao verificado, e vale dizer:** o roteamento discriminando codigo de nao-codigo. O `egc-guardian` carrega o catalogo quando o servidor MCP sobe, entao uma skill nova so passa a rotear na sessao seguinte. Vale um teste manual pos-merge com um prompt de codigo e um de investigacao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-layer “lazy code” discipline: a short always-on decision ladder in `rules/common/coding-style.md` and a routed `lazy-code` skill for code tasks. This keeps solutions minimal while avoiding extra token cost on non-code requests.

- **New Features**
  - Added a 7-step ladder to `rules/common/coding-style.md` with precedence, root-cause bug-fix guidance, “Mark deliberate shortcuts”, and a “Never Simplified Away” list. Clarifies “MANY SMALL FILES” (existing structure) vs new work (fewest files).
  - Introduced `skills/general/lazy-code` with intensity levels (lite/full/ultra), an output contract, and examples. Routed to load only for coding tasks. Updated `catalog-index.ts` and `scripts/lib/skill-index.json`.
  - Updated `README.md` to reflect 231 skills.

- **Migration**
  - Restart the `egc-guardian` MCP server to load the new skill.
  - Manually verify routing with one coding prompt and one non-coding prompt.

<sup>Written for commit ac9be49c2bbefcfdcaaafb56dd078add897e792c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

