### PR TITLE
feat(rules): minimal-change ladder rule and routed skill

### DIFF
--- a/.cursor/rules/common-coding-style.md
+++ b/.cursor/rules/common-coding-style.md
@@ -1,8 +1,14 @@
 ---
-description: "EGC coding style: immutability, file organization, error handling, validation"
+description: "EGC coding style: minimal-change ladder, immutability, file organization, error handling, validation"
 alwaysApply: true
 ---
 # Coding Style
+
+## The Minimal-Change Ladder (CRITICAL)
+
+Stop at the FIRST rung that truly solves the request: 1 no change (it already exists), 2 deletion, 3 one-line fix at the root cause, 4 local change, 5 extend an existing seam, 6 new unit, 7 new abstraction or dependency (justify why every lower rung failed). State the rung when the choice is not obvious. Climbing without need is overengineering; refusing to climb is lazy code.
+
+Never simplified away: error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
 
 ## Immutability (CRITICAL)
 

--- a/.cursor/rules/common-coding-style.md
+++ b/.cursor/rules/common-coding-style.md
@@ -6,9 +6,9 @@ alwaysApply: true
 
 ## The Minimal-Change Ladder (CRITICAL)
 
-Stop at the FIRST rung that truly solves the request: 1 no change (it already exists), 2 deletion, 3 one-line fix at the root cause, 4 local change, 5 extend an existing seam, 6 new unit, 7 new abstraction or dependency (justify why every lower rung failed). State the rung when the choice is not obvious. Climbing without need is overengineering; refusing to climb is lazy code.
+Stop at the FIRST rung that truly solves the request: 1 no change (it already exists), 2 deletion, 3 one-line fix at the root cause, 4 local change, 5 extend an existing seam, 6 new unit, 7 new abstraction or dependency (justify why every lower rung failed). State the rung when the choice is not obvious. Climbing without need is overengineering; refusing to climb is a half-done fix.
 
-Never simplified away: error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
+The Floor (never dropped): error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
 
 ## Immutability (CRITICAL)
 

--- a/.kiro/steering/coding-style.md
+++ b/.kiro/steering/coding-style.md
@@ -1,9 +1,15 @@
 ---
 inclusion: auto
-description: Core coding style rules including immutability, file organization, error handling, and code quality standards.
+description: Core coding style rules including the minimal-change ladder, immutability, file organization, error handling, and code quality standards.
 ---
 
 # Coding Style
+
+## The Minimal-Change Ladder (CRITICAL)
+
+Stop at the FIRST rung that truly solves the request: 1 no change (it already exists), 2 deletion, 3 one-line fix at the root cause, 4 local change, 5 extend an existing seam, 6 new unit, 7 new abstraction or dependency (justify why every lower rung failed). State the rung when the choice is not obvious. Climbing without need is overengineering; refusing to climb is lazy code.
+
+Never simplified away: error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
 
 ## Immutability (CRITICAL)
 

--- a/.kiro/steering/coding-style.md
+++ b/.kiro/steering/coding-style.md
@@ -7,9 +7,9 @@ description: Core coding style rules including the minimal-change ladder, immuta
 
 ## The Minimal-Change Ladder (CRITICAL)
 
-Stop at the FIRST rung that truly solves the request: 1 no change (it already exists), 2 deletion, 3 one-line fix at the root cause, 4 local change, 5 extend an existing seam, 6 new unit, 7 new abstraction or dependency (justify why every lower rung failed). State the rung when the choice is not obvious. Climbing without need is overengineering; refusing to climb is lazy code.
+Stop at the FIRST rung that truly solves the request: 1 no change (it already exists), 2 deletion, 3 one-line fix at the root cause, 4 local change, 5 extend an existing seam, 6 new unit, 7 new abstraction or dependency (justify why every lower rung failed). State the rung when the choice is not obvious. Climbing without need is overengineering; refusing to climb is a half-done fix.
 
-Never simplified away: error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
+The Floor (never dropped): error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
 
 ## Immutability (CRITICAL)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The brain doesn't just remember: it filters. Before any shell output reaches the
 
 ## Prompt Library
 
-As a bonus, EGC gives you access to 61 agents, 230 skills, and 77 commands, plus 109 rules: specialists that review your code on their own, best-practice guides for every language and situation, shortcuts that run a whole sequence of tasks for you, and style rules that keep your code consistent. All written from real engineering sessions, not theory. Don't want to use any of it? Fine: EGC's persistent memory works exactly the same.
+As a bonus, EGC gives you access to 61 agents, 231 skills, and 77 commands, plus 109 rules: specialists that review your code on their own, best-practice guides for every language and situation, shortcuts that run a whole sequence of tasks for you, and style rules that keep your code consistent. All written from real engineering sessions, not theory. Don't want to use any of it? Fine: EGC's persistent memory works exactly the same.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,7 +116,7 @@ sh scripts/install.sh
 
 > **Note:** Gemini CLI free tier was discontinued on June 18, 2026 for individual users. The `~/.gemini/GEMINI.md` target still works for paid Google accounts. For free-tier users, [Antigravity CLI](https://antigravity.dev) is the recommended alternative: EGC supports it via `egc install --target antigravity`.
 4. Registers both MCP servers in every detected tool's config file
-5. Asks interactively whether to install the prompt library (61 agents, 230 skills, 77 commands): skipped automatically in CI
+5. Asks interactively whether to install the prompt library (61 agents, 231 skills, 77 commands): skipped automatically in CI
 6. Installs the Token Crusher binary shim (`~/.egc/bin`): a best-effort, non-fatal step, see [Token Crusher](#token-crusher) below
 
 ### Example output
@@ -140,7 +140,7 @@ EGC install
   ✓ registered egc-memory in Claude Code (user scope)
   ✓ registered in Cursor (~/.cursor/mcp.json)
 
-Install prompt library? (61 agents, 230 skills, 77 commands) [y/N]:
+Install prompt library? (61 agents, 231 skills, 77 commands) [y/N]:
 
 Installing Token Crusher binary shim...
 Shim directory: ~/.egc/bin

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -237,7 +237,7 @@
         "skills/testing/eval-harness",
         "skills/workflows/hookify-rules",
         "skills/workflows/iterative-retrieval",
-        "skills/general/lazy-code",
+        "skills/general/minimal-change",
         "skills/general_part2/plankton-code-quality",
         "skills/workflows/skill-stocktake",
         "skills/workflows/strategic-compact",

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -237,6 +237,7 @@
         "skills/testing/eval-harness",
         "skills/workflows/hookify-rules",
         "skills/workflows/iterative-retrieval",
+        "skills/general/lazy-code",
         "skills/general_part2/plankton-code-quality",
         "skills/workflows/skill-stocktake",
         "skills/workflows/strategic-compact",

--- a/mcp/servers/egc-guardian/src/catalog-index.ts
+++ b/mcp/servers/egc-guardian/src/catalog-index.ts
@@ -712,6 +712,11 @@ export const CATALOG: ReadonlyArray<{ kind: 'agent' | 'skill' | 'rule'; name: st
   },
   {
     "kind": "skill",
+    "name": "lazy-code",
+    "description": "Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and lazy stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation."
+  },
+  {
+    "kind": "skill",
     "name": "healthcare-emr-patterns",
     "description": "EMR/EHR development patterns for healthcare applications. Clinical safety, encounter workflows, prescription generation, clinical decision support integration, and accessibility-first UI for medical data entry."
   },

--- a/mcp/servers/egc-guardian/src/catalog-index.ts
+++ b/mcp/servers/egc-guardian/src/catalog-index.ts
@@ -712,8 +712,8 @@ export const CATALOG: ReadonlyArray<{ kind: 'agent' | 'skill' | 'rule'; name: st
   },
   {
     "kind": "skill",
-    "name": "lazy-code",
-    "description": "Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and lazy stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation."
+    "name": "minimal-change",
+    "description": "Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and half-done stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation."
   },
   {
     "kind": "skill",

--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -44,9 +44,9 @@ Walk this ladder top to bottom before writing any code, and stop at the FIRST ru
 6. **New unit**: a new function or module, only after rungs 1 to 5 genuinely fail.
 7. **New abstraction or dependency**: last resort; justify why every lower rung failed.
 
-When the choice is not obvious, state the rung you picked in one line. Climbing without need is overengineering; refusing to climb when the problem demands it is lazy code. Both are defects.
+When the choice is not obvious, state the rung you picked in one line. Climbing without need is overengineering; refusing to climb when the problem demands it is a half-done fix. Both are defects.
 
-### Never Simplified Away
+### The Floor
 
 Minimal never means dropping any of these: error handling, input validation at boundaries, tests for changed behavior, security checks, resource cleanup, documented invariants. A "simpler" version that loses one of them is not simpler; it is broken.
 

--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -32,6 +32,24 @@ Rationale: Immutable data prevents hidden side effects, makes debugging easier, 
 - Avoid speculative generality
 - Start simple, then refactor when the pressure is real
 
+## The Minimal-Change Ladder (CRITICAL)
+
+Walk this ladder top to bottom before writing any code, and stop at the FIRST rung that truly solves the request:
+
+1. **No change**: the capability already exists (a flag, a config, an existing API). Point to it.
+2. **Deletion**: removing code solves the problem. Prefer deleting over adding.
+3. **One-line fix**: the smallest edit at the true root cause, never at the symptom.
+4. **Local change**: contained to one function or file, using what is already imported.
+5. **Existing seam**: extend an abstraction that already exists instead of creating one.
+6. **New unit**: a new function or module, only after rungs 1 to 5 genuinely fail.
+7. **New abstraction or dependency**: last resort; justify why every lower rung failed.
+
+When the choice is not obvious, state the rung you picked in one line. Climbing without need is overengineering; refusing to climb when the problem demands it is lazy code. Both are defects.
+
+### Never Simplified Away
+
+Minimal never means dropping any of these: error handling, input validation at boundaries, tests for changed behavior, security checks, resource cleanup, documented invariants. A "simpler" version that loses one of them is not simpler; it is broken.
+
 ## File Organization
 
 MANY SMALL FILES > FEW LARGE FILES:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -273,7 +273,7 @@ if ($hasInstallArgs) {
 # Interactive ecosystem install (skipped in headless/CI)
 $isInteractive = [Environment]::UserInteractive -and -not $env:CI -and -not [Console]::IsInputRedirected
 if ($isInteractive -and -not $DryRun) {
-    $ans = Read-Host "`n  Install prompt library? (61 agents, 230 skills, 77 commands) [Y/n]"
+    $ans = Read-Host "`n  Install prompt library? (61 agents, 231 skills, 77 commands) [Y/n]"
     if ([string]::IsNullOrEmpty($ans) -or $ans -eq 'Y' -or $ans -eq 'y') {
         if ((Get-Command gemini -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $env:USERPROFILE ".gemini"))) {
             Write-Host "  installing to Gemini / AGY..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,7 +227,7 @@ node scripts/egc.js doctor --repo-root "$ROOT_DIR" || true
 
 # Interactive ecosystem install (skipped in CI/headless environments)
 if [ -t 0 ] && [ "$DRY_RUN" = false ]; then
-  printf "\n  Install prompt library? (61 agents, 230 skills, 77 commands) [Y/n] "
+  printf "\n  Install prompt library? (61 agents, 231 skills, 77 commands) [Y/n] "
   read -r _install_ans
   _install_ans="${_install_ans:-Y}"
   if [ "$_install_ans" = "Y" ] || [ "$_install_ans" = "y" ]; then

--- a/scripts/lib/skill-index.json
+++ b/scripts/lib/skill-index.json
@@ -712,8 +712,8 @@
     },
     {
       "kind": "skill",
-      "name": "lazy-code",
-      "description": "Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and lazy stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation."
+      "name": "minimal-change",
+      "description": "Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and half-done stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation."
     },
     {
       "kind": "skill",

--- a/scripts/lib/skill-index.json
+++ b/scripts/lib/skill-index.json
@@ -712,6 +712,11 @@
     },
     {
       "kind": "skill",
+      "name": "lazy-code",
+      "description": "Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and lazy stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation."
+    },
+    {
+      "kind": "skill",
       "name": "healthcare-emr-patterns",
       "description": "EMR/EHR development patterns for healthcare applications. Clinical safety, encounter workflows, prescription generation, clinical decision support integration, and accessibility-first UI for medical data entry."
     },

--- a/skills/general/lazy-code/SKILL.md
+++ b/skills/general/lazy-code/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: lazy-code
+description: Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and lazy stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation.
+origin: EGC
+---
+
+# Lazy Code: the Minimal-Change Ladder in practice
+
+The always-on rule in `coding-style.md` gives every agent the ladder. This skill loads only when the task is code, and turns the ladder into a working protocol: how to pick a rung, what the output must contain, and how strict to be for the context at hand.
+
+Two failure modes, one discipline. Lazy code solves the request on paper and leaves a broken edge behind. Overengineered code solves the request and three imaginary future ones, at triple the diff. The ladder exists to kill both with the same move: the smallest change that fully works.
+
+## Rung selection protocol
+
+1. Restate the request as an observable outcome (what behavior changes, for whom).
+2. Start at rung 1 and climb only on evidence: name the reason each lower rung fails before moving up.
+3. Announce the chosen rung in one line whenever the choice is not obvious, for example: `Rung 5: extending the existing adapter registry; a new module (rung 6) would duplicate its lifecycle handling.`
+4. If mid-implementation you discover the rung was wrong, stop and re-announce instead of silently expanding scope.
+
+## Output contract
+
+Every code deliverable under this skill must satisfy all of these:
+
+- **No stubs shipped as done.** No placeholder bodies, no `TODO` standing in for logic, no commented-out intentions. If something is genuinely out of scope, say so in the summary instead of leaving it half-coded.
+- **The diff is sized to the problem.** Every changed line traces back to the stated outcome. Drive-by refactors, renames, and formatting churn belong in their own change.
+- **Nothing from the Never Simplified Away list is missing**: error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
+- **Dead weight is removed, not added.** No speculative parameters, no config for futures nobody asked for, no wrapper around a wrapper.
+- **Done means verified.** State how the change was checked (test run, command output, reproduction), not that it "should work".
+
+## Intensity levels
+
+- **Strict** (default for production paths, shared libraries, installers, security-adjacent code): full protocol, rung announcement mandatory, contract enforced item by item.
+- **Light** (prototypes, spikes, throwaway scripts, sandboxes): the ladder still guides rung choice, but announcements are optional and the contract relaxes to: no silent broken edges, and label the artifact as a prototype.
+
+When in doubt about which intensity applies, ask or default to strict.
+
+## Worked examples
+
+**Deletion beats patching (rung 2).** A flag parser mishandles an option that nothing has set for six releases. The lazy fix wraps it in a try/catch; the overengineered fix rewrites the parser. The ladder answer deletes the dead option and its branch, and adds the one regression test proving the remaining options still parse.
+
+**Root cause beats symptom (rung 3).** A dashboard shows stale numbers after midnight. The lazy fix reloads the page on a timer; the ladder answer is the one-line fix at the date-boundary comparison that caused the staleness, plus a test pinned to the boundary.
+
+**Existing seam beats new machinery (rung 5).** A new screen needs one more operation exposed over HTTP. The overengineered fix builds a second router with its own auth. The ladder answer registers the operation in the dispatcher that already exists and reuses its token gate, because the seam was built for exactly this.
+
+## Anti-pattern table
+
+| Smell | Failure mode | Ladder response |
+|---|---|---|
+| Placeholder body or TODO-as-logic | lazy | Implement or declare out of scope explicitly |
+| Swallowed error to make tests pass | lazy | Handle it; the error path is part of the task |
+| Symptom patch over root cause | lazy | Climb down to rung 3 at the real cause |
+| New layer with a single caller | overengineering | Rung 5: extend the seam that exists |
+| Config knob for an imagined future | overengineering | YAGNI; delete it |
+| Rewrite when an edit suffices | overengineering | Re-walk the ladder from rung 1 |

--- a/skills/general/minimal-change/SKILL.md
+++ b/skills/general/minimal-change/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: lazy-code
-description: Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and lazy stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation.
+name: minimal-change
+description: Apply the minimal-change ladder when writing or modifying code, choosing the smallest rung that truly solves the task and refusing both padded overengineering and half-done stubs. Use for implementation, refactoring, and bug-fix requests; not for research, documentation, or conversation.
 origin: EGC
 ---
 
-# Lazy Code: the Minimal-Change Ladder in practice
+# Minimal Change: the ladder in practice
 
-The always-on rule in `coding-style.md` gives every agent the ladder. This skill loads only when the task is code, and turns the ladder into a working protocol: how to pick a rung, what the output must contain, and how strict to be for the context at hand.
+The always-on rule in `coding-style.md` gives every agent the ladder. This skill loads only when the task is code, and turns the ladder into a working protocol: how to pick a rung, what the delivery must contain, and how strict to be for the context at hand.
 
-Two failure modes, one discipline. Lazy code solves the request on paper and leaves a broken edge behind. Overengineered code solves the request and three imaginary future ones, at triple the diff. The ladder exists to kill both with the same move: the smallest change that fully works.
+Two failure modes, one discipline. A half-done change solves the request on paper and leaves a broken edge behind. An overengineered change solves the request and three imaginary future ones, at triple the diff. The ladder exists to kill both with the same move: the smallest change that fully works.
 
 ## Rung selection protocol
 
@@ -17,28 +17,28 @@ Two failure modes, one discipline. Lazy code solves the request on paper and lea
 3. Announce the chosen rung in one line whenever the choice is not obvious, for example: `Rung 5: extending the existing adapter registry; a new module (rung 6) would duplicate its lifecycle handling.`
 4. If mid-implementation you discover the rung was wrong, stop and re-announce instead of silently expanding scope.
 
-## Output contract
+## Delivery contract
 
 Every code deliverable under this skill must satisfy all of these:
 
 - **No stubs shipped as done.** No placeholder bodies, no `TODO` standing in for logic, no commented-out intentions. If something is genuinely out of scope, say so in the summary instead of leaving it half-coded.
 - **The diff is sized to the problem.** Every changed line traces back to the stated outcome. Drive-by refactors, renames, and formatting churn belong in their own change.
-- **Nothing from the Never Simplified Away list is missing**: error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
+- **Nothing from The Floor is missing**: error handling, boundary validation, tests for changed behavior, security checks, resource cleanup, documented invariants.
 - **Dead weight is removed, not added.** No speculative parameters, no config for futures nobody asked for, no wrapper around a wrapper.
 - **Done means verified.** State how the change was checked (test run, command output, reproduction), not that it "should work".
 
-## Intensity levels
+## Strictness modes
 
 - **Strict** (default for production paths, shared libraries, installers, security-adjacent code): full protocol, rung announcement mandatory, contract enforced item by item.
 - **Light** (prototypes, spikes, throwaway scripts, sandboxes): the ladder still guides rung choice, but announcements are optional and the contract relaxes to: no silent broken edges, and label the artifact as a prototype.
 
-When in doubt about which intensity applies, ask or default to strict.
+When in doubt about which mode applies, ask or default to strict.
 
 ## Worked examples
 
-**Deletion beats patching (rung 2).** A flag parser mishandles an option that nothing has set for six releases. The lazy fix wraps it in a try/catch; the overengineered fix rewrites the parser. The ladder answer deletes the dead option and its branch, and adds the one regression test proving the remaining options still parse.
+**Deletion beats patching (rung 2).** A flag parser mishandles an option that nothing has set for six releases. The quick fix wraps it in a try/catch; the overengineered fix rewrites the parser. The ladder answer deletes the dead option and its branch, and adds the one regression test proving the remaining options still parse.
 
-**Root cause beats symptom (rung 3).** A dashboard shows stale numbers after midnight. The lazy fix reloads the page on a timer; the ladder answer is the one-line fix at the date-boundary comparison that caused the staleness, plus a test pinned to the boundary.
+**Root cause beats symptom (rung 3).** A dashboard shows stale numbers after midnight. The quick fix reloads the page on a timer; the ladder answer is the one-line fix at the date-boundary comparison that caused the staleness, plus a test pinned to the boundary.
 
 **Existing seam beats new machinery (rung 5).** A new screen needs one more operation exposed over HTTP. The overengineered fix builds a second router with its own auth. The ladder answer registers the operation in the dispatcher that already exists and reuses its token gate, because the seam was built for exactly this.
 
@@ -46,9 +46,9 @@ When in doubt about which intensity applies, ask or default to strict.
 
 | Smell | Failure mode | Ladder response |
 |---|---|---|
-| Placeholder body or TODO-as-logic | lazy | Implement or declare out of scope explicitly |
-| Swallowed error to make tests pass | lazy | Handle it; the error path is part of the task |
-| Symptom patch over root cause | lazy | Climb down to rung 3 at the real cause |
+| Placeholder body or TODO-as-logic | half-done | Implement or declare out of scope explicitly |
+| Swallowed error to make tests pass | half-done | Handle it; the error path is part of the task |
+| Symptom patch over root cause | half-done | Climb down to rung 3 at the real cause |
 | New layer with a single caller | overengineering | Rung 5: extend the seam that exists |
 | Config knob for an imagined future | overengineering | YAGNI; delete it |
 | Rewrite when an edit suffices | overengineering | Re-walk the ladder from rung 1 |

--- a/skills/general/minimal-change/SKILL.md
+++ b/skills/general/minimal-change/SKILL.md
@@ -30,7 +30,7 @@ Every code deliverable under this skill must satisfy all of these:
 ## Strictness modes
 
 - **Strict** (default for production paths, shared libraries, installers, security-adjacent code): full protocol, rung announcement mandatory, contract enforced item by item.
-- **Light** (prototypes, spikes, throwaway scripts, sandboxes): the ladder still guides rung choice, but announcements are optional and the contract relaxes to: no silent broken edges, and label the artifact as a prototype.
+- **Light** (prototypes, spikes, throwaway scripts, sandboxes): the ladder still guides rung choice and The Floor holds in full; no mode ever waives it. Announcements become optional, and the rest of the contract relaxes to: no silent broken edges, and label the artifact as a prototype.
 
 When in doubt about which mode applies, ask or default to strict.
 


### PR DESCRIPTION
## What this delivers

The discipline of the smallest solution that fully works, in two layers, so it holds in every LLM that consumes EGC:

**Layer 1, always on and short** (`rules/common/coding-style.md`): a seven-rung decision ladder plus The Floor, the list of guarantees a minimal change can never drop. Marginal tokens in a file that was already loaded, distributed by the `rules-core` module wherever rules already ship, with the cursor and kiro condensations carrying a summary.

**Layer 2, routed** (`skills/general/minimal-change/`): the volume lives here: rung selection protocol, delivery contract, strictness modes, worked examples and an anti-pattern table. The frontmatter description deliberately excludes non-code requests, because that text is what routes it. Registered in the `workflow-quality` module (defaultInstall, 12 targets) and in both catalog indices via the official generator.

Why two layers and not one always-on ruleset: an always-on block is re-sent as input on every call, so on models whose base output is already lean the overhead can exceed the lines saved. The short rung list rides an existing file; the heavy guidance loads only when a code task routes it.

## Validation

- `build-skill-index.js` regenerated both indices (401 entries)
- All six CI component validators pass locally; markdownlint clean on both content files
- 249 tests green across the index-consuming suites (catalog-search 13, prompt-router 7, install-apply 35, install-targets 158, install-lifecycle 36)
- Real installs into scratch homes verified end to end: the ladder and the skill land for claude (`~/.claude/skills/minimal-change/`), cursor (`.cursor/rules/common-coding-style.mdc` + skill) and codex (`.agents/skills/`); gemini, trae and kiro keep exact parity with today (they receive style guidance via the session catalog, not rule files, and the new skill is indexed there)
- README count updated 230 to 231, matching the validator

Closes #1188's goal as a first-party implementation; that PR will be closed with credit.
