### PR TITLE
fix(crusher): preserve English diagnostic inflections

### DIFF
--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -40,7 +40,7 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 // positions and never trigger a \b boundary at all, silently failing to
 // match. \p{L}/\p{N} (with the u flag) are Unicode-aware, so lookaround
 // built from them correctly treats accented letters as word characters.
-const KEEP_WORD_EN_RE = /(?<![\p{L}\p{N}_])(error|fail|failed|failing|warn|warning|fatal|denied|refused|exception|panic)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_EN_RE = /(?<![\p{L}\p{N}_])(errors?|fails?|failed|failing|failures?|warns?|warned|warnings?|fatal|denied|refused|exceptions?|panic(?:ked|king|s)?)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_PT_RE = /(?<![\p{L}\p{N}_])(erro|falha|aviso|negado|recusado|exceção|pânico)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_ES_RE = /(?<![\p{L}\p{N}_])(fallo|falló|falla|fallé|fallando|fallado|fallaron|advertencia|denegado|rechazado|excepción)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_FR_DE_IT_RE = /(?<![\p{L}\p{N}_])(erreur|échec|panne|avertissement|warnung|fehler|errore|avviso)(?![\p{L}\p{N}_])/iu;

--- a/scripts/lib/crusher/engine.js
+++ b/scripts/lib/crusher/engine.js
@@ -40,7 +40,9 @@ const arrayCrusher = tryRequire('../../../mcp/servers/egc-guardian/build/egc-arr
 // positions and never trigger a \b boundary at all, silently failing to
 // match. \p{L}/\p{N} (with the u flag) are Unicode-aware, so lookaround
 // built from them correctly treats accented letters as word characters.
-const KEEP_WORD_EN_RE = /(?<![\p{L}\p{N}_])(errors?|fails?|failed|failing|failures?|warns?|warned|warnings?|fatal|denied|refused|exceptions?|panic(?:ked|king|s)?)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_EN_ERROR_FAILURE_RE = /(?<![\p{L}\p{N}_])(errors?|fails?|failed|failing|failures?)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_EN_WARNING_RE = /(?<![\p{L}\p{N}_])(warns?|warned|warnings?|fatal|denied|refused)(?![\p{L}\p{N}_])/iu;
+const KEEP_WORD_EN_EXCEPTION_PANIC_RE = /(?<![\p{L}\p{N}_])(exceptions?|panic(?:ked|king|s)?)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_PT_RE = /(?<![\p{L}\p{N}_])(erro|falha|aviso|negado|recusado|exceção|pânico)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_ES_RE = /(?<![\p{L}\p{N}_])(fallo|falló|falla|fallé|fallando|fallado|fallaron|advertencia|denegado|rechazado|excepción)(?![\p{L}\p{N}_])/iu;
 const KEEP_WORD_FR_DE_IT_RE = /(?<![\p{L}\p{N}_])(erreur|échec|panne|avertissement|warnung|fehler|errore|avviso)(?![\p{L}\p{N}_])/iu;
@@ -53,11 +55,13 @@ const KEEP_WORD_FR_DE_IT_RE = /(?<![\p{L}\p{N}_])(erreur|échec|panne|avertissem
 // lookbehind, so the exception class name was silently dropped from every
 // language's test/traceback output. Case-sensitive on purpose -- this only
 // needs to catch the capitalized suffix form; the lowercase standalone form
-// is already covered by KEEP_WORD_EN_RE above.
+// is already covered by the English matchers above.
 const KEEP_WORD_PASCAL_SUFFIX_RE = /(?<=[\p{L}\p{N}_])(Error|Exception|Fatal|Warning|Failure|Panic)(?![\p{L}\p{N}_])/u;
 
 function matchesKeepWord(line) {
-  return KEEP_WORD_EN_RE.test(line)
+  return KEEP_WORD_EN_ERROR_FAILURE_RE.test(line)
+    || KEEP_WORD_EN_WARNING_RE.test(line)
+    || KEEP_WORD_EN_EXCEPTION_PANIC_RE.test(line)
     || KEEP_WORD_PT_RE.test(line)
     || KEEP_WORD_ES_RE.test(line)
     || KEEP_WORD_FR_DE_IT_RE.test(line)

--- a/tests/crusher-diagnostic-inflections.test.js
+++ b/tests/crusher-diagnostic-inflections.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { crushOutput } = require(
+  path.join(__dirname, '..', 'scripts', 'lib', 'crusher', 'engine.js')
+);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+const run = (name, fn) => { if (test(name, fn)) passed++; else failed++; };
+
+console.log('\n=== Testing Token Crusher diagnostic inflections ===\n');
+
+run('preserves common English diagnostic inflections outside the summary tail', () => {
+  const lines = [];
+  for (let i = 0; i < 150; i++) lines.push(`  ok test case number ${i} completed normally`);
+
+  lines.push("thread 'tests::handles_bad_input' panicked at src/lib.rs:42:5:");
+  lines.push('2 warnings generated');
+  lines.push('There were 3 failures');
+  lines.push('4 errors detected');
+  lines.push('2 exceptions raised');
+  lines.push('test retry_path fails intermittently');
+  lines.push('compiler warned about an obsolete flag');
+
+  for (let i = 150; i < 300; i++) lines.push(`  ok test case number ${i} completed normally`);
+  lines.push('done');
+
+  const result = crushOutput('cargo test', lines.join('\n'));
+  assert.ok(result, 'large cargo test output should be crushed');
+  assert.ok(result.crushed.includes('panicked at src/lib.rs:42:5'), 'Rust panic location survives');
+  assert.ok(result.crushed.includes('2 warnings generated'), 'plural warnings survive');
+  assert.ok(result.crushed.includes('3 failures'), 'plural failures survive');
+  assert.ok(result.crushed.includes('4 errors detected'), 'plural errors survive');
+  assert.ok(result.crushed.includes('2 exceptions raised'), 'plural exceptions survive');
+  assert.ok(result.crushed.includes('retry_path fails'), 'present-tense fails survives');
+  assert.ok(result.crushed.includes('compiler warned'), 'past-tense warned survives');
+});
+
+run('does not treat diagnostic-looking identifier substrings as keep words', () => {
+  const lines = [];
+  for (let i = 0; i < 150; i++) lines.push(`  ok test case number ${i} completed normally`);
+
+  lines.push('panicRoom is a feature flag');
+  lines.push('warningsCount=2');
+  lines.push('failureMode=true');
+  lines.push('errorCode=500');
+  lines.push('failsafe enabled');
+
+  for (let i = 150; i < 300; i++) lines.push(`  ok test case number ${i} completed normally`);
+  lines.push('done');
+
+  const result = crushOutput('cargo test', lines.join('\n'));
+  assert.ok(result, 'large cargo test output should be crushed');
+  assert.ok(!result.crushed.includes('panicRoom'), 'panicRoom is not a panic diagnostic');
+  assert.ok(!result.crushed.includes('warningsCount'), 'warningsCount is not a warning diagnostic');
+  assert.ok(!result.crushed.includes('failureMode'), 'failureMode is not a failure diagnostic');
+  assert.ok(!result.crushed.includes('errorCode'), 'errorCode is not an error diagnostic');
+  assert.ok(!result.crushed.includes('failsafe'), 'failsafe is not a failure diagnostic');
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/crusher-diagnostic-inflections.test.js
+++ b/tests/crusher-diagnostic-inflections.test.js
@@ -53,7 +53,7 @@ run('preserves common English diagnostic inflections outside the summary tail', 
 
 run('does not treat diagnostic-looking identifier substrings as keep words', () => {
   const lines = [];
-  for (let i = 0; i < 150; i++) lines.push(`  ok test case number ${i} completed normally`);
+  for (let i = 0; i < 150; i++) lines.push(`  ok install line ${i} completed normally`);
 
   lines.push('panicRoom is a feature flag');
   lines.push('warningsCount=2');
@@ -61,11 +61,13 @@ run('does not treat diagnostic-looking identifier substrings as keep words', () 
   lines.push('errorCode=500');
   lines.push('failsafe enabled');
 
-  for (let i = 150; i < 300; i++) lines.push(`  ok test case number ${i} completed normally`);
+  for (let i = 150; i < 300; i++) lines.push(`  ok install line ${i} completed normally`);
   lines.push('done');
 
-  const result = crushOutput('cargo test', lines.join('\n'));
-  assert.ok(result, 'large cargo test output should be crushed');
+  // The package-manager crusher keeps only diagnostic lines plus its tail,
+  // so this isolates keep-word boundaries from test-runner summary matching.
+  const result = crushOutput('npm install', lines.join('\n'));
+  assert.ok(result, 'large install output should be crushed');
   assert.ok(!result.crushed.includes('panicRoom'), 'panicRoom is not a panic diagnostic');
   assert.ok(!result.crushed.includes('warningsCount'), 'warningsCount is not a warning diagnostic');
   assert.ok(!result.crushed.includes('failureMode'), 'failureMode is not a failure diagnostic');


### PR DESCRIPTION
## What Changed

- Extended the English diagnostic keep-word matcher in `scripts/lib/crusher/engine.js` to preserve common inflected forms such as `errors`, `failures`, `warnings`, `exceptions`, and `panicked`.
- Added `tests/crusher-diagnostic-inflections.test.js`.
- Added regression cases that place diagnostics outside the summary tail.
- Added boundary counterexamples such as `panicRoom`, `warningsCount`, `failureMode`, `errorCode`, and `failsafe`.

## Why This Change

While investigating #1220, I found that Token Crusher's English keep-word matcher only recognized a limited set of exact word forms.

For example, Rust commonly emits diagnostics such as:

```text
thread 'tests::handles_bad_input' panicked at src/lib.rs:42:5:
```

The matcher recognized `panic`, but not `panicked`. Similar gaps existed for forms such as `warnings`, `failures`, `errors`, and `exceptions`.

When these lines appeared outside the always-preserved summary tail, they could be removed during compression. This change preserves those diagnostic forms without weakening the existing identifier boundaries.

## Testing Done

- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

Added regression coverage for diagnostic inflections buried between large blocks of non-diagnostic output, along with negative cases for identifier-like substrings.

This PR does not touch shared files under `~/.egc/`.

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves English diagnostic inflections so compression no longer drops lines like “panicked at …”, “warnings”, or “failures” outside the summary tail. Previously only base forms matched; now plural and tense variants are kept without widening identifier boundaries and within CI regex complexity limits.

- Split the English matcher into three Unicode-boundary regexes: errors?/fails?/failed/failing/failures?, warns?/warned/warnings?/fatal/denied/refused, and exceptions?/panic(ked|king|s)?; updated `matchesKeepWord` to OR them.
- No changes to non-English patterns; PascalCase suffix matcher unchanged (comment clarified).
- Added `tests/crusher-diagnostic-inflections.test.js` with preserved diagnostics and identifier-boundary negatives, using the package-manager crusher to avoid summary-tail interference.

<sup>Written for commit fdde7a6fbb501d701f024f0fc080fcd8817ed1e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic filtering to preserve more plural and inflected forms of errors, failures, warnings, exceptions, and panics.
  * Avoided incorrectly treating diagnostic terms embedded within identifiers as standalone messages.

* **Tests**
  * Added coverage for diagnostic phrases, inflected forms, panic locations, and identifier edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->