### PR TITLE
chore: bump plugin version to 1.1.20

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "egc",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "source": {
         "source": "local",
         "path": "../.."

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Battle-tested Codex workflows \u2014 230 shared EGC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
   "author": {
     "name": "Felipe Marzochi",

--- a/.gemini-plugin/marketplace.json
+++ b/.gemini-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "egc",
       "source": "./",
       "description": "EGC - Extended Global Context: 63 agents, 230 skills, 77 commands, persistent memory across sessions, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "author": {
         "name": "Felipe Marzochi",
         "email": "fmarzochi@gmail.com"

--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "egc",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "EGC - Extended Global Context: persistent memory and shared context for AI coding tools. 63 agents, 230 skills, 77 commands, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {
     "name": "Felipe Marzochi",

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "egc-universal",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "egc-universal",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "^1.4.3",

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egc-universal",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Extended Global Context (EGC) plugin for OpenCode - agents, commands, hooks, and skills",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -513,7 +513,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
      */
     "shell.env": async () => {
       const env: Record<string, string> = {
-        EGC_VERSION: "1.1.19",
+        EGC_VERSION: "1.1.20",
         EGC_PLUGIN: "true",
         EGC_HOOK_PROFILE: currentProfile,
         EGC_DISABLED_HOOKS: process.env.EGC_DISABLED_HOOKS || "",
@@ -567,7 +567,7 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
       const contextBlock = [
         "# EGC Context (preserve across compaction)",
         "",
-        "## Active Plugin: EGC - Extended Global Context v1.1.19",
+        "## Active Plugin: EGC - Extended Global Context v1.1.20",
         "- Hooks: file.edited, tool.execute.before/after, session.created/idle/deleted, shell.env, compacting, permission.ask",
         "- Tools: run-tests, check-coverage, security-audit, format-code, lint-check, git-summary, changed-files",
         "- Agents: 13 specialized (planner, architect, tdd-guide, code-reviewer, security-reviewer, build-error-resolver, e2e-runner, refactor-cleaner, doc-updater, go-reviewer, go-build-resolver, database-reviewer, python-reviewer)",

--- a/agent.yaml
+++ b/agent.yaml
@@ -1,6 +1,6 @@
 spec_version: "0.1.1"
 name: egc
-version: 1.1.19
+version: 1.1.20
 description: "EGC - Extended Global Context. Persistent memory and shared context for AI coding tools. Desenvolvido por Felipe Marzochi. @MarzochiFelipe. https://github.com/Fmarzochi/EGC"
 author: fmarzochi
 license: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@egchq/egc",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egchq/egc",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "EGC is a local-first MCP runtime that gives every AI agent the same brain: persistent shared memory, security guardrails, and up to 90% token savings across 20 AI coding tools.",
   "author": "Felipe Marzochi <fmarzochi@gmail.com> (https://github.com/Fmarzochi)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump v1.1.19 to v1.1.20 via `scripts/release.sh`, validated by the npm pack payload and plugin-manifest sync tests.

This patch release carries the corrections born from the v1.1.19 tag-run incident: the PowerShell install suite adopts the shared Windows subprocess budgets (the hardcoded 30s cap starved slow runners; the shared win32 full-install budget is 90s), the chaos harness gained its cleanup hardening (#1284, already on main), and the release checklist now codifies the missing gates: tag-ref CI run green, inbox swept, and the published artifact verified end to end before any announcement.

Pre-bump state: main green (CI, Coverage, CodeQL on 9d453663), Sonar OK, zero open PRs, security alerts 0/0/0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps EGC from 1.1.19 to 1.1.20 so all manifests, packages, and the runtime-reported version align with the new patch release. Previously the plugin reported 1.1.19; now it reports 1.1.20. No functional changes.

- Updates version fields in `package.json`/`package-lock.json` (root and `.opencode`) for `@egchq/egc` and `egc-universal`, and in plugin manifests: `.codex-plugin/plugin.json`, `.gemini-plugin/plugin.json`, `.gemini-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, and `agent.yaml`.
- Updates `EGC_VERSION` and the context banner in `.opencode/plugins/egc-hooks.ts` to 1.1.20.
- Only metadata/string changes; confirm release/pack pipelines pick up 1.1.20. No migration required.

<sup>Written for commit cd3646632ec9275ee3791968ff601bc91a7ecdf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

