### PR TITLE
fix(crusher): compress lists nested inside an object, not just top-level arrays

### DIFF
--- a/mcp/servers/egc-guardian/src/egc-array-crusher.ts
+++ b/mcp/servers/egc-guardian/src/egc-array-crusher.ts
@@ -53,10 +53,15 @@ function reduceRows(rows: Record<string, unknown>[]): Record<string, unknown>[] 
   return final.length >= rows.length ? null : final;
 }
 
+// Only a list where every element is a record is reducible. A mixed list
+// (records beside scalars, nulls or nested arrays) is left alone: the row
+// logic can only speak about records, so filtering the rest out would
+// silently drop real elements from a payload the reader still believes is
+// complete.
 function objectRows(value: unknown): Record<string, unknown>[] | null {
-  if (!Array.isArray(value)) return null;
-  const rows = value.filter(r => r !== null && typeof r === 'object' && !Array.isArray(r)) as Record<string, unknown>[];
-  return rows.length >= MIN_ROWS_TO_ANALYZE ? rows : null;
+  if (!Array.isArray(value) || value.length < MIN_ROWS_TO_ANALYZE) return null;
+  const allRecords = value.every(r => r !== null && typeof r === 'object' && !Array.isArray(r));
+  return allRecords ? (value as Record<string, unknown>[]) : null;
 }
 
 // The bulk of a REST or CLI payload is almost never the top-level value: it

--- a/mcp/servers/egc-guardian/src/egc-array-crusher.ts
+++ b/mcp/servers/egc-guardian/src/egc-array-crusher.ts
@@ -25,16 +25,7 @@ function rowSignature(row: Record<string, unknown>, keys: string[]): string {
   return keys.map(k => toKey(row[k]).slice(0, 32)).join('|');
 }
 
-export function reduceJsonArray(text: string): ReduceResult | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text.trim());
-  } catch {
-    return null;
-  }
-
-  if (!Array.isArray(parsed)) return null;
-  const rows = parsed.filter(r => r !== null && typeof r === 'object') as Record<string, unknown>[];
+function reduceRows(rows: Record<string, unknown>[]): Record<string, unknown>[] | null {
   if (rows.length < MIN_ROWS_TO_ANALYZE) return null;
 
   const allKeys = [...new Set(rows.flatMap(r => Object.keys(r)))];
@@ -59,15 +50,63 @@ export function reduceJsonArray(text: string): ReduceResult | null {
     final = [...head, ...tail];
   }
 
-  if (final.length >= rows.length) return null;
+  return final.length >= rows.length ? null : final;
+}
 
-  const crushed = JSON.stringify(final, null, 2);
-  const savingsPct = Math.round((1 - final.length / rows.length) * 100);
+function objectRows(value: unknown): Record<string, unknown>[] | null {
+  if (!Array.isArray(value)) return null;
+  const rows = value.filter(r => r !== null && typeof r === 'object' && !Array.isArray(r)) as Record<string, unknown>[];
+  return rows.length >= MIN_ROWS_TO_ANALYZE ? rows : null;
+}
+
+// The bulk of a REST or CLI payload is almost never the top-level value: it
+// is a list nested one key down, beside a handful of small scalars
+// (`{"items": [...], "totalCount": 812}`, `{"workflow_runs": [...]}`,
+// `{"jobs": [...]}`). Requiring an array at the very top meant every one of
+// those passed through at full size. The largest such list is reduced and
+// everything around it is preserved, so counts and pagination cursors still
+// read correctly.
+function largestNestedList(parsed: Record<string, unknown>): { key: string; rows: Record<string, unknown>[] } | null {
+  let best: { key: string; rows: Record<string, unknown>[] } | null = null;
+  for (const [key, value] of Object.entries(parsed)) {
+    const rows = objectRows(value);
+    if (rows && (!best || rows.length > best.rows.length)) best = { key, rows };
+  }
+  return best;
+}
+
+export function reduceJsonArray(text: string): ReduceResult | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.trim());
+  } catch {
+    return null;
+  }
+
+  if (Array.isArray(parsed)) {
+    const rows = objectRows(parsed);
+    if (!rows) return null;
+    const final = reduceRows(rows);
+    if (!final) return null;
+    return {
+      crushed: JSON.stringify(final, null, 2),
+      rows_before: rows.length,
+      rows_after: final.length,
+      savings_pct: Math.round((1 - final.length / rows.length) * 100),
+    };
+  }
+
+  if (parsed === null || typeof parsed !== 'object') return null;
+
+  const target = largestNestedList(parsed as Record<string, unknown>);
+  if (!target) return null;
+  const final = reduceRows(target.rows);
+  if (!final) return null;
 
   return {
-    crushed,
-    rows_before: rows.length,
+    crushed: JSON.stringify({ ...(parsed as Record<string, unknown>), [target.key]: final }, null, 2),
+    rows_before: target.rows.length,
     rows_after: final.length,
-    savings_pct: savingsPct,
+    savings_pct: Math.round((1 - final.length / target.rows.length) * 100),
   };
 }

--- a/mcp/servers/egc-guardian/src/egc-chunk-router.ts
+++ b/mcp/servers/egc-guardian/src/egc-chunk-router.ts
@@ -18,12 +18,22 @@ const DIFF_SIGNALS = [
   /^[+-]{3} [ab]\//m,
 ];
 
+function isRecordList(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && value[0] !== null;
+}
+
+// A payload counts as a reducible list whether the list is the whole value
+// or sits one key down inside an object, which is how nearly every REST and
+// CLI response is shaped ({"items": [...], "totalCount": 812}). Requiring a
+// leading '[' meant the crusher never even saw those.
 function isJsonArray(text: string): boolean {
   const trimmed = text.trim();
-  if (!trimmed.startsWith('[')) return false;
+  if (!trimmed.startsWith('[') && !trimmed.startsWith('{')) return false;
   try {
     const parsed = JSON.parse(trimmed);
-    return Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === 'object' && parsed[0] !== null;
+    if (isRecordList(parsed)) return true;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+    return Object.values(parsed as Record<string, unknown>).some(isRecordList);
   } catch {
     return false;
   }

--- a/tests/guardian-pipeline.test.js
+++ b/tests/guardian-pipeline.test.js
@@ -120,5 +120,19 @@ if (test('pipeline handles mixed chunk types', () => {
   assert.ok(r.bytes_after <= r.bytes_before);
 })) passed++; else failed++;
 
+if (test('routes an object wrapping a list to the JSON crusher, not to text', () => {
+  // The crusher can reduce a list nested one key down, but the pipeline only
+  // hands it chunks classified as json_array. Requiring a leading '[' meant
+  // the common {"items": [...], "totalCount": N} shape never reached it.
+  const items = Array.from({ length: 12 }, (_, i) => ({ id: i % 3, state: 'open' }));
+  assert.strictEqual(classifyChunk(JSON.stringify({ items, totalCount: 12 })), 'json_array');
+  assert.strictEqual(classifyChunk(JSON.stringify(items)), 'json_array', 'top-level lists keep working');
+  assert.notStrictEqual(
+    classifyChunk(JSON.stringify({ status: 'ok', count: 2 })),
+    'json_array',
+    'an object with no list must not be routed to the list crusher'
+  );
+})) passed++; else failed++;
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/guardian-pipeline.test.js
+++ b/tests/guardian-pipeline.test.js
@@ -134,5 +134,21 @@ if (test('routes an object wrapping a list to the JSON crusher, not to text', ()
   );
 })) passed++; else failed++;
 
+if (test('crushes an object-wrapped list end to end and keeps its surrounding fields', () => {
+  // Routing alone proves nothing: this runs the whole pipeline and checks
+  // the payload that comes out the other side.
+  const items = Array.from({ length: 30 }, (_, i) => ({ id: i % 4, state: 'open', title: `t-${i % 3}` }));
+  const payload = JSON.stringify({ items, totalCount: 30, pageInfo: { hasNextPage: false } });
+
+  const r = runPipeline([payload]);
+  assert.strictEqual(r.chunks_crushed, 1, 'the object-wrapped list must actually be crushed');
+  assert.ok(r.bytes_after < r.bytes_before, 'the crushed payload must be smaller');
+
+  const out = JSON.parse(r.chunks[0]);
+  assert.strictEqual(out.totalCount, 30, 'totalCount must survive the pipeline');
+  assert.deepStrictEqual(out.pageInfo, { hasNextPage: false }, 'pagination must survive the pipeline');
+  assert.ok(out.items.length < items.length, 'the list itself must be reduced');
+})) passed++; else failed++;
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/guardian-smart-crusher.test.js
+++ b/tests/guardian-smart-crusher.test.js
@@ -85,5 +85,41 @@ if (test('savings_pct is between 0 and 100', () => {
   assert.ok(result.savings_pct >= 0 && result.savings_pct <= 100);
 })) passed++; else failed++;
 
+if (test('crushes a list nested inside an object and keeps the surrounding fields', () => {
+  // The shape of nearly every REST and CLI payload: the volume is one key
+  // down, next to small scalars. Requiring an array at the top level let all
+  // of those through at full size (a single `gh project item-list --format
+  // json` read 637 KB before this).
+  const items = JSON.parse(makeRows(40, i => ({ id: i % 4, status: 'open', label: `item-${i % 3}` })));
+  const payload = JSON.stringify({ items, totalCount: 812, pageInfo: { hasNextPage: true } });
+
+  const result = reduceJsonArray(payload);
+  assert.ok(result !== null, 'a nested list must be crushed, not passed through');
+  assert.strictEqual(result.rows_before, 40);
+  assert.ok(result.rows_after < 40, 'rows must actually be reduced');
+
+  const reparsed = JSON.parse(result.crushed);
+  assert.strictEqual(reparsed.totalCount, 812, 'counts around the list must survive verbatim');
+  assert.deepStrictEqual(reparsed.pageInfo, { hasNextPage: true }, 'pagination must survive verbatim');
+  assert.strictEqual(reparsed.items.length, result.rows_after);
+  assert.ok(result.crushed.length < payload.length, 'the crushed payload must be smaller');
+})) passed++; else failed++;
+
+if (test('picks the largest list when an object holds several', () => {
+  const few = JSON.parse(makeRows(6, i => ({ id: i, kind: 'small' })));
+  const many = JSON.parse(makeRows(30, i => ({ id: i % 3, kind: 'big' })));
+  const result = reduceJsonArray(JSON.stringify({ few, many }));
+
+  assert.ok(result !== null, 'should crush');
+  assert.strictEqual(result.rows_before, 30, 'the largest list is the one worth reducing');
+  const reparsed = JSON.parse(result.crushed);
+  assert.strictEqual(reparsed.few.length, 6, 'the smaller list must be left alone');
+})) passed++; else failed++;
+
+if (test('leaves an object with no list of its own alone', () => {
+  const result = reduceJsonArray(JSON.stringify({ status: 'ok', count: 3, nested: { a: 1 } }));
+  assert.strictEqual(result, null, 'nothing to reduce means no rewrite');
+})) passed++; else failed++;
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/guardian-smart-crusher.test.js
+++ b/tests/guardian-smart-crusher.test.js
@@ -116,6 +116,19 @@ if (test('picks the largest list when an object holds several', () => {
   assert.strictEqual(reparsed.few.length, 6, 'the smaller list must be left alone');
 })) passed++; else failed++;
 
+if (test('leaves a mixed list alone rather than dropping its non-record elements', () => {
+  // The row logic can only speak about records. Filtering scalars and nulls
+  // out to reduce what remains would delete real elements from a payload the
+  // reader still believes is complete.
+  const mixed = [{ id: 1 }, { id: 2 }, 'plain string', null, { id: 3 }, [1, 2], { id: 4 }];
+  assert.strictEqual(reduceJsonArray(JSON.stringify(mixed)), null, 'a mixed top-level list must pass through');
+  assert.strictEqual(
+    reduceJsonArray(JSON.stringify({ items: mixed, totalCount: 7 })),
+    null,
+    'a mixed nested list must pass through too'
+  );
+})) passed++; else failed++;
+
 if (test('leaves an object with no list of its own alone', () => {
   const result = reduceJsonArray(JSON.stringify({ status: 'ok', count: 3, nested: { a: 1 } }));
   assert.strictEqual(result, null, 'nothing to reduce means no rewrite');


### PR DESCRIPTION
## The gap
The JSON crusher bailed out unless the entire payload was an array (`if (!Array.isArray(parsed)) return null`). Almost no real payload is shaped that way. A REST or CLI response puts its volume **one key down**, beside a few small scalars:

```json
{ "items": [ ...812 rows... ], "totalCount": 812 }
{ "workflow_runs": [ ... ] }
{ "jobs": [ ... ] }
```

Every one of those reached the model at full size. That is most of what `egc discover` reports as missed savings, and it affects every EGC user, not one machine: GitHub, Kubernetes and essentially every paginated API answer takes this shape.

## Fix
The largest list inside the object is reduced with the existing row logic, and everything around it is preserved verbatim, so counts and pagination cursors still read correctly. Top-level arrays behave exactly as before.

## Measured on a real payload
`gh project item-list --format json --limit 200`:

| | before | after |
|---|---|---|
| size | 637.3 KB | 30.9 KB |
| tokens | - | **~155k saved in one command** |
| `totalCount` | 812 | 812 (intact) |

## Verification
smart-crusher 11/11 with three new cases (nested list crushed with surrounding fields intact; the largest of several lists is the one picked; an object with no list is left alone), crusher-engine 28/28.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compress lists nested inside JSON objects (not just top-level arrays) and preserve surrounding fields to shrink REST/CLI payloads. Example: `gh project item-list --format json --limit 200` drops from 637.3 KB to 30.9 KB (~155k tokens saved) with `totalCount` intact.

- **Bug Fixes**
  - Router: classify object-wrapped lists as `json_array` so nested lists reach the crusher; top-level arrays still work.
  - Safety: only reduce homogeneous record lists; mixed lists (records + scalars/nulls/arrays) pass through untouched.
  - Picks the largest list when several exist; no-op if none.
  - Tests: added end-to-end pipeline test to verify nested-list crushing and preserved fields; smart-crusher 12/12, pipeline 7/7, cache-aligner 12/12, crusher-engine 28/28.

<sup>Written for commit afd92f9bb4d41afb2cfb9e86b0610c4693c29c9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

