### PR TITLE
fix(mcp): make the server builds self-contained and cross-platform

### DIFF
--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -5,7 +5,7 @@
   "description": "EGC Guardian MCP Server: validation, context reduction, and task orchestration",
   "main": "build/index.js",
   "scripts": {
-    "build": "node ../../../scripts/build-skill-index.js && tsc && chmod +x build/index.js",
+    "build": "node scripts/prebuild.js && tsc && node scripts/postbuild.js",
     "start": "node build/index.js"
   },
   "dependencies": {

--- a/mcp/servers/egc-guardian/scripts/postbuild.js
+++ b/mcp/servers/egc-guardian/scripts/postbuild.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+'use strict';
+
+// Replaces `chmod +x build/index.js`, which is not a command on Windows at
+// all: outside Git Bash the build step simply failed there. fs.chmodSync is
+// skipped on Windows and does the right thing everywhere else, so the same
+// build script now works on every platform without a shell.
+
+// ESM, because this package declares "type": "module".
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const entry = path.join(scriptDir, '..', 'build', 'index.js');
+
+if (!fs.existsSync(entry)) {
+  console.error(`postbuild: ${entry} was not produced by the compile step`);
+  process.exit(1);
+}
+
+if (process.platform !== 'win32') {
+  fs.chmodSync(entry, 0o755);
+}

--- a/mcp/servers/egc-guardian/scripts/postbuild.js
+++ b/mcp/servers/egc-guardian/scripts/postbuild.js
@@ -20,5 +20,11 @@ if (!fs.existsSync(entry)) {
 }
 
 if (process.platform !== 'win32') {
-  fs.chmodSync(entry, 0o755);
+  // Add the owner's execute bit to whatever mode the compiler produced,
+  // rather than forcing 0o755. The server is always run by the user who
+  // installed it, so world-execute buys nothing, and a fixed mode would
+  // also widen read access on a file the compiler had written more
+  // narrowly.
+  const { mode } = fs.statSync(entry);
+  fs.chmodSync(entry, mode | 0o100);
 }

--- a/mcp/servers/egc-guardian/scripts/prebuild.js
+++ b/mcp/servers/egc-guardian/scripts/prebuild.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict';
+
+// The catalog index is generated from the skill files at the repository
+// root, which only exist in a git checkout. The published package ships the
+// generated src/catalog-index.ts instead, so a build run from anywhere but
+// the repo (a copied server directory, an installed runtime, a vendored
+// tree) must not fail on a path that climbs out of this package.
+//
+// This replaces `node ../../../scripts/build-skill-index.js` in the build
+// script, which broke the moment the server was built outside the monorepo.
+
+// ESM, because this package declares "type": "module".
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(packageRoot, '..', '..', '..');
+const generator = path.join(repoRoot, 'scripts', 'build-skill-index.js');
+const generated = path.join(packageRoot, 'src', 'catalog-index.ts');
+
+if (!fs.existsSync(generator)) {
+  if (fs.existsSync(generated)) {
+    console.log('prebuild: catalog index generator not available; using the checked-in src/catalog-index.ts');
+    process.exit(0);
+  }
+  console.error('prebuild: no catalog index and no generator to build one from');
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, [generator], { stdio: 'inherit' });
+if (result.error) {
+  console.error(`prebuild: could not run the catalog index generator: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -4,7 +4,7 @@
   "description": "EGC Memory MCP Server: persistent cross-session project state and decision history",
   "main": "build/index.js",
   "scripts": {
-    "build": "tsc && chmod +x build/index.js",
+    "build": "tsc && node scripts/postbuild.js",
     "start": "node build/index.js"
   },
   "dependencies": {

--- a/mcp/servers/egc-memory/scripts/postbuild.js
+++ b/mcp/servers/egc-memory/scripts/postbuild.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+'use strict';
+
+// Replaces `chmod +x build/index.js`, which is not a command on Windows at
+// all: outside Git Bash the build step simply failed there. fs.chmodSync is
+// skipped on Windows and does the right thing everywhere else, so the same
+// build script now works on every platform without a shell.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const entry = path.join(__dirname, '..', 'build', 'index.js');
+
+if (!fs.existsSync(entry)) {
+  console.error(`postbuild: ${entry} was not produced by the compile step`);
+  process.exit(1);
+}
+
+if (process.platform !== 'win32') {
+  fs.chmodSync(entry, 0o755);
+}

--- a/mcp/servers/egc-memory/scripts/postbuild.js
+++ b/mcp/servers/egc-memory/scripts/postbuild.js
@@ -17,5 +17,11 @@ if (!fs.existsSync(entry)) {
 }
 
 if (process.platform !== 'win32') {
-  fs.chmodSync(entry, 0o755);
+  // Add the owner's execute bit to whatever mode the compiler produced,
+  // rather than forcing 0o755. The server is always run by the user who
+  // installed it, so world-execute buys nothing, and a fixed mode would
+  // also widen read access on a file the compiler had written more
+  // narrowly.
+  const { mode } = fs.statSync(entry);
+  fs.chmodSync(entry, mode | 0o100);
 }

--- a/mcp/servers/egc-memory/src/propagate.ts
+++ b/mcp/servers/egc-memory/src/propagate.ts
@@ -8,7 +8,20 @@ import path from 'node:path';
 // reach. The npm package's "files" list ships scripts/ and
 // mcp/servers/egc-memory/build/ at the same relative depth as this repo, so the
 // path below resolves identically in a real `npm install -g` layout.
-function tryRequireMemoryFilters(): typeof import('../../../../scripts/lib/memory-filters') | null {
+// The shape is declared here rather than pulled in with `typeof import(...)`:
+// that form makes the compiler resolve a file outside this package, so the
+// build failed outright anywhere the repo root was not present (a copied
+// server directory, a vendored tree). The require below is already
+// fault-tolerant at runtime; only the type was making the dependency hard.
+interface MemoryFilters {
+  configureMemoryFilters(options: {
+    projectDir: string;
+    scriptPath: string;
+    dryRun: boolean;
+  }): { configured: boolean; reason?: string; actions: string[] };
+}
+
+function tryRequireMemoryFilters(): MemoryFilters | null {
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require('../../../../scripts/lib/memory-filters');


### PR DESCRIPTION
## Two ways the guardian build reached outside its own package

```json
"build": "node ../../../scripts/build-skill-index.js && tsc && chmod +x build/index.js"
```

**1. A path that climbs out of the package.** `../../../scripts/build-skill-index.js` resolves to the monorepo root. Build the server anywhere else — a copied directory, an installed runtime, a vendored tree — and it fails immediately on a file that is not there.

**2. `chmod` does not exist on Windows.** Outside Git Bash the final step simply fails, so the build was never actually cross-platform despite the rest of the install being carefully made so.

## Fix
The catalog index is generated from skill files that only exist in a git checkout, and the published package ships the generated `src/catalog-index.ts` instead. So:

- `scripts/prebuild.js` runs the generator **when it is reachable** and falls back to the checked-in index when it is not — printing which one it used, so the choice is never silent.
- `scripts/postbuild.js` replaces `chmod` with `fs.chmodSync`, skipped on Windows. `egc-memory` gets the same step for the same reason.

## Verification
Copied the server outside the repo, deleted its `build/`, ran `npm run build`:

```
prebuild: catalog index generator not available; using the checked-in src/catalog-index.ts
-> build/index.js produced, executable bit set
```

Before this change that same command died on the missing generator. Both servers still build normally inside the repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `egc-guardian` and `egc-memory` builds self-contained and cross-platform. Builds now work outside the monorepo and on Windows by replacing repo-root paths and shell `chmod` with Node scripts, and by removing a type-only external import.

- **Bug Fixes**
  - `egc-guardian`: added `scripts/prebuild.js` to run the catalog index generator when available, or fall back to the checked-in `src/catalog-index.ts` with a clear log.
  - Both servers: added `scripts/postbuild.js` to OR in the owner execute bit on `build/index.js` via `fs.chmodSync` on non-Windows; no-op on Windows.
  - `egc-memory`: replaced `typeof import('../../../../scripts/lib/memory-filters')` with a local interface in `src/propagate.ts` so the compiler doesn’t depend on repo-root files.

<sup>Written for commit 48e7eb5cf126abaf79736139691b0135005ebec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

