### PR TITLE
feat(scrubber): strip metadata from PNG and JPEG images

### DIFF
--- a/docs/spec/scrubber.md
+++ b/docs/spec/scrubber.md
@@ -22,6 +22,7 @@ same way the Crusher does. This document is the design contract.
 | Binary guard | `scripts/lib/scrubber/binary-guard.js` | refuse binary as text; text-extension allowlist |
 | Co-author stripper | `scripts/lib/scrubber/coauthor-strip.js` | remove AI trailers, keep humans |
 | Container metadata | `scripts/lib/scrubber/container-meta.js` | strip AI provenance from Markdown/HTML/SVG |
+| Image metadata | `scripts/lib/scrubber/image-meta.js` | strip EXIF/XMP/C2PA/text metadata from PNG and JPEG |
 | Write hook | `scripts/hooks/scrubber-hook.js` | clean Write/Edit/MultiEdit content |
 | Commit hook | `scripts/hooks/scrubber-precommit.js` | strip AI co-authorship in commit messages |
 | Manual CLI | `scripts/hooks/scrubber-cli.js` | on-demand inspect/clean |

--- a/scripts/hooks/scrubber-cli.js
+++ b/scripts/hooks/scrubber-cli.js
@@ -119,7 +119,11 @@ function runClean(source, flags) {
     if (!img.supported) {
       // Recognized but not yet cleaned: never write an unchanged copy that
       // looks scrubbed. Report honestly and touch nothing.
-      process.stderr.write(`note: ${format} is a recognized image format the scrubber does not clean yet; nothing written\n`);
+      if (flags.json) {
+        process.stderr.write(`${JSON.stringify({ format, supported: false, scanned: false, removed: [] }, null, 2)}\n`);
+      } else {
+        process.stderr.write(`note: ${format} is a recognized image format the scrubber does not clean yet; nothing written\n`);
+      }
       return 3;
     }
     // A supported format whose structure is malformed falls through to the

--- a/scripts/hooks/scrubber-cli.js
+++ b/scripts/hooks/scrubber-cli.js
@@ -109,11 +109,21 @@ function runClean(source, flags) {
   const bytes = readBytes(source);
   const format = detectImageFormat(bytes);
   if (format) {
-    // Image: strip metadata blocks from the raw bytes, write binary out.
     const img = cleanImage(bytes);
-    writeCleaned(source, flags, img.cleaned, false);
-    if (flags.json) process.stderr.write(`${JSON.stringify({ format: img.format, removed: img.removed }, null, 2)}\n`);
-    return 0;
+    if (img.supported && img.valid) {
+      // A structurally valid PNG/JPEG: strip metadata blocks, write binary out.
+      writeCleaned(source, flags, img.cleaned, false);
+      if (flags.json) process.stderr.write(`${JSON.stringify({ format: img.format, removed: img.removed }, null, 2)}\n`);
+      return 0;
+    }
+    if (!img.supported) {
+      // Recognized but not yet cleaned: never write an unchanged copy that
+      // looks scrubbed. Report honestly and touch nothing.
+      process.stderr.write(`note: ${format} is a recognized image format the scrubber does not clean yet; nothing written\n`);
+      return 3;
+    }
+    // A supported format whose structure is malformed falls through to the
+    // binary guard below, which refuses a bare magic-byte prefix as binary.
   }
   const text = textFromBytes(bytes, source);
   if (text === null) return 2;

--- a/scripts/hooks/scrubber-cli.js
+++ b/scripts/hooks/scrubber-cli.js
@@ -113,7 +113,9 @@ function runClean(source, flags) {
     if (img.supported && img.valid) {
       // A structurally valid PNG/JPEG: strip metadata blocks, write binary out.
       writeCleaned(source, flags, img.cleaned, false);
-      if (flags.json) process.stderr.write(`${JSON.stringify({ format: img.format, removed: img.removed }, null, 2)}\n`);
+      if (flags.json) {
+        process.stderr.write(`${JSON.stringify({ format: img.format, supported: true, scanned: true, removed: img.removed }, null, 2)}\n`);
+      }
       return 0;
     }
     if (!img.supported) {

--- a/scripts/hooks/scrubber-cli.js
+++ b/scripts/hooks/scrubber-cli.js
@@ -19,6 +19,7 @@ const path = require('node:path');
 const { inspect, clean } = require('../lib/scrubber/engine');
 const { looksBinary } = require('../lib/scrubber/binary-guard');
 const { cleanContainer, inspectContainer } = require('../lib/scrubber/container-meta');
+const { detectImageFormat, cleanImage, inspectImage } = require('../lib/scrubber/image-meta');
 
 // The name used to route container formats (markdown/html/svg). Stdin has no
 // name, so it falls back to a content sniff inside container-meta.
@@ -67,9 +68,8 @@ function parseFlags(args) {
   };
 }
 
-// Read bytes, refuse binary on the raw buffer, then decode to text.
-function readTextOrRefuse(source) {
-  const bytes = readBytes(source);
+// Refuse binary on the raw buffer, then decode to text.
+function textFromBytes(bytes, source) {
   const binary = looksBinary(bytes);
   if (binary) {
     process.stderr.write(`refusing to treat ${source || 'stdin'} as text: it looks like ${binary}\n`);
@@ -78,8 +78,25 @@ function readTextOrRefuse(source) {
   return bytes.toString('utf8');
 }
 
+function writeCleaned(source, flags, data, textMode) {
+  if (source === '-' || source === undefined) {
+    process.stdout.write(data);
+    if (textMode && data.length > 0 && !String(data).endsWith('\n')) process.stdout.write('\n');
+  } else {
+    const dest = flags.inPlace ? source : flags.out || cleanedPath(source);
+    writeBytes(dest, data);
+    process.stderr.write(`wrote ${dest}\n`);
+  }
+}
+
 function runInspect(source) {
-  const text = readTextOrRefuse(source);
+  const bytes = readBytes(source);
+  const format = detectImageFormat(bytes);
+  if (format) {
+    process.stdout.write(`${JSON.stringify(inspectImage(bytes), null, 2)}\n`);
+    return 0;
+  }
+  const text = textFromBytes(bytes, source);
   if (text === null) return 2;
   const container = inspectContainer(containerName(source), text);
   const report = inspect(text);
@@ -89,22 +106,21 @@ function runInspect(source) {
 }
 
 function runClean(source, flags) {
-  const text = readTextOrRefuse(source);
+  const bytes = readBytes(source);
+  const format = detectImageFormat(bytes);
+  if (format) {
+    // Image: strip metadata blocks from the raw bytes, write binary out.
+    const img = cleanImage(bytes);
+    writeCleaned(source, flags, img.cleaned, false);
+    if (flags.json) process.stderr.write(`${JSON.stringify({ format: img.format, removed: img.removed }, null, 2)}\n`);
+    return 0;
+  }
+  const text = textFromBytes(bytes, source);
   if (text === null) return 2;
-  // Strip container metadata first (markdown/html/svg), then the Layer A pass
-  // on the remaining body.
+  // Strip container metadata first (markdown/html/svg), then the Layer A pass.
   const container = cleanContainer(containerName(source), text);
   const result = clean(container.cleaned, { aggressive: flags.aggressive, normalizeDashes: flags.normalizeDashes });
-
-  if (source === '-' || source === undefined) {
-    process.stdout.write(result.cleaned);
-    if (result.cleaned && !result.cleaned.endsWith('\n')) process.stdout.write('\n');
-  } else {
-    const dest = flags.inPlace ? source : flags.out || cleanedPath(source);
-    writeBytes(dest, result.cleaned);
-    process.stderr.write(`wrote ${dest}\n`);
-  }
-
+  writeCleaned(source, flags, result.cleaned, true);
   if (flags.json) {
     process.stderr.write(`${JSON.stringify({ ...result.stats, container: container.removed }, null, 2)}\n`);
   }
@@ -131,4 +147,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { main, cleanedPath, safePath, readTextOrRefuse };
+module.exports = { main, cleanedPath, safePath, textFromBytes };

--- a/scripts/lib/scrubber/image-meta.js
+++ b/scripts/lib/scrubber/image-meta.js
@@ -32,6 +32,7 @@ function detectImageFormat(buf) {
 // chunks (uppercase first letter: IHDR, PLTE, IDAT, IEND, ...) are always kept.
 const PNG_KEEP_ANCILLARY = new Set([
   'tRNS', 'gAMA', 'cHRM', 'sRGB', 'iCCP', 'sBIT', 'bKGD', 'pHYs', 'sPLT', 'hIST',
+  'acTL', 'fcTL', 'fdAT', // APNG animation control and frame data (image data)
 ]);
 
 function keepPngChunk(type) {
@@ -43,22 +44,30 @@ function cleanPng(buf) {
   const removed = [];
   const out = [PNG_SIGNATURE];
   let offset = PNG_SIGNATURE.length;
+  let ihdrFirst = false;
+  let sawIdat = false;
   let sawIend = false;
+  let index = 0;
 
   while (offset + 8 <= buf.length) {
     const length = buf.readUInt32BE(offset);
     const type = buf.toString('latin1', offset + 4, offset + 8);
     const end = offset + 12 + length; // length(4) + type(4) + data + crc(4)
     if (length > buf.length || end > buf.length) return { cleaned: buf, removed: [], valid: false };
+    if (index === 0) ihdrFirst = type === 'IHDR';
+    if (type === 'IDAT') sawIdat = true;
     if (keepPngChunk(type)) out.push(buf.subarray(offset, end));
     else removed.push(`png:${type}`);
     offset = end;
+    index += 1;
     if (type === 'IEND') { sawIend = true; break; }
   }
 
-  // Only rewrite a signature + chunks that end exactly at IEND with no trailing
-  // bytes. Anything else is left untouched.
-  if (!sawIend || offset !== buf.length) return { cleaned: buf, removed: [], valid: false };
+  // Rewrite only a genuine PNG: IHDR first, at least one IDAT, IEND terminating,
+  // and no trailing bytes. Anything else is left untouched.
+  if (!ihdrFirst || !sawIdat || !sawIend || offset !== buf.length) {
+    return { cleaned: buf, removed: [], valid: false };
+  }
   if (removed.length === 0) return { cleaned: buf, removed, valid: true };
   return { cleaned: Buffer.concat(out), removed, valid: true };
 }
@@ -77,14 +86,21 @@ function jpegDropLabel(marker) {
   return `jpeg:app${marker - 0xe0}`; // 0xe1 -> app1, 0xeb -> app11, 0xed -> app13
 }
 
+// Start-of-frame markers (baseline/progressive/lossless), excluding DHT (0xc4),
+// JPG (0xc8), and DAC (0xcc), which are not frame headers.
+function isSofMarker(marker) {
+  return marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+}
+
 // From the start of entropy-coded data, find the next real marker: a 0xff not
-// followed by 0x00 (byte stuffing) and not a restart marker (0xd0-0xd7).
+// followed by 0x00 (byte stuffing), 0xff (fill byte), or a restart marker
+// (0xd0-0xd7). Returns the offset of the 0xff that begins the marker.
 function scanEntropyEnd(buf, from) {
   let p = from;
   while (p + 1 < buf.length) {
     if (buf[p] === 0xff) {
       const next = buf[p + 1];
-      if (next !== 0x00 && !(next >= 0xd0 && next <= 0xd7)) return p;
+      if (next !== 0x00 && next !== 0xff && !(next >= 0xd0 && next <= 0xd7)) return p;
     }
     p += 1;
   }
@@ -95,10 +111,18 @@ function cleanJpeg(buf) {
   const removed = [];
   const out = [];
   let offset = 0;
+  let sawSof = false;
+  let sawSos = false;
   let sawEoi = false;
 
   while (offset + 1 < buf.length) {
     if (buf[offset] !== 0xff) return { cleaned: buf, removed: [], valid: false };
+    // A marker may be preceded by 0xff fill bytes; preserve them and advance to
+    // the 0xff that actually begins the marker.
+    while (offset + 1 < buf.length && buf[offset + 1] === 0xff) {
+      out.push(buf.subarray(offset, offset + 1));
+      offset += 1;
+    }
     const marker = buf[offset + 1];
 
     if (marker === 0xd9) { // EOI
@@ -117,10 +141,13 @@ function cleanJpeg(buf) {
     const segEnd = offset + 2 + segLength;
     if (segLength < 2 || segEnd > buf.length) return { cleaned: buf, removed: [], valid: false };
 
+    if (isSofMarker(marker)) sawSof = true;
+
     if (marker === 0xda) {
       // Start of scan: header (segLength) then entropy data up to the next
       // marker. Copy both verbatim, then resume segment parsing (progressive
       // JPEGs have several scans with segments in between).
+      sawSos = true;
       const scanEnd = scanEntropyEnd(buf, segEnd);
       if (scanEnd < 0) return { cleaned: buf, removed: [], valid: false };
       out.push(buf.subarray(offset, scanEnd));
@@ -132,8 +159,10 @@ function cleanJpeg(buf) {
     offset = segEnd;
   }
 
-  // Require a clean EOI termination with no trailing bytes.
-  if (!sawEoi || offset !== buf.length) return { cleaned: buf, removed: [], valid: false };
+  // Require a real JPEG: a frame header and a scan, a clean EOI, no trailing.
+  if (!sawSof || !sawSos || !sawEoi || offset !== buf.length) {
+    return { cleaned: buf, removed: [], valid: false };
+  }
   if (removed.length === 0) return { cleaned: buf, removed, valid: true };
   return { cleaned: Buffer.concat(out), removed, valid: true };
 }

--- a/scripts/lib/scrubber/image-meta.js
+++ b/scripts/lib/scrubber/image-meta.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// Scrubber image metadata: strip AI-provenance and other non-image metadata
+// (EXIF, XMP, C2PA, text, comments) from common raster formats by parsing the
+// container structure at the byte level. No dependencies. Fail-safe: on any
+// malformed or unexpected structure the original buffer is returned unchanged,
+// so a clean can never corrupt an image.
+//
+// Whole metadata blocks are dropped, never rewritten, and image data is copied
+// verbatim, so re-encoding artifacts are impossible.
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function detectImageFormat(buf) {
+  if (!Buffer.isBuffer(buf) || buf.length < 4) return null;
+  if (buf.length >= 8 && buf.subarray(0, 8).equals(PNG_SIGNATURE)) return 'png';
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpeg';
+  if (buf.length >= 12 && buf.toString('latin1', 0, 4) === 'RIFF' && buf.toString('latin1', 8, 12) === 'WEBP') return 'webp';
+  if (buf.toString('latin1', 0, 3) === 'GIF') return 'gif';
+  if (buf[0] === 0x42 && buf[1] === 0x4d) return 'bmp';
+  return null;
+}
+
+// --- PNG ------------------------------------------------------------------
+
+// Ancillary chunks that carry text / time / provenance, dropped whole. Image
+// and color chunks (IHDR, PLTE, IDAT, IEND, tRNS, gAMA, iCCP, ...) are kept.
+const PNG_DROP_CHUNKS = new Set(['tEXt', 'zTXt', 'iTXt', 'tIME', 'eXIf', 'caBX', 'caNv', 'orNT']);
+
+function cleanPng(buf) {
+  const removed = [];
+  const out = [PNG_SIGNATURE];
+  let offset = PNG_SIGNATURE.length;
+
+  while (offset + 8 <= buf.length) {
+    const length = buf.readUInt32BE(offset);
+    const type = buf.toString('latin1', offset + 4, offset + 8);
+    const end = offset + 12 + length; // length + type(4) + data + crc(4)
+    if (length > buf.length || end > buf.length) return { cleaned: buf, removed: [] }; // malformed: bail
+    const chunk = buf.subarray(offset, end);
+    if (PNG_DROP_CHUNKS.has(type)) {
+      removed.push(`png:${type}`);
+    } else {
+      out.push(chunk);
+    }
+    offset = end;
+    if (type === 'IEND') break;
+  }
+  if (removed.length === 0) return { cleaned: buf, removed };
+  return { cleaned: Buffer.concat(out), removed };
+}
+
+// --- JPEG -----------------------------------------------------------------
+
+// Markers with no length payload.
+const JPEG_STANDALONE = new Set([0xd8, 0xd9, 0x01]);
+function isRstMarker(marker) {
+  return marker >= 0xd0 && marker <= 0xd7;
+}
+// APP1 (EXIF/XMP), APP11 (JUMBF/C2PA), APP13 (IPTC/Photoshop), COM (comment).
+const JPEG_DROP_MARKERS = new Set([0xe1, 0xeb, 0xed, 0xfe]);
+
+function cleanJpeg(buf) {
+  const removed = [];
+  const out = [];
+  let offset = 0;
+
+  while (offset + 1 < buf.length) {
+    if (buf[offset] !== 0xff) return { cleaned: buf, removed: [] }; // not at a marker: bail
+    const marker = buf[offset + 1];
+
+    if (JPEG_STANDALONE.has(marker) || isRstMarker(marker)) {
+      out.push(buf.subarray(offset, offset + 2));
+      offset += 2;
+      continue;
+    }
+    if (marker === 0xda) {
+      // Start of scan: the entropy-coded data runs to the end (or EOI). Copy
+      // the rest verbatim without parsing inside it.
+      out.push(buf.subarray(offset));
+      break;
+    }
+    if (offset + 4 > buf.length) return { cleaned: buf, removed: [] };
+    const segLength = buf.readUInt16BE(offset + 2);
+    const end = offset + 2 + segLength;
+    if (segLength < 2 || end > buf.length) return { cleaned: buf, removed: [] };
+    if (JPEG_DROP_MARKERS.has(marker)) {
+      removed.push(`jpeg:app${marker & 0x0f}`);
+    } else {
+      out.push(buf.subarray(offset, end));
+    }
+    offset = end;
+  }
+
+  if (removed.length === 0) return { cleaned: buf, removed };
+  return { cleaned: Buffer.concat(out), removed };
+}
+
+// --- Dispatch -------------------------------------------------------------
+
+function cleanImage(buf) {
+  const format = detectImageFormat(buf);
+  try {
+    if (format === 'png') return { format, ...cleanPng(buf) };
+    if (format === 'jpeg') return { format, ...cleanJpeg(buf) };
+  } catch {
+    return { format, cleaned: buf, removed: [] };
+  }
+  return { format, cleaned: buf, removed: [] };
+}
+
+function inspectImage(buf) {
+  const { format, removed } = cleanImage(buf);
+  return { format, findings: removed, suspicious: removed.length > 0 };
+}
+
+module.exports = {
+  detectImageFormat,
+  cleanPng,
+  cleanJpeg,
+  cleanImage,
+  inspectImage,
+  PNG_DROP_CHUNKS,
+  JPEG_DROP_MARKERS,
+};

--- a/scripts/lib/scrubber/image-meta.js
+++ b/scripts/lib/scrubber/image-meta.js
@@ -1,15 +1,18 @@
 'use strict';
 
 // Scrubber image metadata: strip AI-provenance and other non-image metadata
-// (EXIF, XMP, C2PA, text, comments) from common raster formats by parsing the
-// container structure at the byte level. No dependencies. Fail-safe: on any
-// malformed or unexpected structure the original buffer is returned unchanged,
-// so a clean can never corrupt an image.
-//
-// Whole metadata blocks are dropped, never rewritten, and image data is copied
-// verbatim, so re-encoding artifacts are impossible.
+// (EXIF, XMP, C2PA, text, comments) from PNG and JPEG by parsing the container
+// structure at the byte level. No dependencies. Fail-safe: the cleaned buffer
+// is only emitted when the whole structure parsed to its exact terminator with
+// no leftover bytes (`valid: true`); on anything malformed the original buffer
+// is returned with `valid: false`, so a clean can never corrupt or truncate an
+// image. Whole metadata blocks are dropped, image data is copied verbatim.
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// Formats we actually clean. Others may be detected (for an honest warning) but
+// are never rewritten.
+const SUPPORTED = new Set(['png', 'jpeg']);
 
 function detectImageFormat(buf) {
   if (!Buffer.isBuffer(buf) || buf.length < 4) return null;
@@ -23,95 +26,141 @@ function detectImageFormat(buf) {
 
 // --- PNG ------------------------------------------------------------------
 
-// Ancillary chunks that carry text / time / provenance, dropped whole. Image
-// and color chunks (IHDR, PLTE, IDAT, IEND, tRNS, gAMA, iCCP, ...) are kept.
-const PNG_DROP_CHUNKS = new Set(['tEXt', 'zTXt', 'iTXt', 'tIME', 'eXIf', 'caBX', 'caNv', 'orNT']);
+// Ancillary chunks worth keeping (color, transparency, rendering). Every other
+// ancillary chunk (text, time, EXIF, C2PA, and unknown/private chunks) is
+// dropped so provenance in an unlisted chunk cannot slip through. Critical
+// chunks (uppercase first letter: IHDR, PLTE, IDAT, IEND, ...) are always kept.
+const PNG_KEEP_ANCILLARY = new Set([
+  'tRNS', 'gAMA', 'cHRM', 'sRGB', 'iCCP', 'sBIT', 'bKGD', 'pHYs', 'sPLT', 'hIST',
+]);
+
+function keepPngChunk(type) {
+  const isCritical = (type.charCodeAt(0) & 0x20) === 0; // uppercase first letter
+  return isCritical || PNG_KEEP_ANCILLARY.has(type);
+}
 
 function cleanPng(buf) {
   const removed = [];
   const out = [PNG_SIGNATURE];
   let offset = PNG_SIGNATURE.length;
+  let sawIend = false;
 
   while (offset + 8 <= buf.length) {
     const length = buf.readUInt32BE(offset);
     const type = buf.toString('latin1', offset + 4, offset + 8);
-    const end = offset + 12 + length; // length + type(4) + data + crc(4)
-    if (length > buf.length || end > buf.length) return { cleaned: buf, removed: [] }; // malformed: bail
-    const chunk = buf.subarray(offset, end);
-    if (PNG_DROP_CHUNKS.has(type)) {
-      removed.push(`png:${type}`);
-    } else {
-      out.push(chunk);
-    }
+    const end = offset + 12 + length; // length(4) + type(4) + data + crc(4)
+    if (length > buf.length || end > buf.length) return { cleaned: buf, removed: [], valid: false };
+    if (keepPngChunk(type)) out.push(buf.subarray(offset, end));
+    else removed.push(`png:${type}`);
     offset = end;
-    if (type === 'IEND') break;
+    if (type === 'IEND') { sawIend = true; break; }
   }
-  if (removed.length === 0) return { cleaned: buf, removed };
-  return { cleaned: Buffer.concat(out), removed };
+
+  // Only rewrite a signature + chunks that end exactly at IEND with no trailing
+  // bytes. Anything else is left untouched.
+  if (!sawIend || offset !== buf.length) return { cleaned: buf, removed: [], valid: false };
+  if (removed.length === 0) return { cleaned: buf, removed, valid: true };
+  return { cleaned: Buffer.concat(out), removed, valid: true };
 }
 
 // --- JPEG -----------------------------------------------------------------
 
-// Markers with no length payload.
-const JPEG_STANDALONE = new Set([0xd8, 0xd9, 0x01]);
+const JPEG_STANDALONE = new Set([0xd8, 0x01]); // SOI and TEM carry no payload
 function isRstMarker(marker) {
   return marker >= 0xd0 && marker <= 0xd7;
 }
 // APP1 (EXIF/XMP), APP11 (JUMBF/C2PA), APP13 (IPTC/Photoshop), COM (comment).
 const JPEG_DROP_MARKERS = new Set([0xe1, 0xeb, 0xed, 0xfe]);
 
+function jpegDropLabel(marker) {
+  if (marker === 0xfe) return 'jpeg:com';
+  return `jpeg:app${marker - 0xe0}`; // 0xe1 -> app1, 0xeb -> app11, 0xed -> app13
+}
+
+// From the start of entropy-coded data, find the next real marker: a 0xff not
+// followed by 0x00 (byte stuffing) and not a restart marker (0xd0-0xd7).
+function scanEntropyEnd(buf, from) {
+  let p = from;
+  while (p + 1 < buf.length) {
+    if (buf[p] === 0xff) {
+      const next = buf[p + 1];
+      if (next !== 0x00 && !(next >= 0xd0 && next <= 0xd7)) return p;
+    }
+    p += 1;
+  }
+  return -1; // no terminating marker: truncated scan
+}
+
 function cleanJpeg(buf) {
   const removed = [];
   const out = [];
   let offset = 0;
+  let sawEoi = false;
 
   while (offset + 1 < buf.length) {
-    if (buf[offset] !== 0xff) return { cleaned: buf, removed: [] }; // not at a marker: bail
+    if (buf[offset] !== 0xff) return { cleaned: buf, removed: [], valid: false };
     const marker = buf[offset + 1];
 
+    if (marker === 0xd9) { // EOI
+      out.push(buf.subarray(offset, offset + 2));
+      offset += 2;
+      sawEoi = true;
+      break;
+    }
     if (JPEG_STANDALONE.has(marker) || isRstMarker(marker)) {
       out.push(buf.subarray(offset, offset + 2));
       offset += 2;
       continue;
     }
-    if (marker === 0xda) {
-      // Start of scan: the entropy-coded data runs to the end (or EOI). Copy
-      // the rest verbatim without parsing inside it.
-      out.push(buf.subarray(offset));
-      break;
-    }
-    if (offset + 4 > buf.length) return { cleaned: buf, removed: [] };
+    if (offset + 4 > buf.length) return { cleaned: buf, removed: [], valid: false };
     const segLength = buf.readUInt16BE(offset + 2);
-    const end = offset + 2 + segLength;
-    if (segLength < 2 || end > buf.length) return { cleaned: buf, removed: [] };
-    if (JPEG_DROP_MARKERS.has(marker)) {
-      removed.push(`jpeg:app${marker & 0x0f}`);
-    } else {
-      out.push(buf.subarray(offset, end));
+    const segEnd = offset + 2 + segLength;
+    if (segLength < 2 || segEnd > buf.length) return { cleaned: buf, removed: [], valid: false };
+
+    if (marker === 0xda) {
+      // Start of scan: header (segLength) then entropy data up to the next
+      // marker. Copy both verbatim, then resume segment parsing (progressive
+      // JPEGs have several scans with segments in between).
+      const scanEnd = scanEntropyEnd(buf, segEnd);
+      if (scanEnd < 0) return { cleaned: buf, removed: [], valid: false };
+      out.push(buf.subarray(offset, scanEnd));
+      offset = scanEnd;
+      continue;
     }
-    offset = end;
+    if (JPEG_DROP_MARKERS.has(marker)) removed.push(jpegDropLabel(marker));
+    else out.push(buf.subarray(offset, segEnd));
+    offset = segEnd;
   }
 
-  if (removed.length === 0) return { cleaned: buf, removed };
-  return { cleaned: Buffer.concat(out), removed };
+  // Require a clean EOI termination with no trailing bytes.
+  if (!sawEoi || offset !== buf.length) return { cleaned: buf, removed: [], valid: false };
+  if (removed.length === 0) return { cleaned: buf, removed, valid: true };
+  return { cleaned: Buffer.concat(out), removed, valid: true };
 }
 
 // --- Dispatch -------------------------------------------------------------
 
 function cleanImage(buf) {
   const format = detectImageFormat(buf);
+  const supported = SUPPORTED.has(format);
+  if (!supported) return { format, supported: false, valid: false, cleaned: buf, removed: [] };
   try {
-    if (format === 'png') return { format, ...cleanPng(buf) };
-    if (format === 'jpeg') return { format, ...cleanJpeg(buf) };
+    const result = format === 'png' ? cleanPng(buf) : cleanJpeg(buf);
+    return { format, supported: true, valid: result.valid, cleaned: result.cleaned, removed: result.removed };
   } catch {
-    return { format, cleaned: buf, removed: [] };
+    return { format, supported: true, valid: false, cleaned: buf, removed: [] };
   }
-  return { format, cleaned: buf, removed: [] };
 }
 
 function inspectImage(buf) {
-  const { format, removed } = cleanImage(buf);
-  return { format, findings: removed, suspicious: removed.length > 0 };
+  const { format, supported, valid, removed } = cleanImage(buf);
+  return {
+    format,
+    supported,
+    scanned: supported && valid,
+    findings: removed,
+    suspicious: removed.length > 0,
+  };
 }
 
 module.exports = {
@@ -120,6 +169,8 @@ module.exports = {
   cleanJpeg,
   cleanImage,
   inspectImage,
-  PNG_DROP_CHUNKS,
+  keepPngChunk,
+  jpegDropLabel,
+  SUPPORTED,
   JPEG_DROP_MARKERS,
 };

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -148,6 +148,18 @@ check('a recognized-but-unsupported image is not written and reports honestly', 
   assert.ok(!fs.existsSync(path.join(tmp, 'pic.cleaned.webp')));
 });
 
+check('a recognized-but-unsupported image with --json emits a JSON report and exit 3', () => {
+  const webp = Buffer.concat([Buffer.from('RIFF', 'latin1'), Buffer.alloc(4), Buffer.from('WEBP', 'latin1'), Buffer.alloc(8)]);
+  const file = tmpFile('pic2.webp', webp);
+  const r = runCli(['clean', file, '--json']);
+  assert.strictEqual(r.code, 3);
+  const report = JSON.parse(r.err);
+  assert.strictEqual(report.format, 'webp');
+  assert.strictEqual(report.supported, false);
+  assert.strictEqual(report.scanned, false);
+  assert.deepStrictEqual(report.removed, []);
+});
+
 check('a bare image magic-byte prefix with no valid structure is refused as binary', () => {
   const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
   const file = tmpFile('broken.png', Buffer.concat([sig, Buffer.from('garbage', 'latin1')]));

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -88,11 +88,32 @@ check('clean -o writes to the chosen output path', () => {
   assert.strictEqual(fs.readFileSync(outPath, 'utf8'), 'pq');
 });
 
-check('refuses a binary file by its raw magic bytes', () => {
-  const file = tmpFile('e.txt', Buffer.from('\x89PNG\r\n\x1a\nrest', 'latin1'));
+check('refuses a non-image binary file by its raw magic bytes', () => {
+  const file = tmpFile('e.txt', Buffer.from('PK\x03\x04rest of a zip', 'latin1'));
   const r = runCli(['clean', file]);
   assert.strictEqual(r.code, 2);
-  assert.ok(/looks like a png/.test(r.err));
+  assert.ok(/looks like a zip/.test(r.err));
+});
+
+check('cleans an image file by stripping metadata chunks', () => {
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const chunk = (type, data) => {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length);
+    return Buffer.concat([len, Buffer.from(type, 'latin1'), data, Buffer.alloc(4)]);
+  };
+  const png = Buffer.concat([
+    sig,
+    chunk('IHDR', Buffer.alloc(13)),
+    chunk('tEXt', Buffer.from('k\0SomeAI', 'latin1')),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+  const file = tmpFile('img.png', png);
+  const r = runCli(['clean', file, '--json']);
+  assert.strictEqual(r.code, 0);
+  const cleaned = fs.readFileSync(path.join(tmp, 'img.cleaned.png'));
+  assert.ok(!cleaned.toString('latin1').includes('SomeAI'));
+  assert.ok(cleaned.subarray(0, 8).equals(sig));
 });
 
 check('reports the stats with --json', () => {

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -106,6 +106,7 @@ check('cleans an image file by stripping metadata chunks', () => {
     sig,
     chunk('IHDR', Buffer.alloc(13)),
     chunk('tEXt', Buffer.from('k\0SomeAI', 'latin1')),
+    chunk('IDAT', Buffer.from([1])),
     chunk('IEND', Buffer.alloc(0)),
   ]);
   const file = tmpFile('img.png', png);

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -138,6 +138,23 @@ check('cleanedPath inserts .cleaned before the extension', () => {
   assert.strictEqual(cli.cleanedPath('dir/file.md'), 'dir/file.cleaned.md');
 });
 
+check('a recognized-but-unsupported image is not written and reports honestly', () => {
+  const webp = Buffer.concat([Buffer.from('RIFF', 'latin1'), Buffer.alloc(4), Buffer.from('WEBP', 'latin1'), Buffer.alloc(8)]);
+  const file = tmpFile('pic.webp', webp);
+  const r = runCli(['clean', file]);
+  assert.strictEqual(r.code, 3);
+  assert.ok(/not clean/.test(r.err));
+  assert.ok(!fs.existsSync(path.join(tmp, 'pic.cleaned.webp')));
+});
+
+check('a bare image magic-byte prefix with no valid structure is refused as binary', () => {
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const file = tmpFile('broken.png', Buffer.concat([sig, Buffer.from('garbage', 'latin1')]));
+  const r = runCli(['clean', file]);
+  assert.strictEqual(r.code, 2);
+  assert.ok(/looks like/.test(r.err));
+});
+
 fs.rmSync(tmp, { recursive: true, force: true });
 
 console.log(`\nPassed: ${passed}`);

--- a/tests/scrubber/image-meta.test.js
+++ b/tests/scrubber/image-meta.test.js
@@ -49,6 +49,8 @@ function jpegSeg(marker, data) {
 
 const SOI = Buffer.from([0xff, 0xd8]);
 const EOI = Buffer.from([0xff, 0xd9]);
+// A minimal Start-of-Frame segment (marker only needs to be recognized).
+const SOF = jpegSeg(0xc0, Buffer.alloc(6));
 // A minimal Start-of-Scan segment plus entropy data with no 0xff bytes.
 const SOS = Buffer.concat([jpegSeg(0xda, Buffer.from([0x01, 0x00])), Buffer.from([0x00, 0x11, 0x22, 0x33])]);
 
@@ -122,6 +124,7 @@ check('jpeg drops APP1 (EXIF/XMP) and keeps the scan verbatim', () => {
     jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')),
     jpegSeg(0xe1, Buffer.from('Exif\0\0secretdata', 'latin1')),
     jpegSeg(0xdb, Buffer.alloc(4)),
+    SOF,
     SOS,
     EOI,
   ]);
@@ -135,7 +138,7 @@ check('jpeg drops APP1 (EXIF/XMP) and keeps the scan verbatim', () => {
 });
 
 check('jpeg labels a COM segment as jpeg:com, not app14', () => {
-  const jpeg = Buffer.concat([SOI, jpegSeg(0xfe, Buffer.from('a comment', 'latin1')), SOS, EOI]);
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xfe, Buffer.from('a comment', 'latin1')), SOF, SOS, EOI]);
   const r = cleanJpeg(jpeg);
   assert.strictEqual(r.valid, true);
   assert.ok(r.removed.includes('jpeg:com'));
@@ -143,7 +146,7 @@ check('jpeg labels a COM segment as jpeg:com, not app14', () => {
 });
 
 check('progressive jpeg drops metadata between two scans', () => {
-  const jpeg = Buffer.concat([SOI, jpegSeg(0xdb, Buffer.alloc(4)), SOS, jpegSeg(0xe1, Buffer.from('Exif\0\0between', 'latin1')), SOS, EOI]);
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xdb, Buffer.alloc(4)), SOF, SOS, jpegSeg(0xe1, Buffer.from('Exif\0\0between', 'latin1')), SOS, EOI]);
   const r = cleanJpeg(jpeg);
   assert.strictEqual(r.valid, true);
   assert.ok(r.removed.includes('jpeg:app1'));
@@ -151,7 +154,7 @@ check('progressive jpeg drops metadata between two scans', () => {
 });
 
 check('jpeg with only baseline segments is unchanged', () => {
-  const jpeg = Buffer.concat([SOI, jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')), SOS, EOI]);
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')), SOF, SOS, EOI]);
   const r = cleanJpeg(jpeg);
   assert.strictEqual(r.valid, true);
   assert.strictEqual(r.removed.length, 0);
@@ -182,7 +185,7 @@ check('cleanImage marks a recognized-but-unsupported format as not scrubbed', ()
 });
 
 check('cleanImage and inspectImage dispatch a valid png', () => {
-  const png = Buffer.concat([PNG_SIG, pngChunk('IHDR', Buffer.alloc(13)), pngChunk('iTXt', Buffer.from('k\0\0\0\0\0v', 'latin1')), pngChunk('IEND', Buffer.alloc(0))]);
+  const png = Buffer.concat([PNG_SIG, pngChunk('IHDR', Buffer.alloc(13)), pngChunk('iTXt', Buffer.from('k\0\0\0\0\0v', 'latin1')), pngChunk('IDAT', Buffer.from([1])), pngChunk('IEND', Buffer.alloc(0))]);
   const c = cleanImage(png);
   assert.strictEqual(c.format, 'png');
   assert.strictEqual(c.supported, true);
@@ -192,6 +195,39 @@ check('cleanImage and inspectImage dispatch a valid png', () => {
   assert.strictEqual(i.scanned, true);
   assert.strictEqual(i.suspicious, true);
   assert.strictEqual(inspectImage(Buffer.from('plain', 'latin1')).suspicious, false);
+});
+
+check('png keeps APNG animation chunks while dropping text', () => {
+  const png = Buffer.concat([
+    PNG_SIG,
+    pngChunk('IHDR', Buffer.alloc(13)),
+    pngChunk('acTL', Buffer.alloc(8)),
+    pngChunk('tEXt', Buffer.from('k\0v', 'latin1')),
+    pngChunk('fcTL', Buffer.alloc(26)),
+    pngChunk('IDAT', Buffer.from([1])),
+    pngChunk('fdAT', Buffer.from([2, 3])),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+  const r = cleanPng(png);
+  assert.strictEqual(r.valid, true);
+  assert.ok(r.removed.includes('png:tEXt'));
+  assert.ok(r.cleaned.toString('latin1').includes('acTL'));
+  assert.ok(r.cleaned.toString('latin1').includes('fcTL'));
+  assert.ok(r.cleaned.toString('latin1').includes('fdAT'));
+});
+
+check('png without IDAT is not a valid image and is left untouched', () => {
+  const png = Buffer.concat([PNG_SIG, pngChunk('IHDR', Buffer.alloc(13)), pngChunk('tEXt', Buffer.from('k\0v', 'latin1')), pngChunk('IEND', Buffer.alloc(0))]);
+  const r = cleanPng(png);
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.cleaned.equals(png));
+});
+
+check('jpeg with 0xff fill bytes before the scan marker is handled', () => {
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xe1, Buffer.from('Exif\0\0z', 'latin1')), SOF, Buffer.from([0xff, 0xff]), SOS, EOI]);
+  const r = cleanJpeg(jpeg);
+  assert.strictEqual(r.valid, true);
+  assert.ok(r.removed.includes('jpeg:app1'));
 });
 
 console.log(`\nPassed: ${passed}`);

--- a/tests/scrubber/image-meta.test.js
+++ b/tests/scrubber/image-meta.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// Scrubber image metadata: PNG chunk and JPEG segment stripping, built on
+// synthetic minimal fixtures so the parser structure is exercised without any
+// real image asset. Fail-safe behavior on malformed input is verified too.
+
+const assert = require('node:assert');
+const {
+  detectImageFormat,
+  cleanPng,
+  cleanJpeg,
+  cleanImage,
+  inspectImage,
+} = require('../../scripts/lib/scrubber/image-meta');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    Error: ${err.stack}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+function check(name, fn) {
+  if (test(name, fn)) passed += 1;
+  else failed += 1;
+}
+
+const PNG_SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function pngChunk(type, data) {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length);
+  const crc = Buffer.alloc(4); // the parser drops whole chunks and ignores CRC
+  return Buffer.concat([len, Buffer.from(type, 'latin1'), data, crc]);
+}
+
+function jpegSeg(marker, data) {
+  const len = Buffer.alloc(2);
+  len.writeUInt16BE(data.length + 2);
+  return Buffer.concat([Buffer.from([0xff, marker]), len, data]);
+}
+
+check('png drops a tEXt chunk and keeps image chunks', () => {
+  const png = Buffer.concat([
+    PNG_SIG,
+    pngChunk('IHDR', Buffer.alloc(13)),
+    pngChunk('tEXt', Buffer.from('Software\0SomeAI', 'latin1')),
+    pngChunk('IDAT', Buffer.from([1, 2, 3])),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+  const r = cleanPng(png);
+  assert.ok(r.removed.includes('png:tEXt'));
+  assert.ok(r.cleaned.subarray(0, 8).equals(PNG_SIG));
+  assert.ok(!r.cleaned.toString('latin1').includes('SomeAI'));
+  assert.ok(r.cleaned.toString('latin1').includes('IHDR'));
+  assert.ok(r.cleaned.toString('latin1').includes('IEND'));
+  assert.strictEqual(cleanPng(r.cleaned).removed.length, 0);
+});
+
+check('png with no metadata chunk is returned unchanged', () => {
+  const png = Buffer.concat([PNG_SIG, pngChunk('IHDR', Buffer.alloc(13)), pngChunk('IDAT', Buffer.from([9])), pngChunk('IEND', Buffer.alloc(0))]);
+  const r = cleanPng(png);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.equals(png));
+});
+
+check('png with a malformed chunk length bails out unchanged', () => {
+  const bad = Buffer.concat([PNG_SIG, Buffer.from([0xff, 0xff, 0xff, 0xff]), Buffer.from('tEXt', 'latin1'), Buffer.from([1, 2])]);
+  const r = cleanPng(bad);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.equals(bad));
+});
+
+check('jpeg drops APP1 (EXIF/XMP) and keeps the scan verbatim', () => {
+  const jpeg = Buffer.concat([
+    Buffer.from([0xff, 0xd8]),
+    jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')),
+    jpegSeg(0xe1, Buffer.from('Exif\0\0secretdata', 'latin1')),
+    jpegSeg(0xdb, Buffer.alloc(4)),
+    Buffer.from([0xff, 0xda]),
+    Buffer.from([0x00, 0x11, 0x22, 0x33]),
+    Buffer.from([0xff, 0xd9]),
+  ]);
+  const r = cleanJpeg(jpeg);
+  assert.ok(r.removed.includes('jpeg:app1'));
+  assert.ok(r.cleaned.subarray(0, 2).equals(Buffer.from([0xff, 0xd8])));
+  assert.ok(!r.cleaned.toString('latin1').includes('secretdata'));
+  assert.ok(r.cleaned.toString('latin1').includes('JFIF'));
+  assert.strictEqual(r.cleaned[r.cleaned.length - 1], 0xd9);
+});
+
+check('jpeg with only baseline segments is unchanged', () => {
+  const jpeg = Buffer.concat([Buffer.from([0xff, 0xd8]), jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')), Buffer.from([0xff, 0xda]), Buffer.from([1, 2]), Buffer.from([0xff, 0xd9])]);
+  const r = cleanJpeg(jpeg);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.equals(jpeg));
+});
+
+check('detectImageFormat recognizes png/jpeg and rejects others', () => {
+  assert.strictEqual(detectImageFormat(PNG_SIG), 'png');
+  assert.strictEqual(detectImageFormat(Buffer.from([0xff, 0xd8, 0xff, 0xe0])), 'jpeg');
+  assert.strictEqual(detectImageFormat(Buffer.from('not an image', 'latin1')), null);
+});
+
+check('cleanImage and inspectImage dispatch by format', () => {
+  const png = Buffer.concat([PNG_SIG, pngChunk('IHDR', Buffer.alloc(13)), pngChunk('iTXt', Buffer.from('k\0\0\0\0\0v', 'latin1')), pngChunk('IEND', Buffer.alloc(0))]);
+  const c = cleanImage(png);
+  assert.strictEqual(c.format, 'png');
+  assert.ok(c.removed.includes('png:iTXt'));
+  assert.strictEqual(inspectImage(png).suspicious, true);
+  assert.strictEqual(inspectImage(Buffer.from('plain', 'latin1')).suspicious, false);
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/scrubber/image-meta.test.js
+++ b/tests/scrubber/image-meta.test.js
@@ -47,6 +47,11 @@ function jpegSeg(marker, data) {
   return Buffer.concat([Buffer.from([0xff, marker]), len, data]);
 }
 
+const SOI = Buffer.from([0xff, 0xd8]);
+const EOI = Buffer.from([0xff, 0xd9]);
+// A minimal Start-of-Scan segment plus entropy data with no 0xff bytes.
+const SOS = Buffer.concat([jpegSeg(0xda, Buffer.from([0x01, 0x00])), Buffer.from([0x00, 0x11, 0x22, 0x33])]);
+
 check('png drops a tEXt chunk and keeps image chunks', () => {
   const png = Buffer.concat([
     PNG_SIG,
@@ -56,6 +61,7 @@ check('png drops a tEXt chunk and keeps image chunks', () => {
     pngChunk('IEND', Buffer.alloc(0)),
   ]);
   const r = cleanPng(png);
+  assert.strictEqual(r.valid, true);
   assert.ok(r.removed.includes('png:tEXt'));
   assert.ok(r.cleaned.subarray(0, 8).equals(PNG_SIG));
   assert.ok(!r.cleaned.toString('latin1').includes('SomeAI'));
@@ -64,42 +70,98 @@ check('png drops a tEXt chunk and keeps image chunks', () => {
   assert.strictEqual(cleanPng(r.cleaned).removed.length, 0);
 });
 
-check('png with no metadata chunk is returned unchanged', () => {
+check('png drops an unknown private ancillary chunk but keeps known color chunks', () => {
+  const png = Buffer.concat([
+    PNG_SIG,
+    pngChunk('IHDR', Buffer.alloc(13)),
+    pngChunk('gAMA', Buffer.alloc(4)),
+    pngChunk('prVt', Buffer.from('hidden provenance', 'latin1')),
+    pngChunk('IDAT', Buffer.from([1])),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+  const r = cleanPng(png);
+  assert.strictEqual(r.valid, true);
+  assert.ok(r.removed.includes('png:prVt'));
+  assert.ok(!r.cleaned.toString('latin1').includes('hidden provenance'));
+  assert.ok(r.cleaned.toString('latin1').includes('gAMA'));
+});
+
+check('png with no droppable chunk is returned unchanged', () => {
   const png = Buffer.concat([PNG_SIG, pngChunk('IHDR', Buffer.alloc(13)), pngChunk('IDAT', Buffer.from([9])), pngChunk('IEND', Buffer.alloc(0))]);
   const r = cleanPng(png);
+  assert.strictEqual(r.valid, true);
   assert.strictEqual(r.removed.length, 0);
   assert.ok(r.cleaned.equals(png));
 });
 
-check('png with a malformed chunk length bails out unchanged', () => {
+check('png with a malformed chunk length bails out unchanged (valid:false)', () => {
   const bad = Buffer.concat([PNG_SIG, Buffer.from([0xff, 0xff, 0xff, 0xff]), Buffer.from('tEXt', 'latin1'), Buffer.from([1, 2])]);
   const r = cleanPng(bad);
+  assert.strictEqual(r.valid, false);
   assert.strictEqual(r.removed.length, 0);
   assert.ok(r.cleaned.equals(bad));
 });
 
+check('png with trailing bytes after IEND is left untouched (no truncation)', () => {
+  const png = Buffer.concat([
+    PNG_SIG,
+    pngChunk('IHDR', Buffer.alloc(13)),
+    pngChunk('tEXt', Buffer.from('x\0y', 'latin1')),
+    pngChunk('IEND', Buffer.alloc(0)),
+    Buffer.from('TRAILER', 'latin1'),
+  ]);
+  const r = cleanPng(png);
+  assert.strictEqual(r.valid, false);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.equals(png));
+});
+
 check('jpeg drops APP1 (EXIF/XMP) and keeps the scan verbatim', () => {
   const jpeg = Buffer.concat([
-    Buffer.from([0xff, 0xd8]),
+    SOI,
     jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')),
     jpegSeg(0xe1, Buffer.from('Exif\0\0secretdata', 'latin1')),
     jpegSeg(0xdb, Buffer.alloc(4)),
-    Buffer.from([0xff, 0xda]),
-    Buffer.from([0x00, 0x11, 0x22, 0x33]),
-    Buffer.from([0xff, 0xd9]),
+    SOS,
+    EOI,
   ]);
   const r = cleanJpeg(jpeg);
+  assert.strictEqual(r.valid, true);
   assert.ok(r.removed.includes('jpeg:app1'));
-  assert.ok(r.cleaned.subarray(0, 2).equals(Buffer.from([0xff, 0xd8])));
+  assert.ok(r.cleaned.subarray(0, 2).equals(SOI));
   assert.ok(!r.cleaned.toString('latin1').includes('secretdata'));
   assert.ok(r.cleaned.toString('latin1').includes('JFIF'));
   assert.strictEqual(r.cleaned[r.cleaned.length - 1], 0xd9);
 });
 
-check('jpeg with only baseline segments is unchanged', () => {
-  const jpeg = Buffer.concat([Buffer.from([0xff, 0xd8]), jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')), Buffer.from([0xff, 0xda]), Buffer.from([1, 2]), Buffer.from([0xff, 0xd9])]);
+check('jpeg labels a COM segment as jpeg:com, not app14', () => {
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xfe, Buffer.from('a comment', 'latin1')), SOS, EOI]);
   const r = cleanJpeg(jpeg);
+  assert.strictEqual(r.valid, true);
+  assert.ok(r.removed.includes('jpeg:com'));
+  assert.ok(!r.removed.includes('jpeg:app14'));
+});
+
+check('progressive jpeg drops metadata between two scans', () => {
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xdb, Buffer.alloc(4)), SOS, jpegSeg(0xe1, Buffer.from('Exif\0\0between', 'latin1')), SOS, EOI]);
+  const r = cleanJpeg(jpeg);
+  assert.strictEqual(r.valid, true);
+  assert.ok(r.removed.includes('jpeg:app1'));
+  assert.ok(!r.cleaned.toString('latin1').includes('between'));
+});
+
+check('jpeg with only baseline segments is unchanged', () => {
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xe0, Buffer.from('JFIF\0', 'latin1')), SOS, EOI]);
+  const r = cleanJpeg(jpeg);
+  assert.strictEqual(r.valid, true);
   assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.equals(jpeg));
+});
+
+check('jpeg truncated without EOI bails out unchanged (valid:false)', () => {
+  const jpeg = Buffer.concat([SOI, jpegSeg(0xe1, Buffer.from('Exif\0\0x', 'latin1')), jpegSeg(0xdb, Buffer.alloc(4))]);
+  const r = cleanJpeg(jpeg);
+  assert.strictEqual(r.valid, false);
   assert.ok(r.cleaned.equals(jpeg));
 });
 
@@ -109,12 +171,26 @@ check('detectImageFormat recognizes png/jpeg and rejects others', () => {
   assert.strictEqual(detectImageFormat(Buffer.from('not an image', 'latin1')), null);
 });
 
-check('cleanImage and inspectImage dispatch by format', () => {
+check('cleanImage marks a recognized-but-unsupported format as not scrubbed', () => {
+  const webp = Buffer.concat([Buffer.from('RIFF', 'latin1'), Buffer.alloc(4), Buffer.from('WEBP', 'latin1'), Buffer.alloc(8)]);
+  const c = cleanImage(webp);
+  assert.strictEqual(c.format, 'webp');
+  assert.strictEqual(c.supported, false);
+  assert.strictEqual(c.valid, false);
+  assert.ok(c.cleaned.equals(webp));
+  assert.strictEqual(inspectImage(webp).scanned, false);
+});
+
+check('cleanImage and inspectImage dispatch a valid png', () => {
   const png = Buffer.concat([PNG_SIG, pngChunk('IHDR', Buffer.alloc(13)), pngChunk('iTXt', Buffer.from('k\0\0\0\0\0v', 'latin1')), pngChunk('IEND', Buffer.alloc(0))]);
   const c = cleanImage(png);
   assert.strictEqual(c.format, 'png');
+  assert.strictEqual(c.supported, true);
+  assert.strictEqual(c.valid, true);
   assert.ok(c.removed.includes('png:iTXt'));
-  assert.strictEqual(inspectImage(png).suspicious, true);
+  const i = inspectImage(png);
+  assert.strictEqual(i.scanned, true);
+  assert.strictEqual(i.suspicious, true);
   assert.strictEqual(inspectImage(Buffer.from('plain', 'latin1')).suspicious, false);
 });
 


### PR DESCRIPTION
Phase 3 of the EGC Scrubber (milestone). Adds `image-meta.js`: byte-level PNG chunk and JPEG segment parsing that drops non-image metadata (EXIF/XMP, C2PA/JUMBF, text, comments, timestamps) while copying image data verbatim.

- Pure Node, no dependencies.
- **Fail-safe**: any malformed or unexpected structure returns the original buffer unchanged, so a clean can never corrupt an image.
- Whole blocks dropped, never rewritten (no re-encode artifacts).
- Wired into the manual CLI: an image file routes through the image cleaner; text/containers keep the Layer A path.

Synthetic-fixture regression tests cover chunk/segment removal, verbatim scan copy, and the fail-safe bail-out. WebP/GIF/BMP/TIFF and zip containers (DOCX/EPUB) are follow-ups (zip needs a hand-rolled reader since there is no zip dependency).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips PNG/JPEG metadata at the byte level and routes images through the CLI cleaner. Previously the CLI refused binary and skipped images; now it detects `png`/`jpeg`, drops non-image metadata without re-encoding, and refuses malformed or unsupported inputs to avoid corruption.

- PNG: drops `tEXt`/`zTXt`/`iTXt`/`tIME`/`eXIf` and unknown ancillary chunks; keeps critical chunks, color/rendering allowlist, and APNG `acTL`/`fcTL`/`fdAT`. Emits cleaned bytes only when IHDR is first, at least one IDAT exists, IEND terminates, and no trailing data.
- JPEG: drops `APP1`/`APP11`/`APP13` and `COM`; handles progressive scans by resuming at the next real marker and tolerates 0xff fill bytes. Emits cleaned bytes only when a SOF and SOS appear before a clean EOI; otherwise returns the original buffer unchanged.
- CLI: `inspect` detects images and prints image JSON; `clean` writes binary only for supported+valid images. With `--json`, both cleaned and recognized-but-unsupported images emit the same schema: `{ format, supported, scanned, removed }`. Unsupported images exit with code 3 and nothing is written; bare magic prefixes fall through to the binary guard.
- Tests/spec: adds synthetic fixtures and CLI cases for strict validation, APNG preservation, progressive JPEG, and the unsupported `--json` path; spec lists the image cleaner.

- Migration: replace imports of `readTextOrRefuse` with `textFromBytes`.

<sup>Written for commit 92d7afaaeb639606d5a4b569d23143d80c73dcf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

