### PR TITLE
Fix/windows installer exceptions

### DIFF
--- a/scripts/crusher-shim.js
+++ b/scripts/crusher-shim.js
@@ -10,18 +10,24 @@
 
 const { install, uninstall, status } = require('./lib/crusher/shim-install');
 
+function toPathResultArray(rawPathResult) {
+  if (Array.isArray(rawPathResult)) {
+    return rawPathResult;
+  }
+  if (rawPathResult) {
+    return [{
+      ...rawPathResult,
+      path: rawPathResult.path || 'Windows user PATH (registry)'
+    }];
+  }
+  return [];
+}
+
 function printInstallResult(result) {
   console.log(`Shim directory: ${result.dir}`);
   if (result.installed.length) console.log(`Installed: ${result.installed.join(', ')}`);
   if (result.skipped.length) console.log(`Not found on this machine (skipped): ${result.skipped.join(', ')}`);
-  const rawPathResult = result?.pathResult;
-  const pathResultArray = Array.isArray(rawPathResult) 
-    ? rawPathResult 
-    : (rawPathResult ? [{ 
-      ...rawPathResult, 
-      path: rawPathResult.path || 'Windows Shim Directory' // <-- Añadimos un label por defecto
-    }] : []);
-
+  const pathResultArray = toPathResultArray(result.pathResult);
   const changed = pathResultArray.filter(r => r && r.changed);
   if (changed.length) {
     console.log(`PATH updated in: ${changed.map(r => r.path).join(', ')}`);
@@ -34,7 +40,8 @@ function printInstallResult(result) {
 function printUninstallResult(result) {
   console.log(`Shim directory: ${result.dir}`);
   console.log(result.removed.length ? `Removed: ${result.removed.join(', ')}` : 'Nothing to remove.');
-  const changed = result.pathResult.filter(r => r.changed);
+  const pathResultArray = toPathResultArray(result.pathResult);
+  const changed = pathResultArray.filter(r => r && r.changed);
   if (changed.length) console.log(`PATH entry removed from: ${changed.map(r => r.path).join(', ')}`);
 }
 

--- a/scripts/crusher-shim.js
+++ b/scripts/crusher-shim.js
@@ -14,7 +14,11 @@ function printInstallResult(result) {
   console.log(`Shim directory: ${result.dir}`);
   if (result.installed.length) console.log(`Installed: ${result.installed.join(', ')}`);
   if (result.skipped.length) console.log(`Not found on this machine (skipped): ${result.skipped.join(', ')}`);
-  const changed = result.pathResult.filter(r => r.changed);
+  const rawPathResult = result?.pathResult;
+  const pathResultArray = Array.isArray(rawPathResult) 
+    ? rawPathResult 
+    : (rawPathResult ? [rawPathResult] : []);
+  const changed = pathResultArray.filter(r => r && r.changed);
   if (changed.length) {
     console.log(`PATH updated in: ${changed.map(r => r.path).join(', ')}`);
     console.log('Open a new terminal (or `source` the file above) for it to take effect.');

--- a/scripts/crusher-shim.js
+++ b/scripts/crusher-shim.js
@@ -17,7 +17,11 @@ function printInstallResult(result) {
   const rawPathResult = result?.pathResult;
   const pathResultArray = Array.isArray(rawPathResult) 
     ? rawPathResult 
-    : (rawPathResult ? [rawPathResult] : []);
+    : (rawPathResult ? [{ 
+      ...rawPathResult, 
+      path: rawPathResult.path || 'Windows Shim Directory' // <-- Añadimos un label por defecto
+    }] : []);
+
   const changed = pathResultArray.filter(r => r && r.changed);
   if (changed.length) {
     console.log(`PATH updated in: ${changed.map(r => r.path).join(', ')}`);

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -218,7 +218,7 @@ if (-not $DryRun) {
     # but only `egc init` configured the filter that keeps that promise --
     # this quick-start script (the README's own documented command) never
     # did (2026-08-01 audit finding). Best-effort: must not fail the install.
-    node -e 'const rootDir = process.argv[1]; const { applyCommitPrivacyFilterCli } = require(rootDir + "/scripts/lib/memory-filters"); applyCommitPrivacyFilterCli({ projectDir: process.cwd(), scriptPath: rootDir + "/scripts/check-state-leak.js", log: m => console.log("  " + m) });' $RootDir
+    node scripts/lib/apply-commit-privacy.js $RootDir
     if ($LASTEXITCODE -ne 0) { Write-Host "  note: commit-privacy filter setup failed (non-fatal)" }
 
     # Write harness config

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -218,7 +218,7 @@ if (-not $DryRun) {
     # but only `egc init` configured the filter that keeps that promise --
     # this quick-start script (the README's own documented command) never
     # did (2026-08-01 audit finding). Best-effort: must not fail the install.
-    node scripts/lib/apply-commit-privacy.js $RootDir
+    node "$RootDir/scripts/lib/apply-commit-privacy.js" $RootDir
     if ($LASTEXITCODE -ne 0) { Write-Host "  note: commit-privacy filter setup failed (non-fatal)" }
 
     # Write harness config

--- a/scripts/lib/apply-commit-privacy.js
+++ b/scripts/lib/apply-commit-privacy.js
@@ -12,4 +12,5 @@ try {
   });
 } catch (err) {
   console.log(`  note: commit-privacy filter setup failed (non-fatal): ${err.message}`);
+  process.exitCode = 1;
 }

--- a/scripts/lib/apply-commit-privacy.js
+++ b/scripts/lib/apply-commit-privacy.js
@@ -1,0 +1,15 @@
+const path = require('path');
+const { applyCommitPrivacyFilterCli } = require('./memory-filters');
+
+const rootDir = process.argv[2] || process.cwd();
+const scriptPath = path.join(rootDir, 'scripts', 'check-state-leak.js');
+
+try {
+  applyCommitPrivacyFilterCli({
+    projectDir: process.cwd(),
+    scriptPath: scriptPath,
+    log: (m) => console.log('  ' + m)
+  });
+} catch (err) {
+  console.log(`  note: commit-privacy filter setup failed (non-fatal): ${err.message}`);
+}

--- a/scripts/lib/apply-commit-privacy.js
+++ b/scripts/lib/apply-commit-privacy.js
@@ -1,16 +1,12 @@
 const path = require('path');
-const { applyCommitPrivacyFilterCli } = require('./memory-filters');
+const { applyCommitPrivacyFilterCli } = require('./apply-commit-privacy-filter-cli');
 
-const rootDir = process.argv[2] || process.cwd();
-const scriptPath = path.join(rootDir, 'scripts', 'check-state-leak.js');
+const scriptPath = process.argv[2]
+  ? path.resolve(process.argv[2], 'scripts', 'git-hooks', 'commit-privacy-filter.js')
+  : undefined;
 
-try {
-  applyCommitPrivacyFilterCli({
-    projectDir: process.cwd(),
-    scriptPath: scriptPath,
-    log: (m) => console.log('  ' + m)
-  });
-} catch (err) {
-  console.log(`  note: commit-privacy filter setup failed (non-fatal): ${err.message}`);
-  process.exitCode = 1;
-}
+applyCommitPrivacyFilterCli({
+  projectDir: process.cwd(),
+  scriptPath: scriptPath,
+  log: (m) => console.log('  ' + m)
+});

--- a/scripts/lib/apply-commit-privacy.js
+++ b/scripts/lib/apply-commit-privacy.js
@@ -1,8 +1,8 @@
 const path = require('path');
-const { applyCommitPrivacyFilterCli } = require('./apply-commit-privacy-filter-cli');
+const { applyCommitPrivacyFilterCli } = require('./memory-filters');
 
 const scriptPath = process.argv[2]
-  ? path.resolve(process.argv[2], 'scripts', 'git-hooks', 'commit-privacy-filter.js')
+  ? path.resolve(process.argv[2], 'scripts', 'check-state-leak.js')
   : undefined;
 
 applyCommitPrivacyFilterCli({


### PR DESCRIPTION
## What Changed
- **PS 5.1 Inline Node SyntaxError (`scripts/install.ps1`):** Extracted inline `node -e` script execution into a dedicated script (`scripts/lib/apply-commit-privacy.js`) to avoid PowerShell 5.1 inner quote-stripping issues.
- **`crusher-shim.js` TypeError (`scripts/crusher-shim.js`):** Added type normalization in `printInstallResult()` to handle `installWindowsPath()` single-object returns (`{ changed, error }`) on Windows and safely wrap them in an array before calling `.filter()`.

## Why This Change
- PowerShell 5.1 stripped inner double quotes when invoking `node -e` inline scripts in `install.ps1`, causing path strings to unquote and throwing `SyntaxError: Invalid regular expression flags`.
- On Windows, `installWindowsPath()` returns a single result object rather than an array, causing `result.pathResult.filter(...)` in `crusher-shim.js` to crash with a `TypeError: result.pathResult.filter is not a function` during installation summary printing.
- Close  #1217

## Testing Done
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] Shell scripts pass shellcheck (if applicable)
- [x] JSON files validate cleanly
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows installer errors on PowerShell 5.1 and resolves PATH summary crashes during install and uninstall on Windows. Fixes #1217.

- **Bug Fixes**
  - PowerShell 5.1: replaced inline `node -e` with `scripts/lib/apply-commit-privacy.js`; restores correct `./memory-filters` import and resolves `scripts/check-state-leak.js`; exit codes respected, failures are non-fatal and logged.
  - `scripts/crusher-shim.js`: normalize `pathResult` to an array for both flows, add a default PATH label ("Windows user PATH (registry)"), and guard filtering before printing.

<sup>Written for commit 0dc1b8cd5bb9e152514abcd68ba5605933de6749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer handling when PATH update results are missing, invalid, or returned as a single entry.
  * Changed PATH records are now filtered more safely during installation and removal.

* **Improvements**
  * Commit privacy filtering is configured more reliably during PowerShell installation.
  * Setup issues during commit privacy configuration remain non-blocking, allowing installation to continue with a notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->