### PR TITLE
test(gain): single source for the parity fixture clock

### DIFF
--- a/tests/ops-gain-parity.test.js
+++ b/tests/ops-gain-parity.test.js
@@ -88,7 +88,10 @@ function createFixtureLedger(nowDate) {
 
   fs.writeFileSync(ledgerPath, entries.map(e => JSON.stringify(e)).join('\n') + '\n');
 
-  return { tmpDir, ledgerPath, sessionId, projectPath };
+  // The normalized clock is returned so every caller derives now/EGC_NOW from
+  // the same instant the fixture entries used; deriving it separately at the
+  // call site is what reintroduces the midnight-boundary parity break.
+  return { tmpDir, ledgerPath, sessionId, projectPath, now: baseDate };
 }
 
 test('savingsLedger operation reads environment-configured metrics ledger without client path parameter exposure', () => {
@@ -112,9 +115,7 @@ test('savingsLedger operation reads environment-configured metrics ledger withou
 });
 
 test('Parity test: panel numbers equal egc gain output for every range against the same fixture ledger', () => {
-  const testNow = new Date();
-  testNow.setHours(12, 0, 0, 0);
-  const { tmpDir, ledgerPath, sessionId, projectPath } = createFixtureLedger(testNow);
+  const { tmpDir, ledgerPath, sessionId, projectPath, now: testNow } = createFixtureLedger(new Date());
   const origFile = process.env.EGC_CRUSHER_METRICS_FILE;
   process.env.EGC_CRUSHER_METRICS_FILE = ledgerPath;
 
@@ -197,9 +198,7 @@ test('HTTP POST /ops/savingsLedger route responds with 401 when token missing/in
   const http = require('node:http');
 
   const origFile = process.env.EGC_CRUSHER_METRICS_FILE;
-  const testNow = new Date();
-  testNow.setHours(12, 0, 0, 0);
-  const { tmpDir, ledgerPath, sessionId, projectPath } = createFixtureLedger(testNow);
+  const { tmpDir, ledgerPath, sessionId, projectPath, now: testNow } = createFixtureLedger(new Date());
   process.env.EGC_CRUSHER_METRICS_FILE = ledgerPath;
 
   const TEST_TOKEN = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';


### PR DESCRIPTION
Follow-up from the #1244 review round: the parity-test fixture normalized its clock to local noon internally while both call sites normalized it again on their side, and nothing tied the two together. A future caller that forgot the call-site normalization would silently reintroduce the midnight-boundary parity break the noon pin exists to prevent.

`createFixtureLedger` now returns the normalized clock, and both tests derive `now`/`EGC_NOW` from that single source; the duplicated `setHours` calls at the call sites are gone.

Tests-only change. All three suites in the file pass locally (3/3).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the parity test clock to a single normalized source to prevent midnight-boundary parity breaks and flaky tests. `createFixtureLedger` now returns the normalized `now`, and both tests use it instead of re-normalizing.

- **Bug Fixes**
  - Return normalized clock from `createFixtureLedger` and derive `now`/`EGC_NOW` from it.
  - Remove duplicate `setHours` at call sites.
  - Tests-only change.

<sup>Written for commit f31843c8712f5482997490bc4f4c761fc83d7cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

