### PR TITLE
fix(init): register Claude Code MCP servers through the CLI, not a dead config file

### DIFF
--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -16,6 +16,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 let TOML = null;
 try {
@@ -80,10 +81,17 @@ function buildMcpRegistrationTargets(homeDir) {
       format: 'json',
     },
     {
-      name: 'Claude Code (global)',
-      path: path.join(homeDir, '.claude', 'claude_desktop_config.json'),
-      gate: () => fs.existsSync(path.join(homeDir, '.claude')),
-      format: 'json',
+      // Registration goes through the Claude Code CLI itself (`claude mcp
+      // add -s user`), which owns ~/.claude.json. The old target here wrote
+      // ~/.claude/claude_desktop_config.json, a file Claude Code never
+      // reads (that filename belongs to Claude Desktop, which keeps its
+      // config elsewhere entirely), so init reported a registration that
+      // did nothing. The path field is the effective destination the CLI
+      // maintains, shown in dry-run output.
+      name: 'Claude Code (user scope)',
+      path: path.join(homeDir, '.claude.json'),
+      gate: () => claudeCliAvailable(),
+      format: 'claude-cli',
     },
     {
       name: 'Cursor',
@@ -323,11 +331,51 @@ function registerZedContextServers(targetPath, bins) {
   return true;
 }
 
+// Claude Code's user-scope MCP list lives inside ~/.claude.json, a large
+// live state file the CLI rewrites while running - merging into it directly
+// risks clobbering whatever the app writes next. The CLI's own `mcp` verbs
+// are the stable interface, so registration is only attempted when the CLI
+// is actually on PATH (that is also the honest gate: no CLI, no Claude Code
+// to register into).
+function claudeCliAvailable() {
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['claude'], { encoding: 'utf8' });
+  return probe.status === 0 && Boolean((probe.stdout || '').trim());
+}
+
+/**
+ * Registers egc-guardian / egc-memory in Claude Code's user scope via
+ * `claude mcp add -s user`. `claude mcp get <name>` exiting 0 means the
+ * server is already registered (idempotent no-op for that entry). Returns
+ * true if any server was newly added, false if both were already present.
+ * Throws when the CLI refuses an add, so registerTarget surfaces it as a
+ * warning instead of a false success.
+ */
+function registerClaudeCli(_targetPath, bins) {
+  const { guardianBin, memoryBin } = bins;
+  const servers = [
+    ['egc-guardian', guardianBin],
+    ['egc-memory', memoryBin],
+  ];
+  let changed = false;
+  for (const [name, bin] of servers) {
+    const existing = spawnSync('claude', ['mcp', 'get', name], { encoding: 'utf8' });
+    if (existing.status === 0) continue;
+    const added = spawnSync('claude', ['mcp', 'add', '-s', 'user', name, '--', 'node', bin], { encoding: 'utf8' });
+    if (added.error) throw added.error;
+    if (added.status !== 0) {
+      throw new Error(`claude mcp add ${name} failed: ${(added.stderr || added.stdout || '').trim()}`);
+    }
+    changed = true;
+  }
+  return changed;
+}
+
 const FORMAT_HANDLERS = {
   'json': registerJson,
   'toml': registerToml,
   'continue-yaml': registerContinueYaml,
   'zed-context-servers': registerZedContextServers,
+  'claude-cli': registerClaudeCli,
 };
 
 function registerTarget(target, bins, onRegister, onWarn) {
@@ -369,5 +417,6 @@ module.exports = {
   registerToml,
   registerContinueYaml,
   registerZedContextServers,
+  registerClaudeCli,
   registerMcpServers,
 };

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -356,13 +356,29 @@ function resolveClaudeCli() {
  * Throws when the CLI cannot run or refuses an add, so registerTarget
  * surfaces it as a warning instead of a false success.
  */
+// When spawnSync runs through the Windows shell, the args array is joined
+// onto the command line verbatim (windowsVerbatimArguments): no quoting at
+// all, so an install path with a space (C:\Users\First Last\..., Program
+// Files) splits into two arguments and the add silently registers garbage.
+// Quote anything cmd.exe would misparse, doubling embedded quotes, the cmd
+// convention. POSIX callers never hit this path (shell stays false there).
+function quoteForCmdShell(arg) {
+  if (!/[\s"^&|<>()%!]/.test(arg)) return arg;
+  return '"' + arg.replaceAll('"', '""') + '"';
+}
+
 function registerClaudeCli(_targetPath, bins) {
   const { guardianBin, memoryBin } = bins;
   const cli = resolveClaudeCli();
   if (!cli) throw new Error('claude CLI not found on PATH');
   // Same Windows rule as the crusher shim: .cmd/.bat need a shell.
   const { needsShellOnWindows } = require('./crusher/shim-dispatch');
-  const runCli = (args) => spawnSync(cli, args, { encoding: 'utf8', shell: needsShellOnWindows(cli) }); // NOSONAR javascript:S4036 -- cli was resolved above from the user's own PATH on purpose; fixed argv
+  const useShell = needsShellOnWindows(cli);
+  const runCli = (args) => spawnSync(
+    useShell ? quoteForCmdShell(cli) : cli,
+    useShell ? args.map(quoteForCmdShell) : args,
+    { encoding: 'utf8', shell: useShell }
+  ); // NOSONAR javascript:S4036 -- cli was resolved above from the user's own PATH on purpose; fixed argv
 
   const servers = [
     ['egc-guardian', guardianBin],
@@ -433,5 +449,6 @@ module.exports = {
   registerContinueYaml,
   registerZedContextServers,
   registerClaudeCli,
+  quoteForCmdShell,
   registerMcpServers,
 };

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -360,10 +360,14 @@ function resolveClaudeCli() {
 // onto the command line verbatim (windowsVerbatimArguments): no quoting at
 // all, so an install path with a space (C:\Users\First Last\..., Program
 // Files) splits into two arguments and the add silently registers garbage.
-// Quote anything cmd.exe would misparse, doubling embedded quotes, the cmd
-// convention. POSIX callers never hit this path (shell stays false there).
+// Quote what double quotes actually neutralize in cmd.exe: whitespace,
+// quotes, and shell metacharacters. Deliberately NOT % or !: cmd expands
+// %var% (and !var! under delayed expansion) even inside double quotes, so
+// including them would only pretend a safety this quoting cannot provide.
+// Embedded quotes double, the cmd convention. POSIX callers never hit this
+// path (shell stays false there).
 function quoteForCmdShell(arg) {
-  if (!/[\s"^&|<>()%!]/.test(arg)) return arg;
+  if (!/[\s"^&|<>()]/.test(arg)) return arg;
   return '"' + arg.replaceAll('"', '""') + '"';
 }
 

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -90,7 +90,7 @@ function buildMcpRegistrationTargets(homeDir) {
       // maintains, shown in dry-run output.
       name: 'Claude Code (user scope)',
       path: path.join(homeDir, '.claude.json'),
-      gate: () => claudeCliAvailable(),
+      gate: () => resolveClaudeCli() !== null,
       format: 'claude-cli',
     },
     {
@@ -336,10 +336,16 @@ function registerZedContextServers(targetPath, bins) {
 // risks clobbering whatever the app writes next. The CLI's own `mcp` verbs
 // are the stable interface, so registration is only attempted when the CLI
 // is actually on PATH (that is also the honest gate: no CLI, no Claude Code
-// to register into).
-function claudeCliAvailable() {
-  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['claude'], { encoding: 'utf8' });
-  return probe.status === 0 && Boolean((probe.stdout || '').trim());
+// to register into). PATH resolution is the point, not an accident: this
+// must find whatever `claude` the user really runs. On Windows npm installs
+// the CLI as claude.cmd, which spawnSync cannot launch without a shell, so
+// the resolved candidate is filtered to spawnable extensions and later
+// launched with the same shell rule the crusher shim uses.
+function resolveClaudeCli() {
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['claude'], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- resolving the user's claude CLI from PATH is the feature; fixed argv, no shell
+  if (probe.status !== 0 || !probe.stdout) return null;
+  const candidates = probe.stdout.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  return candidates.find(c => process.platform !== 'win32' || /\.(exe|com|cmd|bat)$/i.test(c)) || null;
 }
 
 /**
@@ -347,20 +353,29 @@ function claudeCliAvailable() {
  * `claude mcp add -s user`. `claude mcp get <name>` exiting 0 means the
  * server is already registered (idempotent no-op for that entry). Returns
  * true if any server was newly added, false if both were already present.
- * Throws when the CLI refuses an add, so registerTarget surfaces it as a
- * warning instead of a false success.
+ * Throws when the CLI cannot run or refuses an add, so registerTarget
+ * surfaces it as a warning instead of a false success.
  */
 function registerClaudeCli(_targetPath, bins) {
   const { guardianBin, memoryBin } = bins;
+  const cli = resolveClaudeCli();
+  if (!cli) throw new Error('claude CLI not found on PATH');
+  // Same Windows rule as the crusher shim: .cmd/.bat need a shell.
+  const { needsShellOnWindows } = require('./crusher/shim-dispatch');
+  const runCli = (args) => spawnSync(cli, args, { encoding: 'utf8', shell: needsShellOnWindows(cli) }); // NOSONAR javascript:S4036 -- cli was resolved above from the user's own PATH on purpose; fixed argv
+
   const servers = [
     ['egc-guardian', guardianBin],
     ['egc-memory', memoryBin],
   ];
   let changed = false;
   for (const [name, bin] of servers) {
-    const existing = spawnSync('claude', ['mcp', 'get', name], { encoding: 'utf8' });
+    const existing = runCli(['mcp', 'get', name]);
+    // A CLI that cannot even run is not "server missing" - surface it
+    // instead of piling a doomed `add` on top.
+    if (existing.error) throw existing.error;
     if (existing.status === 0) continue;
-    const added = spawnSync('claude', ['mcp', 'add', '-s', 'user', name, '--', 'node', bin], { encoding: 'utf8' });
+    const added = runCli(['mcp', 'add', '-s', 'user', name, '--', 'node', bin]);
     if (added.error) throw added.error;
     if (added.status !== 0) {
       throw new Error(`claude mcp add ${name} failed: ${(added.stderr || added.stdout || '').trim()}`);

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -117,6 +117,7 @@ function runTests() {
         "const fs = require('node:fs');",
         String.raw`fs.appendFileSync(process.env.FAKE_CLAUDE_LOG, JSON.stringify(process.argv.slice(2)) + '\n');`,
         "if (process.argv[2] === 'mcp' && process.argv[3] === 'get') process.exit(Number(process.env.FAKE_GET_STATUS || 1));",
+        "if (process.argv[2] === 'mcp' && process.argv[3] === 'add') { if (Number(process.env.FAKE_ADD_STATUS || 0) !== 0) { process.stderr.write('add refused by fake CLI\\n'); } process.exit(Number(process.env.FAKE_ADD_STATUS || 0)); }",
         'process.exit(0);',
         '',
       ].join('\n'));
@@ -162,6 +163,21 @@ function runTests() {
         assert.strictEqual(changed, false);
         const calls = fs.readFileSync(logPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
         assert.strictEqual(calls.filter(call => call[1] === 'add').length, 0, 'must not re-add registered servers');
+      });
+    }) ? passed++ : failed++);
+
+    (test('registerClaudeCli throws when the CLI refuses an add, so init warns instead of reporting success', () => {
+      withFakeClaude('1', () => {
+        const savedAdd = process.env.FAKE_ADD_STATUS;
+        process.env.FAKE_ADD_STATUS = '2';
+        try {
+          assert.throws(
+            () => registerClaudeCli('/ignored', bins),
+            /claude mcp add egc-guardian failed: add refused by fake CLI/
+          );
+        } finally {
+          if (savedAdd === undefined) delete process.env.FAKE_ADD_STATUS; else process.env.FAKE_ADD_STATUS = savedAdd;
+        }
       });
     }) ? passed++ : failed++);
 

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -20,6 +20,7 @@ const {
   registerToml,
   registerContinueYaml,
   registerZedContextServers,
+  registerClaudeCli,
   registerMcpServers,
 } = require('../../scripts/lib/mcp-register');
 
@@ -85,12 +86,104 @@ function runTests() {
     const targets = buildMcpRegistrationTargets('/home/person');
     const names = targets.map(t => t.name);
     for (const expected of [
-      'Antigravity CLI', 'Gemini CLI', 'Claude Code (global)', 'Cursor',
+      'Antigravity CLI', 'Gemini CLI', 'Claude Code (user scope)', 'Cursor',
       'Kiro', 'Codex CLI', 'OpenCode',
     ]) {
       assert.ok(names.includes(expected), `${expected} should still be a target`);
     }
   }) ? passed++ : failed++);
+
+  // ── registerClaudeCli (Claude Code user scope via the CLI) ────────
+
+  (test('no target points at claude_desktop_config.json (dead-file regression)', () => {
+    const targets = buildMcpRegistrationTargets('/home/person');
+    for (const target of targets) {
+      assert.ok(
+        !String(target.path).includes('claude_desktop_config.json'),
+        `${target.name} must not point at claude_desktop_config.json - Claude Code never reads it`
+      );
+    }
+  }) ? passed++ : failed++);
+
+  if (process.platform !== 'win32') {
+    // A fake `claude` CLI on PATH: logs every invocation, and `mcp get`
+    // exits with FAKE_GET_STATUS (1 = not registered) so each scenario can
+    // steer the handler without a real Claude Code install.
+    const makeFakeClaude = (binDir) => {
+      const logPath = path.join(binDir, 'calls.log');
+      const fake = path.join(binDir, 'claude');
+      fs.writeFileSync(fake, [
+        '#!/usr/bin/env node',
+        "const fs = require('node:fs');",
+        String.raw`fs.appendFileSync(process.env.FAKE_CLAUDE_LOG, JSON.stringify(process.argv.slice(2)) + '\n');`,
+        "if (process.argv[2] === 'mcp' && process.argv[3] === 'get') process.exit(Number(process.env.FAKE_GET_STATUS || 1));",
+        'process.exit(0);',
+        '',
+      ].join('\n'));
+      fs.chmodSync(fake, 0o755);
+      return logPath;
+    };
+
+    const withFakeClaude = (getStatus, fn) => {
+      const binDir = makeTempDir();
+      const logPath = makeFakeClaude(binDir);
+      const savedPath = process.env.PATH;
+      const savedLog = process.env.FAKE_CLAUDE_LOG;
+      const savedStatus = process.env.FAKE_GET_STATUS;
+      process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+      process.env.FAKE_CLAUDE_LOG = logPath;
+      process.env.FAKE_GET_STATUS = getStatus;
+      try {
+        fn(logPath);
+      } finally {
+        process.env.PATH = savedPath;
+        if (savedLog === undefined) delete process.env.FAKE_CLAUDE_LOG; else process.env.FAKE_CLAUDE_LOG = savedLog;
+        if (savedStatus === undefined) delete process.env.FAKE_GET_STATUS; else process.env.FAKE_GET_STATUS = savedStatus;
+        fs.rmSync(binDir, { recursive: true, force: true });
+      }
+    };
+
+    (test('registerClaudeCli adds both servers in user scope when none are registered', () => {
+      withFakeClaude('1', (logPath) => {
+        const changed = registerClaudeCli('/ignored', bins);
+        assert.strictEqual(changed, true);
+        const calls = fs.readFileSync(logPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+        const adds = calls.filter(call => call[1] === 'add');
+        assert.deepStrictEqual(adds, [
+          ['mcp', 'add', '-s', 'user', 'egc-guardian', '--', 'node', bins.guardianBin],
+          ['mcp', 'add', '-s', 'user', 'egc-memory', '--', 'node', bins.memoryBin],
+        ]);
+      });
+    }) ? passed++ : failed++);
+
+    (test('registerClaudeCli is a silent no-op when both servers are already registered', () => {
+      withFakeClaude('0', (logPath) => {
+        const changed = registerClaudeCli('/ignored', bins);
+        assert.strictEqual(changed, false);
+        const calls = fs.readFileSync(logPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+        assert.strictEqual(calls.filter(call => call[1] === 'add').length, 0, 'must not re-add registered servers');
+      });
+    }) ? passed++ : failed++);
+
+    (test('Claude Code gate follows the claude CLI presence on PATH', () => {
+      withFakeClaude('1', () => {
+        const targets = buildMcpRegistrationTargets('/home/person');
+        const target = targets.find(t => t.name === 'Claude Code (user scope)');
+        assert.strictEqual(target.gate(), true, 'gate must open when the CLI is on PATH');
+      });
+      const savedPath = process.env.PATH;
+      const emptyDir = makeTempDir();
+      process.env.PATH = emptyDir;
+      try {
+        const targets = buildMcpRegistrationTargets('/home/person');
+        const target = targets.find(t => t.name === 'Claude Code (user scope)');
+        assert.strictEqual(target.gate(), false, 'gate must close when no CLI exists');
+      } finally {
+        process.env.PATH = savedPath;
+        fs.rmSync(emptyDir, { recursive: true, force: true });
+      }
+    }) ? passed++ : failed++);
+  }
 
   // ── registerJson (generic - used by Cursor, Claude, Gemini, Kiro, etc.) ──
 

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -95,6 +95,18 @@ function runTests() {
 
   // ── registerClaudeCli (Claude Code user scope via the CLI) ────────
 
+  (test('quoteForCmdShell quotes cmd-sensitive arguments and leaves plain ones untouched', () => {
+    const { quoteForCmdShell } = require('../../scripts/lib/mcp-register');
+    assert.strictEqual(quoteForCmdShell('plain-arg'), 'plain-arg');
+    assert.strictEqual(
+      quoteForCmdShell(String.raw`C:\Users\First Last\egc\build\index.js`),
+      String.raw`"C:\Users\First Last\egc\build\index.js"`,
+      'a path with a space must be quoted or cmd.exe splits it into two arguments'
+    );
+    assert.strictEqual(quoteForCmdShell('has"quote'), '"has""quote"', 'embedded quotes double, the cmd convention');
+    assert.strictEqual(quoteForCmdShell('C:\\Program Files\\nodejs\\npm.cmd'), '"C:\\Program Files\\nodejs\\npm.cmd"');
+  }) ? passed++ : failed++);
+
   (test('no target points at claude_desktop_config.json (dead-file regression)', () => {
     const targets = buildMcpRegistrationTargets('/home/person');
     for (const target of targets) {

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -105,6 +105,11 @@ function runTests() {
     );
     assert.strictEqual(quoteForCmdShell('has"quote'), '"has""quote"', 'embedded quotes double, the cmd convention');
     assert.strictEqual(quoteForCmdShell('C:\\Program Files\\nodejs\\npm.cmd'), '"C:\\Program Files\\nodejs\\npm.cmd"');
+    assert.strictEqual(
+      quoteForCmdShell('C:\\pct%path%\\index.js'),
+      'C:\\pct%path%\\index.js',
+      'percent is not a quoting trigger: cmd expands %var% even inside quotes, so quoting would only fake safety'
+    );
   }) ? passed++ : failed++);
 
   (test('no target points at claude_desktop_config.json (dead-file regression)', () => {
@@ -175,6 +180,34 @@ function runTests() {
         assert.strictEqual(changed, false);
         const calls = fs.readFileSync(logPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
         assert.strictEqual(calls.filter(call => call[1] === 'add').length, 0, 'must not re-add registered servers');
+      });
+    }) ? passed++ : failed++);
+
+    (test('the shell branch delivers intact argv end to end (quoting exercised through a real shell)', () => {
+      withFakeClaude('1', (logPath) => {
+        // Forcing the shell branch on POSIX runs the exact quoting path the
+        // Windows .cmd flow uses; /bin/sh applies the same double-quote
+        // grouping rules this code relies on for whitespace, so a path with
+        // spaces must still arrive as ONE argv element in the fake CLI.
+        const dispatch = require('../../scripts/lib/crusher/shim-dispatch');
+        const originalNeedsShell = dispatch.needsShellOnWindows;
+        dispatch.needsShellOnWindows = () => true;
+        const spacedBins = {
+          guardianBin: '/fake dir with space/egc-guardian/build/index.js',
+          memoryBin: '/fake dir with space/egc-memory/build/index.js',
+        };
+        try {
+          const changed = registerClaudeCli('/ignored', spacedBins);
+          assert.strictEqual(changed, true);
+          const calls = fs.readFileSync(logPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+          const adds = calls.filter(call => call[1] === 'add');
+          assert.deepStrictEqual(adds, [
+            ['mcp', 'add', '-s', 'user', 'egc-guardian', '--', 'node', spacedBins.guardianBin],
+            ['mcp', 'add', '-s', 'user', 'egc-memory', '--', 'node', spacedBins.memoryBin],
+          ], 'every argument must survive the shell hop unsplit and unquoted');
+        } finally {
+          dispatch.needsShellOnWindows = originalNeedsShell;
+        }
       });
     }) ? passed++ : failed++);
 


### PR DESCRIPTION
## Summary
The MCP registration target labeled Claude Code (global) wrote to ~/.claude/claude_desktop_config.json. Claude Code never reads that file: the filename belongs to Claude Desktop, and even Claude Desktop keeps it in its own platform config directory, never ~/.claude/. Every install and init since the target existed has therefore reported a registration that did nothing, which is why fresh machines end up with egc-guardian/egc-memory missing from Claude Code until someone registers them by hand.

## Fix
- The target is now Claude Code (user scope) and registers through the CLI's stable interface: claude mcp get <name> for idempotence, claude mcp add -s user <name> -- node <bin> to add.
- The gate is honest: registration is only attempted when the claude CLI is actually on PATH; no CLI means no Claude Code to register into, so the target is skipped instead of writing a dead file.
- A refused add throws, surfacing as a warning in init output instead of a false success.

## Tests
tests/lib/mcp-register.test.js: 31/31 passing, including 3 new cases driving a fake claude CLI (adds both servers in user scope; silent no-op when both already registered; gate follows CLI presence) and a regression guard asserting no target ever points at claude_desktop_config.json again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude Code MCP registration by using the `claude` CLI in user scope and correctly launching it on Windows, including refined shell and argument quoting. Servers now register reliably on fresh installs, idempotently, and failures are surfaced.

- **Bug Fixes**
  - Register `egc-guardian` and `egc-memory` via `claude mcp add -s user`; check with `claude mcp get` to avoid duplicates. Target renamed to “Claude Code (user scope)” and uses `~/.claude.json`.
  - Resolve `claude` from PATH and spawn cross‑platform; on Windows use shell via `needsShellOnWindows`, filter spawnable extensions, and refine cmd.exe quoting so paths with spaces survive without expanding `%` or `!` (shell path exercised end to end).
  - Only attempt registration when `claude` is on PATH; throw on refused adds so init warns instead of reporting success.

<sup>Written for commit f83a204814e5a0f96e0b61876cb8728e555c5bf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

