### PR TITLE
docs(installation): match the guide to what the installer actually does

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,7 +68,7 @@ egc install
 
 This prepares the core runtime, initializes the shared state store, and registers the MCP servers in detected tools. A bare install does **not** create managed target install-state files, so `egc doctor` may report that none exist. That is expected, not an error.
 
-The dashboard also does not start automatically after a bare install. Start it manually with `egc dashboard`, or continue with project setup.
+The dashboard starts right after this stage when you are at an interactive terminal. A headless run (CI, or output redirected to a file) skips it and prints `Dashboard not started (headless environment). Run 'egc dashboard' to start it.` instead.
 
 ### 2. Project setup
 
@@ -152,7 +152,7 @@ shorter or longer than this one. Claude Code is registered through its own
 CLI (`claude mcp add -s user`), which is why those two lines name the
 servers individually. In a headless environment (CI, or output piped to a
 file) the dashboard line is replaced by `Dashboard not started (headless
-environment)`.
+environment). Run 'egc dashboard' to start it.`
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -120,16 +120,21 @@ sh scripts/install.sh
 ```
 EGC install
   node v22.0.0
+  npm 10.0.0
+  Optional dependency not found: uv
+    Required only for Jira and omega-memory MCP servers.
+    Core EGC installation is unaffected. Install: https://docs.astral.sh/uv/
+  installing root dependencies...
   building egc-guardian...
   building egc-memory...
   initializing database...
   bootstrapping cognitive protocol...
-  ✓ ~/.claude/CLAUDE.md updated
-  ✓ ~/.gemini/GEMINI.md updated
+  [cognitive] Claude Code: memory protocol installed (~/.claude/CLAUDE.md)
+  [cognitive] Cursor: memory protocol installed (~/.cursor/rules)
   registering MCP servers...
-  ✓ registered in Claude Code (global)
-  ✓ registered in Cursor
-  ✓ registered in Gemini CLI  ← paid accounts only; see note above
+  ✓ registered egc-guardian in Claude Code (user scope)
+  ✓ registered egc-memory in Claude Code (user scope)
+  ✓ registered in Cursor (~/.cursor/mcp.json)
 
 Install prompt library? (61 agents, 230 skills, 77 commands) [y/N]:
 
@@ -138,8 +143,16 @@ Shim directory: ~/.egc/bin
 Installed: git, npm, gh, ...
 
 Installation complete.
+EGC Dashboard starting at http://localhost:7890
 Run 'egc doctor' to verify.
 ```
+
+Only the tools you actually have are touched, so your own output will be
+shorter or longer than this one. Claude Code is registered through its own
+CLI (`claude mcp add -s user`), which is why those two lines name the
+servers individually. In a headless environment (CI, or output piped to a
+file) the dashboard line is replaced by `Dashboard not started (headless
+environment)`.
 
 ---
 
@@ -169,7 +182,7 @@ cd EGC
 egc doctor
 ```
 
-This checks that both MCP servers are built, registered, and reachable in every detected tool.
+This compares every managed file EGC installed against the source it came from, reporting drift, missing files, and version mismatch per target. It also checks the state store: where it lives, whether the memory store exists yet, and whether older versions left stray copies behind.
 
 ---
 
@@ -197,7 +210,7 @@ egc telemetry status
 
 ## Dashboard
 
-The dashboard starts automatically when you run `egc init`. A bare `egc install` configures the runtime but does not start the dashboard.
+The dashboard starts automatically after `egc install` and `egc init`, whenever you are at an interactive terminal. Headless environments (CI, or output redirected to a file) skip it and say so.
 
 You can control it manually:
 


### PR DESCRIPTION
## Summary
Phase 2 of the README-versus-reality audit, this time on docs/installation.md. Every claim below was checked against a real run of the installer from main in an isolated machine profile, not against the code alone.

## What was wrong
- **Example output** still advertised `registered in Claude Code (global)`, the registration into a file Claude Code never reads that #1193 and #1195 replaced. It also predated the uv notice and the dashboard step, so a first-time user comparing their terminal against the guide would think something went wrong.
- **Dashboard section** stated that a bare `egc install` configures the runtime but does not start the dashboard. That contradicted the README's own promise and, since #1195, the actual behavior.
- **Verify the install** claimed `egc doctor` checks that both MCP servers are built, registered and reachable in every detected tool. It checks none of those three things: it compares managed files against their source and reports on the state store.

## Verification
Installer run from main in a clean profile with Claude Code and Cursor present produced exactly the output now documented (server-by-server CLI registration, Cursor config path, headless dashboard line when piped). Onboarding contract suite: 11/11.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the installation guide to match the installer’s actual output and behavior. Aligns lifecycle and dashboard docs, and clarifies what `egc doctor` checks.

- **Bug Fixes**
  - Example output now mirrors a real run: includes `npm`, optional `uv` notice, per‑server Claude Code CLI registration (`claude mcp add -s user`), Cursor path (`~/.cursor/mcp.json`), and the dashboard start/headless line.
  - Dashboard rules corrected in both lifecycle and dashboard sections: starts automatically after `egc install` and `egc init` in interactive terminals; headless runs skip it and show the exact message.
  - Corrected `egc doctor` description: it verifies managed files and the state store, not MCP build/registration/reachability.

<sup>Written for commit 26eaf807cf32ada8334199088c0593b052d612aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

