### PR TITLE
fix(security): restore the main quality gate and ship the session marker to installed layouts

### DIFF
--- a/scripts/gain.js
+++ b/scripts/gain.js
@@ -79,7 +79,9 @@ function main() {
     // Preserve the existing top-level lifetime fields while adding the scoped
     // report. Derive entry count from report.runs — both come from the same
     // ledger snapshot, avoiding a double-read race.
-    console.log(JSON.stringify({ ...totals, ...report, entries: report.runs }, null, 2));
+    // Machine-readable report printed to the caller's own terminal by design:
+    // the ledger is local, zero-cost, and --json exists to expose it whole.
+    console.log(JSON.stringify({ ...totals, ...report, entries: report.runs }, null, 2)); // NOSONAR jssecurity:S8689
     return;
   }
 

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -42,6 +42,9 @@ const {
 
 const HOOK_LIB_SOURCES = [
   'scripts/lib/session-start-adapter.js',
+  // Flattens next to the adapter; its require falls back from
+  // ./crusher/session-marker to ./session-marker for exactly this layout.
+  'scripts/lib/crusher/session-marker.js',
   'scripts/lib/session-context-loader.js',
   'scripts/lib/branch-state.js',
   'scripts/lib/global-state.js',

--- a/scripts/lib/session-start-adapter.js
+++ b/scripts/lib/session-start-adapter.js
@@ -77,15 +77,32 @@ function runSessionStartAdapter({ host, projectEnv }) {
   const restored = restoreContext(projectPath, normalizedHost);
   postSessionStart(restored.host || normalizedHost, input.session_id || null);
   if (input.session_id) {
-    try {
-      // Bridge the payload session id to Crusher children (see session-marker.js):
-      // a hook cannot export env vars into the harness's future Bash commands.
-      require('./crusher/session-marker').writeMarker(input.session_id, { source: normalizedHost });
-    } catch { // NOSONAR: the marker is best-effort; session start must never break
-      // keep going: restoring context matters more than attribution
+    // Bridge the payload session id to Crusher children (see session-marker.js):
+    // a hook cannot export env vars into the harness's future Bash commands.
+    const marker = requireSessionMarker();
+    if (marker) {
+      try {
+        marker.writeMarker(input.session_id, { source: normalizedHost });
+      } catch { // NOSONAR: the marker is best-effort; session start must never break
+        // keep going: restoring context matters more than attribution
+      }
     }
   }
   return restored;
+}
+
+// Repo layout keeps the lib at ./crusher/session-marker; the flattened egc/lib
+// install (claude-home HOOK_LIB_SOURCES) lands it beside this file instead.
+function requireSessionMarker() {
+  try {
+    return require('./crusher/session-marker');
+  } catch { // NOSONAR: flattened install layout, fall through
+    try {
+      return require('./session-marker');
+    } catch { // NOSONAR: no marker lib shipped means no attribution bridge
+      return null;
+    }
+  }
 }
 
 module.exports = { runSessionStartAdapter };


### PR DESCRIPTION
Two fixes, one area:

1. **Main quality gate back to green (code scanning alert 337).** The #1240 rework of `gain.js` rebuilt the `--json` print without the `NOSONAR jssecurity:S8689` marker this codebase uses for intentional machine-readable prints to the caller's own terminal (`install-apply.js:226/249` are the precedents), which surfaced on main as a new high security finding and dropped `new_security_rating` to 4. The report is the local, zero-cost ledger that `--json` exists to expose whole; the restored marker documents the intent.

2. **The #1247 session marker now reaches installed runtimes.** The claude-home target flattens hook libs into `egc/lib` by basename, so the adapter's `./crusher/session-marker` require could never resolve there and installed machines kept recording session-less entries. `session-marker.js` joins `HOOK_LIB_SOURCES` and the adapter falls back to the flattened path (`./session-marker`), mirroring the established crusher-engine flattening pattern. Package-resolved flows (shims, `egc run`, `gain`, the Gemini wrapper) already shipped it via the `files: scripts/` field and need nothing.

Tests: marker suite, install-targets suite and an adapter load smoke, all green locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the intentional `--json` report print in `scripts/gain.js` to clear the security alert and bring the main quality gate back to green. Ships the session marker to installed layouts so installed runtimes record session IDs.

- **Bug Fixes**
  - `scripts/gain.js`: add `// NOSONAR jssecurity:S8689` to the `--json` console output to resolve code scanning alert 337.
  - Session marker propagation: include `scripts/lib/crusher/session-marker.js` in `claude-home` `HOOK_LIB_SOURCES` and add a fallback `require` in `session-start-adapter.js` from `./crusher/session-marker` to `./session-marker` to support flattened installs.

<sup>Written for commit 328f6584aac306a043b516ac3272a716471439f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

