### PR TITLE
fix(catalog): point the devfleet entry at the repository that exists

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -136,7 +136,7 @@
     "devfleet": {
       "type": "http",
       "url": "http://localhost:18801/mcp",
-      "description": "Multi-agent orchestration: dispatch parallel Gemini Code agents in isolated worktrees. Plan projects, auto-chain missions, read structured reports. Repo: https://github.com/LEC-AI/egc-devfleet. Requires: devfleet process running on localhost:18801."
+      "description": "Multi-agent orchestration: dispatch parallel Gemini Code agents in isolated worktrees. Plan projects, auto-chain missions, read structured reports. Repo: https://github.com/LEC-AI/claude-devfleet. Requires: devfleet process running on localhost:18801."
     },
     "token-optimizer": {
       "command": "npx",


### PR DESCRIPTION
## What the user loses

The `devfleet` entry in the MCP catalog points to `github.com/LEC-AI/egc-devfleet`, which returns **404**. A user who follows the catalog link to install the orchestrator lands on a dead page and cannot set up the server the entry advertises.

## Fix

The entry now points to `github.com/LEC-AI/claude-devfleet`, verified against the GitHub API: the repository exists, is public, and its server uses the same `localhost:18801` port and HTTP transport the catalog entry already declares. One string changed, no structural changes.

## Verification

- `jq empty` confirms the catalog stays valid JSON and zero `egc-devfleet` references remain.
- Consumer suites green: `tests/lib/mcp-register.test.js` (37/37), `tests/lib/mcp-config.test.js` (3/3), `tests/lib/install-targets.test.js` (158/158).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the `devfleet` MCP catalog entry to point to `LEC-AI/claude-devfleet` instead of the 404 `LEC-AI/egc-devfleet`, so users can reach the correct orchestrator repo and set up the server. Port and transport stay the same.

<sup>Written for commit 668723260dfeecc05d4468312725e7f5c80f384f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

