### PR TITLE
fix(install): one MCP registration list for all three entry points

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -334,42 +334,6 @@ if (-not $DryRun) {
         }
     }
 
-    # Claude Code: registration goes through the CLI's own user scope. The
-    # old path here wrote Claude Desktop's config file while labeling it
-    # Claude Code - a different application entirely. No CLI on PATH means
-    # no Claude Code to register into.
-    if (Get-Command claude -ErrorAction SilentlyContinue) {
-        # A non-zero exit from `claude mcp get` is the expected "not
-        # registered yet" answer, but PowerShell 7.4+ turns native exit
-        # codes into terminating errors while $ErrorActionPreference is
-        # Stop, which would abort the whole installer before the check
-        # below could read $LASTEXITCODE.
-        $previousNativePref = $null
-        if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
-            $previousNativePref = $PSNativeCommandUseErrorActionPreference
-            $PSNativeCommandUseErrorActionPreference = $false
-        }
-        try {
-            foreach ($server in @(
-                @{ Name = "egc-guardian"; Bin = $GuardianBin },
-                @{ Name = "egc-memory"; Bin = $MemoryBin }
-            )) {
-                claude mcp get $server.Name *> $null
-                if ($LASTEXITCODE -ne 0) {
-                    claude mcp add -s user $server.Name -- node $server.Bin *> $null
-                    if ($LASTEXITCODE -eq 0) {
-                        Write-Host "  v registered $($server.Name) in Claude Code (user scope)"
-                    } else {
-                        Write-Host "  note: could not register $($server.Name) in Claude Code. Run manually: claude mcp add -s user $($server.Name) -- node `"$($server.Bin)`""
-                    }
-                }
-            }
-        } finally {
-            if ($null -ne $previousNativePref) {
-                $PSNativeCommandUseErrorActionPreference = $previousNativePref
-            }
-        }
-    }
 
     # Claude Code - project .mcp.json: merge into an existing file in the
     # directory the installer was invoked from only. The package's own

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -334,25 +334,6 @@ if (-not $DryRun) {
         }
     }
 
-
-    # Claude Code - project .mcp.json: merge into an existing file in the
-    # directory the installer was invoked from only. The package's own
-    # bundled .mcp.json is not a user project, and creating a file in an
-    # arbitrary cwd would litter. (Get-Location is useless here - the
-    # script Set-Location'd to the package root long ago.)
-    $projectMcp = Join-Path $InvokedFromDir ".mcp.json"
-    if (Test-Path $projectMcp) {
-        $invokedPhysical = Resolve-PhysicalDirectory $InvokedFromDir
-        $rootPhysical = Resolve-PhysicalDirectory $RootDir
-        if (-not $invokedPhysical -or -not $rootPhysical) {
-            # Unresolvable means unknown, and an unknown directory is never
-            # worth the risk of writing into the package's own config.
-            Write-Host "  note: skipped project .mcp.json (could not resolve $InvokedFromDir to a physical path)"
-        } elseif ($invokedPhysical -ne $rootPhysical) {
-            Register-McpJson -Target $projectMcp -Label "Claude Code (project .mcp.json)"
-        }
-    }
-
     # One registration list for every entry point. This block used to be a
     # hand-written copy of scripts/lib/mcp-register.js and had drifted:
     # Continue.dev and Zed were never registered here, so installing through

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -367,7 +367,15 @@ if (-not $DryRun) {
     $geminiConfigDir = Join-Path (Join-Path $env:USERPROFILE ".gemini") "config"
     $geminiConfig    = Join-Path $geminiConfigDir "mcp_config.json"
 
-    & node (Join-Path $RootDir "scripts/lib/mcp-register-cli.js") $GuardianBin $MemoryBin
+    # Run from the directory the person invoked the installer in, so a
+    # project .mcp.json there is picked up; the script itself moved to the
+    # package root long ago.
+    Push-Location $InvokedFromDir
+    try {
+        & node (Join-Path $RootDir "scripts/lib/mcp-register-cli.js") $GuardianBin $MemoryBin
+    } finally {
+        Pop-Location
+    }
 
     # Obsidian propagation (delegated to Node)
     # $claudeConfig (Claude Desktop's file) is gone from both lists: Claude

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -389,67 +389,21 @@ if (-not $DryRun) {
         }
     }
 
-    # Cursor (Windows path)
-    $cursorConfig = Join-Path (Join-Path $env:USERPROFILE ".cursor") "mcp.json"
-    if ((Get-Command cursor -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $env:USERPROFILE ".cursor"))) {
-        Register-McpJson -Target $cursorConfig -Label "Cursor"
-    }
-
-    # Kiro
-    $kiroConfig = Join-Path (Join-Path (Join-Path $env:USERPROFILE ".kiro") "settings") "mcp.json"
-    if ((Get-Command kiro -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $env:USERPROFILE ".kiro"))) {
-        Register-McpJson -Target $kiroConfig -Label "Kiro"
-    }
-
-    # OpenCode
-    $opencodeConfig = Join-Path (Join-Path $env:APPDATA "opencode") "config.json"
-    if ((Get-Command opencode -ErrorAction SilentlyContinue) -or (Test-Path (Split-Path $opencodeConfig -Parent))) {
-        Register-McpJson -Target $opencodeConfig -Label "OpenCode"
-    }
-
-    # AGY (Antigravity CLI)
-    $agyDir    = Join-Path (Join-Path $env:USERPROFILE ".gemini") "antigravity-cli"
-    $agyConfig = Join-Path $agyDir "mcp_config.json"
-    if (Test-Path $agyDir) {
-        Register-McpJson -Target $agyConfig -Label "Antigravity CLI"
-    }
-
-    # Gemini CLI (only when AGY is absent)
+    # One registration list for every entry point. This block used to be a
+    # hand-written copy of scripts/lib/mcp-register.js and had drifted:
+    # Continue.dev and Zed were never registered here, so installing through
+    # PowerShell wired up fewer tools than `egc init` did on the same machine.
+    # The paths below are still computed because the Obsidian propagation
+    # further down reads them.
+    $cursorConfig    = Join-Path (Join-Path $env:USERPROFILE ".cursor") "mcp.json"
+    $kiroConfig      = Join-Path (Join-Path (Join-Path $env:USERPROFILE ".kiro") "settings") "mcp.json"
+    $opencodeConfig  = Join-Path (Join-Path $env:APPDATA "opencode") "config.json"
+    $agyDir          = Join-Path (Join-Path $env:USERPROFILE ".gemini") "antigravity-cli"
+    $agyConfig       = Join-Path $agyDir "mcp_config.json"
     $geminiConfigDir = Join-Path (Join-Path $env:USERPROFILE ".gemini") "config"
     $geminiConfig    = Join-Path $geminiConfigDir "mcp_config.json"
-    if ((Test-Path $geminiConfigDir) -and -not (Test-Path $agyDir)) {
-        Register-McpJson -Target $geminiConfig -Label "Gemini CLI"
-    }
 
-    # Codex CLI (TOML - delegated to Node)
-    $codexToml = Join-Path (Join-Path $env:USERPROFILE ".codex") "config.toml"
-    if ((Get-Command codex -ErrorAction SilentlyContinue) -or (Test-Path $codexToml)) {
-        $tmpCodexJs = Join-Path $env:TEMP ("egc_codex_" + [System.Guid]::NewGuid().ToString("N") + ".js")
-        Set-Content -Path $tmpCodexJs -Encoding UTF8 -Value @'
-const fs=require("fs"),path=require("path");
-const[,,t,g,m]=process.argv;
-// Escape backslashes (Windows paths are the common case here) and double
-// quotes so the path stays a valid TOML basic string; mirrors tomlEscape in
-// scripts/install.sh and scripts/lib/mcp-register.js. Without this, a raw
-// Windows path like C:\Users\x\... corrupts the TOML (\U... reads as an
-// invalid/wrong Unicode escape).
-const tomlEscape=(p)=>p.split("\\").join("\\\\").split('"').join('\\"');
-const ge='\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["'+tomlEscape(g)+'"]\n';
-const me='\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["'+tomlEscape(m)+'"]\n';
-let c=fs.existsSync(t)?fs.readFileSync(t,"utf8"):"";
-let ch=false;
-if(!c.includes("egc-guardian")){c+=ge;ch=true;}
-if(!c.includes("egc-memory")){c+=me;ch=true;}
-if(!ch)process.exit(0);
-const d=path.dirname(t);if(!fs.existsSync(d))fs.mkdirSync(d,{recursive:true});
-fs.writeFileSync(t,c);
-'@
-        try {
-            node $tmpCodexJs $codexToml $GuardianBin $MemoryBin 2>$null
-            if ($LASTEXITCODE -eq 0) { Write-Host "  v registered in Codex CLI ($codexToml)" }
-        } catch {}
-        Remove-Item $tmpCodexJs -ErrorAction SilentlyContinue
-    }
+    & node (Join-Path $RootDir "scripts/lib/mcp-register-cli.js") $GuardianBin $MemoryBin
 
     # Obsidian propagation (delegated to Node)
     # $claudeConfig (Claude Desktop's file) is gone from both lists: Claude

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -261,13 +261,12 @@ echo "  registering MCP servers..."
 # installers at all, so installing through the shell wired up fewer tools
 # than `egc init` did on the same machine. The project .mcp.json is passed
 # in because only the shell knows the directory the person invoked it from.
-_project_mcp=""
-if [[ "$INVOKED_FROM_DIR" != "$ROOT_DIR" ]]; then
-  _project_mcp="$INVOKED_FROM_DIR/.mcp.json"
-fi
 # Claude Code is part of that same list (registered through its own CLI, in
-# user scope), so there is no separate call for it here any more.
-node "$ROOT_DIR/scripts/lib/mcp-register-cli.js" "$GUARDIAN_BIN" "$MEMORY_BIN" "$_project_mcp"
+# user scope), so there is no separate call for it here any more. The
+# subshell runs the CLI from the directory the person invoked the installer
+# in, which is how a project .mcp.json there gets picked up: the script
+# itself cd'd to the package root long ago.
+(cd "$INVOKED_FROM_DIR" && node "$ROOT_DIR/scripts/lib/mcp-register-cli.js" "$GUARDIAN_BIN" "$MEMORY_BIN")
 
 set -e
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -252,26 +252,6 @@ fi
 GUARDIAN_BIN="$MCP_ROOT_DIR/mcp/servers/egc-guardian/build/index.js"
 MEMORY_BIN="$MCP_ROOT_DIR/mcp/servers/egc-memory/build/index.js"
 
-# Claude Code's user-scope MCP list lives in ~/.claude.json, owned by the
-# CLI itself; `claude mcp add -s user` is the stable interface (the same
-# approach scripts/lib/mcp-register.js uses for `egc init`). `claude mcp
-# get` exiting 0 means the server is already registered.
-register_mcp_claude_cli() {
-  local name bin
-  for name in egc-guardian egc-memory; do
-    bin="$GUARDIAN_BIN"
-    if [[ "$name" = "egc-memory" ]]; then bin="$MEMORY_BIN"; fi
-    if claude mcp get "$name" >/dev/null 2>&1; then
-      continue
-    fi
-    if claude mcp add -s user "$name" -- node "$bin" >/dev/null 2>&1; then
-      echo "  ✓ registered $name in Claude Code (user scope)"
-    else
-      echo "  note: could not register $name in Claude Code. Run manually: claude mcp add -s user $name -- node \"$bin\""
-    fi
-  done
-}
-
 set +e
 echo "  registering MCP servers..."
 
@@ -285,17 +265,9 @@ _project_mcp=""
 if [[ "$INVOKED_FROM_DIR" != "$ROOT_DIR" ]]; then
   _project_mcp="$INVOKED_FROM_DIR/.mcp.json"
 fi
+# Claude Code is part of that same list (registered through its own CLI, in
+# user scope), so there is no separate call for it here any more.
 node "$ROOT_DIR/scripts/lib/mcp-register-cli.js" "$GUARDIAN_BIN" "$MEMORY_BIN" "$_project_mcp"
-
-# Claude Code: registration goes through the CLI's own user scope. The old
-# path here wrote ~/.claude/claude_desktop_config.json, a file Claude Code
-# never reads (that filename belongs to Claude Desktop, which keeps its
-# config elsewhere entirely), so install reported a registration that did
-# nothing. Kept in the shell because the CLI call needs a real terminal
-# environment, unlike the file writes above.
-if command -v claude >/dev/null 2>&1; then
-  register_mcp_claude_cli
-fi
 
 set -e
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -252,50 +252,6 @@ fi
 GUARDIAN_BIN="$MCP_ROOT_DIR/mcp/servers/egc-guardian/build/index.js"
 MEMORY_BIN="$MCP_ROOT_DIR/mcp/servers/egc-memory/build/index.js"
 
-register_mcp_json() {
-  local target="$1"
-  local label="$2"
-  node - "$target" "$GUARDIAN_BIN" "$MEMORY_BIN" <<'NODEEOF'
-const fs   = require("fs");
-const path = require("path");
-
-const [,, target, guardianBin, memoryBin] = process.argv;
-
-let obj = { mcpServers: {} };
-if (fs.existsSync(target)) {
-  try {
-    obj = JSON.parse(fs.readFileSync(target, "utf8"));
-  } catch (_) {
-    // Existing config is not valid JSON: leave it untouched and signal a skip
-    // (exit 2) so the caller does not print a false "registered" success.
-    process.exit(2);
-  }
-}
-if (!obj.mcpServers) obj.mcpServers = {};
-
-let changed = false;
-if (!obj.mcpServers["egc-guardian"]) {
-  obj.mcpServers["egc-guardian"] = { command: "node", args: [guardianBin] };
-  changed = true;
-}
-if (!obj.mcpServers["egc-memory"]) {
-  obj.mcpServers["egc-memory"] = { command: "node", args: [memoryBin] };
-  changed = true;
-}
-if (!changed) process.exit(0);
-
-const dir = path.dirname(target);
-if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-fs.writeFileSync(target, JSON.stringify(obj, null, 2) + "\n");
-NODEEOF
-  local rc=$?
-  if [[ $rc -eq 0 ]]; then
-    echo "  ✓ registered in $label ($target)"
-  elif [[ $rc -eq 2 ]]; then
-    echo "  note: skipped $label ($target): existing config is not valid JSON"
-  fi
-}
-
 # Claude Code's user-scope MCP list lives in ~/.claude.json, owned by the
 # CLI itself; `claude mcp add -s user` is the stable interface (the same
 # approach scripts/lib/mcp-register.js uses for `egc init`). `claude mcp
@@ -316,98 +272,29 @@ register_mcp_claude_cli() {
   done
 }
 
-register_mcp_toml_codex() {
-  local target="$1"
-  node - "$target" "$GUARDIAN_BIN" "$MEMORY_BIN" <<'NODEEOF'
-const fs   = require("fs");
-const path = require("path");
-
-const [,, target, guardianBin, memoryBin] = process.argv;
-
-// Escape backslashes (Windows paths) and double quotes (legal in a POSIX dir
-// name) so the path stays a valid TOML basic string; mirrors tomlEscape in
-// scripts/lib/mcp-register.js.
-const tomlEscape = (p) => p.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
-
-const guardianEntry =
-  `\n[[mcp_servers]]\nname = "egc-guardian"\ncommand = "node"\nargs = ["${tomlEscape(guardianBin)}"]\n`;
-const memoryEntry =
-  `\n[[mcp_servers]]\nname = "egc-memory"\ncommand = "node"\nargs = ["${tomlEscape(memoryBin)}"]\n`;
-
-let content = "";
-if (fs.existsSync(target)) {
-  content = fs.readFileSync(target, "utf8");
-}
-
-let appended = false;
-if (!content.includes('"egc-guardian"') && !content.includes("'egc-guardian'")) {
-  content += guardianEntry;
-  appended = true;
-}
-if (!content.includes('"egc-memory"') && !content.includes("'egc-memory'")) {
-  content += memoryEntry;
-  appended = true;
-}
-if (!appended) process.exit(0);
-
-const dir = path.dirname(target);
-if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-fs.writeFileSync(target, content);
-NODEEOF
-  local rc=$?
-  if [ $rc -eq 0 ]; then
-    echo "  ✓ registered in Codex CLI ($target)"
-  fi
-}
-
 set +e
 echo "  registering MCP servers..."
 
-# AGY (Antigravity CLI)
-if [ -d "$HOME/.gemini/antigravity-cli" ]; then
-  register_mcp_json "$HOME/.gemini/antigravity-cli/mcp_config.json" "Antigravity CLI"
+# One registration list for every entry point. This block used to be a
+# hand-written copy of scripts/lib/mcp-register.js, and the copies had
+# drifted: Continue.dev and Zed were never registered by the shell
+# installers at all, so installing through the shell wired up fewer tools
+# than `egc init` did on the same machine. The project .mcp.json is passed
+# in because only the shell knows the directory the person invoked it from.
+_project_mcp=""
+if [[ "$INVOKED_FROM_DIR" != "$ROOT_DIR" ]]; then
+  _project_mcp="$INVOKED_FROM_DIR/.mcp.json"
 fi
+node "$ROOT_DIR/scripts/lib/mcp-register-cli.js" "$GUARDIAN_BIN" "$MEMORY_BIN" "$_project_mcp"
 
-# Gemini CLI (only when AGY is absent to avoid duplication)
-if [ -d "$HOME/.gemini/config" ] && ! [ -d "$HOME/.gemini/antigravity-cli" ]; then
-  register_mcp_json "$HOME/.gemini/config/mcp_config.json" "Gemini CLI"
-fi
-
-# Claude Code: global config
 # Claude Code: registration goes through the CLI's own user scope. The old
 # path here wrote ~/.claude/claude_desktop_config.json, a file Claude Code
 # never reads (that filename belongs to Claude Desktop, which keeps its
 # config elsewhere entirely), so install reported a registration that did
-# nothing. No CLI on PATH means no Claude Code to register into.
+# nothing. Kept in the shell because the CLI call needs a real terminal
+# environment, unlike the file writes above.
 if command -v claude >/dev/null 2>&1; then
   register_mcp_claude_cli
-fi
-# Merge into an existing project .mcp.json in the directory the installer
-# was invoked from only: the package's own bundled .mcp.json is not a user
-# project, and creating a file in an arbitrary cwd would litter. ($PWD is
-# useless here - the script cd'd to the package root long ago.)
-if [[ -f "$INVOKED_FROM_DIR/.mcp.json" ]] && [[ "$INVOKED_FROM_DIR" != "$ROOT_DIR" ]]; then
-  register_mcp_json "$INVOKED_FROM_DIR/.mcp.json" "Claude Code (project .mcp.json)"
-fi
-
-# Cursor
-if command -v cursor >/dev/null 2>&1 || [ -d "$HOME/.cursor" ]; then
-  register_mcp_json "$HOME/.cursor/mcp.json" "Cursor"
-fi
-
-# Kiro
-if command -v kiro >/dev/null 2>&1 || [ -d "$HOME/.kiro" ]; then
-  register_mcp_json "$HOME/.kiro/settings/mcp.json" "Kiro"
-fi
-
-# Codex CLI
-if command -v codex >/dev/null 2>&1 || [ -f "$HOME/.codex/config.toml" ]; then
-  register_mcp_toml_codex "$HOME/.codex/config.toml"
-fi
-
-# OpenCode
-if command -v opencode >/dev/null 2>&1 || [ -f "$HOME/.config/opencode/config.json" ]; then
-  register_mcp_json "$HOME/.config/opencode/config.json" "OpenCode"
 fi
 
 set -e

--- a/scripts/lib/mcp-register-cli.js
+++ b/scripts/lib/mcp-register-cli.js
@@ -33,7 +33,13 @@ if (!guardianBin || !memoryBin) {
 }
 
 const bins = { guardianBin, memoryBin };
-const homeDir = process.env.HOME || process.env.USERPROFILE || os.homedir();
+// Git for Windows sets HOME to the MSYS home, which is not where the tools
+// this registers keep their config. On Windows the profile the installer
+// itself uses is USERPROFILE, so that wins there; everywhere else HOME is
+// the answer.
+const homeDir = process.platform === 'win32'
+  ? (process.env.USERPROFILE || process.env.HOME || os.homedir())
+  : (process.env.HOME || process.env.USERPROFILE || os.homedir());
 
 registerMcpServers(homeDir, bins, {
   onRegister: (target) => console.log(`  ✓ registered in ${target.name} (${target.path})`),
@@ -44,10 +50,23 @@ registerMcpServers(homeDir, bins, {
 // directory is the process's own working directory, so no argument can turn
 // this into a writer of arbitrary files. The package's own bundled config
 // is excluded: it is nobody's project.
+// Compared physically and, on Windows, case-insensitively: reaching the
+// package root through a junction or a differently-cased path would
+// otherwise read as somebody's project and rewrite the bundled config.
+function canonical(dir) {
+  let resolved;
+  try {
+    resolved = fs.realpathSync.native(dir);
+  } catch {
+    resolved = path.resolve(dir);
+  }
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
 const packageRoot = path.resolve(__dirname, '..', '..');
 const projectMcp = path.join(process.cwd(), '.mcp.json');
 
-if (path.dirname(projectMcp) !== packageRoot && fs.existsSync(projectMcp)) {
+if (canonical(path.dirname(projectMcp)) !== canonical(packageRoot) && fs.existsSync(projectMcp)) {
   try {
     if (registerJson(projectMcp, bins)) {
       console.log(`  ✓ registered in Claude Code (project .mcp.json) (${projectMcp})`);

--- a/scripts/lib/mcp-register-cli.js
+++ b/scripts/lib/mcp-register-cli.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+
+// CLI face of mcp-register.js for the shell installers.
+//
+// install.sh and install.ps1 used to carry their own hand-written copy of
+// the registration list, and the three copies had already drifted: the
+// shells never registered Continue.dev or Zed, install.ps1 pointed OpenCode
+// at a different directory than everything else, and only the shells gated
+// Gemini CLI on Antigravity being absent. Whoever installed through the
+// shell silently got fewer tools wired up than whoever ran `egc init`.
+// There is one list now, and all three paths read it from here.
+//
+// Usage:
+//   node scripts/lib/mcp-register-cli.js <guardianBin> <memoryBin> [projectMcpPath]
+//
+// projectMcpPath is optional and only merged when the file already exists:
+// creating a project config in a directory the person did not ask about is
+// litter, and the package's own bundled .mcp.json is nobody's project.
+
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { registerMcpServers, registerJson } = require('./mcp-register');
+
+const [, , guardianBin, memoryBin, projectMcpPath] = process.argv;
+
+if (!guardianBin || !memoryBin) {
+  console.error('mcp-register-cli: guardian and memory bin paths are required');
+  process.exit(2);
+}
+
+const bins = { guardianBin, memoryBin };
+const homeDir = process.env.HOME || process.env.USERPROFILE || os.homedir();
+
+registerMcpServers(homeDir, bins, {
+  onRegister: (target) => console.log(`  ✓ registered in ${target.name} (${target.path})`),
+  onWarn: (target, err) => console.log(`  note: skipped ${target.name} (${target.path}): ${err.message}`),
+});
+
+if (projectMcpPath && fs.existsSync(projectMcpPath)) {
+  try {
+    if (registerJson(projectMcpPath, bins)) {
+      console.log(`  ✓ registered in Claude Code (project .mcp.json) (${path.resolve(projectMcpPath)})`);
+    }
+  } catch (err) {
+    console.log(`  note: skipped project .mcp.json (${projectMcpPath}): ${err.message}`);
+  }
+}

--- a/scripts/lib/mcp-register-cli.js
+++ b/scripts/lib/mcp-register-cli.js
@@ -12,18 +12,20 @@
 // There is one list now, and all three paths read it from here.
 //
 // Usage:
-//   node scripts/lib/mcp-register-cli.js <guardianBin> <memoryBin> [projectMcpPath]
+//   node scripts/lib/mcp-register-cli.js <guardianBin> <memoryBin>
 //
-// projectMcpPath is optional and only merged when the file already exists:
-// creating a project config in a directory the person did not ask about is
-// litter, and the package's own bundled .mcp.json is nobody's project.
+// A project .mcp.json is picked up from the working directory this runs in,
+// which the shell installers set to the directory the person invoked them
+// from. It is only ever merged when it already exists: creating a project
+// config in a directory nobody asked about is litter, and the package's own
+// bundled .mcp.json is nobody's project.
 
 const path = require('node:path');
 const fs = require('node:fs');
 const os = require('node:os');
 const { registerMcpServers, registerJson } = require('./mcp-register');
 
-const [, , guardianBin, memoryBin, projectMcpPath] = process.argv;
+const [, , guardianBin, memoryBin] = process.argv;
 
 if (!guardianBin || !memoryBin) {
   console.error('mcp-register-cli: guardian and memory bin paths are required');
@@ -38,26 +40,19 @@ registerMcpServers(homeDir, bins, {
   onWarn: (target, err) => console.log(`  note: skipped ${target.name} (${target.path}): ${err.message}`),
 });
 
-// The project path arrives as a command-line argument, so it is validated
-// before any filesystem access: this flow may only ever touch a file named
-// .mcp.json that already exists. A mistyped or malicious argument can
-// therefore not turn the installer into a writer of arbitrary files.
-function resolveProjectMcpPath(candidate) {
-  const resolved = path.resolve(candidate);
-  if (path.basename(resolved) !== '.mcp.json') return null;
-  if (!fs.existsSync(resolved)) return null;
-  return resolved;
-}
+// The filename is fixed here rather than accepted from the caller, and the
+// directory is the process's own working directory, so no argument can turn
+// this into a writer of arbitrary files. The package's own bundled config
+// is excluded: it is nobody's project.
+const packageRoot = path.resolve(__dirname, '..', '..');
+const projectMcp = path.join(process.cwd(), '.mcp.json');
 
-if (projectMcpPath) {
-  const resolvedProjectMcp = resolveProjectMcpPath(projectMcpPath);
-  if (resolvedProjectMcp) {
-    try {
-      if (registerJson(resolvedProjectMcp, bins)) {
-        console.log(`  ✓ registered in Claude Code (project .mcp.json) (${resolvedProjectMcp})`);
-      }
-    } catch (err) {
-      console.log(`  note: skipped project .mcp.json (${resolvedProjectMcp}): ${err.message}`);
+if (path.dirname(projectMcp) !== packageRoot && fs.existsSync(projectMcp)) {
+  try {
+    if (registerJson(projectMcp, bins)) {
+      console.log(`  ✓ registered in Claude Code (project .mcp.json) (${projectMcp})`);
     }
+  } catch (err) {
+    console.log(`  note: skipped project .mcp.json (${projectMcp}): ${err.message}`);
   }
 }

--- a/scripts/lib/mcp-register-cli.js
+++ b/scripts/lib/mcp-register-cli.js
@@ -38,12 +38,26 @@ registerMcpServers(homeDir, bins, {
   onWarn: (target, err) => console.log(`  note: skipped ${target.name} (${target.path}): ${err.message}`),
 });
 
-if (projectMcpPath && fs.existsSync(projectMcpPath)) {
-  try {
-    if (registerJson(projectMcpPath, bins)) {
-      console.log(`  ✓ registered in Claude Code (project .mcp.json) (${path.resolve(projectMcpPath)})`);
+// The project path arrives as a command-line argument, so it is validated
+// before any filesystem access: this flow may only ever touch a file named
+// .mcp.json that already exists. A mistyped or malicious argument can
+// therefore not turn the installer into a writer of arbitrary files.
+function resolveProjectMcpPath(candidate) {
+  const resolved = path.resolve(candidate);
+  if (path.basename(resolved) !== '.mcp.json') return null;
+  if (!fs.existsSync(resolved)) return null;
+  return resolved;
+}
+
+if (projectMcpPath) {
+  const resolvedProjectMcp = resolveProjectMcpPath(projectMcpPath);
+  if (resolvedProjectMcp) {
+    try {
+      if (registerJson(resolvedProjectMcp, bins)) {
+        console.log(`  ✓ registered in Claude Code (project .mcp.json) (${resolvedProjectMcp})`);
+      }
+    } catch (err) {
+      console.log(`  note: skipped project .mcp.json (${resolvedProjectMcp}): ${err.message}`);
     }
-  } catch (err) {
-    console.log(`  note: skipped project .mcp.json (${projectMcpPath}): ${err.message}`);
   }
 }

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -17,6 +17,12 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+// A tool the person installed but never launched owns no config directory,
+// so an existence check alone would skip it. The shell installers used to
+// cover that with `command -v`; sharing the repo's own probe keeps the two
+// detections from drifting, and it falls back to a PATH scan where `which`
+// itself is missing.
+const { commandExists } = require('./utils');
 
 let TOML = null;
 try {
@@ -66,16 +72,6 @@ function tomlHasActiveServer(content, serverName) {
  * `gate()` returns true, so we don't create config files for tools the
  * person doesn't have installed.
  */
-// A tool the person has installed but has not launched yet owns no config
-// directory, so an existence check alone would skip it. The shell
-// installers used to cover that case with `command -v`; the registry now
-// carries it, or delegating to the registry would silently drop those
-// registrations.
-function commandExists(command) {
-  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [command], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- fixed tool names from this file, array form, no shell
-  return probe.status === 0 && Boolean((probe.stdout || '').trim());
-}
-
 // %APPDATA% is the documented location, with the conventional layout as a
 // fallback for the rare environment that does not export it. Computed once
 // so the path a target advertises and the path its gate checks can never

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -145,6 +145,18 @@ function buildMcpRegistrationTargets(homeDir) {
       gate: () => fs.existsSync(path.join(homeDir, '.config', 'zed')),
       format: 'zed-context-servers',
     },
+    // Windows installs of OpenCode have been seen under %APPDATA% rather
+    // than the XDG-style path above, which is where install.ps1 wrote until
+    // the three registration lists were unified. Kept as a separate,
+    // existence-gated entry so no Windows user loses a registration that
+    // used to work; on any other platform the gate never opens.
+    {
+      name: 'OpenCode (Windows AppData)',
+      path: path.join(process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming'), 'opencode', 'config.json'),
+      gate: () => process.platform === 'win32'
+        && fs.existsSync(path.join(process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming'), 'opencode', 'config.json')),
+      format: 'json',
+    },
   ];
 }
 

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -152,7 +152,12 @@ function buildMcpRegistrationTargets(homeDir) {
     {
       name: 'OpenCode',
       path: path.join(homeDir, '.config', 'opencode', 'config.json'),
-      gate: () => fs.existsSync(path.join(homeDir, '.config', 'opencode', 'config.json')) || commandExists('opencode'),
+      // The PATH signal deliberately does not open this target on Windows:
+      // OpenCode reads %APPDATA% there, so writing the XDG-style file for a
+      // freshly installed copy would produce a config the editor never sees.
+      // The AppData target below handles that case instead.
+      gate: () => fs.existsSync(path.join(homeDir, '.config', 'opencode', 'config.json'))
+        || (process.platform !== 'win32' && commandExists('opencode')),
       format: 'json',
     },
     {
@@ -169,7 +174,8 @@ function buildMcpRegistrationTargets(homeDir) {
     {
       name: 'OpenCode (Windows AppData)',
       path: openCodeAppData,
-      gate: () => process.platform === 'win32' && fs.existsSync(openCodeAppData),
+      gate: () => process.platform === 'win32'
+        && (fs.existsSync(openCodeAppData) || commandExists('opencode')),
       format: 'json',
     },
   ];

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -66,7 +66,27 @@ function tomlHasActiveServer(content, serverName) {
  * `gate()` returns true, so we don't create config files for tools the
  * person doesn't have installed.
  */
+// A tool the person has installed but has not launched yet owns no config
+// directory, so an existence check alone would skip it. The shell
+// installers used to cover that case with `command -v`; the registry now
+// carries it, or delegating to the registry would silently drop those
+// registrations.
+function commandExists(command) {
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', [command], { encoding: 'utf8' }); // NOSONAR javascript:S4036 -- fixed tool names from this file, array form, no shell
+  return probe.status === 0 && Boolean((probe.stdout || '').trim());
+}
+
+// %APPDATA% is the documented location, with the conventional layout as a
+// fallback for the rare environment that does not export it. Computed once
+// so the path a target advertises and the path its gate checks can never
+// drift apart.
+function windowsAppDataOpenCodeConfig(homeDir) {
+  const appData = process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming');
+  return path.join(appData, 'opencode', 'config.json');
+}
+
 function buildMcpRegistrationTargets(homeDir) {
+  const openCodeAppData = windowsAppDataOpenCodeConfig(homeDir);
   return [
     {
       name: 'Antigravity CLI',
@@ -96,7 +116,7 @@ function buildMcpRegistrationTargets(homeDir) {
     {
       name: 'Cursor',
       path: path.join(homeDir, '.cursor', 'mcp.json'),
-      gate: () => fs.existsSync(path.join(homeDir, '.cursor')),
+      gate: () => fs.existsSync(path.join(homeDir, '.cursor')) || commandExists('cursor'),
       format: 'json',
     },
     {
@@ -124,19 +144,19 @@ function buildMcpRegistrationTargets(homeDir) {
     {
       name: 'Kiro',
       path: path.join(homeDir, '.kiro', 'settings', 'mcp.json'),
-      gate: () => fs.existsSync(path.join(homeDir, '.kiro')),
+      gate: () => fs.existsSync(path.join(homeDir, '.kiro')) || commandExists('kiro'),
       format: 'json',
     },
     {
       name: 'Codex CLI',
       path: path.join(homeDir, '.codex', 'config.toml'),
-      gate: () => fs.existsSync(path.join(homeDir, '.codex', 'config.toml')),
+      gate: () => fs.existsSync(path.join(homeDir, '.codex', 'config.toml')) || commandExists('codex'),
       format: 'toml',
     },
     {
       name: 'OpenCode',
       path: path.join(homeDir, '.config', 'opencode', 'config.json'),
-      gate: () => fs.existsSync(path.join(homeDir, '.config', 'opencode', 'config.json')),
+      gate: () => fs.existsSync(path.join(homeDir, '.config', 'opencode', 'config.json')) || commandExists('opencode'),
       format: 'json',
     },
     {
@@ -152,9 +172,8 @@ function buildMcpRegistrationTargets(homeDir) {
     // used to work; on any other platform the gate never opens.
     {
       name: 'OpenCode (Windows AppData)',
-      path: path.join(process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming'), 'opencode', 'config.json'),
-      gate: () => process.platform === 'win32'
-        && fs.existsSync(path.join(process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming'), 'opencode', 'config.json')),
+      path: openCodeAppData,
+      gate: () => process.platform === 'win32' && fs.existsSync(openCodeAppData),
       format: 'json',
     },
   ];

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -489,14 +489,46 @@ function commandExists(cmd) {
     if (isWindows) {
       // shell:true inherits PATHEXT so `where npm` resolves npm.cmd/.exe correctly
       const result = spawnSync('where', [cmd], { stdio: 'pipe', shell: true });
-      return result.status === 0;
+      if (result.status === 0) return true;
     } else {
       const result = spawnSync('which', [cmd], { stdio: 'pipe' });
-      return result.status === 0;
+      if (result.status === 0) return true;
     }
   } catch {
-    return false;
+    // Fall through to the manual scan below.
   }
+
+  return existsOnPath(cmd);
+}
+
+/**
+ * PATH scan without spawning anything. Minimal images (Alpine, distroless,
+ * some CI containers) ship no `which` at all, and a probe that cannot run
+ * looks exactly like "the command is not installed" - which would silently
+ * skip work for a tool the person really does have.
+ */
+function existsOnPath(cmd) {
+  const directories = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  const extensions = isWindows
+    ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+    : [''];
+
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      const candidate = path.join(directory, cmd + extension);
+      try {
+        if (isWindows) {
+          if (fs.existsSync(candidate)) return true;
+        } else {
+          fs.accessSync(candidate, fs.constants.X_OK);
+          return true;
+        }
+      } catch {
+        // Not here; keep looking.
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -508,7 +508,18 @@ function commandExists(cmd) {
  * skip work for a tool the person really does have.
  */
 function existsOnPath(cmd) {
-  const directories = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  const rawPath = process.env.PATH;
+  // An unset or empty PATH means there is nowhere to look, which is not the
+  // same as an empty entry inside a populated PATH.
+  if (!rawPath) return false;
+
+  const directories = rawPath
+    .split(path.delimiter)
+    // POSIX shells read a leading, trailing or doubled separator as the
+    // current directory; Windows does not, so the empty entry is dropped
+    // there instead of silently searching somewhere it never would.
+    .map(entry => (entry === '' ? (isWindows ? null : '.') : entry))
+    .filter(entry => entry !== null);
   const extensions = isWindows
     ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
     : [''];
@@ -517,12 +528,13 @@ function existsOnPath(cmd) {
     for (const extension of extensions) {
       const candidate = path.join(directory, cmd + extension);
       try {
-        if (isWindows) {
-          if (fs.existsSync(candidate)) return true;
-        } else {
-          fs.accessSync(candidate, fs.constants.X_OK);
-          return true;
-        }
+        // A directory named like the command would pass both the Windows
+        // existence check and the POSIX executable check (searchable
+        // directories carry the execute bit), so the type is settled first.
+        if (!fs.statSync(candidate).isFile()) continue;
+        if (isWindows) return true;
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
       } catch {
         // Not here; keep looking.
       }

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -519,9 +519,15 @@ function existsOnPath(cmd) {
     // current directory; Windows does not, so the empty entry is dropped
     // there instead of silently searching somewhere it never would.
     .map(entry => (entry === '' ? (isWindows ? null : '.') : entry))
-    .filter(entry => entry !== null);
+    .filter(entry => entry !== null)
+    // Windows PATH entries are sometimes quoted; the quotes are shell
+    // syntax, not part of the directory name, and would make every lookup
+    // inside that entry fail.
+    .map(entry => (isWindows ? entry.replace(/^"(.*)"$/, '$1') : entry));
+  // An explicit extension is honored as written: appending PATHEXT to a
+  // name that already carries one would only ever look for node.exe.EXE.
   const extensions = isWindows
-    ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+    ? [...(path.extname(cmd) ? [''] : []), ...(process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)]
     : [''];
 
   for (const directory of directories) {

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -93,6 +93,51 @@ function runTests() {
     }
   }) ? passed++ : failed++);
 
+  (test('the Windows AppData OpenCode target follows APPDATA and only opens on win32', () => {
+    const tmpHome = makeTempDir();
+    const savedPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const savedAppData = process.env.APPDATA;
+    const appData = path.join(tmpHome, 'AppData', 'Roaming');
+    const config = path.join(appData, 'opencode', 'config.json');
+    fs.mkdirSync(path.dirname(config), { recursive: true });
+    fs.writeFileSync(config, JSON.stringify({ mcpServers: {} }));
+    process.env.APPDATA = appData;
+    try {
+      const target = () => buildMcpRegistrationTargets(tmpHome).find(t => t.name === 'OpenCode (Windows AppData)');
+      assert.strictEqual(target().path, config, 'the advertised path must come from APPDATA');
+
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      assert.strictEqual(target().gate(), true, 'an existing AppData config on Windows must be registered');
+
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      assert.strictEqual(target().gate(), false, 'the Windows-only target must never open elsewhere');
+    } finally {
+      if (savedPlatform) Object.defineProperty(process, 'platform', savedPlatform);
+      if (savedAppData === undefined) delete process.env.APPDATA; else process.env.APPDATA = savedAppData;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
+  (test('a tool present on PATH but not yet configured is still registered', () => {
+    // Someone who installed Cursor and has not launched it owns no ~/.cursor
+    // yet; an existence-only gate would skip them, which is exactly what the
+    // shell installers used to prevent with their own `command -v` checks.
+    const tmpHome = makeTempDir();
+    const binDir = makeTempDir();
+    const savedPath = process.env.PATH;
+    fs.writeFileSync(path.join(binDir, 'cursor'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+    try {
+      const target = buildMcpRegistrationTargets(tmpHome).find(t => t.name === 'Cursor');
+      assert.strictEqual(fs.existsSync(path.join(tmpHome, '.cursor')), false, 'precondition: no config directory');
+      assert.strictEqual(target.gate(), true, 'the binary on PATH must be enough to register');
+    } finally {
+      process.env.PATH = savedPath;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
   // ── registerClaudeCli (Claude Code user scope via the CLI) ────────
 
   (test('quoteForCmdShell quotes cmd-sensitive arguments and leaves plain ones untouched', () => {

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -118,6 +118,40 @@ function runTests() {
     }
   }) ? passed++ : failed++);
 
+  (test('a fresh Windows OpenCode is routed to AppData, never to the XDG path', () => {
+    // Installed but never launched: neither config file exists, so only the
+    // PATH signal is available. Writing the XDG file on Windows would
+    // produce a config the editor never reads.
+    const tmpHome = makeTempDir();
+    const binDir = makeTempDir();
+    const savedPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const savedPath = process.env.PATH;
+    const savedAppData = process.env.APPDATA;
+    fs.writeFileSync(path.join(binDir, 'opencode.cmd'), '@echo off\r\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(binDir, 'opencode'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+    process.env.APPDATA = path.join(tmpHome, 'AppData', 'Roaming');
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      const targets = buildMcpRegistrationTargets(tmpHome);
+      const appData = targets.find(t => t.name === 'OpenCode (Windows AppData)');
+      const xdg = targets.find(t => t.name === 'OpenCode');
+      assert.strictEqual(appData.gate(), true, 'the AppData target must open for a PATH-visible OpenCode on Windows');
+      assert.strictEqual(xdg.gate(), false, 'the XDG target must stay closed on Windows');
+
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      const posixTargets = buildMcpRegistrationTargets(tmpHome);
+      assert.strictEqual(posixTargets.find(t => t.name === 'OpenCode').gate(), true, 'elsewhere the XDG target is the right one');
+      assert.strictEqual(posixTargets.find(t => t.name === 'OpenCode (Windows AppData)').gate(), false);
+    } finally {
+      if (savedPlatform) Object.defineProperty(process, 'platform', savedPlatform);
+      process.env.PATH = savedPath;
+      if (savedAppData === undefined) delete process.env.APPDATA; else process.env.APPDATA = savedAppData;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
   (test('a tool present on PATH but not yet configured is still registered', () => {
     // Someone who installed Cursor and has not launched it owns no ~/.cursor
     // yet; an existence-only gate would skip them, which is exactly what the

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -125,7 +125,10 @@ function runTests() {
     const tmpHome = makeTempDir();
     const binDir = makeTempDir();
     const savedPath = process.env.PATH;
-    fs.writeFileSync(path.join(binDir, 'cursor'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    // Windows only recognizes a PATHEXT extension as executable, so an
+    // extension-less stand-in would make this assert nothing there.
+    const binName = process.platform === 'win32' ? 'cursor.cmd' : 'cursor';
+    fs.writeFileSync(path.join(binDir, binName), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
     process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
     try {
       const target = buildMcpRegistrationTargets(tmpHome).find(t => t.name === 'Cursor');

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -109,7 +109,7 @@ case "$1" in
   -e) printf '20' ;;
   --version) printf 'v20.0.0\\n' ;;
   *dashboard-launch-cli.js) printf "Dashboard not started (headless environment). Run 'egc dashboard' to start it.\\n" ;;
-  *mcp-register-cli.js) printf "MCP-CLI-PROJECT-ARG:%s\\n" "$4" ;;
+  *mcp-register-cli.js) printf "MCP-CLI-CWD:%s\\n" "$(pwd -P)" ;;
 esac
 exit 0
 `);
@@ -249,8 +249,8 @@ async function runTests() {
       // /private/var, and comparing the two spellings would fail there
       // while passing on Linux.
       assert.ok(
-        result.stdout.includes(`MCP-CLI-PROJECT-ARG:${path.join(fs.realpathSync(projectDir), '.mcp.json')}`),
-        `installer must pass the invoking directory's .mcp.json to the registration CLI, got:\n${result.stdout}`
+        result.stdout.includes(`MCP-CLI-CWD:${fs.realpathSync(projectDir)}`),
+        `the registration CLI must run from the invoking directory, got:\n${result.stdout}`
       );
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -244,8 +244,12 @@ async function runTests() {
       // The shell's job is to hand the registration CLI the directory the
       // person invoked it from; the merge itself is covered by the
       // mcp-register unit tests.
+      // realpath, because the installer captures the invoking directory
+      // with `pwd -P`: on macOS a temp dir under /var is physically
+      // /private/var, and comparing the two spellings would fail there
+      // while passing on Linux.
       assert.ok(
-        result.stdout.includes(`MCP-CLI-PROJECT-ARG:${path.join(projectDir, '.mcp.json')}`),
+        result.stdout.includes(`MCP-CLI-PROJECT-ARG:${path.join(fs.realpathSync(projectDir), '.mcp.json')}`),
         `installer must pass the invoking directory's .mcp.json to the registration CLI, got:\n${result.stdout}`
       );
     } finally {

--- a/tests/scripts/install-onboarding.test.js
+++ b/tests/scripts/install-onboarding.test.js
@@ -109,6 +109,7 @@ case "$1" in
   -e) printf '20' ;;
   --version) printf 'v20.0.0\\n' ;;
   *dashboard-launch-cli.js) printf "Dashboard not started (headless environment). Run 'egc dashboard' to start it.\\n" ;;
+  *mcp-register-cli.js) printf "MCP-CLI-PROJECT-ARG:%s\\n" "$4" ;;
 esac
 exit 0
 `);
@@ -240,9 +241,12 @@ async function runTests() {
     });
     try {
       assertSuccessfulRun(result);
+      // The shell's job is to hand the registration CLI the directory the
+      // person invoked it from; the merge itself is covered by the
+      // mcp-register unit tests.
       assert.ok(
-        result.stdout.includes('registered in Claude Code (project .mcp.json)'),
-        `invoking-directory .mcp.json must be merged, got:\n${result.stdout}`
+        result.stdout.includes(`MCP-CLI-PROJECT-ARG:${path.join(projectDir, '.mcp.json')}`),
+        `installer must pass the invoking directory's .mcp.json to the registration CLI, got:\n${result.stdout}`
       );
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });

--- a/tests/scripts/install-ps1.test.js
+++ b/tests/scripts/install-ps1.test.js
@@ -132,12 +132,24 @@ function runTests() {
     );
   })) passed++; else failed++;
 
-  if (test('escapes backslashes and quotes before writing a path into Codex CLI TOML', () => {
-    // A raw Windows path (C:\Users\x\...) concatenated into a TOML basic
-    // string is corrupted: TOML treats \U as the start of an 8-hex-digit
-    // Unicode escape. Must mirror install.sh's tomlEscape.
-    assert.ok(scriptSource.includes('tomlEscape'), 'Codex CLI TOML writer must escape paths via a tomlEscape helper');
-    assert.ok(scriptSource.includes('tomlEscape(g)') && scriptSource.includes('tomlEscape(m)'), 'both guardian and memory TOML entries must go through tomlEscape');
+  if (test('delegates MCP registration to the shared CLI instead of keeping its own copy of the list', () => {
+    // Both installers and `egc init` now read one list, so Continue.dev and
+    // Zed cannot silently go unregistered on the shell path again, and the
+    // Codex TOML escaping this test used to police lives with the writer
+    // itself (registerToml/tomlEscape in scripts/lib/mcp-register.js,
+    // covered by tests/lib/mcp-register.test.js).
+    assert.ok(
+      scriptSource.includes('scripts/lib/mcp-register-cli.js'),
+      'install.ps1 must register MCP servers through the shared CLI'
+    );
+    assert.ok(
+      !scriptSource.includes('[[mcp_servers]]'),
+      'install.ps1 must not carry its own TOML writer any more'
+    );
+    assert.ok(
+      !bashSource.includes('[[mcp_servers]]'),
+      'install.sh must not carry its own TOML writer any more'
+    );
   })) passed++; else failed++;
 
   if (test('only builds egc-guardian/egc-memory when src/ is present (published tarball has none)', () => {


### PR DESCRIPTION
## Summary
Three entry points install EGC (`egc init`, `install.sh`, `install.ps1`) and each kept its own hand-written copy of which tools get the MCP servers registered. The copies had drifted, and the drift was invisible because every path prints success either way.

## What was actually broken
- **Continue.dev and Zed were never registered by either shell installer.** Someone following the documented shell command got fewer tools wired up than someone running `egc init` on the same machine.
- **install.ps1 pointed OpenCode at `%APPDATA%\opencode`** while `mcp-register.js` used the XDG-style path.
- **Only the shells gated Gemini CLI on Antigravity being absent**, so the two paths disagreed about that too.

## Fix
Both shells now call a thin CLI over the existing registry (`scripts/lib/mcp-register-cli.js`), so there is one list and one set of format handlers (JSON, TOML, Continue YAML, Zed context servers, Claude CLI). Their hand-rolled JSON and TOML writers are deleted, which also removes the duplicated TOML escaping. The Windows AppData location for OpenCode survives as its own existence-gated target so no Windows user loses a registration that used to work.

## Verification
Clean machine profile with Continue.dev and Zed present: the shell installer registered both, which it never did before this change. Suites: mcp-register 34/34, install-sh 6/6, install-ps1 7/7, install-onboarding 11/11.

Note for a follow-up, found while mapping this: `egc install --target <tool>` never registers MCP servers at all (only `egc init` and the shells do), yet docs/installation.md tells the reader that `egc install --target zed` writes Zed's context servers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies MCP registration across `egc init`, `install.sh`, and `install.ps1` via a shared CLI. Tightens PATH detection and Windows handling (correct OpenCode AppData routing) and only reads a project `.mcp.json` from the working directory.

- **Bug Fixes**
  - Shell installers now register Continue.dev and Zed; consistent Gemini-vs-Antigravity gating.
  - Detect tools by PATH as well as config dirs using `commandExists` with a spawn-free PATH scan fallback; accepts only real files, honors empty PATH entries, and handles explicit extensions and quoted Windows PATH entries.
  - Correct Windows behavior: prefer `USERPROFILE`; support OpenCode at `%APPDATA%\opencode` and route PATH-only installs there on Windows.
  - Project config: only merge an existing `.mcp.json` from the invoking CWD; exclude the package root via canonical physical path (case-insensitive on Windows); removed duplicate project merge and Claude registration in installers.
  - Added tests to pin the Windows OpenCode routing when only on PATH.

- **Refactors**
  - Added `scripts/lib/mcp-register-cli.js`; all entry points share one registration list and format writers; removed shell JSON/TOML writers. Installers run the CLI from the invoking directory.

<sup>Written for commit 3e61f622e389a36e876e5d4218ac78469ca6ab27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

