### PR TITLE
chore: bump plugin version to 1.1.19

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "egc",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "source": {
         "source": "local",
         "path": "../.."

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Battle-tested Codex workflows \u2014 230 shared EGC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
   "author": {
     "name": "Felipe Marzochi",

--- a/.gemini-plugin/marketplace.json
+++ b/.gemini-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "egc",
       "source": "./",
       "description": "EGC - Extended Global Context: 63 agents, 230 skills, 77 commands, persistent memory across sessions, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "author": {
         "name": "Felipe Marzochi",
         "email": "fmarzochi@gmail.com"

--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "EGC - Extended Global Context: persistent memory and shared context for AI coding tools. 63 agents, 230 skills, 77 commands, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {
     "name": "Felipe Marzochi",

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "egc-universal",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "egc-universal",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.4.3",

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egc-universal",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Extended Global Context (EGC) plugin for OpenCode - agents, commands, hooks, and skills",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -513,7 +513,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
      */
     "shell.env": async () => {
       const env: Record<string, string> = {
-        EGC_VERSION: "1.1.18",
+        EGC_VERSION: "1.1.19",
         EGC_PLUGIN: "true",
         EGC_HOOK_PROFILE: currentProfile,
         EGC_DISABLED_HOOKS: process.env.EGC_DISABLED_HOOKS || "",
@@ -567,7 +567,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
       const contextBlock = [
         "# EGC Context (preserve across compaction)",
         "",
-        "## Active Plugin: EGC - Extended Global Context v1.1.18",
+        "## Active Plugin: EGC - Extended Global Context v1.1.19",
         "- Hooks: file.edited, tool.execute.before/after, session.created/idle/deleted, shell.env, compacting, permission.ask",
         "- Tools: run-tests, check-coverage, security-audit, format-code, lint-check, git-summary, changed-files",
         "- Agents: 13 specialized (planner, architect, tdd-guide, code-reviewer, security-reviewer, build-error-resolver, e2e-runner, refactor-cleaner, doc-updater, go-reviewer, go-build-resolver, database-reviewer, python-reviewer)",

--- a/agent.yaml
+++ b/agent.yaml
@@ -1,6 +1,6 @@
 spec_version: "0.1.1"
 name: egc
-version: 1.1.18
+version: 1.1.19
 description: "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools. Desenvolvido por Felipe Marzochi. @MarzochiFelipe. https://github.com/Fmarzochi/EGC"
 author: fmarzochi
 license: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egchq/egc",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "EGC is a local-first MCP runtime that gives every AI agent the same brain: persistent shared memory, security guardrails, and up to 90% token savings across 20 AI coding tools.",
   "author": "Felipe Marzochi <fmarzochi@gmail.com> (https://github.com/Fmarzochi)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump v1.1.18 to v1.1.19 via `scripts/release.sh`, covering package.json, both lockfiles, agent.yaml, and every plugin manifest, validated by the npm pack payload test and the plugin-manifest sync test.

This release ships the real-time session mesh (transport, turn-boundary adapters across the cognitive protocol v4 and five native hook surfaces, push on by default), the retirement of Gemini CLI, Continue.dev, and Roo Code (20 supported tools), the auto-update retirement skip, and the session-bus exactly-once fix proven by the chaos audition.

Pre-bump gate, all green: CI main (CI + Scorecard + CodeQL), Sonar quality gate OK, security alerts 0/0/0 by query, zero open PRs, full local suite 4222 passing, inbox clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps EGC from 1.1.18 to 1.1.19 across packages, manifests, and agent metadata, and updates the OpenCode hook env/context to the new version. This tags the release that enables the real-time session mesh by default, retires Gemini CLI, Continue.dev, and Roo Code integrations, and ships the session-bus exactly-once fix.

**Review focus**
- Versions set to 1.1.19 in `@egchq/egc` (`package.json`/`package-lock.json`), `egc-universal` (`.opencode/package.json`/lockfile), `agent.yaml`, `.codex-plugin/plugin.json`, `.gemini-plugin/plugin.json`, and marketplace manifests.
- `EGC_VERSION` and the “Active Plugin” line in `.opencode/plugins/egc-hooks.ts` updated to 1.1.19; no logic changes beyond metadata/strings.

**Migration**
- If you depend on Gemini CLI, Continue.dev, or Roo Code integrations, pin to 1.1.18 or migrate to supported tools before updating.

<sup>Written for commit 96cf91e5cb503298d5659f9ae360d41036c1e98f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

