### PR TITLE
test(mesh): keep the bus moving until the parked waiter wakes

### DIFF
--- a/tests/egc-memory-mesh-transport.test.js
+++ b/tests/egc-memory-mesh-transport.test.js
@@ -217,7 +217,22 @@ async function main() {
 
           const wake = transport.waitForChange(8000);
           await bus.sendEvent(db, { fromSession: 'mesh-a', toSession: 'mesh-b', kind: 'ping' });
-          assert.strictEqual(await wake, 'change', 'sqlite write woke the parked waiter');
+          // A single write can land inside FSEvents' stream warm-up window on
+          // a fresh watcher and get dropped (the exact macOS-runner race the
+          // #1277 deadline fix and the fresh-watcher append fix documented),
+          // so keep the bus moving with neutral heartbeat re-announces until
+          // the waiter wakes: production sessions keep writing too, and the
+          // delivery assert below reads the bus, never one wake.
+          const heartbeat = setInterval(() => {
+            bus.announce(db, { sessionId: 'mesh-a', projectPath: '/p' }).catch(() => {});
+          }, 250);
+          let reason;
+          try {
+            reason = await wake;
+          } finally {
+            clearInterval(heartbeat);
+          }
+          assert.strictEqual(reason, 'change', 'sqlite write woke the parked waiter');
           const events = await bus.readEvents(db, { sessionId: 'mesh-b' });
           assert.strictEqual(events.length, 1);
           assert.strictEqual(events[0].kind, 'ping');

--- a/tests/egc-memory-mesh-transport.test.js
+++ b/tests/egc-memory-mesh-transport.test.js
@@ -325,7 +325,19 @@ async function main() {
         // still requires the wake to arrive.
         const wait = observer.waitForChange(5000).then(reason => { woke = reason === 'change'; });
         fs.appendFileSync(`${dbPath}-wal`, 'append');
-        await wait;
+        // Same FSEvents warm-up race as the waiter case above: one append can
+        // be dropped by a brand-new stream even inside a generous deadline
+        // (macOS runner, run for 4b38c7f), so keep appending until the sanity
+        // wake lands. The closed transport's zero-waiters assert is unaffected
+        // by extra writes.
+        const appender = setInterval(() => {
+          try { fs.appendFileSync(`${dbPath}-wal`, 'append'); } catch { /* dir gone on teardown */ } // NOSONAR
+        }, 250);
+        try {
+          await wait;
+        } finally {
+          clearInterval(appender);
+        }
         assert.strictEqual(woke, true, 'a live transport still wakes (sanity)');
         assert.strictEqual(transport.pendingWaiters(), 0, 'closed transport holds no waiters');
       } finally {


### PR DESCRIPTION
## Summary

Two flaky cases in `egc-memory-mesh-transport.test.js`, both hit by the macOS runner during this testing week's CI rounds, both the same FSEvents warm-up race the #1277 deadline fix documented: a brand-new watcher can drop a single write that lands inside its stream warm-up window.

- **waiter-parked case** (run for 4ba4140, macOS Node 22 npm): one `sendEvent` then a parked wait. Now keeps the bus moving with neutral heartbeat re-announces (idempotent, no new event for the receiver) every 250ms until the waiter wakes; the delivery assert still reads exactly one ping.
- **close() sanity case** (run for 4b38c7f, macOS Node 20 bun): #1277 stretched the deadline but kept a single append. Now keeps appending every 250ms until the sanity wake lands; the zero-waiters assert is unaffected.

Mirrors the fresh-watcher append remedy already merged for the watch-mode case. Test-only.

## Verification

Full file locally: 10 passed, 0 failed, both changed cases green.