### PR TITLE
chore(deps): bump codeql-action to 4.37.4 across all six references

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -100,6 +100,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Why Dependabot's PRs cannot pass on their own
Dependabot opened three PRs for the same action — init (#1199), analyze (#1200), upload-sarif (#1201). Two of them fail, and the log says exactly why:

```
##[error]Loaded a configuration file for version '4.37.4', but running version '4.37.3'
```

The `init` step writes a config that the `analyze` step rejects when their versions differ. The three steps are **one unit**: no single-step bump can ever go green, and re-running them will not help.

GitHub's own [codeql-action README](https://github.com/github/codeql-action) recommends referencing a major version tag (`v4`) so *"your workflow automatically picks up the latest release within that major version"* — i.e. every step moves together. This repo pins by SHA instead, for supply-chain reasons (Scorecard `pinned-dependencies`, tracked in #322), so moving them together has to be done in one commit.

## This PR
All **six** references across five workflows (`codeql.yml` ×2, `cflite_pr`, `cflite_batch`, `cflite_cron`, `scorecard`) now point at `f205ea1c3313d32999d8d6a48b4f6530d4437b38` — the commit behind tag `v4.37.4`, verified against the GitHub API and identical to the SHA Dependabot proposed.

Supersedes #1199, #1200 and #1201, which should be closed once this merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `github/codeql-action` to v4.37.4 across all six references to keep `init`, `analyze`, and `upload-sarif` in sync and fix CI failures from mixed versions. All steps now use commit f205ea1c3313d32999d8d6a48b4f6530d4437b38.

- **Dependencies**
  - Bumped `github/codeql-action/init`, `github/codeql-action/analyze`, and `github/codeql-action/upload-sarif` to v4.37.4 (f205ea1c3).
  - Updated in five workflows: `codeql.yml` (init, analyze), `cflite_pr`, `cflite_batch`, `cflite_cron`, `scorecard`.

<sup>Written for commit 8588f6cf52a6c05cefbfd9e1ba61b91fc6511ee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

