### PR TITLE
fix(hooks): summarize learned skills by their When to Activate section

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -437,6 +437,7 @@ function summarizeLearnedSkillFile(filePath, learnedRoot) {
   const title = extractMarkdownHeading(content) || slug;
   const summary = truncateSummary(
     extractSection(content, 'When to Use')
+      || extractSection(content, 'When to Activate')
       || extractSection(content, 'Trigger')
       || extractSection(content, 'Problem')
       || extractFirstParagraph(content)

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -701,6 +701,10 @@ async function runTests() {
           additionalContext.includes('stale lock during startup'),
           'Should summarize the When to Activate section, not the intro paragraph'
         );
+        assert.ok(
+          !additionalContext.includes('Background notes that should not become the summary'),
+          'Intro paragraph must not leak into the learned skill summary'
+        );
       } finally {
         fs.rmSync(isoHome, { recursive: true, force: true });
       }

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -664,6 +664,17 @@ async function runTests() {
           'Use when a CLI tool silently exits without a result payload.',
         ].join('\n'),
       );
+      fs.writeFileSync(
+        path.join(learnedDir, 'activation-pattern.md'),
+        [
+          '# Activation Pattern',
+          '',
+          'Background notes that should not become the summary.',
+          '',
+          '## When to Activate',
+          'Use when the harness reports a stale lock during startup.',
+        ].join('\n'),
+      );
 
       try {
         const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
@@ -685,6 +696,10 @@ async function runTests() {
         assert.ok(
           additionalContext.includes('CLI tool silently exits'),
           'Should summarize directory-style learned skill trigger text'
+        );
+        assert.ok(
+          additionalContext.includes('stale lock during startup'),
+          'Should summarize the When to Activate section, not the intro paragraph'
         );
       } finally {
         fs.rmSync(isoHome, { recursive: true, force: true });


### PR DESCRIPTION
## What the user loses

A learned skill whose activation guidance lives under a `## When to Activate` heading is summarized by its intro paragraph, or by the bare title, because the summarizer only recognizes `When to Use`, `Trigger` and `Problem` sections. The session-start injection then shows background prose instead of the one line that tells the model when the skill applies, so the skill is effectively invisible at the moment it should fire.

## Fix

The summary fallback chain in `summarizeLearnedSkillFile` now recognizes `When to Activate` right after `When to Use`.

## Test

The learned-skills injection test gains a third fixture whose only guidance section is `## When to Activate`, preceded by an intro paragraph that must not become the summary. The new assertion fails without the fix (verified by reverting the production line and re-running the suite: 226/227 with exactly this failure) and passes with it (227/227).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes learned skill summaries to use the "When to Activate" section so session-start shows the activation cue, not background text. Adds a negative assertion to prevent intro text from leaking into summaries.

- **Bug Fixes**
  - Updated `summarizeLearnedSkillFile` to extract "When to Activate" right after "When to Use", ahead of "Trigger", "Problem", or the intro.
  - Expanded tests with an `activation-pattern.md` fixture plus positive and negative assertions to ensure the summary uses activation guidance and excludes the intro paragraph.

<sup>Written for commit f7c241702c053db16a93513295fe748fe11f18a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

