### PR TITLE
feat(scrubber): activate the write hook by registering it in the hooks runtime

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -27,6 +27,18 @@
         "id": "pre:config-protection"
       },
       {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('path');const r=(()=>{var e=process.env.EGC_PLUGIN_ROOT||process.env.ECC_PLUGIN_ROOT||process.env.GEMINI_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.gemini'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['egc'],['egc@egc'],['marketplace','egc'],['everything-gemini'],['everything-gemini@everything-gemini'],['marketplace','everything-gemini']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['egc','everything-gemini']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();const s=p.join(r,'scripts/hooks/plugin-hook-bootstrap.js');process.env.GEMINI_PLUGIN_ROOT=r;process.argv.splice(1,0,s);require(s)\" node scripts/hooks/run-with-flags.js pre:scrubber scripts/hooks/scrubber-hook.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "EGC Scrubber: clean AI provenance marks (invisible Unicode, long dashes) from written content before it hits disk. Fail-open.",
+        "id": "pre:scrubber"
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/tests/scrubber/hook-registration.test.js
+++ b/tests/scrubber/hook-registration.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// Verifies the Scrubber write hook is wired into hooks.json so it actually runs
+// at Write/Edit/MultiEdit time (the automatic activation, not just the module).
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    Error: ${err.stack}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+function check(name, fn) {
+  if (test(name, fn)) passed += 1;
+  else failed += 1;
+}
+
+const repoRoot = path.resolve(__dirname, '../..');
+const hooks = JSON.parse(fs.readFileSync(path.join(repoRoot, 'hooks/hooks.json'), 'utf8'));
+
+function scrubberMatcher() {
+  return hooks.hooks.PreToolUse.find(m => m.id === 'pre:scrubber');
+}
+
+check('a pre:scrubber matcher is registered for Write/Edit/MultiEdit', () => {
+  const m = scrubberMatcher();
+  assert.ok(m, 'pre:scrubber matcher missing from hooks.json');
+  assert.strictEqual(m.matcher, 'Write|Edit|MultiEdit');
+  assert.ok(Array.isArray(m.hooks) && m.hooks.length === 1);
+});
+
+check('the scrubber matcher dispatches through run-with-flags to scrubber-hook.js', () => {
+  const hook = scrubberMatcher().hooks[0];
+  assert.strictEqual(hook.type, 'command');
+  assert.ok(hook.command.includes('run-with-flags.js pre:scrubber scripts/hooks/scrubber-hook.js'));
+  assert.ok(/scrubber-hook\.js standard/.test(hook.command), 'scrubber must be active in the default (standard) profile');
+  assert.ok(typeof hook.timeout === 'number' && hook.timeout > 0);
+});
+
+check('the referenced scrubber hook script exists', () => {
+  assert.ok(fs.existsSync(path.join(repoRoot, 'scripts/hooks/scrubber-hook.js')));
+});
+
+check('the scrubber hook exports run() so run-with-flags uses the fast require path', () => {
+  const src = fs.readFileSync(path.join(repoRoot, 'scripts/hooks/scrubber-hook.js'), 'utf8');
+  assert.ok(/\bmodule\.exports\b/.test(src) && /\brun\b/.test(src));
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Phase 6 of the EGC Scrubber (milestone): turn the write hook on.

Wires `scrubber-hook.js` into `hooks/hooks.json` as a `PreToolUse` `Write|Edit|MultiEdit` matcher (id `pre:scrubber`), mirroring the existing pre-write guardian's bootstrap wrapper and dispatching through `run-with-flags.js`. Active in the `standard` (default) profile, so content is cleaned of invisible-Unicode and long-dash marks before it hits disk with nothing to invoke.

**Scope (honest):** this activates the hook for the tools that load the shared hooks runtime registry (`egc, claude, cursor, opencode, codebuddy` per the `hooks-runtime` module). Tools with their own native hook schemas merged by per-tool installer modules (Claude settings, Cursor, Copilot, Continue, Antigravity, OpenHands, Amazon Q) are **not** touched here: extending each of those installer modules is a separate, higher-risk change that should be reviewed rather than bundled.

**Verification:** `validate-hooks` (43 matchers), the install/doctor/harness/plugin-manifest suites, unicode-safety, and a real end-to-end dispatch of a ZWSP-bearing Write payload through `run-with-flags` (returns cleaned `updatedInput`) all pass. Additive: one matcher entry, no install-engine change. A registration test guards the wiring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates the EGC Scrubber by registering a pre-write hook in the shared hooks runtime so written content is scrubbed automatically. Previously the scrubber existed but wasn’t invoked; now `PreToolUse` `Write|Edit|MultiEdit` events run it (fail-open), cleaning invisible Unicode and long dashes before disk writes.

**Review notes**
- Registers `pre:scrubber` in `hooks/hooks.json` with a `Write|Edit|MultiEdit` matcher; dispatches via `run-with-flags.js` to `scripts/hooks/scrubber-hook.js` in the `standard` profile.
- Affects tools that load the shared hooks runtime (`egc`, `claude`, `cursor`, `opencode`, `codebuddy`); per-tool installers (e.g., Claude settings, Cursor, Copilot, Continue, Antigravity, OpenHands, Amazon Q) are unchanged.
- Adds `tests/scrubber/hook-registration.test.js` to guard the wiring and ensure the hook exports `run()`; no install-engine changes.

<sup>Written for commit 8eb89c6a1593d507d4f26d3ec36744d32780cda1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

