### PR TITLE
chore(agents): move doc-updater to gemini-3.6-flash

### DIFF
--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -2,7 +2,7 @@
 name: doc-updater
 description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: gemini-2.0-flash
+model: gemini-3.6-flash
 stack: ["*"]
 ---
 

--- a/scripts/ci/validate-agents.js
+++ b/scripts/ci/validate-agents.js
@@ -12,7 +12,7 @@ const AGENTS_DIR = path.join(__dirname, '../../agents');
 const REQUIRED_FIELDS = ['model', 'tools'];
 const VALID_MODELS = [
   'haiku', 'sonnet', 'opus', 'pro', 'flash', 'lite', 'ultra',
-  'gemini-3.1-pro',
+  'gemini-3.1-pro', 'gemini-3.6-flash',
   'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite',
   'gemini-2.0-pro', 'gemini-2.0-flash', 'gemini-2.0-flash-lite',
   'gemini-1.5-pro', 'gemini-1.5-flash', 'gemini-1.5-flash-8b'


### PR DESCRIPTION
## What

Moves the doc-updater agent from gemini-2.0-flash to gemini-3.6-flash and adds gemini-3.6-flash to the model allowlist in scripts/ci/validate-agents.js.

## Why

gemini-3.6-flash is GA since Jul 21, consumes about 17 percent fewer output tokens than 3.5-flash and is priced lower. doc-updater generates codemaps and documentation, a volume task where the flash tier is the right cost profile. This is the follow-up suggested during the #1190 review.

## Verification

node scripts/ci/validate-agents.js passes with 61 agent files on this branch. Model distribution after this change: 47 gemini-3.1-pro, 13 sonnet, 1 gemini-3.6-flash.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the doc-updater agent from gemini-2.0-flash to gemini-3.6-flash and adds the new model to the CI allowlist. This lowers cost and output token usage for high-volume codemap and docs generation.

<sup>Written for commit 862402a457d2321e99462f438cd543dcdc531eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

