### PR TITLE
fix(core): finish no-console contract for install() and add syncPromise regression test (#1245)

### DIFF
--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -217,8 +217,8 @@ function resolvePackageRoot() {
 // HOME, permissions) only removes one of four resolution strategies -- the
 // existing ones are unaffected -- so it is logged and swallowed rather than
 // failing the whole install.
-function writeGuardianCliMarker(onWarning) {
-  const markerPath = path.join(os.homedir(), '.egc', 'guardian-cli-path.json');
+function writeGuardianCliMarker(onWarning, homeDir) {
+  const markerPath = path.join(homeDir || os.homedir(), '.egc', 'guardian-cli-path.json');
   try {
     fs.mkdirSync(path.dirname(markerPath), { recursive: true });
     fs.writeFileSync(
@@ -236,7 +236,7 @@ function writeGuardianCliMarker(onWarning) {
   }
 }
 
-function applyInstallPlan(plan, { onWarning } = {}) {
+function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
   const resolvedClaudeHooksPlan = buildResolvedClaudeHooks(plan);
   const disabledServers = parseDisabledMcpServers(process.env.EGC_DISABLED_MCPS || process.env.ECC_DISABLED_MCPS);
 
@@ -268,7 +268,7 @@ function applyInstallPlan(plan, { onWarning } = {}) {
   }
 
   writeInstallState(plan.installStatePath, plan.statePreview);
-  writeGuardianCliMarker(onWarning);
+  writeGuardianCliMarker(onWarning, homeDir);
 
   // Capture the async promise so callers (e.g. install() in the operations
   // registry) can await it before restoring console.error, ensuring that the
@@ -276,6 +276,8 @@ function applyInstallPlan(plan, { onWarning } = {}) {
   // The promise is attached as a non-enumerable property so it never appears
   // in JSON.stringify() output (e.g. egc install --json).
   const syncPromise = syncInstallStateToStore(plan.statePreview, {
+    homeDir,
+    dbPath,
     onError: error => {
       const msg = `Warning: Failed to sync install state to status store: ${error.message}`;
       if (typeof onWarning === 'function') {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -217,7 +217,7 @@ function resolvePackageRoot() {
 // HOME, permissions) only removes one of four resolution strategies -- the
 // existing ones are unaffected -- so it is logged and swallowed rather than
 // failing the whole install.
-function writeGuardianCliMarker() {
+function writeGuardianCliMarker(onWarning) {
   const markerPath = path.join(os.homedir(), '.egc', 'guardian-cli-path.json');
   try {
     fs.mkdirSync(path.dirname(markerPath), { recursive: true });
@@ -227,7 +227,12 @@ function writeGuardianCliMarker() {
       'utf8'
     );
   } catch (error) {
-    console.error(`Warning: Failed to write Guardian CLI marker: ${error.message}`);
+    const msg = `Warning: Failed to write Guardian CLI marker: ${error.message}`;
+    if (typeof onWarning === 'function') {
+      onWarning(msg);
+    } else {
+      console.error(msg);
+    }
   }
 }
 
@@ -263,7 +268,7 @@ function applyInstallPlan(plan, { onWarning } = {}) {
   }
 
   writeInstallState(plan.installStatePath, plan.statePreview);
-  writeGuardianCliMarker();
+  writeGuardianCliMarker(onWarning);
 
   // Capture the async promise so callers (e.g. install() in the operations
   // registry) can await it before restoring console.error, ensuring that the

--- a/tests/lib/operations-registry.test.js
+++ b/tests/lib/operations-registry.test.js
@@ -166,8 +166,48 @@ async function main() {
     assert.ok(Object.hasOwn(result, 'plan'),    'dryRun result must have plan');
     assert.strictEqual(result.applied, null,    'dryRun result.applied must be null');
     assert.deepStrictEqual(result.warnings, [], 'dryRun result.warnings must be []');
-    // syncPromise must not appear in JSON output (non-enumerable)
-    assert.ok(!Object.keys(result).includes('syncPromise'), 'syncPromise must not be enumerable');
+  });
+
+  await run('applyInstallPlan() result has no enumerable syncPromise and survives JSON round-trip', async () => {
+    // Regression test for #1245: the non-enumerable syncPromise property added
+    // to the applyInstallPlan result must not appear in JSON.stringify output.
+    // This test calls the real apply path (not dryRun) against an isolated temp
+    // directory so no production state is touched.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-test-apply-'));
+    try {
+      const { createInstallPlanFromRequest } = require('../../scripts/lib/install/runtime');
+      const { applyInstallPlan }             = require('../../scripts/lib/install/apply');
+
+      const plan = createInstallPlanFromRequest(
+        { mode: 'legacy', target: 'cursor', languages: ['javascript'] },
+        { sourceRoot: path.join(__dirname, '../..'), projectRoot: tmpDir }
+      );
+
+      const warnings = [];
+      const result = applyInstallPlan(plan, { onWarning: msg => warnings.push(msg) });
+
+      // syncPromise must not be enumerable — should not appear in JSON output
+      assert.ok(
+        !Object.keys(result).includes('syncPromise'),
+        'syncPromise must not be an enumerable key on the apply result'
+      );
+      const json = JSON.stringify(result);
+      assert.ok(
+        !json.includes('syncPromise'),
+        'JSON.stringify(result) must not contain "syncPromise"'
+      );
+
+      // Result must survive a JSON round-trip without data loss on serializable fields
+      const reparsed = JSON.parse(json);
+      assert.ok(reparsed.applied === true, 'round-tripped result.applied must be true');
+
+      // Settle the sync promise to avoid unhandled rejection
+      if (result.syncPromise) {
+        await result.syncPromise.catch(() => { /* best-effort: ignore store errors in test */ });
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   // ── doctor() ─────────────────────────────────────────────────────────────

--- a/tests/lib/operations-registry.test.js
+++ b/tests/lib/operations-registry.test.js
@@ -220,13 +220,12 @@ async function main() {
 
       // Settle the sync promise; store failures are expected since tmpDir has
       // no real EGC install — assert they land in warnings, not on the console.
-      try {
-        await result.syncPromise;
-      } catch (storeError) {
-        // Store open/migration failure in isolated dir: confirm onWarning captured it.
-        assert.ok(warnings.length > 0 || storeError,
-          'store errors must either be caught by onWarning or be rethrown here');
-      }
+      await result.syncPromise;
+      // The sync either succeeded (db written) or its failure was captured by onWarning.
+      assert.ok(
+        fs.existsSync(tmpDbPath) || warnings.some(w => w.includes('Failed to sync install state')),
+        'store sync must either write the isolated db or surface its failure through onWarning'
+      );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/lib/operations-registry.test.js
+++ b/tests/lib/operations-registry.test.js
@@ -171,8 +171,8 @@ async function main() {
   await run('applyInstallPlan() result has no enumerable syncPromise and survives JSON round-trip', async () => {
     // Regression test for #1245: the non-enumerable syncPromise property added
     // to the applyInstallPlan result must not appear in JSON.stringify output.
-    // This test calls the real apply path (not dryRun) against an isolated temp
-    // directory so no production state is touched.
+    // All side effects are isolated: projectRoot, homeDir, and dbPath all point
+    // into a single temp directory so no real ~/.egc state is touched.
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-test-apply-'));
     try {
       const { createInstallPlanFromRequest } = require('../../scripts/lib/install/runtime');
@@ -183,27 +183,49 @@ async function main() {
         { sourceRoot: path.join(__dirname, '../..'), projectRoot: tmpDir }
       );
 
-      const warnings = [];
-      const result = applyInstallPlan(plan, { onWarning: msg => warnings.push(msg) });
+      // Use spread to collect warnings immutably; pass homeDir+dbPath so
+      // writeGuardianCliMarker and syncInstallStateToStore stay inside tmpDir.
+      let warnings = [];
+      const tmpDbPath = path.join(tmpDir, 'state.db');
+      const result = applyInstallPlan(plan, {
+        onWarning: msg => { warnings = [...warnings, msg]; },
+        homeDir:   tmpDir,
+        dbPath:    tmpDbPath,
+      });
 
-      // syncPromise must not be enumerable — should not appear in JSON output
-      assert.ok(
-        !Object.keys(result).includes('syncPromise'),
-        'syncPromise must not be an enumerable key on the apply result'
-      );
+      // Assert syncPromise exists on the result as a non-enumerable, thenable property.
+      const descriptor = Object.getOwnPropertyDescriptor(result, 'syncPromise');
+      assert.ok(descriptor !== undefined,
+        'syncPromise must exist as an own property on the apply result');
+      assert.strictEqual(descriptor.enumerable, false,
+        'syncPromise must be non-enumerable');
+      assert.ok(typeof descriptor.value.then === 'function',
+        'syncPromise must be thenable (a Promise)');
+
+      // Assert syncPromise does not appear in JSON output
       const json = JSON.stringify(result);
-      assert.ok(
-        !json.includes('syncPromise'),
-        'JSON.stringify(result) must not contain "syncPromise"'
-      );
+      assert.ok(!json.includes('syncPromise'),
+        'JSON.stringify(result) must not contain "syncPromise"');
 
-      // Result must survive a JSON round-trip without data loss on serializable fields
+      // All enumerable keys must survive a JSON round-trip without data loss
+      const enumerableKeys = Object.keys(result);
       const reparsed = JSON.parse(json);
-      assert.ok(reparsed.applied === true, 'round-tripped result.applied must be true');
+      assert.deepStrictEqual(
+        Object.keys(reparsed).sort(),
+        enumerableKeys.sort(),
+        'round-tripped result must have the same enumerable keys'
+      );
+      assert.strictEqual(reparsed.applied, true,
+        'round-tripped result.applied must be true');
 
-      // Settle the sync promise to avoid unhandled rejection
-      if (result.syncPromise) {
-        await result.syncPromise.catch(() => { /* best-effort: ignore store errors in test */ });
+      // Settle the sync promise; store failures are expected since tmpDir has
+      // no real EGC install — assert they land in warnings, not on the console.
+      try {
+        await result.syncPromise;
+      } catch (storeError) {
+        // Store open/migration failure in isolated dir: confirm onWarning captured it.
+        assert.ok(warnings.length > 0 || storeError,
+          'store errors must either be caught by onWarning or be rethrown here');
       }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
 
Follow-up to #1240. Closes #1245.
 
Two seams left by the final round of the operations library PR, both verified against the merged code. Neither touches any logic introduced before #1240 — they complete the `onWarning` threading and add the missing regression test.
 
---
 
## What changed
 
### `scripts/lib/install/apply.js`
 
**P1 — `writeGuardianCliMarker()` now routes through `onWarning`**
 
The store-sync path was migrated to `onWarning` in #1240, but the Guardian CLI marker catch block (around line 230) was still calling `console.error` directly. When `~/.egc` cannot be created, the registry `install()` operation broke its JSON-only contract by leaking the warning to the real console.
 
`writeGuardianCliMarker()` now accepts `onWarning` as a parameter and routes the failure message through it when provided, falling back to `console.error` for the direct CLI path. `applyInstallPlan()` passes its `onWarning` down so both warning paths (Guardian marker + store sync) are fully covered. The operation contract — return plain JSON, never write to the console — now holds end to end.
 
```js
// Before
function writeGuardianCliMarker() {
  ...
  } catch (error) {
    console.error(`Warning: Failed to write Guardian CLI marker: ${error.message}`);
  }
}
 
// After
function writeGuardianCliMarker(onWarning) {
  ...
  } catch (error) {
    const msg = `Warning: Failed to write Guardian CLI marker: ${error.message}`;
    if (typeof onWarning === 'function') {
      onWarning(msg);
    } else {
      console.error(msg); // fallback for direct CLI path
    }
  }
}
```
 
---
 
### `tests/lib/operations-registry.test.js`
 
**P2 — Real apply-path regression test for `syncPromise` serialization**
 
The dryRun test from #1240 never reaches `applyInstallPlan()` — it short-circuits before the apply path — so nothing asserted that a real applied result survives a JSON round-trip without `syncPromise`. This meant the `Object.defineProperty(result, 'syncPromise', { enumerable: false })` fix had zero test coverage.
 
New test `applyInstallPlan() result has no enumerable syncPromise and survives JSON round-trip`:
 
- Calls `applyInstallPlan()` against an isolated `fs.mkdtempSync` directory so no production state is touched
- Passes an `onWarning` collector so no console writes escape
- Asserts `Object.keys(result)` does not include `'syncPromise'`
- Asserts `JSON.stringify(result)` does not contain `'syncPromise'`
- Asserts the round-tripped `result.applied === true` (lossless serialization)
- Settles `result.syncPromise` to avoid unhandled rejections in CI
- Cleans up the temp directory in `finally`
---
 
## Acceptance criteria
 
### ✅ `writeGuardianCliMarker()` routes through `onWarning`
 
Both warning paths in `applyInstallPlan()` now go through the same callback:
 
```
Guardian CLI marker failure  → writeGuardianCliMarker(onWarning) → onWarning(msg)
Store-sync failure           → syncInstallStateToStore onError   → onWarning(msg)
```
 
`console.error` is only reached when `onWarning` is not provided (direct CLI path).
 
### ✅ Regression test covers the real apply path
 
```
✓ applyInstallPlan() result has no enumerable syncPromise and survives JSON round-trip
```
 
Test confirmed passing with a real `cursor` target plan written to a temp directory.
 
### ✅ Full test suite green
 
```
27 tests: 27 passed, 0 failed   (parity test)
 
Total Tests: 4146
Passed:      4146  ✓
Failed:         0  ✓
```
 
---
 
## Files changed
 
```
scripts/lib/install/apply.js           |  18 +++++++--
tests/lib/operations-registry.test.js |  40 ++++++++++++++++++-
 
2 files changed, 54 insertions(+), 4 deletions(-)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the no-console contract for `install()` by routing Guardian marker warnings through `onWarning` and letting callers redirect filesystem side effects via `homeDir` and `dbPath`. Adds an isolated regression test to guarantee a non-enumerable, thenable `syncPromise` and JSON-only results with failures captured via `onWarning`.

- **Bug Fixes**
  - `writeGuardianCliMarker(onWarning, homeDir)` routes warnings via the callback; `applyInstallPlan()` forwards `{ onWarning, homeDir, dbPath }` and only falls back to `console.error` when no callback is provided.
  - Regression test: fully isolates `projectRoot`, `homeDir`, and `dbPath`; asserts `syncPromise` exists, is non-enumerable and thenable, is excluded from JSON, keys round-trip cleanly, and that either the isolated `state.db` is written or the failure surfaces through `onWarning` (promise never rejects).

<sup>Written for commit d7614bf023080e364346bafc80b01e1c8e2e9adf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation warnings are now routed through the configured warning handler, with a console fallback when no handler is provided.
  * Installation results remain reliable and serializable, while background processing completes before temporary resources are cleaned up.

* **Tests**
  * Added integration coverage for installation behavior, result serialization, and proper completion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->