### PR TITLE
docs(readme): move the Guardian coverage caveat out of the feature bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install -g @egchq/egc && egc install
 ```
 
 - **Reduce context waste by up to 90%, cut token costs, and keep every AI perfectly aligned across sessions.**
-- **Guardian: validate every command before execution and block dangerous writes. Every shared brain comes with a built-in safety layer.** ([coverage depends on each tool's hook support](docs/security/SECURITY-ASSESSMENT.md#known-limitations))
+- **Guardian: validate every command before execution and block dangerous writes. Every shared brain comes with a built-in safety layer.**
 - **One command, zero config: memory stays local and encrypted on your machine, and never gets committed to git.**
 
 <div align="center">


### PR DESCRIPTION
## What

Removes the parenthetical hook-coverage caveat and its link from the Guardian feature bullet at the top of the README.

## Why

The README top section is the marketing surface. The detailed caveat remains exactly where it belongs: in the Guardian section further down (which keeps its pointer to the Security Assessment) and in docs/security/SECURITY-ASSESSMENT.md under Known Limitations. No information is lost; the bullet just stops carrying documentation duty.

## Verification

Single-line change. Heading structure untouched, so the translated READMEs stay structurally valid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the coverage caveat and link from the Guardian feature bullet at the top of the README to keep the marketing summary focused. The limitation remains documented in the Guardian section and in docs/security/SECURITY-ASSESSMENT.md under Known Limitations.

<sup>Written for commit 0f42be91769eeab4f45dfd015b9ddda33caa32d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

