### PR TITLE
fix(tests): give the mesh close() sanity wake a CI-safe deadline

### DIFF
--- a/tests/egc-memory-mesh-transport.test.js
+++ b/tests/egc-memory-mesh-transport.test.js
@@ -291,7 +291,11 @@ async function main() {
       let woke = false;
       const observer = mesh.createMeshTransport({ dbPath });
       try {
-        const wait = observer.waitForChange(300).then(reason => { woke = reason === 'change'; });
+        // A generous deadline, not a tight window: on macOS a just-created
+        // FSEvents stream takes a beat before it starts reporting, and 300ms
+        // flaked on a busy runner (main run for 5dc0c116). The assertion
+        // still requires the wake to arrive.
+        const wait = observer.waitForChange(5000).then(reason => { woke = reason === 'change'; });
         fs.appendFileSync(`${dbPath}-wal`, 'append');
         await wait;
         assert.strictEqual(woke, true, 'a live transport still wakes (sanity)');


### PR DESCRIPTION
One flaked job on main (run for 5dc0c116, `Test (macos-latest, Node 22.x, bun)`): the final case of `egc-memory-mesh-transport.test.js` arms a freshly created watcher and expected its sanity wake within 300ms. On macOS a just-created FSEvents stream takes a beat before it starts reporting (the watch-bench report in `tools/mesh-lab/watch-bench/` documents the platform's latency behavior), and a busy runner pushed the first event past the window; six sibling runs of the same test passed. The deadline is now 5s, consistent with the other wake cases in the file, and the assertion still requires the wake to actually arrive. Test-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the sanity wake deadline in `egc-memory-mesh-transport.test.js` from 300ms to 5s to deflake macOS runs where a new FSEvents stream starts late. Previously the test required a wake within 300ms; now it allows up to 5s while still requiring the wake to arrive.

- Matches the 5s deadline used by the other wake cases in this file.
- Test-only change; no runtime behavior changes. May lengthen this case on slow CI nodes.

<sup>Written for commit d36db435bc7def7c6e75661102930dd4bd334747. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

