### PR TITLE
chore(spec): bump SPEC_VERSION to 0.1.1

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -1,4 +1,4 @@
-spec_version: "0.1.0"
+spec_version: "0.1.1"
 name: egc
 version: 1.1.18
 description: "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools. Desenvolvido por Felipe Marzochi. @MarzochiFelipe. https://github.com/Fmarzochi/EGC"

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -4,7 +4,7 @@ The EGC specification is executable. It lives in JSON Schemas under `schemas/`, 
 
 ## Spec version
 
-`SPEC_VERSION = 0.1.0` (declared in `agent.yaml`)
+`SPEC_VERSION = 0.1.1` (declared in `agent.yaml`)
 
 Semver applies: `MAJOR.MINOR.PATCH`.
 


### PR DESCRIPTION
Follow-up to #1223.

The spec declares its own versioning rule: `PATCH: Documentation, typo, non-contract changes`. #1223 corrected two stale statements (install targets described as registering MCP servers, and a validator file removed back in #307) without changing any contract, so `SPEC_VERSION` moves from 0.1.0 to 0.1.1 in `agent.yaml`, with the spec index kept in sync.

Product version is untouched: this is the spec contract version, not the package version.

Verification: `tests/ci/agent-yaml-surface.test.js` 4/4, `tests/spec/integration-tiers.test.js` 5/5, `tests/plugin-manifest.test.js` 39/39.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the spec version from 0.1.0 to 0.1.1 to reflect documentation-only updates. No contract changes or package/product version changes.

Updates `spec_version` in `agent.yaml` and syncs the version in `docs/spec/README.md`.

<sup>Written for commit 79c82e1f409ec628e76531946535bf0011a2d406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

