### PR TITLE
fix(install): keep one copy-file owner per destination and heal shared-destination states

### DIFF
--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -651,6 +651,53 @@ function materializeScaffoldOperation(sourceRoot, operation) {
   });
 }
 
+// Two modules can record a copy-file for the same destination with different
+// sources: on the codex target the native .agents tree (agents-core) and the
+// flattened skills/<category> catalog modules both cover
+// <root>/skills/<name>/SKILL.md, and the two sources differ in frontmatter.
+// apply.js writes operations in order, so the last writer wins on disk while
+// every other recorded owner keeps flagging the file as drifted in doctor,
+// and repair re-copies it back and forth between sources forever. One
+// destination keeps exactly one copy-file operation: the one whose source
+// lives under the adapter's native tree when the target has one (the native
+// layout is that target's own propagated format), otherwise the first
+// recorded one.
+function dedupeCopyFileDestinations(operations, nativeRootRelativePath) {
+  const nativeRoot = String(nativeRootRelativePath || '')
+    .replaceAll('\\', '/')
+    .replace(/\/+$/, '');
+  const isNativeSource = operation => {
+    if (!nativeRoot) {
+      return false;
+    }
+    const source = String(operation.sourceRelativePath || '').replaceAll('\\', '/');
+    return source === nativeRoot || source.startsWith(`${nativeRoot}/`);
+  };
+
+  const winnerIndexByDestination = new Map();
+  const result = [];
+
+  for (const operation of operations) {
+    if (operation.kind !== 'copy-file') {
+      result.push(operation);
+      continue;
+    }
+
+    const winnerIndex = winnerIndexByDestination.get(operation.destinationPath);
+    if (winnerIndex === undefined) {
+      winnerIndexByDestination.set(operation.destinationPath, result.length);
+      result.push(operation);
+      continue;
+    }
+
+    if (isNativeSource(operation) && !isNativeSource(result[winnerIndex])) {
+      result[winnerIndex] = operation;
+    }
+  }
+
+  return result;
+}
+
 function createManifestInstallPlan(options = {}) {
   const sourceRoot = options.sourceRoot || getSourceRoot();
   const projectRoot = options.projectRoot || process.cwd();
@@ -696,7 +743,10 @@ function createManifestInstallPlan(options = {}) {
     target,
   });
   const adapter = getInstallTargetAdapter(target);
-  const operations = plan.operations.flatMap(operation => materializeScaffoldOperation(sourceRoot, operation));
+  const operations = dedupeCopyFileDestinations(
+    plan.operations.flatMap(operation => materializeScaffoldOperation(sourceRoot, operation)),
+    adapter.nativeRootRelativePath
+  );
   const source = {
     repoVersion: getPackageVersion(sourceRoot),
     repoCommit: getRepoCommit(sourceRoot),

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -663,9 +663,10 @@ function materializeScaffoldOperation(sourceRoot, operation) {
 // layout is that target's own propagated format), otherwise the first
 // recorded one.
 function dedupeCopyFileDestinations(operations, nativeRootRelativePath) {
-  const nativeRoot = String(nativeRootRelativePath || '')
-    .replaceAll('\\', '/')
-    .replace(/\/+$/, '');
+  let nativeRoot = String(nativeRootRelativePath || '').replaceAll('\\', '/');
+  while (nativeRoot.endsWith('/')) {
+    nativeRoot = nativeRoot.slice(0, -1);
+  }
   const isNativeSource = operation => {
     if (!nativeRoot) {
       return false;

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -659,9 +659,53 @@ function inspectManagedOperation(repoRoot, operation) {
   return inspectResult('unverified', operation, destinationPath);
 }
 
+// Install-states written before copy-file destinations were deduplicated at
+// plan time can record several copy-file operations for one destination (two
+// modules shipping the same file, e.g. a target's native tree and the
+// flattened skill catalog). The file on disk can only ever match one source,
+// so when ANY recorded owner matches, the destination is healthy and the
+// other owners must not report it as drifted. When no owner matches, exactly
+// one representative speaks for the destination, preferably one whose source
+// still exists, so repair re-copies a single deterministic source and
+// converges instead of ping-ponging between owners forever.
+function collapseSharedDestinationInspections(inspections) {
+  const groupsByDestination = new Map();
+  for (const inspection of inspections) {
+    if (inspection.operation?.kind !== 'copy-file' || !inspection.destinationPath) {
+      continue;
+    }
+    const group = groupsByDestination.get(inspection.destinationPath);
+    if (group) {
+      group.push(inspection);
+    } else {
+      groupsByDestination.set(inspection.destinationPath, [inspection]);
+    }
+  }
+
+  const suppressed = new Set();
+  for (const group of groupsByDestination.values()) {
+    if (group.length < 2) {
+      continue;
+    }
+    const keeper = group.find(inspection => inspection.status === 'ok')
+      || group.find(inspection => inspection.status === 'drifted' || inspection.status === 'missing')
+      || group[0];
+    for (const inspection of group) {
+      if (inspection !== keeper) {
+        suppressed.add(inspection);
+      }
+    }
+  }
+
+  return inspections.filter(inspection => !suppressed.has(inspection));
+}
+
 function summarizeManagedOperationHealth(repoRoot, operations) {
-  return operations.reduce((summary, operation) => {
-    const inspection = inspectManagedOperation(repoRoot, operation);
+  const inspections = collapseSharedDestinationInspections(
+    operations.map(operation => inspectManagedOperation(repoRoot, operation))
+  );
+
+  return inspections.reduce((summary, inspection) => {
     if (inspection.status === 'missing') {
       summary.missing.push(inspection);
     } else if (inspection.status === 'drifted') {

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -668,7 +668,12 @@ function inspectManagedOperation(repoRoot, operation) {
 // one representative speaks for the destination, preferably one whose source
 // still exists, so repair re-copies a single deterministic source and
 // converges instead of ping-ponging between owners forever.
-function collapseSharedDestinationInspections(inspections) {
+function operationSourceExists(repoRoot, operation) {
+  const sourcePath = resolveOperationSourcePath(repoRoot, operation);
+  return Boolean(sourcePath) && fs.existsSync(sourcePath);
+}
+
+function collapseSharedDestinationInspections(repoRoot, inspections) {
   const groupsByDestination = new Map();
   for (const inspection of inspections) {
     if (inspection.operation?.kind !== 'copy-file' || !inspection.destinationPath) {
@@ -687,7 +692,16 @@ function collapseSharedDestinationInspections(inspections) {
     if (group.length < 2) {
       continue;
     }
+    // Representative order: a matching owner proves the file healthy; then a
+    // repairable owner whose source still exists (a missing destination
+    // reports 'missing' for every owner without looking at sources, so an
+    // orphaned first owner must not shadow a sibling repair could actually
+    // copy from); then any repairable owner; then whatever is first.
     const keeper = group.find(inspection => inspection.status === 'ok')
+      || group.find(inspection => (
+        (inspection.status === 'drifted' || inspection.status === 'missing')
+        && operationSourceExists(repoRoot, inspection.operation)
+      ))
       || group.find(inspection => inspection.status === 'drifted' || inspection.status === 'missing')
       || group[0];
     for (const inspection of group) {
@@ -702,6 +716,7 @@ function collapseSharedDestinationInspections(inspections) {
 
 function summarizeManagedOperationHealth(repoRoot, operations) {
   const inspections = collapseSharedDestinationInspections(
+    repoRoot,
     operations.map(operation => inspectManagedOperation(repoRoot, operation))
   );
 

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -672,7 +672,7 @@ function inspectManagedOperation(repoRoot, operation) {
 // (a skill file reshaped into a folder across versions) must not be
 // preferred, or repair's copyFileSync would fail on it while a sibling with
 // a real file source sat unused.
-function operationSourceExists(repoRoot, operation) {
+function operationHasCopyableSource(repoRoot, operation) {
   const sourcePath = resolveOperationSourcePath(repoRoot, operation);
   if (!sourcePath) {
     return false;
@@ -711,7 +711,7 @@ function collapseSharedDestinationInspections(repoRoot, inspections) {
     const keeper = group.find(inspection => inspection.status === 'ok')
       || group.find(inspection => (
         (inspection.status === 'drifted' || inspection.status === 'missing')
-        && operationSourceExists(repoRoot, inspection.operation)
+        && operationHasCopyableSource(repoRoot, inspection.operation)
       ))
       || group.find(inspection => inspection.status === 'drifted' || inspection.status === 'missing')
       || group[0];

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -668,9 +668,20 @@ function inspectManagedOperation(repoRoot, operation) {
 // one representative speaks for the destination, preferably one whose source
 // still exists, so repair re-copies a single deterministic source and
 // converges instead of ping-ponging between owners forever.
+// A regular file only: an orphaned source path that survives as a DIRECTORY
+// (a skill file reshaped into a folder across versions) must not be
+// preferred, or repair's copyFileSync would fail on it while a sibling with
+// a real file source sat unused.
 function operationSourceExists(repoRoot, operation) {
   const sourcePath = resolveOperationSourcePath(repoRoot, operation);
-  return Boolean(sourcePath) && fs.existsSync(sourcePath);
+  if (!sourcePath) {
+    return false;
+  }
+  try {
+    return fs.statSync(sourcePath).isFile();
+  } catch (_error) { // NOSONAR: an unreadable source is simply not preferable
+    return false;
+  }
 }
 
 function collapseSharedDestinationInspections(repoRoot, inspections) {

--- a/tests/lib/install-executor.test.js
+++ b/tests/lib/install-executor.test.js
@@ -170,14 +170,19 @@ function runTests() {
     const projectRoot = createTempDir('install-executor-project-');
     try {
       writeJson(sourceRoot, 'package.json', { version: '1.2.3' });
+      // The catalog module comes FIRST in the manifest on purpose: plan
+      // operations follow manifest order, so the catalog source is recorded
+      // first and only the native-preference replacement branch can make the
+      // native tree win. With the native module first, first-recorded-wins
+      // alone would produce the same winner and the branch would go untested.
       writeJson(sourceRoot, path.join('manifests', 'install-modules.json'), {
         version: 7,
         modules: [
           {
-            id: 'fixture-native-tree',
-            kind: 'agents',
-            description: 'Native tree fixture',
-            paths: ['.agents'],
+            id: 'fixture-catalog',
+            kind: 'skills',
+            description: 'Catalog fixture',
+            paths: ['skills/testing/demo'],
             targets: ['codex'],
             dependencies: [],
             defaultInstall: true,
@@ -185,10 +190,10 @@ function runTests() {
             stability: 'stable',
           },
           {
-            id: 'fixture-catalog',
-            kind: 'skills',
-            description: 'Catalog fixture',
-            paths: ['skills/testing/demo'],
+            id: 'fixture-native-tree',
+            kind: 'agents',
+            description: 'Native tree fixture',
+            paths: ['.agents'],
             targets: ['codex'],
             dependencies: [],
             defaultInstall: true,

--- a/tests/lib/install-executor.test.js
+++ b/tests/lib/install-executor.test.js
@@ -158,6 +158,88 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  // The native .agents tree and the flattened skills/<category> catalog both
+  // cover <root>/skills/<name>/SKILL.md on the codex target with sources that
+  // differ, so without plan-time dedupe the same destination gets two
+  // copy-file owners and doctor/repair disagree about which one the file
+  // should match. The plan must keep exactly one owner per destination and
+  // prefer the source under the adapter's native tree.
+  if (test('keeps one copy-file owner per destination, preferring the native tree source', () => {
+    const sourceRoot = createTempDir('install-executor-source-');
+    const homeDir = createTempDir('install-executor-home-');
+    const projectRoot = createTempDir('install-executor-project-');
+    try {
+      writeJson(sourceRoot, 'package.json', { version: '1.2.3' });
+      writeJson(sourceRoot, path.join('manifests', 'install-modules.json'), {
+        version: 7,
+        modules: [
+          {
+            id: 'fixture-native-tree',
+            kind: 'agents',
+            description: 'Native tree fixture',
+            paths: ['.agents'],
+            targets: ['codex'],
+            dependencies: [],
+            defaultInstall: true,
+            cost: 'light',
+            stability: 'stable',
+          },
+          {
+            id: 'fixture-catalog',
+            kind: 'skills',
+            description: 'Catalog fixture',
+            paths: ['skills/testing/demo'],
+            targets: ['codex'],
+            dependencies: [],
+            defaultInstall: true,
+            cost: 'light',
+            stability: 'stable',
+          },
+        ],
+      });
+      writeJson(sourceRoot, path.join('manifests', 'install-profiles.json'), {
+        version: 1,
+        profiles: {
+          fixture: {
+            description: 'Fixture profile',
+            modules: ['fixture-native-tree', 'fixture-catalog'],
+          },
+        },
+      });
+      writeFile(sourceRoot, path.join('.agents', 'skills', 'demo', 'SKILL.md'), 'native flavor\n');
+      writeFile(sourceRoot, path.join('skills', 'testing', 'demo', 'SKILL.md'), 'catalog flavor\n');
+      fs.mkdirSync(path.join(homeDir, '.agents'), { recursive: true });
+
+      const plan = createManifestInstallPlan({
+        sourceRoot,
+        homeDir,
+        projectRoot,
+        target: 'codex',
+        profileId: 'fixture',
+      });
+
+      const skillOperations = plan.operations.filter(operation => (
+        operation.kind === 'copy-file'
+        && operation.destinationPath === path.join(homeDir, '.agents', 'skills', 'demo', 'SKILL.md')
+      ));
+      assert.strictEqual(skillOperations.length, 1);
+      assert.strictEqual(skillOperations[0].moduleId, 'fixture-native-tree');
+      assert.strictEqual(
+        skillOperations[0].sourceRelativePath.split(path.sep).join('/'),
+        '.agents/skills/demo/SKILL.md'
+      );
+
+      const copyDestinations = plan.operations
+        .filter(operation => operation.kind === 'copy-file')
+        .map(operation => operation.destinationPath);
+      assert.strictEqual(new Set(copyDestinations).size, copyDestinations.length);
+    } finally {
+      cleanup(sourceRoot);
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('plans Gemini legacy rules with warnings and state preview', () => {
     const sourceRoot = createTempDir('install-executor-source-');
     const homeDir = createTempDir('install-executor-home-');

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -1082,6 +1082,31 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('repair skips an orphaned source that survives as a directory and copies from the file sibling', () => {
+    const fixture = writeSharedDestinationFixture('about to vanish\n');
+    const homeDir = createTempDir('install-lifecycle-home-');
+    try {
+      fs.rmSync(fixture.destinationPath);
+      const nativeSourcePath = path.join(fixture.repoRootFixture, 'native', 'skills', 'demo', 'SKILL.md');
+      fs.rmSync(nativeSourcePath);
+      fs.mkdirSync(nativeSourcePath);
+
+      const result = repairInstalledStates({
+        repoRoot: fixture.repoRootFixture,
+        homeDir,
+        projectRoot: fixture.projectRoot,
+        targets: ['cursor'],
+      });
+
+      assert.deepStrictEqual(result.results[0].repairedPaths, [fixture.destinationPath]);
+      assert.strictEqual(fs.readFileSync(fixture.destinationPath, 'utf8'), 'catalog flavor\n');
+    } finally {
+      cleanup(fixture.repoRootFixture);
+      cleanup(fixture.projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
   if (test('doctor reports manifest resolution drift for non-legacy installs', () => {
     const homeDir = createTempDir('install-lifecycle-home-');
     const projectRoot = createTempDir('install-lifecycle-project-');

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -918,6 +918,128 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // States written before plan-time destination dedupe can hold two copy-file
+  // operations for one destination with sources that legitimately differ (the
+  // codex target's native tree vs the flattened skill catalog). The three
+  // cases below pin the contract: matching either source is healthy, a real
+  // mismatch is reported once, and repair converges in a single pass instead
+  // of ping-ponging between the two sources.
+  function writeSharedDestinationFixture(withDestinationContent) {
+    const repoRootFixture = createTempDir('install-lifecycle-sharedsrc-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+    fs.writeFileSync(path.join(repoRootFixture, 'package.json'), '{"version":"1.2.3"}\n');
+    fs.mkdirSync(path.join(repoRootFixture, 'manifests'), { recursive: true });
+    fs.writeFileSync(path.join(repoRootFixture, 'manifests', 'install-modules.json'), '{"version":1,"modules":[]}\n');
+    fs.writeFileSync(path.join(repoRootFixture, 'manifests', 'install-profiles.json'), '{"version":1,"profiles":{}}\n');
+    fs.mkdirSync(path.join(repoRootFixture, 'native', 'skills', 'demo'), { recursive: true });
+    fs.writeFileSync(path.join(repoRootFixture, 'native', 'skills', 'demo', 'SKILL.md'), 'native flavor\n');
+    fs.mkdirSync(path.join(repoRootFixture, 'catalog', 'skills', 'demo'), { recursive: true });
+    fs.writeFileSync(path.join(repoRootFixture, 'catalog', 'skills', 'demo', 'SKILL.md'), 'catalog flavor\n');
+
+    const targetRoot = path.join(projectRoot, '.cursor');
+    const statePath = path.join(targetRoot, 'egc-install-state.json');
+    const destinationPath = path.join(targetRoot, 'skills', 'demo', 'SKILL.md');
+    fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+    fs.writeFileSync(destinationPath, withDestinationContent);
+
+    const buildOperation = sourceRelativePath => ({
+      kind: 'copy-file',
+      moduleId: 'fixture-module',
+      sourcePath: path.join(repoRootFixture, sourceRelativePath),
+      sourceRelativePath,
+      destinationPath,
+      strategy: 'preserve-relative-path',
+      ownership: 'managed',
+      scaffoldOnly: false,
+    });
+
+    writeState(statePath, {
+      adapter: { id: 'cursor-project', target: 'cursor', kind: 'project' },
+      targetRoot,
+      installStatePath: statePath,
+      request: { profile: null, modules: [], legacyLanguages: [], legacyMode: true },
+      resolution: { selectedModules: ['fixture-module'], skippedModules: [] },
+      operations: [
+        buildOperation('native/skills/demo/SKILL.md'),
+        buildOperation('catalog/skills/demo/SKILL.md'),
+      ],
+      source: { repoVersion: '1.2.3', repoCommit: 'abc123', manifestVersion: 1 },
+    });
+
+    return { repoRootFixture, projectRoot, destinationPath };
+  }
+
+  if (test('doctor accepts a shared destination when the file matches either recorded source', () => {
+    const fixture = writeSharedDestinationFixture('catalog flavor\n');
+    const homeDir = createTempDir('install-lifecycle-home-');
+    try {
+      const report = buildDoctorReport({
+        repoRoot: fixture.repoRootFixture,
+        homeDir,
+        projectRoot: fixture.projectRoot,
+        targets: ['cursor'],
+      });
+
+      assert.strictEqual(report.results.length, 1);
+      assert.ok(!report.results[0].issues.some(issue => issue.code === 'drifted-managed-files'));
+    } finally {
+      cleanup(fixture.repoRootFixture);
+      cleanup(fixture.projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('doctor reports a shared destination once when the file matches no recorded source', () => {
+    const fixture = writeSharedDestinationFixture('edited by hand\n');
+    const homeDir = createTempDir('install-lifecycle-home-');
+    try {
+      const report = buildDoctorReport({
+        repoRoot: fixture.repoRootFixture,
+        homeDir,
+        projectRoot: fixture.projectRoot,
+        targets: ['cursor'],
+      });
+
+      const driftIssue = report.results[0].issues.find(issue => issue.code === 'drifted-managed-files');
+      assert.ok(driftIssue);
+      assert.deepStrictEqual(driftIssue.paths, [fixture.destinationPath]);
+    } finally {
+      cleanup(fixture.repoRootFixture);
+      cleanup(fixture.projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair converges a drifted shared destination in one pass', () => {
+    const fixture = writeSharedDestinationFixture('edited by hand\n');
+    const homeDir = createTempDir('install-lifecycle-home-');
+    try {
+      const firstPass = repairInstalledStates({
+        repoRoot: fixture.repoRootFixture,
+        homeDir,
+        projectRoot: fixture.projectRoot,
+        targets: ['cursor'],
+      });
+
+      assert.deepStrictEqual(firstPass.results[0].repairedPaths, [fixture.destinationPath]);
+      assert.strictEqual(fs.readFileSync(fixture.destinationPath, 'utf8'), 'native flavor\n');
+
+      const secondPass = repairInstalledStates({
+        repoRoot: fixture.repoRootFixture,
+        homeDir,
+        projectRoot: fixture.projectRoot,
+        targets: ['cursor'],
+      });
+
+      assert.strictEqual(secondPass.results[0].repairedPaths.length, 0);
+      assert.strictEqual(fs.readFileSync(fixture.destinationPath, 'utf8'), 'native flavor\n');
+    } finally {
+      cleanup(fixture.repoRootFixture);
+      cleanup(fixture.projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
   if (test('doctor reports manifest resolution drift for non-legacy installs', () => {
     const homeDir = createTempDir('install-lifecycle-home-');
     const projectRoot = createTempDir('install-lifecycle-project-');

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -1040,6 +1040,48 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('doctor accepts a shared destination matching the first recorded source too', () => {
+    const fixture = writeSharedDestinationFixture('native flavor\n');
+    const homeDir = createTempDir('install-lifecycle-home-');
+    try {
+      const report = buildDoctorReport({
+        repoRoot: fixture.repoRootFixture,
+        homeDir,
+        projectRoot: fixture.projectRoot,
+        targets: ['cursor'],
+      });
+
+      assert.ok(!report.results[0].issues.some(issue => issue.code === 'drifted-managed-files'));
+    } finally {
+      cleanup(fixture.repoRootFixture);
+      cleanup(fixture.projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair of a missing shared destination copies from the owner whose source still exists', () => {
+    const fixture = writeSharedDestinationFixture('about to vanish\n');
+    const homeDir = createTempDir('install-lifecycle-home-');
+    try {
+      fs.rmSync(fixture.destinationPath);
+      fs.rmSync(path.join(fixture.repoRootFixture, 'native', 'skills', 'demo', 'SKILL.md'));
+
+      const result = repairInstalledStates({
+        repoRoot: fixture.repoRootFixture,
+        homeDir,
+        projectRoot: fixture.projectRoot,
+        targets: ['cursor'],
+      });
+
+      assert.deepStrictEqual(result.results[0].repairedPaths, [fixture.destinationPath]);
+      assert.strictEqual(fs.readFileSync(fixture.destinationPath, 'utf8'), 'catalog flavor\n');
+    } finally {
+      cleanup(fixture.repoRootFixture);
+      cleanup(fixture.projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
   if (test('doctor reports manifest resolution drift for non-legacy installs', () => {
     const homeDir = createTempDir('install-lifecycle-home-');
     const projectRoot = createTempDir('install-lifecycle-project-');


### PR DESCRIPTION
## Summary

Fixes the permanent `drifted-managed-files: 24 managed file(s) differ from the source repo` warning on codex-home installs (#1294).

Two modules recorded a copy-file operation for the same destination with divergent sources: `agents-core` ships the native `.agents` tree while the catalog modules ship the flattened `skills/<category>` copy, and the two differ by the `origin: EGC` frontmatter line. The file on disk can only match one source, so doctor flagged the other owner forever and every `egc repair` pass re-copied the file, flipping it between the two flavors.

## Changes

- **Plan-time dedupe** (`install-executor.js`): `createManifestInstallPlan` keeps exactly one copy-file operation per destination. The source under the adapter's native tree wins (the native layout is that target's own propagated format); otherwise the first recorded operation wins. Merge and hook operations are untouched: several merges into one file are legitimate.
- **Inspection-time grouping** (`install-lifecycle.js`): install-states written by earlier versions still hold the duplicates, so `summarizeManagedOperationHealth` now treats a destination as healthy when the file matches ANY recorded owner, reports it once when it matches none, and repair re-copies a single deterministic source, converging in one pass. Existing installs heal without reinstalling.

## Verification

- New tests: plan keeps one owner per destination preferring the native tree; doctor accepts a shared destination matching either source; doctor reports a real mismatch once; repair converges in one pass and stays converged.
- On the machine that reported the bug, against the untouched v1.1.20 install-states: the 24-file codex warning clears, `repair --dry-run` plans zero work for codex-home, and a freshly planned codex install contains zero duplicated copy-file destinations.
- `tests/lib/install-executor.test.js` 12 passed, `tests/lib/install-lifecycle.test.js` 39 passed, `tests/scripts/doctor.test.js` 19 passed, `tests/scripts/repair.test.js` 11 passed.

Fixes #1294

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps one copy-file owner per destination and heals shared-destination states. Previously two modules could own one destination with different sources, leaving doctor in permanent drift and repair flip-flopping; plans now keep one owner (preferring the native tree), doctor groups by destination, and repair selects a deterministic live regular-file source to converge in one pass.

- Review notes
  - Plan-time (`scripts/lib/install-executor.js`): `createManifestInstallPlan` runs `dedupeCopyFileDestinations`, preferring sources under `adapter.nativeRootRelativePath`; native-root normalization drops the backtracking regex. Merge and hook operations are unchanged.
  - Inspection/repair (`scripts/lib/install-lifecycle.js`): inspections collapse by destination; matching any recorded owner is healthy; real mismatches are reported once; the representative prefers an owner whose source is a regular file so repair can copy. Helper name updated to reflect the regular-file check.

- Rollout
  - No migration required. Existing installs heal on the next doctor or repair run.

<sup>Written for commit 61fe9ab86e184abeacc12f36408df4157ae30521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

