### PR TITLE
test(mesh): harden chaos harness cleanup

### DIFF
--- a/tests/egc-memory-session-bus-chaos.test.js
+++ b/tests/egc-memory-session-bus-chaos.test.js
@@ -203,6 +203,9 @@ async function workerMain() {
       handleMessage(JSON.parse(line));
     }
   });
+  process.stdin.on('end', () => {
+    process.exit(0);
+  });
 
   send({ type: 'ready', pid: process.pid });
 }
@@ -434,6 +437,18 @@ async function runHarness() {
   }
 
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-session-bus-chaos-'));
+  try {
+    await runHarnessInTemp(tempRoot, ts);
+  } finally {
+    try {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`[WARN] failed to remove chaos temp directory: ${error.message}`);
+    }
+  }
+}
+
+async function runHarnessInTemp(tempRoot, ts) {
   const busModule = compileProductionBus(tempRoot, ts);
   const bus = require(busModule);
   const results = [];
@@ -666,11 +681,6 @@ async function runHarness() {
   if (metrics.lockReleaseMs !== undefined) console.log(`lock release after SIGKILL: ${metrics.lockReleaseMs}ms`);
   if (failed > 0) {
     console.log('\nInvariant violations are intentional hard failures for #1254; do not mask them as expected failures.');
-  }
-  try {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  } catch (error) {
-    console.warn(`[WARN] failed to remove chaos temp directory: ${error.message}`);
   }
   process.exitCode = failed > 0 ? 1 : 0;
 }


### PR DESCRIPTION
## What Changed

Follow-up cleanup for #1271.

This hardens the multi-process session-bus chaos harness in two small test-only areas:

- workers now exit when their stdin pipe reaches `end`
- the temporary harness root is now covered by `try/finally`, so it is removed even if production-source compilation or setup fails

No production code is changed.

## Why This Change

This addresses the two hygiene follow-ups noted after #1271 was merged.

### Worker shutdown

Previously, a worker only listened for stdin `data`.

If the parent harness is terminated abruptly, such as with `SIGKILL`, the worker can outlive the parent after its stdin pipe closes. That can leave orphaned processes holding SQLite/WAL resources.

Workers now exit when stdin emits `end`.

### Temporary directory cleanup

Previously, `tempRoot` was created and `compileProductionBus()` ran before the cleanup block was reached.

If compilation failed, the temporary directory could be leaked.

The harness body now runs inside a helper covered by `try/finally`, ensuring the temporary root is removed on both success and failure.

## Testing

- [x] Test-only change
- [x] No production behavior changed
- [x] Existing chaos scenarios remain unchanged
- [x] DCO sign-off included

## Type of Change

- [ ] `fix`: Production bug fix
- [ ] `feat`: New feature
- [ ] `refactor`: Production refactoring
- [ ] `docs`: Documentation
- [x] `test`: Test/harness maintenance
- [ ] `ci`: CI/CD changes

## Notes

This is intentionally a small follow-up to the already-merged #1271 and only addresses the two post-merge cleanup suggestions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the multi-process session-bus chaos harness so workers exit when stdin closes and the temporary harness root is always removed. Previously workers ignored stdin end and temp directories could leak on compilation failure; now workers exit on `end` and cleanup runs in a `try/finally`.

**Reviewer notes**
- Workers now call `process.exit(0)` when stdin emits `end`, preventing orphaned processes and SQLite/WAL locks if the parent dies.
- The harness body runs in `runHarnessInTemp(...)` under `try/finally`, ensuring the temp root is removed even if production-source compilation fails.
- Test-only change; no production code or chaos scenarios are altered.

<sup>Written for commit d9d63fece14b595e038ab1977e5992056ae8ab99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved worker shutdown behavior so processes exit cleanly when standard input reaches end-of-file.
  - Improved temporary-resource cleanup during harness execution, including when test runs encounter errors.
  - Increased reliability of test result reporting and execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->