### PR TITLE
test(crusher): isolate the session-marker fallback from the machine's live session

### DIFF
--- a/tests/crusher-metrics.test.js
+++ b/tests/crusher-metrics.test.js
@@ -73,9 +73,24 @@ run('resolves canonical project and session conventions with legacy fallbacks', 
   const legacy = resolveMetricContext({ cwd, env: { PROJECT_ROOT: legacyRoot } });
   assert.strictEqual(legacy.project, path.resolve(legacyRoot));
 
-  const fallback = resolveMetricContext({ cwd, env: {} });
-  assert.strictEqual(fallback.project, path.resolve(cwd));
-  assert.strictEqual(fallback.session, UNKNOWN_SCOPE);
+  // The marker fallback reads process.env and the real home directory, not
+  // the injected env above, so on a machine with a live session (the marker
+  // file kept fresh by that session's hooks) this case would resolve the
+  // REAL session id instead of the unknown fallback. Point the marker at a
+  // path that cannot exist so the case is hermetic everywhere.
+  const priorMarkerFile = process.env.EGC_SESSION_MARKER_FILE;
+  process.env.EGC_SESSION_MARKER_FILE = path.join(os.tmpdir(), `egc-metrics-no-marker-${process.pid}.json`);
+  try {
+    const fallback = resolveMetricContext({ cwd, env: {} });
+    assert.strictEqual(fallback.project, path.resolve(cwd));
+    assert.strictEqual(fallback.session, UNKNOWN_SCOPE);
+  } finally {
+    if (priorMarkerFile === undefined) {
+      delete process.env.EGC_SESSION_MARKER_FILE;
+    } else {
+      process.env.EGC_SESSION_MARKER_FILE = priorMarkerFile;
+    }
+  }
 });
 
 run('normalizes legacy rows into unknown attribution buckets', () => {


### PR DESCRIPTION
## Summary

Found while running the full suite during this testing week: `tests/crusher-metrics.test.js` failed on a machine with a live EGC session while passing in CI. The unknown-session fallback case reads the real metrics marker (`~/.egc/metrics/active-session.json`) through `process.env`, so a live session's hooks keep that marker fresh and the case resolves the REAL session id instead of `unknown`. CI never sees it because its environment has no marker.

## Change

Test-only: the case points `EGC_SESSION_MARKER_FILE` at a nonexistent tmpdir path for the fallback assertion and restores the variable in a `finally`. No product behavior changes.

## Verification

On the machine that reproduced the failure (live session, fresh marker): the case now passes; full file 5 passed, 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the crusher metrics test’s unknown-session fallback from a machine’s live EGC session so the test is hermetic. Previously it read the real `~/.egc/metrics/active-session.json` and resolved a real session id on machines with active sessions; now it forces a nonexistent marker path so the fallback resolves to `unknown`.

- Test-only: updates `tests/crusher-metrics.test.js` to set `EGC_SESSION_MARKER_FILE` to a tmp path during the fallback assertion and restore it in a `finally`. No product behavior changes; fixes local failures while CI remains unchanged.

<sup>Written for commit 52f2b0b2609d839e0e0dc9f3d17100ff05416b03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

