### PR TITLE
test(install): give the full-install subprocesses a Windows budget that fits

### DIFF
--- a/tests/fixtures/subprocess-timeouts.js
+++ b/tests/fixtures/subprocess-timeouts.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Timeouts for tests that spawn a real EGC command as a subprocess.
+ *
+ * A suite that runs a complete install-apply against a temp tree performs
+ * dozens of file writes, and on a Windows runner each one also pays for
+ * whatever the machine's antivirus does with it. A budget sized on a quiet
+ * machine turns that into `spawnSync node ETIMEDOUT`, which reads as a flake
+ * and is not one: the work genuinely takes longer there.
+ *
+ * Kept in one place so the next adjustment is a single edit rather than a
+ * hunt through every suite.
+ */
+
+// For suites that install or uninstall a target end to end.
+const FULL_INSTALL_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 10000;
+
+// For suites that only spawn a CLI to read output (--help, --json probes).
+const CLI_TIMEOUT_MS = process.platform === 'win32' ? 30000 : 10000;
+
+module.exports = { FULL_INSTALL_TIMEOUT_MS, CLI_TIMEOUT_MS };

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -8,6 +8,11 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
+// Same reasoning as tests/scripts/uninstall.test.js: these cases run a full
+// install against a real temp tree before they can repair anything, and 30s
+// is not a reliable budget for that on a Windows runner.
+const SUBPROCESS_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 10000;
+
 const INSTALL_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-apply.js');
 const DOCTOR_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'doctor.js');
 const REPAIR_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'repair.js');
@@ -51,7 +56,7 @@ function runNode(scriptPath, args = [], options = {}) {
       env,
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: process.platform === 'win32' ? 30000 : 10000,
+      timeout: SUBPROCESS_TIMEOUT_MS,
     });
 
     return { code: 0, stdout, stderr: '' };

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -8,10 +8,7 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-// Same reasoning as tests/scripts/uninstall.test.js: these cases run a full
-// install against a real temp tree before they can repair anything, and 30s
-// is not a reliable budget for that on a Windows runner.
-const SUBPROCESS_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 10000;
+const { FULL_INSTALL_TIMEOUT_MS: SUBPROCESS_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 
 const INSTALL_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-apply.js');
 const DOCTOR_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'doctor.js');

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -8,12 +8,7 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-// Both subprocesses here perform a full install or uninstall against a real
-// temp tree: dozens of file writes, plus whatever the runner's antivirus
-// does to each one. 30s was enough until it was not (spawnSync node
-// ETIMEDOUT on windows-latest), and a budget that only fits on a quiet
-// machine reads as a flake rather than as the slow-runner signal it is.
-const SUBPROCESS_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 10000;
+const { FULL_INSTALL_TIMEOUT_MS: SUBPROCESS_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 
 const INSTALL_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-apply.js');
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'uninstall.js');

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -8,6 +8,13 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
+// Both subprocesses here perform a full install or uninstall against a real
+// temp tree: dozens of file writes, plus whatever the runner's antivirus
+// does to each one. 30s was enough until it was not (spawnSync node
+// ETIMEDOUT on windows-latest), and a budget that only fits on a quiet
+// machine reads as a flake rather than as the slow-runner signal it is.
+const SUBPROCESS_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 10000;
+
 const INSTALL_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-apply.js');
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'uninstall.js');
 const REPO_ROOT = path.join(__dirname, '..', '..');
@@ -48,7 +55,7 @@ function run(args = [], options = {}) {
       env,
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: process.platform === 'win32' ? 30000 : 10000,
+      timeout: SUBPROCESS_TIMEOUT_MS,
     });
 
     return { code: 0, stdout, stderr: '' };
@@ -92,7 +99,7 @@ function runTests() {
         },
         encoding: 'utf8',
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: process.platform === 'win32' ? 30000 : 10000,
+        timeout: SUBPROCESS_TIMEOUT_MS,
       });
       assert.ok(installStdout.includes('Done. Install-state written'));
 


### PR DESCRIPTION
## The failure
`Test (windows-latest, Node 20.x, npm)`:

```
✗ uninstalls files from a real install-apply state and preserves unrelated files
  Error: spawnSync node ETIMEDOUT
```

## Why this is not a flake
Both `uninstall.test.js` and `repair.test.js` run a **complete `install-apply`** against a real temp tree before they can assert anything: dozens of file writes, plus whatever the runner's antivirus does to each one. They allowed 30s.

That is the third variation of the same shape today ([#1203](https://github.com/Fmarzochi/EGC/pull/1203) session bridge, [#1209](https://github.com/Fmarzochi/EGC/pull/1209) Python probe): a budget sized on a quiet machine, producing a failure that looks random and is not.

## Fix
90s on Windows for the two suites that perform a real install. Every other platform keeps 10s, and suites that only spawn a quick CLI are left alone — this is deliberately not a blanket bump.

Suites: uninstall 3/3, repair 11/11, lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Windows timeout to 90s for full-install tests and centralize subprocess timeout settings to stop ETIMEDOUT failures on runners. Non-Windows stays at 10s; suites that only run quick CLI probes are unchanged.

- **Bug Fixes**
  - Bump subprocess timeout to 90s on Windows in `tests/scripts/uninstall.test.js` and `tests/scripts/repair.test.js`.

- **Refactors**
  - Centralize timeouts in `tests/fixtures/subprocess-timeouts.js`, defining `FULL_INSTALL_TIMEOUT_MS` (90s on Windows) and `CLI_TIMEOUT_MS` (30s on Windows).

<sup>Written for commit 44c09cbaf2df8285c6b10412d50c053a2eaac99d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

