### PR TITLE
fix(crusher): bridge the harness session id to the ledger via a SessionStart marker

### DIFF
--- a/scripts/lib/crusher/metrics.js
+++ b/scripts/lib/crusher/metrics.js
@@ -48,11 +48,23 @@ function normalizeEntry(entry) {
 /** Resolve the attribution available to a Crusher child process. */
 function resolveMetricContext({ cwd = process.cwd(), env = process.env } = {}) {
   const project = env.EGC_PROJECT_ROOT || env.EGC_PROJECT_DIR || env.PROJECT_ROOT || cwd;
-  const session = env.EGC_SESSION_ID || env.ECC_SESSION_ID;
+  // The environment only carries a session id under a wrapper-launched host
+  // (e.g. the Gemini CLI). Hooks cannot export variables into the harness's
+  // Bash environment, so everywhere else the SessionStart-written marker file
+  // is the bridge; env always wins when both exist.
+  const session = env.EGC_SESSION_ID || env.ECC_SESSION_ID || readSessionMarker();
   return {
     project: normalizeProject(project),
     session: normalizeScope(session),
   };
+}
+
+function readSessionMarker() {
+  try {
+    return require('./session-marker').readMarkerSession();
+  } catch { // NOSONAR: attribution is best-effort; a missing marker lib means no fallback
+    return null;
+  }
 }
 
 /** Append one best-effort ledger row without ever breaking the wrapped command. */

--- a/scripts/lib/crusher/session-marker.js
+++ b/scripts/lib/crusher/session-marker.js
@@ -25,6 +25,9 @@ const path = require('node:path');
 
 const SESSION_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+// Filesystem mtime granularity can land a fresh write fractionally ahead of
+// Date.now(); a marker is only "from the future" past this slack.
+const FUTURE_SKEW_MS = 60 * 1000;
 
 function markerFilePath() {
   return process.env.EGC_SESSION_MARKER_FILE
@@ -53,16 +56,28 @@ function writeMarker(sessionId, { source } = {}) {
   }
 }
 
-/** Return the fresh marker session id, or null when absent, stale or invalid. */
+/**
+ * Return the fresh marker session id, or null when absent, stale or invalid.
+ *
+ * Freshness is measured from the file's mtime, not from startedAt: every
+ * successful read touches the file, so a session that keeps recording ledger
+ * entries keeps its own marker fresh past the window, while a marker nobody
+ * uses ages out. startedAt stays in the body as the informational session
+ * start. A stale or invalid marker is never touched.
+ */
 function readMarkerSession({ maxAgeMs = DEFAULT_MAX_AGE_MS, now = Date.now() } = {}) {
   try {
-    const raw = fs.readFileSync(markerFilePath(), 'utf8');
-    const row = JSON.parse(raw);
+    const file = markerFilePath();
+    const mtimeMs = fs.statSync(file).mtimeMs;
+    const age = now - mtimeMs;
+    if (age < -FUTURE_SKEW_MS || age > maxAgeMs) return null;
+    const row = JSON.parse(fs.readFileSync(file, 'utf8'));
     if (typeof row?.session !== 'string' || !SESSION_ID_RE.test(row.session)) return null;
-    const startedAt = Date.parse(row.startedAt);
-    if (!Number.isFinite(startedAt)) return null;
-    const age = now - startedAt;
-    if (age < 0 || age > maxAgeMs) return null;
+    try {
+      fs.utimesSync(file, new Date(now), new Date(now));
+    } catch { // NOSONAR: refreshing is best-effort; a read-only marker still resolves
+      // stale-out will eventually apply; resolution still works this call
+    }
     return row.session;
   } catch { // NOSONAR: no marker (or an unreadable one) simply means no fallback
     return null;

--- a/scripts/lib/crusher/session-marker.js
+++ b/scripts/lib/crusher/session-marker.js
@@ -25,6 +25,11 @@ const path = require('node:path');
 
 const SESSION_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+// Hard cap measured from startedAt: readers touch the file to keep a live
+// session's attribution alive past the idle window, but any reader can touch
+// (record() from strays, a plain egc gain), so without this cap a dead
+// session's marker could be kept alive indefinitely by machine-wide activity.
+const DEFAULT_MAX_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000;
 // Filesystem mtime granularity can land a fresh write fractionally ahead of
 // Date.now(); a marker is only "from the future" past this slack.
 const FUTURE_SKEW_MS = 60 * 1000;
@@ -59,13 +64,16 @@ function writeMarker(sessionId, { source } = {}) {
 /**
  * Return the fresh marker session id, or null when absent, stale or invalid.
  *
- * Freshness is measured from the file's mtime, not from startedAt: every
- * successful read touches the file, so a session that keeps recording ledger
- * entries keeps its own marker fresh past the window, while a marker nobody
- * uses ages out. startedAt stays in the body as the informational session
- * start. A stale or invalid marker is never touched.
+ * Two clocks bound the fallback. The idle window reads from the file's
+ * mtime: every successful read touches the file, so a session that keeps
+ * recording ledger entries keeps its own marker fresh past the window, while
+ * a marker nobody uses ages out. The lifetime cap reads from startedAt: any
+ * reader can touch the file (strays, a plain egc gain), so idle refresh alone
+ * would let machine-wide activity keep a dead session's marker alive forever;
+ * past the cap the marker expires no matter how recently it was touched. A
+ * stale or invalid marker is never touched.
  */
-function readMarkerSession({ maxAgeMs = DEFAULT_MAX_AGE_MS, now = Date.now() } = {}) {
+function readMarkerSession({ maxAgeMs = DEFAULT_MAX_AGE_MS, maxLifetimeMs = DEFAULT_MAX_LIFETIME_MS, now = Date.now() } = {}) {
   try {
     const file = markerFilePath();
     const mtimeMs = fs.statSync(file).mtimeMs;
@@ -73,6 +81,8 @@ function readMarkerSession({ maxAgeMs = DEFAULT_MAX_AGE_MS, now = Date.now() } =
     if (age < -FUTURE_SKEW_MS || age > maxAgeMs) return null;
     const row = JSON.parse(fs.readFileSync(file, 'utf8'));
     if (typeof row?.session !== 'string' || !SESSION_ID_RE.test(row.session)) return null;
+    const startedAt = Date.parse(row.startedAt);
+    if (!Number.isFinite(startedAt) || now - startedAt > maxLifetimeMs) return null;
     try {
       fs.utimesSync(file, new Date(now), new Date(now));
     } catch { // NOSONAR: refreshing is best-effort; a read-only marker still resolves

--- a/scripts/lib/crusher/session-marker.js
+++ b/scripts/lib/crusher/session-marker.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// Session marker: bridges the harness session id into Crusher child processes.
+//
+// Hooks receive `session_id` in their JSON payload, but a hook process cannot
+// export environment variables into the harness's future Bash commands, and
+// the PreToolUse rewrite is ignored for assistant-issued calls (the same
+// confirmed limitation rules/common/memory.md documents). The result was a
+// ledger where `egc gain` could never resolve "Current session" outside a
+// wrapper-launched host like the Gemini CLI.
+//
+// The bridge: the SessionStart adapter writes this marker file, and
+// resolveMetricContext() in metrics.js falls back to it whenever
+// EGC_SESSION_ID is absent from the environment. A freshness window bounds
+// the fallback so a marker left behind by a closed session cannot claim
+// entries forever, and each new SessionStart overwrites the file, so with
+// concurrent sessions the most recently started one wins (recording the
+// limitation is deliberate: the payload is the only trustworthy source, and
+// no clear-on-stop exists because the Stop hook fires per assistant turn,
+// not per session).
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SESSION_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function markerFilePath() {
+  return process.env.EGC_SESSION_MARKER_FILE
+    || path.join(os.homedir(), '.egc', 'metrics', 'active-session.json');
+}
+
+/** Persist the harness session id for later Crusher child processes. */
+function writeMarker(sessionId, { source } = {}) {
+  try {
+    if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return false;
+    const file = markerFilePath();
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    const row = {
+      session: sessionId,
+      source: typeof source === 'string' && source ? source : 'unknown',
+      startedAt: new Date().toISOString(),
+    };
+    // Atomic replace: a Crusher child reading mid-write must never see a
+    // truncated JSON body.
+    const tmp = `${file}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(row) + '\n', { mode: 0o600 });
+    fs.renameSync(tmp, file);
+    return true;
+  } catch { // NOSONAR: the marker is best-effort; session start must never break
+    return false;
+  }
+}
+
+/** Return the fresh marker session id, or null when absent, stale or invalid. */
+function readMarkerSession({ maxAgeMs = DEFAULT_MAX_AGE_MS, now = Date.now() } = {}) {
+  try {
+    const raw = fs.readFileSync(markerFilePath(), 'utf8');
+    const row = JSON.parse(raw);
+    if (typeof row?.session !== 'string' || !SESSION_ID_RE.test(row.session)) return null;
+    const startedAt = Date.parse(row.startedAt);
+    if (!Number.isFinite(startedAt)) return null;
+    const age = now - startedAt;
+    if (age < 0 || age > maxAgeMs) return null;
+    return row.session;
+  } catch { // NOSONAR: no marker (or an unreadable one) simply means no fallback
+    return null;
+  }
+}
+
+module.exports = {
+  markerFilePath,
+  writeMarker,
+  readMarkerSession,
+};

--- a/scripts/lib/session-start-adapter.js
+++ b/scripts/lib/session-start-adapter.js
@@ -76,6 +76,15 @@ function runSessionStartAdapter({ host, projectEnv }) {
   const projectPath = resolveProjectPath(input, projectEnv);
   const restored = restoreContext(projectPath, normalizedHost);
   postSessionStart(restored.host || normalizedHost, input.session_id || null);
+  if (input.session_id) {
+    try {
+      // Bridge the payload session id to Crusher children (see session-marker.js):
+      // a hook cannot export env vars into the harness's future Bash commands.
+      require('./crusher/session-marker').writeMarker(input.session_id, { source: normalizedHost });
+    } catch { // NOSONAR: the marker is best-effort; session start must never break
+      // keep going: restoring context matters more than attribution
+    }
+  }
   return restored;
 }
 

--- a/tests/lib/crusher-session-marker.test.js
+++ b/tests/lib/crusher-session-marker.test.js
@@ -13,15 +13,30 @@ const {
 const { resolveMetricContext } = require('../../scripts/lib/crusher/metrics');
 
 let failed = 0;
+const pending = [];
 
+function report(name, error) {
+  if (error === undefined) {
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  failed += 1;
+  console.log(`  ✗ ${name}`);
+  console.log(`    Error: ${error.message}`);
+}
+
+// Sync and async alike: a returned promise is awaited before the exit code is
+// decided, so a rejected async case reports ✗ instead of being swallowed.
 function test(name, fn) {
   try {
-    fn();
-    console.log(`  ✓ ${name}`);
+    const ret = fn();
+    if (ret && typeof ret.then === 'function') {
+      pending.push(ret.then(() => report(name), error => report(name, error)));
+      return;
+    }
+    report(name);
   } catch (error) {
-    failed += 1;
-    console.log(`  ✗ ${name}`);
-    console.log(`    Error: ${error.message}`);
+    report(name, error);
   }
 }
 
@@ -130,6 +145,33 @@ test('corrupted body, invalid id and bad timestamps read as null', () => {
     assert.strictEqual(readMarkerSession(), null);
     fs.writeFileSync(file, JSON.stringify({ session: 'bad id!', startedAt: new Date().toISOString() }));
     assert.strictEqual(readMarkerSession(), null);
+    fs.writeFileSync(file, JSON.stringify({ session: 'sess-ok', startedAt: 'yesterday-ish' }));
+    assert.strictEqual(readMarkerSession(), null);
+  });
+});
+
+test('the startedAt lifetime cap expires a marker no matter how fresh its mtime', () => {
+  withMarkerFile(file => {
+    const now = Date.now();
+    const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const sixDaysAgo = new Date(now - 6 * 24 * 60 * 60 * 1000).toISOString();
+
+    fs.writeFileSync(file, JSON.stringify({ session: 'sess-old', source: 'claude', startedAt: eightDaysAgo }));
+    setMtime(file, now - 1000);
+    assert.strictEqual(readMarkerSession({ now }), null, 'past the lifetime cap even a touched marker must expire');
+
+    fs.writeFileSync(file, JSON.stringify({ session: 'sess-week', source: 'claude', startedAt: sixDaysAgo }));
+    setMtime(file, now - 1000);
+    assert.strictEqual(readMarkerSession({ now }), 'sess-week', 'within the cap a fresh marker must resolve');
+  });
+});
+
+test('a rejected async test reports as a failure (harness self-check)', () => {
+  const before = failed;
+  test('async harness probe (expected ✗)', () => Promise.reject(new Error('probe')));
+  return Promise.resolve().then(() => Promise.resolve()).then(() => {
+    assert.strictEqual(failed, before + 1, 'the async rejection must increment failed');
+    failed = before;
   });
 });
 
@@ -152,5 +194,7 @@ test('no env and no marker keeps the unknown scope', () => {
   });
 });
 
-console.log(failed ? `\n${failed} failed\n` : '\nall passed\n');
-process.exit(failed ? 1 : 0);
+Promise.all(pending).then(() => {
+  console.log(failed ? `\n${failed} failed\n` : '\nall passed\n');
+  process.exit(failed ? 1 : 0);
+});

--- a/tests/lib/crusher-session-marker.test.js
+++ b/tests/lib/crusher-session-marker.test.js
@@ -12,12 +12,21 @@ const {
 } = require('../../scripts/lib/crusher/session-marker');
 const { resolveMetricContext } = require('../../scripts/lib/crusher/metrics');
 
-function createTempDir(prefix) {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    failed += 1;
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+  }
 }
 
-function cleanup(dirPath) {
-  fs.rmSync(dirPath, { recursive: true, force: true });
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
 
 function withMarkerFile(fn) {
@@ -30,78 +39,118 @@ function withMarkerFile(fn) {
   } finally {
     if (saved === undefined) delete process.env.EGC_SESSION_MARKER_FILE;
     else process.env.EGC_SESSION_MARKER_FILE = saved;
-    cleanup(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 
-// ── markerFilePath ──────────────────────────────────────────────────────────
+function setMtime(file, epochMs) {
+  fs.utimesSync(file, new Date(epochMs), new Date(epochMs));
+}
 
-withMarkerFile(file => {
-  assert.strictEqual(markerFilePath(), file, 'EGC_SESSION_MARKER_FILE must override the default path');
+console.log('\ncrusher session marker\n');
+
+test('EGC_SESSION_MARKER_FILE overrides the default path', () => {
+  withMarkerFile(file => {
+    assert.strictEqual(markerFilePath(), file);
+  });
 });
 
-// ── write + read round trip ─────────────────────────────────────────────────
-
-withMarkerFile(file => {
-  assert.strictEqual(writeMarker('sess-abc_123.X', { source: 'claude' }), true);
-  const row = JSON.parse(fs.readFileSync(file, 'utf8'));
-  assert.strictEqual(row.session, 'sess-abc_123.X');
-  assert.strictEqual(row.source, 'claude');
-  assert.ok(Number.isFinite(Date.parse(row.startedAt)), 'startedAt must be a parseable timestamp');
-  assert.strictEqual(readMarkerSession(), 'sess-abc_123.X');
+test('write + read round trip preserves session, source and startedAt', () => {
+  withMarkerFile(file => {
+    assert.strictEqual(writeMarker('sess-abc_123.X', { source: 'claude' }), true);
+    const row = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.strictEqual(row.session, 'sess-abc_123.X');
+    assert.strictEqual(row.source, 'claude');
+    assert.ok(Number.isFinite(Date.parse(row.startedAt)), 'startedAt must be a parseable timestamp');
+    assert.strictEqual(readMarkerSession(), 'sess-abc_123.X');
+  });
 });
 
-// ── invalid session ids are rejected without writing ────────────────────────
-
-withMarkerFile(file => {
-  assert.strictEqual(writeMarker(''), false);
-  assert.strictEqual(writeMarker(null), false);
-  assert.strictEqual(writeMarker('has spaces'), false);
-  assert.strictEqual(writeMarker("id'; rm -rf /"), false);
-  assert.strictEqual(writeMarker('x'.repeat(129)), false);
-  assert.strictEqual(fs.existsSync(file), false, 'no marker file may exist after rejected writes');
+test('invalid session ids are rejected without writing a file', () => {
+  withMarkerFile(file => {
+    assert.strictEqual(writeMarker(''), false);
+    assert.strictEqual(writeMarker(null), false);
+    assert.strictEqual(writeMarker('has spaces'), false);
+    assert.strictEqual(writeMarker("id'; rm -rf /"), false);
+    assert.strictEqual(writeMarker('x'.repeat(129)), false);
+    assert.strictEqual(fs.existsSync(file), false);
+  });
 });
 
-// ── missing, stale and corrupted markers all mean "no fallback" ─────────────
-
-withMarkerFile(() => {
-  assert.strictEqual(readMarkerSession(), null, 'missing marker must read as null');
+test('missing marker reads as null', () => {
+  withMarkerFile(() => {
+    assert.strictEqual(readMarkerSession(), null);
+  });
 });
 
-withMarkerFile(file => {
-  assert.strictEqual(writeMarker('sess-fresh'), true);
-  const written = JSON.parse(fs.readFileSync(file, 'utf8'));
-  const startedAt = Date.parse(written.startedAt);
-  const past25h = startedAt + 25 * 60 * 60 * 1000;
-  assert.strictEqual(readMarkerSession({ now: past25h }), null, 'a marker older than the window must be stale');
-  assert.strictEqual(readMarkerSession({ now: startedAt + 1000 }), 'sess-fresh', 'a fresh marker must resolve');
-  assert.strictEqual(readMarkerSession({ now: startedAt - 1000 }), null, 'a marker from the future must not resolve');
+test('marker staleness is measured from mtime, both directions', () => {
+  withMarkerFile(file => {
+    assert.strictEqual(writeMarker('sess-fresh'), true);
+    const now = Date.now();
+    setMtime(file, now - 25 * 60 * 60 * 1000);
+    assert.strictEqual(readMarkerSession({ now }), null, 'a marker untouched for >24h must be stale');
+    setMtime(file, now - 1000);
+    assert.strictEqual(readMarkerSession({ now }), 'sess-fresh', 'a recently touched marker must resolve');
+    setMtime(file, now + 60 * 60 * 1000);
+    assert.strictEqual(readMarkerSession({ now }), null, 'a marker from the future must not resolve');
+  });
 });
 
-withMarkerFile(file => {
-  fs.writeFileSync(file, 'not json at all');
-  assert.strictEqual(readMarkerSession(), null, 'corrupted marker must read as null');
-  fs.writeFileSync(file, JSON.stringify({ session: 'bad id!', startedAt: new Date().toISOString() }));
-  assert.strictEqual(readMarkerSession(), null, 'marker with invalid id must read as null');
-  fs.writeFileSync(file, JSON.stringify({ session: 'sess-ok', startedAt: 'yesterday-ish' }));
-  assert.strictEqual(readMarkerSession(), null, 'marker with unparseable startedAt must read as null');
+test('successful reads refresh mtime so live sessions outlive the window', () => {
+  withMarkerFile(file => {
+    assert.strictEqual(writeMarker('sess-live'), true);
+    const now = Date.now();
+    setMtime(file, now - 23 * 60 * 60 * 1000);
+    assert.strictEqual(readMarkerSession({ now }), 'sess-live');
+    const refreshed = fs.statSync(file).mtimeMs;
+    assert.ok(Math.abs(refreshed - now) < 5000, 'a successful read must touch the marker to now');
+    assert.strictEqual(
+      readMarkerSession({ now: now + 23 * 60 * 60 * 1000 }),
+      'sess-live',
+      'the refreshed marker must survive past the original window'
+    );
+  });
 });
 
-// ── resolveMetricContext fallback chain ─────────────────────────────────────
-
-withMarkerFile(() => {
-  assert.strictEqual(writeMarker('sess-marker'), true);
-
-  const withoutEnv = resolveMetricContext({ env: { EGC_PROJECT_ROOT: '/tmp/proj' } });
-  assert.strictEqual(withoutEnv.session, 'sess-marker', 'marker must fill the session when env has none');
-
-  const withEnv = resolveMetricContext({ env: { EGC_SESSION_ID: 'sess-env', EGC_PROJECT_ROOT: '/tmp/proj' } });
-  assert.strictEqual(withEnv.session, 'sess-env', 'env must always win over the marker');
+test('stale reads do not refresh the marker', () => {
+  withMarkerFile(file => {
+    assert.strictEqual(writeMarker('sess-dead'), true);
+    const now = Date.now();
+    const old = now - 25 * 60 * 60 * 1000;
+    setMtime(file, old);
+    assert.strictEqual(readMarkerSession({ now }), null);
+    const after = fs.statSync(file).mtimeMs;
+    assert.ok(Math.abs(after - old) < 5000, 'a stale marker must keep its old mtime');
+  });
 });
 
-withMarkerFile(() => {
-  const context = resolveMetricContext({ env: { EGC_PROJECT_ROOT: '/tmp/proj' } });
-  assert.strictEqual(context.session, 'unknown', 'no env and no marker must keep the unknown scope');
+test('corrupted body, invalid id and bad timestamps read as null', () => {
+  withMarkerFile(file => {
+    fs.writeFileSync(file, 'not json at all');
+    assert.strictEqual(readMarkerSession(), null);
+    fs.writeFileSync(file, JSON.stringify({ session: 'bad id!', startedAt: new Date().toISOString() }));
+    assert.strictEqual(readMarkerSession(), null);
+  });
 });
 
-console.log('crusher-session-marker: all assertions passed');
+test('resolveMetricContext falls back to the marker only when env has no session', () => {
+  withMarkerFile(() => {
+    assert.strictEqual(writeMarker('sess-marker'), true);
+
+    const withoutEnv = resolveMetricContext({ env: { EGC_PROJECT_ROOT: '/tmp/proj' } });
+    assert.strictEqual(withoutEnv.session, 'sess-marker');
+
+    const withEnv = resolveMetricContext({ env: { EGC_SESSION_ID: 'sess-env', EGC_PROJECT_ROOT: '/tmp/proj' } });
+    assert.strictEqual(withEnv.session, 'sess-env');
+  });
+});
+
+test('no env and no marker keeps the unknown scope', () => {
+  withMarkerFile(() => {
+    const context = resolveMetricContext({ env: { EGC_PROJECT_ROOT: '/tmp/proj' } });
+    assert.strictEqual(context.session, 'unknown');
+  });
+});
+
+console.log(failed ? `\n${failed} failed\n` : '\nall passed\n');
+process.exit(failed ? 1 : 0);

--- a/tests/lib/crusher-session-marker.test.js
+++ b/tests/lib/crusher-session-marker.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  markerFilePath,
+  writeMarker,
+  readMarkerSession,
+} = require('../../scripts/lib/crusher/session-marker');
+const { resolveMetricContext } = require('../../scripts/lib/crusher/metrics');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function withMarkerFile(fn) {
+  const dir = createTempDir('egc-session-marker-');
+  const file = path.join(dir, 'active-session.json');
+  const saved = process.env.EGC_SESSION_MARKER_FILE;
+  process.env.EGC_SESSION_MARKER_FILE = file;
+  try {
+    return fn(file);
+  } finally {
+    if (saved === undefined) delete process.env.EGC_SESSION_MARKER_FILE;
+    else process.env.EGC_SESSION_MARKER_FILE = saved;
+    cleanup(dir);
+  }
+}
+
+// ── markerFilePath ──────────────────────────────────────────────────────────
+
+withMarkerFile(file => {
+  assert.strictEqual(markerFilePath(), file, 'EGC_SESSION_MARKER_FILE must override the default path');
+});
+
+// ── write + read round trip ─────────────────────────────────────────────────
+
+withMarkerFile(file => {
+  assert.strictEqual(writeMarker('sess-abc_123.X', { source: 'claude' }), true);
+  const row = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.strictEqual(row.session, 'sess-abc_123.X');
+  assert.strictEqual(row.source, 'claude');
+  assert.ok(Number.isFinite(Date.parse(row.startedAt)), 'startedAt must be a parseable timestamp');
+  assert.strictEqual(readMarkerSession(), 'sess-abc_123.X');
+});
+
+// ── invalid session ids are rejected without writing ────────────────────────
+
+withMarkerFile(file => {
+  assert.strictEqual(writeMarker(''), false);
+  assert.strictEqual(writeMarker(null), false);
+  assert.strictEqual(writeMarker('has spaces'), false);
+  assert.strictEqual(writeMarker("id'; rm -rf /"), false);
+  assert.strictEqual(writeMarker('x'.repeat(129)), false);
+  assert.strictEqual(fs.existsSync(file), false, 'no marker file may exist after rejected writes');
+});
+
+// ── missing, stale and corrupted markers all mean "no fallback" ─────────────
+
+withMarkerFile(() => {
+  assert.strictEqual(readMarkerSession(), null, 'missing marker must read as null');
+});
+
+withMarkerFile(file => {
+  assert.strictEqual(writeMarker('sess-fresh'), true);
+  const written = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const startedAt = Date.parse(written.startedAt);
+  const past25h = startedAt + 25 * 60 * 60 * 1000;
+  assert.strictEqual(readMarkerSession({ now: past25h }), null, 'a marker older than the window must be stale');
+  assert.strictEqual(readMarkerSession({ now: startedAt + 1000 }), 'sess-fresh', 'a fresh marker must resolve');
+  assert.strictEqual(readMarkerSession({ now: startedAt - 1000 }), null, 'a marker from the future must not resolve');
+});
+
+withMarkerFile(file => {
+  fs.writeFileSync(file, 'not json at all');
+  assert.strictEqual(readMarkerSession(), null, 'corrupted marker must read as null');
+  fs.writeFileSync(file, JSON.stringify({ session: 'bad id!', startedAt: new Date().toISOString() }));
+  assert.strictEqual(readMarkerSession(), null, 'marker with invalid id must read as null');
+  fs.writeFileSync(file, JSON.stringify({ session: 'sess-ok', startedAt: 'yesterday-ish' }));
+  assert.strictEqual(readMarkerSession(), null, 'marker with unparseable startedAt must read as null');
+});
+
+// ── resolveMetricContext fallback chain ─────────────────────────────────────
+
+withMarkerFile(() => {
+  assert.strictEqual(writeMarker('sess-marker'), true);
+
+  const withoutEnv = resolveMetricContext({ env: { EGC_PROJECT_ROOT: '/tmp/proj' } });
+  assert.strictEqual(withoutEnv.session, 'sess-marker', 'marker must fill the session when env has none');
+
+  const withEnv = resolveMetricContext({ env: { EGC_SESSION_ID: 'sess-env', EGC_PROJECT_ROOT: '/tmp/proj' } });
+  assert.strictEqual(withEnv.session, 'sess-env', 'env must always win over the marker');
+});
+
+withMarkerFile(() => {
+  const context = resolveMetricContext({ env: { EGC_PROJECT_ROOT: '/tmp/proj' } });
+  assert.strictEqual(context.session, 'unknown', 'no env and no marker must keep the unknown scope');
+});
+
+console.log('crusher-session-marker: all assertions passed');


### PR DESCRIPTION
## Problem

`egc gain` shows `Current session: unavailable (no EGC_SESSION_ID)` in every host that is not wrapper-launched. Hooks receive `session_id` in their JSON payload, but a hook process cannot export environment variables into the harness's future Bash commands, and the PreToolUse rewrite is ignored for assistant-issued calls (the documented limitation in `rules/common/memory.md`), so neither the PATH shims nor `egc run` ever see a session id: every ledger row records without a session scope.

Same defect class as the EGC-434 audit finding 2.3 (components reading only the environment and discarding the payload session id).

## Fix

- New `scripts/lib/crusher/session-marker.js`: the SessionStart adapter persists `~/.egc/metrics/active-session.json` (atomic tmp+rename, mode 0600, id validated against `^[A-Za-z0-9._-]{1,128}$`).
- `resolveMetricContext()` falls back to the marker when the environment carries no session id; the environment always wins when present; a 24h freshness window keeps a dead session's marker from claiming entries forever; each new SessionStart overwrites the file (most recently started session wins, documented).
- One fallback point fixes both sides: `record()` stamps new ledger entries, and `aggregateBreakdown()` resolves the current session for `egc gain` through the same context.

## Tests

`tests/lib/crusher-session-marker.test.js`: round trip, invalid-id rejection (including injection-shaped ids), missing/stale/future/corrupted markers, and the full `resolveMetricContext` precedence chain. Shim-dispatch and operations-registry suites re-run locally as regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridges the harness session ID into Crusher via a SessionStart marker so ledger entries and `egc gain` resolve the current session outside wrapper-launched hosts. Freshness now uses the marker file’s mtime with read-refresh and a startedAt lifetime cap, so long sessions stay attributed and dead ones expire.

- **Bug Fixes**
  - Writes a session marker at `~/.egc/metrics/active-session.json` on SessionStart (atomic tmp+rename, mode 0600, ID validated).
  - `resolveMetricContext()` falls back to the marker when the env lacks a session; env always wins; freshness is mtime-based with a 24h window and small future-skew tolerance; successful reads refresh mtime; a 7-day lifetime cap from `startedAt` prevents indefinite attribution; stale/invalid markers are ignored.
  - Ledger rows now record a session scope, and `egc gain` shows the current session using the same context.

<sup>Written for commit e16cb54caa59cfd3e1fb04d7a80383f1cefa0a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

