### PR TITLE
feat(dashboard): operable doctor and target install buttons over the operations library

### DIFF
--- a/dashboard/ops.js
+++ b/dashboard/ops.js
@@ -387,7 +387,7 @@ function configureCommitPrivacyBestEffort(projectRoot) {
  * deliberately left to its default so the plan resolves against the same
  * reference repo the CLI uses; that is what keeps the install-state identical.
  */
-function runInstall(body, context) {
+async function runInstall(body, context) {
   let request;
   try {
     assertKnownProfile(body.profile);
@@ -405,7 +405,9 @@ function runInstall(body, context) {
     throw error;
   }
 
-  const result = operations.install(request, {
+  // install() awaits the install-state store sync internally, so warnings that
+  // only surface after that IO land in result.warnings rather than nowhere.
+  const result = await operations.install(request, {
     projectRoot: context.projectRoot,
     homeDir:     context.homeDir,
   });
@@ -522,8 +524,12 @@ function createOpsHandler(options = {}) {
     }
 
     readJsonBody(req)
-      .then(body => {
-        const { result, targets } = handler(body, context);
+      // Handlers may be sync or async - install() is async since #1235, because
+      // it awaits the install-state store sync so late warnings are captured.
+      // Resolving the handler's return here keeps both kinds working, instead
+      // of serialising a Promise into the response body.
+      .then(body => handler(body, context))
+      .then(({ result, targets }) => {
         const payload = { ok: true, operation, result };
         if (targets) payload.targets = targets;
         sendJson(res, 200, payload);

--- a/dashboard/ops.js
+++ b/dashboard/ops.js
@@ -517,8 +517,15 @@ function createOpsHandler(options = {}) {
     }
 
     const operation = pathname.slice(OPS_PREFIX.length);
+    // typeof, not just truthiness: the operation name comes off the request
+    // path, and this is the guard that has to hold before it selects what gets
+    // called. A Map already keeps inherited keys out of reach, so this is
+    // belt-and-braces against a non-function ever being registered in the
+    // table by mistake - and it is the sanitizer CodeQL's
+    // js/unvalidated-dynamic-method-call recognises, which a truthiness check
+    // alone is not.
     const handler = OPERATION_HANDLERS.get(operation);
-    if (!handler) {
+    if (typeof handler !== 'function') {
       sendJson(res, 404, { ok: false, error: `Unknown operation: ${operation}` });
       return true;
     }

--- a/dashboard/ops.js
+++ b/dashboard/ops.js
@@ -1,0 +1,340 @@
+'use strict';
+
+/**
+ * dashboard/ops.js
+ *
+ * The panel's door onto the shared operations library (#1235). Every button on
+ * the doctor screen posts to POST /ops/<operation> and lands on the exact same
+ * registry function the CLI calls, so a panel install and an
+ * `egc install --target <x>` write the same install-state file.
+ *
+ * Auth is local and mandatory from the first route: the server mints a token
+ * under ~/.egc/ on startup and injects it into index.html the same way the port
+ * is injected, so only a panel this server actually served can drive it. A
+ * request without the token gets 401 and never reaches an operation. CORS is
+ * pinned to the panel's own origin - the 127.0.0.1 bind stays as it is.
+ */
+
+const crypto = require('node:crypto');
+const fs     = require('node:fs');
+const os     = require('node:os');
+const path   = require('node:path');
+
+const operations = require('../scripts/lib/operations/index');
+const { normalizeInstallRequest } = require('../scripts/lib/install/request');
+const { listInstallTargetAdapters } = require('../scripts/lib/install-targets/registry');
+
+const TOKEN_FILE_NAME = 'dashboard-token';
+const TOKEN_BYTES     = 32;
+const TOKEN_HEADER    = 'x-egc-token';
+const MAX_BODY_BYTES  = 64 * 1024;
+const OPS_PREFIX      = '/ops/';
+
+// The reference repo is wherever this dashboard lives, which for a global
+// install is the published npm package - the same default `egc doctor` and
+// `egc repair` use when no --repo-root is given.
+const REPO_ROOT = path.join(__dirname, '..');
+
+function resolveHomeDir(homeDir) {
+  return homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
+}
+
+function resolveTokenPath(homeDir) {
+  return path.join(resolveHomeDir(homeDir), '.egc', TOKEN_FILE_NAME);
+}
+
+function readTokenFile(tokenPath) {
+  try {
+    const raw = fs.readFileSync(tokenPath, 'utf8').trim();
+    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Return the local ops token, creating it on first launch.
+ *
+ * ~/.egc/dashboard-token is shared across concurrent EGC processes: two
+ * dashboards started close together can both observe it as absent. The write
+ * uses the 'wx' flag so exactly one of them creates the file and the loser
+ * reads back the winner's token instead of overwriting it - overwriting would
+ * silently 401 every request from the panel the winner already served.
+ * See CONTRIBUTING "Concurrent-Access Regression Tests".
+ *
+ * @param {object} [options]
+ * @param {string} [options.homeDir] - Resolve the token under this home
+ * @returns {{ token: string, tokenPath: string }}
+ */
+function loadOrCreateOpsToken(options = {}) {
+  const tokenPath = resolveTokenPath(options.homeDir);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+
+  const existing = readTokenFile(tokenPath);
+  if (existing) {
+    return { token: existing, tokenPath };
+  }
+
+  const candidate = crypto.randomBytes(TOKEN_BYTES).toString('hex');
+
+  try {
+    const fd = fs.openSync(tokenPath, 'wx', 0o600);
+    try {
+      fs.writeSync(fd, `${candidate}\n`);
+    } finally {
+      fs.closeSync(fd);
+    }
+    return { token: candidate, tokenPath };
+  } catch (error) {
+    if (error.code !== 'EEXIST') throw error;
+
+    // Lost the race: whoever created the file owns the token.
+    const winner = readTokenFile(tokenPath);
+    if (winner) {
+      return { token: winner, tokenPath };
+    }
+
+    // The file exists but holds nothing usable, so no panel can be
+    // authenticating against it. Replace it rather than refuse to start.
+    fs.writeFileSync(tokenPath, `${candidate}\n`, { mode: 0o600 });
+    return { token: candidate, tokenPath };
+  }
+}
+
+function tokensMatch(presented, expected) {
+  if (typeof presented !== 'string' || typeof expected !== 'string') return false;
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  // timingSafeEqual throws on a length mismatch, which is itself the answer.
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+function panelOrigins(port) {
+  return [`http://localhost:${port}`, `http://127.0.0.1:${port}`];
+}
+
+function isPanelOrigin(origin, port) {
+  return panelOrigins(port).includes(origin);
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    let exceeded = false;
+
+    req.on('data', chunk => {
+      if (exceeded) return;
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        exceeded = true;
+        const error = new Error('Payload too large');
+        error.statusCode = 413;
+        reject(error);
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on('error', reject);
+
+    req.on('end', () => {
+      if (exceeded) return;
+      const raw = Buffer.concat(chunks).toString('utf8').trim();
+      if (!raw) {
+        resolve({});
+        return;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (_) {
+        const error = new Error('Invalid JSON');
+        error.statusCode = 400;
+        reject(error);
+        return;
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        const error = new Error('Request body must be a JSON object');
+        error.statusCode = 400;
+        reject(error);
+        return;
+      }
+      resolve(parsed);
+    });
+  });
+}
+
+function toStringArray(value) {
+  if (typeof value === 'string' && value.trim()) return [value.trim()];
+  if (!Array.isArray(value)) return [];
+  return value.map(entry => String(entry).trim()).filter(Boolean);
+}
+
+/**
+ * Every install target the panel can offer, flagged with whether the doctor
+ * report already found an install-state for it. buildDoctorReport only reports
+ * targets that exist on disk, so the not-yet-installed ones - the whole point
+ * of an install button on a fresh machine - come from the adapter registry.
+ */
+function listTargetCatalog(report) {
+  const installed = new Set(
+    (report?.results || []).map(result => result.adapter?.id).filter(Boolean)
+  );
+
+  return listInstallTargetAdapters().map(adapter => ({
+    id:        adapter.id,
+    target:    adapter.target,
+    kind:      adapter.kind,
+    installed: installed.has(adapter.id),
+  }));
+}
+
+function runDoctor(body, context) {
+  const report = operations.doctor({
+    repoRoot:    REPO_ROOT,
+    homeDir:     context.homeDir,
+    projectRoot: context.projectRoot,
+    targets:     toStringArray(body.targets),
+  });
+  return { result: report, targets: listTargetCatalog(report) };
+}
+
+/**
+ * Mirror of scripts/install-apply.js: the same normalized request, planned and
+ * applied with the same projectRoot/homeDir. sourceRoot is deliberately left to
+ * its default so the plan resolves against the same reference repo the CLI uses
+ * - that is what keeps the written install-state byte-identical.
+ */
+function runInstall(body, context) {
+  let request;
+  try {
+    request = normalizeInstallRequest({
+      target:              body.target,
+      profileId:           body.profile,
+      moduleIds:           toStringArray(body.modules),
+      includeComponentIds: toStringArray(body.with),
+      excludeComponentIds: toStringArray(body.without),
+    });
+  } catch (error) {
+    error.statusCode = 400;
+    throw error;
+  }
+
+  return {
+    result: operations.install(request, {
+      projectRoot: context.projectRoot,
+      homeDir:     context.homeDir,
+    }),
+  };
+}
+
+function runRepair(body, context) {
+  return {
+    result: operations.repair({
+      repoRoot:    REPO_ROOT,
+      homeDir:     context.homeDir,
+      projectRoot: context.projectRoot,
+      targets:     toStringArray(body.targets),
+      dryRun:      body.dryRun === true,
+    }),
+  };
+}
+
+const OPERATION_HANDLERS = {
+  doctor:  runDoctor,
+  install: runInstall,
+  repair:  runRepair,
+};
+
+function listOpsOperations() {
+  return Object.keys(OPERATION_HANDLERS);
+}
+
+/**
+ * Build the /ops request handler.
+ *
+ * @param {object} options
+ * @param {string} options.token   - The token the panel was handed
+ * @param {number} options.port    - Port the panel is served from
+ * @param {string} [options.homeDir]
+ * @param {string} [options.projectRoot]
+ * @returns {(req, res) => boolean} true when the request was an /ops request
+ *                                  and has been answered
+ */
+function createOpsHandler(options = {}) {
+  const { token, port } = options;
+  const context = {
+    homeDir:     resolveHomeDir(options.homeDir),
+    projectRoot: options.projectRoot || process.cwd(),
+  };
+
+  return function handleOps(req, res) {
+    const pathname = (req.url || '').split('?')[0];
+    if (!pathname.startsWith(OPS_PREFIX)) return false;
+
+    // Restricted to the panel's own origin, unlike the permissive
+    // any-loopback-port header the telemetry routes carry.
+    const origin = req.headers.origin || '';
+    res.setHeader('Access-Control-Allow-Origin', `http://localhost:${port}`);
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', `Content-Type, ${TOKEN_HEADER}`);
+    res.setHeader('Vary', 'Origin');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return true;
+    }
+
+    if (req.method !== 'POST') {
+      sendJson(res, 405, { ok: false, error: 'Method not allowed' });
+      return true;
+    }
+
+    if (origin && !isPanelOrigin(origin, port)) {
+      sendJson(res, 403, { ok: false, error: 'Origin not allowed' });
+      return true;
+    }
+
+    if (!tokensMatch(req.headers[TOKEN_HEADER], token)) {
+      sendJson(res, 401, { ok: false, error: 'Missing or invalid EGC dashboard token' });
+      return true;
+    }
+
+    const operation = pathname.slice(OPS_PREFIX.length);
+    const handler = OPERATION_HANDLERS[operation];
+    if (!handler) {
+      sendJson(res, 404, { ok: false, error: `Unknown operation: ${operation}` });
+      return true;
+    }
+
+    readJsonBody(req)
+      .then(body => {
+        const { result, targets } = handler(body, context);
+        const payload = { ok: true, operation, result };
+        if (targets) payload.targets = targets;
+        sendJson(res, 200, payload);
+      })
+      .catch(error => {
+        sendJson(res, error.statusCode || 500, { ok: false, error: error.message });
+      });
+
+    return true;
+  };
+}
+
+module.exports = {
+  TOKEN_FILE_NAME,
+  TOKEN_HEADER,
+  createOpsHandler,
+  listOpsOperations,
+  loadOrCreateOpsToken,
+  resolveTokenPath,
+};

--- a/dashboard/ops.js
+++ b/dashboard/ops.js
@@ -23,12 +23,25 @@ const path   = require('node:path');
 const operations = require('../scripts/lib/operations/index');
 const { normalizeInstallRequest } = require('../scripts/lib/install/request');
 const { listInstallTargetAdapters } = require('../scripts/lib/install-targets/registry');
+const { findDefaultInstallConfigPath, loadInstallConfig } = require('../scripts/lib/install/config');
+const { listInstallProfiles } = require('../scripts/lib/install-manifests');
+const { applyCommitPrivacyFilterCli } = require('../scripts/lib/memory-filters');
+const { listInstalledPlugins, reinstallAllPlugins } = require('../scripts/lib/plugin-registry');
 
 const TOKEN_FILE_NAME = 'dashboard-token';
 const TOKEN_BYTES     = 32;
 const TOKEN_HEADER    = 'x-egc-token';
 const MAX_BODY_BYTES  = 64 * 1024;
 const OPS_PREFIX      = '/ops/';
+// Bounded wait for a concurrent creator to finish writing the token file.
+const TOKEN_RACE_ATTEMPTS = 10;
+const TOKEN_RACE_WAIT_MS  = 5;
+// An empty token file younger than this is a live writer; older than it, the
+// writer died between creating and writing and nobody is coming back for it.
+const TOKEN_STALE_MS = 5000;
+// Every token this writes is exactly TOKEN_BYTES hex-encoded. Accepting
+// anything shorter would let a truncated write pass as a whole token.
+const TOKEN_PATTERN = new RegExp(`^[0-9a-f]{${TOKEN_BYTES * 2}}$`, 'i');
 
 // The reference repo is wherever this dashboard lives, which for a global
 // install is the published npm package - the same default `egc doctor` and
@@ -43,17 +56,72 @@ function resolveTokenPath(homeDir) {
   return path.join(resolveHomeDir(homeDir), '.egc', TOKEN_FILE_NAME);
 }
 
-function readTokenFile(tokenPath) {
-  try {
-    const raw = fs.readFileSync(tokenPath, 'utf8').trim();
-    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
-  } catch (_) {
-    return null;
-  }
+// The token is resolved once, at startup, before the server accepts a
+// connection, so blocking here delays nothing that is already running.
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 /**
- * Return the local ops token, creating it on first launch.
+ * The token on disk, or null when the file is absent or holds no whole token.
+ *
+ * Only ENOENT means "absent". A file that exists but cannot be read - root
+ * owned after a `sudo egc dashboard`, a restrictive ACL - still holds somebody
+ * else's live token, and reporting it as missing would lead to replacing it.
+ * Those errors propagate so the caller can degrade instead of overwrite.
+ */
+function readTokenFile(tokenPath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(tokenPath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+  const token = raw.trim();
+  return TOKEN_PATTERN.test(token) ? token : null;
+}
+
+// fs.writeSync is not obliged to write the whole buffer in one call, and a
+// short write here leaves a truncated token that the next reader would have to
+// reject - or, worse, accept.
+function writeAllSync(fd, text) {
+  const buffer = Buffer.from(text, 'utf8');
+  let written = 0;
+  while (written < buffer.length) {
+    written += fs.writeSync(fd, buffer, written, buffer.length - written);
+  }
+}
+
+// An empty token file is either a winner between its create and its write, or
+// the wreckage of one that died in that window. mtime tells the two apart.
+function emptyTokenFileAge(tokenPath) {
+  const stat = fs.statSync(tokenPath);
+  return stat.size === 0 ? Date.now() - stat.mtimeMs : null;
+}
+
+function replaceTokenFile(tokenPath, token) {
+  // 'w' hands its mode argument to open(), and POSIX applies that only when
+  // O_CREAT actually creates the file. Replacing an existing token file
+  // therefore inherits whatever mode it already had, so a world-readable one
+  // left by a shell redirect or a restored backup would receive the live
+  // token and stay world-readable. Set the permission explicitly.
+  const fd = fs.openSync(tokenPath, 'w', 0o600);
+  try {
+    writeAllSync(fd, `${token}\n`);
+    try {
+      fs.fchmodSync(fd, 0o600);
+    } catch (_) {
+      // Windows has no POSIX mode to set; the file is already user-scoped.
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  return token;
+}
+
+/**
+ * Read the token from disk, or write `candidate` there if nobody has yet.
  *
  * ~/.egc/dashboard-token is shared across concurrent EGC processes: two
  * dashboards started close together can both observe it as absent. The write
@@ -62,42 +130,76 @@ function readTokenFile(tokenPath) {
  * silently 401 every request from the panel the winner already served.
  * See CONTRIBUTING "Concurrent-Access Regression Tests".
  *
- * @param {object} [options]
- * @param {string} [options.homeDir] - Resolve the token under this home
- * @returns {{ token: string, tokenPath: string }}
+ * Throws whatever the filesystem throws; loadOrCreateOpsToken decides what a
+ * failure means.
  */
-function loadOrCreateOpsToken(options = {}) {
-  const tokenPath = resolveTokenPath(options.homeDir);
+function persistOpsToken(tokenPath, candidate) {
   fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
 
   const existing = readTokenFile(tokenPath);
-  if (existing) {
-    return { token: existing, tokenPath };
-  }
-
-  const candidate = crypto.randomBytes(TOKEN_BYTES).toString('hex');
+  if (existing) return existing;
 
   try {
     const fd = fs.openSync(tokenPath, 'wx', 0o600);
     try {
-      fs.writeSync(fd, `${candidate}\n`);
+      writeAllSync(fd, `${candidate}\n`);
     } finally {
       fs.closeSync(fd);
     }
-    return { token: candidate, tokenPath };
+    return candidate;
   } catch (error) {
     if (error.code !== 'EEXIST') throw error;
 
-    // Lost the race: whoever created the file owns the token.
-    const winner = readTokenFile(tokenPath);
-    if (winner) {
-      return { token: winner, tokenPath };
+    // Lost the race: whoever created the file owns the token. The file is
+    // created before it is written, so a loser that looks in that window sees
+    // it empty - that is a winner mid-write, not a corrupt file, and replacing
+    // it would hand two live dashboards two different tokens. Give the winner
+    // time to finish before concluding the file is unusable.
+    for (let attempt = 0; attempt < TOKEN_RACE_ATTEMPTS; attempt += 1) {
+      const winner = readTokenFile(tokenPath);
+      if (winner) return winner;
+      sleepSync(TOKEN_RACE_WAIT_MS);
     }
 
-    // The file exists but holds nothing usable, so no panel can be
-    // authenticating against it. Replace it rather than refuse to start.
-    fs.writeFileSync(tokenPath, `${candidate}\n`, { mode: 0o600 });
-    return { token: candidate, tokenPath };
+    // Still nothing usable. An empty file that was touched moments ago is the
+    // winner-mid-write case the loop above is for, and racing its pending
+    // write is worse than not persisting at all - so leave it and let this
+    // process run on a token that lives only in memory. Anything else (an
+    // empty file nobody came back to, content that is not a token) is
+    // wreckage, and replacing it is what lets the next start be healthy.
+    const emptyFor = emptyTokenFileAge(tokenPath);
+    if (emptyFor !== null && emptyFor < TOKEN_STALE_MS) {
+      throw new Error(
+        `${tokenPath} is being written by another EGC process`,
+        { cause: error }
+      );
+    }
+    return replaceTokenFile(tokenPath, candidate);
+  }
+}
+
+/**
+ * Return the local ops token, creating it on first launch.
+ *
+ * A token that cannot be written is not a reason to take the dashboard down:
+ * ~/.egc is root-owned on the global installs EGC#1231/#1234/#1239 exist to
+ * survive, and this runs at module load in server.js, so throwing here would
+ * kill the whole panel over a feature it does not need to render. The session
+ * falls back to a token that lives only in memory - /ops still works for the
+ * panel this process serves, and only survival across a restart is lost.
+ *
+ * @param {object} [options]
+ * @param {string} [options.homeDir] - Resolve the token under this home
+ * @returns {{ token: string, tokenPath: string, persisted: boolean, error?: string }}
+ */
+function loadOrCreateOpsToken(options = {}) {
+  const tokenPath = resolveTokenPath(options.homeDir);
+  const candidate = crypto.randomBytes(TOKEN_BYTES).toString('hex');
+
+  try {
+    return { token: persistOpsToken(tokenPath, candidate), tokenPath, persisted: true };
+  } catch (error) {
+    return { token: candidate, tokenPath, persisted: false, error: error.message };
   }
 }
 
@@ -135,8 +237,14 @@ function readJsonBody(req) {
         exceeded = true;
         const error = new Error('Payload too large');
         error.statusCode = 413;
+        // Stop reading, but do NOT destroy the socket here: reject() only
+        // schedules the .catch that writes the 413, so destroying now would
+        // tear the connection down before a single byte of it went out and
+        // the caller would see a network error instead of the reason. Node
+        // closes the socket itself once the response ends with the request
+        // body unread.
+        req.pause();
         reject(error);
-        req.destroy();
         return;
       }
       chunks.push(chunk);
@@ -177,6 +285,40 @@ function toStringArray(value) {
   return value.map(entry => String(entry).trim()).filter(Boolean);
 }
 
+function badRequest(message) {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+}
+
+/**
+ * Check target and profile names against the registries before any library
+ * sees them. Two reasons. A name that is not a target is a bad request, and
+ * without this it surfaces as a 500 carrying an internal message. And the
+ * manifests look profiles up on a plain object, so an inherited name like
+ * `constructor` reaches `profile.modules is not iterable` instead of the
+ * "Unknown install profile" this returns - the same shape of hole the
+ * operation dispatch had, closed here at the edge of the new HTTP surface.
+ */
+function assertKnownTargets(targets) {
+  if (targets.length === 0) return targets;
+  const known = new Set(listInstallTargetAdapters().flatMap(a => [a.id, a.target]));
+  for (const target of targets) {
+    if (!known.has(target)) throw badRequest(`Unknown install target: ${target}`);
+  }
+  return targets;
+}
+
+function assertKnownProfile(profileId) {
+  if (profileId === undefined || profileId === null || profileId === '') return profileId;
+  if (typeof profileId !== 'string') throw badRequest('profile must be a string');
+  const known = listInstallProfiles().map(profile => profile.id);
+  if (!known.includes(profileId)) {
+    throw badRequest(`Unknown install profile: ${profileId}`);
+  }
+  return profileId;
+}
+
 /**
  * Every install target the panel can offer, flagged with whether the doctor
  * report already found an install-state for it. buildDoctorReport only reports
@@ -201,60 +343,124 @@ function runDoctor(body, context) {
     repoRoot:    REPO_ROOT,
     homeDir:     context.homeDir,
     projectRoot: context.projectRoot,
-    targets:     toStringArray(body.targets),
+    targets:     assertKnownTargets(toStringArray(body.targets)),
   });
   return { result: report, targets: listTargetCatalog(report) };
 }
 
 /**
- * Mirror of scripts/install-apply.js: the same normalized request, planned and
- * applied with the same projectRoot/homeDir. sourceRoot is deliberately left to
- * its default so the plan resolves against the same reference repo the CLI uses
- * - that is what keeps the written install-state byte-identical.
+ * `egc install` merges ./egc-install.json into the request whenever no --config
+ * and no positional languages were given (scripts/install-apply.js
+ * resolveInstallConfig). The panel passes neither, so the same default applies
+ * to it - without this, a project holding an egc-install.json would get a
+ * different install-state from the button than from the command beside it.
+ */
+function loadDefaultInstallConfig(projectRoot) {
+  const configPath = findDefaultInstallConfigPath({ cwd: projectRoot });
+  return configPath ? loadInstallConfig(configPath, { cwd: projectRoot }) : null;
+}
+
+/**
+ * The git filter that keeps the README's "memory never gets committed" promise.
+ * `egc install` sets it up after applying (scripts/install-apply.js
+ * configureCommitPrivacyFilterBestEffort) and, as the name says, never lets a
+ * failure here fail the install.
+ */
+function configureCommitPrivacyBestEffort(projectRoot) {
+  const messages = [];
+  try {
+    applyCommitPrivacyFilterCli({
+      projectDir: projectRoot,
+      scriptPath: path.join(REPO_ROOT, 'scripts', 'check-state-leak.js'),
+      log:        message => messages.push(String(message)),
+    });
+    return { ok: true, messages };
+  } catch (error) {
+    return { ok: false, messages, error: error.message };
+  }
+}
+
+/**
+ * Mirror of scripts/install-apply.js: the same normalized request - default
+ * install config included - planned and applied with the same projectRoot and
+ * homeDir, then the same commit-privacy filter setup. sourceRoot is
+ * deliberately left to its default so the plan resolves against the same
+ * reference repo the CLI uses; that is what keeps the install-state identical.
  */
 function runInstall(body, context) {
   let request;
   try {
+    assertKnownProfile(body.profile);
+    if (body.target) assertKnownTargets([String(body.target)]);
     request = normalizeInstallRequest({
       target:              body.target,
       profileId:           body.profile,
       moduleIds:           toStringArray(body.modules),
       includeComponentIds: toStringArray(body.with),
       excludeComponentIds: toStringArray(body.without),
+      config:              loadDefaultInstallConfig(context.projectRoot),
     });
   } catch (error) {
     error.statusCode = 400;
     throw error;
   }
 
+  const result = operations.install(request, {
+    projectRoot: context.projectRoot,
+    homeDir:     context.homeDir,
+  });
+
   return {
-    result: operations.install(request, {
-      projectRoot: context.projectRoot,
-      homeDir:     context.homeDir,
-    }),
+    result: {
+      ...result,
+      commitPrivacy: configureCommitPrivacyBestEffort(context.projectRoot),
+    },
   };
+}
+
+/**
+ * `egc repair` repairs install-state and then reinstalls every plugin in the
+ * lock file (scripts/repair.js executePluginRepairs), skipping both on a dry
+ * run and when nothing is installed. The command printed beside the Repair
+ * button does that, so the button does too.
+ */
+function reinstallPluginsBestEffort() {
+  try {
+    if (listInstalledPlugins().length === 0) return [];
+    return reinstallAllPlugins();
+  } catch (error) {
+    return [{ name: '(plugins)', success: false, errors: [error.message] }];
+  }
 }
 
 function runRepair(body, context) {
-  return {
-    result: operations.repair({
-      repoRoot:    REPO_ROOT,
-      homeDir:     context.homeDir,
-      projectRoot: context.projectRoot,
-      targets:     toStringArray(body.targets),
-      dryRun:      body.dryRun === true,
-    }),
-  };
+  const dryRun = body.dryRun === true;
+  const result = operations.repair({
+    repoRoot:    REPO_ROOT,
+    homeDir:     context.homeDir,
+    projectRoot: context.projectRoot,
+    targets:     assertKnownTargets(toStringArray(body.targets)),
+    dryRun,
+  });
+
+  const pluginRepairs = dryRun ? [] : reinstallPluginsBestEffort();
+  return { result: pluginRepairs.length > 0 ? { ...result, pluginRepairs } : result };
 }
 
-const OPERATION_HANDLERS = {
-  doctor:  runDoctor,
-  install: runInstall,
-  repair:  runRepair,
-};
+// A Map, not an object literal: the operation name comes straight off the
+// request path, and an object literal would resolve inherited keys too.
+// `OPERATION_HANDLERS['constructor']` is a truthy function, so it would sail
+// past the not-found check and be invoked - answering 200 for /ops/constructor,
+// or throwing out of the handler for /ops/__defineGetter__. A Map lookup only
+// ever sees keys that were explicitly put in it.
+const OPERATION_HANDLERS = new Map([
+  ['doctor',  runDoctor],
+  ['install', runInstall],
+  ['repair',  runRepair],
+]);
 
 function listOpsOperations() {
-  return Object.keys(OPERATION_HANDLERS);
+  return [...OPERATION_HANDLERS.keys()];
 }
 
 /**
@@ -309,7 +515,7 @@ function createOpsHandler(options = {}) {
     }
 
     const operation = pathname.slice(OPS_PREFIX.length);
-    const handler = OPERATION_HANDLERS[operation];
+    const handler = OPERATION_HANDLERS.get(operation);
     if (!handler) {
       sendJson(res, 404, { ok: false, error: `Unknown operation: ${operation}` });
       return true;

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -832,8 +832,17 @@ function renderDoctor(payload){
   const report=payload.result||{};
   const results=report.results||[];
   const summary=report.summary||{};
+  /* Warnings are informative, the same way `egc doctor` now exits 0 on a
+     warnings-only run: the headline says healthy unless something actually
+     failed. The warning count is still shown, and a warned target still gets
+     its Repair button - it is reported, just not called broken. */
+  const errors=summary.errorCount||0;
+  const warnings=summary.warningCount||0;
+  const headline=errors>0
+    ? `${errors} error${errors===1?'':'s'}`
+    : (warnings>0?'healthy, with warnings':'healthy');
   document.getElementById('docSummary').textContent=
-    `checked ${summary.checkedCount||0} · ok ${summary.okCount||0} · warnings ${summary.warningCount||0} · errors ${summary.errorCount||0}`;
+    `${headline} · checked ${summary.checkedCount||0} · ok ${summary.okCount||0} · warnings ${warnings} · errors ${errors}`;
 
   const missing=docTargetRows(payload.targets).filter(row=>!row.installed);
   const blocks=['<div class="doc-note" id="docStatus">Each button runs the command shown beside it.</div>'];

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -223,6 +223,33 @@ body.minimized footer{display:none!important;}
 .tl-what{font-family:SFMono-Regular,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .tl-dur{text-align:right;font-variant-numeric:tabular-nums;font-size:10px;}
 
+/* ── DOCTOR SCREEN ────────────────────────────────────── */
+.doc-open{font-size:10px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:var(--muted);background:none;border:1px solid var(--hairline);border-radius:6px;padding:4px 10px;font-family:inherit;cursor:pointer;transition:color .12s,border-color .12s;}
+.doc-open:hover{color:var(--primary);border-color:var(--primary-soft);}
+.doctor-screen{display:none;position:fixed;inset:0;z-index:200;background:var(--canvas);flex-direction:column;}
+.doctor-screen.on{display:flex;}
+.doc-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:11px 20px;border-bottom:1px solid var(--hairline);flex-shrink:0;}
+.doc-head-l{display:flex;align-items:center;gap:10px;}
+.doc-sum{font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;}
+.doc-body{flex:1;overflow-y:auto;padding:14px 20px 28px;display:flex;flex-direction:column;gap:10px;}
+.doc-body::-webkit-scrollbar{width:2px;}
+.doc-body::-webkit-scrollbar-thumb{background:var(--hairline);}
+.doc-sec{font-size:9px;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--muted);margin-top:8px;}
+.doc-item{border:1px solid var(--hairline);border-radius:9px;padding:11px 13px;display:flex;flex-direction:column;gap:7px;}
+.doc-item-head{display:flex;align-items:center;gap:9px;flex-wrap:wrap;}
+.doc-name{font-size:12px;font-weight:600;color:var(--ink);}
+.doc-kind{font-size:9px;letter-spacing:1px;text-transform:uppercase;color:var(--muted);}
+.doc-badge{font-size:9px;font-weight:600;letter-spacing:1px;text-transform:uppercase;border-radius:9999px;padding:2px 9px;border:1px solid var(--hairline);color:var(--muted);}
+.doc-badge.ok{color:var(--primary);border-color:rgba(0,217,146,.35);}
+.doc-badge.warning{color:#e0a33a;border-color:rgba(224,163,58,.35);}
+.doc-badge.error{color:#e5534b;border-color:rgba(229,83,75,.35);}
+.doc-issue{font-size:11px;color:var(--muted);font-family:SFMono-Regular,monospace;word-break:break-all;}
+.doc-action{display:flex;align-items:center;gap:9px;flex-wrap:wrap;}
+.doc-cmd{font-family:SFMono-Regular,monospace;font-size:10.5px;color:var(--muted);background:var(--canvas-soft);border:1px solid var(--hairline);border-radius:5px;padding:3px 8px;user-select:all;}
+.doc-note{font-size:11px;color:var(--muted);}
+.doc-note.err{color:#e5534b;}
+.doc-note.ok{color:var(--primary);}
+
 /* ── RESPONSIVE ───────────────────────────────────────── */
 @media(max-width:1100px)and(min-width:681px){
   .main{grid-template-columns:1fr 1fr;}
@@ -435,6 +462,8 @@ body.minimized footer{display:none!important;}
     <div class="ide-pills" id="idePills"></div>
     <div class="vd"></div>
     <div class="ws-chip"><div class="ws-dot" id="wsDot"></div><span id="wsLbl">offline</span></div>
+    <div class="vd"></div>
+    <button class="doc-open" id="docOpen" onclick="openDoctor()" title="Install health">Doctor</button>
     <div class="win-controls">
       <button class="wc-btn wc-min" id="wcMin" title="Minimize">
         <svg width="8" height="2" viewBox="0 0 8 2"><rect y="0" width="8" height="2" fill="#000" opacity=".5"/></svg>
@@ -580,6 +609,20 @@ body.minimized footer{display:none!important;}
   <div class="tl-list" id="tlList"></div>
 </footer>
 
+<section class="doctor-screen" id="doctorScreen">
+  <div class="doc-head">
+    <div class="doc-head-l">
+      <span class="eye">Doctor</span>
+      <span class="doc-sum" id="docSummary">not run yet</span>
+    </div>
+    <div class="doc-head-l">
+      <button class="btn-sm" id="docRefresh" onclick="runDoctor()">refresh</button>
+      <button class="btn-sm" onclick="closeDoctor()">close</button>
+    </div>
+  </div>
+  <div class="doc-body" id="docBody"></div>
+</section>
+
 <nav class="tab-bar">
   <div class="tab-btn a" id="tb-brain" onclick="swTab('brain')"><span class="tab-ico">🧠</span>Brain</div>
   <div class="tab-btn" id="tb-agents" onclick="swTab('agents')"><span class="tab-ico">🤖</span>Agents</div>
@@ -701,6 +744,165 @@ function swTab(name){
   if(name==='brain') setTimeout(()=>brain?.resize(),50);
 }
 swTab('brain');
+
+/* ── DOCTOR SCREEN ─────────────────────────────────────── */
+/* Every button here posts to POST /ops/<operation>, which runs the same
+   operations-registry function the CLI runs. The command shown next to a
+   button is the CLI equivalent of pressing it, so either door does the same
+   work. The token was injected into this page by the server that served it;
+   without it /ops answers 401. */
+const OPS_TOKEN = window.__EGC_OPS_TOKEN || '';
+let docBusy = false;
+
+async function callOp(operation, body){
+  const res = await fetch(`/ops/${operation}`, {
+    method:'POST',
+    headers:{'Content-Type':'application/json','X-EGC-Token':OPS_TOKEN},
+    body:JSON.stringify(body||{}),
+  });
+  let payload={};
+  try{ payload=await res.json(); }catch(_){}
+  if(!res.ok||!payload.ok) throw new Error(payload.error||`${operation} failed (HTTP ${res.status})`);
+  return payload;
+}
+
+function docSay(message,kind){
+  const el=document.getElementById('docStatus');
+  if(!el) return;
+  el.className='doc-note'+(kind?' '+kind:'');
+  el.textContent=message;
+}
+
+function docSetBusy(busy){
+  docBusy=busy;
+  document.querySelectorAll('#docBody button, #docRefresh').forEach(b=>{b.disabled=busy;});
+}
+
+/* One row per target, not per adapter: `egc install --target <x>` resolves to
+   a single adapter, so a target with both a home and a project adapter still
+   has exactly one correct command. */
+function docTargetRows(targets){
+  const byTarget=new Map();
+  for(const entry of targets||[]){
+    const row=byTarget.get(entry.target)||{target:entry.target,kinds:[],installed:false};
+    row.kinds.push(entry.kind);
+    row.installed=row.installed||entry.installed;
+    byTarget.set(entry.target,row);
+  }
+  return [...byTarget.values()];
+}
+
+function docResultBlock(result){
+  const status=result.status||'ok';
+  const target=result.adapter?.target||'';
+  const issues=(result.issues||[])
+    .map(i=>`<div class="doc-issue">[${esc(i.severity)}] ${esc(i.code)}: ${esc(i.message)}</div>`)
+    .join('');
+  const action=status==='ok'?'':`<div class="doc-action">
+        <button class="btn-sm" onclick="opRepair('${esc(target)}')">Repair</button>
+        <code class="doc-cmd">egc repair --target ${esc(target)}</code>
+      </div>`;
+  return `<div class="doc-item">
+      <div class="doc-item-head">
+        <span class="doc-name">${esc(result.adapter?.id||'')}</span>
+        <span class="doc-badge ${esc(status)}">${esc(status)}</span>
+        <span class="doc-kind">${esc(result.adapter?.kind||'')}</span>
+      </div>
+      <div class="doc-issue">${esc(result.installStatePath||'')}</div>
+      ${issues}
+      ${action}
+    </div>`;
+}
+
+function docInstallBlock(row){
+  return `<div class="doc-item">
+      <div class="doc-item-head">
+        <span class="doc-name">${esc(row.target)}</span>
+        <span class="doc-badge">not installed</span>
+        <span class="doc-kind">${esc(row.kinds.join(' · '))}</span>
+      </div>
+      <div class="doc-action">
+        <button class="btn-sm" onclick="opInstall('${esc(row.target)}')">Install</button>
+        <code class="doc-cmd">egc install --target ${esc(row.target)} --profile full</code>
+      </div>
+    </div>`;
+}
+
+function renderDoctor(payload){
+  const report=payload.result||{};
+  const results=report.results||[];
+  const summary=report.summary||{};
+  document.getElementById('docSummary').textContent=
+    `checked ${summary.checkedCount||0} · ok ${summary.okCount||0} · warnings ${summary.warningCount||0} · errors ${summary.errorCount||0}`;
+
+  const missing=docTargetRows(payload.targets).filter(row=>!row.installed);
+  const blocks=['<div class="doc-note" id="docStatus">Each button runs the command shown beside it.</div>'];
+
+  blocks.push('<div class="doc-sec">Installed targets</div>');
+  blocks.push(results.length
+    ? results.map(docResultBlock).join('')
+    : '<div class="doc-note">No install-state found for this home/project. That is the expected state after a bare install — pick a target below.</div>');
+
+  if(missing.length){
+    blocks.push('<div class="doc-sec">Available targets</div>');
+    blocks.push(missing.map(docInstallBlock).join(''));
+  }
+
+  document.getElementById('docBody').innerHTML=blocks.join('');
+}
+
+async function runDoctor(){
+  if(docBusy) return;
+  docSetBusy(true);
+  try{
+    renderDoctor(await callOp('doctor'));
+  }catch(err){
+    document.getElementById('docBody').innerHTML=
+      `<div class="doc-note err" id="docStatus">${esc(err.message)}</div>`;
+  }finally{
+    docSetBusy(false);
+  }
+}
+
+async function opInstall(target){
+  if(docBusy) return;
+  docSetBusy(true);
+  docSay(`Installing ${target}…`);
+  try{
+    await callOp('install',{target,profile:'full'});
+    await runDoctor();
+    docSay(`Installed ${target}.`,'ok');
+  }catch(err){
+    docSay(err.message,'err');
+  }finally{
+    docSetBusy(false);
+  }
+}
+
+async function opRepair(target){
+  if(docBusy) return;
+  docSetBusy(true);
+  docSay(`Repairing ${target}…`);
+  try{
+    const {result}=await callOp('repair',{targets:[target]});
+    const repaired=(result.results||[]).reduce((n,r)=>n+(r.repairedPaths||[]).length,0);
+    await runDoctor();
+    docSay(`Repaired ${repaired} file${repaired===1?'':'s'} for ${target}.`,'ok');
+  }catch(err){
+    docSay(err.message,'err');
+  }finally{
+    docSetBusy(false);
+  }
+}
+
+function openDoctor(){
+  document.getElementById('doctorScreen').classList.add('on');
+  runDoctor();
+}
+
+function closeDoctor(){
+  document.getElementById('doctorScreen').classList.remove('on');
+}
 
 /* ── SESSION TIMER — anchored to server start ───────────── */
 let T0=Date.now();
@@ -1501,6 +1703,10 @@ if('serviceWorker' in navigator){
   document.addEventListener('fullscreenchange',()=>{
     const btn=document.getElementById('wcMax');
     btn.title=document.fullscreenElement?'Exit Fullscreen':'Maximize';
+  });
+
+  document.addEventListener('keydown',e=>{
+    if(e.key==='Escape'&&document.getElementById('doctorScreen')?.classList.contains('on')) closeDoctor();
   });
 
   document.getElementById('wcClose').addEventListener('click',()=>{

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -851,17 +851,42 @@ function renderDoctor(payload){
   document.getElementById('docBody').innerHTML=blocks.join('');
 }
 
-async function runDoctor(){
-  if(docBusy) return;
-  docSetBusy(true);
+/* `force` is how opInstall/opRepair refresh the screen: they still hold the
+   busy flag so the buttons stay disabled until their own success line is
+   shown, and without it this would return before re-reading the report and
+   leave the screen showing pre-operation state. */
+async function runDoctor(force){
+  if(docBusy&&!force) return false;
+  if(!force) docSetBusy(true);
   try{
     renderDoctor(await callOp('doctor'));
+    return true;
   }catch(err){
+    /* The token is read once, at page load. A 401 means the one on disk has
+       changed since, and only a reload can pick the new one up. */
+    const hint=/token/i.test(err.message)?' Reload the page to pick up the current token.':'';
     document.getElementById('docBody').innerHTML=
-      `<div class="doc-note err" id="docStatus">${esc(err.message)}</div>`;
+      `<div class="doc-note err" id="docStatus">${esc(err.message+hint)}</div>`;
+    return false;
   }finally{
-    docSetBusy(false);
+    /* renderDoctor replaced #docBody, so the disabled flags were set on
+       buttons that no longer exist - re-apply them to the fresh ones. */
+    docSetBusy(Boolean(force));
   }
+}
+
+/* The operation succeeded but the refresh that follows it did not: the error
+   runDoctor painted is the only thing on screen, and overwriting it with a
+   green success line would erase the one message that explains the empty
+   report. Say both, and keep the failure's styling. */
+function docReport(refreshed,message,warnings){
+  const detail=(warnings||[]).length ? ` ${warnings.join(' ')}` : '';
+  if(!refreshed){
+    const el=document.getElementById('docStatus');
+    if(el) el.textContent=`${message}${detail} — but the report could not be reloaded: ${el.textContent}`;
+    return;
+  }
+  docSay(`${message}${detail}`, detail ? '' : 'ok');
 }
 
 async function opInstall(target){
@@ -869,9 +894,13 @@ async function opInstall(target){
   docSetBusy(true);
   docSay(`Installing ${target}…`);
   try{
-    await callOp('install',{target,profile:'full'});
-    await runDoctor();
-    docSay(`Installed ${target}.`,'ok');
+    const {result}=await callOp('install',{target,profile:'full'});
+    /* applyInstallPlan's stderr is captured into result.warnings precisely so
+       a caller can surface it - "every module was skipped" arrives that way,
+       and reads as a clean success if it is thrown away. */
+    const warnings=[...(result.warnings||[]),...((result.plan&&result.plan.warnings)||[])].map(String);
+    const refreshed=await runDoctor(true);
+    docReport(refreshed,`Installed ${target}.`,warnings);
   }catch(err){
     docSay(err.message,'err');
   }finally{
@@ -885,9 +914,25 @@ async function opRepair(target){
   docSay(`Repairing ${target}…`);
   try{
     const {result}=await callOp('repair',{targets:[target]});
-    const repaired=(result.results||[]).reduce((n,r)=>n+(r.repairedPaths||[]).length,0);
-    await runDoctor();
-    docSay(`Repaired ${repaired} file${repaired===1?'':'s'} for ${target}.`,'ok');
+    const entries=result.results||[];
+    const repaired=entries.reduce((n,r)=>n+(r.repairedPaths||[]).length,0);
+    const unrepairable=entries.reduce((n,r)=>n+(r.unrepairable||[]).length,0);
+    const failedPlugins=(result.pluginRepairs||[]).filter(p=>!p.success).length;
+    const refreshed=await runDoctor(true);
+
+    /* `egc repair` distinguishes these; a green "Repaired 0 files" over a
+       target whose files could not be written, or whose install-state is
+       gone, would say the opposite of what happened. */
+    if(entries.length===0){
+      docSay(`No install-state found for ${target}. Nothing to repair.`,'err');
+    }else if(unrepairable>0||failedPlugins>0||(result.summary&&result.summary.errorCount>0)){
+      const parts=[`Repaired ${repaired} file${repaired===1?'':'s'} for ${target}`];
+      if(unrepairable>0) parts.push(`${unrepairable} could not be repaired`);
+      if(failedPlugins>0) parts.push(`${failedPlugins} plugin${failedPlugins===1?'':'s'} failed to reinstall`);
+      docSay(`${parts.join('; ')}. Run the command above for the details.`,'err');
+    }else{
+      docReport(refreshed,`Repaired ${repaired} file${repaired===1?'':'s'} for ${target}.`);
+    }
   }catch(err){
     docSay(err.message,'err');
   }finally{

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -7,9 +7,15 @@ const fs      = require('fs');
 const os      = require('os');
 const { execSync, execFileSync } = require('child_process');
 const { createAccumulator } = require('./accumulator');
+const { createOpsHandler, loadOrCreateOpsToken } = require('./ops');
 const { PORT } = require('./port');
 const PUBLIC = path.join(__dirname, 'public');
 const CFG    = path.join(__dirname, 'config.json');
+
+// Minted before the first request is served: /ops refuses anything that does
+// not present it, and the panel receives it the same way it receives the port.
+const { token: OPS_TOKEN } = loadOrCreateOpsToken();
+const handleOps = createOpsHandler({ token: OPS_TOKEN, port: PORT });
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -149,6 +155,11 @@ const clients = new Set();
 
 // ── HTTP server ─────────────────────────────────────────────
 const server = http.createServer((req, res) => {
+  // ── POST /ops/<operation> ───────────────────────────────
+  // Answered first so it sets its own token-aware CORS headers instead of the
+  // permissive any-loopback-port ones the telemetry routes below carry.
+  if (handleOps(req, res)) return;
+
   const reqOrigin = req.headers.origin || '';
   res.setHeader('Access-Control-Allow-Origin',
     /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(reqOrigin) ? reqOrigin : `http://localhost:${PORT}`);
@@ -436,9 +447,12 @@ const grandTotal = Object.values(byIde).reduce(
     res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
     if (segment === '/index.html') {
       // Inject the configured port so the frontend WebSocket connects to the
-      // correct address regardless of what EGC_PORT is set to.
+      // correct address regardless of what EGC_PORT is set to, and the local
+      // ops token so the panel this server just served is the only client that
+      // can drive POST /ops.
       const html = fs.readFileSync(filePath, 'utf8')
-        .replace('</head>', `<script>window.__EGC_PORT=${PORT};</script></head>`);
+        .replace('</head>',
+          `<script>window.__EGC_PORT=${PORT};window.__EGC_OPS_TOKEN=${JSON.stringify(OPS_TOKEN)};</script></head>`);
       res.end(html);
     } else {
       res.end(fs.readFileSync(filePath));

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -14,7 +14,8 @@ const CFG    = path.join(__dirname, 'config.json');
 
 // Minted before the first request is served: /ops refuses anything that does
 // not present it, and the panel receives it the same way it receives the port.
-const { token: OPS_TOKEN } = loadOrCreateOpsToken();
+const OPS = loadOrCreateOpsToken();
+const OPS_TOKEN = OPS.token;
 const handleOps = createOpsHandler({ token: OPS_TOKEN, port: PORT });
 
 const MIME = {
@@ -444,6 +445,14 @@ const grandTotal = Object.values(byIde).reduce(
   }
   if (filePath && fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
     const ext = path.extname(filePath);
+    if (segment === '/index.html') {
+      // This is the one response that carries the ops token, so it does not
+      // get the permissive any-loopback-port header the rest of the routes
+      // share: another local web origin must not be able to read the token
+      // out of it. /ops would refuse that origin anyway, but the token has no
+      // reason to leave this one.
+      res.setHeader('Access-Control-Allow-Origin', `http://localhost:${PORT}`);
+    }
     res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
     if (segment === '/index.html') {
       // Inject the configured port so the frontend WebSocket connects to the
@@ -478,6 +487,10 @@ try {
 
 server.listen(PORT, '127.0.0.1', () => {
   console.log(`EGC Dashboard running at http://localhost:${PORT}`);
+  if (!OPS.persisted) {
+    console.error(`[EGC] Could not write ${OPS.tokenPath} (${OPS.error}).`);
+    console.error('[EGC] Doctor actions still work; the token is regenerated on each restart.');
+  }
 });
 
 server.on('error', err => {

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -152,7 +152,10 @@ function main() {
       projectRoot: process.cwd(),
       targets: options.targets,
     });
-    const hasIssues = report.summary.errorCount > 0 || report.summary.warningCount > 0;
+    // Warnings are informative: drift and version skew are worth reporting but
+    // do not mean the install is broken, and a warnings-only run is a healthy
+    // run. Exit 1 is reserved for real failures so scripts and CI can trust it.
+    const hasFailures = report.summary.errorCount > 0;
     const stateDb = checkStateDb(homeDir);
 
     if (options.json) {
@@ -199,7 +202,7 @@ function main() {
       }
     }
 
-    process.exitCode = hasIssues ? 1 : 0;
+    process.exitCode = hasFailures ? 1 : 0;
   } catch (error) {
     console.error(`Error: ${error.message}`);
     process.exit(1);

--- a/scripts/lib/operations/index.js
+++ b/scripts/lib/operations/index.js
@@ -10,11 +10,12 @@
  * Wraps (without rewriting):
  *   - doctor        → buildDoctorReport       (install-lifecycle.js)
  *   - install       → createInstallPlanFromRequest + applyInstallPlan
+ *   - repair        → repairInstalledStates    (install-lifecycle.js)
  *   - savingsLedger → aggregateBreakdown       (crusher/metrics.js)
  *   - state         → createStateStore + createQueryApi (state-store/)
  */
 
-const { buildDoctorReport }            = require('../install-lifecycle');
+const { buildDoctorReport, repairInstalledStates } = require('../install-lifecycle');
 const { createInstallPlanFromRequest }  = require('../install/runtime');
 const { readAll, aggregateBreakdown }  = require('../crusher/metrics');
 const { createStateStore }             = require('../state-store/index');
@@ -112,6 +113,35 @@ async function install(request, options) {
 }
 
 // ---------------------------------------------------------------------------
+// Operation: repair
+// ---------------------------------------------------------------------------
+
+/**
+ * Rebuild the EGC-managed files recorded in install-state.
+ *
+ * Same parameters `egc repair` passes through, so a caller that hands over
+ * `{ targets, dryRun }` gets the result the CLI would print.
+ *
+ * @param {object} [params]
+ * @param {string} [params.repoRoot]     - Reference repo to repair against
+ * @param {string} [params.homeDir]      - Override home directory
+ * @param {string} [params.projectRoot]  - Override project root path
+ * @param {string[]} [params.targets]    - Specific install targets to repair
+ * @param {boolean} [params.dryRun]      - Plan the repairs without writing them
+ * @returns {{ dryRun, results, summary }}
+ */
+function repair(params) {
+  const p = normalizeParams(params);
+  return repairInstalledStates({
+    repoRoot:    p.repoRoot,
+    homeDir:     p.homeDir,
+    projectRoot: p.projectRoot,
+    targets:     p.targets,
+    dryRun:      p.dryRun,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Operation: savingsLedger
 // ---------------------------------------------------------------------------
 
@@ -195,6 +225,7 @@ async function state(params) {
 const REGISTRY = [
   { name: 'doctor',        fn: doctor,        async: false },
   { name: 'install',       fn: install,       async: true  },
+  { name: 'repair',        fn: repair,        async: false },
   { name: 'savingsLedger', fn: savingsLedger, async: false },
   { name: 'state',         fn: state,         async: true  },
 ];
@@ -210,6 +241,7 @@ function listOperations() {
 module.exports = {
   doctor,
   install,
+  repair,
   savingsLedger,
   state,
   listOperations,

--- a/tests/dashboard-ops.test.js
+++ b/tests/dashboard-ops.test.js
@@ -293,7 +293,7 @@ test('installing a target over /ops writes the same install-state as the CLI pat
     // The same operation the CLI reaches, with the arguments install-apply.js
     // passes, run against a second scratch project.
     const request = normalizeInstallRequest({ target: 'cursor', profileId: 'minimal' });
-    const cli = operations.install(request, { projectRoot: cliProject, homeDir });
+    const cli = await operations.install(request, { projectRoot: cliProject, homeDir });
 
     const panelStatePath = res.payload.result.applied.installStatePath;
     const cliStatePath = cli.applied.installStatePath;

--- a/tests/dashboard-ops.test.js
+++ b/tests/dashboard-ops.test.js
@@ -1,0 +1,427 @@
+'use strict';
+
+/**
+ * Tests for the dashboard operations door (Fmarzochi/EGC#1236).
+ *
+ * Covers the token gate on POST /ops, the CORS restriction to the panel's own
+ * origin, a full operation round-trip over HTTP, and the concurrent-access
+ * behaviour of the shared ~/.egc/dashboard-token file.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Point HOME at a scratch directory before anything resolves it, so nothing
+// this file runs touches the real ~/.egc.
+const SANDBOX_HOME = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'egc-ops-home-')));
+process.env.HOME = SANDBOX_HOME;
+process.env.USERPROFILE = SANDBOX_HOME;
+
+const {
+  TOKEN_FILE_NAME,
+  TOKEN_HEADER,
+  createOpsHandler,
+  listOpsOperations,
+  loadOrCreateOpsToken,
+  resolveTokenPath,
+} = require('../dashboard/ops');
+
+const { normalizeInstallRequest } = require('../scripts/lib/install/request');
+const operations = require('../scripts/lib/operations/index');
+
+const SERVER_SOURCE = fs.readFileSync(
+  path.join(__dirname, '..', 'dashboard', 'server.js'),
+  'utf8'
+);
+
+function makeTempDir(prefix) {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+function removeDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * Start a server that answers nothing but /ops, so a request that the handler
+ * declines is visible as a 404 rather than silently succeeding.
+ */
+async function startOpsServer({ token, homeDir, projectRoot }) {
+  const server = http.createServer((req, res) => {
+    if (handler && handler(req, res)) return;
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end('{"ok":false,"error":"not an ops route"}');
+  });
+
+  let handler = null;
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  handler = createOpsHandler({ token, port, homeDir, projectRoot });
+
+  return {
+    port,
+    origin: `http://127.0.0.1:${port}`,
+    close: () => new Promise(resolve => server.close(resolve)),
+  };
+}
+
+async function postOps(server, operation, { token, body, origin, method } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (token !== undefined) headers[TOKEN_HEADER] = token;
+  if (origin !== undefined) headers.Origin = origin;
+
+  const res = await fetch(`${server.origin}/ops/${operation}`, {
+    method: method || 'POST',
+    headers,
+    body: method === 'OPTIONS' ? undefined : JSON.stringify(body || {}),
+  });
+
+  let payload;
+  try {
+    payload = await res.json();
+  } catch (_) {
+    payload = null;
+  }
+
+  return { status: res.status, payload, headers: res.headers };
+}
+
+/**
+ * An install-state file records absolute paths and two timestamps. Fold both
+ * away so two installs into different scratch directories can be compared
+ * byte for byte.
+ */
+function normalizeInstallState(raw, root) {
+  const escapedRoot = JSON.stringify(root).slice(1, -1);
+  return raw
+    .split(escapedRoot).join('<ROOT>')
+    .replace(/"installedAt": "[^"]*"/g, '"installedAt": "<TIMESTAMP>"')
+    .replace(/"lastValidatedAt": "[^"]*"/g, '"lastValidatedAt": "<TIMESTAMP>"');
+}
+
+// ---------------------------------------------------------------------------
+// Token gate
+// ---------------------------------------------------------------------------
+
+test('/ops without a token returns 401 and never runs the operation', async () => {
+  const server = await startOpsServer({ token: 'a'.repeat(64) });
+  try {
+    const res = await postOps(server, 'doctor');
+    assert.equal(res.status, 401);
+    assert.equal(res.payload.ok, false);
+    assert.match(res.payload.error, /token/i);
+  } finally {
+    await server.close();
+  }
+});
+
+test('/ops with the wrong token returns 401', async () => {
+  const server = await startOpsServer({ token: 'a'.repeat(64) });
+  try {
+    const res = await postOps(server, 'doctor', { token: 'b'.repeat(64) });
+    assert.equal(res.status, 401);
+  } finally {
+    await server.close();
+  }
+});
+
+test('/ops with a token of a different length returns 401 rather than throwing', async () => {
+  // crypto.timingSafeEqual throws on a length mismatch; the gate must answer.
+  const server = await startOpsServer({ token: 'a'.repeat(64) });
+  try {
+    const res = await postOps(server, 'doctor', { token: 'short' });
+    assert.equal(res.status, 401);
+  } finally {
+    await server.close();
+  }
+});
+
+test('/ops with the token returns 200 and the operation result', async () => {
+  const token = 'c'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await postOps(server, 'doctor', { token });
+    assert.equal(res.status, 200);
+    assert.equal(res.payload.ok, true);
+    assert.equal(res.payload.operation, 'doctor');
+    assert.ok(res.payload.result.summary, 'doctor result must carry a summary');
+    assert.ok(Array.isArray(res.payload.result.results));
+  } finally {
+    await server.close();
+  }
+});
+
+test('an unknown operation returns 404, and only after the token check', async () => {
+  const token = 'd'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    assert.equal((await postOps(server, 'rm-rf', { token })).status, 404);
+    // No token: the gate answers first, so an unknown name cannot be probed.
+    assert.equal((await postOps(server, 'rm-rf')).status, 401);
+  } finally {
+    await server.close();
+  }
+});
+
+test('a non-POST method on /ops is rejected', async () => {
+  const token = 'e'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await fetch(`${server.origin}/ops/doctor`, {
+      method: 'GET',
+      headers: { [TOKEN_HEADER]: token },
+    });
+    assert.equal(res.status, 405);
+  } finally {
+    await server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CORS
+// ---------------------------------------------------------------------------
+
+test('/ops rejects a foreign origin even when the token is correct', async () => {
+  const token = 'f'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await postOps(server, 'doctor', { token, origin: 'http://evil.example' });
+    assert.equal(res.status, 403);
+    assert.match(res.payload.error, /origin/i);
+  } finally {
+    await server.close();
+  }
+});
+
+test('/ops accepts the panel\'s own origin and advertises only that origin', async () => {
+  const token = '0'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await postOps(server, 'doctor', {
+      token,
+      origin: `http://127.0.0.1:${server.port}`,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get('access-control-allow-origin'),
+      `http://localhost:${server.port}`,
+      'the ops routes must not echo back an arbitrary loopback origin'
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test('/ops answers a preflight without requiring the token', async () => {
+  const server = await startOpsServer({ token: '1'.repeat(64) });
+  try {
+    const res = await fetch(`${server.origin}/ops/doctor`, { method: 'OPTIONS' });
+    assert.equal(res.status, 204);
+    assert.match(res.headers.get('access-control-allow-headers'), new RegExp(TOKEN_HEADER, 'i'));
+  } finally {
+    await server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Operation round-trip
+// ---------------------------------------------------------------------------
+
+test('installing a target over /ops writes the same install-state as the CLI path', async () => {
+  const token = '2'.repeat(64);
+  const panelProject = makeTempDir('egc-ops-panel-');
+  const cliProject = makeTempDir('egc-ops-cli-');
+  const homeDir = makeTempDir('egc-ops-install-home-');
+  const server = await startOpsServer({ token, homeDir, projectRoot: panelProject });
+
+  try {
+    const res = await postOps(server, 'install', {
+      token,
+      body: { target: 'cursor', profile: 'minimal' },
+    });
+
+    assert.equal(res.status, 200, `install failed: ${JSON.stringify(res.payload)}`);
+    assert.equal(res.payload.ok, true);
+    assert.ok(res.payload.result.plan, 'the result must carry the plan');
+    assert.ok(res.payload.result.applied, 'the result must carry what was applied');
+
+    // The same operation the CLI reaches, with the arguments install-apply.js
+    // passes, run against a second scratch project.
+    const request = normalizeInstallRequest({ target: 'cursor', profileId: 'minimal' });
+    const cli = operations.install(request, { projectRoot: cliProject, homeDir });
+
+    const panelStatePath = res.payload.result.applied.installStatePath;
+    const cliStatePath = cli.applied.installStatePath;
+    assert.ok(fs.existsSync(panelStatePath), 'the panel install must write an install-state file');
+    assert.ok(fs.existsSync(cliStatePath), 'the CLI install must write an install-state file');
+
+    assert.equal(
+      normalizeInstallState(fs.readFileSync(panelStatePath, 'utf8'), panelProject),
+      normalizeInstallState(fs.readFileSync(cliStatePath, 'utf8'), cliProject),
+      'the panel and the CLI must produce the same install-state modulo paths and timestamps'
+    );
+  } finally {
+    await server.close();
+    removeDir(panelProject);
+    removeDir(cliProject);
+    removeDir(homeDir);
+  }
+});
+
+test('doctor over /ops reports every install target adapter for the buttons', async () => {
+  const token = '3'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await postOps(server, 'doctor', { token });
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.payload.targets), 'doctor must carry the target catalog');
+    assert.ok(res.payload.targets.length > 0);
+    for (const entry of res.payload.targets) {
+      assert.equal(typeof entry.id, 'string');
+      assert.equal(typeof entry.target, 'string');
+      assert.equal(typeof entry.installed, 'boolean');
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('an install request with no profile or modules is a 400, not a 500', async () => {
+  const token = '4'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await postOps(server, 'install', { token, body: { target: 'cursor' } });
+    assert.equal(res.status, 400);
+    assert.equal(res.payload.ok, false);
+  } finally {
+    await server.close();
+  }
+});
+
+test('a malformed body is a 400', async () => {
+  const token = '5'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await fetch(`${server.origin}/ops/doctor`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', [TOKEN_HEADER]: token },
+      body: '{not json',
+    });
+    assert.equal(res.status, 400);
+  } finally {
+    await server.close();
+  }
+});
+
+test('the exposed operations all come from the shared registry', () => {
+  const registryNames = operations.listOperations();
+  for (const name of listOpsOperations()) {
+    assert.ok(
+      registryNames.includes(name),
+      `/ops/${name} must be backed by an operations-registry entry`
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Token file
+// ---------------------------------------------------------------------------
+
+test('loadOrCreateOpsToken creates ~/.egc/<token file> and reuses it', () => {
+  const homeDir = makeTempDir('egc-ops-token-');
+  try {
+    const first = loadOrCreateOpsToken({ homeDir });
+    assert.equal(first.tokenPath, path.join(homeDir, '.egc', TOKEN_FILE_NAME));
+    assert.match(first.token, /^[0-9a-f]{64}$/);
+    assert.ok(fs.existsSync(first.tokenPath));
+
+    const second = loadOrCreateOpsToken({ homeDir });
+    assert.equal(second.token, first.token, 'a restart must not invalidate a served panel');
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+test('the token file is not world-readable', { skip: process.platform === 'win32' }, () => {
+  const homeDir = makeTempDir('egc-ops-token-mode-');
+  try {
+    const { tokenPath } = loadOrCreateOpsToken({ homeDir });
+    assert.equal(fs.statSync(tokenPath).mode & 0o077, 0, 'the token must stay owner-only');
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+test('loadOrCreateOpsToken: concurrent start — the loser reads back the winner\'s token', () => {
+  // Two dashboards started close together can both observe the token file as
+  // absent before either writes. Simulate the loser's view: readFileSync sees
+  // nothing on the first look, but a winner has already written a real token
+  // by the time the loser's own write executes. Overwriting it would 401 every
+  // request from the panel the winner already served.
+  const homeDir = makeTempDir('egc-ops-token-race-');
+  const tokenPath = resolveTokenPath(homeDir);
+  try {
+    const winner = loadOrCreateOpsToken({ homeDir });
+
+    const origReadFileSync = fs.readFileSync;
+    let firstLook = true;
+    fs.readFileSync = (target, ...rest) => {
+      if (target === tokenPath && firstLook) {
+        firstLook = false;
+        const error = new Error('ENOENT: no such file or directory');
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return origReadFileSync(target, ...rest);
+    };
+
+    let loser;
+    try {
+      loser = loadOrCreateOpsToken({ homeDir });
+    } finally {
+      fs.readFileSync = origReadFileSync;
+    }
+
+    assert.equal(
+      loser.token,
+      winner.token,
+      'the loser must adopt the token that actually won the race on disk'
+    );
+    assert.equal(
+      origReadFileSync(tokenPath, 'utf8').trim(),
+      winner.token,
+      'the winner\'s token on disk must remain untouched'
+    );
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Server wiring
+// ---------------------------------------------------------------------------
+
+test('server.js mints the token before serving and hands it to the panel', () => {
+  assert.match(
+    SERVER_SOURCE,
+    /loadOrCreateOpsToken\(\)/,
+    'the token must be created at startup, not on first request'
+  );
+  assert.match(
+    SERVER_SOURCE,
+    /window\.__EGC_OPS_TOKEN=/,
+    'the token must be injected into index.html the way the port is'
+  );
+  assert.match(
+    SERVER_SOURCE,
+    /if \(handleOps\(req, res\)\) return;/,
+    '/ops must be answered before the permissive loopback CORS headers are set'
+  );
+});
+
+process.on('exit', () => removeDir(SANDBOX_HOME));

--- a/tests/dashboard-ops.test.js
+++ b/tests/dashboard-ops.test.js
@@ -14,6 +14,7 @@ const http = require('node:http');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 // Point HOME at a scratch directory before anything resolves it, so nothing
 // this file runs touches the real ~/.egc.
@@ -168,6 +169,44 @@ test('an unknown operation returns 404, and only after the token check', async (
   }
 });
 
+test('an inherited Object.prototype key is not dispatchable as an operation', async () => {
+  // CodeQL "Unvalidated dynamic method call": with an object-literal handler
+  // table, OPERATION_HANDLERS['constructor'] is a truthy function, so it
+  // passed the not-found check and was invoked - /ops/constructor answered 200
+  // and echoed the request body back, and /ops/__defineGetter__ threw out of
+  // the handler. Every one of these must be an ordinary 404.
+  const token = '6'.repeat(64);
+  const server = await startOpsServer({ token });
+  const inherited = [
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    '__defineGetter__',
+    '__proto__',
+    'isPrototypeOf',
+    'propertyIsEnumerable',
+  ];
+  try {
+    for (const name of inherited) {
+      const res = await postOps(server, name, { token, body: { targets: ['probe'] } });
+      assert.equal(res.status, 404, `/ops/${name} must be 404, got ${res.status}`);
+      assert.equal(res.payload.ok, false);
+      assert.equal(
+        res.payload.targets,
+        undefined,
+        `/ops/${name} must not reflect the request body back`
+      );
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('listOpsOperations reports only the explicitly registered operations', () => {
+  assert.deepEqual(listOpsOperations().sort(), ['doctor', 'install', 'repair']);
+});
+
 test('a non-POST method on /ops is rejected', async () => {
   const token = 'e'.repeat(64);
   const server = await startOpsServer({ token });
@@ -273,6 +312,127 @@ test('installing a target over /ops writes the same install-state as the CLI pat
   }
 });
 
+test('the panel install matches the real `egc install` CLI, not just the same library call', async () => {
+  // The parity check above builds its "CLI side" from normalizeInstallRequest,
+  // which is the panel's own path - it cannot catch the panel diverging from
+  // what scripts/install-apply.js actually does. Run the CLI for real.
+  const token = '7'.repeat(64);
+  const panelProject = makeTempDir('egc-ops-panel-cli-');
+  const cliProject = makeTempDir('egc-ops-cli-cli-');
+  const homeDir = makeTempDir('egc-ops-cli-home-');
+  const server = await startOpsServer({ token, homeDir, projectRoot: panelProject });
+
+  try {
+    const res = await postOps(server, 'install', {
+      token,
+      body: { target: 'cursor', profile: 'minimal' },
+    });
+    assert.equal(res.status, 200, `install failed: ${JSON.stringify(res.payload)}`);
+
+    const cli = spawnSync(
+      process.execPath,
+      [
+        path.join(__dirname, '..', 'scripts', 'install-apply.js'),
+        '--target', 'cursor', '--profile', 'minimal', '--json',
+      ],
+      {
+        cwd: cliProject,
+        encoding: 'utf8',
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir, EGC_INSTALL_DELEGATED: '1' },
+      }
+    );
+    assert.equal(cli.status, 0, `CLI install failed: ${cli.stderr}`);
+
+    const cliStatePath = JSON.parse(cli.stdout).result.installStatePath;
+    const panelStatePath = res.payload.result.applied.installStatePath;
+
+    assert.equal(
+      normalizeInstallState(fs.readFileSync(panelStatePath, 'utf8'), panelProject),
+      normalizeInstallState(fs.readFileSync(cliStatePath, 'utf8'), cliProject),
+      'the panel and `egc install --target cursor --profile minimal` must agree'
+    );
+  } finally {
+    await server.close();
+    removeDir(panelProject);
+    removeDir(cliProject);
+    removeDir(homeDir);
+  }
+});
+
+test('the panel install honours ./egc-install.json the way the CLI does', async () => {
+  // scripts/install-apply.js merges the default config into the request when
+  // no --config and no positional languages were given. A panel that ignored
+  // it would write a different install-state from the command beside the
+  // button in any project that ships one.
+  const token = '8'.repeat(64);
+  const projectRoot = makeTempDir('egc-ops-config-');
+  const homeDir = makeTempDir('egc-ops-config-home-');
+  fs.writeFileSync(
+    path.join(projectRoot, 'egc-install.json'),
+    `${JSON.stringify({ version: 1, target: 'cursor', profile: 'minimal' }, null, 2)}\n`
+  );
+  const server = await startOpsServer({ token, homeDir, projectRoot });
+
+  try {
+    // No target and no profile in the body: everything must come from the file.
+    const res = await postOps(server, 'install', { token, body: {} });
+    assert.equal(res.status, 200, `install failed: ${JSON.stringify(res.payload)}`);
+    assert.equal(res.payload.result.plan.target, 'cursor');
+    assert.equal(res.payload.result.plan.profileId, 'minimal');
+  } finally {
+    await server.close();
+    removeDir(projectRoot);
+    removeDir(homeDir);
+  }
+});
+
+test('an unknown target or profile is a 400 with a clear message, not a 500', async () => {
+  // The manifests look profiles up on a plain object, so an inherited name
+  // reaches "profile.modules is not iterable" rather than the "Unknown install
+  // profile" a caller can act on. Both are caught at the route boundary.
+  const token = 'a1'.repeat(32);
+  const server = await startOpsServer({ token });
+  try {
+    for (const profile of ['constructor', 'toString', '__proto__', 'not-a-profile']) {
+      const res = await postOps(server, 'install', { token, body: { target: 'cursor', profile } });
+      assert.equal(res.status, 400, `profile ${profile} must be a 400, got ${res.status}`);
+      assert.match(res.payload.error, /Unknown install profile/);
+    }
+    const badTarget = await postOps(server, 'install', {
+      token,
+      body: { target: 'nope', profile: 'minimal' },
+    });
+    assert.equal(badTarget.status, 400);
+    assert.match(badTarget.payload.error, /Unknown install target/);
+
+    const badDoctor = await postOps(server, 'doctor', { token, body: { targets: ['nope'] } });
+    assert.equal(badDoctor.status, 400);
+  } finally {
+    await server.close();
+  }
+});
+
+test('an oversized body is answered with 413, not a dropped connection', async () => {
+  // reject() only schedules the handler that writes the response, so
+  // destroying the request socket in the same tick would discard the 413
+  // before a byte of it went out and the caller would see a network error.
+  const token = '9'.repeat(64);
+  const server = await startOpsServer({ token });
+  try {
+    const res = await fetch(`${server.origin}/ops/doctor`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', [TOKEN_HEADER]: token },
+      body: JSON.stringify({ targets: ['x'.repeat(128 * 1024)] }),
+    });
+    assert.equal(res.status, 413);
+    const payload = await res.json();
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /too large/i);
+  } finally {
+    await server.close();
+  }
+});
+
 test('doctor over /ops reports every install target adapter for the buttons', async () => {
   const token = '3'.repeat(64);
   const server = await startOpsServer({ token });
@@ -347,11 +507,221 @@ test('loadOrCreateOpsToken creates ~/.egc/<token file> and reuses it', () => {
   }
 });
 
+test('an unwritable ~/.egc degrades to an in-memory token instead of killing the dashboard', () => {
+  // server.js resolves the token at module load, so throwing here would take
+  // the whole panel down. ~/.egc is root-owned on the global installs #1231,
+  // #1234 and #1239 exist to survive; the doctor screen is not worth that.
+  const homeDir = makeTempDir('egc-ops-token-readonly-');
+  const origMkdirSync = fs.mkdirSync;
+  fs.mkdirSync = () => {
+    const error = new Error('EACCES: permission denied');
+    error.code = 'EACCES';
+    throw error;
+  };
+
+  let result;
+  try {
+    result = loadOrCreateOpsToken({ homeDir });
+  } finally {
+    fs.mkdirSync = origMkdirSync;
+    removeDir(homeDir);
+  }
+
+  assert.equal(result.persisted, false, 'the failure must be reported, not hidden');
+  assert.match(result.token, /^[0-9a-f]{64}$/, 'the session still gets a usable token');
+  assert.match(result.error, /EACCES/);
+});
+
+test('a token that could not be persisted still gates /ops normally', async () => {
+  const homeDir = makeTempDir('egc-ops-token-readonly-gate-');
+  const origMkdirSync = fs.mkdirSync;
+  fs.mkdirSync = () => {
+    const error = new Error('EACCES: permission denied');
+    error.code = 'EACCES';
+    throw error;
+  };
+  let token;
+  try {
+    token = loadOrCreateOpsToken({ homeDir }).token;
+  } finally {
+    fs.mkdirSync = origMkdirSync;
+  }
+
+  const server = await startOpsServer({ token });
+  try {
+    assert.equal((await postOps(server, 'doctor')).status, 401);
+    assert.equal((await postOps(server, 'doctor', { token })).status, 200);
+  } finally {
+    await server.close();
+    removeDir(homeDir);
+  }
+});
+
 test('the token file is not world-readable', { skip: process.platform === 'win32' }, () => {
   const homeDir = makeTempDir('egc-ops-token-mode-');
   try {
     const { tokenPath } = loadOrCreateOpsToken({ homeDir });
     assert.equal(fs.statSync(tokenPath).mode & 0o077, 0, 'the token must stay owner-only');
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+test('loadOrCreateOpsToken: concurrent start — the loser waits out a winner that has created but not yet written', () => {
+  // The window the retry loop exists for: the winner has done openSync(wx) so
+  // the file exists, but has not written the token into it yet. The loser must
+  // spin until the token appears rather than take the file's emptiness as
+  // permission to replace it.
+  const homeDir = makeTempDir('egc-ops-token-midwrite-');
+  const tokenPath = resolveTokenPath(homeDir);
+  const winnerToken = 'd'.repeat(64);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  fs.writeFileSync(tokenPath, '');
+
+  const origReadFileSync = fs.readFileSync;
+  let looks = 0;
+  fs.readFileSync = (target, ...rest) => {
+    if (target === tokenPath) {
+      looks += 1;
+      // Empty for the first few looks, then the winner's write lands.
+      if (looks >= 4) return `${winnerToken}\n`;
+      return '';
+    }
+    return origReadFileSync(target, ...rest);
+  };
+
+  let result;
+  try {
+    result = loadOrCreateOpsToken({ homeDir });
+  } finally {
+    fs.readFileSync = origReadFileSync;
+    removeDir(homeDir);
+  }
+
+  assert.ok(looks >= 4, `the loser must re-read while the file is empty (looked ${looks} times)`);
+  assert.equal(result.token, winnerToken, 'the loser must adopt the winner\'s token');
+  assert.equal(result.persisted, true);
+});
+
+test('loadOrCreateOpsToken: a winner mid-write is never overwritten, even after the retries run out', () => {
+  // If the token never appears within the budget, the empty file is still a
+  // live writer's. Overwriting it would race a write that is still coming, so
+  // this process must degrade to an in-memory token instead.
+  const homeDir = makeTempDir('egc-ops-token-stalled-');
+  const tokenPath = resolveTokenPath(homeDir);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  fs.writeFileSync(tokenPath, '');
+
+  let result;
+  try {
+    result = loadOrCreateOpsToken({ homeDir });
+    assert.equal(result.persisted, false, 'a stalled winner must not be clobbered');
+    assert.match(result.token, /^[0-9a-f]{64}$/, 'this process still gets a usable token');
+    assert.equal(
+      fs.readFileSync(tokenPath, 'utf8'),
+      '',
+      'the winner\'s file must be left exactly as it was'
+    );
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+test('loadOrCreateOpsToken: an abandoned empty token file is replaced, not honoured forever', () => {
+  // The other side of the previous test: nobody is coming back for this one,
+  // so refusing to write would leave every future start degraded.
+  const homeDir = makeTempDir('egc-ops-token-abandoned-');
+  const tokenPath = resolveTokenPath(homeDir);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  fs.writeFileSync(tokenPath, '');
+  const longAgo = new Date(Date.now() - 60_000);
+  fs.utimesSync(tokenPath, longAgo, longAgo);
+
+  try {
+    const result = loadOrCreateOpsToken({ homeDir });
+    assert.equal(result.persisted, true);
+    assert.equal(fs.readFileSync(tokenPath, 'utf8').trim(), result.token);
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+test('loadOrCreateOpsToken: a truncated token is not accepted as a whole one', () => {
+  const homeDir = makeTempDir('egc-ops-token-truncated-');
+  const tokenPath = resolveTokenPath(homeDir);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  // A short write leaves a syntactically plausible prefix behind.
+  fs.writeFileSync(tokenPath, `${'a'.repeat(40)}\n`);
+  const longAgo = new Date(Date.now() - 60_000);
+  fs.utimesSync(tokenPath, longAgo, longAgo);
+
+  try {
+    const { token } = loadOrCreateOpsToken({ homeDir });
+    assert.notEqual(token, 'a'.repeat(40), 'a 40-character prefix is not a token');
+    assert.match(token, /^[0-9a-f]{64}$/);
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+test('loadOrCreateOpsToken: an unreadable token file is not treated as absent', () => {
+  // A present-but-unreadable file holds somebody else's live token. Reading it
+  // as "missing" would lead straight to replacing it.
+  const homeDir = makeTempDir('egc-ops-token-unreadable-');
+  const tokenPath = resolveTokenPath(homeDir);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  const owner = 'e'.repeat(64);
+  fs.writeFileSync(tokenPath, `${owner}\n`);
+
+  const origReadFileSync = fs.readFileSync;
+  fs.readFileSync = (target, ...rest) => {
+    if (target === tokenPath) {
+      const error = new Error('EACCES: permission denied');
+      error.code = 'EACCES';
+      throw error;
+    }
+    return origReadFileSync(target, ...rest);
+  };
+
+  let result;
+  try {
+    result = loadOrCreateOpsToken({ homeDir });
+  } finally {
+    fs.readFileSync = origReadFileSync;
+  }
+
+  try {
+    assert.equal(result.persisted, false, 'an unreadable file must not be replaced');
+    assert.match(result.error, /EACCES/);
+    assert.equal(
+      origReadFileSync(tokenPath, 'utf8').trim(),
+      owner,
+      'the existing token must survive untouched'
+    );
+  } finally {
+    removeDir(homeDir);
+  }
+});
+
+test('loadOrCreateOpsToken: replacing a corrupt file does not leave it world-readable', { skip: process.platform === 'win32' }, () => {
+  // fs.writeFileSync's mode option is honoured only when open() creates the
+  // file, so replacing a pre-existing 0644 file would otherwise write the live
+  // token into it and leave the permission alone.
+  const homeDir = makeTempDir('egc-ops-token-widemode-');
+  const tokenPath = resolveTokenPath(homeDir);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  fs.writeFileSync(tokenPath, 'not-a-token\n');
+  fs.chmodSync(tokenPath, 0o644);
+
+  try {
+    const { token, persisted } = loadOrCreateOpsToken({ homeDir });
+    assert.equal(persisted, true);
+    assert.equal(fs.readFileSync(tokenPath, 'utf8').trim(), token);
+    assert.equal(
+      fs.statSync(tokenPath).mode & 0o077,
+      0,
+      'the replaced token file must not stay group/world readable'
+    );
   } finally {
     removeDir(homeDir);
   }
@@ -407,19 +777,26 @@ test('loadOrCreateOpsToken: concurrent start — the loser reads back the winner
 // ---------------------------------------------------------------------------
 
 test('server.js mints the token before serving and hands it to the panel', () => {
+  // Whitespace-tolerant on purpose: these assert that the wiring exists, not
+  // how it is formatted, so a Prettier run cannot fail them.
   assert.match(
     SERVER_SOURCE,
-    /loadOrCreateOpsToken\(\)/,
+    /loadOrCreateOpsToken\s*\(/,
     'the token must be created at startup, not on first request'
   );
   assert.match(
     SERVER_SOURCE,
-    /window\.__EGC_OPS_TOKEN=/,
+    /window\.__EGC_OPS_TOKEN\s*=/,
     'the token must be injected into index.html the way the port is'
   );
-  assert.match(
-    SERVER_SOURCE,
-    /if \(handleOps\(req, res\)\) return;/,
+  // The /ops dispatch has to come before the permissive any-loopback-port CORS
+  // header is set, so position is the thing worth asserting, not the spelling.
+  const opsAt  = SERVER_SOURCE.search(/handleOps\s*\(\s*req\s*,\s*res\s*\)/);
+  const corsAt = SERVER_SOURCE.search(/Access-Control-Allow-Origin/);
+  assert.ok(opsAt !== -1, 'server.js must dispatch /ops');
+  assert.ok(corsAt !== -1, 'server.js must still set the telemetry CORS header');
+  assert.ok(
+    opsAt < corsAt,
     '/ops must be answered before the permissive loopback CORS headers are set'
   );
 });

--- a/tests/dashboard-ops.test.js
+++ b/tests/dashboard-ops.test.js
@@ -32,6 +32,7 @@ const {
 } = require('../dashboard/ops');
 
 const { normalizeInstallRequest } = require('../scripts/lib/install/request');
+const { getInstallTargetAdapter } = require('../scripts/lib/install-targets/registry');
 const operations = require('../scripts/lib/operations/index');
 
 const SERVER_SOURCE = fs.readFileSync(
@@ -341,9 +342,17 @@ test('the panel install matches the real `egc install` CLI, not just the same li
         env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir, EGC_INSTALL_DELEGATED: '1' },
       }
     );
-    assert.equal(cli.status, 0, `CLI install failed: ${cli.stderr}`);
+    assert.equal(cli.status, 0, `CLI install failed: ${cli.stderr}\n${cli.stdout}`);
 
-    const cliStatePath = JSON.parse(cli.stdout).result.installStatePath;
+    // Ask the adapter where the install-state lands rather than parsing the
+    // CLI's stdout: install-apply.js runs regenerateTopologyCache() before it
+    // prints, and scripts/runtime/discovery.js logs to stdout when it
+    // succeeds, so the JSON is not reliably the only thing on that stream.
+    const cliStatePath = getInstallTargetAdapter('cursor').getInstallStatePath({
+      repoRoot:    path.join(__dirname, '..'),
+      projectRoot: cliProject,
+      homeDir,
+    });
     const panelStatePath = res.payload.result.applied.installStatePath;
 
     assert.equal(

--- a/tests/dashboard-ops.test.js
+++ b/tests/dashboard-ops.test.js
@@ -208,6 +208,27 @@ test('listOpsOperations reports only the explicitly registered operations', () =
   assert.deepEqual(listOpsOperations().sort(), ['doctor', 'install', 'repair']);
 });
 
+test('every registered operation actually dispatches to something callable', async () => {
+  // The other side of the `typeof handler !== 'function'` guard: that check
+  // turns a non-function in the table into a 404, so a name that silently
+  // stopped being callable would look exactly like a name that was never
+  // registered. Asserting each registered name does NOT 404 catches that.
+  const token = 'b2'.repeat(32);
+  const server = await startOpsServer({ token });
+  try {
+    for (const name of listOpsOperations()) {
+      const res = await postOps(server, name, { token, body: {} });
+      assert.notEqual(
+        res.status,
+        404,
+        `/ops/${name} is registered but did not dispatch (got 404)`
+      );
+    }
+  } finally {
+    await server.close();
+  }
+});
+
 test('a non-POST method on /ops is rejected', async () => {
   const token = 'e'.repeat(64);
   const server = await startOpsServer({ token });

--- a/tests/dashboard-ops.test.js
+++ b/tests/dashboard-ops.test.js
@@ -214,9 +214,22 @@ test('every registered operation actually dispatches to something callable', asy
   // stopped being callable would look exactly like a name that was never
   // registered. Asserting each registered name does NOT 404 catches that.
   const token = 'b2'.repeat(32);
-  const server = await startOpsServer({ token });
+  // Scratch home AND project, like every other round-trip test here. Inheriting
+  // process.cwd() as the project root is safe only by accident today: runInstall
+  // reads ./egc-install.json from it before normalizeInstallRequest can reject
+  // an empty body, so the day this repo grows one at its root this test would
+  // start installing into the checkout of whoever runs it.
+  const homeDir = makeTempDir('egc-ops-dispatch-home-');
+  const projectRoot = makeTempDir('egc-ops-dispatch-project-');
+  const server = await startOpsServer({ token, homeDir, projectRoot });
+
+  // Materialised once and asserted non-empty, so this cannot pass vacuously if
+  // the registry ever came back empty.
+  const operations = listOpsOperations();
+  assert.ok(operations.length > 0, 'the registry must expose at least one operation');
+
   try {
-    for (const name of listOpsOperations()) {
+    for (const name of operations) {
       const res = await postOps(server, name, { token, body: {} });
       assert.notEqual(
         res.status,
@@ -226,6 +239,8 @@ test('every registered operation actually dispatches to something callable', asy
     }
   } finally {
     await server.close();
+    removeDir(projectRoot);
+    removeDir(homeDir);
   }
 });
 
@@ -483,13 +498,22 @@ test('doctor over /ops reports every install target adapter for the buttons', as
 
 test('an install request with no profile or modules is a 400, not a 500', async () => {
   const token = '4'.repeat(64);
-  const server = await startOpsServer({ token });
+  // Isolated for the same reason as the dispatch test: a known target with no
+  // profile clears both boundary checks, so runInstall reaches
+  // loadDefaultInstallConfig(projectRoot). Against the checkout, an
+  // egc-install.json at the repo root would supply the missing profile and turn
+  // this into a real install before the assertion could fail.
+  const homeDir = makeTempDir('egc-ops-noselection-home-');
+  const projectRoot = makeTempDir('egc-ops-noselection-project-');
+  const server = await startOpsServer({ token, homeDir, projectRoot });
   try {
     const res = await postOps(server, 'install', { token, body: { target: 'cursor' } });
     assert.equal(res.status, 400);
     assert.equal(res.payload.ok, false);
   } finally {
     await server.close();
+    removeDir(projectRoot);
+    removeDir(homeDir);
   }
 });
 

--- a/tests/lib/operations-registry.test.js
+++ b/tests/lib/operations-registry.test.js
@@ -84,7 +84,7 @@ async function main() {
 
   await run('listOperations() returns all expected operations', () => {
     const names = listOperations();
-    for (const expected of ['doctor', 'install', 'savingsLedger', 'state']) {
+    for (const expected of ['doctor', 'install', 'repair', 'savingsLedger', 'state']) {
       assert.ok(names.includes(expected),
         `Expected operation "${expected}" missing. Got: ${names.join(', ')}`);
     }

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -379,7 +379,9 @@ function runTests() {
 
       const result = run(['--target', 'egc', '--repo-root', altRepoRoot, '--json'], { cwd: projectRoot, homeDir });
       const parsed = JSON.parse(result.stdout);
-      assert.strictEqual(result.code, 1);
+      // Drift is a warning, and warnings are informative: the exit code stays
+      // 0. What this test guards is that the drift is still *reported*.
+      assert.strictEqual(result.code, 0, result.stderr);
       assert.ok(
         parsed.results[0].issues.some(issue => issue.code === 'drifted-managed-files'),
         'a real content edit must still be reported as drift, CRLF normalization must not mask it'
@@ -452,6 +454,71 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('a warnings-only run exits 0, an error exits 1 (warnings are informative)', () => {
+    // Product decision: drift and version skew are worth reporting but do not
+    // mean the install is broken. Exit 1 is reserved for real failures so a
+    // script or CI job can branch on it. Both directions are asserted here so
+    // neither half can regress on its own.
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const targetRoot = path.join(homeDir, '.gemini');
+      const statePath = path.join(targetRoot, 'egc', 'install-state.json');
+      const managedFile = path.join(targetRoot, 'rules', 'common', 'coding-style.md');
+      fs.mkdirSync(path.dirname(managedFile), { recursive: true });
+      fs.writeFileSync(managedFile, 'DRIFTED CONTENT, does not match the repo file\n');
+
+      writeState(statePath, {
+        adapter: { id: 'egc-home', target: 'egc', kind: 'home' },
+        targetRoot,
+        installStatePath: statePath,
+        request: {
+          profile: null,
+          modules: [],
+          legacyLanguages: ['typescript'],
+          legacyMode: true,
+        },
+        resolution: {
+          selectedModules: ['legacy-egc-rules'],
+          skippedModules: [],
+        },
+        operations: [
+          {
+            kind: 'copy-file',
+            moduleId: 'legacy-egc-rules',
+            sourceRelativePath: 'rules/common/coding-style.md',
+            destinationPath: managedFile,
+            strategy: 'preserve-relative-path',
+            ownership: 'managed',
+            scaffoldOnly: false,
+          },
+        ],
+        source: {
+          repoVersion: CURRENT_PACKAGE_VERSION,
+          repoCommit: 'abc123',
+          manifestVersion: CURRENT_MANIFEST_VERSION,
+        },
+      });
+
+      const warned = run(['--target', 'egc', '--json'], { cwd: projectRoot, homeDir });
+      const warnedReport = JSON.parse(warned.stdout);
+      assert.ok(warnedReport.summary.warningCount > 0, 'the fixture must produce a warning');
+      assert.strictEqual(warnedReport.summary.errorCount, 0, 'and no error');
+      assert.strictEqual(warned.code, 0, `a warnings-only run must exit 0: ${warned.stderr}`);
+
+      // Same install, managed file removed: that is a real failure.
+      fs.rmSync(managedFile, { force: true });
+      const failed = run(['--target', 'egc', '--json'], { cwd: projectRoot, homeDir });
+      const failedReport = JSON.parse(failed.stdout);
+      assert.ok(failedReport.summary.errorCount > 0, 'a missing managed file must be an error');
+      assert.strictEqual(failed.code, 1, 'a run with errors must still exit 1');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('reports a drifted install as WARNING with issue detail in human-readable output', () => {
     const homeDir = createTempDir('doctor-home-');
     const projectRoot = createTempDir('doctor-project-');
@@ -496,7 +563,9 @@ function runTests() {
       });
 
       const result = run(['--target', 'egc'], { cwd: projectRoot, homeDir });
-      assert.strictEqual(result.code, 1, result.stderr);
+      // Warnings are informative, so a warnings-only run exits 0: exit 1 is
+      // reserved for real failures.
+      assert.strictEqual(result.code, 0, result.stderr);
       assert.ok(result.stdout.includes('Status: WARNING'));
       assert.ok(result.stdout.includes('[warning] drifted-managed-files'));
     } finally {

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -108,7 +108,9 @@ function runTests() {
         cwd: projectRoot,
         homeDir,
       });
-      assert.strictEqual(doctorBefore.code, 1);
+      // Drift is a warning, and a warnings-only doctor run exits 0. What
+      // matters here is that the drift is reported, asserted next.
+      assert.strictEqual(doctorBefore.code, 0, doctorBefore.stderr);
       assert.ok(JSON.parse(doctorBefore.stdout).results[0].issues.some(issue => issue.code === 'drifted-managed-files'));
 
       const repairResult = runNode(REPAIR_SCRIPT, ['--target', 'cursor', '--json'], {
@@ -298,7 +300,9 @@ function runTests() {
         cwd: projectRoot,
         homeDir,
       });
-      assert.strictEqual(doctorBefore.code, 1);
+      // Drift is a warning, and a warnings-only doctor run exits 0. What
+      // matters here is that the drift is reported, asserted next.
+      assert.strictEqual(doctorBefore.code, 0, doctorBefore.stderr);
       assert.ok(JSON.parse(doctorBefore.stdout).results[0].issues.some(issue => issue.code === 'drifted-managed-files'));
 
       const installedAtBefore = JSON.parse(fs.readFileSync(statePath, 'utf8')).installedAt;


### PR DESCRIPTION
## Summary

Makes the doctor screen operable. Every fixable item is a button that executes the
same operation as the equivalent CLI command, with that command displayed next to it.

Closes #1236.

> **Draft — stacked on #1240.** This slice needs the operations library from #1235,
> which is not on `main` yet, so this branch is built on top of `Maqbool61:feat/operations-library-1235`
> as suggested in the issue. The first three commits are that PR's. I will rebase onto
> `main` and leave only my commit once #1240 merges.

## Component Type

Core Engine / Orchestrator.

## Changes

**`POST /ops/<operation>` (`dashboard/ops.js`, new)** — dispatches to the slice 1 registry.
`doctor`, `install`, and `repair` are exposed; `savingsLedger` and `state` stay CLI-only
until a screen needs them. Envelope is `{ ok, operation, result }`.

**Local token auth, from the first route.** The server mints a 256-bit token at
`~/.egc/dashboard-token` (mode 0600) on startup and injects it into `index.html` the same
way the port already is. `/ops` answers 401 without it; comparison is `timingSafeEqual`,
guarded against the length-mismatch throw. The gate runs before operation lookup, so an
unauthenticated caller cannot even probe which operations exist. CORS on `/ops` is pinned
to the panel's own origin instead of the permissive any-loopback-port header the telemetry
routes carry; a foreign `Origin` is 403. The `127.0.0.1` bind is unchanged.

**Doctor screen (`dashboard/public/index.html`).** Renders `buildDoctorReport` results with
a Repair button per unhealthy target and an Install button per target that has no
install-state, each beside its copy-pasteable command (`egc repair --target <x>`,
`egc install --target <x> --profile full`). Buttons are grouped by target rather than by
adapter, because `egc install --target <x>` resolves to a single adapter — so a target with
both a home and a project adapter still shows exactly one correct command.

**`repair` added to the operations registry.** The screen needs it and the registry is the
single door; it wraps `repairInstalledStates` with the parameters `egc repair` passes. The
existing parity test uses inclusion checks and passes unchanged.

**Install targets come from `scripts/lib/install-targets/registry.js`** (31 adapters).
`buildDoctorReport` only reports install-states that exist, so on a fresh machine — the
state #1242 just made read as healthy — the report is empty and the adapter registry is
what makes the install buttons possible.

## Validation

Acceptance criteria:

- **Panel install == CLI install.** A test installs `--target cursor --profile minimal` over
  HTTP and again through the `normalizeInstallRequest` → `operations.install` path
  `scripts/install-apply.js` uses, into two scratch projects, then asserts the two
  install-state files are equal after folding away paths and the two timestamps.
  `sourceRoot` is deliberately left to its default so both resolve against the same
  reference repo.
- **401 without the token, 200 with it** — covered, plus wrong token, short token,
  non-POST, unknown operation, foreign origin, and preflight.
- **The displayed command is correct** — one row per target, so the command always names a
  target the CLI resolves.
- **Full suite green** — `node tests/run-all.js` reports the same 12 failures before and
  after this change (`diff` of failure lines is empty). They are Windows-environment
  issues (POSIX `0600` modes, `/etc/...` paths, `$HOME` vs `USERPROFILE`) in
  `egc-guardian-bypass-hardening`, `egc-memory-encryption`, and `egc-memory-integrity` —
  files this PR does not touch. On the CI Linux matrix they are expected to pass.

Concurrent-access test included, as CONTRIBUTING requires: `~/.egc/dashboard-token` is
shared across EGC processes, so two dashboards starting together can both see it as absent.
The write uses the `wx` flag and the loser reads back the winner's token — overwriting it
would silently 401 every request from the panel the winner already served. The test follows
the `loadOrCreateEncKey` TOCTOU pattern in `tests/egc-memory-encryption.test.js`.

Cross-platform: no platform-specific paths; the `0600` assertion skips on Windows, where
POSIX modes are not implemented.

No dependencies added — `dashboard/ops.js` uses Node built-ins plus existing in-repo
modules. `npm audit --audit-level=high`: 0 vulnerabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Doctor screen operable with Install/Repair buttons that run the same operations as the CLI, with the exact CLI command shown beside each action. Adds a locked `/ops` endpoint with a local token and strict CORS, and treats warnings‑only doctor runs as healthy.

- **New Features**
  - `POST /ops/<operation>` dispatches via a Map to the shared registry (`doctor`, `install`, `repair`) and returns `{ ok, operation, result [, targets] }`. `install` is awaited so responses include the plan, install‑state path, and warnings; `doctor` also returns a target catalog so install buttons show on fresh machines.
  - Local token at `~/.egc/dashboard-token`, injected only into `index.html`. `/ops` is pinned to the panel’s origin, answers preflight without the token, and is served before permissive telemetry CORS.
  - CLI parity: Install merges `./egc-install.json` by default and configures the commit‑privacy git filter; Repair reinstalls plugins from the lock file. The UI shows the exact CLI command, and the doctor headline reads “healthy” (or “healthy, with warnings”).

- **Bug Fixes**
  - Dispatch hardening: inherited names no longer resolve; unknown ops return 404; function‑type guard on handler call (CodeQL‑safe).
  - Input validation: target/profile names are checked at the edge and return 400 when unknown.
  - Async handling: `install` is awaited so results aren’t empty.
  - Token/request handling: only `ENOENT` means “absent”; truncated tokens are rejected; replacements force `0600`; concurrent creators are race‑safe; unwritable `~/.egc` degrades to an in‑memory token; strict origin checks; oversized bodies return 413; OPTIONS answered without requiring the token; `index.html` carries the token with tight CORS.
  - Doctor UX: refresh preserves busy state and errors, surfaces install warnings, reports unrepairable/missing states, and suggests reload on 401.

<sup>Written for commit 630f18c14462519d1c3fcd342cf23efc09342c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized operations interface with repair workflows, state management, operation discovery, and request validation.
  * Improved dashboard operation handling, including authentication, configuration support, and safer request processing.

* **Bug Fixes**
  * Doctor checks now succeed for warnings-only results while still failing for errors.
  * Improved install warning reporting, malformed request handling, and state cleanup.

* **Tests**
  * Expanded coverage for dashboard operations, authentication, validation, repair workflows, configuration handling, and startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->