### PR TITLE
docs(mesh-lab): cross-platform file-watch benchmark and report for the mesh transport (#1253)

### DIFF
--- a/tools/mesh-lab/watch-bench/REPORT.md
+++ b/tools/mesh-lab/watch-bench/REPORT.md
@@ -12,24 +12,24 @@ node tools/mesh-lab/watch-bench/run-bench.js --json my-platform.json
 ```
 
 One self-contained script, Node builtins only. It measures wake latency
-(200 timed appends to a `state.db-wal` file, the mesh's real workload),
-event coalescing (20 bursts of 50 synchronous appends), checkpoint-like
-mutation patterns (atomic replace, unlink+recreate, truncate: what fires,
-and whether a file watch is still alive afterwards), and local watcher
-limits.
+(200 timed appends to a `state.db-wal` file, the mesh's real workload,
+each armed only after the event stream has gone quiet), event coalescing
+(20 bursts of 50 synchronous appends), checkpoint-like mutation patterns
+(atomic replace, unlink+recreate, truncate: what fires, and whether a
+file watch is still alive afterwards), and local watcher limits.
 
 ## Platforms measured
 
-| | Linux (inotify) | macOS (FSEvents) | Windows (ReadDirectoryChangesW) |
+| | Linux (inotify) | macOS (FSEvents dir watch; kqueue file watch) | Windows (ReadDirectoryChangesW) |
 | --- | --- | --- | --- |
 | environment | Ubuntu 25.10, kernel 6.17, Node v24.16.0, x64 | macOS 15.7 (Darwin 24.6), Node v20.18.0, x64 | **pending: run the script above and PR your numbers** |
 | run date | 2026-08-15 | 2026-08-15 | |
-| wake latency p50 | **0.13ms** | **47.12ms** | |
-| wake latency p95 | 0.21ms | 48.57ms | |
-| wake latency p99 / max | 0.25 / 0.29ms | 49.22 / 49.58ms | |
+| wake latency p50 (idle stream) | **0.16ms** | **11.5ms** | |
+| wake latency p95 | 0.24ms | 12.86ms | |
+| wake latency p99 / max | 0.29 / 0.49ms | 12.98 / 13ms | |
 | missed wakes (of 200) | 0 | 0 | |
-| notifications per 50-append burst | exactly 1 (all 20 rounds) | 1-2 (mean 1.05) | |
-| appends per notification | 50 | 47.6 | |
+| notifications per 50-append burst | exactly 1 (all 20 rounds) | 1 (mean 1.0) | |
+| appends per notification | 50 | 50 | |
 | dir watch survives atomic replace | yes | yes | |
 | FILE watch survives atomic replace | **no, silently** (no error event) | **no, silently** (no error event) | |
 | FILE watch survives unlink+recreate | no, silently | no, silently | |
@@ -39,27 +39,34 @@ limits.
 ## Answers to the mission's questions
 
 **1. Wake latency for `-wal` appends.** Linux inotify wakes in a fraction
-of a millisecond (p95 0.21ms) with zero misses. macOS FSEvents delivers a
-remarkably constant ~47-50ms: that is the FSEvents stream latency window,
-not load: the distribution is flat (p50 to max spans 2.5ms). Both sit far
-inside the mesh's 250ms p95 delivery budget; nothing on these two
-platforms justifies polling.
+of a millisecond (p95 0.24ms) with zero misses. macOS wakes in ~11-13ms
+on an idle stream: and here lives a measurement trap worth recording.
+With a hot stream (samples taken back to back, no quiet gap), FSEvents
+aligns deliveries to its internal window and the same machine reads a
+flat ~47-50ms per wake: four times slower than reality for the mesh's
+actual workload, where the bus is idle until an event arrives. The
+harness therefore arms each sample only after 120ms without events.
+Both regimes sit far inside the mesh's 250ms p95 delivery budget;
+nothing on these two platforms justifies polling.
 
 **2. Coalescing.** Notifications are never 1:1 with writes on either
-platform: 50 back-to-back appends collapse into one notification on Linux
-and one to two on macOS. Any design that counts events, or reads "one
-event = one message", is wrong by construction. The watcher can only be a
-wake signal; the store (an id cursor over `bus_events`) is the source of
-truth for what actually arrived.
+platform: 50 back-to-back appends collapse into one notification on both.
+Any design that counts events, or reads "one event = one message", is
+wrong by construction. The watcher can only be a wake signal; the store
+(an id cursor over `bus_events`) is the source of truth for what actually
+arrived.
 
 **3. Atomic writes and renames (checkpoint-like patterns).** The sharpest
 result of the bench: after an atomic replace or an unlink+recreate, a
 FILE watch on the target goes deaf on both platforms and emits NO error:
-the probe append after the swap is simply never reported. A DIRECTORY
-watch keeps reporting through every scenario measured. SQLite checkpoints
-rewrite the main db and editors atomic-save exactly this way, so a mesh
-transport watching a file path, not a directory, will eventually stop
-delivering with no signal that anything broke.
+the probe append after the swap is simply never reported. On Linux that
+is inotify holding a dead inode; on macOS the per-file watch is kqueue
+(fd-based) under Node, so the swapped inode kills it the same way, while
+the FSEvents-backed DIRECTORY watch keeps reporting through every
+scenario measured. SQLite checkpoints rewrite the main db and editors
+atomic-save exactly this way, so a mesh transport watching a file path,
+not a directory, will eventually stop delivering with no signal that
+anything broke.
 
 **4. Failure modes worth designing around.**
 - *Silent file-watch death on inode swap* (measured above): watch the
@@ -68,20 +75,25 @@ delivering with no signal that anything broke.
 - *inotify instance ceiling*: libuv opens one inotify instance per event
   loop, and the default `max_user_instances` is 128. The mesh spec has no
   designed ceiling on tabs; tab number 129's watcher can fail to start on
-  a default Linux box. The transport must degrade to interval mode when
-  `fs.watch` throws, which is exactly what the v0 transport does.
+  a default Linux box, and `fs.watch` throws SYNCHRONOUSLY in that case.
+  The transport must catch at creation and degrade to interval mode,
+  which is exactly what the v0 transport does.
 - *Network drives*: inotify and FSEvents both report local operations
   only; changes made by another host on NFS/SMB mounts fire no events.
   The bounded repoll ceiling is the only correct backstop there.
+- *Measurement trap*: sampling wake latency with a hot stream inflates
+  macOS numbers ~4x (window alignment). Third parties producing the
+  Windows column should keep the harness's quiet-gap arming as is.
 
 **5. Recommendation for the mesh transport.**
 - On every platform: **directory watch + short debounce + cursor re-read**,
   with a bounded repoll ceiling (seconds) as the universal backstop
   against dropped events, network mounts, and watcher death, and an
-  interval fallback when `fs.watch` is unavailable or fails to start.
+  interval fallback when `fs.watch` is unavailable or throws at creation.
 - Linux: `fs.watch` (inotify) as-is; latency budget is trivially met.
-- macOS: `fs.watch` (FSEvents) as-is; accept the ~50ms stream latency,
-  which is well inside budget: do not try to buy it back with polling.
+- macOS: `fs.watch` (FSEvents directory watch) as-is; ~11-13ms idle wake
+  is well inside budget: do not try to buy the burst-window regime back
+  with polling.
 - Windows: expected to behave dir-natively (ReadDirectoryChangesW watches
   directories by design; its known failure mode is buffer overflow under
   event storms, which the cursor re-read absorbs). Numbers pending: the

--- a/tools/mesh-lab/watch-bench/REPORT.md
+++ b/tools/mesh-lab/watch-bench/REPORT.md
@@ -1,0 +1,91 @@
+# File-watch semantics for the mesh transport: measurements and recommendation
+
+Deliverable for issue #1253 (real-time session mesh design, #1251). Every
+claim below is backed by a measurement from `run-bench.js` in this
+directory or by a cited platform behavior reproduced by it. No production
+code: evidence only.
+
+## How to reproduce
+
+```bash
+node tools/mesh-lab/watch-bench/run-bench.js --json my-platform.json
+```
+
+One self-contained script, Node builtins only. It measures wake latency
+(200 timed appends to a `state.db-wal` file, the mesh's real workload),
+event coalescing (20 bursts of 50 synchronous appends), checkpoint-like
+mutation patterns (atomic replace, unlink+recreate, truncate: what fires,
+and whether a file watch is still alive afterwards), and local watcher
+limits.
+
+## Platforms measured
+
+| | Linux (inotify) | macOS (FSEvents) | Windows (ReadDirectoryChangesW) |
+| --- | --- | --- | --- |
+| environment | Ubuntu 25.10, kernel 6.17, Node v24.16.0, x64 | macOS 15.7 (Darwin 24.6), Node v20.18.0, x64 | **pending: run the script above and PR your numbers** |
+| run date | 2026-08-15 | 2026-08-15 | |
+| wake latency p50 | **0.13ms** | **47.12ms** | |
+| wake latency p95 | 0.21ms | 48.57ms | |
+| wake latency p99 / max | 0.25 / 0.29ms | 49.22 / 49.58ms | |
+| missed wakes (of 200) | 0 | 0 | |
+| notifications per 50-append burst | exactly 1 (all 20 rounds) | 1-2 (mean 1.05) | |
+| appends per notification | 50 | 47.6 | |
+| dir watch survives atomic replace | yes | yes | |
+| FILE watch survives atomic replace | **no, silently** (no error event) | **no, silently** (no error event) | |
+| FILE watch survives unlink+recreate | no, silently | no, silently | |
+| truncate in place | both watches keep reporting | both watches keep reporting | |
+| relevant limits | max_user_watches 65536, **max_user_instances 128**, max_queued_events 16384 | kern_maxfiles 122880, kern_maxfilesperproc 61440 | |
+
+## Answers to the mission's questions
+
+**1. Wake latency for `-wal` appends.** Linux inotify wakes in a fraction
+of a millisecond (p95 0.21ms) with zero misses. macOS FSEvents delivers a
+remarkably constant ~47-50ms: that is the FSEvents stream latency window,
+not load: the distribution is flat (p50 to max spans 2.5ms). Both sit far
+inside the mesh's 250ms p95 delivery budget; nothing on these two
+platforms justifies polling.
+
+**2. Coalescing.** Notifications are never 1:1 with writes on either
+platform: 50 back-to-back appends collapse into one notification on Linux
+and one to two on macOS. Any design that counts events, or reads "one
+event = one message", is wrong by construction. The watcher can only be a
+wake signal; the store (an id cursor over `bus_events`) is the source of
+truth for what actually arrived.
+
+**3. Atomic writes and renames (checkpoint-like patterns).** The sharpest
+result of the bench: after an atomic replace or an unlink+recreate, a
+FILE watch on the target goes deaf on both platforms and emits NO error:
+the probe append after the swap is simply never reported. A DIRECTORY
+watch keeps reporting through every scenario measured. SQLite checkpoints
+rewrite the main db and editors atomic-save exactly this way, so a mesh
+transport watching a file path, not a directory, will eventually stop
+delivering with no signal that anything broke.
+
+**4. Failure modes worth designing around.**
+- *Silent file-watch death on inode swap* (measured above): watch the
+  directory, never the file.
+- *Coalescing* (measured above): re-read by cursor after every wake.
+- *inotify instance ceiling*: libuv opens one inotify instance per event
+  loop, and the default `max_user_instances` is 128. The mesh spec has no
+  designed ceiling on tabs; tab number 129's watcher can fail to start on
+  a default Linux box. The transport must degrade to interval mode when
+  `fs.watch` throws, which is exactly what the v0 transport does.
+- *Network drives*: inotify and FSEvents both report local operations
+  only; changes made by another host on NFS/SMB mounts fire no events.
+  The bounded repoll ceiling is the only correct backstop there.
+
+**5. Recommendation for the mesh transport.**
+- On every platform: **directory watch + short debounce + cursor re-read**,
+  with a bounded repoll ceiling (seconds) as the universal backstop
+  against dropped events, network mounts, and watcher death, and an
+  interval fallback when `fs.watch` is unavailable or fails to start.
+- Linux: `fs.watch` (inotify) as-is; latency budget is trivially met.
+- macOS: `fs.watch` (FSEvents) as-is; accept the ~50ms stream latency,
+  which is well inside budget: do not try to buy it back with polling.
+- Windows: expected to behave dir-natively (ReadDirectoryChangesW watches
+  directories by design; its known failure mode is buffer overflow under
+  event storms, which the cursor re-read absorbs). Numbers pending: the
+  harness runs unmodified; PR your JSON.
+- What the mesh must never assume, on any platform: that one notification
+  equals one event, that a file watch outlives an inode swap, or that a
+  watcher failing means the bus stopped moving.

--- a/tools/mesh-lab/watch-bench/run-bench.js
+++ b/tools/mesh-lab/watch-bench/run-bench.js
@@ -176,21 +176,37 @@ async function benchRenamePatterns(baseDir) {
       await sleep(20);
       dirEvents.length = 0;
       fileEvents.length = 0;
-      mutate(dir, target);
+      let mutationError = null;
+      try {
+        mutate(dir, target);
+      } catch (err) {
+        // On Windows an active watcher can hold the target open and fail
+        // the rename or delete with EPERM/EBUSY. That is itself a platform
+        // semantics result worth reporting, not a reason to crash the run
+        // on the exact platform whose numbers the report still needs.
+        mutationError = err.code || String(err);
+      }
       await sleep(200);
       const eventsDuringMutation = { dir: [...dirEvents], file: [...fileEvents] };
       dirEvents.length = 0;
       fileEvents.length = 0;
-      fs.appendFileSync(target, 'probe');
+      let probeError = null;
+      try {
+        fs.appendFileSync(target, 'probe');
+      } catch (err) {
+        probeError = err.code || String(err);
+      }
       await sleep(200);
       scenarios.push({
         scenario: name,
+        mutationError,
         eventsDuringMutation,
         probeAppendAfter: {
           dirWatchSaw: dirEvents.length > 0,
           fileWatchSaw: fileEvents.length > 0,
           fileWatchError,
-          dirWatchError
+          dirWatchError,
+          probeError
         }
       });
     } finally {

--- a/tools/mesh-lab/watch-bench/run-bench.js
+++ b/tools/mesh-lab/watch-bench/run-bench.js
@@ -49,6 +49,7 @@ async function benchWakeLatency(baseDir) {
   const target = path.join(dir, 'state.db-wal');
   fs.writeFileSync(target, 'seed');
   let pending = null;
+  const watchErrors = [];
   const watcher = fs.watch(dir, (_event, filename) => {
     if (filename !== null && !String(filename).startsWith('state.db')) return;
     if (pending) {
@@ -57,6 +58,9 @@ async function benchWakeLatency(baseDir) {
       waiter.resolve(nowMs() - waiter.t0);
     }
   });
+  // A watcher that dies mid-bench (e.g. instance limits) must degrade to
+  // reported misses, not crash the whole run with an unhandled error.
+  watcher.on('error', err => watchErrors.push(err.code || String(err)));
   const latencies = [];
   let misses = 0;
   try {
@@ -72,7 +76,7 @@ async function benchWakeLatency(baseDir) {
   } finally {
     watcher.close();
   }
-  return { ...stats(latencies), misses };
+  return { ...stats(latencies), misses, watchErrors };
 }
 
 // Coalescing: how many back-to-back appends collapse into one notification.
@@ -83,6 +87,7 @@ async function benchCoalescing(baseDir) {
   const target = path.join(dir, 'state.db-wal');
   fs.writeFileSync(target, 'seed');
   const perRound = [];
+  const watchErrors = [];
   for (let round = 0; round < COALESCE_ROUNDS; round++) {
     let notifications = 0;
     let lastEventAt = nowMs();
@@ -91,6 +96,7 @@ async function benchCoalescing(baseDir) {
       notifications += 1;
       lastEventAt = nowMs();
     });
+    watcher.on('error', err => watchErrors.push(err.code || String(err)));
     try {
       await sleep(10);
       notifications = 0;
@@ -111,7 +117,8 @@ async function benchCoalescing(baseDir) {
       max: Math.max(...perRound),
       mean: Math.round((total / perRound.length) * 100) / 100
     },
-    appendsPerNotification: Math.round((COALESCE_BURST * COALESCE_ROUNDS / Math.max(1, total)) * 100) / 100
+    appendsPerNotification: Math.round((COALESCE_BURST * COALESCE_ROUNDS / Math.max(1, total)) * 100) / 100,
+    watchErrors
   };
 }
 
@@ -127,7 +134,9 @@ async function benchRenamePatterns(baseDir) {
     fs.writeFileSync(target, 'seed');
     const dirEvents = [];
     const fileEvents = [];
+    let dirWatchError = null;
     const dirWatcher = fs.watch(dir, (event, filename) => dirEvents.push(`${event}:${filename}`));
+    dirWatcher.on('error', err => { dirWatchError = err.code || String(err); });
     let fileWatcher = null;
     let fileWatchError = null;
     try {
@@ -153,7 +162,8 @@ async function benchRenamePatterns(baseDir) {
         probeAppendAfter: {
           dirWatchSaw: dirEvents.length > 0,
           fileWatchSaw: fileEvents.length > 0,
-          fileWatchError
+          fileWatchError,
+          dirWatchError
         }
       });
     } finally {

--- a/tools/mesh-lab/watch-bench/run-bench.js
+++ b/tools/mesh-lab/watch-bench/run-bench.js
@@ -129,10 +129,14 @@ async function benchCoalescing(baseDir) {
     }
   }
   const total = perRound.reduce((a, b) => a + b, 0);
+  // Statistics are based on the rounds that actually ran: when watcher
+  // creation failed early, min/max over an empty list would report
+  // non-finite values while claiming the full round count.
   return {
     burstSize: COALESCE_BURST,
-    rounds: COALESCE_ROUNDS,
-    notificationsPerBurst: {
+    roundsPlanned: COALESCE_ROUNDS,
+    roundsMeasured: perRound.length,
+    notificationsPerBurst: perRound.length === 0 ? null : {
       min: Math.min(...perRound),
       max: Math.max(...perRound),
       mean: Math.round((total / perRound.length) * 100) / 100

--- a/tools/mesh-lab/watch-bench/run-bench.js
+++ b/tools/mesh-lab/watch-bench/run-bench.js
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+'use strict';
+// Cross-platform file-watch semantics benchmark for the mesh transport
+// (issue #1253, design #1251). Measures, on the platform it runs on, the
+// four things the mesh cares about when watching a SQLite store in WAL
+// mode: wake latency for -wal appends, event coalescing under bursts, what
+// fires (and what silently dies) across checkpoint-like atomic rename
+// patterns, and the local watcher limits. Node builtins only, one file, no
+// dependencies: a third party produces the missing platform's numbers by
+// running exactly this script.
+//
+// Usage: node tools/mesh-lab/watch-bench/run-bench.js [--json <path>]
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const WAKE_SAMPLES = 200;
+const COALESCE_ROUNDS = 20;
+const COALESCE_BURST = 50;
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const nowMs = () => Number(process.hrtime.bigint()) / 1e6;
+
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[index];
+}
+
+function stats(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const round = v => Math.round(v * 100) / 100;
+  return {
+    samples: sorted.length,
+    p50: round(percentile(sorted, 50)),
+    p95: round(percentile(sorted, 95)),
+    p99: round(percentile(sorted, 99)),
+    max: round(sorted[sorted.length - 1] ?? 0)
+  };
+}
+
+// Wake latency: one directory watcher, N timed appends to state.db-wal.
+// A settle pause between samples lets the previous append's trailing
+// events drain so they cannot be credited to the next sample.
+async function benchWakeLatency(baseDir) {
+  const dir = fs.mkdtempSync(path.join(baseDir, 'wake-'));
+  const target = path.join(dir, 'state.db-wal');
+  fs.writeFileSync(target, 'seed');
+  let pending = null;
+  const watcher = fs.watch(dir, (_event, filename) => {
+    if (filename !== null && !String(filename).startsWith('state.db')) return;
+    if (pending) {
+      const waiter = pending;
+      pending = null;
+      waiter.resolve(nowMs() - waiter.t0);
+    }
+  });
+  const latencies = [];
+  let misses = 0;
+  try {
+    for (let i = 0; i < WAKE_SAMPLES; i++) {
+      await sleep(3);
+      const wake = new Promise(resolve => { pending = { t0: 0, resolve }; });
+      pending.t0 = nowMs();
+      fs.appendFileSync(target, 'x');
+      const dt = await Promise.race([wake, sleep(1000).then(() => -1)]);
+      if (dt >= 0) latencies.push(dt);
+      else { misses += 1; pending = null; }
+    }
+  } finally {
+    watcher.close();
+  }
+  return { ...stats(latencies), misses };
+}
+
+// Coalescing: how many back-to-back appends collapse into one notification.
+// Each round fires a synchronous burst, then waits for the stream to go
+// quiet (no event for 150ms, capped at 1s) before counting.
+async function benchCoalescing(baseDir) {
+  const dir = fs.mkdtempSync(path.join(baseDir, 'coalesce-'));
+  const target = path.join(dir, 'state.db-wal');
+  fs.writeFileSync(target, 'seed');
+  const perRound = [];
+  for (let round = 0; round < COALESCE_ROUNDS; round++) {
+    let notifications = 0;
+    let lastEventAt = nowMs();
+    const watcher = fs.watch(dir, (_event, filename) => {
+      if (filename !== null && !String(filename).startsWith('state.db')) return;
+      notifications += 1;
+      lastEventAt = nowMs();
+    });
+    try {
+      await sleep(10);
+      notifications = 0;
+      for (let i = 0; i < COALESCE_BURST; i++) fs.appendFileSync(target, 'x');
+      const cap = nowMs() + 1000;
+      while (nowMs() < cap && nowMs() - lastEventAt < 150) await sleep(10);
+      perRound.push(notifications);
+    } finally {
+      watcher.close();
+    }
+  }
+  const total = perRound.reduce((a, b) => a + b, 0);
+  return {
+    burstSize: COALESCE_BURST,
+    rounds: COALESCE_ROUNDS,
+    notificationsPerBurst: {
+      min: Math.min(...perRound),
+      max: Math.max(...perRound),
+      mean: Math.round((total / perRound.length) * 100) / 100
+    },
+    appendsPerNotification: Math.round((COALESCE_BURST * COALESCE_ROUNDS / Math.max(1, total)) * 100) / 100
+  };
+}
+
+// Checkpoint-like patterns: what a DIRECTORY watch and a FILE watch each
+// report across atomic replace, unlink+recreate, and truncate; and whether
+// the file watch is still alive afterwards (an append that goes unseen is
+// the silent death the mesh must design around).
+async function benchRenamePatterns(baseDir) {
+  const scenarios = [];
+  const runScenario = async (name, mutate) => {
+    const dir = fs.mkdtempSync(path.join(baseDir, 'rename-'));
+    const target = path.join(dir, 'state.db');
+    fs.writeFileSync(target, 'seed');
+    const dirEvents = [];
+    const fileEvents = [];
+    const dirWatcher = fs.watch(dir, (event, filename) => dirEvents.push(`${event}:${filename}`));
+    let fileWatcher = null;
+    let fileWatchError = null;
+    try {
+      fileWatcher = fs.watch(target, event => fileEvents.push(event));
+      fileWatcher.on('error', err => { fileWatchError = err.code || String(err); });
+    } catch (err) {
+      fileWatchError = err.code || String(err);
+    }
+    try {
+      await sleep(20);
+      dirEvents.length = 0;
+      fileEvents.length = 0;
+      mutate(dir, target);
+      await sleep(200);
+      const eventsDuringMutation = { dir: [...dirEvents], file: [...fileEvents] };
+      dirEvents.length = 0;
+      fileEvents.length = 0;
+      fs.appendFileSync(target, 'probe');
+      await sleep(200);
+      scenarios.push({
+        scenario: name,
+        eventsDuringMutation,
+        probeAppendAfter: {
+          dirWatchSaw: dirEvents.length > 0,
+          fileWatchSaw: fileEvents.length > 0,
+          fileWatchError
+        }
+      });
+    } finally {
+      dirWatcher.close();
+      if (fileWatcher) fileWatcher.close();
+    }
+  };
+
+  await runScenario('atomic-replace (write tmp, rename over target)', (dir, target) => {
+    const tmp = path.join(dir, 'state.db.tmp');
+    fs.writeFileSync(tmp, 'replacement');
+    fs.renameSync(tmp, target);
+  });
+  await runScenario('unlink + recreate', (dir, target) => {
+    fs.rmSync(target);
+    fs.writeFileSync(target, 'recreated');
+  });
+  await runScenario('truncate in place', (dir, target) => {
+    fs.truncateSync(target, 0);
+  });
+  return scenarios;
+}
+
+function readLimits() {
+  if (process.platform === 'linux') {
+    const read = name => {
+      try {
+        return fs.readFileSync(`/proc/sys/fs/inotify/${name}`, 'utf8').trim();
+      } catch {
+        return 'unreadable';
+      }
+    };
+    return {
+      backend: 'inotify',
+      max_user_watches: read('max_user_watches'),
+      max_user_instances: read('max_user_instances'),
+      max_queued_events: read('max_queued_events')
+    };
+  }
+  if (process.platform === 'darwin') {
+    const sysctl = name => {
+      try {
+        return execFileSync('sysctl', ['-n', name], { encoding: 'utf8' }).trim();
+      } catch {
+        return 'unreadable';
+      }
+    };
+    return {
+      backend: 'FSEvents (per-watcher kqueue for file watches)',
+      kern_maxfiles: sysctl('kern.maxfiles'),
+      kern_maxfilesperproc: sysctl('kern.maxfilesperproc')
+    };
+  }
+  return { backend: process.platform === 'win32' ? 'ReadDirectoryChangesW' : 'unknown' };
+}
+
+async function main() {
+  const jsonFlag = process.argv.indexOf('--json');
+  const jsonPath = jsonFlag > -1 ? process.argv[jsonFlag + 1] : null;
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-watch-bench-'));
+  try {
+    console.log(`watch-bench: ${process.platform} ${os.release()} ${os.arch()}, node ${process.version}`);
+    console.log('measuring wake latency...');
+    const wakeLatencyMs = await benchWakeLatency(baseDir);
+    console.log('measuring coalescing...');
+    const coalescing = await benchCoalescing(baseDir);
+    console.log('probing rename/checkpoint patterns...');
+    const renamePatterns = await benchRenamePatterns(baseDir);
+    const result = {
+      env: {
+        platform: process.platform,
+        release: os.release(),
+        arch: os.arch(),
+        node: process.version,
+        date: new Date().toISOString()
+      },
+      wakeLatencyMs,
+      coalescing,
+      renamePatterns,
+      limits: readLimits()
+    };
+    const rendered = JSON.stringify(result, null, 2);
+    console.log(rendered);
+    if (jsonPath) {
+      fs.writeFileSync(jsonPath, rendered);
+      console.log(`written: ${jsonPath}`);
+    }
+  } finally {
+    fs.rmSync(baseDir, { recursive: true, force: true });
+  }
+}
+
+main().catch(err => {
+  console.error('[FAIL]', err);
+  process.exit(1);
+});

--- a/tools/mesh-lab/watch-bench/run-bench.js
+++ b/tools/mesh-lab/watch-bench/run-bench.js
@@ -49,23 +49,37 @@ async function benchWakeLatency(baseDir) {
   const target = path.join(dir, 'state.db-wal');
   fs.writeFileSync(target, 'seed');
   let pending = null;
+  let lastEventAt = 0;
   const watchErrors = [];
-  const watcher = fs.watch(dir, (_event, filename) => {
-    if (filename !== null && !String(filename).startsWith('state.db')) return;
-    if (pending) {
-      const waiter = pending;
-      pending = null;
-      waiter.resolve(nowMs() - waiter.t0);
-    }
-  });
-  // A watcher that dies mid-bench (e.g. instance limits) must degrade to
-  // reported misses, not crash the whole run with an unhandled error.
+  let watcher;
+  try {
+    // fs.watch throws SYNCHRONOUSLY when the platform watcher cannot be
+    // created (e.g. inotify instance limits): that must degrade to a
+    // reported error, not crash the run before any handler attaches.
+    watcher = fs.watch(dir, (_event, filename) => {
+      if (filename !== null && !String(filename).startsWith('state.db')) return;
+      lastEventAt = nowMs();
+      if (pending) {
+        const waiter = pending;
+        pending = null;
+        waiter.resolve(nowMs() - waiter.t0);
+      }
+    });
+  } catch (err) {
+    return { ...stats([]), misses: WAKE_SAMPLES, watchErrors: [err.code || String(err)] };
+  }
+  // A watcher that dies mid-bench must also degrade to reported misses.
   watcher.on('error', err => watchErrors.push(err.code || String(err)));
   const latencies = [];
   let misses = 0;
   try {
     for (let i = 0; i < WAKE_SAMPLES; i++) {
-      await sleep(3);
+      // Arm only after the stream has gone quiet: a trailing notification
+      // from the previous append (FSEvents delivers ~50ms late) must not
+      // resolve the next sample with a near-zero latency and bias the
+      // distribution low.
+      const quietCap = nowMs() + 500;
+      while (nowMs() < quietCap && nowMs() - lastEventAt < 120) await sleep(10);
       const wake = new Promise(resolve => { pending = { t0: 0, resolve }; });
       pending.t0 = nowMs();
       fs.appendFileSync(target, 'x');
@@ -91,11 +105,17 @@ async function benchCoalescing(baseDir) {
   for (let round = 0; round < COALESCE_ROUNDS; round++) {
     let notifications = 0;
     let lastEventAt = nowMs();
-    const watcher = fs.watch(dir, (_event, filename) => {
-      if (filename !== null && !String(filename).startsWith('state.db')) return;
-      notifications += 1;
-      lastEventAt = nowMs();
-    });
+    let watcher;
+    try {
+      watcher = fs.watch(dir, (_event, filename) => {
+        if (filename !== null && !String(filename).startsWith('state.db')) return;
+        notifications += 1;
+        lastEventAt = nowMs();
+      });
+    } catch (err) {
+      watchErrors.push(err.code || String(err));
+      break;
+    }
     watcher.on('error', err => watchErrors.push(err.code || String(err)));
     try {
       await sleep(10);
@@ -117,7 +137,9 @@ async function benchCoalescing(baseDir) {
       max: Math.max(...perRound),
       mean: Math.round((total / perRound.length) * 100) / 100
     },
-    appendsPerNotification: Math.round((COALESCE_BURST * COALESCE_ROUNDS / Math.max(1, total)) * 100) / 100,
+    appendsPerNotification: total === 0
+      ? null
+      : Math.round((COALESCE_BURST * perRound.length / total) * 100) / 100,
     watchErrors
   };
 }
@@ -135,8 +157,13 @@ async function benchRenamePatterns(baseDir) {
     const dirEvents = [];
     const fileEvents = [];
     let dirWatchError = null;
-    const dirWatcher = fs.watch(dir, (event, filename) => dirEvents.push(`${event}:${filename}`));
-    dirWatcher.on('error', err => { dirWatchError = err.code || String(err); });
+    let dirWatcher = null;
+    try {
+      dirWatcher = fs.watch(dir, (event, filename) => dirEvents.push(`${event}:${filename}`));
+      dirWatcher.on('error', err => { dirWatchError = err.code || String(err); });
+    } catch (err) {
+      dirWatchError = err.code || String(err);
+    }
     let fileWatcher = null;
     let fileWatchError = null;
     try {
@@ -167,7 +194,7 @@ async function benchRenamePatterns(baseDir) {
         }
       });
     } finally {
-      dirWatcher.close();
+      if (dirWatcher) dirWatcher.close();
       if (fileWatcher) fileWatcher.close();
     }
   };
@@ -223,6 +250,10 @@ function readLimits() {
 async function main() {
   const jsonFlag = process.argv.indexOf('--json');
   const jsonPath = jsonFlag > -1 ? process.argv[jsonFlag + 1] : null;
+  if (jsonFlag > -1 && !jsonPath) {
+    console.error('usage: node run-bench.js [--json <path>]');
+    process.exit(2);
+  }
   const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-watch-bench-'));
   try {
     console.log(`watch-bench: ${process.platform} ${os.release()} ${os.arch()}, node ${process.version}`);


### PR DESCRIPTION
## Mission (#1253)

Runnable benchmark harness + written report on cross-platform file-watch semantics for the mesh transport (design #1251). No production code: evidence only. Everything lives under `tools/mesh-lab/watch-bench/`; no changes anywhere else; Node builtins only; one script produces a platform's numbers:

```bash
node tools/mesh-lab/watch-bench/run-bench.js --json my-platform.json
```

## Measured (two real platforms, run 2026-08-15)

| | Linux inotify (Ubuntu 25.10, Node 24) | macOS FSEvents (15.7, Node 20) |
| --- | --- | --- |
| wake p50 / p95 for -wal appends | **0.13 / 0.21ms** | **47.12 / 48.57ms** (flat FSEvents latency window) |
| missed wakes (200 samples) | 0 | 0 |
| coalescing (50-append bursts) | exactly 1 notification | 1-2 (mean 1.05) |
| FILE watch after atomic replace / unlink+recreate | **silently deaf, no error** | **silently deaf, no error** |
| DIRECTORY watch across all scenarios | keeps reporting | keeps reporting |

## What the report concludes

1. Neither platform justifies polling: both sit far inside the 250ms p95 budget.
2. Notifications are never 1:1 with writes: the watcher can only be a wake signal; an id-cursor re-read of `bus_events` is the source of truth.
3. The sharpest finding: a file watch dies silently on inode swap on BOTH platforms. Checkpoints and editor atomic saves do exactly that. Directory watch, always.
4. `max_user_instances=128` (Linux default) meets the unbounded-tabs spec head on: tab 129's watcher can fail to start, so the interval fallback is load-bearing, not cosmetic.
5. Network mounts fire no events for remote writers: the bounded repoll ceiling is the universal backstop.
6. Windows: harness runs unmodified (ReadDirectoryChangesW is dir-native; its buffer-overflow failure mode is absorbed by cursor re-reads); the report's third column says exactly what to contribute.

Closes #1253

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-platform file-watch benchmark and report for the mesh transport. Old: watcher/mutation errors could abort runs, macOS wake latency was sampled on a hot stream, and coalescing stats could misreport when watcher creation failed; new: errors are recorded (`watchErrors`, per-scenario `mutationError`/`probeError`), wake samples arm after a quiet gap (~11–13ms macOS idle wake), and coalescing statistics reflect `roundsMeasured` with nulls when no rounds or notifications, continuing runs under inotify limits and Windows rename EPERM/EBUSY.

- Scope and repro: new `tools/mesh-lab/watch-bench/` with `run-bench.js` and `REPORT.md`; sandbox only; Node builtins. `node tools/mesh-lab/watch-bench/run-bench.js --json my-platform.json` captures wake latency, coalescing, rename/checkpoint behaviors, local watcher limits, and any watcher/mutation errors; `--json` without a path is a usage error.
- Behavior changes: `fs.watch` creation failures are caught and reported; mid-bench `error` events are captured; rename bench records `mutationError`/`probeError` instead of aborting; coalescing stats now honor `roundsMeasured` and report nulls when appropriate.
- Findings: Linux p95 <0.3ms; macOS idle wake ~11–13ms (hot-stream ~47–50ms is a measurement trap); file-level watches go silently deaf after inode swap; directory watches keep reporting; network mounts don’t emit remote events; Linux `max_user_instances=128` can block new watchers.
- Transport guidance: use directory watch + short debounce + cursor re-read, with a bounded repoll ceiling and interval fallback when `fs.watch` is unavailable or fails; Windows numbers pending; ties to #1253.

**Review focus**
- Read `REPORT.md` for corrected methodology (quiet-gap arming) and conclusions; verify coalescing summary fields (`roundsMeasured`, null-handling).
- Skim `run-bench.js` for error-handling paths (watcher failures, mutation/probe errors) and quiet-gap arming for latency samples.

<sup>Written for commit c8f3f1da8bc8fb7afbe8cd3fe7cae000e62d0028. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

