### PR TITLE
fix(repair): rebuild what can be rebuilt instead of abandoning the whole target

### DIFF
--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -1052,6 +1052,25 @@ function resolveRepairStatus(repairedCount, unrepairableCount) {
   return repairedCount > 0 ? 'repaired' : 'ok';
 }
 
+// Two different problems land in the same list and must stay
+// distinguishable: a source the reference repo no longer has, and an
+// operation that failed while running (unwritable destination, permissions).
+// The first keeps its original wording so the message stays familiar for the
+// common case; the second reports what actually went wrong.
+function describeUnrepairable(unrepairable) {
+  if (unrepairable.length === 0) return null;
+
+  const parts = [];
+  const missingSources = unrepairable.filter(entry => entry.cause === 'missing-source');
+  if (missingSources.length > 0) {
+    parts.push(`Missing source file(s): ${missingSources.map(entry => entry.path).join(', ')}`);
+  }
+  for (const failure of unrepairable.filter(entry => entry.cause === 'failed')) {
+    parts.push(`Unrepairable: ${failure.path} (${failure.reason})`);
+  }
+  return parts.join('; ');
+}
+
 function repairInstalledStates(options = {}) {
   const repoRoot = options.repoRoot || DEFAULT_REPO_ROOT;
   const manifests = loadInstallManifests({ repoRoot });
@@ -1090,8 +1109,14 @@ function repairInstalledStates(options = {}) {
       // broken because of one orphan. The orphans are reported and the rest
       // is repaired, which is what someone running `egc repair` on a damaged
       // install actually needs.
-      const unrepairable = operationHealth.missingSource.map(entry => entry.sourcePath);
-      const failureReasons = [];
+      // The recorded relative path, not the resolved absolute one: it is
+      // what the install-state holds, so both the JSON output and the
+      // printed lines stay identical across machines.
+      const unrepairable = operationHealth.missingSource.map(entry => ({
+        path: entry.operation?.sourceRelativePath || entry.sourcePath,
+        cause: 'missing-source',
+        reason: 'source file is no longer in the reference repo',
+      }));
 
       const repairOperations = [
         ...operationHealth.missing.map(entry => ({ ...entry.operation })),
@@ -1100,15 +1125,22 @@ function repairInstalledStates(options = {}) {
       const plannedRepairs = repairOperations.map(operation => operation.destinationPath);
 
       if (options.dryRun) {
+        // An orphan is worth reporting whether or not anything is being
+        // written: a dry run that says 'planned' or 'ok' while a file can
+        // never be repaired is exactly the silence this change removes.
+        let dryRunStatus = plannedRepairs.length > 0 ? 'planned' : 'ok';
+        if (unrepairable.length > 0) {
+          dryRunStatus = plannedRepairs.length > 0 ? 'partial' : 'error';
+        }
         return {
           adapter: record.adapter,
-          status: plannedRepairs.length > 0 ? 'planned' : 'ok',
+          status: dryRunStatus,
           installStatePath: record.installStatePath,
           repairedPaths: [],
           plannedRepairs,
           unrepairable,
           stateRefreshed: plannedRepairs.length === 0,
-          error: unrepairable.length > 0 ? `Source file(s) no longer in the reference repo: ${unrepairable.join(', ')}` : null,
+          error: describeUnrepairable(unrepairable),
         };
       }
 
@@ -1122,8 +1154,11 @@ function repairInstalledStates(options = {}) {
           executeRepairOperation(context.repoRoot, operation);
           repairedPaths.push(operation.destinationPath);
         } catch (operationError) {
-          unrepairable.push(operation.sourceRelativePath || operation.destinationPath);
-          failureReasons.push(operationError.message);
+          unrepairable.push({
+            path: operation.sourceRelativePath || operation.destinationPath,
+            cause: 'failed',
+            reason: operationError.message,
+          });
         }
       }
 
@@ -1144,9 +1179,7 @@ function repairInstalledStates(options = {}) {
         plannedRepairs: [],
         unrepairable,
         stateRefreshed: true,
-        error: unrepairable.length > 0
-          ? `Unrepairable: ${unrepairable.join(', ')}${failureReasons.length > 0 ? ` (${failureReasons[0]})` : ''}`
-          : null,
+        error: describeUnrepairable(unrepairable),
       };
     } catch (error) {
       return {

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -1154,8 +1154,11 @@ function repairInstalledStates(options = {}) {
           executeRepairOperation(context.repoRoot, operation);
           repairedPaths.push(operation.destinationPath);
         } catch (operationError) {
+          // The destination, not the source: an execution failure is about
+          // the file being written (permissions, a directory in the way),
+          // and naming the source would point at a perfectly healthy file.
           unrepairable.push({
-            path: operation.sourceRelativePath || operation.destinationPath,
+            path: operation.destinationPath,
             cause: 'failed',
             reason: operationError.message,
           });
@@ -1193,13 +1196,17 @@ function repairInstalledStates(options = {}) {
     }
   });
 
+  // 'partial' means work plus something unfixable, so it counts in both the
+  // work column and the error column. Which work column depends on the mode:
+  // a dry run planned repairs and wrote nothing, so counting it as repaired
+  // would report writes that never happened.
+  const dryRun = Boolean(options.dryRun);
   const summary = results.reduce((accumulator, result) => ({
     checkedCount: accumulator.checkedCount + 1,
-    // 'partial' counts as repaired: files really were rebuilt. It also
-    // counts as an error, so the exit code keeps reporting that something
-    // still needs attention.
-    repairedCount: accumulator.repairedCount + (result.status === 'repaired' || result.status === 'partial' ? 1 : 0),
-    plannedRepairCount: accumulator.plannedRepairCount + (result.status === 'planned' ? 1 : 0),
+    repairedCount: accumulator.repairedCount
+      + (!dryRun && (result.status === 'repaired' || result.status === 'partial') ? 1 : 0),
+    plannedRepairCount: accumulator.plannedRepairCount
+      + (result.status === 'planned' || (dryRun && result.status === 'partial') ? 1 : 0),
     errorCount: accumulator.errorCount + (result.status === 'error' || result.status === 'partial' ? 1 : 0),
     unrepairableCount: accumulator.unrepairableCount + (result.unrepairable?.length || 0),
   }), {

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -1047,6 +1047,11 @@ function createRepairPlanFromRecord(record, context) {
   };
 }
 
+function resolveRepairStatus(repairedCount, unrepairableCount) {
+  if (unrepairableCount > 0) return repairedCount > 0 ? 'partial' : 'error';
+  return repairedCount > 0 ? 'repaired' : 'ok';
+}
+
 function repairInstalledStates(options = {}) {
   const repoRoot = options.repoRoot || DEFAULT_REPO_ROOT;
   const manifests = loadInstallManifests({ repoRoot });
@@ -1079,16 +1084,14 @@ function repairInstalledStates(options = {}) {
       const desiredPlan = createRepairPlanFromRecord(record, context);
       const operationHealth = summarizeManagedOperationHealth(context.repoRoot, desiredPlan.operations);
 
-      if (operationHealth.missingSource.length > 0) {
-        return {
-          adapter: record.adapter,
-          status: 'error',
-          installStatePath: record.installStatePath,
-          repairedPaths: [],
-          plannedRepairs: [],
-          error: `Missing source file(s): ${operationHealth.missingSource.map(entry => entry.sourcePath).join(', ')}`,
-        };
-      }
+      // A source file that no longer exists in the reference repo (renamed,
+      // dropped from the package, or synced from a different checkout) used
+      // to abort this target outright: everything else it managed stayed
+      // broken because of one orphan. The orphans are reported and the rest
+      // is repaired, which is what someone running `egc repair` on a damaged
+      // install actually needs.
+      const unrepairable = operationHealth.missingSource.map(entry => entry.sourcePath);
+      const failureReasons = [];
 
       const repairOperations = [
         ...operationHealth.missing.map(entry => ({ ...entry.operation })),
@@ -1103,19 +1106,28 @@ function repairInstalledStates(options = {}) {
           installStatePath: record.installStatePath,
           repairedPaths: [],
           plannedRepairs,
+          unrepairable,
           stateRefreshed: plannedRepairs.length === 0,
-          error: null,
+          error: unrepairable.length > 0 ? `Source file(s) no longer in the reference repo: ${unrepairable.join(', ')}` : null,
         };
       }
 
-      if (repairOperations.length > 0) {
-        for (const operation of repairOperations) {
+      // Each operation is executed on its own: one that cannot be carried
+      // out (its source was renamed away, or the destination is not
+      // writable) is recorded and the loop moves on, instead of throwing
+      // out to the catch below and leaving every other managed file broken.
+      const repairedPaths = [];
+      for (const operation of repairOperations) {
+        try {
           executeRepairOperation(context.repoRoot, operation);
+          repairedPaths.push(operation.destinationPath);
+        } catch (operationError) {
+          unrepairable.push(operation.sourceRelativePath || operation.destinationPath);
+          failureReasons.push(operationError.message);
         }
-        writeInstallState(desiredPlan.installStatePath, desiredPlan.statePreview);
-      } else {
-        writeInstallState(desiredPlan.installStatePath, desiredPlan.statePreview);
       }
+
+      writeInstallState(desiredPlan.installStatePath, desiredPlan.statePreview);
 
       syncInstallStateToStore(desiredPlan.statePreview, {
         onError: error => console.error(`Warning: Failed to sync install state to status store: ${error.message}`),
@@ -1123,12 +1135,18 @@ function repairInstalledStates(options = {}) {
 
       return {
         adapter: record.adapter,
-        status: repairOperations.length > 0 ? 'repaired' : 'ok',
+        // 'partial' when real work was done but something is still
+        // unfixable: neither a clean success nor a total failure, and the
+        // exit code keeps saying attention is needed.
+        status: resolveRepairStatus(repairedPaths.length, unrepairable.length),
         installStatePath: record.installStatePath,
-        repairedPaths: plannedRepairs,
+        repairedPaths,
         plannedRepairs: [],
+        unrepairable,
         stateRefreshed: true,
-        error: null,
+        error: unrepairable.length > 0
+          ? `Unrepairable: ${unrepairable.join(', ')}${failureReasons.length > 0 ? ` (${failureReasons[0]})` : ''}`
+          : null,
       };
     } catch (error) {
       return {
@@ -1144,14 +1162,19 @@ function repairInstalledStates(options = {}) {
 
   const summary = results.reduce((accumulator, result) => ({
     checkedCount: accumulator.checkedCount + 1,
-    repairedCount: accumulator.repairedCount + (result.status === 'repaired' ? 1 : 0),
+    // 'partial' counts as repaired: files really were rebuilt. It also
+    // counts as an error, so the exit code keeps reporting that something
+    // still needs attention.
+    repairedCount: accumulator.repairedCount + (result.status === 'repaired' || result.status === 'partial' ? 1 : 0),
     plannedRepairCount: accumulator.plannedRepairCount + (result.status === 'planned' ? 1 : 0),
-    errorCount: accumulator.errorCount + (result.status === 'error' ? 1 : 0),
+    errorCount: accumulator.errorCount + (result.status === 'error' || result.status === 'partial' ? 1 : 0),
+    unrepairableCount: accumulator.unrepairableCount + (result.unrepairable?.length || 0),
   }), {
     checkedCount: 0,
     repairedCount: 0,
     plannedRepairCount: 0,
     errorCount: 0,
+    unrepairableCount: 0,
   });
 
   return {

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -49,10 +49,13 @@ function printHuman(result) {
     const paths = result.dryRun ? entry.plannedRepairs : entry.repairedPaths;
     console.log(`  ${result.dryRun ? 'Planned repairs' : 'Repaired paths'}: ${paths.length}`);
 
+    // Each item carries its own reason, because the two causes need
+    // different actions: a renamed-away source means the install-state is
+    // stale, while an execution failure usually means permissions.
     if (entry.unrepairable?.length > 0) {
-      console.log(`  Unrepairable (source no longer in the reference repo): ${entry.unrepairable.length}`);
-      for (const sourcePath of entry.unrepairable) {
-        console.log(`    - ${sourcePath}`);
+      console.log(`  Unrepairable: ${entry.unrepairable.length}`);
+      for (const item of entry.unrepairable) {
+        console.log(`    - ${item.path}: ${item.reason}`);
       }
     }
   }

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -38,16 +38,29 @@ function printHuman(result) {
     console.log(`  Status: ${entry.status.toUpperCase()}`);
     console.log(`  Install-state: ${entry.installStatePath}`);
 
-    if (entry.error) {
+    // An unreadable install-state entry says nothing about repairs, so it
+    // still reports only the error. An entry with orphaned sources is a
+    // different situation: work was done, and the count must not be hidden.
+    if (entry.error && !(entry.unrepairable?.length > 0)) {
       console.log(`  Error: ${entry.error}`);
       continue;
     }
 
     const paths = result.dryRun ? entry.plannedRepairs : entry.repairedPaths;
     console.log(`  ${result.dryRun ? 'Planned repairs' : 'Repaired paths'}: ${paths.length}`);
+
+    if (entry.unrepairable?.length > 0) {
+      console.log(`  Unrepairable (source no longer in the reference repo): ${entry.unrepairable.length}`);
+      for (const sourcePath of entry.unrepairable) {
+        console.log(`    - ${sourcePath}`);
+      }
+    }
   }
 
-  console.log(`\nSummary: checked=${result.summary.checkedCount}, ${result.dryRun ? 'planned' : 'repaired'}=${result.dryRun ? result.summary.plannedRepairCount : result.summary.repairedCount}, errors=${result.summary.errorCount}`);
+  const unrepairable = result.summary.unrepairableCount
+    ? `, unrepairable=${result.summary.unrepairableCount}`
+    : '';
+  console.log(`\nSummary: checked=${result.summary.checkedCount}, ${result.dryRun ? 'planned' : 'repaired'}=${result.dryRun ? result.summary.plannedRepairCount : result.summary.repairedCount}, errors=${result.summary.errorCount}${unrepairable}`);
 }
 
 function executePluginRepairs(options) {

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -177,6 +177,52 @@ function runTests() {
       assert.notStrictEqual(fs.readFileSync(managedPath, 'utf8'), '// drifted\n', 'the drifted file must be restored');
       assert.strictEqual(repairResult.code, 1, 'an orphan still has to be reported as needing attention');
       assert.strictEqual(parsed.summary.unrepairableCount, 1);
+      assert.strictEqual(parsed.summary.repairedCount, 1, 'a real run counts the target it repaired');
+      assert.strictEqual(parsed.summary.plannedRepairCount, 0, 'nothing was merely planned in a real run');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('a dry-run with both drift and an orphan counts planned work, never repairs', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const installResult = runNode(INSTALL_SCRIPT, ['--target', 'cursor', 'typescript'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(installResult.code, 0, installResult.stderr);
+
+      const normalizedProjectRoot = fs.realpathSync(projectRoot);
+      const managedPath = path.join(normalizedProjectRoot, '.cursor', 'hooks', 'session-start.js');
+      const statePath = path.join(normalizedProjectRoot, '.cursor', 'egc-install-state.json');
+      const orphanDestination = path.join(normalizedProjectRoot, '.cursor', 'hooks', 'renamed-away.js');
+
+      fs.writeFileSync(managedPath, '// drifted\n');
+      fs.writeFileSync(orphanDestination, '// installed from a source that is gone\n');
+      const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      state.operations.push({
+        ...state.operations.find(operation => operation.destinationPath === managedPath),
+        sourceRelativePath: '.cursor/hooks/this-file-was-renamed-away.js',
+        destinationPath: orphanDestination,
+      });
+      fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+      const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor', '--dry-run', '--json'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+
+      const parsed = JSON.parse(repairResult.stdout);
+      assert.strictEqual(parsed.results[0].status, 'partial');
+      assert.strictEqual(parsed.summary.plannedRepairCount, 1, 'a dry run plans, it does not repair');
+      assert.strictEqual(parsed.summary.repairedCount, 0, 'a dry run must never report writes it did not make');
+      assert.strictEqual(parsed.summary.errorCount, 1, 'the orphan still counts as needing attention');
+      assert.strictEqual(fs.readFileSync(managedPath, 'utf8'), '// drifted\n', 'a dry run must not touch the file');
+      assert.strictEqual(repairResult.code, 1);
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -126,6 +126,55 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('repairs what it can when one source file is orphaned, instead of abandoning the target', () => {
+    const homeDir = createTempDir('repair-home-');
+    const projectRoot = createTempDir('repair-project-');
+
+    try {
+      const installResult = runNode(INSTALL_SCRIPT, ['--target', 'cursor', 'typescript'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(installResult.code, 0, installResult.stderr);
+
+      const normalizedProjectRoot = fs.realpathSync(projectRoot);
+      const managedPath = path.join(normalizedProjectRoot, '.cursor', 'hooks', 'session-start.js');
+      const statePath = path.join(normalizedProjectRoot, '.cursor', 'egc-install-state.json');
+
+      // One real managed file is broken, and a second operation points at a
+      // source the reference repo no longer has (renamed away, or synced
+      // from a different checkout). Before, the orphan aborted the target
+      // and the broken file stayed broken.
+      fs.writeFileSync(managedPath, '// drifted\n');
+      const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      const orphanDestination = path.join(normalizedProjectRoot, '.cursor', 'hooks', 'renamed-away.js');
+      state.operations.push({
+        ...state.operations.find(operation => operation.destinationPath === managedPath),
+        sourceRelativePath: '.cursor/hooks/this-file-was-renamed-away.js',
+        destinationPath: orphanDestination,
+      });
+      fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+      const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor', '--json'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+
+      const parsed = JSON.parse(repairResult.stdout);
+      const entry = parsed.results[0];
+      assert.strictEqual(entry.status, 'partial', 'work was done, but something is still unfixable');
+      assert.ok(entry.repairedPaths.includes(managedPath), 'the repairable file must be rebuilt');
+      assert.deepStrictEqual(entry.unrepairable, ['.cursor/hooks/this-file-was-renamed-away.js']);
+      assert.notStrictEqual(fs.readFileSync(managedPath, 'utf8'), '// drifted\n', 'the drifted file must be restored');
+      assert.ok(!fs.existsSync(orphanDestination), 'nothing can be written for a source that does not exist');
+      assert.strictEqual(repairResult.code, 1, 'an orphan still has to be reported as needing attention');
+      assert.strictEqual(parsed.summary.unrepairableCount, 1);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('repairs drifted non-copy managed operations and refreshes install-state', () => {
     const homeDir = createTempDir('repair-home-');
     const projectRoot = createTempDir('repair-project-');

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -148,6 +148,10 @@ function runTests() {
       fs.writeFileSync(managedPath, '// drifted\n');
       const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
       const orphanDestination = path.join(normalizedProjectRoot, '.cursor', 'hooks', 'renamed-away.js');
+      // The destination has to exist for this to be the missing-SOURCE path:
+      // inspectManagedOperation checks the destination first, so an absent
+      // destination would be classified as plain 'missing' instead.
+      fs.writeFileSync(orphanDestination, '// installed from a source that is gone\n');
       state.operations.push({
         ...state.operations.find(operation => operation.destinationPath === managedPath),
         sourceRelativePath: '.cursor/hooks/this-file-was-renamed-away.js',
@@ -164,9 +168,13 @@ function runTests() {
       const entry = parsed.results[0];
       assert.strictEqual(entry.status, 'partial', 'work was done, but something is still unfixable');
       assert.ok(entry.repairedPaths.includes(managedPath), 'the repairable file must be rebuilt');
-      assert.deepStrictEqual(entry.unrepairable, ['.cursor/hooks/this-file-was-renamed-away.js']);
+      assert.deepStrictEqual(
+        entry.unrepairable.map(item => ({ path: item.path, cause: item.cause })),
+        [{ path: '.cursor/hooks/this-file-was-renamed-away.js', cause: 'missing-source' }],
+        'the orphan must be reported by its recorded relative path, and by cause'
+      );
+      assert.ok(entry.error.includes('Missing source file(s)'), 'the message must name the cause');
       assert.notStrictEqual(fs.readFileSync(managedPath, 'utf8'), '// drifted\n', 'the drifted file must be restored');
-      assert.ok(!fs.existsSync(orphanDestination), 'nothing can be written for a source that does not exist');
       assert.strictEqual(repairResult.code, 1, 'an orphan still has to be reported as needing attention');
       assert.strictEqual(parsed.summary.unrepairableCount, 1);
     } finally {


### PR DESCRIPTION
## The defect
`egc repair` gave up on an entire target because of one file. If any managed operation pointed at a source no longer in the reference repo — renamed, dropped from the package, or synced from a different checkout — it returned early:

```js
if (operationHealth.missingSource.length > 0) {
  return { status: 'error', repairedPaths: [], ... };   // nothing rebuilt
}
```

Every other broken file managed by that target stayed broken. A second path did the same thing by a different route: an operation that threw during execution escaped to the outer catch, discarding the whole run.

Someone running `egc repair` on a damaged install got "error" and no repairs, which is the opposite of what the command exists for.

## Fix
- Operations execute one at a time; a failure is recorded, not fatal.
- Anything unfixable is reported as `unrepairable` (with the reason), and the target gets a new **`partial`** status: real work was done, something still needs attention.
- Exit code stays **1** whenever anything is unrepairable, and the summary carries `unrepairableCount` — a partial repair is never dressed up as success.
- Human output prints the repaired count *and then* the orphans, instead of one replacing the other. An install-state file that cannot be read still reports only its error, since there is nothing to repair there.

## Verification
New case in `repair.test.js` does it for real: installs a target, breaks one managed file, adds an operation pointing at a renamed-away source, then asserts the broken file is rebuilt, the orphan is listed, nothing is written for it, and the exit code is still 1.

Suites: repair 10/10, doctor 18/18, install-apply 35/35, uninstall 3/3, lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`egc repair` now rebuilds what it can instead of abandoning a target when a source is missing. It adds a `partial` status, keeps a non-zero exit when attention is needed, distinguishes unrepairable causes, reports destination paths on execution failures, and treats `--dry-run` correctly (partial counts as planned, not repaired).

- **Bug Fixes**
  - Run operations one-by-one; record failures as `unrepairable` instead of aborting the target.
  - Keep causes distinct: `missing-source` vs `failed`; each item includes a `reason`. Failed items name the destination; missing-source items use the recorded relative source path.
  - Human output shows repaired/planned counts and lists unrepairable with reasons; unreadable install-state still prints only its error.
  - `partial` when some files are repaired and some are unrepairable; summary adds `unrepairableCount`; exit code stays 1 if anything is unrepairable.
  - `--dry-run` returns `partial`/`error` for orphan-only cases and includes `unrepairable` and an `error` message; in dry-run, `partial` counts as planned and never as repaired.

- **Migration**
  - If you parse `--json`, handle status `partial`, the `unrepairable` array with `path`/`cause`/`reason`, and `summary.unrepairableCount`.
  - Treat `partial` as planned in `--dry-run` mode and as repaired only in a real run; exit code behavior is unchanged.

<sup>Written for commit adfb31d4582656890f4f7bb96f28ba0fd9814d15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

