### PR TITLE
fix(deps): bump js-yaml to 4.3.1 closing CVE-2026-59870 (high)

### DIFF
--- a/fuzz/package-lock.json
+++ b/fuzz/package-lock.json
@@ -1566,9 +1566,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2887,9 +2887,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Bumps js-yaml to 4.3.1 in the root and fuzz lockfiles, closing GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, high severity: quadratic CPU consumption in omap resolution). Lockfile-only change inside the existing semver ranges; no code touched.

## Why now

The advisory was published after the last green PR runs, so Security Scan / npm audit began failing on the post-merge run on main (run 31145010690).

## Verification

npm audit --audit-level=high reports 0 vulnerabilities in both the root and fuzz directories on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `js-yaml` to 4.3.1 to patch CVE-2026-59870 (high) and restore passing security scans. Lockfile-only update to package-lock.json in root and fuzz; no code changes.

<sup>Written for commit d0ac89b2463a3d973302ce1262e6b5f897e4a39b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

