### PR TITLE
docs(scrubber): formalize the best-effort layer contract in the spec

### DIFF
--- a/docs/spec/scrubber.md
+++ b/docs/spec/scrubber.md
@@ -66,8 +66,32 @@ preserves the legitimate ones by default.
 
 ## Best-effort layer
 
-Statistical token-sampling text marks are handled only by the rewrite workflow in
-the skill. No model is bundled and no undetectability is claimed.
+Statistical token-sampling watermarks live in word choice, not in any removable
+character, so the only lever is to rewrite the prose. This layer is deliberately
+kept out of the automatic write hook and the deterministic CLI: it is a manual,
+opt-in workflow in the `content-scrubber` skill
+(`references/rewrite-workflow.md`), because a rewrite changes the text's meaning
+surface and must be a human decision, not a silent edit on every save.
+
+Contract for this layer:
+
+- **Best-effort only, never certified.** No public detector or key exists, so no
+  rewrite can be presented as proof of human authorship or as "undetectable".
+  The residual risk is reported honestly (lower for short, predictable text;
+  higher for long, high-entropy prose).
+- **No bundled model.** The agent running the skill is the rewrite model; EGC
+  ships no weights and makes no network call. Prefer a non-origin, open-weight
+  model, since rewriting with the same model that produced the text can re-stamp
+  it.
+- **Deterministic clean brackets every rewrite.** The workflow runs the
+  guaranteed layer (invisible Unicode + dashes) before and after the rewrite, so
+  the lossless removals always apply even when the statistical pass is skipped.
+- **Meaning is preserved.** Every fact, number, name, and technical identifier
+  survives; for code, only natural-language parts and private names change and
+  program behavior is untouched.
+
+The guaranteed layer stays the default: when quality matters more than
+statistical hygiene, use the lossless path and keep the original prose.
 
 ## Out of scope
 


### PR DESCRIPTION
Phase 5 of the EGC Scrubber (milestone). The best-effort statistical-rewrite family (Family 3) already ships as the manual `content-scrubber` skill workflow; this promotes its contract to the spec so all three families are documented at the same level.

- Why the rewrite stays a manual, opt-in skill workflow (not an automatic hook edit).
- Best-effort only, never certified undetectable; residual risk reported honestly.
- No bundled model; deterministic clean brackets every rewrite; meaning and program behavior preserved.

Documentation only, no code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formalizes the best-effort statistical rewrite layer in the scrubber spec and clarifies why it remains a manual, opt-in workflow. Behavior is unchanged; this aligns the contract across all scrubber layers and sets reviewer expectations for usage and risk.

- Keeps the rewrite outside automatic hooks and the deterministic CLI; use the `content-scrubber` skill’s rewrite workflow (`references/rewrite-workflow.md`).
- States the layer is best-effort only with honest residual-risk reporting; no undetectability claims.
- Confirms no bundled model or network calls; prefer a non-origin, open‑weight model to avoid re-stamping.
- Guarantees clean brackets run before and after any rewrite so lossless removals always apply, even if the statistical pass is skipped.
- Preserves meaning: facts, numbers, names, and technical identifiers stay intact; for code, only natural-language parts and private names change, with behavior unchanged.
- Reiterates the guaranteed layer as the default path when prose quality outweighs statistical hygiene.

<sup>Written for commit 327bfff61189236e1053a8dc91d0b21f7706d7ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

