### PR TITLE
fix(guardian): stop denying reads of files that hold no secret

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -890,7 +890,10 @@ export function isReadDeniedPath(p: string, baseDir: string = process.cwd()): bo
 
   // Protection came from the filename alone. Allow the persistence-only
   // ones; everything else (.env, .pem, tokens, auth files) stays denied.
-  return !READ_SAFE_FILE_PATTERNS.some(pattern => pattern.test(normalizedP));
+  // Folded on the same terms as the denial side: where the filesystem opens
+  // ~/.BASHRC and ~/.bashrc as one file, both spellings have to be readable,
+  // or the case fix would have quietly turned a harmless read into a denial.
+  return !READ_SAFE_FILE_PATTERNS.some(pattern => pattern.test(foldCase(normalizedP)));
 }
 
 export interface ValidationResult {

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -802,14 +802,12 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
 // write denial stays exactly as it was.
 //
 // Derived from the write protection by subtraction, never restated: a read
-// is denied wherever a write is denied, EXCEPT for the few locations listed
+// is denied wherever a write is denied, EXCEPT for the locations listed
 // here. Stating the readable set positively (rather than re-listing what to
 // deny) means a credential store added to the write protection tomorrow is
 // read-protected automatically, instead of silently becoming readable
 // because a parallel list was not updated.
 //
-// Every entry below is functional configuration, not a credential: knowing
-// its contents tells you how an install is wired, nothing more.
 // Deliberately narrow: specific directories whose entire contents are
 // operational, never a whole tree with secrets carved back out. Opening
 // /etc or ~/.egc wholesale and then listing the secrets inside them is a

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -810,50 +810,62 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
 //
 // Every entry below is functional configuration, not a credential: knowing
 // its contents tells you how an install is wired, nothing more.
+// Deliberately narrow: specific directories whose entire contents are
+// operational, never a whole tree with secrets carved back out. Opening
+// /etc or ~/.egc wholesale and then listing the secrets inside them is a
+// denylist wearing an allowlist's clothes, and it leaks by omission -- an
+// audit of exactly that shape turned up /etc/ssl/private, /etc/wireguard,
+// /etc/krb5.keytab, the shadow backup files (/etc/shadow-), and
+// ~/.egc/encryption.key.bak, none of which had been listed. Anything not
+// named here stays denied, so a secret nobody thought of stays protected.
 function buildReadSafePaths(): string[] {
   const home = os.homedir();
   return [
-    // EGC's own install surface: shim manifest, metrics ledger, logs.
-    path.join(home, '.egc'),
-    // System and service configuration.
-    '/etc',
-    // Binary directory: listing what is on PATH is diagnosis, not exposure.
-    path.join(home, '.local', 'bin'),
-    // User service units: what runs at login.
+    // EGC's own install surface: shim manifest and the binaries it wraps.
+    path.join(home, '.egc', 'bin'),
+    // Token Crusher ledger, which `egc gain` reports from.
+    path.join(home, '.egc', 'metrics'),
+    path.join(home, '.egc', 'logs'),
+    // Service definitions: what runs, and how.
+    '/etc/systemd',
     path.join(home, '.config', 'systemd', 'user'),
+    // Listing what sits ahead of /usr/bin on PATH is diagnosis, not exposure.
+    path.join(home, '.local', 'bin'),
   ];
 }
 
 export const READ_SAFE_PATHS: string[] = buildReadSafePaths();
 
-// Carved back out of the read-safe areas above, because their content IS
-// the secret even though they sit inside an otherwise diagnosable tree.
-function buildReadSecretPaths(): string[] {
-  const home = os.homedir();
-  return [
-    path.join(home, '.egc', 'encryption.key'),
-    path.join(home, '.egc', 'state'),
-    '/etc/shadow',
-    '/etc/gshadow',
-    '/etc/sudoers',
-    '/etc/sudoers.d',
-    '/etc/ssh',
-  ];
-}
-
-export const READ_SECRET_PATHS: string[] = buildReadSecretPaths();
-
 // Files that are dangerous to modify but harmless to read: shell startup
 // files and git config are persistence mechanisms, not credential stores.
+// Anchored, and only ever consulted for a path that is NOT inside a denied
+// directory -- otherwise a file named ~/.ssh/.gitconfig would read as safe.
 const READ_SAFE_FILE_PATTERNS: RegExp[] = [
   /(^|[\\/])\.(bashrc|zshrc|bash_profile|zprofile|profile)$/,
   /(^|[\\/])\.gitconfig$/,
-  /(^|[\\/])\.git[\\/](config|hooks([\\/]|$))/,
+  /(^|[\\/])\.git[\\/](config|hooks)$/,
+  /(^|[\\/])\.git[\\/]hooks[\\/]/,
 ];
 
+// macOS and Windows resolve paths case-insensitively, so a comparison that
+// is not folded there would let `cat /etc/SHADOW` or `~/.egc/ENCRYPTION.KEY`
+// slip past a check written in lower case.
+const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
+
+function foldCase(p: string): string {
+  return CASE_INSENSITIVE_FS ? p.toLowerCase() : p;
+}
+
 function isUnder(candidate: string, parent: string): boolean {
-  const resolvedParent = resolveRealOrLexical(parent);
-  return candidate === resolvedParent || candidate.startsWith(resolvedParent + path.sep);
+  const resolvedParent = foldCase(resolveRealOrLexical(parent));
+  const folded = foldCase(candidate);
+  return folded === resolvedParent || folded.startsWith(resolvedParent + path.sep);
+}
+
+// Whether the protection comes from the path living inside a denied
+// directory (a credential store) rather than from the filename alone.
+function isUnderDeniedDirectory(normalizedP: string): boolean {
+  return DENIED_PATHS.some(denied => isUnder(normalizedP, denied));
 }
 
 export function isReadDeniedPath(p: string, baseDir: string = process.cwd()): boolean {
@@ -866,12 +878,15 @@ export function isReadDeniedPath(p: string, baseDir: string = process.cwd()): bo
     : trimmed;
   const normalizedP = resolveRealOrLexical(path.resolve(baseDir, expanded));
 
-  // A secret carved out of a readable tree wins over that tree.
-  if (READ_SECRET_PATHS.some(secret => isUnder(normalizedP, secret))) return true;
+  // An explicitly operational location is readable.
+  if (READ_SAFE_PATHS.some(safe => isUnder(normalizedP, safe))) return false;
 
-  if (READ_SAFE_FILE_PATTERNS.some(pattern => pattern.test(normalizedP))) return false;
+  // Inside a credential store, the filename means nothing: deny.
+  if (isUnderDeniedDirectory(normalizedP)) return true;
 
-  return !READ_SAFE_PATHS.some(safe => isUnder(normalizedP, safe));
+  // Protection came from the filename alone. Allow the persistence-only
+  // ones; everything else (.env, .pem, tokens, auth files) stays denied.
+  return !READ_SAFE_FILE_PATTERNS.some(pattern => pattern.test(normalizedP));
 }
 
 export interface ValidationResult {

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -794,6 +794,77 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
   return false;
 }
 
+// Reading and writing carry different risk, and treating them alike is what
+// made the guardian deny `cat ~/.egc/bin/manifest.json`, `ls ~/.egc/bin` or
+// `cat /etc/systemd/oomd.conf` -- none of which expose a secret, all of
+// which someone diagnosing their own install genuinely needs. Writing into
+// those directories can hijack execution or plant persistence, so every
+// write denial stays exactly as it was.
+//
+// A read is denied only when the file's *content* is the secret: private
+// keys, credential stores, token files, the shadow password database. The
+// directories below are denied wholesale because everything inside them is
+// of that kind.
+function buildReadDeniedPaths(): string[] {
+  const home = os.homedir();
+  const paths = [
+    path.join(home, '.ssh'),
+    path.join(home, '.aws'),
+    path.join(home, '.gnupg'),
+    // The key that decrypts EGC's own state files.
+    path.join(home, '.egc', 'encryption.key'),
+    '/etc/shadow',
+    '/etc/gshadow',
+    '/etc/sudoers',
+    '/etc/sudoers.d',
+    '/etc/ssh',
+  ];
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || '';
+    if (appData) paths.push(path.join(appData, 'gnupg'));
+  }
+
+  return paths;
+}
+
+export const READ_DENIED_PATHS: string[] = buildReadDeniedPaths();
+
+// File patterns whose content is the secret, wherever they live. This is the
+// subset of PROTECTED_FILE_PATTERNS that a read must still refuse; the rest
+// of that list covers files that are merely dangerous to *modify*.
+export const READ_DENIED_FILE_PATTERNS: RegExp[] = [
+  /\.env$/,
+  /\.env\.(?!example$|sample$|template$)/,
+  /\.pem$/,
+  /\.key$/,
+  /\.p12$/,
+  /\.npmrc$/,
+  /\.pypirc$/,
+  /credentials?\.json$/i,
+  /oauth[^\\/]*\.json$/i,
+  /[^\\/]*token[^\\/]*\.json$/i,
+  /(^|[\\/])\.claude\.json$/,
+  /(^|[\\/])id_(rsa|dsa|ecdsa|ed25519)$/,
+];
+
+export function isReadDeniedPath(p: string, baseDir: string = process.cwd()): boolean {
+  const trimmed = p.trim();
+  const expanded = trimmed.startsWith('~')
+    ? path.join(os.homedir(), trimmed.slice(1))
+    : trimmed;
+  const normalizedP = resolveRealOrLexical(path.resolve(baseDir, expanded));
+
+  for (const denied of READ_DENIED_PATHS) {
+    const resolvedDenied = resolveRealOrLexical(denied);
+    if (normalizedP === resolvedDenied || normalizedP.startsWith(resolvedDenied + path.sep)) {
+      return true;
+    }
+  }
+
+  return READ_DENIED_FILE_PATTERNS.some(pattern => pattern.test(normalizedP));
+}
+
 export interface ValidationResult {
   allowed: boolean;
   reason?: string;
@@ -986,7 +1057,7 @@ a => a === '-r' || a === '-R' || a === '--recursive' ||
     }
   }
   for (const p of fileFlagValues) {
-    if (isProtectedPath(p, cwd)) {
+    if (isReadDeniedPath(p, cwd)) {
       return {
         allowed: false,
         reason: `grep pattern file '${p}' is a protected path`,
@@ -1007,7 +1078,7 @@ a => a === '-r' || a === '-R' || a === '--recursive' ||
 
   if (isRecursive) {
 for (const p of pathArgs) {
-  if (p === '/' || p === home || isProtectedPath(p, cwd)) {
+  if (p === '/' || p === home || isReadDeniedPath(p, cwd)) {
     return {
       allowed: false,
       reason: `grep recursive over protected path '${p}' is forbidden`,
@@ -1017,7 +1088,7 @@ for (const p of pathArgs) {
 }
 // If no explicit path args, grep defaults to '.', which is fine.
 // But if the only non-flag positional IS '/' (i.e., pattern was empty), still block.
-if (positionalArgs.length === 1 && (positionalArgs[0] === '/' || isProtectedPath(positionalArgs[0], cwd))) {
+if (positionalArgs.length === 1 && (positionalArgs[0] === '/' || isReadDeniedPath(positionalArgs[0], cwd))) {
   return {
     allowed: false,
     reason: `grep over protected path '${positionalArgs[0]}' is forbidden`,
@@ -1028,7 +1099,7 @@ if (positionalArgs.length === 1 && (positionalArgs[0] === '/' || isProtectedPath
 
   // Even without -r, block explicit protected paths
   for (const p of pathArgs) {
-if (isProtectedPath(p, cwd)) {
+if (isReadDeniedPath(p, cwd)) {
   return {
     allowed: false,
     reason: `grep over protected path '${p}' is forbidden`,
@@ -1043,7 +1114,7 @@ if (isProtectedPath(p, cwd)) {
 function validateCatArgs(args: string[], cwd?: string): ValidationResult {
   for (const arg of args) {
 const candidate = arg.startsWith('-') ? embeddedPathCandidate(arg) : arg;
-if (candidate !== null && isProtectedPath(candidate, cwd)) {
+if (candidate !== null && isReadDeniedPath(candidate, cwd)) {
   return {
     allowed: false,
     reason: `cat of protected path '${arg}' is forbidden`,
@@ -1073,7 +1144,7 @@ return {
     .map(a => (a.startsWith('-') ? embeddedPathCandidate(a) : a))
     .filter((a): a is string => a !== null);
   for (const p of pathArgs) {
-if (isProtectedPath(p, cwd)) {
+if (isReadDeniedPath(p, cwd)) {
   return {
     allowed: false,
     reason: `find over protected path '${p}' is forbidden`,
@@ -1088,7 +1159,7 @@ function validateReadOnlyPathArgs(baseCommand: string, args: string[], cwd?: str
   // These are read-only but we still block protected paths
   for (const arg of args) {
 const candidate = arg.startsWith('-') ? embeddedPathCandidate(arg) : arg;
-if (candidate !== null && isProtectedPath(candidate, cwd)) {
+if (candidate !== null && isReadDeniedPath(candidate, cwd)) {
   return {
     allowed: false,
     reason: `${baseCommand} on protected path '${arg}' is forbidden`,

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -760,6 +760,15 @@ export function resolveRealOrLexical(p: string): string {
 // pass it explicitly -- otherwise a relative path is judged against this
 // process's own cwd, which is not guaranteed to match the shell the command
 // actually runs in.
+// macOS and Windows resolve paths case-insensitively; Linux does not. Every
+// path comparison in this file folds through here so a case variant cannot
+// name a protected file while dodging the check written for it.
+const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
+
+function foldCase(p: string): string {
+  return CASE_INSENSITIVE_FS ? p.toLowerCase() : p;
+}
+
 export function isProtectedPath(p: string, baseDir: string = process.cwd()): boolean {
   // Trim first: a trailing newline (routine for anything piped through
   // `echo`) or stray whitespace survives path.resolve() into the final
@@ -777,16 +786,22 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
   // this check into a denied path. Fall back to the lexical path (then the
   // parent) when the target does not exist yet, e.g. a write being created.
   const normalizedP = resolveRealOrLexical(path.resolve(baseDir, expanded));
+  // macOS and Windows open `.ENV`, `/etc/SHADOW` and `~/.SSH/id_rsa` as the
+  // very same files their lower-case spellings name, so a comparison that is
+  // not folded there protects only one spelling of each secret. Folding is
+  // applied to both sides, and only where the filesystem actually behaves
+  // that way -- on Linux those are genuinely different files.
+  const candidate = foldCase(normalizedP);
 
   for (const denied of DENIED_PATHS) {
-    const resolvedDenied = resolveRealOrLexical(denied);
-    if (normalizedP === resolvedDenied || normalizedP.startsWith(resolvedDenied + path.sep)) {
+    const resolvedDenied = foldCase(resolveRealOrLexical(denied));
+    if (candidate === resolvedDenied || candidate.startsWith(resolvedDenied + path.sep)) {
       return true;
     }
   }
 
   for (const pattern of PROTECTED_FILE_PATTERNS) {
-    if (pattern.test(normalizedP)) {
+    if (pattern.test(candidate)) {
       return true;
     }
   }
@@ -844,15 +859,6 @@ const READ_SAFE_FILE_PATTERNS: RegExp[] = [
   /(^|[\\/])\.git[\\/](config|hooks)$/,
   /(^|[\\/])\.git[\\/]hooks[\\/]/,
 ];
-
-// macOS and Windows resolve paths case-insensitively, so a comparison that
-// is not folded there would let `cat /etc/SHADOW` or `~/.egc/ENCRYPTION.KEY`
-// slip past a check written in lower case.
-const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
-
-function foldCase(p: string): string {
-  return CASE_INSENSITIVE_FS ? p.toLowerCase() : p;
-}
 
 function isUnder(candidate: string, parent: string): boolean {
   const resolvedParent = foldCase(resolveRealOrLexical(parent));

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -805,64 +805,77 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
 // keys, credential stores, token files, the shadow password database. The
 // directories below are denied wholesale because everything inside them is
 // of that kind.
-function buildReadDeniedPaths(): string[] {
+// Derived from the write protection by subtraction, never restated: a read
+// is denied wherever a write is denied, EXCEPT for the few locations listed
+// here. Stating the readable set positively (rather than re-listing what to
+// deny) means a credential store added to the write protection tomorrow is
+// read-protected automatically, instead of silently becoming readable
+// because a parallel list was not updated.
+//
+// Every entry below is functional configuration, not a credential: knowing
+// its contents tells you how an install is wired, nothing more.
+function buildReadSafePaths(): string[] {
   const home = os.homedir();
-  const paths = [
-    path.join(home, '.ssh'),
-    path.join(home, '.aws'),
-    path.join(home, '.gnupg'),
-    // The key that decrypts EGC's own state files.
+  return [
+    // EGC's own install surface: shim manifest, metrics ledger, logs.
+    path.join(home, '.egc'),
+    // System and service configuration.
+    '/etc',
+    // Binary directory: listing what is on PATH is diagnosis, not exposure.
+    path.join(home, '.local', 'bin'),
+    // User service units: what runs at login.
+    path.join(home, '.config', 'systemd', 'user'),
+  ];
+}
+
+export const READ_SAFE_PATHS: string[] = buildReadSafePaths();
+
+// Carved back out of the read-safe areas above, because their content IS
+// the secret even though they sit inside an otherwise diagnosable tree.
+function buildReadSecretPaths(): string[] {
+  const home = os.homedir();
+  return [
     path.join(home, '.egc', 'encryption.key'),
+    path.join(home, '.egc', 'state'),
     '/etc/shadow',
     '/etc/gshadow',
     '/etc/sudoers',
     '/etc/sudoers.d',
     '/etc/ssh',
   ];
-
-  if (process.platform === 'win32') {
-    const appData = process.env.APPDATA || '';
-    if (appData) paths.push(path.join(appData, 'gnupg'));
-  }
-
-  return paths;
 }
 
-export const READ_DENIED_PATHS: string[] = buildReadDeniedPaths();
+export const READ_SECRET_PATHS: string[] = buildReadSecretPaths();
 
-// File patterns whose content is the secret, wherever they live. This is the
-// subset of PROTECTED_FILE_PATTERNS that a read must still refuse; the rest
-// of that list covers files that are merely dangerous to *modify*.
-export const READ_DENIED_FILE_PATTERNS: RegExp[] = [
-  /\.env$/,
-  /\.env\.(?!example$|sample$|template$)/,
-  /\.pem$/,
-  /\.key$/,
-  /\.p12$/,
-  /\.npmrc$/,
-  /\.pypirc$/,
-  /credentials?\.json$/i,
-  /oauth[^\\/]*\.json$/i,
-  /[^\\/]*token[^\\/]*\.json$/i,
-  /(^|[\\/])\.claude\.json$/,
-  /(^|[\\/])id_(rsa|dsa|ecdsa|ed25519)$/,
+// Files that are dangerous to modify but harmless to read: shell startup
+// files and git config are persistence mechanisms, not credential stores.
+const READ_SAFE_FILE_PATTERNS: RegExp[] = [
+  /(^|[\\/])\.(bashrc|zshrc|bash_profile|zprofile|profile)$/,
+  /(^|[\\/])\.gitconfig$/,
+  /(^|[\\/])\.git[\\/](config|hooks([\\/]|$))/,
 ];
 
+function isUnder(candidate: string, parent: string): boolean {
+  const resolvedParent = resolveRealOrLexical(parent);
+  return candidate === resolvedParent || candidate.startsWith(resolvedParent + path.sep);
+}
+
 export function isReadDeniedPath(p: string, baseDir: string = process.cwd()): boolean {
+  // Not protected at all: nothing to decide.
+  if (!isProtectedPath(p, baseDir)) return false;
+
   const trimmed = p.trim();
   const expanded = trimmed.startsWith('~')
     ? path.join(os.homedir(), trimmed.slice(1))
     : trimmed;
   const normalizedP = resolveRealOrLexical(path.resolve(baseDir, expanded));
 
-  for (const denied of READ_DENIED_PATHS) {
-    const resolvedDenied = resolveRealOrLexical(denied);
-    if (normalizedP === resolvedDenied || normalizedP.startsWith(resolvedDenied + path.sep)) {
-      return true;
-    }
-  }
+  // A secret carved out of a readable tree wins over that tree.
+  if (READ_SECRET_PATHS.some(secret => isUnder(normalizedP, secret))) return true;
 
-  return READ_DENIED_FILE_PATTERNS.some(pattern => pattern.test(normalizedP));
+  if (READ_SAFE_FILE_PATTERNS.some(pattern => pattern.test(normalizedP))) return false;
+
+  return !READ_SAFE_PATHS.some(safe => isUnder(normalizedP, safe));
 }
 
 export interface ValidationResult {
@@ -1078,7 +1091,7 @@ a => a === '-r' || a === '-R' || a === '--recursive' ||
 
   if (isRecursive) {
 for (const p of pathArgs) {
-  if (p === '/' || p === home || isReadDeniedPath(p, cwd)) {
+  if (p === '/' || p === home || isProtectedPath(p, cwd)) {
     return {
       allowed: false,
       reason: `grep recursive over protected path '${p}' is forbidden`,
@@ -1088,7 +1101,7 @@ for (const p of pathArgs) {
 }
 // If no explicit path args, grep defaults to '.', which is fine.
 // But if the only non-flag positional IS '/' (i.e., pattern was empty), still block.
-if (positionalArgs.length === 1 && (positionalArgs[0] === '/' || isReadDeniedPath(positionalArgs[0], cwd))) {
+if (positionalArgs.length === 1 && (positionalArgs[0] === '/' || isProtectedPath(positionalArgs[0], cwd))) {
   return {
     allowed: false,
     reason: `grep over protected path '${positionalArgs[0]}' is forbidden`,
@@ -1144,7 +1157,7 @@ return {
     .map(a => (a.startsWith('-') ? embeddedPathCandidate(a) : a))
     .filter((a): a is string => a !== null);
   for (const p of pathArgs) {
-if (isReadDeniedPath(p, cwd)) {
+if (isProtectedPath(p, cwd)) {
   return {
     allowed: false,
     reason: `find over protected path '${p}' is forbidden`,

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -801,10 +801,6 @@ export function isProtectedPath(p: string, baseDir: string = process.cwd()): boo
 // those directories can hijack execution or plant persistence, so every
 // write denial stays exactly as it was.
 //
-// A read is denied only when the file's *content* is the secret: private
-// keys, credential stores, token files, the shadow password database. The
-// directories below are denied wholesale because everything inside them is
-// of that kind.
 // Derived from the write protection by subtraction, never restated: a read
 // is denied wherever a write is denied, EXCEPT for the few locations listed
 // here. Stating the readable set positively (rather than re-listing what to

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -214,5 +214,43 @@ run('git config includeIf.<condition>.path write is blocked (audit EGC-533, Find
   assert.strictEqual(v.allowed, false, 'includeIf.*.path loads another config file wholesale, same as include.path');
 });
 
+// Reading and writing carry different risk. Writing into these directories
+// can hijack execution or plant persistence; reading a manifest or a service
+// config only tells you how your own install is set up, and denying that was
+// blocking legitimate diagnosis.
+run('reading a functional file under a write-protected directory is allowed', () => {
+  const home = require('node:os').homedir();
+  for (const cmd of [
+    `cat ${path.join(home, '.egc', 'bin', 'manifest.json')}`,
+    `ls ${path.join(home, '.egc', 'bin')}`,
+    'cat /etc/systemd/oomd.conf',
+  ]) {
+    assert.strictEqual(validateCommand(cmd).allowed, true, `${cmd} exposes no secret and must be readable`);
+  }
+});
+
+run('reading an actual secret is still refused', () => {
+  const home = require('node:os').homedir();
+  for (const cmd of [
+    `cat ${path.join(home, '.ssh', 'id_rsa')}`,
+    `cat ${path.join(home, '.egc', 'encryption.key')}`,
+    `cat ${path.join(home, '.npmrc')}`,
+    'cat /etc/shadow',
+  ]) {
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} exposes a credential and must stay denied`);
+  }
+});
+
+run('write protection is untouched by the read split', () => {
+  const home = require('node:os').homedir();
+  for (const target of [
+    path.join(home, '.egc', 'bin', 'git'),
+    path.join(home, '.ssh', 'authorized_keys'),
+    '/etc/passwd',
+  ]) {
+    assert.strictEqual(validateWrite(target).allowed, false, `${target} must remain write-protected`);
+  }
+});
+
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
 if (failed > 0) process.exit(1);

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -241,6 +241,31 @@ run('reading an actual secret is still refused', () => {
   }
 });
 
+run('a recursive walk cannot reach a secret through a readable parent', () => {
+  const home = require('node:os').homedir();
+  // Reading one functional file inside ~/.egc is fine; walking the tree is
+  // not, because the walk would reach the encryption key.
+  for (const cmd of [
+    `grep -r secret ${path.join(home, '.egc')}`,
+    `find ${path.join(home, '.config', 'github-copilot')} -name "*.json"`,
+  ]) {
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} traverses into protected content`);
+  }
+});
+
+run('credential stores outside the readable areas stay denied', () => {
+  const home = require('node:os').homedir();
+  // These are covered by the write protection and are not on the read-safe
+  // list, so subtraction keeps them denied without restating them.
+  for (const cmd of [
+    `cat ${path.join(home, '.codex', 'auth.json')}`,
+    `cat ${path.join(home, '.gemini', 'google_accounts.json')}`,
+    `cat ${path.join(home, '.local', 'share', 'kiro-cli', 'data.sqlite3')}`,
+  ]) {
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} is a credential store`);
+  }
+});
+
 run('write protection is untouched by the read split', () => {
   const home = require('node:os').homedir();
   for (const target of [

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -241,15 +241,40 @@ run('reading an actual secret is still refused', () => {
   }
 });
 
-run('a recursive walk cannot reach a secret through a readable parent', () => {
+run('recursive walks stay out of protected trees, readable subdirectory or not', () => {
   const home = require('node:os').homedir();
-  // Reading one functional file inside ~/.egc is fine; walking the tree is
-  // not, because the walk would reach the encryption key.
+  // Direct denied roots, and -- the case that actually matters here -- a
+  // directory whose *contents* are readable one file at a time. `cat
+  // ~/.egc/bin/manifest.json` is allowed; walking ~/.egc/bin is not, because
+  // tree-walking commands keep the full write-protection check rather than
+  // the narrower read one.
   for (const cmd of [
     `grep -r secret ${path.join(home, '.egc')}`,
     `find ${path.join(home, '.config', 'github-copilot')} -name "*.json"`,
+    `grep -r token ${path.join(home, '.egc', 'bin')}`,
+    `find ${path.join(home, '.egc', 'metrics')} -name "*.jsonl"`,
   ]) {
-    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} traverses into protected content`);
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} walks a protected tree`);
+  }
+
+  // The single-file reads inside those same directories stay allowed, which
+  // is the whole point of the split.
+  assert.strictEqual(
+    validateCommand(`cat ${path.join(home, '.egc', 'bin', 'manifest.json')}`).allowed,
+    true,
+    'reading one operational file must still work'
+  );
+});
+
+run('a case variant cannot name a secret past the guard', () => {
+  // macOS and Windows open .ENV and /etc/SHADOW as the same files their
+  // lower-case spellings name. The check folds case there, so the variant is
+  // refused; on Linux these are genuinely different paths and the assertion
+  // only applies where the filesystem behaves that way.
+  if (process.platform !== 'darwin' && process.platform !== 'win32') return;
+  const home = require('node:os').homedir();
+  for (const cmd of ['cat /etc/SHADOW', 'cat .ENV', `cat ${path.join(home, '.egc', 'ENCRYPTION.KEY')}`]) {
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} names a protected file`);
   }
 });
 

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -266,6 +266,43 @@ run('credential stores outside the readable areas stay denied', () => {
   }
 });
 
+run('a persistence-file name cannot unlock a credential directory', () => {
+  const home = require('node:os').homedir();
+  // .bashrc and .gitconfig are readable where they normally live, but the
+  // filename must not make them readable inside a credential store, and the
+  // .git/config pattern must not stretch to .git/config_keys.
+  for (const cmd of [
+    `cat ${path.join(home, '.ssh', '.gitconfig')}`,
+    `cat ${path.join(home, '.aws', '.bashrc')}`,
+    `cat ${path.join(home, '.ssh', '.git', 'config')}`,
+    `cat ${path.join(home, '.ssh', '.git', 'config_keys')}`,
+  ]) {
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} sits inside a credential store`);
+  }
+});
+
+run('system secrets are denied without having to be enumerated', () => {
+  // The readable set is narrow on purpose (specific directories, not whole
+  // trees), so none of these had to be listed anywhere to stay protected --
+  // which is the point, since an audit found every one of them missing from
+  // an earlier attempt that opened /etc and ~/.egc wholesale.
+  const home = require('node:os').homedir();
+  for (const cmd of [
+    'cat /etc/shadow-',
+    'cat /etc/gshadow-',
+    'cat /etc/sudoers.tmp',
+    'cat /etc/ssl/private/server.key',
+    'cat /etc/wireguard/wg0.conf',
+    'cat /etc/krb5.keytab',
+    'cat /etc/master.passwd',
+    `cat ${path.join(home, '.egc', 'encryption.key.bak')}`,
+    `cat ${path.join(home, '.egc', 'state.bak')}`,
+    `cat ${path.join(home, '.egc', 'state', 'project.md')}`,
+  ]) {
+    assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} must stay denied`);
+  }
+});
+
 run('write protection is untouched by the read split', () => {
   const home = require('node:os').homedir();
   for (const target of [

--- a/tests/egc-guardian-bypass-hardening.test.js
+++ b/tests/egc-guardian-bypass-hardening.test.js
@@ -276,6 +276,16 @@ run('a case variant cannot name a secret past the guard', () => {
   for (const cmd of ['cat /etc/SHADOW', 'cat .ENV', `cat ${path.join(home, '.egc', 'ENCRYPTION.KEY')}`]) {
     assert.strictEqual(validateCommand(cmd).allowed, false, `${cmd} names a protected file`);
   }
+
+  // The same folding has to apply to the readable side, or the case fix
+  // would turn harmless reads into denials on exactly those systems.
+  for (const cmd of [
+    `cat ${path.join(home, '.BASHRC')}`,
+    `cat ${path.join(home, '.GITCONFIG')}`,
+    `cat ${path.join(home, '.egc', 'BIN', 'manifest.json')}`,
+  ]) {
+    assert.strictEqual(validateCommand(cmd).allowed, true, `${cmd} names a harmless file`);
+  }
 });
 
 run('credential stores outside the readable areas stay denied', () => {


### PR DESCRIPTION
## The contradiction
The guardian judged reading and writing by the same rule, so every path protected against writes became unreadable too. In practice that refused things like:

```
cat ~/.egc/bin/manifest.json     -> denied
ls ~/.egc/bin                    -> denied
cat /etc/systemd/oomd.conf       -> denied
```

None of those expose anything. They are what someone reaches for when diagnosing their own install, and the protection's own comment states the intent plainly: *"no legitimate reason for an AI tool to **write** here"*.

## Fix
Reads are now judged by whether the file's **content** is the secret: private keys, credential and token stores, `.env`, `.npmrc`, `.pypirc`, the shadow password database, EGC's own encryption key. Everything else living under a write-protected directory is readable.

**No write denial changed.** `isProtectedPath` still guards `validateWrite` and the dev-tool path; only the seven read call sites (ls, grep ×4, cat, find, head/stat) moved to the new check.

## Verified on a real machine
| | before | after |
|---|---|---|
| `cat ~/.egc/bin/manifest.json` | denied | **allowed** |
| `ls ~/.egc/bin` | denied | **allowed** |
| `cat /etc/systemd/oomd.conf` | denied | **allowed** |
| `cat ~/.ssh/id_rsa` | denied | denied |
| `cat ~/.egc/encryption.key` | denied | denied |
| `cat ~/.npmrc` | denied | denied |
| `cat /etc/shadow` | denied | denied |
| write `~/.egc/bin/git` | denied | denied |
| write `~/.ssh/authorized_keys` | denied | denied |
| write `/etc/passwd` | denied | denied |

Suites: bypass-hardening 79/79 (three new cases covering both directions), destructive-cli 73/73, symlink 3/3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split read vs write checks to allow direct reads of operational files while keeping secrets and recursive walks blocked. The readable set is now a small, explicit list of non-secret dirs; write protections are unchanged.

- **Bug Fixes**
  - Added isReadDeniedPath: reads are denied wherever writes are denied, except for these operational dirs: ~/.egc/bin, ~/.egc/metrics, ~/.egc/logs, /etc/systemd, ~/.config/systemd/user, ~/.local/bin. Secrets inside any tree (e.g., ~/.egc/encryption.key, /etc/shadow, /etc/ssl/private, /etc/wireguard) remain denied.
  - Only direct reads use the new check (cat, ls, grep file args, head/stat); tree-walking commands (grep -r/-R, find) still use full write-protection to prevent reaching secrets.
  - Hardened patterns: allow persistence-only files (.bashrc/.zshrc, .gitconfig, .git/config/hooks) only outside denied dirs; anchor .git patterns; fold case on macOS/Windows in both denial and readable checks so casing variants of secrets stay blocked while harmless reads like ~/.BASHRC, ~/.GITCONFIG, and ~/.egc/BIN/manifest.json are allowed.
  - Tests added; suites pass: egc-guardian 126/126, bypass-hardening 84/84, destructive-cli 73/73, symlink 3/3.

- **Refactors**
  - Merged validator header comments to reflect the final design (no behavior change).

<sup>Written for commit ed950e18359225b869bf51fd939be39cee3ae3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

