### PR TITLE
chore(deps): bump codeql-action init and analyze to v4.37.6 in one commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -100,6 +100,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## What

Pins both `github/codeql-action/init` and `github/codeql-action/analyze` to the same v4.37.6 commit SHA (`5595ccaf912efad79be6eef63a5619ff05969be3`) in `.github/workflows/codeql.yml`.

## Why

Dependabot proposed the two bumps as separate pull requests (#1261 for `init`, #1260 for `analyze`). Each one on its own leaves the pair on different versions, and the analyze step then fails on every language:

```
Loaded a configuration file for version '4.37.6', but running version '4.37.4'
```

The init step writes a configuration file stamped with its own version, and the analyze step refuses to read a file written by a different version. Both steps have to move in the same commit, so this single change replaces the two split updates. `upload-sarif` was already moved to the same SHA in #1262.

## Verification

CI green on this branch, including the three CodeQL languages (actions, javascript-typescript, python) that failed in #1260 and #1261.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `github/codeql-action/init` and `github/codeql-action/analyze` to v4.37.6 (SHA `5595ccaf912efad79be6eef63a5619ff05969be3`) to keep versions in sync so `analyze` accepts the config written by `init`. Previously, split updates left them mismatched and `analyze` failed with “Loaded a configuration file for version '4.37.6', but running version '4.37.4'.”

**Review notes**
- Updates only the two `uses` lines in `.github/workflows/codeql.yml` to the same SHA.
- Expect green CodeQL jobs for actions, JavaScript/TypeScript, and Python.
- No migration or runtime impact.

<sup>Written for commit 0ba1b8ff61bbbf0a0d89ac0f19c245fb2d29d7c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

