### PR TITLE
docs(install): correct what --target zed actually does

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,14 +32,18 @@ Memory is shared across EGC targets. Context saved while using Copilot is the sa
 
 ### Zed
 
-EGC registers `egc-guardian` and `egc-memory` directly into Zed's `context_servers` config. Paths are resolved at install time so it works regardless of how EGC was installed.
-
 ```bash
 npm install -g @egchq/egc
 egc install --target zed
 ```
 
-The installer writes to `~/.config/zed/settings.json` under the `context_servers` key. No manual JSON editing required.
+This installs EGC's skills into `~/.config/zed/`. It does **not** register the MCP servers: `--target <tool>` only ever installs skills and rules.
+
+To get `egc-guardian` and `egc-memory` into Zed's `context_servers`, run the installer or `egc init` instead. Both detect Zed and write to `~/.config/zed/settings.json` with paths resolved at install time:
+
+```bash
+egc init
+```
 
 ---
 


### PR DESCRIPTION
## The false claim
`docs/installation.md` told the reader:

> EGC registers `egc-guardian` and `egc-memory` directly into Zed's `context_servers` config. [...] The installer writes to `~/.config/zed/settings.json` under the `context_servers` key.

right under `egc install --target zed`. That command does no such thing. `scripts/lib/install-targets/zed-home.js` is a flat skill-plan adapter (`rootSegments: ['.config','zed']`) and never touches `context_servers`; MCP registration lives in `egc init` and the shell installers.

Someone following that section ends up with skills installed, no MCP servers, and nothing telling them so.

## Fix
The section now says what `--target` does (skills and rules only), states plainly that it does not register MCP, and points at the command that does. Found while mapping registration coverage for #1197.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Zed install docs to state that `egc install --target zed` only installs skills and rules into `~/.config/zed/` and does not register MCP servers. Adds guidance to use the installer or `egc init` to register `egc-guardian` and `egc-memory` in Zed’s `context_servers` (`~/.config/zed/settings.json`).

<sup>Written for commit 432103b4842dae7fa3b389427af7384be38da058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

