### PR TITLE
fix(install): make the bare install honest about Claude Code, project .mcp.json, and the dashboard

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -256,18 +256,34 @@ if (-not $DryRun) {
     # Claude Code - a different application entirely. No CLI on PATH means
     # no Claude Code to register into.
     if (Get-Command claude -ErrorAction SilentlyContinue) {
-        foreach ($server in @(
-            @{ Name = "egc-guardian"; Bin = $GuardianBin },
-            @{ Name = "egc-memory"; Bin = $MemoryBin }
-        )) {
-            claude mcp get $server.Name *> $null
-            if ($LASTEXITCODE -ne 0) {
-                claude mcp add -s user $server.Name -- node $server.Bin *> $null
-                if ($LASTEXITCODE -eq 0) {
-                    Write-Host "  v registered $($server.Name) in Claude Code (user scope)"
-                } else {
-                    Write-Host "  note: could not register $($server.Name) in Claude Code. Run manually: claude mcp add -s user $($server.Name) -- node `"$($server.Bin)`""
+        # A non-zero exit from `claude mcp get` is the expected "not
+        # registered yet" answer, but PowerShell 7.4+ turns native exit
+        # codes into terminating errors while $ErrorActionPreference is
+        # Stop, which would abort the whole installer before the check
+        # below could read $LASTEXITCODE.
+        $previousNativePref = $null
+        if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+            $previousNativePref = $PSNativeCommandUseErrorActionPreference
+            $PSNativeCommandUseErrorActionPreference = $false
+        }
+        try {
+            foreach ($server in @(
+                @{ Name = "egc-guardian"; Bin = $GuardianBin },
+                @{ Name = "egc-memory"; Bin = $MemoryBin }
+            )) {
+                claude mcp get $server.Name *> $null
+                if ($LASTEXITCODE -ne 0) {
+                    claude mcp add -s user $server.Name -- node $server.Bin *> $null
+                    if ($LASTEXITCODE -eq 0) {
+                        Write-Host "  v registered $($server.Name) in Claude Code (user scope)"
+                    } else {
+                        Write-Host "  note: could not register $($server.Name) in Claude Code. Run manually: claude mcp add -s user $($server.Name) -- node `"$($server.Bin)`""
+                    }
                 }
+            }
+        } finally {
+            if ($null -ne $previousNativePref) {
+                $PSNativeCommandUseErrorActionPreference = $previousNativePref
             }
         }
     }
@@ -277,8 +293,12 @@ if (-not $DryRun) {
     # bundled .mcp.json is not a user project, and creating a file in an
     # arbitrary cwd would litter. (Get-Location is useless here - the
     # script Set-Location'd to the package root long ago.)
+    # Raw string comparison would call C:/repo and C:\repo different
+    # directories, which is exactly what happens when the installer is
+    # launched from Git Bash on Windows.
+    $normalize = { param($p) [System.IO.Path]::GetFullPath($p).TrimEnd('\', '/') }
     $projectMcp = Join-Path $InvokedFromDir ".mcp.json"
-    if ((Test-Path $projectMcp) -and ($InvokedFromDir -ne $RootDir)) {
+    if ((Test-Path $projectMcp) -and ((& $normalize $InvokedFromDir) -ne (& $normalize $RootDir))) {
         Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"
     }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -246,15 +246,33 @@ if (-not $DryRun) {
         }
     }
 
-    # Claude Code (Windows path)
-    $claudeConfig = Join-Path (Join-Path $env:APPDATA "Claude") "claude_desktop_config.json"
-    if ((Get-Command claude -ErrorAction SilentlyContinue) -or (Test-Path (Split-Path $claudeConfig -Parent))) {
-        Register-McpJson -Target $claudeConfig -Label "Claude Code"
+    # Claude Code: registration goes through the CLI's own user scope. The
+    # old path here wrote Claude Desktop's config file while labeling it
+    # Claude Code - a different application entirely. No CLI on PATH means
+    # no Claude Code to register into.
+    if (Get-Command claude -ErrorAction SilentlyContinue) {
+        foreach ($server in @(
+            @{ Name = "egc-guardian"; Bin = $GuardianBin },
+            @{ Name = "egc-memory"; Bin = $MemoryBin }
+        )) {
+            claude mcp get $server.Name *> $null
+            if ($LASTEXITCODE -ne 0) {
+                claude mcp add -s user $server.Name -- node $server.Bin *> $null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "  v registered $($server.Name) in Claude Code (user scope)"
+                } else {
+                    Write-Host "  note: could not register $($server.Name) in Claude Code. Run manually: claude mcp add -s user $($server.Name) -- node `"$($server.Bin)`""
+                }
+            }
+        }
     }
 
-    # Claude Code - project .mcp.json (if present)
-    $projectMcp = Join-Path $RootDir ".mcp.json"
-    if (Test-Path $projectMcp) {
+    # Claude Code - project .mcp.json: merge into an existing file in the
+    # invoking directory only. The package's own bundled .mcp.json is not a
+    # user project, and creating a file in an arbitrary cwd would litter.
+    $invokingDir = (Get-Location).Path
+    $projectMcp = Join-Path $invokingDir ".mcp.json"
+    if ((Test-Path $projectMcp) -and ($invokingDir -ne $RootDir)) {
         Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"
     }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -23,6 +23,47 @@ function Install-Deps {
     }
 }
 
+# Two paths can name the same directory in several ways: different separators
+# (C:/repo vs C:\repo, routine when the installer is launched from Git Bash),
+# a trailing slash, or a symlink/junction anywhere along the path, including a
+# parent component. Comparing anything less than the fully resolved physical
+# path risks treating the package's own directory as somebody's project and
+# rewriting its bundled .mcp.json. .NET's ResolveLinkTarget is unavailable in
+# Windows PowerShell 5.1, so each component is resolved in turn (with a small
+# depth cap for chained links), which works on every supported version.
+function Resolve-PhysicalDirectory {
+    param([string]$Path)
+
+    try {
+        $full = [System.IO.Path]::GetFullPath($Path)
+    } catch {
+        return $Path.TrimEnd('\', '/')
+    }
+
+    $current = [System.IO.Path]::GetPathRoot($full)
+    $remainder = $full.Substring($current.Length).Trim('\', '/')
+    if ($remainder) {
+        foreach ($segment in ($remainder -split '[\\/]+')) {
+            $current = Join-Path $current $segment
+            for ($hop = 0; $hop -lt 10; $hop++) {
+                try {
+                    $item = Get-Item -LiteralPath $current -Force -ErrorAction Stop
+                } catch {
+                    break
+                }
+                if (-not $item.PSObject.Properties['Target'] -or -not $item.Target) { break }
+                $target = @($item.Target)[0]
+                if (-not [System.IO.Path]::IsPathRooted($target)) {
+                    $target = Join-Path (Split-Path -Parent $item.FullName) $target
+                }
+                $current = [System.IO.Path]::GetFullPath($target)
+            }
+        }
+    }
+
+    return [System.IO.Path]::GetFullPath($current).TrimEnd('\', '/')
+}
+
 # Forward --help directly to the Node installer
 if ($args -contains '--help') {
     node $EgcInstall @args
@@ -293,30 +334,8 @@ if (-not $DryRun) {
     # bundled .mcp.json is not a user project, and creating a file in an
     # arbitrary cwd would litter. (Get-Location is useless here - the
     # script Set-Location'd to the package root long ago.)
-    # Two directories can name the same place three ways: different
-    # separators (C:/repo vs C:\repo, routine when the installer is launched
-    # from Git Bash), a trailing slash, or a symlink/junction pointing at the
-    # package root. All three must compare equal, or the installer would
-    # treat its own bundled .mcp.json as somebody's project file.
-    $normalize = {
-        param($p)
-        try {
-            $item = Get-Item -LiteralPath $p -Force -ErrorAction Stop
-            $resolved = $item.FullName
-            if ($item.PSObject.Properties['Target'] -and $item.Target) {
-                $target = @($item.Target)[0]
-                if (-not [System.IO.Path]::IsPathRooted($target)) {
-                    $target = Join-Path (Split-Path -Parent $item.FullName) $target
-                }
-                $resolved = $target
-            }
-            return [System.IO.Path]::GetFullPath($resolved).TrimEnd('\', '/')
-        } catch {
-            return [System.IO.Path]::GetFullPath($p).TrimEnd('\', '/')
-        }
-    }
     $projectMcp = Join-Path $InvokedFromDir ".mcp.json"
-    if ((Test-Path $projectMcp) -and ((& $normalize $InvokedFromDir) -ne (& $normalize $RootDir))) {
+    if ((Test-Path $projectMcp) -and ((Resolve-PhysicalDirectory $InvokedFromDir) -ne (Resolve-PhysicalDirectory $RootDir))) {
         Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"
     }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -40,28 +40,64 @@ function Resolve-PhysicalDirectory {
         return $Path.TrimEnd('\', '/')
     }
 
-    $current = [System.IO.Path]::GetPathRoot($full)
-    $remainder = $full.Substring($current.Length).Trim('\', '/')
-    if ($remainder) {
-        foreach ($segment in ($remainder -split '[\\/]+')) {
-            $current = Join-Path $current $segment
-            for ($hop = 0; $hop -lt 10; $hop++) {
-                try {
-                    $item = Get-Item -LiteralPath $current -Force -ErrorAction Stop
-                } catch {
-                    break
-                }
-                if (-not $item.PSObject.Properties['Target'] -or -not $item.Target) { break }
-                $target = @($item.Target)[0]
-                if (-not [System.IO.Path]::IsPathRooted($target)) {
-                    $target = Join-Path (Split-Path -Parent $item.FullName) $target
-                }
-                $current = [System.IO.Path]::GetFullPath($target)
-            }
-        }
+    # Components are consumed from a queue rather than a fixed list: when one
+    # of them turns out to be a link, the target's own components are pushed
+    # back onto the front of the queue, so links nested inside a link target
+    # get resolved on the same pass. The step budget only bounds pathological
+    # cycles; it is never reached by a real directory tree.
+    $pending = New-Object 'System.Collections.Generic.Queue[string]'
+    $resolved = [System.IO.Path]::GetPathRoot($full)
+    foreach ($segment in ($full.Substring($resolved.Length).Trim('\', '/') -split '[\\/]+')) {
+        if ($segment) { $pending.Enqueue($segment) }
     }
 
-    return [System.IO.Path]::GetFullPath($current).TrimEnd('\', '/')
+    $steps = 0
+    while ($pending.Count -gt 0) {
+        $steps++
+        if ($steps -gt 512) { break }
+
+        $segment = $pending.Dequeue()
+        if ($segment -eq '.') { continue }
+        if ($segment -eq '..') {
+            $resolved = [System.IO.Path]::GetFullPath((Join-Path $resolved '..'))
+            continue
+        }
+
+        $candidate = Join-Path $resolved $segment
+        $item = $null
+        try {
+            $item = Get-Item -LiteralPath $candidate -Force -ErrorAction Stop
+        } catch {
+            $item = $null
+        }
+
+        $target = $null
+        if ($item -and $item.PSObject.Properties['Target'] -and $item.Target) {
+            $target = @($item.Target)[0]
+        }
+        if (-not $target) {
+            $resolved = $candidate
+            continue
+        }
+
+        $remaining = @($pending.ToArray())
+        $pending.Clear()
+        if ([System.IO.Path]::IsPathRooted($target)) {
+            $targetRoot = [System.IO.Path]::GetPathRoot($target)
+            $targetTail = $target.Substring($targetRoot.Length)
+            $resolved = $targetRoot
+        } else {
+            # A relative target is relative to the link's own directory, which
+            # is exactly where $resolved already points.
+            $targetTail = $target
+        }
+        foreach ($piece in ($targetTail.Trim('\', '/') -split '[\\/]+')) {
+            if ($piece) { $pending.Enqueue($piece) }
+        }
+        foreach ($piece in $remaining) { $pending.Enqueue($piece) }
+    }
+
+    return [System.IO.Path]::GetFullPath($resolved).TrimEnd('\', '/')
 }
 
 # Forward --help directly to the Node installer

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -411,14 +411,10 @@ fs.writeFileSync(t,JSON.stringify(obj,null,2)+"\n");
     Write-Host ""
     Write-Host "Installation complete."
     if (-not $hasInstallArgs) {
-        # Same rule as install.sh and shouldAutoLaunch(): a person at an
-        # interactive terminal gets the dashboard the README promises; CI
-        # and redirected runs stay headless with an honest message.
-        if (-not [Console]::IsOutputRedirected -and -not $env:CI) {
-            & node (Join-Path $RootDir "scripts/lib/dashboard-launch-cli.js") $RootDir
-        } else {
-            Write-Host "Dashboard not started (headless environment). Run 'egc dashboard' to start it."
-        }
+        # Same single decision point as install.sh: shouldAutoLaunch()
+        # inside the wrapper decides whether to launch, and prints the
+        # headless message itself when it declines.
+        & node (Join-Path $RootDir "scripts/lib/dashboard-launch-cli.js") $RootDir
     }
     Write-Host "Run 'egc doctor' to verify."
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -402,8 +402,14 @@ fs.writeFileSync(t,JSON.stringify(obj,null,2)+"\n");
     Write-Host ""
     Write-Host "Installation complete."
     if (-not $hasInstallArgs) {
-        Write-Host "Dashboard was not started automatically."
-        Write-Host "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup."
+        # Same rule as install.sh and shouldAutoLaunch(): a person at an
+        # interactive terminal gets the dashboard the README promises; CI
+        # and redirected runs stay headless with an honest message.
+        if (-not [Console]::IsOutputRedirected -and -not $env:CI) {
+            & node (Join-Path $RootDir "scripts/lib/dashboard-launch-cli.js") $RootDir
+        } else {
+            Write-Host "Dashboard not started (headless environment). Run 'egc dashboard' to start it."
+        }
     }
     Write-Host "Run 'egc doctor' to verify."
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,5 +1,10 @@
 $ErrorActionPreference = "Stop"
 
+# The directory the person ran the installer FROM. Captured here, before any
+# Set-Location moves to the package root, because the project .mcp.json merge
+# near the end must target their project, not the package.
+$InvokedFromDir = (Get-Location).Path
+
 $RootDir       = Split-Path -Parent $PSScriptRoot
 $BootstrapDb   = Join-Path (Join-Path $RootDir "scripts") "bootstrap-state-db.js"
 $EgcInstall    = Join-Path (Join-Path $RootDir "scripts") "install-apply.js"
@@ -268,11 +273,12 @@ if (-not $DryRun) {
     }
 
     # Claude Code - project .mcp.json: merge into an existing file in the
-    # invoking directory only. The package's own bundled .mcp.json is not a
-    # user project, and creating a file in an arbitrary cwd would litter.
-    $invokingDir = (Get-Location).Path
-    $projectMcp = Join-Path $invokingDir ".mcp.json"
-    if ((Test-Path $projectMcp) -and ($invokingDir -ne $RootDir)) {
+    # directory the installer was invoked from only. The package's own
+    # bundled .mcp.json is not a user project, and creating a file in an
+    # arbitrary cwd would litter. (Get-Location is useless here - the
+    # script Set-Location'd to the package root long ago.)
+    $projectMcp = Join-Path $InvokedFromDir ".mcp.json"
+    if ((Test-Path $projectMcp) -and ($InvokedFromDir -ne $RootDir)) {
         Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"
     }
 
@@ -339,7 +345,11 @@ fs.writeFileSync(t,c);
     }
 
     # Obsidian propagation (delegated to Node)
-    $obsidianSources = @($agyConfig, $geminiConfig, $claudeConfig, $cursorConfig)
+    # $claudeConfig (Claude Desktop's file) is gone from both lists: Claude
+    # Code never read it, so it was a dead source and a dead target alike.
+    # Propagating obsidian into Claude Code's real user scope needs the CLI
+    # (claude mcp add-json) and is tracked as a follow-up.
+    $obsidianSources = @($agyConfig, $geminiConfig, $cursorConfig)
     $findObsTmp = Join-Path $env:TEMP ("egc_obs_find_" + [System.Guid]::NewGuid().ToString("N") + ".js")
     Set-Content -Path $findObsTmp -Encoding UTF8 -Value @'
 const fs=require("fs");
@@ -370,7 +380,6 @@ fs.writeFileSync(t,JSON.stringify(obj,null,2)+"\n");
         $propagateTargets = @(
             @{ P = $agyConfig;     L = "Antigravity CLI" }
             @{ P = $geminiConfig;  L = "Gemini CLI" }
-            @{ P = $claudeConfig;  L = "Claude Code" }
             @{ P = $cursorConfig;  L = "Cursor" }
             @{ P = $kiroConfig;    L = "Kiro" }
             @{ P = $opencodeConfig; L = "OpenCode" }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,10 +34,14 @@ function Install-Deps {
 function Resolve-PhysicalDirectory {
     param([string]$Path)
 
+    # Returns $null when the path cannot be fully resolved. Callers must
+    # treat that as "unknown", never as "different": a partial answer here
+    # is what would let the installer mistake its own directory for a user
+    # project and rewrite the bundled .mcp.json.
     try {
         $full = [System.IO.Path]::GetFullPath($Path)
     } catch {
-        return $Path.TrimEnd('\', '/')
+        return $null
     }
 
     # Components are consumed from a queue rather than a fixed list: when one
@@ -54,7 +58,9 @@ function Resolve-PhysicalDirectory {
     $steps = 0
     while ($pending.Count -gt 0) {
         $steps++
-        if ($steps -gt 512) { break }
+        # Only a cyclic link chain gets here; a real tree never does. The
+        # path stays unresolved rather than half-resolved.
+        if ($steps -gt 512) { return $null }
 
         $segment = $pending.Dequeue()
         if ($segment -eq '.') { continue }
@@ -371,8 +377,16 @@ if (-not $DryRun) {
     # arbitrary cwd would litter. (Get-Location is useless here - the
     # script Set-Location'd to the package root long ago.)
     $projectMcp = Join-Path $InvokedFromDir ".mcp.json"
-    if ((Test-Path $projectMcp) -and ((Resolve-PhysicalDirectory $InvokedFromDir) -ne (Resolve-PhysicalDirectory $RootDir))) {
-        Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"
+    if (Test-Path $projectMcp) {
+        $invokedPhysical = Resolve-PhysicalDirectory $InvokedFromDir
+        $rootPhysical = Resolve-PhysicalDirectory $RootDir
+        if (-not $invokedPhysical -or -not $rootPhysical) {
+            # Unresolvable means unknown, and an unknown directory is never
+            # worth the risk of writing into the package's own config.
+            Write-Host "  note: skipped project .mcp.json (could not resolve $InvokedFromDir to a physical path)"
+        } elseif ($invokedPhysical -ne $rootPhysical) {
+            Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"
+        }
     }
 
     # Cursor (Windows path)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -293,10 +293,28 @@ if (-not $DryRun) {
     # bundled .mcp.json is not a user project, and creating a file in an
     # arbitrary cwd would litter. (Get-Location is useless here - the
     # script Set-Location'd to the package root long ago.)
-    # Raw string comparison would call C:/repo and C:\repo different
-    # directories, which is exactly what happens when the installer is
-    # launched from Git Bash on Windows.
-    $normalize = { param($p) [System.IO.Path]::GetFullPath($p).TrimEnd('\', '/') }
+    # Two directories can name the same place three ways: different
+    # separators (C:/repo vs C:\repo, routine when the installer is launched
+    # from Git Bash), a trailing slash, or a symlink/junction pointing at the
+    # package root. All three must compare equal, or the installer would
+    # treat its own bundled .mcp.json as somebody's project file.
+    $normalize = {
+        param($p)
+        try {
+            $item = Get-Item -LiteralPath $p -Force -ErrorAction Stop
+            $resolved = $item.FullName
+            if ($item.PSObject.Properties['Target'] -and $item.Target) {
+                $target = @($item.Target)[0]
+                if (-not [System.IO.Path]::IsPathRooted($target)) {
+                    $target = Join-Path (Split-Path -Parent $item.FullName) $target
+                }
+                $resolved = $target
+            }
+            return [System.IO.Path]::GetFullPath($resolved).TrimEnd('\', '/')
+        } catch {
+            return [System.IO.Path]::GetFullPath($p).TrimEnd('\', '/')
+        }
+    }
     $projectMcp = Join-Path $InvokedFromDir ".mcp.json"
     if ((Test-Path $projectMcp) -and ((& $normalize $InvokedFromDir) -ne (& $normalize $RootDir))) {
         Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -526,15 +526,12 @@ echo "Installation complete."
 if [ "$_has_install_args" = false ]; then
   if [ "$DRY_RUN" = true ]; then
     echo "Dashboard launch skipped (--dry-run)."
-  elif [ -t 1 ] && [ -z "${CI:-}" ]; then
-    # The README promises a live dashboard right after installation; the
-    # shared launcher keeps that true for a person at a terminal. The
-    # gate is duplicated here (TTY + not CI, same rule as
-    # shouldAutoLaunch) so headless installs never even need node for
-    # this step.
-    node "$ROOT_DIR/scripts/lib/dashboard-launch-cli.js" "$ROOT_DIR" || true
   else
-    echo "Dashboard not started (headless environment). Run 'egc dashboard' to start it."
+    # The README promises a live dashboard right after installation. The
+    # launch/skip decision lives in exactly one place - shouldAutoLaunch()
+    # inside the wrapper - so the shell never second-guesses it; the
+    # wrapper prints the headless message itself when it declines.
+    node "$ROOT_DIR/scripts/lib/dashboard-launch-cli.js" "$ROOT_DIR" || true
   fi
 fi
 echo "Run 'egc doctor' to verify."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -519,22 +519,17 @@ fi
 echo ""
 echo "Installation complete."
 if [ "$_has_install_args" = false ]; then
-  if [ "$DRY_RUN" = false ]; then
+  if [ "$DRY_RUN" = true ]; then
+    echo "Dashboard launch skipped (--dry-run)."
+  elif [ -t 1 ] && [ -z "${CI:-}" ]; then
     # The README promises a live dashboard right after installation; the
-    # shared launcher keeps that true for a person at a terminal while
-    # shouldAutoLaunch() keeps CI and scripted installs headless.
-    node - "$ROOT_DIR" <<'NODEEOF'
-const path = require("path");
-const { launchDashboard, shouldAutoLaunch } = require(path.join(process.argv[2], "scripts", "lib", "dashboard-launch"));
-if (shouldAutoLaunch()) {
-  launchDashboard({ rootDir: process.argv[2], log: (line) => console.log(line) });
-} else {
-  console.log("Dashboard not started (headless environment). Run 'egc dashboard' to start it.");
-}
-NODEEOF
+    # shared launcher keeps that true for a person at a terminal. The
+    # gate is duplicated here (TTY + not CI, same rule as
+    # shouldAutoLaunch) so headless installs never even need node for
+    # this step.
+    node "$ROOT_DIR/scripts/lib/dashboard-launch-cli.js" "$ROOT_DIR" || true
   else
-    echo "Dashboard was not started automatically."
-    echo "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup."
+    echo "Dashboard not started (headless environment). Run 'egc dashboard' to start it."
   fi
 fi
 echo "Run 'egc doctor' to verify."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -288,6 +288,26 @@ NODEEOF
   fi
 }
 
+# Claude Code's user-scope MCP list lives in ~/.claude.json, owned by the
+# CLI itself; `claude mcp add -s user` is the stable interface (the same
+# approach scripts/lib/mcp-register.js uses for `egc init`). `claude mcp
+# get` exiting 0 means the server is already registered.
+register_mcp_claude_cli() {
+  local name bin
+  for name in egc-guardian egc-memory; do
+    bin="$GUARDIAN_BIN"
+    if [ "$name" = "egc-memory" ]; then bin="$MEMORY_BIN"; fi
+    if claude mcp get "$name" >/dev/null 2>&1; then
+      continue
+    fi
+    if claude mcp add -s user "$name" -- node "$bin" >/dev/null 2>&1; then
+      echo "  ✓ registered $name in Claude Code (user scope)"
+    else
+      echo "  note: could not register $name in Claude Code. Run manually: claude mcp add -s user $name -- node \"$bin\""
+    fi
+  done
+}
+
 register_mcp_toml_codex() {
   local target="$1"
   node - "$target" "$GUARDIAN_BIN" "$MEMORY_BIN" <<'NODEEOF'
@@ -346,11 +366,19 @@ if [ -d "$HOME/.gemini/config" ] && ! [ -d "$HOME/.gemini/antigravity-cli" ]; th
 fi
 
 # Claude Code: global config
-if command -v claude >/dev/null 2>&1 || [ -d "$HOME/.claude" ]; then
-  register_mcp_json "$HOME/.claude/claude_desktop_config.json" "Claude Code (global)"
-  if [ -f "$ROOT_DIR/.mcp.json" ]; then
-    register_mcp_json "$ROOT_DIR/.mcp.json" "Claude Code (project .mcp.json)"
-  fi
+# Claude Code: registration goes through the CLI's own user scope. The old
+# path here wrote ~/.claude/claude_desktop_config.json, a file Claude Code
+# never reads (that filename belongs to Claude Desktop, which keeps its
+# config elsewhere entirely), so install reported a registration that did
+# nothing. No CLI on PATH means no Claude Code to register into.
+if command -v claude >/dev/null 2>&1; then
+  register_mcp_claude_cli
+fi
+# Merge into an existing project .mcp.json in the invoking directory only:
+# the package's own bundled .mcp.json is not a user project, and creating a
+# file in an arbitrary cwd would litter.
+if [ -f "$PWD/.mcp.json" ] && [ "$PWD" != "$ROOT_DIR" ]; then
+  register_mcp_json "$PWD/.mcp.json" "Claude Code (project .mcp.json)"
 fi
 
 # Cursor
@@ -491,7 +519,22 @@ fi
 echo ""
 echo "Installation complete."
 if [ "$_has_install_args" = false ]; then
-  echo "Dashboard was not started automatically."
-  echo "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup."
+  if [ "$DRY_RUN" = false ]; then
+    # The README promises a live dashboard right after installation; the
+    # shared launcher keeps that true for a person at a terminal while
+    # shouldAutoLaunch() keeps CI and scripted installs headless.
+    node - "$ROOT_DIR" <<'NODEEOF'
+const path = require("path");
+const { launchDashboard, shouldAutoLaunch } = require(path.join(process.argv[2], "scripts", "lib", "dashboard-launch"));
+if (shouldAutoLaunch()) {
+  launchDashboard({ rootDir: process.argv[2], log: (line) => console.log(line) });
+} else {
+  console.log("Dashboard not started (headless environment). Run 'egc dashboard' to start it.");
+}
+NODEEOF
+  else
+    echo "Dashboard was not started automatically."
+    echo "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup."
+  fi
 fi
 echo "Run 'egc doctor' to verify."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -300,7 +300,7 @@ register_mcp_claude_cli() {
   local name bin
   for name in egc-guardian egc-memory; do
     bin="$GUARDIAN_BIN"
-    if [ "$name" = "egc-memory" ]; then bin="$MEMORY_BIN"; fi
+    if [[ "$name" = "egc-memory" ]]; then bin="$MEMORY_BIN"; fi
     if claude mcp get "$name" >/dev/null 2>&1; then
       continue
     fi
@@ -382,7 +382,7 @@ fi
 # was invoked from only: the package's own bundled .mcp.json is not a user
 # project, and creating a file in an arbitrary cwd would litter. ($PWD is
 # useless here - the script cd'd to the package root long ago.)
-if [ -f "$INVOKED_FROM_DIR/.mcp.json" ] && [ "$INVOKED_FROM_DIR" != "$ROOT_DIR" ]; then
+if [[ -f "$INVOKED_FROM_DIR/.mcp.json" ]] && [[ "$INVOKED_FROM_DIR" != "$ROOT_DIR" ]]; then
   register_mcp_json "$INVOKED_FROM_DIR/.mcp.json" "Claude Code (project .mcp.json)"
 fi
 
@@ -524,7 +524,7 @@ fi
 echo ""
 echo "Installation complete."
 if [ "$_has_install_args" = false ]; then
-  if [ "$DRY_RUN" = true ]; then
+  if [[ "$DRY_RUN" = true ]]; then
     echo "Dashboard launch skipped (--dry-run)."
   else
     # The README promises a live dashboard right after installation. The

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,10 @@
 set -e
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# The directory the person ran the installer FROM. Captured here, before the
+# first cd (line ~94 already moves to the package root), because the project
+# .mcp.json merge near the end must target their project, not the package.
+INVOKED_FROM_DIR="$(pwd -P)"
 
 # On Windows via Git Bash/MSYS, $ROOT_DIR is a POSIX-style mount path (e.g.
 # /c/Users/x/EGC) that bash and node-run-from-bash understand, but any path
@@ -374,11 +378,12 @@ fi
 if command -v claude >/dev/null 2>&1; then
   register_mcp_claude_cli
 fi
-# Merge into an existing project .mcp.json in the invoking directory only:
-# the package's own bundled .mcp.json is not a user project, and creating a
-# file in an arbitrary cwd would litter.
-if [ -f "$PWD/.mcp.json" ] && [ "$PWD" != "$ROOT_DIR" ]; then
-  register_mcp_json "$PWD/.mcp.json" "Claude Code (project .mcp.json)"
+# Merge into an existing project .mcp.json in the directory the installer
+# was invoked from only: the package's own bundled .mcp.json is not a user
+# project, and creating a file in an arbitrary cwd would litter. ($PWD is
+# useless here - the script cd'd to the package root long ago.)
+if [ -f "$INVOKED_FROM_DIR/.mcp.json" ] && [ "$INVOKED_FROM_DIR" != "$ROOT_DIR" ]; then
+  register_mcp_json "$INVOKED_FROM_DIR/.mcp.json" "Claude Code (project .mcp.json)"
 fi
 
 # Cursor

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Both of these resolve symlinks (pwd -P). Mixing logical and physical
+# paths would break the comparison further down on macOS, where /tmp is a
+# symlink to /private/tmp: a repo cloned under /tmp would look like an
+# unrelated user project to the installer.
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd -P)"
 # The directory the person ran the installer FROM. Captured here, before the
 # first cd (line ~94 already moves to the package root), because the project
 # .mcp.json merge near the end must target their project, not the package.
@@ -524,14 +528,11 @@ fi
 echo ""
 echo "Installation complete."
 if [ "$_has_install_args" = false ]; then
-  if [[ "$DRY_RUN" = true ]]; then
-    echo "Dashboard launch skipped (--dry-run)."
-  else
-    # The README promises a live dashboard right after installation. The
-    # launch/skip decision lives in exactly one place - shouldAutoLaunch()
-    # inside the wrapper - so the shell never second-guesses it; the
-    # wrapper prints the headless message itself when it declines.
-    node "$ROOT_DIR/scripts/lib/dashboard-launch-cli.js" "$ROOT_DIR" || true
-  fi
+  # The README promises a live dashboard right after installation. The
+  # launch/skip decision lives in exactly one place, shouldAutoLaunch()
+  # inside the wrapper, so the shell never second-guesses it; the wrapper
+  # prints the headless message itself when it declines. (No --dry-run
+  # branch here: a dry run exits long before this point.)
+  node "$ROOT_DIR/scripts/lib/dashboard-launch-cli.js" "$ROOT_DIR" || true
 fi
 echo "Run 'egc doctor' to verify."

--- a/scripts/lib/dashboard-launch-cli.js
+++ b/scripts/lib/dashboard-launch-cli.js
@@ -16,7 +16,10 @@ if (shouldAutoLaunch()) {
   // and take the installer's exit code with it: a dashboard that did not
   // start is never a reason to fail an otherwise complete installation.
   launchDashboard({ rootDir, log: (line) => console.log(line) })
-    .catch((err) => console.log(`Dashboard startup skipped: ${err.message}`));
+    // A rejection value is not guaranteed to be an Error; reading .message
+    // off null here would throw inside the handler and reintroduce the very
+    // unhandled rejection this catch exists to prevent.
+    .catch((err) => console.log(`Dashboard startup skipped: ${err instanceof Error ? err.message : String(err)}`));
 } else {
   console.log("Dashboard not started (headless environment). Run 'egc dashboard' to start it.");
 }

--- a/scripts/lib/dashboard-launch-cli.js
+++ b/scripts/lib/dashboard-launch-cli.js
@@ -11,7 +11,12 @@ const { launchDashboard, shouldAutoLaunch } = require('./dashboard-launch');
 const rootDir = process.argv[2] || path.join(__dirname, '..', '..');
 
 if (shouldAutoLaunch()) {
-  launchDashboard({ rootDir, log: (line) => console.log(line) });
+  // launchDashboard resolves rather than rejects on its own failures, but an
+  // unexpected rejection here would surface as an UnhandledPromiseRejection
+  // and take the installer's exit code with it: a dashboard that did not
+  // start is never a reason to fail an otherwise complete installation.
+  launchDashboard({ rootDir, log: (line) => console.log(line) })
+    .catch((err) => console.log(`Dashboard startup skipped: ${err.message}`));
 } else {
   console.log("Dashboard not started (headless environment). Run 'egc dashboard' to start it.");
 }

--- a/scripts/lib/dashboard-launch-cli.js
+++ b/scripts/lib/dashboard-launch-cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+'use strict';
+
+// Tiny CLI wrapper over dashboard-launch for the shell installers: they
+// cannot require() the module directly, and the launch decision must stay
+// in one place. argv[2] is the repo/package root the dashboard runs from.
+
+const path = require('node:path');
+const { launchDashboard, shouldAutoLaunch } = require('./dashboard-launch');
+
+const rootDir = process.argv[2] || path.join(__dirname, '..', '..');
+
+if (shouldAutoLaunch()) {
+  launchDashboard({ rootDir, log: (line) => console.log(line) });
+} else {
+  console.log("Dashboard not started (headless environment). Run 'egc dashboard' to start it.");
+}

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -28,6 +28,7 @@ const DASHBOARD_MESSAGES = [
   "Dashboard not started (headless environment). Run 'egc dashboard' to start it.",
 ];
 const DASHBOARD_LAUNCHER_REF = 'scripts/lib/dashboard-launch-cli.js';
+const DASHBOARD_LAUNCHER = path.join(REPO_ROOT, 'scripts', 'lib', 'dashboard-launch-cli.js');
 
 function test(name, fn) {
   try {
@@ -84,10 +85,15 @@ function createInstallerFixture() {
     fs.symlinkSync(executable, path.join(binDir, command));
   }
 
+  // The fake node also stands in for the dashboard wrapper: the installer
+  // now delegates the whole launch decision to it, so the fixture emulates
+  // what the real wrapper prints in a headless environment (the CI=1 the
+  // runner sets is exactly the case shouldAutoLaunch() declines).
   writeExecutable(path.join(binDir, 'node'), `#!/bin/sh
 case "$1" in
   -e) printf '20' ;;
   --version) printf 'v20.0.0\\n' ;;
+  *dashboard-launch-cli.js) printf "Dashboard not started (headless environment). Run 'egc dashboard' to start it.\\n" ;;
 esac
 exit 0
 `);
@@ -144,6 +150,7 @@ function runTests() {
       installApply: fs.readFileSync(INSTALL_APPLY, 'utf8'),
       bash: fs.readFileSync(INSTALL_SH, 'utf8'),
       powerShell: fs.readFileSync(INSTALL_PS1, 'utf8'),
+      dashboardWrapper: fs.readFileSync(DASHBOARD_LAUNCHER, 'utf8'),
       guide: fs.readFileSync(INSTALLATION_GUIDE, 'utf8'),
     };
   })) passed++; else failed++;
@@ -160,13 +167,17 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('bash and PowerShell explain dashboard startup after bare installs only', () => {
+  if (test('bash and PowerShell delegate dashboard startup to the shared wrapper, after bare installs only', () => {
+    // The launch/skip decision and its wording live in exactly one place;
+    // the shells must not re-implement either.
     for (const message of DASHBOARD_MESSAGES) {
-      assert.ok(sources.bash.includes(message), `install.sh missing: ${message}`);
-      assert.ok(sources.powerShell.includes(message), `install.ps1 missing: ${message}`);
+      assert.ok(sources.dashboardWrapper.includes(message), `dashboard-launch-cli.js missing: ${message}`);
+      assert.ok(!sources.bash.includes(message), 'install.sh must not duplicate the wrapper wording');
+      assert.ok(!sources.powerShell.includes(message), 'install.ps1 must not duplicate the wrapper wording');
     }
     assert.ok(sources.bash.includes(DASHBOARD_LAUNCHER_REF), 'install.sh must launch the dashboard through the shared CLI wrapper');
     assert.ok(sources.powerShell.includes(DASHBOARD_LAUNCHER_REF), 'install.ps1 must launch the dashboard through the shared CLI wrapper');
+    assert.ok(sources.dashboardWrapper.includes('shouldAutoLaunch'), 'the wrapper owns the launch decision');
     assert.ok(sources.bash.includes('if [ "$_has_install_args" = false ]; then'));
     assert.ok(sources.powerShell.includes('if (-not $hasInstallArgs)'));
   })) passed++; else failed++;
@@ -216,6 +227,23 @@ function runTests() {
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }
+  })) passed++; else failed++;
+
+  if (test('the dashboard wrapper itself declines and explains in a headless environment', () => {
+    // Runs the real wrapper (not a fixture stand-in) with stdout piped and
+    // CI set: the branch every headless install takes, end to end.
+    const wrapper = path.join(REPO_ROOT, 'scripts', 'lib', 'dashboard-launch-cli.js');
+    const result = spawnSync(process.execPath, [wrapper, REPO_ROOT], {
+      encoding: 'utf8',
+      env: { ...process.env, CI: '1' },
+      timeout: INSTALL_TIMEOUT_MS,
+    });
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(
+      result.stdout.trim(),
+      "Dashboard not started (headless environment). Run 'egc dashboard' to start it.",
+      'the wrapper owns the launch decision and must explain itself when it declines'
+    );
   })) passed++; else failed++;
 
   if (test('Bash install arguments suppress the bare-install dashboard notice', () => {

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -229,6 +229,44 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('shouldAutoLaunch says yes exactly for an interactive, non-CI terminal', () => {
+    // The interactive branch cannot be driven end to end without a pty (and
+    // spawning a real dashboard plus a browser mid-test would be a side
+    // effect no suite should have), so the decision itself is exercised
+    // directly - this is the predicate install.sh and install.ps1 now
+    // delegate to entirely.
+    const { shouldAutoLaunch } = require(path.join(REPO_ROOT, 'scripts', 'lib', 'dashboard-launch'));
+    const savedTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    const savedCI = process.env.CI;
+    const withStdout = (isTTY, ci, assertion) => {
+      Object.defineProperty(process.stdout, 'isTTY', { value: isTTY, configurable: true });
+      if (ci === undefined) delete process.env.CI; else process.env.CI = ci;
+      assertion();
+    };
+    try {
+      withStdout(true, undefined, () => assert.strictEqual(shouldAutoLaunch(), true, 'a person at a terminal must get the dashboard'));
+      withStdout(true, '1', () => assert.strictEqual(shouldAutoLaunch(), false, 'CI must stay headless even on a TTY'));
+      withStdout(false, undefined, () => assert.strictEqual(shouldAutoLaunch(), false, 'piped output must stay headless'));
+    } finally {
+      if (savedTTY) Object.defineProperty(process.stdout, 'isTTY', savedTTY);
+      if (savedCI === undefined) delete process.env.CI; else process.env.CI = savedCI;
+    }
+  })) passed++; else failed++;
+
+  if (test('launchDashboard declines without spawning anything when the dashboard script is absent', () => {
+    const { launchDashboard } = require(path.join(REPO_ROOT, 'scripts', 'lib', 'dashboard-launch'));
+    const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-dashboard-root-'));
+    const logged = [];
+    try {
+      return launchDashboard({ rootDir: emptyRoot, log: (line) => logged.push(line) }).then(launched => {
+        assert.strictEqual(launched, false, 'a missing dashboard script must not be treated as a launch');
+        assert.deepStrictEqual(logged, [], 'nothing to say when there is nothing to launch');
+      });
+    } finally {
+      fs.rmSync(emptyRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('the dashboard wrapper itself declines and explains in a headless environment', () => {
     // Runs the real wrapper (not a fixture stand-in) with stdout piped and
     // CI set: the branch every headless install takes, end to end.

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -166,7 +166,7 @@ function runTests() {
       assert.ok(sources.powerShell.includes(message), `install.ps1 missing: ${message}`);
     }
     assert.ok(sources.bash.includes(DASHBOARD_LAUNCHER_REF), 'install.sh must launch the dashboard through the shared CLI wrapper');
-    assert.ok(sources.powerShell.includes('scripts/lib/dashboard-launch-cli.js'), 'install.ps1 must launch the dashboard through the shared CLI wrapper');
+    assert.ok(sources.powerShell.includes(DASHBOARD_LAUNCHER_REF), 'install.ps1 must launch the dashboard through the shared CLI wrapper');
     assert.ok(sources.bash.includes('if [ "$_has_install_args" = false ]; then'));
     assert.ok(sources.powerShell.includes('if (-not $hasInstallArgs)'));
   })) passed++; else failed++;
@@ -182,6 +182,39 @@ function runTests() {
       }
     } finally {
       cleanup();
+    }
+  })) passed++; else failed++;
+
+  if (test('bare Bash install merges an existing project .mcp.json from the invoking directory', () => {
+    if (process.platform === 'win32') return;
+
+    // The installer cd's to the package root early, so this only works when
+    // the invoking directory is captured before that cd - the exact
+    // regression this test pins.
+    const fixture = createInstallerFixture();
+    const projectDir = path.join(fixture.root, 'my-project');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.mcp.json'), JSON.stringify({ mcpServers: {} }, null, 2));
+    const result = spawnSync(fixture.bash, [fixture.installScript], {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        CI: '1',
+        HOME: fixture.homeDir,
+        USERPROFILE: fixture.homeDir,
+        PATH: fixture.binDir,
+      },
+      encoding: 'utf8',
+      timeout: INSTALL_TIMEOUT_MS,
+    });
+    try {
+      assertSuccessfulRun(result);
+      assert.ok(
+        result.stdout.includes('registered in Claude Code (project .mcp.json)'),
+        `invoking-directory .mcp.json must be merged, got:\n${result.stdout}`
+      );
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
     }
   })) passed++; else failed++;
 

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -32,7 +32,22 @@ const DASHBOARD_LAUNCHER = path.join(REPO_ROOT, 'scripts', 'lib', 'dashboard-lau
 
 function test(name, fn) {
   try {
-    fn();
+    const returned = fn();
+    // A promise returned into this synchronous harness would be reported as
+    // a pass before its assertions ran; async cases must use testAsync.
+    assert.ok(!(returned && typeof returned.then === 'function'), 'async test body must be run through testAsync');
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+async function testAsync(name, fn) {
+  try {
+    await fn();
     console.log(`  \u2713 ${name}`);
     return true;
   } catch (error) {
@@ -143,7 +158,7 @@ function assertSuccessfulRun(result) {
   assert.ok(result.stdout.includes('Installation complete.'), 'installer did not reach completion');
 }
 
-function runTests() {
+async function runTests() {
   console.log('\n=== Testing install onboarding guidance ===\n');
 
   let passed = 0;
@@ -258,15 +273,14 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('launchDashboard declines without spawning anything when the dashboard script is absent', () => {
+  if (await testAsync('launchDashboard declines without spawning anything when the dashboard script is absent', async () => {
     const { launchDashboard } = require(path.join(REPO_ROOT, 'scripts', 'lib', 'dashboard-launch'));
     const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-dashboard-root-'));
     const logged = [];
     try {
-      return launchDashboard({ rootDir: emptyRoot, log: (line) => logged.push(line) }).then(launched => {
-        assert.strictEqual(launched, false, 'a missing dashboard script must not be treated as a launch');
-        assert.deepStrictEqual(logged, [], 'nothing to say when there is nothing to launch');
-      });
+      const launched = await launchDashboard({ rootDir: emptyRoot, log: (line) => logged.push(line) });
+      assert.strictEqual(launched, false, 'a missing dashboard script must not be treated as a launch');
+      assert.deepStrictEqual(logged, [], 'nothing to say when there is nothing to launch');
     } finally {
       fs.rmSync(emptyRoot, { recursive: true, force: true });
     }
@@ -321,4 +335,7 @@ function runTests() {
   process.exit(failed > 0 ? 1 : 0);
 }
 
-runTests();
+runTests().catch((error) => {
+  console.log(`  ✗ harness failure\n    ${error.stack || error.message}`);
+  process.exit(1);
+});

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -20,10 +20,14 @@ const UV_MESSAGES = [
   'Required only for Jira and omega-memory MCP servers.',
   'Core EGC installation is unaffected.',
 ];
+// The README promises a live dashboard right after installation, so the
+// bare-install contract is now: interactive terminals launch it through
+// scripts/lib/dashboard-launch-cli.js, and headless runs (CI, pipes) print
+// this honest line instead of pretending nothing was supposed to happen.
 const DASHBOARD_MESSAGES = [
-  'Dashboard was not started automatically.',
-  "Run 'egc dashboard' to start it, or run 'egc init' inside a project for project setup.",
+  "Dashboard not started (headless environment). Run 'egc dashboard' to start it.",
 ];
+const DASHBOARD_LAUNCHER_REF = 'scripts/lib/dashboard-launch-cli.js';
 
 function test(name, fn) {
   try {
@@ -161,6 +165,8 @@ function runTests() {
       assert.ok(sources.bash.includes(message), `install.sh missing: ${message}`);
       assert.ok(sources.powerShell.includes(message), `install.ps1 missing: ${message}`);
     }
+    assert.ok(sources.bash.includes(DASHBOARD_LAUNCHER_REF), 'install.sh must launch the dashboard through the shared CLI wrapper');
+    assert.ok(sources.powerShell.includes('scripts/lib/dashboard-launch-cli.js'), 'install.ps1 must launch the dashboard through the shared CLI wrapper');
     assert.ok(sources.bash.includes('if [ "$_has_install_args" = false ]; then'));
     assert.ok(sources.powerShell.includes('if (-not $hasInstallArgs)'));
   })) passed++; else failed++;

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -104,6 +104,11 @@ fi
 exit 0
 `);
   writeExecutable(path.join(binDir, 'npx'), '#!/bin/sh\nexit 0\n');
+  // Without this stand-in, a machine that really has Claude Code on PATH
+  // would have the suite register MCP servers into its own user scope.
+  // Exit 0 means "already registered", so the installer performs no
+  // mutation at all.
+  writeExecutable(path.join(binDir, 'claude'), '#!/bin/sh\nexit 0\n');
 
   const bash = findExecutable('bash');
   assert.ok(bash, 'bash is required for install.sh execution coverage');


### PR DESCRIPTION
## Summary
Fixes C, D, and the bash/PowerShell twin of the dead-file registration (findings 3, 7, 8 of the sandbox audit), all in the bare-install path the README documents.

## What was broken
- install.sh line 350 wrote ~/.claude/claude_desktop_config.json labeled Claude Code (global); install.ps1 wrote Claude Desktop's APPDATA config labeled Claude Code. Claude Code reads neither: every bare install reported a registration that did nothing (the same defect #1193 fixed for egc init, in its installer twins).
- The 'Claude Code (project .mcp.json)' step registered into the installed npm package's own bundled .mcp.json, which is not a user project.
- README's Quick Start promises a live dashboard right after installation; the bare install explicitly printed that it did not start one.

## Now
- Both installers register through claude mcp add -s user (idempotent via claude mcp get), only when the claude CLI actually exists on PATH.
- The project .mcp.json step merges only into an existing file in the invoking directory and never touches the package's bundled copy.
- install.sh ends by invoking the shared scripts/lib/dashboard-launch.js: interactive terminals get the promised dashboard, CI and pipes stay headless with an honest message.

## Verification
bash -n on install.sh; the dashboard snippet executed standalone with piped stdout prints the headless message (branch proof); the interactive branch is the same launchDashboard call egc init has shipped since #893. install.ps1 parsing is covered by CI (no local pwsh).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bare install so Claude Code registration actually registers, merges a project `.mcp.json` from the invoking directory, and starts the dashboard only when it should. Adds fail‑closed physical-path resolution to avoid writing into the package’s bundled `.mcp.json`.

- **Bug Fixes**
  - Register MCP servers via the `claude` CLI user scope; safely handle PowerShell 7.4 non-zero exits around `claude mcp get`; skip cleanly when `claude` isn’t on PATH.
  - Merge only into an existing project `.mcp.json` in the invoking directory captured before any cd; compare physical paths using queue-based link resolution at every component, fail closed when paths can’t be fully resolved, normalize Windows paths, and use `pwd -P` on POSIX to avoid `/tmp` vs `/private/tmp` mismatches.
  - Launch via `scripts/lib/dashboard-launch-cli.js`; headless runs print: "Dashboard not started (headless environment). Run 'egc dashboard' to start it."; wrapper guards against unexpected and non-Error rejections so install never fails.

- **Refactors**
  - Make `scripts/lib/dashboard-launch-cli.js` the single owner of the dashboard launch decision; shells no longer duplicate TTY/CI checks or wording; remove the dead `--dry-run` message.
  - Expand runtime tests for `shouldAutoLaunch`, wrapper messaging/delegation and headless execution, the no-script branch, invoking-dir `.mcp.json`, and async handling; add a `claude` stub to keep runs inert.

<sup>Written for commit a43a8b2967c7fd99e673df96efc6feaed49368a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

