### PR TITLE
test(hooks): give the Python probe the same budget the monitor gets

### DIFF
--- a/tests/hooks/insaits-security-monitor.test.js
+++ b/tests/hooks/insaits-security-monitor.test.js
@@ -12,6 +12,11 @@ const { spawnSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'insaits-security-monitor.py');
 const MONITOR_TIMEOUT_MS = 30000;
+// Probing `python --version` pays the same cold interpreter start the monitor
+// itself does, which on Windows regularly costs more than a few seconds. A
+// budget too small here reports "no Python on this machine" and the suite
+// fails with spawnSync ETIMEDOUT instead of skipping or running.
+const PYTHON_PROBE_TIMEOUT_MS = process.platform === 'win32' ? 20000 : 5000;
 
 function createTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'insaits-monitor-'));
@@ -32,7 +37,7 @@ function findPython() {
   for (const candidate of candidates) {
     const result = spawnSync(candidate.command, [...candidate.args, '--version'], {
       encoding: 'utf8',
-      timeout: 5000,
+      timeout: PYTHON_PROBE_TIMEOUT_MS,
     });
     if (result.status === 0) {
       return candidate;


### PR DESCRIPTION
## The failure
`Test (windows-latest, Node 20.x, npm)` on unrelated PRs:

```
FAIL clean scan exits 0 and writes an audit event
  Error: spawnSync python ETIMEDOUT
```

## Root cause
`tests/hooks/insaits-security-monitor.test.js` allows the monitor itself **30s** (`MONITOR_TIMEOUT_MS`) but probes `python --version` with a hardcoded **5s**. The probe pays the same cold interpreter start the monitor does, and on Windows that regularly exceeds 5s — so the probe times out, the suite decides there is no Python on the machine, and the run dies.

This is the same shape as #1203 (session bridge): a budget sized for Linux applied to every platform, producing a failure that looks flaky and is not.

## Fix
Windows gets 20s for the probe; every other platform keeps 5s. Suite: 5/5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the `python --version` probe timeout in the security monitor tests to handle cold starts on Windows and stop ETIMEDOUT failures. Windows now gets 20s; other platforms stay at 5s, preventing false "no Python" detections and stabilizing CI.

<sup>Written for commit 751fee24cfafa9d24580ee229e9db7dda1eb5ba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

