### PR TITLE
fix(crusher): stop the PATH shim from resolving to itself under a HOME override

### DIFF
--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -56,14 +56,17 @@ function exitLikeChild(result) {
   process.exit(typeof result.status === 'number' ? result.status : 1);
 }
 
-// process.argv[1] is the launcher file itself when a POSIX launcher
-// require()s this module, and shim-dispatch.js when the Windows .cmd spawns
-// `node shim-dispatch.js <name>`. Either way it is a physical location tied
-// to this exact invocation, immune to HOME/USERPROFILE overrides -- which is
-// what makes it a trustworthy "never resolve back into here" anchor, unlike
-// anything derived from os.homedir() (see resolveRealBinary in shim-paths).
-function launcherPath() {
-  return process.argv[1] ? path.resolve(process.argv[1]) : null;
+// The physical directory of the launcher for this exact invocation, immune
+// to HOME/USERPROFILE overrides -- which is what makes it a trustworthy
+// "never resolve back into here" anchor, unlike anything derived from
+// os.homedir() (see resolveRealBinary in shim-paths). On POSIX the shebang
+// launcher require()s this module, so process.argv[1] is the launcher file.
+// The Windows .cmd spawns `node shim-dispatch.js <name>` instead (argv[1]
+// is this module, not the launcher), so the .cmd bakes its own directory
+// into EGC_SHIM_LAUNCHER_DIR via %~dp0 -- that wins when present.
+function launcherDir() {
+  if (process.env.EGC_SHIM_LAUNCHER_DIR) return path.resolve(process.env.EGC_SHIM_LAUNCHER_DIR);
+  return process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : null;
 }
 
 // Last line of defense against the shim spawning itself: if resolution
@@ -106,7 +109,7 @@ function loadCrusher() {
 function runShim(name, args) {
   refuseDirectRecursion(name);
 
-  const realBinary = resolveRealBinary(name, launcherPath());
+  const realBinary = resolveRealBinary(name, launcherDir());
   if (!realBinary) {
     process.stderr.write(`${name}: command not found\n`);
     process.exit(127);

--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -25,7 +25,7 @@
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { writeSync } = require('node:fs');
-const { resolveRealBinary } = require('./shim-paths');
+const { resolveRealBinary, realpathOrResolve } = require('./shim-paths');
 
 const SPAWN_OPTIONS = {
   encoding: 'utf8',
@@ -65,8 +65,11 @@ function exitLikeChild(result) {
 // is this module, not the launcher), so the .cmd bakes its own directory
 // into EGC_SHIM_LAUNCHER_DIR via %~dp0 -- that wins when present.
 function launcherDir() {
-  if (process.env.EGC_SHIM_LAUNCHER_DIR) return path.resolve(process.env.EGC_SHIM_LAUNCHER_DIR);
-  return process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : null;
+  if (process.env.EGC_SHIM_LAUNCHER_DIR) return realpathOrResolve(process.env.EGC_SHIM_LAUNCHER_DIR);
+  // realpath the launcher FILE before dirname: a launcher reached through a
+  // symlink (say /usr/local/bin/npm -> ~/.egc/bin/npm) must anchor to the
+  // physical shim directory, not to wherever the symlink happens to live.
+  return process.argv[1] ? path.dirname(realpathOrResolve(process.argv[1])) : null;
 }
 
 // Last line of defense against the shim spawning itself: if resolution
@@ -75,6 +78,12 @@ function launcherDir() {
 // OOM killer steps in. A legitimate nested invocation (an npm script
 // running npm) never trips this: the pid recorded by the outer shim is the
 // shim's own, not the real binary that spawned the inner one.
+// Known limitation: on Windows the .cmd launcher interposes a cmd.exe hop,
+// so process.ppid is the intermediate cmd.exe and the recorded pid never
+// matches -- this breaker cannot fire there. The physical-anchor exclusion
+// (launcherDir / EGC_SHIM_LAUNCHER_DIR) is the effective defense on that
+// platform; bridging the pid chain across cmd.exe would need a per-call
+// process walk that costs more than it protects.
 function refuseDirectRecursion(name) {
   if (process.env.EGC_SHIM_PENDING !== `${name}:${process.ppid}`) return;
   process.stderr.write(

--- a/scripts/lib/crusher/shim-dispatch.js
+++ b/scripts/lib/crusher/shim-dispatch.js
@@ -17,6 +17,10 @@
 //   - Engine/metrics modules unavailable, or the command kind is 'generic'
 //     -> full passthrough, zero capture, zero behavior change.
 //   - Any unexpected error at any point -> full passthrough.
+//   - Resolution that would re-enter the shim itself (seen under HOME
+//     overrides that hide the manifest) -> rejected up front by physical
+//     path, and a child that still turns out to be the shim exits 127 at
+//     depth 1 instead of recursing (see refuseDirectRecursion).
 
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
@@ -52,8 +56,38 @@ function exitLikeChild(result) {
   process.exit(typeof result.status === 'number' ? result.status : 1);
 }
 
-function passthrough(realBinary, args) {
-  const result = spawnSync(realBinary, args, { stdio: 'inherit', shell: needsShellOnWindows(realBinary) });
+// process.argv[1] is the launcher file itself when a POSIX launcher
+// require()s this module, and shim-dispatch.js when the Windows .cmd spawns
+// `node shim-dispatch.js <name>`. Either way it is a physical location tied
+// to this exact invocation, immune to HOME/USERPROFILE overrides -- which is
+// what makes it a trustworthy "never resolve back into here" anchor, unlike
+// anything derived from os.homedir() (see resolveRealBinary in shim-paths).
+function launcherPath() {
+  return process.argv[1] ? path.resolve(process.argv[1]) : null;
+}
+
+// Last line of defense against the shim spawning itself: if resolution
+// still handed back the shim, the child sees its own name recorded by its
+// direct parent and stops at depth 1 instead of forking until the machine's
+// OOM killer steps in. A legitimate nested invocation (an npm script
+// running npm) never trips this: the pid recorded by the outer shim is the
+// shim's own, not the real binary that spawned the inner one.
+function refuseDirectRecursion(name) {
+  if (process.env.EGC_SHIM_PENDING !== `${name}:${process.ppid}`) return;
+  process.stderr.write(
+    `${name}: the EGC Token Crusher shim resolved to itself and refused to recurse ` +
+    `(usually a HOME override hiding the shim's manifest). Re-run 'egc crusher-shim install' ` +
+    `to rebuild the manifest, or drop the shim directory from PATH for this command.\n`
+  );
+  process.exit(127);
+}
+
+function childEnv(name) {
+  return { ...process.env, EGC_SHIM_PENDING: `${name}:${process.pid}` };
+}
+
+function passthrough(name, realBinary, args) {
+  const result = spawnSync(realBinary, args, { stdio: 'inherit', shell: needsShellOnWindows(realBinary), env: childEnv(name) });
   if (result.error) {
     process.stderr.write(`${path.basename(realBinary)}: ${result.error.message}\n`);
     process.exit(127);
@@ -70,7 +104,9 @@ function loadCrusher() {
 }
 
 function runShim(name, args) {
-  const realBinary = resolveRealBinary(name);
+  refuseDirectRecursion(name);
+
+  const realBinary = resolveRealBinary(name, launcherPath());
   if (!realBinary) {
     process.stderr.write(`${name}: command not found\n`);
     process.exit(127);
@@ -81,16 +117,16 @@ function runShim(name, args) {
   // and compress on its own otherwise, since it runs as an independent child
   // with no other visibility into that intent.
   if (process.env.EGC_CRUSHER_RAW === '1' || process.stdout.isTTY) {
-    return passthrough(realBinary, args);
+    return passthrough(name, realBinary, args);
   }
 
   const crusher = loadCrusher();
   const commandLine = [name, ...args].join(' ');
   if (!crusher || crusher.commandKind(commandLine) === 'generic') {
-    return passthrough(realBinary, args);
+    return passthrough(name, realBinary, args);
   }
 
-  const result = spawnSync(realBinary, args, { ...SPAWN_OPTIONS, shell: needsShellOnWindows(realBinary) });
+  const result = spawnSync(realBinary, args, { ...SPAWN_OPTIONS, shell: needsShellOnWindows(realBinary), env: childEnv(name) });
   if (result.error) {
     // ENOBUFS (output exceeded maxBuffer) is not "command not found" -- exit
     // 127 there would be actively misleading to anything inspecting the

--- a/scripts/lib/crusher/shim-install.js
+++ b/scripts/lib/crusher/shim-install.js
@@ -57,12 +57,18 @@ function windowsLauncherSource(name) {
   // exception handling, so the existence check happens up front instead of
   // catching node's own error after the fact (see posixLauncherSource for
   // why this check exists at all).
+  // %~dp0 is the directory this .cmd physically lives in. The dispatcher
+  // cannot learn that from process.argv[1] on Windows (it sees
+  // shim-dispatch.js, not the launcher), and deriving it from USERPROFILE
+  // breaks under profile overrides -- the exact recursion hole the POSIX
+  // side closes via its shebang launcher path.
   return [
     '@echo off',
     `if not exist "${DISPATCH_MODULE}" (`,
     `  echo ${launcherNotFoundMessage(name)}`,
     '  exit /b 127',
     ')',
+    'set "EGC_SHIM_LAUNCHER_DIR=%~dp0"',
     `node "${DISPATCH_MODULE}" ${name} %*`,
     '',
   ].join('\r\n');

--- a/scripts/lib/crusher/shim-paths.js
+++ b/scripts/lib/crusher/shim-paths.js
@@ -56,10 +56,13 @@ function normalizePathForCompare(p) {
 // launcher files stay where they are. Identity comparisons therefore go
 // through the filesystem's physical view of a path whenever the path exists;
 // path.resolve alone would keep a symlinked PATH entry distinct from the
-// shim directory it aliases.
+// shim directory it aliases. realpathSync.native, not plain realpathSync:
+// only the native call canonicalizes Windows 8.3 short names (RUNNER~1 vs
+// runneradmin), and a PATH entry spelled in short form must still match the
+// long-form launcher directory it aliases.
 function realpathOrResolve(p) {
   try {
-    return fs.realpathSync(p);
+    return fs.realpathSync.native(p);
   } catch {
     return path.resolve(p);
   }

--- a/scripts/lib/crusher/shim-paths.js
+++ b/scripts/lib/crusher/shim-paths.js
@@ -118,12 +118,15 @@ function resolveWithoutShim(name, extraExcludeDirs = []) {
 // `where` lists an extension-less sibling first when one exists (common in
 // Node installs, where `npm` is an MSYS shell wrapper next to npm.cmd), and
 // CreateProcess cannot execute it -- resolution must skip candidates the
-// platform cannot actually spawn.
+// platform cannot actually spawn. Deliberately NOT the full PATHEXT list:
+// .exe/.com launch directly and .cmd/.bat go through the shell (see
+// needsShellOnWindows), but .JS/.VBS/.WSF entries need cscript and would
+// fail the dispatch instead of letting a later usable candidate run.
+const WINDOWS_SPAWNABLE_EXTS = ['.exe', '.com', '.cmd', '.bat'];
 function isSpawnable(candidate) {
   if (process.platform !== 'win32') return true;
-  const exts = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
   const lower = candidate.toLowerCase();
-  return exts.some(ext => lower.endsWith(ext.toLowerCase()));
+  return WINDOWS_SPAWNABLE_EXTS.some(ext => lower.endsWith(ext));
 }
 
 // launcherDir is the physical directory of the launcher for the invocation
@@ -158,6 +161,7 @@ module.exports = {
   readManifest,
   pathEnvKey,
   normalizePathForCompare,
+  realpathOrResolve,
   resolveWithoutShim,
   resolveRealBinary,
 };

--- a/scripts/lib/crusher/shim-paths.js
+++ b/scripts/lib/crusher/shim-paths.js
@@ -29,9 +29,9 @@ function manifestPath() {
   return path.join(shimDir(), 'manifest.json');
 }
 
-function readManifest() {
+function readManifest(dir = shimDir()) {
   try {
-    return JSON.parse(fs.readFileSync(manifestPath(), 'utf8'));
+    return JSON.parse(fs.readFileSync(path.join(dir, 'manifest.json'), 'utf8'));
   } catch {
     return {};
   }
@@ -51,32 +51,77 @@ function normalizePathForCompare(p) {
   return process.platform === 'win32' || process.platform === 'darwin' ? resolved.toLowerCase() : resolved;
 }
 
+// A HOME/USERPROFILE override moves what os.homedir() returns, so everything
+// derived from shimDir() silently points somewhere else while the installed
+// launcher files stay where they are. Identity comparisons therefore go
+// through the filesystem's physical view of a path whenever the path exists;
+// path.resolve alone would keep a symlinked PATH entry distinct from the
+// shim directory it aliases.
+function realpathOrResolve(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+function excludedDirSet(extraExcludeDirs) {
+  return new Set(
+    [shimDir(), ...extraExcludeDirs].map(d => normalizePathForCompare(realpathOrResolve(d)))
+  );
+}
+
+// Spawning whatever resolution returns is exactly how the shim once recursed
+// into itself under a HOME override (each level a fresh node process, until
+// the machine's OOM killer stepped in): a candidate that physically lives in
+// a shim directory is never a "real" binary, no matter how it was found.
+function isShimCandidate(candidate, excluded) {
+  return excluded.has(normalizePathForCompare(path.dirname(realpathOrResolve(candidate))));
+}
+
 // Resolves the real binary on PATH with the shim directory filtered out, so
 // this never just finds the shim itself (directly at install time, before
 // any manifest exists, and as a fallback at dispatch time if the manifest is
-// missing, stale, or its target no longer exists).
-function resolveWithoutShim(name) {
-  const dir = shimDir();
+// missing, stale, or its target no longer exists). shimDir() follows
+// HOME/USERPROFILE, so callers that know a physical shim location the
+// override would hide (the dispatcher knows its own launcher file) pass it
+// via extraExcludeDirs; every candidate is also checked physically, since a
+// PATH entry can reach the shim directory under a different spelling.
+function resolveWithoutShim(name, extraExcludeDirs = []) {
+  const excluded = excludedDirSet(extraExcludeDirs);
   const key = pathEnvKey();
-  const normalizedDir = normalizePathForCompare(dir);
   const filtered = (process.env[key] || '')
     .split(path.delimiter)
-    .filter(p => p && normalizePathForCompare(p) !== normalizedDir);
+    .filter(p => p && !excluded.has(normalizePathForCompare(realpathOrResolve(p))));
 
-  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [name], { // NOSONAR jssecurity:S8705 -- name is always a hardcoded SHIM_BINARY_NAMES entry or the launcher's own baked-in name, never untrusted input; array-form with no shell also rules out injection
+  // `where` already lists every match; `which` needs -a for the same, so a
+  // first hit that turns out to live in a shim directory is not the end of
+  // the search.
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', process.platform === 'win32' ? [name] : ['-a', name], { // NOSONAR jssecurity:S8705 -- name is always a hardcoded SHIM_BINARY_NAMES entry or the launcher's own baked-in name, never untrusted input; array-form with no shell also rules out injection
     encoding: 'utf8',
     env: { ...process.env, [key]: filtered.join(path.delimiter) },
   });
   if (probe.status !== 0 || !probe.stdout) return null;
-  const first = probe.stdout.split(/\r?\n/).map(l => l.trim()).find(Boolean);
-  return first || null;
+  const candidates = probe.stdout.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  return candidates.find(c => !isShimCandidate(c, excluded)) || null;
 }
 
-function resolveRealBinary(name) {
-  const manifest = readManifest();
-  const fromManifest = manifest[name];
-  if (fromManifest && fs.existsSync(fromManifest)) return fromManifest;
-  return resolveWithoutShim(name);
+// launcherPath is the physical launcher file of the invocation in progress
+// (process.argv[1] at dispatch time). It anchors two things a HOME override
+// would otherwise break: where the manifest actually lives (next to the
+// launcher, not under the overridden home), and which directory must never
+// be resolved back into.
+function resolveRealBinary(name, launcherPath = null) {
+  const launcherDir = launcherPath ? path.dirname(realpathOrResolve(launcherPath)) : null;
+  const excludeDirs = launcherDir ? [launcherDir] : [];
+  const excluded = excludedDirSet(excludeDirs);
+
+  const manifestDirs = [...new Set([launcherDir, shimDir()].filter(Boolean))];
+  for (const dir of manifestDirs) {
+    const target = readManifest(dir)[name];
+    if (target && fs.existsSync(target) && !isShimCandidate(target, excluded)) return target;
+  }
+  return resolveWithoutShim(name, excludeDirs);
 }
 
 module.exports = {

--- a/scripts/lib/crusher/shim-paths.js
+++ b/scripts/lib/crusher/shim-paths.js
@@ -96,27 +96,51 @@ function resolveWithoutShim(name, extraExcludeDirs = []) {
 
   // `where` already lists every match; `which` needs -a for the same, so a
   // first hit that turns out to live in a shim directory is not the end of
-  // the search.
-  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', process.platform === 'win32' ? [name] : ['-a', name], { // NOSONAR jssecurity:S8705 -- name is always a hardcoded SHIM_BINARY_NAMES entry or the launcher's own baked-in name, never untrusted input; array-form with no shell also rules out injection
+  // the search. Minimal `which` implementations (busybox/Alpine) reject -a
+  // entirely, so a failed -a probe retries plain `which` -- one candidate is
+  // still better than failing closed with "command not found".
+  const probeEnv = { ...process.env, [key]: filtered.join(path.delimiter) };
+  let probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', process.platform === 'win32' ? [name] : ['-a', name], { // NOSONAR jssecurity:S8705 -- name is always a hardcoded SHIM_BINARY_NAMES entry or the launcher's own baked-in name, never untrusted input; array-form with no shell also rules out injection
     encoding: 'utf8',
-    env: { ...process.env, [key]: filtered.join(path.delimiter) },
+    env: probeEnv,
   });
+  if (process.platform !== 'win32' && (probe.status !== 0 || !probe.stdout)) {
+    probe = spawnSync('which', [name], { encoding: 'utf8', env: probeEnv }); // NOSONAR jssecurity:S8705 -- same fixed-name, no-shell invocation as above
+  }
   if (probe.status !== 0 || !probe.stdout) return null;
   const candidates = probe.stdout.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
-  return candidates.find(c => !isShimCandidate(c, excluded)) || null;
+  return candidates.find(c => !isShimCandidate(c, excluded) && isSpawnable(c)) || null;
 }
 
-// launcherPath is the physical launcher file of the invocation in progress
-// (process.argv[1] at dispatch time). It anchors two things a HOME override
-// would otherwise break: where the manifest actually lives (next to the
-// launcher, not under the overridden home), and which directory must never
-// be resolved back into.
-function resolveRealBinary(name, launcherPath = null) {
-  const launcherDir = launcherPath ? path.dirname(realpathOrResolve(launcherPath)) : null;
-  const excludeDirs = launcherDir ? [launcherDir] : [];
+// `where` lists an extension-less sibling first when one exists (common in
+// Node installs, where `npm` is an MSYS shell wrapper next to npm.cmd), and
+// CreateProcess cannot execute it -- resolution must skip candidates the
+// platform cannot actually spawn.
+function isSpawnable(candidate) {
+  if (process.platform !== 'win32') return true;
+  const exts = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+  const lower = candidate.toLowerCase();
+  return exts.some(ext => lower.endsWith(ext.toLowerCase()));
+}
+
+// launcherDir is the physical directory of the launcher for the invocation
+// in progress (derived from process.argv[1] on POSIX, or baked into the
+// .cmd via EGC_SHIM_LAUNCHER_DIR on Windows). It anchors two things a
+// HOME/USERPROFILE override would otherwise break: where the manifest
+// actually lives (next to the launcher, not under the overridden home), and
+// which directory must never be resolved back into.
+function resolveRealBinary(name, launcherDir = null) {
+  const anchoredDir = launcherDir ? realpathOrResolve(launcherDir) : null;
+  const excludeDirs = anchoredDir ? [anchoredDir] : [];
   const excluded = excludedDirSet(excludeDirs);
 
-  const manifestDirs = [...new Set([launcherDir, shimDir()].filter(Boolean))];
+  const seenDirs = new Set();
+  const manifestDirs = [anchoredDir, shimDir()].filter(Boolean).filter(dir => {
+    const dirKey = normalizePathForCompare(realpathOrResolve(dir));
+    if (seenDirs.has(dirKey)) return false;
+    seenDirs.add(dirKey);
+    return true;
+  });
   for (const dir of manifestDirs) {
     const target = readManifest(dir)[name];
     if (target && fs.existsSync(target) && !isShimCandidate(target, excluded)) return target;

--- a/tests/crush-run-raw-shim.test.js
+++ b/tests/crush-run-raw-shim.test.js
@@ -16,30 +16,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const CRUSH_RUN = path.join(__dirname, '..', 'scripts', 'crush-run.js');
-const DISPATCH_MODULE = path.join(__dirname, '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
-
-// Built with String.fromCharCode/RegExp instead of typing the raw U+2028 and
-// U+2029 characters, so this file never carries invisible codepoints of its
-// own while implementing a fix for exactly that class of problem.
-const LINE_SEPARATOR = String.fromCharCode(0x2028);
-const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
-const UNSAFE_CODE_CHARS = {
-  '<': '\\u003C',
-  '>': '\\u003E',
-  [LINE_SEPARATOR]: '\\u2028',
-  [PARAGRAPH_SEPARATOR]: '\\u2029',
-};
-const UNSAFE_CODE_CHARS_RE = new RegExp(`[<>${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`, 'g');
-
-// JSON.stringify alone is not a safe way to embed a value inside generated
-// source code: it leaves characters like < > and the U+2028/U+2029 line
-// separators untouched, which can still break out of the surrounding syntax
-// depending on context (flagged by CodeQL as js/bad-code-sanitization). These
-// fake binaries only ever receive fixed test fixtures, never external input,
-// but the construction itself should not rely on that.
-function jsStringLiteral(value) {
-  return JSON.stringify(value).replace(UNSAFE_CODE_CHARS_RE, (c) => UNSAFE_CODE_CHARS[c]);
-}
+const { jsStringLiteral, writeShimLauncher } = require('./lib/shim-fixtures');
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -47,20 +24,6 @@ function createTempDir(prefix) {
 
 function cleanup(...dirs) {
   for (const dir of dirs) fs.rmSync(dir, { recursive: true, force: true });
-}
-
-// Mirrors shim-install.js's posixLauncherSource(): the exact launcher shape
-// `egc crusher-shim install` writes to ~/.egc/bin/<name>.
-function writeShimLauncher(binDir, name) {
-  const launcherPath = path.join(binDir, name);
-  const source = [
-    '#!/usr/bin/env node',
-    `require(${jsStringLiteral(DISPATCH_MODULE)}).runShim(${jsStringLiteral(name)}, process.argv.slice(2));`,
-    '',
-  ].join('\n');
-  fs.writeFileSync(launcherPath, source);
-  fs.chmodSync(launcherPath, 0o755);
-  return launcherPath;
 }
 
 // Stands in for the real /usr/bin/git that the shim launcher resolves to via

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -327,17 +327,21 @@ function runTests() {
       const realNpm = writeFakeBinary(realBinDir, 'npm', { stdout: 'REAL-NPM-RAN\n' });
       fs.writeFileSync(path.join(installedShimDir, 'manifest.json'), JSON.stringify({ npm: realNpm }));
 
+      // realBinDir deliberately NOT on PATH: the only way to reach the real
+      // binary is the manifest sitting beside the anchored launcher dir, so
+      // a regression in that anchored lookup fails here instead of being
+      // masked by an equivalent PATH fallback.
       const result = runShim(overrideHome, 'npm', ['--version'], {
         env: {
           ...process.env,
           HOME: overrideHome,
           USERPROFILE: overrideHome,
           EGC_SHIM_LAUNCHER_DIR: installedShimDir,
-          PATH: [installedShimDir, realBinDir, path.dirname(process.execPath)].join(path.delimiter),
+          PATH: [installedShimDir, path.dirname(process.execPath)].join(path.delimiter),
         },
       });
       assert.strictEqual(result.status, 0, result.stderr);
-      assert.ok(result.stdout.includes('REAL-NPM-RAN'), 'the manifest beside the anchored launcher dir must win over the decoy');
+      assert.ok(result.stdout.includes('REAL-NPM-RAN'), 'only the manifest beside the anchored launcher dir can reach the real npm');
     } finally {
       cleanup(installHome);
       cleanup(overrideHome);

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -95,6 +95,20 @@ function seedManifest(homeDir, entries) {
   fs.writeFileSync(path.join(binDir, 'manifest.json'), JSON.stringify(entries));
 }
 
+// Mirrors shim-install.js's posixLauncherSource(): the exact launcher shape
+// `egc crusher-shim install` writes to ~/.egc/bin/<name>, pointing back at
+// this checkout's shim-dispatch.js.
+function writeShimLauncher(binDir, name) {
+  const launcherPath = path.join(binDir, name);
+  fs.writeFileSync(launcherPath, [
+    '#!/usr/bin/env node',
+    `require(${jsStringLiteral(DISPATCH_SCRIPT)}).runShim(${jsStringLiteral(name)}, process.argv.slice(2));`,
+    '',
+  ].join('\n'));
+  fs.chmodSync(launcherPath, 0o755);
+  return launcherPath;
+}
+
 function runShim(homeDir, name, args, options = {}) {
   // os.homedir() reads USERPROFILE on Windows, HOME everywhere else -- both
   // must be set or the real runner/user home leaks into the child process.
@@ -250,6 +264,86 @@ function runTests() {
       const result = runShim(dir, 'totally-fake-binary-xyz-123', []);
       assert.strictEqual(result.status, 127);
       assert.strictEqual(result.signal, null, 'must exit cleanly, not crash/signal');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('a HOME override hiding the manifest still resolves the real binary, never the shim itself (fork-bomb regression)', () => {
+    if (process.platform === 'win32') return; // exercises the POSIX shebang launcher
+    const installHome = createTempDir('egc-shim-dispatch-install-');
+    const overrideHome = createTempDir('egc-shim-dispatch-override-');
+    const realBinDir = createTempDir('egc-shim-dispatch-real-');
+    try {
+      const installedShimDir = path.join(installHome, '.egc', 'bin');
+      fs.mkdirSync(installedShimDir, { recursive: true });
+      const launcher = writeShimLauncher(installedShimDir, 'npm');
+      writeFakeBinary(realBinDir, 'npm', { stdout: 'REAL-NPM-RAN\n' });
+
+      // No manifest anywhere reachable: HOME points at an empty directory,
+      // and the launcher's own directory is first on PATH -- the exact
+      // pre-fix setup where resolution found the launcher and forked until
+      // the machine died.
+      const result = spawnSync(launcher, ['--version'], {
+        encoding: 'utf8',
+        timeout: 15000,
+        env: {
+          ...process.env,
+          HOME: overrideHome,
+          USERPROFILE: overrideHome,
+          PATH: [installedShimDir, realBinDir, path.dirname(process.execPath), '/usr/bin', '/bin'].join(path.delimiter),
+        },
+      });
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('REAL-NPM-RAN'), 'expected the real npm to run');
+    } finally {
+      cleanup(installHome);
+      cleanup(overrideHome);
+      cleanup(realBinDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('when nothing but the shim itself is on PATH, the launcher fails open with 127 instead of recursing', () => {
+    if (process.platform === 'win32') return; // exercises the POSIX shebang launcher
+    const installHome = createTempDir('egc-shim-dispatch-install-');
+    const overrideHome = createTempDir('egc-shim-dispatch-override-');
+    try {
+      const installedShimDir = path.join(installHome, '.egc', 'bin');
+      fs.mkdirSync(installedShimDir, { recursive: true });
+      // A name that exists nowhere else guarantees resolution can only ever
+      // find the launcher itself -- which it must refuse.
+      const launcher = writeShimLauncher(installedShimDir, 'egc-test-shim-only-binary');
+
+      const result = spawnSync(launcher, [], {
+        encoding: 'utf8',
+        timeout: 15000,
+        env: {
+          ...process.env,
+          HOME: overrideHome,
+          USERPROFILE: overrideHome,
+          PATH: [installedShimDir, path.dirname(process.execPath), '/usr/bin', '/bin'].join(path.delimiter),
+        },
+      });
+      assert.strictEqual(result.status, 127);
+      assert.ok(result.stderr.includes('command not found'), `expected a clean failure, got: ${result.stderr}`);
+    } finally {
+      cleanup(installHome);
+      cleanup(overrideHome);
+    }
+  })) passed++; else failed++;
+
+  if (test('a shim spawned directly by a same-name shim refuses to recurse (EGC_SHIM_PENDING circuit breaker)', () => {
+    const dir = createTempDir('egc-shim-dispatch-');
+    try {
+      seedManifest(dir, {});
+      // This process plays the role of the outer shim: the child sees
+      // EGC_SHIM_PENDING naming it with its direct parent's pid, which is
+      // the depth-1 signature of the shim having resolved to itself.
+      const result = runShim(dir, 'npm', ['--version'], {
+        env: { ...process.env, HOME: dir, USERPROFILE: dir, EGC_SHIM_PENDING: `npm:${process.pid}` },
+      });
+      assert.strictEqual(result.status, 127);
+      assert.ok(result.stderr.includes('refused to recurse'), `expected the circuit-breaker message, got: ${result.stderr}`);
     } finally {
       cleanup(dir);
     }

--- a/tests/lib/crusher-shim-dispatch.test.js
+++ b/tests/lib/crusher-shim-dispatch.test.js
@@ -6,31 +6,8 @@ const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
-const DISPATCH_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
 const { needsShellOnWindows } = require('../../scripts/lib/crusher/shim-dispatch');
-
-// Built with String.fromCharCode/RegExp instead of typing the raw U+2028 and
-// U+2029 characters, so this file never carries invisible codepoints of its
-// own while implementing a fix for exactly that class of problem.
-const LINE_SEPARATOR = String.fromCharCode(0x2028);
-const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
-const UNSAFE_CODE_CHARS = {
-  '<': '\\u003C',
-  '>': '\\u003E',
-  [LINE_SEPARATOR]: '\\u2028',
-  [PARAGRAPH_SEPARATOR]: '\\u2029',
-};
-const UNSAFE_CODE_CHARS_RE = new RegExp(`[<>${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`, 'g');
-
-// JSON.stringify alone is not a safe way to embed a value inside generated
-// source code: it leaves characters like < > and the U+2028/U+2029 line
-// separators untouched, which can still break out of the surrounding syntax
-// depending on context (flagged by CodeQL as js/bad-code-sanitization). These
-// fake binaries only ever receive fixed test fixtures, never external input,
-// but the construction itself should not rely on that.
-function jsStringLiteral(value) {
-  return JSON.stringify(value).replace(UNSAFE_CODE_CHARS_RE, (c) => UNSAFE_CODE_CHARS[c]);
-}
+const { DISPATCH_SCRIPT, jsStringLiteral, writeShimLauncher } = require('./shim-fixtures');
 
 function withPlatform(value, fn) {
   const original = Object.getOwnPropertyDescriptor(process, 'platform');
@@ -93,20 +70,6 @@ function seedManifest(homeDir, entries) {
   const binDir = path.join(homeDir, '.egc', 'bin');
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(path.join(binDir, 'manifest.json'), JSON.stringify(entries));
-}
-
-// Mirrors shim-install.js's posixLauncherSource(): the exact launcher shape
-// `egc crusher-shim install` writes to ~/.egc/bin/<name>, pointing back at
-// this checkout's shim-dispatch.js.
-function writeShimLauncher(binDir, name) {
-  const launcherPath = path.join(binDir, name);
-  fs.writeFileSync(launcherPath, [
-    '#!/usr/bin/env node',
-    `require(${jsStringLiteral(DISPATCH_SCRIPT)}).runShim(${jsStringLiteral(name)}, process.argv.slice(2));`,
-    '',
-  ].join('\n'));
-  fs.chmodSync(launcherPath, 0o755);
-  return launcherPath;
 }
 
 function runShim(homeDir, name, args, options = {}) {
@@ -346,6 +309,39 @@ function runTests() {
       assert.ok(result.stderr.includes('refused to recurse'), `expected the circuit-breaker message, got: ${result.stderr}`);
     } finally {
       cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('EGC_SHIM_LAUNCHER_DIR anchors manifest lookup and exclusion when argv[1] is not the launcher (.cmd dispatch shape)', () => {
+    // The Windows .cmd launcher spawns `node shim-dispatch.js <name>`, so
+    // process.argv[1] is this module, not the launcher; the .cmd bakes its
+    // own directory into EGC_SHIM_LAUNCHER_DIR instead. Simulated portably
+    // by spawning the dispatcher exactly that way with the anchor set.
+    const installHome = createTempDir('egc-shim-dispatch-install-');
+    const overrideHome = createTempDir('egc-shim-dispatch-override-');
+    const realBinDir = createTempDir('egc-shim-dispatch-real-');
+    try {
+      const installedShimDir = path.join(installHome, '.egc', 'bin');
+      fs.mkdirSync(installedShimDir, { recursive: true });
+      writeFakeBinary(installedShimDir, 'npm', { stdout: 'DECOY-RAN\n' });
+      const realNpm = writeFakeBinary(realBinDir, 'npm', { stdout: 'REAL-NPM-RAN\n' });
+      fs.writeFileSync(path.join(installedShimDir, 'manifest.json'), JSON.stringify({ npm: realNpm }));
+
+      const result = runShim(overrideHome, 'npm', ['--version'], {
+        env: {
+          ...process.env,
+          HOME: overrideHome,
+          USERPROFILE: overrideHome,
+          EGC_SHIM_LAUNCHER_DIR: installedShimDir,
+          PATH: [installedShimDir, realBinDir, path.dirname(process.execPath)].join(path.delimiter),
+        },
+      });
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('REAL-NPM-RAN'), 'the manifest beside the anchored launcher dir must win over the decoy');
+    } finally {
+      cleanup(installHome);
+      cleanup(overrideHome);
+      cleanup(realBinDir);
     }
   })) passed++; else failed++;
 

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -161,6 +161,89 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('a HOME override never makes resolution return the launcher itself (fork-bomb regression)', () => {
+    // The exact failure that used to fork-bomb the machine: launchers
+    // installed under one home, the process running with HOME pointing
+    // somewhere else, and the launcher's own directory still on PATH.
+    const installHome = createTempDir('egc-shim-paths-install-');
+    const overrideHome = createTempDir('egc-shim-paths-override-');
+    const realBinDir = createTempDir('egc-shim-paths-real-');
+    try {
+      const installedShimDir = path.join(installHome, '.egc', 'bin');
+      fs.mkdirSync(installedShimDir, { recursive: true });
+      const launcher = path.join(installedShimDir, 'npm');
+      writeFakeExecutable(launcher);
+      const realNpm = path.join(realBinDir, 'npm');
+      writeFakeExecutable(realNpm);
+
+      withHome(overrideHome, () => {
+        const savedPath = process.env.PATH;
+        process.env.PATH = `${installedShimDir}${path.delimiter}${realBinDir}${path.delimiter}${savedPath}`;
+        try {
+          const found = resolveRealBinary('npm', launcher);
+          assert.ok(found, 'expected npm to resolve somewhere');
+          assert.strictEqual(path.resolve(found), path.resolve(realNpm), 'must skip the launcher directory and find the real npm');
+        } finally {
+          process.env.PATH = savedPath;
+        }
+      });
+    } finally {
+      cleanup(installHome);
+      cleanup(overrideHome);
+      cleanup(realBinDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('the manifest next to the launcher wins even when HOME points elsewhere', () => {
+    const installHome = createTempDir('egc-shim-paths-install-');
+    const overrideHome = createTempDir('egc-shim-paths-override-');
+    try {
+      const installedShimDir = path.join(installHome, '.egc', 'bin');
+      fs.mkdirSync(installedShimDir, { recursive: true });
+      const launcher = path.join(installedShimDir, 'npm');
+      writeFakeExecutable(launcher);
+      const realNpm = path.join(installHome, 'real-npm');
+      writeFakeExecutable(realNpm);
+      fs.writeFileSync(path.join(installedShimDir, 'manifest.json'), JSON.stringify({ npm: realNpm }));
+
+      withHome(overrideHome, () => {
+        assert.strictEqual(resolveRealBinary('npm', launcher), realNpm);
+      });
+    } finally {
+      cleanup(installHome);
+      cleanup(overrideHome);
+    }
+  })) passed++; else failed++;
+
+  if (test('a manifest entry pointing back into a shim directory is rejected, not spawned', () => {
+    const home = createTempDir('egc-shim-paths-');
+    const realBinDir = createTempDir('egc-shim-paths-real-');
+    try {
+      withHome(home, () => {
+        const dir = shimDir();
+        fs.mkdirSync(dir, { recursive: true });
+        const launcher = path.join(dir, 'npm');
+        writeFakeExecutable(launcher);
+        const realNpm = path.join(realBinDir, 'npm');
+        writeFakeExecutable(realNpm);
+        fs.writeFileSync(manifestPath(), JSON.stringify({ npm: launcher }));
+
+        const savedPath = process.env.PATH;
+        process.env.PATH = `${dir}${path.delimiter}${realBinDir}${path.delimiter}${savedPath}`;
+        try {
+          const found = resolveRealBinary('npm', launcher);
+          assert.ok(found, 'expected npm to resolve somewhere');
+          assert.strictEqual(path.resolve(found), path.resolve(realNpm), 'a poisoned manifest must fall through to a real PATH lookup');
+        } finally {
+          process.env.PATH = savedPath;
+        }
+      });
+    } finally {
+      cleanup(home);
+      cleanup(realBinDir);
+    }
+  })) passed++; else failed++;
+
   if (test('resolveRealBinary prefers a valid manifest entry over a fresh PATH lookup', () => {
     const dir = createTempDir('egc-shim-paths-');
     try {

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -194,10 +194,11 @@ function runTests() {
         try {
           const found = resolveRealBinary('npm', installedShimDir);
           assert.ok(found, 'expected npm to resolve somewhere');
-          // realpathSync, not path.resolve: Windows runners hand out the
-          // temp dir under its 8.3 short name (RUNNER~1) while `where`
-          // reports the long form -- same file, two spellings.
-          assert.strictEqual(fs.realpathSync(found), fs.realpathSync(realNpm), 'must skip the launcher directory and find the real npm');
+          // realpathSync.native, not plain realpathSync: only the native
+          // call expands Windows 8.3 short names, and the runner hands out
+          // the temp dir as RUNNER~1 while `where` reports runneradmin --
+          // same file, two spellings.
+          assert.strictEqual(fs.realpathSync.native(found), fs.realpathSync.native(realNpm), 'must skip the launcher directory and find the real npm');
         } finally {
           process.env.PATH = savedPath;
         }
@@ -244,8 +245,8 @@ function runTests() {
         try {
           const found = resolveRealBinary('npm', dir);
           assert.ok(found, 'expected npm to resolve somewhere');
-          // realpathSync for the same 8.3 short-name reason as above.
-          assert.strictEqual(fs.realpathSync(found), fs.realpathSync(realNpm), 'a poisoned manifest must fall through to a real PATH lookup');
+          // realpathSync.native for the same 8.3 short-name reason as above.
+          assert.strictEqual(fs.realpathSync.native(found), fs.realpathSync.native(realNpm), 'a poisoned manifest must fall through to a real PATH lookup');
         } finally {
           process.env.PATH = savedPath;
         }

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -194,7 +194,10 @@ function runTests() {
         try {
           const found = resolveRealBinary('npm', installedShimDir);
           assert.ok(found, 'expected npm to resolve somewhere');
-          assert.strictEqual(path.resolve(found), path.resolve(realNpm), 'must skip the launcher directory and find the real npm');
+          // realpathSync, not path.resolve: Windows runners hand out the
+          // temp dir under its 8.3 short name (RUNNER~1) while `where`
+          // reports the long form -- same file, two spellings.
+          assert.strictEqual(fs.realpathSync(found), fs.realpathSync(realNpm), 'must skip the launcher directory and find the real npm');
         } finally {
           process.env.PATH = savedPath;
         }
@@ -241,7 +244,8 @@ function runTests() {
         try {
           const found = resolveRealBinary('npm', dir);
           assert.ok(found, 'expected npm to resolve somewhere');
-          assert.strictEqual(path.resolve(found), path.resolve(realNpm), 'a poisoned manifest must fall through to a real PATH lookup');
+          // realpathSync for the same 8.3 short-name reason as above.
+          assert.strictEqual(fs.realpathSync(found), fs.realpathSync(realNpm), 'a poisoned manifest must fall through to a real PATH lookup');
         } finally {
           process.env.PATH = savedPath;
         }

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -56,6 +56,20 @@ function writeFakeExecutable(filePath) {
   fs.chmodSync(filePath, 0o755);
 }
 
+// Windows resolves binaries through PATHEXT, so an extension-less fake is
+// invisible to `where`; a .cmd file is the faithful stand-in for the real
+// npm.cmd/yarn.cmd wrappers there.
+function writeFakeCommand(dir, name) {
+  if (process.platform === 'win32') {
+    const binPath = path.join(dir, `${name}.cmd`);
+    fs.writeFileSync(binPath, '@echo off\r\nexit /b 0\r\n');
+    return binPath;
+  }
+  const binPath = path.join(dir, name);
+  writeFakeExecutable(binPath);
+  return binPath;
+}
+
 function test(name, fn) {
   try {
     fn();
@@ -171,10 +185,8 @@ function runTests() {
     try {
       const installedShimDir = path.join(installHome, '.egc', 'bin');
       fs.mkdirSync(installedShimDir, { recursive: true });
-      const launcher = path.join(installedShimDir, 'npm');
-      writeFakeExecutable(launcher);
-      const realNpm = path.join(realBinDir, 'npm');
-      writeFakeExecutable(realNpm);
+      const launcher = writeFakeCommand(installedShimDir, 'npm');
+      const realNpm = writeFakeCommand(realBinDir, 'npm');
 
       withHome(overrideHome, () => {
         const savedPath = process.env.PATH;
@@ -200,10 +212,8 @@ function runTests() {
     try {
       const installedShimDir = path.join(installHome, '.egc', 'bin');
       fs.mkdirSync(installedShimDir, { recursive: true });
-      const launcher = path.join(installedShimDir, 'npm');
-      writeFakeExecutable(launcher);
-      const realNpm = path.join(installHome, 'real-npm');
-      writeFakeExecutable(realNpm);
+      const launcher = writeFakeCommand(installedShimDir, 'npm');
+      const realNpm = writeFakeCommand(installHome, 'real-npm');
       fs.writeFileSync(path.join(installedShimDir, 'manifest.json'), JSON.stringify({ npm: realNpm }));
 
       withHome(overrideHome, () => {
@@ -222,10 +232,8 @@ function runTests() {
       withHome(home, () => {
         const dir = shimDir();
         fs.mkdirSync(dir, { recursive: true });
-        const launcher = path.join(dir, 'npm');
-        writeFakeExecutable(launcher);
-        const realNpm = path.join(realBinDir, 'npm');
-        writeFakeExecutable(realNpm);
+        const launcher = writeFakeCommand(dir, 'npm');
+        const realNpm = writeFakeCommand(realBinDir, 'npm');
         fs.writeFileSync(manifestPath(), JSON.stringify({ npm: launcher }));
 
         const savedPath = process.env.PATH;

--- a/tests/lib/crusher-shim-paths.test.js
+++ b/tests/lib/crusher-shim-paths.test.js
@@ -185,14 +185,14 @@ function runTests() {
     try {
       const installedShimDir = path.join(installHome, '.egc', 'bin');
       fs.mkdirSync(installedShimDir, { recursive: true });
-      const launcher = writeFakeCommand(installedShimDir, 'npm');
+      writeFakeCommand(installedShimDir, 'npm');
       const realNpm = writeFakeCommand(realBinDir, 'npm');
 
       withHome(overrideHome, () => {
         const savedPath = process.env.PATH;
         process.env.PATH = `${installedShimDir}${path.delimiter}${realBinDir}${path.delimiter}${savedPath}`;
         try {
-          const found = resolveRealBinary('npm', launcher);
+          const found = resolveRealBinary('npm', installedShimDir);
           assert.ok(found, 'expected npm to resolve somewhere');
           assert.strictEqual(path.resolve(found), path.resolve(realNpm), 'must skip the launcher directory and find the real npm');
         } finally {
@@ -212,12 +212,12 @@ function runTests() {
     try {
       const installedShimDir = path.join(installHome, '.egc', 'bin');
       fs.mkdirSync(installedShimDir, { recursive: true });
-      const launcher = writeFakeCommand(installedShimDir, 'npm');
+      writeFakeCommand(installedShimDir, 'npm');
       const realNpm = writeFakeCommand(installHome, 'real-npm');
       fs.writeFileSync(path.join(installedShimDir, 'manifest.json'), JSON.stringify({ npm: realNpm }));
 
       withHome(overrideHome, () => {
-        assert.strictEqual(resolveRealBinary('npm', launcher), realNpm);
+        assert.strictEqual(resolveRealBinary('npm', installedShimDir), realNpm);
       });
     } finally {
       cleanup(installHome);
@@ -239,7 +239,7 @@ function runTests() {
         const savedPath = process.env.PATH;
         process.env.PATH = `${dir}${path.delimiter}${realBinDir}${path.delimiter}${savedPath}`;
         try {
-          const found = resolveRealBinary('npm', launcher);
+          const found = resolveRealBinary('npm', dir);
           assert.ok(found, 'expected npm to resolve somewhere');
           assert.strictEqual(path.resolve(found), path.resolve(realNpm), 'a poisoned manifest must fall through to a real PATH lookup');
         } finally {

--- a/tests/lib/shim-fixtures.js
+++ b/tests/lib/shim-fixtures.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Shared fixtures for suites that exercise the Token Crusher PATH shim, so
+// the launcher shape lives in one place and the suites cannot drift from
+// what `egc crusher-shim install` actually writes.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DISPATCH_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'lib', 'crusher', 'shim-dispatch.js');
+
+// Built with String.fromCharCode/RegExp instead of typing the raw U+2028 and
+// U+2029 characters, so this file never carries invisible codepoints of its
+// own while building fixtures for exactly that class of problem.
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
+const UNSAFE_CODE_CHARS = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  [LINE_SEPARATOR]: '\\u2028',
+  [PARAGRAPH_SEPARATOR]: '\\u2029',
+};
+const UNSAFE_CODE_CHARS_RE = new RegExp(`[<>${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`, 'g');
+
+// JSON.stringify alone is not a safe way to embed a value inside generated
+// source code: it leaves characters like < > and the U+2028/U+2029 line
+// separators untouched, which can still break out of the surrounding syntax
+// depending on context (flagged by CodeQL as js/bad-code-sanitization).
+// These fixtures only ever receive fixed test values, never external input,
+// but the construction itself should not rely on that.
+function jsStringLiteral(value) {
+  return JSON.stringify(value).replace(UNSAFE_CODE_CHARS_RE, (c) => UNSAFE_CODE_CHARS[c]);
+}
+
+// Mirrors shim-install.js's posixLauncherSource(): the launcher shape
+// `egc crusher-shim install` writes to ~/.egc/bin/<name>, pointing back at
+// this checkout's shim-dispatch.js. The EGC_TEST_SHIM_DEPTH lines are
+// test-only armor: if every anti-recursion layer under test regressed at
+// once, the chain dies at depth 3 with a distinct exit code (97), so the
+// suite fails with an assertion instead of fork-bombing the machine that
+// runs it.
+function writeShimLauncher(binDir, name) {
+  const launcherPath = path.join(binDir, name);
+  fs.writeFileSync(launcherPath, [
+    '#!/usr/bin/env node',
+    'const depth = Number(process.env.EGC_TEST_SHIM_DEPTH || 0);',
+    "if (depth > 3) { process.stderr.write('test shim depth exceeded\\n'); process.exit(97); }",
+    'process.env.EGC_TEST_SHIM_DEPTH = String(depth + 1);',
+    `require(${jsStringLiteral(DISPATCH_SCRIPT)}).runShim(${jsStringLiteral(name)}, process.argv.slice(2));`,
+    '',
+  ].join('\n'));
+  fs.chmodSync(launcherPath, 0o755);
+  return launcherPath;
+}
+
+module.exports = { DISPATCH_SCRIPT, jsStringLiteral, writeShimLauncher };


### PR DESCRIPTION
## Summary

The Token Crusher PATH shim could resolve to **itself** and fork until the host machine's OOM killer stepped in. This PR makes shim identity physical (anchored to the launcher file) instead of HOME-derived, and adds a depth-1 circuit breaker so the failure mode of any future resolution bug is a clean exit 127, never a fork bomb.

## Root cause

`shimDir()` derives `~/.egc/bin` from `os.homedir()`, which follows `HOME`/`USERPROFILE`. Running any shimmed binary with `HOME` pointed elsewhere (sandboxed installs, CI, containers) breaks both consumers of that path:

- the anti-recursion PATH filter excludes a directory that does not exist, while the real `~/.egc/bin` stays on PATH, so `which npm` returns the launcher itself;
- the manifest (which records each real binary) is looked up under the overridden home and silently misses.

`spawnSync(launcher)` then re-enters the shim: infinite recursion, one node process per level. Reproduced on a real machine: `npm install -g @egchq/egc` with an isolated HOME reached 2.4 GB in 11 seconds without extracting a single file, and the userspace OOM killer took down the entire terminal scope with it (systemd journal: `Failed with result 'oom-kill'`, dozens of node processes killed).

## Fix (three independent layers)

1. **Physical identity.** Dispatch passes the launcher file (`process.argv[1]`) into resolution: its directory is excluded from PATH probing, and the manifest is read from beside the launcher first, immune to HOME overrides (`shimDir()` remains the fallback for normal operation).
2. **Candidate sanity.** Any candidate, whether from a manifest entry or the PATH probe, that physically lives in a shim directory (realpath comparison) is rejected; probing uses `which -a` so a first bad hit does not end the search.
3. **Circuit breaker.** The shim records `EGC_SHIM_PENDING=<name>:<pid>` in its child's environment. A shim that finds its own name recorded by its direct parent exits 127 with an actionable message at depth 1. Legitimate nested invocations (an npm script running npm) never trip it: the recorded pid is the shim's, not the real binary's.

## Tests

- `tests/lib/crusher-shim-paths.test.js`: +3 unit cases (HOME-override resolution, manifest-beside-launcher, poisoned manifest) - 14/14 passing.
- `tests/lib/crusher-shim-dispatch.test.js`: +3 integration cases executing a real launcher (HOME override resolves the real binary; shim-only PATH fails open with 127; circuit breaker refuses direct recursion) - 13/13 passing.
- `tests/crush-run-raw-shim.test.js`: unchanged, still 2/2.
- End-to-end on the reproducing machine: the exact detonating scenario (shim first on PATH + isolated HOME) now completes `npm install -g @egchq/egc` in 5 seconds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recursion in the Token Crusher PATH shim when HOME/USERPROFILE is overridden on POSIX and Windows. Resolution now anchors to the physical launcher, rejects shim paths, handles Windows 8.3 names, and fails fast with exit 127 on direct recursion.

- **Bug Fixes**
  - Anchor identity to the physical launcher dir: on POSIX via realpathed process.argv[1]; on Windows via `EGC_SHIM_LAUNCHER_DIR` from `%~dp0`. Exclude that dir from PATH probing and read the manifest beside it; fall back to `shimDir()`.
  - Reject candidates that live in shim directories via realpath checks (`fs.realpathSync.native` for Windows 8.3 canonicalization). Probe PATH with `which -a`/`where`, fall back to plain `which` if `-a` is unsupported; on Windows, accept only spawnable `.exe/.com/.cmd/.bat` candidates.
  - Add `EGC_SHIM_PENDING` circuit breaker: a same‑name shim spawned by a shim exits 127 with guidance; legitimate nested calls are unaffected. Note: this breaker cannot fire across the `cmd.exe` hop on Windows; the physical anchor covers that case.
  - Tests: shared launcher fixtures with a depth guard; Windows uses `.cmd` fixtures and asserts via `realpathSync.native`; integration covers the `EGC_SHIM_LAUNCHER_DIR` anchor and avoids PATH masking.

<sup>Written for commit 1c69572e113863347c06ebc73609b83edc1c5618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

