### PR TITLE
chore: retarget agents to gemini-3.1-pro

### DIFF
--- a/agents/a11y-architect.md
+++ b/agents/a11y-architect.md
@@ -1,7 +1,7 @@
 ---
 name: a11y-architect
 description: Accessibility Architect specializing in WCAG 2.2 compliance for Web and Native platforms. Use PROACTIVELY when designing UI components, establishing design systems, or auditing code for inclusive user experiences.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 stack: ["*"]
 ---

--- a/agents/a11y-architect.md
+++ b/agents/a11y-architect.md
@@ -1,7 +1,7 @@
 ---
 name: a11y-architect
 description: Accessibility Architect specializing in WCAG 2.2 compliance for Web and Native platforms. Use PROACTIVELY when designing UI components, establishing design systems, or auditing code for inclusive user experiences.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 stack: ["*"]
 ---

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: REPO-OWNED ARCHITECT for system design, scalability, and technical decision-making. Use PROACTIVELY when planning new features, refactoring large systems, or making architectural decisions.
 tools: ["Read", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: REPO-OWNED ARCHITECT for system design, scalability, and technical decision-making. Use PROACTIVELY when planning new features, refactoring large systems, or making architectural decisions.
 tools: ["Read", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/build-error-resolver.md
+++ b/agents/build-error-resolver.md
@@ -2,7 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist. Use PROACTIVELY when build fails or type errors occur. Fixes build/type errors only with minimal diffs, no architectural edits. Focuses on getting the build green quickly.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/build-error-resolver.md
+++ b/agents/build-error-resolver.md
@@ -2,7 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist. Use PROACTIVELY when build fails or type errors occur. Fixes build/type errors only with minimal diffs, no architectural edits. Focuses on getting the build green quickly.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -2,7 +2,7 @@
 name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -2,7 +2,7 @@
 name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -1,7 +1,7 @@
 ---
 name: code-architect
 description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing implementation blueprints with concrete files, interfaces, data flow, and build order.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -1,7 +1,7 @@
 ---
 name: code-architect
 description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing implementation blueprints with concrete files, interfaces, data flow, and build order.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -1,7 +1,7 @@
 ---
 name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, and documenting dependencies to inform new development.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -1,7 +1,7 @@
 ---
 name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, and documenting dependencies to inform new development.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code. MUST BE USED for all code changes.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code. MUST BE USED for all code changes.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving behavior. Focus on recently modified code unless instructed otherwise.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 stack: ["*"]
 ---

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving behavior. Focus on recently modified code unless instructed otherwise.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 stack: ["*"]
 ---

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: comment-analyzer
 description: Analyze code comments for accuracy, completeness, maintainability, and comment rot risk.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: comment-analyzer
 description: Analyze code comments for accuracy, completeness, maintainability, and comment rot risk.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/conversation-analyzer.md
+++ b/agents/conversation-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: conversation-analyzer
 description: Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Triggered by /hookify without arguments.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Grep]
 stack: ["*"]
 ---

--- a/agents/conversation-analyzer.md
+++ b/agents/conversation-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: conversation-analyzer
 description: Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Triggered by /hookify without arguments.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Grep]
 stack: ["*"]
 ---

--- a/agents/cpp-build-resolver.md
+++ b/agents/cpp-build-resolver.md
@@ -2,7 +2,7 @@
 name: cpp-build-resolver
 description: C++ build, CMake, and compilation error resolution specialist. Fixes build errors, linker issues, and template errors with minimal changes. Use when C++ builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["cpp"]
 ---
 

--- a/agents/cpp-build-resolver.md
+++ b/agents/cpp-build-resolver.md
@@ -2,7 +2,7 @@
 name: cpp-build-resolver
 description: C++ build, CMake, and compilation error resolution specialist. Fixes build errors, linker issues, and template errors with minimal changes. Use when C++ builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["cpp"]
 ---
 

--- a/agents/cpp-reviewer.md
+++ b/agents/cpp-reviewer.md
@@ -2,7 +2,7 @@
 name: cpp-reviewer
 description: Expert C++ code reviewer specializing in memory safety, modern C++ idioms, concurrency, and performance. Use for all C++ code changes. MUST BE USED for C++ projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["cpp"]
 ---
 

--- a/agents/cpp-reviewer.md
+++ b/agents/cpp-reviewer.md
@@ -2,7 +2,7 @@
 name: cpp-reviewer
 description: Expert C++ code reviewer specializing in memory safety, modern C++ idioms, concurrency, and performance. Use for all C++ code changes. MUST BE USED for C++ projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["cpp"]
 ---
 

--- a/agents/csharp-reviewer.md
+++ b/agents/csharp-reviewer.md
@@ -2,7 +2,7 @@
 name: csharp-reviewer
 description: Expert C# code reviewer specializing in .NET conventions, async patterns, security, nullable reference types, and performance. Use for all C# code changes. MUST BE USED for C# projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["csharp"]
 ---
 

--- a/agents/csharp-reviewer.md
+++ b/agents/csharp-reviewer.md
@@ -2,7 +2,7 @@
 name: csharp-reviewer
 description: Expert C# code reviewer specializing in .NET conventions, async patterns, security, nullable reference types, and performance. Use for all C# code changes. MUST BE USED for C# projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["csharp"]
 ---
 

--- a/agents/dart-build-resolver.md
+++ b/agents/dart-build-resolver.md
@@ -2,7 +2,7 @@
 name: dart-build-resolver
 description: Dart/Flutter build, analysis, and dependency error resolution specialist. Fixes `dart analyze` errors, Flutter compilation failures, pub dependency conflicts, and build_runner issues with minimal, surgical changes. Use when Dart/Flutter builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["dart"]
 ---
 

--- a/agents/dart-build-resolver.md
+++ b/agents/dart-build-resolver.md
@@ -2,7 +2,7 @@
 name: dart-build-resolver
 description: Dart/Flutter build, analysis, and dependency error resolution specialist. Fixes `dart analyze` errors, Flutter compilation failures, pub dependency conflicts, and build_runner issues with minimal, surgical changes. Use when Dart/Flutter builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["dart"]
 ---
 

--- a/agents/database-reviewer.md
+++ b/agents/database-reviewer.md
@@ -2,7 +2,7 @@
 name: database-reviewer
 description: PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/database-reviewer.md
+++ b/agents/database-reviewer.md
@@ -2,7 +2,7 @@
 name: database-reviewer
 description: PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -2,7 +2,7 @@
 name: doc-updater
 description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-2.0-flash
 stack: ["*"]
 ---
 

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -2,7 +2,7 @@
 name: doc-updater
 description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.0-flash
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/docs-lookup.md
+++ b/agents/docs-lookup.md
@@ -2,7 +2,7 @@
 name: docs-lookup
 description: When the user asks how to use a library, framework, or API or needs up-to-date code examples, use Context7 MCP to fetch current documentation and return answers with examples. Invoke for docs/API/setup questions.
 tools: ["Read", "Grep", "mcp__context7__resolve-library-id", "mcp__context7__query-docs"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/docs-lookup.md
+++ b/agents/docs-lookup.md
@@ -2,7 +2,7 @@
 name: docs-lookup
 description: When the user asks how to use a library, framework, or API or needs up-to-date code examples, use Context7 MCP to fetch current documentation and return answers with examples. Invoke for docs/API/setup questions.
 tools: ["Read", "Grep", "mcp__context7__resolve-library-id", "mcp__context7__query-docs"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/e2e-runner.md
+++ b/agents/e2e-runner.md
@@ -2,7 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Vercel Agent Browser (preferred) with Playwright fallback. Use PROACTIVELY for generating, maintaining, and running E2E tests. Manages test journeys, quarantines flaky tests, uploads artifacts (screenshots, videos, traces), and ensures critical user flows work.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/e2e-runner.md
+++ b/agents/e2e-runner.md
@@ -2,7 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Vercel Agent Browser (preferred) with Playwright fallback. Use PROACTIVELY for generating, maintaining, and running E2E tests. Manages test journeys, quarantines flaky tests, uploads artifacts (screenshots, videos, traces), and ensures critical user flows work.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/flutter-reviewer.md
+++ b/agents/flutter-reviewer.md
@@ -2,7 +2,7 @@
 name: flutter-reviewer
 description: Flutter and Dart code reviewer. Reviews Flutter code for widget best practices, state management patterns, Dart idioms, performance pitfalls, accessibility, and clean architecture violations. Library-agnostic: works with any state management solution and tooling.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["dart"]
 ---
 

--- a/agents/flutter-reviewer.md
+++ b/agents/flutter-reviewer.md
@@ -2,7 +2,7 @@
 name: flutter-reviewer
 description: Flutter and Dart code reviewer. Reviews Flutter code for widget best practices, state management patterns, Dart idioms, performance pitfalls, accessibility, and clean architecture violations. Library-agnostic: works with any state management solution and tooling.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["dart"]
 ---
 

--- a/agents/gan-evaluator.md
+++ b/agents/gan-evaluator.md
@@ -2,7 +2,7 @@
 name: gan-evaluator
 description: "GAN Harness: Evaluator agent. Tests the live running application via Playwright, scores against rubric, and provides actionable feedback to the Generator."
 tools: ["Read", "Write", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 color: red
 stack: ["*"]
 ---

--- a/agents/gan-evaluator.md
+++ b/agents/gan-evaluator.md
@@ -2,7 +2,7 @@
 name: gan-evaluator
 description: "GAN Harness: Evaluator agent. Tests the live running application via Playwright, scores against rubric, and provides actionable feedback to the Generator."
 tools: ["Read", "Write", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 color: red
 stack: ["*"]
 ---

--- a/agents/gan-generator.md
+++ b/agents/gan-generator.md
@@ -2,7 +2,7 @@
 name: gan-generator
 description: "GAN Harness: Generator agent. Implements features according to the spec, reads evaluator feedback, and iterates until quality threshold is met."
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 color: green
 stack: ["*"]
 ---

--- a/agents/gan-generator.md
+++ b/agents/gan-generator.md
@@ -2,7 +2,7 @@
 name: gan-generator
 description: "GAN Harness: Generator agent. Implements features according to the spec, reads evaluator feedback, and iterates until quality threshold is met."
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 color: green
 stack: ["*"]
 ---

--- a/agents/gan-planner.md
+++ b/agents/gan-planner.md
@@ -2,7 +2,7 @@
 name: gan-planner
 description: "GAN Harness: Planner agent. Expands a one-line prompt into a full product specification with features, sprints, evaluation criteria, and design direction."
 tools: ["Read", "Write", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 color: purple
 stack: ["*"]
 ---

--- a/agents/gan-planner.md
+++ b/agents/gan-planner.md
@@ -2,7 +2,7 @@
 name: gan-planner
 description: "GAN Harness: Planner agent. Expands a one-line prompt into a full product specification with features, sprints, evaluation criteria, and design direction."
 tools: ["Read", "Write", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 color: purple
 stack: ["*"]
 ---

--- a/agents/go-build-resolver.md
+++ b/agents/go-build-resolver.md
@@ -2,7 +2,7 @@
 name: go-build-resolver
 description: Go build, vet, and compilation error resolution specialist. Fixes build errors, go vet issues, and linter warnings with minimal changes. Use when Go builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["golang"]
 ---
 

--- a/agents/go-build-resolver.md
+++ b/agents/go-build-resolver.md
@@ -2,7 +2,7 @@
 name: go-build-resolver
 description: Go build, vet, and compilation error resolution specialist. Fixes build errors, go vet issues, and linter warnings with minimal changes. Use when Go builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["golang"]
 ---
 

--- a/agents/go-reviewer.md
+++ b/agents/go-reviewer.md
@@ -2,7 +2,7 @@
 name: go-reviewer
 description: Expert Go code reviewer specializing in idiomatic Go, concurrency patterns, error handling, and performance. Use for all Go code changes. MUST BE USED for Go projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["golang"]
 ---
 

--- a/agents/go-reviewer.md
+++ b/agents/go-reviewer.md
@@ -2,7 +2,7 @@
 name: go-reviewer
 description: Expert Go code reviewer specializing in idiomatic Go, concurrency patterns, error handling, and performance. Use for all Go code changes. MUST BE USED for Go projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["golang"]
 ---
 

--- a/agents/harness-optimizer.md
+++ b/agents/harness-optimizer.md
@@ -2,7 +2,7 @@
 name: harness-optimizer
 description: Analyze and improve the local agent harness configuration for reliability, cost, and throughput.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 color: teal
 stack: ["*"]
 ---

--- a/agents/harness-optimizer.md
+++ b/agents/harness-optimizer.md
@@ -2,7 +2,7 @@
 name: harness-optimizer
 description: Analyze and improve the local agent harness configuration for reliability, cost, and throughput.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 color: teal
 stack: ["*"]
 ---

--- a/agents/healthcare-reviewer.md
+++ b/agents/healthcare-reviewer.md
@@ -2,7 +2,7 @@
 name: healthcare-reviewer
 description: Reviews healthcare application code for clinical safety, CDSS accuracy, PHI compliance, and medical data integrity. Specialized for EMR/EHR, clinical decision support, and health information systems.
 tools: ["Read", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["python", "*"]
 ---
 

--- a/agents/healthcare-reviewer.md
+++ b/agents/healthcare-reviewer.md
@@ -2,7 +2,7 @@
 name: healthcare-reviewer
 description: Reviews healthcare application code for clinical safety, CDSS accuracy, PHI compliance, and medical data integrity. Specialized for EMR/EHR, clinical decision support, and health information systems.
 tools: ["Read", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["python", "*"]
 ---
 

--- a/agents/java-build-resolver.md
+++ b/agents/java-build-resolver.md
@@ -2,7 +2,7 @@
 name: java-build-resolver
 description: Java/Maven/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Java compiler errors, and Maven/Gradle issues with minimal changes. Use when Java or Spring Boot builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["java"]
 ---
 

--- a/agents/java-build-resolver.md
+++ b/agents/java-build-resolver.md
@@ -2,7 +2,7 @@
 name: java-build-resolver
 description: Java/Maven/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Java compiler errors, and Maven/Gradle issues with minimal changes. Use when Java or Spring Boot builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["java"]
 ---
 

--- a/agents/java-reviewer.md
+++ b/agents/java-reviewer.md
@@ -2,7 +2,7 @@
 name: java-reviewer
 description: Expert Java and Spring Boot code reviewer specializing in layered architecture, JPA patterns, security, and concurrency. Use for all Java code changes. MUST BE USED for Spring Boot projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["java"]
 ---
 You are a senior Java engineer ensuring high standards of idiomatic Java and Spring Boot best practices.

--- a/agents/java-reviewer.md
+++ b/agents/java-reviewer.md
@@ -2,7 +2,7 @@
 name: java-reviewer
 description: Expert Java and Spring Boot code reviewer specializing in layered architecture, JPA patterns, security, and concurrency. Use for all Java code changes. MUST BE USED for Spring Boot projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["java"]
 ---
 You are a senior Java engineer ensuring high standards of idiomatic Java and Spring Boot best practices.

--- a/agents/kotlin-build-resolver.md
+++ b/agents/kotlin-build-resolver.md
@@ -2,7 +2,7 @@
 name: kotlin-build-resolver
 description: Kotlin/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Kotlin compiler errors, and Gradle issues with minimal changes. Use when Kotlin builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["kotlin"]
 ---
 

--- a/agents/kotlin-build-resolver.md
+++ b/agents/kotlin-build-resolver.md
@@ -2,7 +2,7 @@
 name: kotlin-build-resolver
 description: Kotlin/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Kotlin compiler errors, and Gradle issues with minimal changes. Use when Kotlin builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["kotlin"]
 ---
 

--- a/agents/kotlin-reviewer.md
+++ b/agents/kotlin-reviewer.md
@@ -2,7 +2,7 @@
 name: kotlin-reviewer
 description: Kotlin and Android/KMP code reviewer. Reviews Kotlin code for idiomatic patterns, coroutine safety, Compose best practices, clean architecture violations, and common Android pitfalls.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["kotlin"]
 ---
 

--- a/agents/kotlin-reviewer.md
+++ b/agents/kotlin-reviewer.md
@@ -2,7 +2,7 @@
 name: kotlin-reviewer
 description: Kotlin and Android/KMP code reviewer. Reviews Kotlin code for idiomatic patterns, coroutine safety, Compose best practices, clean architecture violations, and common Android pitfalls.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["kotlin"]
 ---
 

--- a/agents/loop-operator.md
+++ b/agents/loop-operator.md
@@ -2,7 +2,7 @@
 name: loop-operator
 description: Operate autonomous agent loops, monitor progress, and intervene safely when loops stall.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 color: orange
 stack: ["*"]
 ---

--- a/agents/loop-operator.md
+++ b/agents/loop-operator.md
@@ -2,7 +2,7 @@
 name: loop-operator
 description: Operate autonomous agent loops, monitor progress, and intervene safely when loops stall.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 color: orange
 stack: ["*"]
 ---

--- a/agents/opensource-forker.md
+++ b/agents/opensource-forker.md
@@ -2,7 +2,7 @@
 name: opensource-forker
 description: Fork any project for open-sourcing. Copies files, strips secrets and credentials (20+ patterns), replaces internal references with placeholders, generates .env.example, and cleans git history. First stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/opensource-forker.md
+++ b/agents/opensource-forker.md
@@ -2,7 +2,7 @@
 name: opensource-forker
 description: Fork any project for open-sourcing. Copies files, strips secrets and credentials (20+ patterns), replaces internal references with placeholders, generates .env.example, and cleans git history. First stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/opensource-packager.md
+++ b/agents/opensource-packager.md
@@ -2,7 +2,7 @@
 name: opensource-packager
 description: Generate complete open-source packaging for a sanitized project. Produces GEMINI.md, setup.sh, README.md, LICENSE, CONTRIBUTING.md, and GitHub issue templates. Makes any repo immediately usable with Gemini Code. Third stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/opensource-packager.md
+++ b/agents/opensource-packager.md
@@ -2,7 +2,7 @@
 name: opensource-packager
 description: Generate complete open-source packaging for a sanitized project. Produces GEMINI.md, setup.sh, README.md, LICENSE, CONTRIBUTING.md, and GitHub issue templates. Makes any repo immediately usable with Gemini Code. Third stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/opensource-sanitizer.md
+++ b/agents/opensource-sanitizer.md
@@ -2,7 +2,7 @@
 name: opensource-sanitizer
 description: Verify an open-source fork is fully sanitized before release. Scans for leaked secrets, PII, internal references, and dangerous files using 20+ regex patterns. Generates a PASS/FAIL/PASS-WITH-WARNINGS report. Second stage of the opensource-pipeline skill. Use PROACTIVELY before any public release.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/opensource-sanitizer.md
+++ b/agents/opensource-sanitizer.md
@@ -2,7 +2,7 @@
 name: opensource-sanitizer
 description: Verify an open-source fork is fully sanitized before release. Scans for leaked secrets, PII, internal references, and dangerous files using 20+ regex patterns. Generates a PASS/FAIL/PASS-WITH-WARNINGS report. Second stage of the opensource-pipeline skill. Use PROACTIVELY before any public release.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/performance-optimizer.md
+++ b/agents/performance-optimizer.md
@@ -2,7 +2,7 @@
 name: performance-optimizer
 description: Performance analysis and optimization specialist. Use PROACTIVELY for identifying bottlenecks, optimizing slow code, reducing bundle sizes, and improving runtime performance. Profiling, memory leaks, render optimization, and algorithmic improvements.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/performance-optimizer.md
+++ b/agents/performance-optimizer.md
@@ -2,7 +2,7 @@
 name: performance-optimizer
 description: Performance analysis and optimization specialist. Use PROACTIVELY for identifying bottlenecks, optimizing slow code, reducing bundle sizes, and improving runtime performance. Profiling, memory leaks, render optimization, and algorithmic improvements.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -2,7 +2,7 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use PROACTIVELY when users request feature implementation, architectural changes, or complex refactoring. Automatically activated for planning tasks.
 tools: ["Read", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -2,7 +2,7 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use PROACTIVELY when users request feature implementation, architectural changes, or complex refactoring. Automatically activated for planning tasks.
 tools: ["Read", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/pr-test-analyzer.md
+++ b/agents/pr-test-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-test-analyzer
 description: Review pull request test coverage quality and completeness, with emphasis on behavioral coverage and real bug prevention.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/pr-test-analyzer.md
+++ b/agents/pr-test-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-test-analyzer
 description: Review pull request test coverage quality and completeness, with emphasis on behavioral coverage and real bug prevention.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/python-reviewer.md
+++ b/agents/python-reviewer.md
@@ -2,7 +2,7 @@
 name: python-reviewer
 description: Expert Python code reviewer specializing in PEP 8 compliance, Pythonic idioms, type hints, security, and performance. Use for all Python code changes. MUST BE USED for Python projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["python"]
 ---
 

--- a/agents/python-reviewer.md
+++ b/agents/python-reviewer.md
@@ -2,7 +2,7 @@
 name: python-reviewer
 description: Expert Python code reviewer specializing in PEP 8 compliance, Pythonic idioms, type hints, security, and performance. Use for all Python code changes. MUST BE USED for Python projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["python"]
 ---
 

--- a/agents/pytorch-build-resolver.md
+++ b/agents/pytorch-build-resolver.md
@@ -2,7 +2,7 @@
 name: pytorch-build-resolver
 description: PyTorch runtime, CUDA, and training error resolution specialist. Fixes tensor shape mismatches, device errors, gradient issues, DataLoader problems, and mixed precision failures with minimal changes. Use when PyTorch training or inference crashes.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["python"]
 ---
 

--- a/agents/pytorch-build-resolver.md
+++ b/agents/pytorch-build-resolver.md
@@ -2,7 +2,7 @@
 name: pytorch-build-resolver
 description: PyTorch runtime, CUDA, and training error resolution specialist. Fixes tensor shape mismatches, device errors, gradient issues, DataLoader problems, and mixed precision failures with minimal changes. Use when PyTorch training or inference crashes.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["python"]
 ---
 

--- a/agents/refactor-cleaner.md
+++ b/agents/refactor-cleaner.md
@@ -2,7 +2,7 @@
 name: refactor-cleaner
 description: Dead code cleanup and consolidation specialist. Use PROACTIVELY for removing unused code, duplicates, and refactoring. Runs analysis tools (knip, depcheck, ts-prune) to identify dead code and safely removes it.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/refactor-cleaner.md
+++ b/agents/refactor-cleaner.md
@@ -2,7 +2,7 @@
 name: refactor-cleaner
 description: Dead code cleanup and consolidation specialist. Use PROACTIVELY for removing unused code, duplicates, and refactoring. Runs analysis tools (knip, depcheck, ts-prune) to identify dead code and safely removes it.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/rust-build-resolver.md
+++ b/agents/rust-build-resolver.md
@@ -2,7 +2,7 @@
 name: rust-build-resolver
 description: Rust build, compilation, and dependency error resolution specialist. Fixes cargo build errors, borrow checker issues, and Cargo.toml problems with minimal changes. Use when Rust builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["rust"]
 ---
 

--- a/agents/rust-build-resolver.md
+++ b/agents/rust-build-resolver.md
@@ -2,7 +2,7 @@
 name: rust-build-resolver
 description: Rust build, compilation, and dependency error resolution specialist. Fixes cargo build errors, borrow checker issues, and Cargo.toml problems with minimal changes. Use when Rust builds fail.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["rust"]
 ---
 

--- a/agents/rust-reviewer.md
+++ b/agents/rust-reviewer.md
@@ -2,7 +2,7 @@
 name: rust-reviewer
 description: Expert Rust code reviewer specializing in ownership, lifetimes, error handling, unsafe usage, and idiomatic patterns. Use for all Rust code changes. MUST BE USED for Rust projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["rust"]
 ---
 

--- a/agents/rust-reviewer.md
+++ b/agents/rust-reviewer.md
@@ -2,7 +2,7 @@
 name: rust-reviewer
 description: Expert Rust code reviewer specializing in ownership, lifetimes, error handling, unsafe usage, and idiomatic patterns. Use for all Rust code changes. MUST BE USED for Rust projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["rust"]
 ---
 

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Security vulnerability detection and remediation specialist. Use PROACTIVELY after writing code that handles user input, authentication, API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe crypto, and OWASP Top 10 vulnerabilities.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Security vulnerability detection and remediation specialist. Use PROACTIVELY after writing code that handles user input, authentication, API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe crypto, and OWASP Top 10 vulnerabilities.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/seo-specialist.md
+++ b/agents/seo-specialist.md
@@ -2,7 +2,7 @@
 name: seo-specialist
 description: SEO specialist for technical SEO audits, on-page optimization, structured data, Core Web Vitals, and content/keyword mapping. Use for site audits, meta tag reviews, schema markup, sitemap and robots issues, and SEO remediation plans.
 tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/seo-specialist.md
+++ b/agents/seo-specialist.md
@@ -2,7 +2,7 @@
 name: seo-specialist
 description: SEO specialist for technical SEO audits, on-page optimization, structured data, Core Web Vitals, and content/keyword mapping. Use for site audits, meta tag reviews, schema markup, sitemap and robots issues, and SEO remediation plans.
 tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/silent-failure-hunter.md
+++ b/agents/silent-failure-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: silent-failure-hunter
 description: Review code for silent failures, swallowed errors, bad fallbacks, and missing error propagation.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/silent-failure-hunter.md
+++ b/agents/silent-failure-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: silent-failure-hunter
 description: Review code for silent failures, swallowed errors, bad fallbacks, and missing error propagation.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/tdd-guide.md
+++ b/agents/tdd-guide.md
@@ -2,7 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist enforcing write-tests-first methodology. Use PROACTIVELY when writing new features, fixing bugs, or refactoring code. Ensures 80%+ test coverage.
 tools: ["Read", "Write", "Edit", "Bash", "Grep"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["*"]
 ---
 

--- a/agents/tdd-guide.md
+++ b/agents/tdd-guide.md
@@ -2,7 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist enforcing write-tests-first methodology. Use PROACTIVELY when writing new features, fixing bugs, or refactoring code. Ensures 80%+ test coverage.
 tools: ["Read", "Write", "Edit", "Bash", "Grep"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["*"]
 ---
 

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: type-design-analyzer
 description: Analyze type design for encapsulation, invariant expression, usefulness, and enforcement.
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: type-design-analyzer
 description: Analyze type design for encapsulation, invariant expression, usefulness, and enforcement.
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 tools: [Read, Grep, Glob, Bash]
 stack: ["*"]
 ---

--- a/agents/typescript-reviewer.md
+++ b/agents/typescript-reviewer.md
@@ -2,7 +2,7 @@
 name: typescript-reviewer
 description: Expert TypeScript/JavaScript code reviewer specializing in type safety, async correctness, Node/web security, and idiomatic patterns. Use for all TypeScript and JavaScript code changes. MUST BE USED for TypeScript/JavaScript projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-2.5-pro
+model: gemini-3.6-pro
 stack: ["typescript", "javascript"]
 ---
 

--- a/agents/typescript-reviewer.md
+++ b/agents/typescript-reviewer.md
@@ -2,7 +2,7 @@
 name: typescript-reviewer
 description: Expert TypeScript/JavaScript code reviewer specializing in type safety, async correctness, Node/web security, and idiomatic patterns. Use for all TypeScript and JavaScript code changes. MUST BE USED for TypeScript/JavaScript projects.
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: gemini-3.6-pro
+model: gemini-3.1-pro
 stack: ["typescript", "javascript"]
 ---
 

--- a/scripts/ci/validate-agents.js
+++ b/scripts/ci/validate-agents.js
@@ -12,6 +12,7 @@ const AGENTS_DIR = path.join(__dirname, '../../agents');
 const REQUIRED_FIELDS = ['model', 'tools'];
 const VALID_MODELS = [
   'haiku', 'sonnet', 'opus', 'pro', 'flash', 'lite', 'ultra',
+  'gemini-3.1-pro',
   'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite',
   'gemini-2.0-pro', 'gemini-2.0-flash', 'gemini-2.0-flash-lite',
   'gemini-1.5-pro', 'gemini-1.5-flash', 'gemini-1.5-flash-8b'


### PR DESCRIPTION
> Substitui o #1189, fechado automaticamente quando a branch foi renomeada de `chore/agents-gemini-3-6-pro` para `chore/agents-gemini-3-1-pro`. Mesmos commits, mesmo conteudo.

## O que a branch entrega

Move 47 agents de `gemini-2.5-pro` para `gemini-3.1-pro` e adiciona esse modelo a allowlist do `validate-agents.js`. Uma linha por agent, nenhuma outra alteracao.

## O caminho ate aqui, porque muda o que o PR significa

O objetivo original era resolver o aviso do `egc doctor`: 50 managed files com drift, todos `agents/*.md` divergindo **so no campo `model`**. Os agents instalados rodavam `gemini-3.6-pro` e a fonte declarava `gemini-2.5-pro`. Como `egc repair` restaura a partir da fonte, ele faria **downgrade** dos 50 em vez de reparar, entao a correcao certa era levar o bump pra fonte.

So que **`gemini-3.6-pro` nao existe.** O Google lancou o Gemini 3.6 **Flash** em 21/07/2026, e o 3.5 **Pro** foi adiado tres vezes sem sair. Nunca houve um "3.6 pro". O nome veio de um replace local que pegou o "3.6" do Flash e colou no "pro".

**Quem pegou isso foi o CI deste repositorio.** A allowlist do `validate-agents.js` rejeitou o nome e derrubou o job `Validate Components`. O validador estava certo e o PR e que estava errado, o que e exatamente o que essa allowlist existe pra fazer.

Alvo corrigido para `gemini-3.1-pro`: GA desde fevereiro de 2026, o Gemini de raciocinio mais forte disponivel, e o upgrade honesto de `gemini-2.5-pro` que era a intencao desde o inicio.

## Mudanca na allowlist

A lista nao tinha **nenhuma** entrada da familia Gemini 3, parando no 2.5, apesar de ter sido tocada em 03/08. Adicionei apenas `gemini-3.1-pro`, que e o que este PR usa. `gemini-3.6-flash` e `gemini-3.5-flash-lite` tambem sao GA e podem entrar quando algum agent for usa-los.

## doc-updater fica em flash

Era o **unico** agent fora da familia pro e tinha entrado no bump por acidente do regex, que pega qualquer `model: gemini-*`. Ele gera codemap e documentacao, tarefa de volume onde flash e a escolha de custo certa. Mantido em `gemini-2.0-flash`.

Se valer modernizar tambem o tier flash, `gemini-3.6-flash` e GA desde 21/07 e consome 17% menos tokens de saida que o 3.5-flash. Fica como sugestao, fora do escopo deste PR.

## Efeito no egc doctor: leia antes de esperar verde

**Este PR nao zera o aviso do `egc doctor`, e agora menos ainda.**

Primeiro porque o doctor compara o instalado contra o **pacote npm** (`node_modules/@egchq/egc`), nao contra o clone git; confirmei pelos `sourcePath` do `install-state.json`. So uma release publicada muda isso.

Segundo, e mais importante: os agents **instalados** na maquina ainda apontam para `gemini-3.6-pro`, um modelo que nao existe. Isso e um problema ativo independente deste PR e precisa de uma reinstalacao ou correcao local, nao de um merge.

## Verificacao

Job `Validate Components` reproduzido inteiro localmente: `validate-agents`, `validate-hooks`, `validate-commands`, `validate-skills`, `validate-skill-frontmatter`, `validate-translation-structure` e `catalog.js`, todos exit 0.

Diff de 47 agents, 94 linhas, todas linhas `model:`. Distribuicao final: 47x `gemini-3.1-pro`, 13x `sonnet`, 1x `gemini-2.0-flash`.

Fim de linha CRLF preservado: o regex nao inclui o terminador, porque consumir o `\r` reescreveria a linha como LF e deixaria os arquivos mistos.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retargets 47 agents from gemini-2.5-pro to gemini-3.1-pro and updates the CI allowlist to accept this model. This corrects the earlier invalid gemini-3.6-pro target and unblocks model validation.

- **Migration**
  - After publishing a new `@egchq/egc`, reinstall agents to apply gemini-3.1-pro; until then, `egc doctor` may keep reporting drift.
  - If local agents were set to gemini-3.6-pro, reinstall or update them to gemini-3.1-pro.

<sup>Written for commit 817018af576b9a575f933d28e442e08b7db8325d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

