### PR TITLE
fix(doctor): report state stores honestly instead of a blanket divergence warning

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -71,15 +71,28 @@ function printHuman(report) {
   console.log(`\nSummary: checked=${report.summary.checkedCount}, ok=${report.summary.okCount}, warnings=${report.summary.warningCount}, errors=${report.summary.errorCount}`);
 }
 
+// Windows filesystems are case-insensitive and drive letters arrive in
+// either case depending on the shell (C:\Users vs c:\users under Git
+// Bash), so path identity folds case there; POSIX stays case-sensitive.
+function samePath(a, b) {
+  const resolvedA = path.resolve(a);
+  const resolvedB = path.resolve(b);
+  if (process.platform === 'win32') return resolvedA.toLowerCase() === resolvedB.toLowerCase();
+  return resolvedA === resolvedB;
+}
+
 // Stray copies of the CLI store left in harness directories by the
 // pre-#1104 resolution order (the state-fragmentation bug). Reported with
 // size and last write so the person can tell live data from stale copies.
-function findStateDbFragments(canonicalDbPath, homeDir) {
+// Neither the store in active use nor the canonical ~/.egc location ever
+// counts as a stray: when the CLI resolves to a harness directory, the
+// canonical store is what everything consolidates INTO, not a fragment.
+function findStateDbFragments(activeDbPath, canonicalDbPath, homeDir) {
   const fragments = [];
   const roots = [path.join(homeDir, '.egc'), ...getKnownHarnessDirs(homeDir)];
   for (const root of roots) {
     const candidate = path.join(root, 'egc', 'state.db');
-    if (path.resolve(candidate) === path.resolve(canonicalDbPath)) continue;
+    if (samePath(candidate, activeDbPath) || samePath(candidate, canonicalDbPath)) continue;
     try {
       const stat = fs.statSync(candidate);
       fragments.push({ path: candidate, sizeBytes: stat.size, modifiedAt: stat.mtime.toISOString() });
@@ -93,6 +106,7 @@ function findStateDbFragments(canonicalDbPath, homeDir) {
 function checkStateDb(homeDir) {
   const rootDir = getEGCDir();
   const dbPath = path.join(rootDir, 'egc', 'state.db');
+  const canonicalDbPath = path.join(homeDir, '.egc', 'egc', 'state.db');
   // The memory server always keeps its store under ~/.egc/memory, no matter
   // what getEGCDir() resolves to (mcp/servers/egc-memory/src/index.ts).
   // Probing it under rootDir made this check blind whenever the CLI
@@ -101,22 +115,23 @@ function checkStateDb(homeDir) {
 
   const hasHarnessDb = fs.existsSync(dbPath);
   const hasMemoryDb = fs.existsSync(memoryDbPath);
-  const fragments = findStateDbFragments(dbPath, homeDir);
+  const fragments = findStateDbFragments(dbPath, canonicalDbPath, homeDir);
   // The CLI store belongs in the shared ~/.egc; anywhere else means path
   // resolution picked a harness directory and history is being split.
-  const cliStoreMisplaced = hasHarnessDb
-    && path.resolve(dbPath) !== path.resolve(path.join(homeDir, '.egc', 'egc', 'state.db'));
+  const cliStoreMisplaced = hasHarnessDb && !samePath(dbPath, canonicalDbPath);
+  // Fragments never substitute for a live store: the egc init guidance has
+  // to survive their presence.
+  const missing = !hasHarnessDb && !hasMemoryDb;
 
-  if (!hasHarnessDb && !hasMemoryDb && fragments.length === 0) {
-    return { missing: true, dbPath };
+  if (hasHarnessDb && hasMemoryDb && !cliStoreMisplaced && fragments.length === 0) {
+    // Both stores exist where they belong and no strays: the two-store
+    // layout (CLI events + MCP memory, different engines and schemas) is
+    // the current design, not a fault - nothing to report.
+    return null;
   }
-  if (cliStoreMisplaced || fragments.length > 0 || !hasMemoryDb || !hasHarnessDb) {
-    return { dbPath, memoryDbPath, hasHarnessDb, hasMemoryDb, cliStoreMisplaced, fragments };
-  }
-  // Both stores exist where they belong and no strays: the two-store layout
-  // (CLI events + MCP memory, different engines and schemas) is the current
-  // design, not a fault - nothing to report.
-  return null;
+  // One predictable shape for --json consumers no matter which condition
+  // fired.
+  return { missing, dbPath, memoryDbPath, hasHarnessDb, hasMemoryDb, cliStoreMisplaced, fragments };
 }
 
 function main() {
@@ -146,34 +161,33 @@ function main() {
         if (stateDb.missing) {
           console.log('  WARNING: state.db not found at ' + stateDb.dbPath);
           console.log('  Run: egc init  to create the state store');
-        } else {
-          if (stateDb.cliStoreMisplaced) {
-            console.log('  WARNING: the CLI event store landed in a harness directory:');
-            console.log(`    ${stateDb.dbPath}`);
-            console.log('  It belongs in the shared ~/.egc store; in a harness directory its');
-            console.log('  history is invisible to the rest of EGC. Consolidate it with:');
-            console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
+        }
+        if (stateDb.cliStoreMisplaced) {
+          console.log('  WARNING: the CLI event store landed in a harness directory:');
+          console.log(`    ${stateDb.dbPath}`);
+          console.log('  It belongs in the shared ~/.egc store; in a harness directory its');
+          console.log('  history is invisible to the rest of EGC. Consolidate it with:');
+          console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
+        }
+        if (stateDb.fragments.length > 0) {
+          const plural = stateDb.fragments.length === 1 ? 'copy' : 'copies';
+          console.log(`  WARNING: found ${stateDb.fragments.length} stray state.db ${plural} left behind by older versions:`);
+          for (const fragment of stateDb.fragments) {
+            console.log(`    ${fragment.path} (${fragment.sizeBytes} bytes, last write ${fragment.modifiedAt})`);
           }
-          if (stateDb.fragments.length > 0) {
-            const plural = stateDb.fragments.length === 1 ? 'copy' : 'copies';
-            console.log(`  WARNING: found ${stateDb.fragments.length} stray state.db ${plural} left behind by older versions:`);
-            for (const fragment of stateDb.fragments) {
-              console.log(`    ${fragment.path} (${fragment.sizeBytes} bytes, last write ${fragment.modifiedAt})`);
-            }
-            console.log('  Nothing is lost, but new sessions no longer write there. Consolidate');
-            console.log('  them into the main store (dry-run by default) with:');
-            console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
-          }
-          if (stateDb.hasHarnessDb && !stateDb.hasMemoryDb) {
-            console.log('  Note: the MCP memory store does not exist yet at');
-            console.log(`    ${stateDb.memoryDbPath}`);
-            console.log('  It is created automatically the first time a session saves state.');
-          }
-          if (!stateDb.hasHarnessDb && stateDb.hasMemoryDb && stateDb.fragments.length === 0) {
-            console.log('  Note: the CLI event store does not exist yet at');
-            console.log(`    ${stateDb.dbPath}`);
-            console.log('  Run: egc init  to create it');
-          }
+          console.log('  Nothing is lost, but new sessions no longer write there. Consolidate');
+          console.log('  them into the main store (dry-run by default) with:');
+          console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
+        }
+        if (stateDb.hasHarnessDb && !stateDb.hasMemoryDb) {
+          console.log('  Note: the MCP memory store does not exist yet at');
+          console.log(`    ${stateDb.memoryDbPath}`);
+          console.log('  It is created automatically the first time a session saves state.');
+        }
+        if (!stateDb.hasHarnessDb && stateDb.hasMemoryDb) {
+          console.log('  Note: the CLI event store does not exist yet at');
+          console.log(`    ${stateDb.dbPath}`);
+          console.log('  Run: egc init  to create it');
         }
       }
     }

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const fs = require('node:fs');
 const { buildDoctorReport } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
-const { getEGCDir } = require('./lib/utils');
+const { getEGCDir, getKnownHarnessDirs } = require('./lib/utils');
 const { parseTargetArgs } = require('./lib/cli-target-args');
 
 function showHelp(exitCode = 0) {
@@ -71,19 +71,51 @@ function printHuman(report) {
   console.log(`\nSummary: checked=${report.summary.checkedCount}, ok=${report.summary.okCount}, warnings=${report.summary.warningCount}, errors=${report.summary.errorCount}`);
 }
 
-function checkStateDb() {
+// Stray copies of the CLI store left in harness directories by the
+// pre-#1104 resolution order (the state-fragmentation bug). Reported with
+// size and last write so the person can tell live data from stale copies.
+function findStateDbFragments(canonicalDbPath, homeDir) {
+  const fragments = [];
+  const roots = [path.join(homeDir, '.egc'), ...getKnownHarnessDirs(homeDir)];
+  for (const root of roots) {
+    const candidate = path.join(root, 'egc', 'state.db');
+    if (path.resolve(candidate) === path.resolve(canonicalDbPath)) continue;
+    try {
+      const stat = fs.statSync(candidate);
+      fragments.push({ path: candidate, sizeBytes: stat.size, modifiedAt: stat.mtime.toISOString() });
+    } catch {
+      // Absent: not a fragment.
+    }
+  }
+  return fragments;
+}
+
+function checkStateDb(homeDir) {
   const rootDir = getEGCDir();
   const dbPath = path.join(rootDir, 'egc', 'state.db');
-  const memoryDbPath = path.join(rootDir, 'memory', 'state.db');
-  
+  // The memory server always keeps its store under ~/.egc/memory, no matter
+  // what getEGCDir() resolves to (mcp/servers/egc-memory/src/index.ts).
+  // Probing it under rootDir made this check blind whenever the CLI
+  // resolved to a harness directory.
+  const memoryDbPath = path.join(homeDir, '.egc', 'memory', 'state.db');
+
   const hasHarnessDb = fs.existsSync(dbPath);
   const hasMemoryDb = fs.existsSync(memoryDbPath);
-  
-  if (hasHarnessDb && hasMemoryDb) {
-    return { divergent: true, dbPath, memoryDbPath };
-  } else if (!hasHarnessDb && !hasMemoryDb) {
+  const fragments = findStateDbFragments(dbPath, homeDir);
+  // The CLI store belongs in the shared ~/.egc; anywhere else means path
+  // resolution picked a harness directory and history is being split.
+  const cliStoreMisplaced = hasHarnessDb
+    && path.resolve(dbPath) !== path.resolve(path.join(homeDir, '.egc', 'egc', 'state.db'));
+
+  if (!hasHarnessDb && !hasMemoryDb && fragments.length === 0) {
     return { missing: true, dbPath };
   }
+  if (cliStoreMisplaced || fragments.length > 0 || !hasMemoryDb || !hasHarnessDb) {
+    return { dbPath, memoryDbPath, hasHarnessDb, hasMemoryDb, cliStoreMisplaced, fragments };
+  }
+  // Both stores exist where they belong and no strays: the two-store layout
+  // (CLI events + MCP memory, different engines and schemas) is the current
+  // design, not a fault - nothing to report.
   return null;
 }
 
@@ -94,14 +126,15 @@ function main() {
       showHelp(0);
     }
 
+    const homeDir = process.env.HOME || process.env.USERPROFILE || os.homedir();
     const report = buildDoctorReport({
       repoRoot: options.repoRoot || path.join(__dirname, '..'),
-      homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
+      homeDir,
       projectRoot: process.cwd(),
       targets: options.targets,
     });
     const hasIssues = report.summary.errorCount > 0 || report.summary.warningCount > 0;
-    const stateDb = checkStateDb();
+    const stateDb = checkStateDb(homeDir);
 
     if (options.json) {
       const out = stateDb ? { ...report, stateDb } : report;
@@ -110,14 +143,37 @@ function main() {
       printHuman(report);
       if (stateDb) {
         console.log('\nState store:');
-        if (stateDb.divergent) {
-          console.log('  WARNING: Divergent database architecture detected!');
-          console.log(`  Harness DB: ${stateDb.dbPath}`);
-          console.log(`  Memory DB:  ${stateDb.memoryDbPath}`);
-          console.log('  (This is a known architectural limitation where the MCP memory server and harnesses log to separate databases)');
-        } else if (stateDb.missing) {
+        if (stateDb.missing) {
           console.log('  WARNING: state.db not found at ' + stateDb.dbPath);
           console.log('  Run: egc init  to create the state store');
+        } else {
+          if (stateDb.cliStoreMisplaced) {
+            console.log('  WARNING: the CLI event store landed in a harness directory:');
+            console.log(`    ${stateDb.dbPath}`);
+            console.log('  It belongs in the shared ~/.egc store; in a harness directory its');
+            console.log('  history is invisible to the rest of EGC. Consolidate it with:');
+            console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
+          }
+          if (stateDb.fragments.length > 0) {
+            const plural = stateDb.fragments.length === 1 ? 'copy' : 'copies';
+            console.log(`  WARNING: found ${stateDb.fragments.length} stray state.db ${plural} left behind by older versions:`);
+            for (const fragment of stateDb.fragments) {
+              console.log(`    ${fragment.path} (${fragment.sizeBytes} bytes, last write ${fragment.modifiedAt})`);
+            }
+            console.log('  Nothing is lost, but new sessions no longer write there. Consolidate');
+            console.log('  them into the main store (dry-run by default) with:');
+            console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
+          }
+          if (stateDb.hasHarnessDb && !stateDb.hasMemoryDb) {
+            console.log('  Note: the MCP memory store does not exist yet at');
+            console.log(`    ${stateDb.memoryDbPath}`);
+            console.log('  It is created automatically the first time a session saves state.');
+          }
+          if (!stateDb.hasHarnessDb && stateDb.hasMemoryDb && stateDb.fragments.length === 0) {
+            console.log('  Note: the CLI event store does not exist yet at');
+            console.log(`    ${stateDb.dbPath}`);
+            console.log('  Run: egc init  to create it');
+          }
         }
       }
     }

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -116,9 +116,13 @@ function checkStateDb(homeDir) {
   const hasHarnessDb = fs.existsSync(dbPath);
   const hasMemoryDb = fs.existsSync(memoryDbPath);
   const fragments = findStateDbFragments(dbPath, canonicalDbPath, homeDir);
-  // The CLI store belongs in the shared ~/.egc; anywhere else means path
-  // resolution picked a harness directory and history is being split.
-  const cliStoreMisplaced = hasHarnessDb && !samePath(dbPath, canonicalDbPath);
+  // The CLI store belongs in the shared ~/.egc; landing in a KNOWN harness
+  // directory means resolution picked a harness and history is being split.
+  // An explicit custom EGC_DIR anywhere else is a deliberate override, not
+  // a misplacement, and gets no scary guidance.
+  const cliStoreMisplaced = hasHarnessDb
+    && !samePath(dbPath, canonicalDbPath)
+    && getKnownHarnessDirs(homeDir).some((harnessDir) => samePath(rootDir, harnessDir));
   // Fragments never substitute for a live store: the egc init guidance has
   // to survive their presence.
   const missing = !hasHarnessDb && !hasMemoryDb;

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -766,6 +766,7 @@ module.exports = {
   // Directories
   getHomeDir,
   getEGCDir,
+  getKnownHarnessDirs,
   getClaudeDir, // NOSONAR: deprecated alias kept as a public export for backward compatibility
   getSessionsDir,
   getLegacySessionsDir,

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -64,6 +64,7 @@ function run(args = [], options = {}) {
     ...process.env,
     HOME: options.homeDir || process.env.HOME,
     USERPROFILE: options.homeDir || process.env.USERPROFILE,
+    ...(options.env || {}),
   };
 
   try {
@@ -598,6 +599,75 @@ function runTests() {
       assert.ok(result.stdout.includes('1 stray state.db copy'));
       assert.ok(result.stdout.includes(strayPath));
       assert.ok(result.stdout.includes('merge-fragmented-state-dbs.js'), 'must point at the consolidation script');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('keeps the egc init guidance when nothing exists but a stray fragment does', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      // ~/.egc exists but holds no store yet, so resolution lands there
+      // (Tier 3a) and the harness-dir copy is genuinely a stray.
+      fs.mkdirSync(path.join(homeDir, '.egc'), { recursive: true });
+      const strayPath = path.join(homeDir, '.claude', 'egc', 'state.db');
+      fs.mkdirSync(path.dirname(strayPath), { recursive: true });
+      fs.writeFileSync(strayPath, 'stale-bytes');
+
+      const result = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('WARNING: state.db not found'), 'a fragment must not swallow the missing-store guidance');
+      assert.ok(result.stdout.includes('Run: egc init'), 'the person still needs to know how to create the store');
+      assert.ok(result.stdout.includes(strayPath), 'and the fragment must still be listed');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('warns about a misplaced CLI store without listing the canonical ~/.egc store as a stray', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const harnessDir = path.join(homeDir, '.gemini');
+      const misplacedDb = path.join(harnessDir, 'egc', 'state.db');
+      const canonicalDb = path.join(homeDir, '.egc', 'egc', 'state.db');
+      const memoryDb = path.join(homeDir, '.egc', 'memory', 'state.db');
+      for (const file of [misplacedDb, canonicalDb, memoryDb]) {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, '');
+      }
+
+      // EGC_DIR pins resolution to the harness dir, reproducing a CLI whose
+      // store landed away from ~/.egc.
+      const result = run([], { cwd: projectRoot, homeDir, env: { EGC_DIR: harnessDir } });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('WARNING: the CLI event store landed in a harness directory'));
+      assert.ok(result.stdout.includes(misplacedDb));
+      assert.ok(!result.stdout.includes(`${canonicalDb} (`), 'the canonical ~/.egc store must never be listed as a stray copy');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('--json always emits the full stateDb shape', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const result = run(['--json'], { cwd: projectRoot, homeDir });
+      const parsed = JSON.parse(result.stdout);
+      assert.ok(parsed.stateDb, 'missing stores must still produce a stateDb block');
+      for (const key of ['missing', 'dbPath', 'memoryDbPath', 'hasHarnessDb', 'hasMemoryDb', 'cliStoreMisplaced', 'fragments']) {
+        assert.ok(Object.hasOwn(parsed.stateDb, key), `stateDb must always carry ${key}`);
+      }
+      assert.strictEqual(parsed.stateDb.missing, true);
+      assert.ok(Array.isArray(parsed.stateDb.fragments));
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -611,7 +611,7 @@ function runTests() {
 
     try {
       // ~/.egc exists but holds no store yet, so resolution lands there
-      // (Tier 3a) and the harness-dir copy is genuinely a stray.
+      // (tier 4 of getEGCDir) and the harness-dir copy is genuinely a stray.
       fs.mkdirSync(path.join(homeDir, '.egc'), { recursive: true });
       const strayPath = path.join(homeDir, '.claude', 'egc', 'state.db');
       fs.mkdirSync(path.dirname(strayPath), { recursive: true });

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -555,7 +555,7 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('warns about a divergent database architecture when both harness and memory state.db exist', () => {
+  if (test('stays quiet when both stores live in the shared ~/.egc (two-store layout is the current design)', () => {
     const homeDir = createTempDir('doctor-home-');
     const projectRoot = createTempDir('doctor-project-');
 
@@ -570,11 +570,53 @@ function runTests() {
 
       const result = run([], { cwd: projectRoot, homeDir });
       assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(!result.stdout.includes('Divergent database architecture'), 'the healthy two-store layout must not be presented as a defect');
+      assert.ok(!result.stdout.includes('State store:'), 'nothing to report means no state-store section at all');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('lists stray state.db fragments with size, last write, and the merge-script pointer', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const egcDir = computeEGCDirForHome(homeDir);
+      fs.mkdirSync(path.join(egcDir, 'egc'), { recursive: true });
+      fs.mkdirSync(path.join(egcDir, 'memory'), { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'egc', 'state.db'), '');
+      fs.writeFileSync(path.join(egcDir, 'memory', 'state.db'), '');
+      const strayPath = path.join(homeDir, '.gemini', 'egc', 'state.db');
+      fs.mkdirSync(path.dirname(strayPath), { recursive: true });
+      fs.writeFileSync(strayPath, 'stale-bytes');
+
+      const result = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
       assert.ok(result.stdout.includes('State store:'));
-      assert.ok(result.stdout.includes('WARNING: Divergent database architecture detected!'));
-      assert.ok(result.stdout.includes(`Harness DB: ${dbPath}`));
-      assert.ok(result.stdout.includes(`Memory DB:  ${memoryDbPath}`));
-      assert.ok(result.stdout.includes('known architectural limitation'));
+      assert.ok(result.stdout.includes('1 stray state.db copy'));
+      assert.ok(result.stdout.includes(strayPath));
+      assert.ok(result.stdout.includes('merge-fragmented-state-dbs.js'), 'must point at the consolidation script');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('notes a not-yet-created memory store as informational, not a warning', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const egcDir = computeEGCDirForHome(homeDir);
+      fs.mkdirSync(path.join(egcDir, 'egc'), { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'egc', 'state.db'), '');
+
+      const result = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('Note: the MCP memory store does not exist yet'));
+      assert.ok(!result.stdout.includes('WARNING: the CLI event store'), 'a store in the right place must not trigger the misplacement warning');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);


### PR DESCRIPTION
## Summary
Part B1 of the sandbox-audit fixes: egc doctor's state-store check was both blind and alarmist.

## What was wrong
- It probed the memory DB at getEGCDir()/memory/state.db, but the memory server always stores at ~/.egc/memory/state.db (mcp/servers/egc-memory/src/index.ts), so the check malfunctioned whenever the CLI resolved to a harness directory.
- Both stores existing triggered WARNING: Divergent database architecture - presenting the current two-store design (CLI event store and MCP memory store, different engines and schemas) as a defect.
- Real fragmentation (stray */egc/state.db copies left in harness dirs by the pre-#1104 resolution order) was never reported.

## Now
- Memory store probed at its fixed home.
- Stray fragments listed with size and last write, pointing at the existing scripts/maintenance/merge-fragmented-state-dbs.js (additive, backed up, dry-run by default).
- A CLI store that itself landed in a harness directory warns for real.
- A not-yet-created store is an informational note, not a warning.
- Healthy layout (both stores in ~/.egc, no strays) reports nothing.

## Tests
tests/scripts/doctor.test.js: 15/15 - the old divergence expectation replaced by the quiet-healthy case, plus new fragment-listing and informational-note cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `egc doctor` state-store check to report real issues and drop the blanket “divergent architecture” warning. It now probes the memory DB at the right path, lists real fragments, and only warns for misplacement in known harness dirs.

- **Bug Fixes**
  - Probe memory store at `~/.egc/memory/state.db`; pass `homeDir`.
  - Detect stray `state.db` in known harness dirs; exclude active and canonical stores; show size/mtime; link `scripts/maintenance/merge-fragmented-state-dbs.js`.
  - Warn only when the CLI store lands in a known harness dir; do not flag a custom `EGC_DIR` elsewhere; treat not-yet-created stores as notes; keep “egc init” guidance when only fragments exist.
  - Normalize path identity on Windows (case-insensitive) to avoid false fragments.
  - `--json` always returns a uniform `stateDb` object; healthy two‑store layout in `~/.egc` reports nothing.

<sup>Written for commit ced619f557a049a0a70b01e72c665d794bf5375e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

