### PR TITLE
docs(spec): stop claiming install targets register MCP servers

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -22,7 +22,7 @@ A 90-day deprecation window applies for `MAJOR` breaking changes to public-facin
 | Agent memory interchange | [`agent-memory-interchange.md`](./agent-memory-interchange.md) | gap: reference `egc export` / `egc import` pair planned |
 | Hooks contract | `schemas/hooks.schema.json` | `tests/hooks/hooks.test.js` |
 | Plugin manifest | `schemas/plugin.schema.json` | `tests/plugin-manifest.test.js` |
-| Runtime map | `schemas/runtime-map.schema.json` | `tests/test_orchestrator.py` |
+| Runtime map | `schemas/runtime-map.schema.json` | gap: `tests/test_orchestrator.py` was removed in #307; the schema's consumers (`scripts/runtime/discovery.js`, `scripts/orchestration/router.py`) have no dedicated validator |
 | Install profiles | `schemas/install-profiles.schema.json` | `tests/lib/install-manifests.test.js` |
 | Install modules | `schemas/install-modules.schema.json` | `tests/scripts/doctor.test.js` |
 | Install components | `schemas/install-components.schema.json` | `tests/lib/install-manifests.test.js` |

--- a/docs/spec/integration-tiers.md
+++ b/docs/spec/integration-tiers.md
@@ -8,7 +8,7 @@ EGC supports 23 AI coding tools through 3 distinct integration mechanisms. This 
 
 | Tier | Name | What ships | Install pipeline |
 |------|------|------------|------------------|
-| **1** | Full unified | Skills, agents, rules, hooks, MCP, install manifest | `scripts/install-apply.js` via `SUPPORTED_INSTALL_TARGETS` |
+| **1** | Full unified | Skills, agents, rules, hooks, install manifest | `scripts/install-apply.js` via `SUPPORTED_INSTALL_TARGETS` |
 | **2** | Custom-script | Tool-specific assets via dedicated installer | `.{tool}/install.sh` called from `install.sh` |
 | **3** | Protocol-only | MCP server registration + memory protocol injection | `scripts/bootstrap-cognitive.js` + `install.sh` MCP registration |
 
@@ -16,7 +16,7 @@ EGC supports 23 AI coding tools through 3 distinct integration mechanisms. This 
 
 | # | Tool | Tier | Target id | Install path | Notes |
 |---|------|------|-----------|--------------|-------|
-| 1 | **Claude Code** | 1 | `claude` | `~/.claude/skills/<name>/SKILL.md` | Skills installed flat; MCP + cognitive bootstrap via `~/.claude/CLAUDE.md` |
+| 1 | **Claude Code** | 1 | `claude` | `~/.claude/skills/<name>/SKILL.md` | Skills installed flat; cognitive bootstrap via `~/.claude/CLAUDE.md`. MCP registration happens through Claude Code's own CLI (`claude mcp add -s user`), driven by `egc init` and the shell installers, not by this target (#1193) |
 | 2 | **Antigravity (AGY)** | 1 | `antigravity` | `.agents/` (project-scoped, per repo) | Skills, agents, rules, and commands installed per-project; GateGuard hooks registered; no home-level target (Antigravity has no global rule discovery) |
 | 3 | **Gemini CLI** | 1 | `gemini` | `~/.gemini/` | Cognitive bootstrap into `GEMINI.md` |
 | 4 | **Cursor** | 1 | `cursor` | `~/.cursor/` | Rules injected into global cursor.rules |
@@ -26,8 +26,8 @@ EGC supports 23 AI coding tools through 3 distinct integration mechanisms. This 
 | 8 | **Windsurf** | 1 | `windsurf` | `~/.codeium/windsurf/skills/<name>/SKILL.md` | Skills installed flat |
 | 9 | **Amp** | 1 | `amp` | `~/.amp/skills/<name>/SKILL.md` | Skills installed flat; Guardian + Token Crusher wired via Amp's Plugin API (`tool.call` event, `.amp/plugins/` project or `~/.config/amp/plugins/` home -- a genuinely different root than the skills path above), executed in-process by Amp's own Bun runtime, same pattern as OpenCode's plugin |
 | 10 | **VS Code Copilot** | 1 | `copilot` | `~/.github/skills/<name>/SKILL.md` | Skills installed flat |
-| 11 | **Zed** | 1 | `zed` | `~/.config/zed/skills/<name>/` | Skills installed flat (category stripped); MCP via `context_servers` in `settings.json`; cognitive bootstrap into `~/.config/zed/AGENTS.md` |
-| 12 | **Continue.dev** | 1 | `continue` | `~/.continue/skills/<name>/SKILL.md` | Skills installed flat; MCP via YAML block files in `~/.continue/mcpServers/`; memory protocol prompt in `~/.continue/prompts/`; rules discovered natively at workspace `.continue/rules/` |
+| 11 | **Zed** | 1 | `zed` | `~/.config/zed/skills/<name>/` | Skills installed flat (category stripped); cognitive bootstrap into `~/.config/zed/AGENTS.md`. MCP registration into `context_servers` in `settings.json` is **not** part of this target: like every `--target`, it installs skills and rules only. The MCP servers are registered by `egc init` and by the shell installers, which detect Zed independently (corrected in #1206) |
+| 12 | **Continue.dev** | 1 | `continue` | `~/.continue/skills/<name>/SKILL.md` | Skills installed flat; memory protocol prompt in `~/.continue/prompts/`; rules discovered natively at workspace `.continue/rules/`. MCP registration writes YAML block files into `~/.continue/mcpServers/`, but it belongs to `egc init` and the shell installers, not to this target (#1197 made all three entry points share one registration list) |
 | 13 | **Kiro** | 1 | `kiro` | `~/.kiro/skills/<name>/` (home) and `.kiro/skills/<name>/` (project) | Skills installed flat via the unified pipeline; the legacy `.kiro/install.sh` script still handles project-local agents, steering docs, hooks, scripts, and settings (a separate concern from skill distribution, not yet migrated) |
 | 14 | **Trae** | 1 | `trae` | `.trae/skills/<name>/` (project only, no home target) | Skills installed flat via the unified pipeline; the legacy `.trae/install.sh` script still handles commands, agents, rules, and the `~/.trae/MEMORY.md` memory protocol (project-scoped only; `TRAE_ENV=cn` for `~/.trae-cn/`) |
 | 15 | **JetBrains Junie** | 1 | `junie` | `.junie/guidelines.md` | Project guidelines installed via the unified pipeline using JetBrains Junie's native guidelines discovery path |


### PR DESCRIPTION
## What was wrong

The executable spec under `docs/spec/` had drifted from the code in two ways:

**1. MCP registration attributed to install targets (three places).** The Tier 1 row listed "MCP" among what the unified pipeline ships, and the per-tool table said the `claude`, `zed` and `continue` targets register MCP servers. Verified against the code: `claude-home.js`, `zed-home.js` and `continue-home.js` contain zero MCP registration; the whole registry lives in `scripts/lib/mcp-register.js`, driven by `egc init` and the shell installers. This is exactly the claim #1206 corrected in `docs/installation.md` ("`--target <tool>` only ever installs skills and rules"), which survived untouched in the spec.

**2. A validator that no longer exists.** The runtime-map row pointed at `tests/test_orchestrator.py`, deleted in #307. The schema's real consumers (`scripts/runtime/discovery.js`, `scripts/orchestration/router.py`) have no dedicated validator, so the row now sits with the other honest gaps the spec already tracks rather than claiming coverage it does not have.

## What was checked and found correct

- All 24 `SUPPORTED_INSTALL_TARGETS` identifiers in the compatibility commitments match `install-manifests.js` exactly.
- Both Tier 2 entry points (`.kiro/install.sh`, `.trae/install.sh`) exist and are executable.
- The legacy plugin identifiers still resolve through `resolve-egc-root.js`.
- Every other "Validated by" file in the table exists.
- The four declared gaps (harness contract schema, per-harness smoke tests, ADRs, HARNESS-{target}.md) are all still genuinely missing, so those entries stay honest.

Documentation only, no contract change, so `SPEC_VERSION` stays at 0.1.0.

## Verification

`tests/spec/integration-tiers.test.js` 5/5, `tests/scripts/bootstrap-cognitive.test.js` 50/50, `tests/hooks/doc-file-warning.test.js` 60/60, `tests/ci/agent-yaml-surface.test.js` 4/4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the executable spec to stop claiming Tier 1 install targets register MCP servers and to reflect that the runtime map validator no longer exists. Targets install skills and rules only; MCP registration is handled by `egc init` and the shell installers.

- **Bug Fixes**
  - Removed “MCP” from Tier 1 “What ships” and clarified `claude`, `zed`, and `continue` targets don’t register MCP servers.
  - Marked the runtime map validator as a gap and referenced its real consumers in `scripts/runtime/discovery.js` and `scripts/orchestration/router.py`.

<sup>Written for commit 7dc651dbbbf3ba81da34f473905f7c08812b4fa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

