### PR TITLE
fix(hooks): give the session bridge enough time to run on Windows

### DIFF
--- a/scripts/hooks/egc-session-bridge.js
+++ b/scripts/hooks/egc-session-bridge.js
@@ -7,7 +7,12 @@ const os = require('node:os');
 const path = require('node:path');
 
 const HOOK_ID = 'egc-session-bridge';
-const DEFAULT_TIMEOUT_MS = 5000;
+// Python's cold start on Windows routinely costs several seconds (interpreter
+// launch plus whatever scans the machine runs on a new process), and when the
+// budget runs out mid-write the bridge records nothing while this hook still
+// exits 0 by design. The result is a session whose events silently never land.
+// The old 5s applied everywhere and was too tight for exactly that platform.
+const DEFAULT_TIMEOUT_MS = process.platform === 'win32' ? 20000 : 5000;
 const SAFE_PYTHON_BASENAMES = new Set(['python3', 'python3.exe', 'python', 'python.exe']);
 
 function readStdin() {
@@ -82,7 +87,12 @@ function run() {
   });
 
   if (result.error) {
-    process.stderr.write(`[${HOOK_ID}] soft-fail: ${result.error.message}\n`);
+    // ETIMEDOUT arrives here too, and it is the failure worth naming: it
+    // means the bridge was killed before it could record anything.
+    const detail = result.error.code === 'ETIMEDOUT'
+      ? `timed out after ${DEFAULT_TIMEOUT_MS}ms`
+      : result.error.message;
+    process.stderr.write(`[${HOOK_ID}] soft-fail: ${detail}\n`);
     return 0;
   }
   if ((result.stderr || '').trim()) {

--- a/tests/scripts/egc-session-bridge.test.js
+++ b/tests/scripts/egc-session-bridge.test.js
@@ -115,7 +115,10 @@ if (!pythonAvailable()) {
       assert.strictEqual(r.status, 0, r.stderr);
       const events = readJsonLines(path.join(tmp, '.sessions', 'execution_log.jsonl'));
       const match = events.find(e => e.execution_id === sid && e.type === 'session.sessionstart');
-      assert.ok(match, `expected session.sessionstart for ${sid}, got ${JSON.stringify(events)}`);
+      // The hook exits 0 even when the bridge fails, by design, so its
+      // stderr is the only place the reason shows up. Without it a failure
+      // here reads as "no events" and says nothing about why.
+      assert.ok(match, `expected session.sessionstart for ${sid}, got ${JSON.stringify(events)}; hook stderr: ${r.stderr || '(empty)'}`);
       assert.strictEqual(match.data.source, 'node-hook');
     } finally {
       cleanup(tmp);
@@ -133,7 +136,7 @@ if (!pythonAvailable()) {
       assert.strictEqual(r.status, 0, r.stderr);
       const events = readJsonLines(path.join(tmp, '.sessions', 'execution_log.jsonl'));
       const match = events.find(e => e.execution_id === sid && e.type === 'session.sessionend');
-      assert.ok(match, `expected session.sessionend for ${sid}, got ${JSON.stringify(events)}`);
+      assert.ok(match, `expected session.sessionend for ${sid}, got ${JSON.stringify(events)}; hook stderr: ${r.stderr || '(empty)'}`);
     } finally {
       cleanup(tmp);
     }


### PR DESCRIPTION
## The failure
main went red on `Test (windows-latest, Node 20.x, yarn)`:

```
✗ SessionStart emits session.sessionstart trace event
  Error: expected session.sessionstart for sess-start-..., got []
```

This has now happened three times and was written off as flaky each time. It is not flaky, it is a real Windows defect.

## Root cause
`scripts/hooks/egc-session-bridge.js` spawns Python with a **5 second budget applied to every platform**. A cold interpreter start on Windows regularly costs more than that, and when the budget runs out the bridge is killed before it writes anything. The hook still returns 0 — correct behavior, a hook must never break someone's session — so the loss is completely silent. On a Windows machine, session start and end events simply never land and nobody finds out.

## Fix
- Windows gets 20s; every other platform keeps 5s.
- The soft-fail line names a timeout as a timeout instead of printing a generic spawn error.
- Both test assertions now include the hook's stderr. A hook that always exits 0 leaves stderr as the only evidence of *why* nothing was written, which is exactly what made the previous three failures undiagnosable.

## Verification
Forcing the budget to 1ms reproduces CI's message character for character, and the new diagnostic explains it:

```
Error: expected session.sessionstart for sess-start-...; got [];
       hook stderr: [egc-session-bridge] soft-fail: timed out after 1ms
```

Restored to the real value: suite 6/6.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost session start/end events on Windows by raising the Python session bridge timeout to 20s and making timeouts explicit; tests now surface hook stderr for clearer failures.

- **Bug Fixes**
  - Windows-only timeout set to 20s; other platforms stay at 5s.
  - Soft-fail logs ETIMEDOUT as “timed out after <ms>”.
  - Test assertions include hook stderr to aid diagnosis.

<sup>Written for commit 6062ca1cc338ae6b89d68a349117f75015a0cbf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

