### PR TITLE
feat(scrubber): redact PDF Document Info metadata in place (partial)

### DIFF
--- a/docs/spec/scrubber.md
+++ b/docs/spec/scrubber.md
@@ -23,6 +23,7 @@ same way the Crusher does. This document is the design contract.
 | Co-author stripper | `scripts/lib/scrubber/coauthor-strip.js` | remove AI trailers, keep humans |
 | Container metadata | `scripts/lib/scrubber/container-meta.js` | strip AI provenance from Markdown/HTML/SVG |
 | Image metadata | `scripts/lib/scrubber/image-meta.js` | strip EXIF/XMP/C2PA/text metadata from PNG and JPEG |
+| PDF metadata | `scripts/lib/scrubber/pdf-meta.js` | redact PDF Document Info metadata in place (partial) |
 | Write hook | `scripts/hooks/scrubber-hook.js` | clean Write/Edit/MultiEdit content |
 | Commit hook | `scripts/hooks/scrubber-precommit.js` | strip AI co-authorship in commit messages |
 | Manual CLI | `scripts/hooks/scrubber-cli.js` | on-demand inspect/clean |
@@ -34,6 +35,15 @@ provenance, and SVG metadata blocks, but it never corrupts ordinary content. A
 provenance key whose value is nested, a block scalar, a flow collection, an open
 quote, or a sequence is left intact rather than risk dropping unrelated lines,
 since removing it reliably would need a full YAML parse.
+
+PDF metadata cleaning is explicitly partial and never claims to be exhaustive. It
+redacts the Document Information Dictionary values (Title, Author, Subject,
+Keywords, Creator, Producer, CreationDate, ModDate) in place with same-length
+blanks, so byte offsets and the cross-reference table stay valid and the file is
+never corrupted. Metadata inside compressed object streams or a compressed XMP
+packet is out of reach without decompressing and rebuilding the xref, and
+encrypted PDFs are left untouched; both cases are reported so a PDF clean is
+never treated as complete.
 
 ## Guaranteed layer (deterministic, verifiable)
 

--- a/scripts/hooks/scrubber-cli.js
+++ b/scripts/hooks/scrubber-cli.js
@@ -20,6 +20,7 @@ const { inspect, clean } = require('../lib/scrubber/engine');
 const { looksBinary } = require('../lib/scrubber/binary-guard');
 const { cleanContainer, inspectContainer } = require('../lib/scrubber/container-meta');
 const { detectImageFormat, cleanImage, inspectImage } = require('../lib/scrubber/image-meta');
+const { detectPdf, cleanPdf, inspectPdf } = require('../lib/scrubber/pdf-meta');
 
 // The name used to route container formats (markdown/html/svg). Stdin has no
 // name, so it falls back to a content sniff inside container-meta.
@@ -96,6 +97,10 @@ function runInspect(source) {
     process.stdout.write(`${JSON.stringify(inspectImage(bytes), null, 2)}\n`);
     return 0;
   }
+  if (detectPdf(bytes)) {
+    process.stdout.write(`${JSON.stringify(inspectPdf(bytes), null, 2)}\n`);
+    return 0;
+  }
   const text = textFromBytes(bytes, source);
   if (text === null) return 2;
   const container = inspectContainer(containerName(source), text);
@@ -130,6 +135,21 @@ function runClean(source, flags) {
     }
     // A supported format whose structure is malformed falls through to the
     // binary guard below, which refuses a bare magic-byte prefix as binary.
+  }
+  if (detectPdf(bytes)) {
+    const doc = cleanPdf(bytes);
+    if (doc.encrypted) {
+      if (flags.json) process.stderr.write(`${JSON.stringify({ format: 'pdf', encrypted: true, partial: true, removed: [] }, null, 2)}\n`);
+      else process.stderr.write('note: encrypted PDF left untouched; nothing written\n');
+      return 3;
+    }
+    // Same-length redaction keeps offsets valid; write the binary out. The
+    // result is honestly partial: compressed-stream and XMP metadata are not
+    // reached.
+    writeCleaned(source, flags, doc.cleaned, false);
+    if (flags.json) process.stderr.write(`${JSON.stringify({ format: 'pdf', partial: true, removed: doc.removed }, null, 2)}\n`);
+    else process.stderr.write('note: PDF metadata cleaned (partial: compressed-stream and XMP metadata are not handled)\n');
+    return 0;
   }
   const text = textFromBytes(bytes, source);
   if (text === null) return 2;

--- a/scripts/lib/scrubber/pdf-meta.js
+++ b/scripts/lib/scrubber/pdf-meta.js
@@ -1,0 +1,113 @@
+'use strict';
+
+// Scrubber PDF metadata: redact the Document Information Dictionary metadata
+// (Title, Author, Subject, Keywords, Creator, Producer, CreationDate, ModDate)
+// by blanking each value in place with same-length spaces. Same-length editing
+// keeps every byte offset intact, so the cross-reference table stays valid and
+// the PDF can never be corrupted or truncated by a clean.
+//
+// Honest about being partial: metadata carried inside compressed object streams
+// (/ObjStm) or a compressed XMP packet is not reachable without decompressing
+// and rebuilding the xref, which is out of scope here. Encrypted PDFs are left
+// untouched. The result always reports `partial: true` so a caller never treats
+// a PDF clean as exhaustive.
+
+const PDF_META_KEYS = ['Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer', 'CreationDate', 'ModDate'];
+
+const SPACE = 0x20;
+const BACKSLASH = 0x5c;
+const LPAREN = 0x28;
+const RPAREN = 0x29;
+const LANGLE = 0x3c;
+const RANGLE = 0x3e;
+
+function detectPdf(buf) {
+  return Buffer.isBuffer(buf) && buf.length >= 5 && buf.toString('latin1', 0, 5) === '%PDF-';
+}
+
+function isWhitespace(byte) {
+  return byte === 0x20 || byte === 0x0a || byte === 0x0d || byte === 0x09 || byte === 0x0c || byte === 0x00;
+}
+
+// Blank a PDF literal string `( ... )` starting at `open`. Returns the offset
+// just past the closing paren, or -1 if the string is unterminated.
+function blankLiteralString(bytes, open) {
+  let depth = 1;
+  let i = open + 1;
+  while (i < bytes.length && depth > 0) {
+    const byte = bytes[i];
+    if (byte === BACKSLASH) { i += 2; continue; } // skip the escaped byte
+    if (byte === LPAREN) depth += 1;
+    else if (byte === RPAREN) { depth -= 1; if (depth === 0) break; }
+    i += 1;
+  }
+  if (i >= bytes.length || bytes[i] !== RPAREN) return -1;
+  bytes.fill(SPACE, open + 1, i);
+  return i + 1;
+}
+
+// Blank a PDF hex string `< ... >` starting at `open`. Returns the offset just
+// past the closing angle, or -1 if unterminated.
+function blankHexString(bytes, open) {
+  let i = open + 1;
+  while (i < bytes.length && bytes[i] !== RANGLE) i += 1;
+  if (i >= bytes.length) return -1;
+  bytes.fill(SPACE, open + 1, i);
+  return i + 1;
+}
+
+// From `after` (just past a key name), skip whitespace and blank the string
+// value if one follows. Returns true if a value was blanked.
+function blankValueAfter(bytes, after) {
+  let i = after;
+  while (i < bytes.length && isWhitespace(bytes[i])) i += 1;
+  if (i >= bytes.length) return false;
+  if (bytes[i] === LPAREN) return blankLiteralString(bytes, i) > 0;
+  // A single `<` opens a hex string; `<<` opens a dictionary and is not a value.
+  if (bytes[i] === LANGLE && bytes[i + 1] !== LANGLE) return blankHexString(bytes, i) > 0;
+  return false;
+}
+
+function cleanPdf(buf) {
+  if (!detectPdf(buf)) return { cleaned: buf, removed: [], partial: true, encrypted: false };
+  // An encrypted PDF stores its strings as ciphertext; blanking them would not
+  // reliably erase the plaintext and could confuse a reader. Leave it untouched.
+  if (buf.includes('/Encrypt')) {
+    return { cleaned: buf, removed: [], partial: true, encrypted: true };
+  }
+
+  const bytes = Buffer.from(buf); // never mutate the caller's buffer
+  const removed = [];
+  for (const key of PDF_META_KEYS) {
+    const token = Buffer.from(`/${key}`, 'latin1');
+    let from = 0;
+    let blankedThisKey = false;
+    for (;;) {
+      const at = bytes.indexOf(token, from);
+      if (at < 0) break;
+      const after = at + token.length;
+      // The next byte must delimit the key name (whitespace or a value opener),
+      // so `/Creator` never matches inside `/CreatorTool`.
+      const next = bytes[after];
+      if (next === undefined || isWhitespace(next) || next === LPAREN || next === LANGLE) {
+        if (blankValueAfter(bytes, after)) blankedThisKey = true;
+      }
+      from = after;
+    }
+    if (blankedThisKey) removed.push(`pdf:${key}`);
+  }
+
+  return { cleaned: removed.length > 0 ? bytes : buf, removed, partial: true, encrypted: false };
+}
+
+function inspectPdf(buf) {
+  const { removed, partial, encrypted } = cleanPdf(buf);
+  return { format: 'pdf', partial, encrypted, findings: removed, suspicious: removed.length > 0 };
+}
+
+module.exports = {
+  detectPdf,
+  cleanPdf,
+  inspectPdf,
+  PDF_META_KEYS,
+};

--- a/scripts/lib/scrubber/pdf-meta.js
+++ b/scripts/lib/scrubber/pdf-meta.js
@@ -74,39 +74,57 @@ function isEncrypted(buf) {
   return /\/Encrypt\s+\d+\s+\d+\s+R/.test(buf.toString('latin1'));
 }
 
-function isAlpha(byte) {
-  return (byte >= 0x41 && byte <= 0x5a) || (byte >= 0x61 && byte <= 0x7a);
+// The (num, gen) targets of every `/Info N G R` trailer reference. Incremental
+// updates can carry more than one trailer, so all are collected.
+function infoTargets(buf) {
+  const targets = [];
+  const re = /\/Info\s+(\d+)\s+(\d+)\s+R/g;
+  const text = buf.toString('latin1');
+  let m = re.exec(text);
+  while (m !== null) {
+    targets.push([parseInt(m[1], 10), parseInt(m[2], 10)]);
+    m = re.exec(text);
+  }
+  return targets;
 }
 
-// Byte ranges [start, end) covered by `stream ... endstream` payloads. Metadata
-// is never blanked inside these: a stream holds binary (often Flate-compressed)
-// data, and editing it would corrupt the stream. The `stream` keyword ends a
-// line and is not the tail of `endstream`.
-function streamRegions(bytes) {
-  const streamKw = Buffer.from('stream', 'latin1');
-  const endKw = Buffer.from('endstream', 'latin1');
-  const regions = [];
+// The byte range [start, end) of `num gen obj ... endobj`, requiring a real
+// delimiter before the header so `1 0 obj` never matches inside `11 0 obj`.
+function findObject(bytes, num, gen) {
+  const header = Buffer.from(`${num} ${gen} obj`, 'latin1');
+  const endKw = Buffer.from('endobj', 'latin1');
   let from = 0;
   for (;;) {
-    const s = bytes.indexOf(streamKw, from);
-    if (s < 0) break;
-    const before = bytes[s - 1];
-    const after = bytes[s + streamKw.length];
-    const isKeyword = (after === 0x0a || after === 0x0d) && !isAlpha(before);
-    if (!isKeyword) { from = s + streamKw.length; continue; }
-    const e = bytes.indexOf(endKw, s + streamKw.length);
-    if (e < 0) break;
-    regions.push([s, e + endKw.length]);
-    from = e + endKw.length;
+    const start = bytes.indexOf(header, from);
+    if (start < 0) return null;
+    if (start === 0 || isWhitespace(bytes[start - 1])) {
+      const end = bytes.indexOf(endKw, start + header.length);
+      if (end < 0) return null;
+      return [start, end + endKw.length];
+    }
+    from = start + header.length;
   }
-  return regions;
 }
 
-function insideAny(regions, at) {
-  for (const [start, end] of regions) {
-    if (at >= start && at < end) return true;
+// Blank metadata string values found strictly inside [start, end). The Info
+// object is a plain dictionary object, never a stream, so this can never touch
+// stream bytes.
+function blankKeysInRegion(bytes, start, end, removedSet) {
+  for (const key of PDF_META_KEYS) {
+    const token = Buffer.from(`/${key}`, 'latin1');
+    let from = start;
+    for (;;) {
+      const at = bytes.indexOf(token, from);
+      if (at < 0 || at >= end) break;
+      const after = at + token.length;
+      // The next byte must delimit the key, so `/Creator` never matches inside
+      // `/CreatorTool`.
+      const next = bytes[after];
+      const delimited = next === undefined || isWhitespace(next) || next === LPAREN || next === LANGLE;
+      if (delimited && blankValueAfter(bytes, after)) removedSet.add(`pdf:${key}`);
+      from = after;
+    }
   }
-  return false;
 }
 
 function cleanPdf(buf) {
@@ -117,30 +135,19 @@ function cleanPdf(buf) {
     return { cleaned: buf, removed: [], partial: true, encrypted: true };
   }
 
-  const bytes = Buffer.from(buf); // never mutate the caller's buffer
-  const streams = streamRegions(bytes);
-  const removed = [];
-  for (const key of PDF_META_KEYS) {
-    const token = Buffer.from(`/${key}`, 'latin1');
-    let from = 0;
-    let blankedThisKey = false;
-    for (;;) {
-      const at = bytes.indexOf(token, from);
-      if (at < 0) break;
-      const after = at + token.length;
-      // The next byte must delimit the key name (whitespace or a value opener),
-      // so `/Creator` never matches inside `/CreatorTool`. Never touch a match
-      // inside a stream payload, which would corrupt it.
-      const next = bytes[after];
-      const delimited = next === undefined || isWhitespace(next) || next === LPAREN || next === LANGLE;
-      if (delimited && !insideAny(streams, at) && blankValueAfter(bytes, after)) {
-        blankedThisKey = true;
-      }
-      from = after;
-    }
-    if (blankedThisKey) removed.push(`pdf:${key}`);
-  }
+  // Redact only inside the Document Info object(s) named by the trailer. If the
+  // Info dictionary lives in a compressed object stream it is not reachable in
+  // the raw bytes, and nothing is blanked (honestly partial).
+  const targets = infoTargets(buf);
+  if (targets.length === 0) return { cleaned: buf, removed: [], partial: true, encrypted: false };
 
+  const bytes = Buffer.from(buf); // never mutate the caller's buffer
+  const removedSet = new Set();
+  for (const [num, gen] of targets) {
+    const region = findObject(bytes, num, gen);
+    if (region) blankKeysInRegion(bytes, region[0], region[1], removedSet);
+  }
+  const removed = [...removedSet];
   return { cleaned: removed.length > 0 ? bytes : buf, removed, partial: true, encrypted: false };
 }
 

--- a/scripts/lib/scrubber/pdf-meta.js
+++ b/scripts/lib/scrubber/pdf-meta.js
@@ -68,15 +68,57 @@ function blankValueAfter(bytes, after) {
   return false;
 }
 
+// True only when /Encrypt appears as the trailer's indirect reference
+// (`/Encrypt N G R`), not when the literal shows up in page text or a stream.
+function isEncrypted(buf) {
+  return /\/Encrypt\s+\d+\s+\d+\s+R/.test(buf.toString('latin1'));
+}
+
+function isAlpha(byte) {
+  return (byte >= 0x41 && byte <= 0x5a) || (byte >= 0x61 && byte <= 0x7a);
+}
+
+// Byte ranges [start, end) covered by `stream ... endstream` payloads. Metadata
+// is never blanked inside these: a stream holds binary (often Flate-compressed)
+// data, and editing it would corrupt the stream. The `stream` keyword ends a
+// line and is not the tail of `endstream`.
+function streamRegions(bytes) {
+  const streamKw = Buffer.from('stream', 'latin1');
+  const endKw = Buffer.from('endstream', 'latin1');
+  const regions = [];
+  let from = 0;
+  for (;;) {
+    const s = bytes.indexOf(streamKw, from);
+    if (s < 0) break;
+    const before = bytes[s - 1];
+    const after = bytes[s + streamKw.length];
+    const isKeyword = (after === 0x0a || after === 0x0d) && !isAlpha(before);
+    if (!isKeyword) { from = s + streamKw.length; continue; }
+    const e = bytes.indexOf(endKw, s + streamKw.length);
+    if (e < 0) break;
+    regions.push([s, e + endKw.length]);
+    from = e + endKw.length;
+  }
+  return regions;
+}
+
+function insideAny(regions, at) {
+  for (const [start, end] of regions) {
+    if (at >= start && at < end) return true;
+  }
+  return false;
+}
+
 function cleanPdf(buf) {
   if (!detectPdf(buf)) return { cleaned: buf, removed: [], partial: true, encrypted: false };
   // An encrypted PDF stores its strings as ciphertext; blanking them would not
   // reliably erase the plaintext and could confuse a reader. Leave it untouched.
-  if (buf.includes('/Encrypt')) {
+  if (isEncrypted(buf)) {
     return { cleaned: buf, removed: [], partial: true, encrypted: true };
   }
 
   const bytes = Buffer.from(buf); // never mutate the caller's buffer
+  const streams = streamRegions(bytes);
   const removed = [];
   for (const key of PDF_META_KEYS) {
     const token = Buffer.from(`/${key}`, 'latin1');
@@ -87,10 +129,12 @@ function cleanPdf(buf) {
       if (at < 0) break;
       const after = at + token.length;
       // The next byte must delimit the key name (whitespace or a value opener),
-      // so `/Creator` never matches inside `/CreatorTool`.
+      // so `/Creator` never matches inside `/CreatorTool`. Never touch a match
+      // inside a stream payload, which would corrupt it.
       const next = bytes[after];
-      if (next === undefined || isWhitespace(next) || next === LPAREN || next === LANGLE) {
-        if (blankValueAfter(bytes, after)) blankedThisKey = true;
+      const delimited = next === undefined || isWhitespace(next) || next === LPAREN || next === LANGLE;
+      if (delimited && !insideAny(streams, at) && blankValueAfter(bytes, after)) {
+        blankedThisKey = true;
       }
       from = after;
     }

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -169,7 +169,7 @@ check('a bare image magic-byte prefix with no valid structure is refused as bina
 });
 
 check('cleans a pdf by redacting Info metadata in place', () => {
-  const pdfBuf = Buffer.from('%PDF-1.4\n<< /Producer (SomeAI) >>\n%%EOF\n', 'latin1');
+  const pdfBuf = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Producer (SomeAI) >>\nendobj\ntrailer\n<< /Info 1 0 R >>\n%%EOF\n', 'latin1');
   const file = tmpFile('doc.pdf', pdfBuf);
   const r = runCli(['clean', file, '--json']);
   assert.strictEqual(r.code, 0);

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -168,6 +168,25 @@ check('a bare image magic-byte prefix with no valid structure is refused as bina
   assert.ok(/looks like/.test(r.err));
 });
 
+check('cleans a pdf by redacting Info metadata in place', () => {
+  const pdfBuf = Buffer.from('%PDF-1.4\n<< /Producer (SomeAI) >>\n%%EOF\n', 'latin1');
+  const file = tmpFile('doc.pdf', pdfBuf);
+  const r = runCli(['clean', file, '--json']);
+  assert.strictEqual(r.code, 0);
+  const cleaned = fs.readFileSync(path.join(tmp, 'doc.cleaned.pdf'));
+  assert.strictEqual(cleaned.length, pdfBuf.length);
+  assert.ok(!cleaned.toString('latin1').includes('SomeAI'));
+});
+
+check('leaves an encrypted pdf untouched and exits 3', () => {
+  const pdfBuf = Buffer.from('%PDF-1.4\n<< /Encrypt 5 0 R /Producer (SomeAI) >>\n%%EOF\n', 'latin1');
+  const file = tmpFile('enc.pdf', pdfBuf);
+  const r = runCli(['clean', file]);
+  assert.strictEqual(r.code, 3);
+  assert.ok(/encrypted/.test(r.err));
+  assert.ok(!fs.existsSync(path.join(tmp, 'enc.cleaned.pdf')));
+});
+
 fs.rmSync(tmp, { recursive: true, force: true });
 
 console.log(`\nPassed: ${passed}`);

--- a/tests/scrubber/pdf-meta.test.js
+++ b/tests/scrubber/pdf-meta.test.js
@@ -1,8 +1,9 @@
 'use strict';
 
 // Scrubber PDF metadata: in-place, same-length redaction of the Document
-// Information Dictionary. Built on synthetic minimal PDFs so the byte-offset
-// guarantee (cleaned length equals original length) is verified directly.
+// Information Dictionary, scoped to the Info object named by the trailer. Built
+// on synthetic minimal PDFs so the byte-offset guarantee (cleaned length equals
+// original length) and the stream-safety guarantee are verified directly.
 
 const assert = require('node:assert');
 const { detectPdf, cleanPdf, inspectPdf } = require('../../scripts/lib/scrubber/pdf-meta');
@@ -26,17 +27,23 @@ function check(name, fn) {
   else failed += 1;
 }
 
-function pdf(body) {
-  return Buffer.from(`%PDF-1.4\n${body}\n%%EOF\n`, 'latin1');
+// A PDF whose trailer points /Info at object 1, whose dictionary body is
+// `infoDict`. `extra` inserts additional objects between the Info object and
+// the trailer.
+function pdfWithInfo(infoDict, extra = '') {
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj\n<< ${infoDict} >>\nendobj\n${extra}trailer\n<< /Info 1 0 R >>\n%%EOF\n`,
+    'latin1',
+  );
 }
 
 check('detectPdf recognizes the PDF header only', () => {
-  assert.strictEqual(detectPdf(pdf('x')), true);
+  assert.strictEqual(detectPdf(pdfWithInfo('/Title (x)')), true);
   assert.strictEqual(detectPdf(Buffer.from('not a pdf', 'latin1')), false);
 });
 
 check('blanks Info dictionary metadata in place, preserving length', () => {
-  const buf = pdf('1 0 obj\n<< /Title (My Title) /Producer (SomeAI 1.0) /Author (Jane) >>\nendobj');
+  const buf = pdfWithInfo('/Title (My Title) /Producer (SomeAI 1.0) /Author (Jane)');
   const r = cleanPdf(buf);
   assert.strictEqual(r.partial, true);
   assert.strictEqual(r.encrypted, false);
@@ -48,12 +55,11 @@ check('blanks Info dictionary metadata in place, preserving length', () => {
   assert.ok(!text.includes('SomeAI'));
   assert.ok(!text.includes('My Title'));
   assert.ok(!text.includes('Jane'));
-  assert.ok(text.includes('/Producer ('));
   assert.ok(text.includes('%%EOF'));
 });
 
 check('blanks a hex-string metadata value', () => {
-  const buf = pdf('<< /Producer <536f6d654149> >>');
+  const buf = pdfWithInfo('/Producer <536f6d654149>');
   const r = cleanPdf(buf);
   assert.ok(r.removed.includes('pdf:Producer'));
   assert.strictEqual(r.cleaned.length, buf.length);
@@ -61,21 +67,21 @@ check('blanks a hex-string metadata value', () => {
 });
 
 check('does not match a key that is a prefix of a longer name', () => {
-  const buf = pdf('<< /CreatorTool (KeepThis) >>');
+  const buf = pdfWithInfo('/CreatorTool (KeepThis)');
   const r = cleanPdf(buf);
   assert.strictEqual(r.removed.length, 0);
   assert.ok(r.cleaned.toString('latin1').includes('KeepThis'));
 });
 
 check('does not treat a following dictionary as a hex value', () => {
-  const buf = pdf('<< /Author << /Nested (x) >> >>');
+  const buf = pdfWithInfo('/Author << /Nested (x) >>');
   const r = cleanPdf(buf);
   assert.strictEqual(r.removed.length, 0);
   assert.ok(r.cleaned.toString('latin1').includes('/Nested (x)'));
 });
 
 check('leaves an encrypted PDF untouched and reports it', () => {
-  const buf = pdf('trailer << /Encrypt 5 0 R /Info 1 0 R >>\n1 0 obj << /Producer (SomeAI) >> endobj');
+  const buf = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Producer (SomeAI) >>\nendobj\ntrailer\n<< /Encrypt 5 0 R /Info 1 0 R >>\n%%EOF\n', 'latin1');
   const r = cleanPdf(buf);
   assert.strictEqual(r.encrypted, true);
   assert.strictEqual(r.removed.length, 0);
@@ -90,29 +96,44 @@ check('a non-pdf buffer is returned unchanged', () => {
   assert.ok(r.cleaned.equals(buf));
 });
 
-check('inspectPdf reports partial and suspicious honestly', () => {
-  const suspicious = inspectPdf(pdf('<< /Producer (SomeAI) >>'));
-  assert.strictEqual(suspicious.partial, true);
-  assert.strictEqual(suspicious.suspicious, true);
-  const clean = inspectPdf(pdf('<< /Type /Catalog >>'));
-  assert.strictEqual(clean.suspicious, false);
+check('a pdf with no /Info reference has nothing blanked (honestly partial)', () => {
+  const buf = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Producer (SomeAI) >>\nendobj\ntrailer\n<< /Root 2 0 R >>\n%%EOF\n', 'latin1');
+  const r = cleanPdf(buf);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.toString('latin1').includes('SomeAI'));
 });
 
 check('does not treat /Encrypt in page text as an encrypted PDF', () => {
-  const buf = pdf('<< /Producer (SomeAI) >>\nBT (the word /Encrypt appears here) Tj ET');
+  const buf = pdfWithInfo('/Producer (SomeAI)', '5 0 obj\n(a string mentioning /Encrypt here)\nendobj\n');
   const r = cleanPdf(buf);
   assert.strictEqual(r.encrypted, false);
   assert.ok(r.removed.includes('pdf:Producer'));
   assert.ok(!r.cleaned.toString('latin1').includes('SomeAI'));
 });
 
-check('never blanks a metadata key inside a stream payload', () => {
-  const streamData = '/Producer (keep me: I am inside a stream)';
-  const buf = pdf(`<< /Producer (RealMeta) >>\n5 0 obj\n<< /Length ${streamData.length} >>\nstream\n${streamData}\nendstream\nendobj`);
+check('never blanks a metadata key outside the Info object (e.g. inside a stream)', () => {
+  const streamObj = '5 0 obj\n<< /Length 33 >>\nstream\n/Producer (keep me inside the stream)\nendstream\nendobj\n';
+  const buf = pdfWithInfo('/Producer (RealMeta)', streamObj);
   const r = cleanPdf(buf);
   assert.ok(r.removed.includes('pdf:Producer'));
-  assert.ok(!r.cleaned.toString('latin1').includes('RealMeta')); // dictionary value blanked
-  assert.ok(r.cleaned.toString('latin1').includes('keep me: I am inside a stream')); // stream untouched
+  assert.ok(!r.cleaned.toString('latin1').includes('RealMeta')); // Info value blanked
+  assert.ok(r.cleaned.toString('latin1').includes('keep me inside the stream')); // stream untouched
+});
+
+check('resolves /Info without matching a longer object number', () => {
+  const buf = Buffer.from('%PDF-1.4\n11 0 obj\n<< /Producer (WrongObj) >>\nendobj\n1 0 obj\n<< /Producer (RightMeta) >>\nendobj\ntrailer\n<< /Info 1 0 R >>\n%%EOF\n', 'latin1');
+  const r = cleanPdf(buf);
+  assert.ok(r.removed.includes('pdf:Producer'));
+  assert.ok(!r.cleaned.toString('latin1').includes('RightMeta'));
+  assert.ok(r.cleaned.toString('latin1').includes('WrongObj')); // 11 0 obj is not the target
+});
+
+check('inspectPdf reports partial and suspicious honestly', () => {
+  const suspicious = inspectPdf(pdfWithInfo('/Producer (SomeAI)'));
+  assert.strictEqual(suspicious.partial, true);
+  assert.strictEqual(suspicious.suspicious, true);
+  const clean = inspectPdf(pdfWithInfo('/Trapped /False'));
+  assert.strictEqual(clean.suspicious, false);
 });
 
 console.log(`\nPassed: ${passed}`);

--- a/tests/scrubber/pdf-meta.test.js
+++ b/tests/scrubber/pdf-meta.test.js
@@ -98,6 +98,23 @@ check('inspectPdf reports partial and suspicious honestly', () => {
   assert.strictEqual(clean.suspicious, false);
 });
 
+check('does not treat /Encrypt in page text as an encrypted PDF', () => {
+  const buf = pdf('<< /Producer (SomeAI) >>\nBT (the word /Encrypt appears here) Tj ET');
+  const r = cleanPdf(buf);
+  assert.strictEqual(r.encrypted, false);
+  assert.ok(r.removed.includes('pdf:Producer'));
+  assert.ok(!r.cleaned.toString('latin1').includes('SomeAI'));
+});
+
+check('never blanks a metadata key inside a stream payload', () => {
+  const streamData = '/Producer (keep me: I am inside a stream)';
+  const buf = pdf(`<< /Producer (RealMeta) >>\n5 0 obj\n<< /Length ${streamData.length} >>\nstream\n${streamData}\nendstream\nendobj`);
+  const r = cleanPdf(buf);
+  assert.ok(r.removed.includes('pdf:Producer'));
+  assert.ok(!r.cleaned.toString('latin1').includes('RealMeta')); // dictionary value blanked
+  assert.ok(r.cleaned.toString('latin1').includes('keep me: I am inside a stream')); // stream untouched
+});
+
 console.log(`\nPassed: ${passed}`);
 console.log(`Failed: ${failed}`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/scrubber/pdf-meta.test.js
+++ b/tests/scrubber/pdf-meta.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+// Scrubber PDF metadata: in-place, same-length redaction of the Document
+// Information Dictionary. Built on synthetic minimal PDFs so the byte-offset
+// guarantee (cleaned length equals original length) is verified directly.
+
+const assert = require('node:assert');
+const { detectPdf, cleanPdf, inspectPdf } = require('../../scripts/lib/scrubber/pdf-meta');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    Error: ${err.stack}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+function check(name, fn) {
+  if (test(name, fn)) passed += 1;
+  else failed += 1;
+}
+
+function pdf(body) {
+  return Buffer.from(`%PDF-1.4\n${body}\n%%EOF\n`, 'latin1');
+}
+
+check('detectPdf recognizes the PDF header only', () => {
+  assert.strictEqual(detectPdf(pdf('x')), true);
+  assert.strictEqual(detectPdf(Buffer.from('not a pdf', 'latin1')), false);
+});
+
+check('blanks Info dictionary metadata in place, preserving length', () => {
+  const buf = pdf('1 0 obj\n<< /Title (My Title) /Producer (SomeAI 1.0) /Author (Jane) >>\nendobj');
+  const r = cleanPdf(buf);
+  assert.strictEqual(r.partial, true);
+  assert.strictEqual(r.encrypted, false);
+  assert.ok(r.removed.includes('pdf:Title'));
+  assert.ok(r.removed.includes('pdf:Producer'));
+  assert.ok(r.removed.includes('pdf:Author'));
+  assert.strictEqual(r.cleaned.length, buf.length); // byte offsets preserved
+  const text = r.cleaned.toString('latin1');
+  assert.ok(!text.includes('SomeAI'));
+  assert.ok(!text.includes('My Title'));
+  assert.ok(!text.includes('Jane'));
+  assert.ok(text.includes('/Producer ('));
+  assert.ok(text.includes('%%EOF'));
+});
+
+check('blanks a hex-string metadata value', () => {
+  const buf = pdf('<< /Producer <536f6d654149> >>');
+  const r = cleanPdf(buf);
+  assert.ok(r.removed.includes('pdf:Producer'));
+  assert.strictEqual(r.cleaned.length, buf.length);
+  assert.ok(!r.cleaned.toString('latin1').includes('536f6d654149'));
+});
+
+check('does not match a key that is a prefix of a longer name', () => {
+  const buf = pdf('<< /CreatorTool (KeepThis) >>');
+  const r = cleanPdf(buf);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.toString('latin1').includes('KeepThis'));
+});
+
+check('does not treat a following dictionary as a hex value', () => {
+  const buf = pdf('<< /Author << /Nested (x) >> >>');
+  const r = cleanPdf(buf);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.toString('latin1').includes('/Nested (x)'));
+});
+
+check('leaves an encrypted PDF untouched and reports it', () => {
+  const buf = pdf('trailer << /Encrypt 5 0 R /Info 1 0 R >>\n1 0 obj << /Producer (SomeAI) >> endobj');
+  const r = cleanPdf(buf);
+  assert.strictEqual(r.encrypted, true);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.equals(buf));
+  assert.ok(r.cleaned.toString('latin1').includes('SomeAI'));
+});
+
+check('a non-pdf buffer is returned unchanged', () => {
+  const buf = Buffer.from('/Producer (SomeAI)', 'latin1');
+  const r = cleanPdf(buf);
+  assert.strictEqual(r.removed.length, 0);
+  assert.ok(r.cleaned.equals(buf));
+});
+
+check('inspectPdf reports partial and suspicious honestly', () => {
+  const suspicious = inspectPdf(pdf('<< /Producer (SomeAI) >>'));
+  assert.strictEqual(suspicious.partial, true);
+  assert.strictEqual(suspicious.suspicious, true);
+  const clean = inspectPdf(pdf('<< /Type /Catalog >>'));
+  assert.strictEqual(clean.suspicious, false);
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Phase 4 of the EGC Scrubber (milestone). Adds `pdf-meta.js`: same-length, in-place redaction of the PDF Document Information Dictionary.

- **Never corrupts**: values are blanked with equal-length spaces, so byte offsets and the xref table stay valid.
- **Honestly partial**: metadata inside compressed object streams or a compressed XMP packet is not reached (needs decompression + xref rebuild); encrypted PDFs are left untouched. Both are reported, so a PDF clean is never presented as exhaustive.
- Literal and hex string values handled; a following dictionary is not mistaken for a value; a key that is a prefix of a longer name is not matched.
- Wired into the manual CLI.

Synthetic-fixture tests cover offset-preserving redaction, the encrypted and non-pdf paths, and the partial reporting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts PDF Document Info metadata in place and routes PDFs through the manual scrubber CLI. Previously PDFs were ignored; now the CLI detects PDFs, blanks Document Info values with same-length spaces, leaves encrypted PDFs untouched, and always reports a partial result.

- Scopes redaction strictly to the trailer’s `/Info N G R` object(s); never touches stream data. Resolves all `/Info` references, guards object-number boundaries (e.g., never resolves into `11 0 obj`), handles literal and hex strings, never matches key prefixes, and never treats `<<` as a hex value. Info in compressed object streams or compressed XMP is out of reach; `partial: true` is always set.
- CLI: `inspect` reports `{ format: 'pdf', partial, encrypted, findings }`. `clean` writes same-length–redacted bytes and reports `{ format: 'pdf', partial: true, removed }`. If encrypted, writes nothing, exits 3, and reports `{ format: 'pdf', encrypted: true, partial: true, removed: [] }`.

<sup>Written for commit 53dd32c23bbbcadb6b987bc12f63407bf0ee217a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

