### PR TITLE
feat(scrubber): wire the write hook into Claude's native settings

### DIFF
--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -727,6 +727,15 @@ const CRUSHER_HOOK_LIB_SOURCES = [
   'scripts/lib/crusher/engine.js',
 ];
 
+// scrubber-hook.js's transitive scrubber-lib dependencies, copied next to it so
+// the write hook works even in an install that omits the hooks-runtime module.
+const SCRUBBER_HOOK_LIB_SOURCES = [
+  'scripts/lib/scrubber/engine.js',
+  'scripts/lib/scrubber/binary-guard.js',
+  'scripts/lib/scrubber/unicode-marks.js',
+  'scripts/lib/scrubber/dash-normalize.js',
+];
+
 function resolveCrusherHookScriptDestination(targetRoot) {
   return path.join(targetRoot, 'scripts', 'hooks', 'crusher-hook.js');
 }
@@ -752,6 +761,25 @@ function createCrusherScriptCopyOperations(createRemappedOperation, targetRoot) 
     ),
     ...CRUSHER_HOOK_LIB_SOURCES.map(src => createRemappedOperation(
       CRUSHER_HOOK_MODULE_ID,
+      src,
+      path.join(targetRoot, ...src.split('/')),
+      { strategy: 'preserve-relative-path' }
+    )),
+  ];
+}
+
+// Copy scrubber-hook.js and its scrubber-lib dependencies unconditionally, so
+// registering the Scrubber settings entry never points at a missing script.
+function createScrubberScriptCopyOperations(createRemappedOperation, targetRoot) {
+  return [
+    createRemappedOperation(
+      SCRUBBER_HOOK_MODULE_ID,
+      SCRUBBER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+      resolveScrubberHookScriptDestination(targetRoot),
+      { strategy: 'preserve-relative-path' }
+    ),
+    ...SCRUBBER_HOOK_LIB_SOURCES.map(src => createRemappedOperation(
+      SCRUBBER_HOOK_MODULE_ID,
       src,
       path.join(targetRoot, ...src.split('/')),
       { strategy: 'preserve-relative-path' }
@@ -1275,6 +1303,7 @@ module.exports = {
   createAdapterStdinJsonCopyOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
   createPreToolUseScrubberHookMergeOperation,
+  createScrubberScriptCopyOperations,
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,
   createUserPromptSubmitHookMergeOperation,

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -77,6 +77,8 @@ const BASH_DISPATCHER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/bash-hoo
 const BASH_DISPATCHER_HOOK_MODULE_ID = 'claude-bash-dispatcher-hook';
 const WRITE_VALIDATOR_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/pre-write-guardian-validate.js';
 const WRITE_VALIDATOR_HOOK_MODULE_ID = 'claude-write-validator-hook';
+const SCRUBBER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/scrubber-hook.js';
+const SCRUBBER_HOOK_MODULE_ID = 'claude-scrubber-hook';
 const ROUTER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/prompt-router.js';
 const ROUTER_HOOK_MODULE_ID = 'claude-prompt-router-hook';
 const GATEGUARD_HOOK_SCRIPT_SOURCE_RELATIVE_PATH = 'scripts/hooks/gateguard-fact-force.js';
@@ -613,6 +615,25 @@ function createPreToolUseWriteValidatorHookMergeOperation(targetRoot, matcher) {
     targetRoot,
     WRITE_VALIDATOR_HOOK_MODULE_ID,
     WRITE_VALIDATOR_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    hookScriptPath,
+    matcher
+  );
+}
+
+// EGC Scrubber: registered as its own PreToolUse entry (alongside, not instead
+// of, the write validator above) so Edit/Write/MultiEdit content is cleaned of
+// invisible-Unicode carriers and long dashes before it reaches disk. Fail-open.
+// The script ships with the hooks runtime; see scripts/hooks/scrubber-hook.js.
+function resolveScrubberHookScriptDestination(targetRoot) {
+  return path.join(targetRoot, 'scripts', 'hooks', 'scrubber-hook.js');
+}
+
+function createPreToolUseScrubberHookMergeOperation(targetRoot, matcher) {
+  const hookScriptPath = resolveScrubberHookScriptDestination(targetRoot);
+  return buildPreToolUseMergeOperation(
+    targetRoot,
+    SCRUBBER_HOOK_MODULE_ID,
+    SCRUBBER_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
     hookScriptPath,
     matcher
   );
@@ -1253,6 +1274,7 @@ module.exports = {
   ADAPTER_STDIN_JSON_SOURCE_RELATIVE_PATH,
   createAdapterStdinJsonCopyOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
+  createPreToolUseScrubberHookMergeOperation,
   createSessionStartHookMergeOperation,
   createStopHookMergeOperation,
   createUserPromptSubmitHookMergeOperation,

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -60,7 +60,7 @@ const HOOK_LIB_SOURCES = [
   'scripts/check-state-leak.js',
 ];
 
-function createSessionStateHookOperations(adapter, targetRoot) {
+function createSessionStateHookOperations(adapter, targetRoot, includeScrubberCopy) {
   const libDestDir = path.join(targetRoot, 'egc', 'lib');
   const libOperations = HOOK_LIB_SOURCES.map(src =>
     createRemappedOperation(
@@ -114,13 +114,17 @@ function createSessionStateHookOperations(adapter, targetRoot) {
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'MultiEdit'),
     // EGC Scrubber: clean invisible-Unicode and long-dash marks from written
     // content before it hits disk, alongside the write validator above. Copy the
-    // hook and its scrubber-lib deps unconditionally so it works even without
-    // the hooks-runtime module, then register it for Edit/Write/MultiEdit.
-    ...createScrubberScriptCopyOperations(
-      (moduleId, sourceRelativePath, destinationPath, options) =>
-        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options),
-      targetRoot
-    ),
+    // hook and its scrubber-lib deps only when the hooks-runtime module is NOT
+    // present (that module already ships scripts/hooks + scripts/lib), so a
+    // minimal install still gets a working hook and no destination ever has two
+    // owners. Then register it for Edit/Write/MultiEdit.
+    ...(includeScrubberCopy
+      ? createScrubberScriptCopyOperations(
+        (moduleId, sourceRelativePath, destinationPath, options) =>
+          createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options),
+        targetRoot
+      )
+      : []),
     createPreToolUseScrubberHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseScrubberHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseScrubberHookMergeOperation(targetRoot, 'MultiEdit'),
@@ -153,9 +157,12 @@ module.exports = createInstallTargetAdapter({
 
     // Deterministic memory loading: every Claude Code install registers the
     // SessionStart state hook, even when no content modules are selected.
+    // hooks-runtime ships scripts/hooks + scripts/lib itself, so only copy the
+    // Scrubber files explicitly when that module is not part of this install.
+    const hasHooksRuntime = modules.some(module => module.id === 'hooks-runtime');
     return [
       ...moduleOperations,
-      ...createSessionStateHookOperations(adapter, targetRoot),
+      ...createSessionStateHookOperations(adapter, targetRoot, !hasHooksRuntime),
     ];
   },
 });

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -32,6 +32,7 @@ const {
   createUserPromptSubmitRouterHookMergeOperation,
   createPreToolUseBashDispatcherHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
+  createPreToolUseScrubberHookMergeOperation,
   createPreToolUseGateGuardHookMergeOperation,
   createPreCompactHookMergeOperation,
   createPostCompactHookMergeOperation,
@@ -110,6 +111,11 @@ function createSessionStateHookOperations(adapter, targetRoot) {
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'MultiEdit'),
+    // EGC Scrubber: clean invisible-Unicode and long-dash marks from written
+    // content before it hits disk, alongside the write validator above.
+    createPreToolUseScrubberHookMergeOperation(targetRoot, 'Edit'),
+    createPreToolUseScrubberHookMergeOperation(targetRoot, 'Write'),
+    createPreToolUseScrubberHookMergeOperation(targetRoot, 'MultiEdit'),
     // GateGuard fact-forcing gate: Bash already gets this via
     // bash-hook-dispatcher.js above. Edit/Write/MultiEdit only had the
     // protected-path validator until now, so register GateGuard on them

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -33,6 +33,7 @@ const {
   createPreToolUseBashDispatcherHookMergeOperation,
   createPreToolUseWriteValidatorHookMergeOperation,
   createPreToolUseScrubberHookMergeOperation,
+  createScrubberScriptCopyOperations,
   createPreToolUseGateGuardHookMergeOperation,
   createPreCompactHookMergeOperation,
   createPostCompactHookMergeOperation,
@@ -112,7 +113,14 @@ function createSessionStateHookOperations(adapter, targetRoot) {
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseWriteValidatorHookMergeOperation(targetRoot, 'MultiEdit'),
     // EGC Scrubber: clean invisible-Unicode and long-dash marks from written
-    // content before it hits disk, alongside the write validator above.
+    // content before it hits disk, alongside the write validator above. Copy the
+    // hook and its scrubber-lib deps unconditionally so it works even without
+    // the hooks-runtime module, then register it for Edit/Write/MultiEdit.
+    ...createScrubberScriptCopyOperations(
+      (moduleId, sourceRelativePath, destinationPath, options) =>
+        createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options),
+      targetRoot
+    ),
     createPreToolUseScrubberHookMergeOperation(targetRoot, 'Edit'),
     createPreToolUseScrubberHookMergeOperation(targetRoot, 'Write'),
     createPreToolUseScrubberHookMergeOperation(targetRoot, 'MultiEdit'),

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -942,15 +942,23 @@ function runTests() {
     const repoRoot = path.join(__dirname, '..', '..');
     const homeDir = '/Users/example';
     const plan = planInstallTargetScaffold({ target: 'claude', repoRoot, homeDir, modules: [] });
-    const scrubberOps = plan.operations.filter(
+    const scrubberMerges = plan.operations.filter(
       operation => normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/scrubber-hook.js'
+        && operation.hookEvent === 'PreToolUse'
     );
-    assert.strictEqual(scrubberOps.length, 3, 'Should plan the Scrubber hook for Edit, Write, and MultiEdit');
-    for (const op of scrubberOps) {
-      assert.strictEqual(op.hookEvent, 'PreToolUse');
+    assert.strictEqual(scrubberMerges.length, 3, 'Should register the Scrubber hook for Edit, Write, and MultiEdit');
+    for (const op of scrubberMerges) {
       assert.strictEqual(op.destinationPath, path.join(homeDir, '.claude', 'settings.json'));
     }
-    assert.deepStrictEqual(scrubberOps.map(o => o.hookMatcher).sort(), ['Edit', 'MultiEdit', 'Write']);
+    assert.deepStrictEqual(scrubberMerges.map(o => o.hookMatcher).sort(), ['Edit', 'MultiEdit', 'Write']);
+    // The hook script and its scrubber-lib dependencies are copied too, so a
+    // minimal install without hooks-runtime still has a working hook.
+    for (const dep of ['scripts/hooks/scrubber-hook.js', 'scripts/lib/scrubber/engine.js', 'scripts/lib/scrubber/binary-guard.js']) {
+      assert.ok(
+        plan.operations.some(op => normalizedRelativePath(op.sourceRelativePath) === dep && op.hookEvent !== 'PreToolUse'),
+        `Should copy ${dep}`
+      );
+    }
   })) passed++; else failed++;
 
   if (test('claude adapter copies egc-memory-save.js and its lib deps even with no modules selected (EGC-495)', () => {

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -938,6 +938,21 @@ function runTests() {
     assert.ok(mergeOperation.hookCommand.includes(hookScriptPath));
   })) passed++; else failed++;
 
+  if (test('claude adapter plans the Scrubber write hook for Edit, Write, and MultiEdit', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+    const plan = planInstallTargetScaffold({ target: 'claude', repoRoot, homeDir, modules: [] });
+    const scrubberOps = plan.operations.filter(
+      operation => normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/scrubber-hook.js'
+    );
+    assert.strictEqual(scrubberOps.length, 3, 'Should plan the Scrubber hook for Edit, Write, and MultiEdit');
+    for (const op of scrubberOps) {
+      assert.strictEqual(op.hookEvent, 'PreToolUse');
+      assert.strictEqual(op.destinationPath, path.join(homeDir, '.claude', 'settings.json'));
+    }
+    assert.deepStrictEqual(scrubberOps.map(o => o.hookMatcher).sort(), ['Edit', 'MultiEdit', 'Write']);
+  })) passed++; else failed++;
+
   if (test('claude adapter copies egc-memory-save.js and its lib deps even with no modules selected (EGC-495)', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const homeDir = '/Users/example';

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -594,7 +594,7 @@ function runTests() {
       assert.strictEqual(settings.model, 'opus');
 
       const preToolUseGroups = settings.hooks.PreToolUse;
-      assert.strictEqual(preToolUseGroups.length, 8, 'Reinstall must not duplicate PreToolUse hooks');
+      assert.strictEqual(preToolUseGroups.length, 11, 'Reinstall must not duplicate PreToolUse hooks');
       assert.strictEqual(preToolUseGroups[0].hooks[0].command, 'echo guard');
       assert.ok(
         preToolUseGroups[1].hooks[0].command.includes('bash-hook-dispatcher.js'),
@@ -608,12 +608,19 @@ function runTests() {
       assert.strictEqual(preToolUseGroups[3].matcher, 'Write');
       assert.strictEqual(preToolUseGroups[4].matcher, 'MultiEdit');
       assert.ok(
-        preToolUseGroups[5].hooks[0].command.includes('gateguard-fact-force.js'),
-        'EGC GateGuard fact-forcing gate should be registered for Edit'
+        preToolUseGroups[5].hooks[0].command.includes('scrubber-hook.js'),
+        'EGC Scrubber should be registered for Edit'
       );
       assert.strictEqual(preToolUseGroups[5].matcher, 'Edit');
       assert.strictEqual(preToolUseGroups[6].matcher, 'Write');
       assert.strictEqual(preToolUseGroups[7].matcher, 'MultiEdit');
+      assert.ok(
+        preToolUseGroups[8].hooks[0].command.includes('gateguard-fact-force.js'),
+        'EGC GateGuard fact-forcing gate should be registered for Edit'
+      );
+      assert.strictEqual(preToolUseGroups[8].matcher, 'Edit');
+      assert.strictEqual(preToolUseGroups[9].matcher, 'Write');
+      assert.strictEqual(preToolUseGroups[10].matcher, 'MultiEdit');
 
       const sessionStartGroups = settings.hooks.SessionStart;
       assert.strictEqual(sessionStartGroups.length, 2, 'Reinstall must not duplicate the EGC hook');


### PR DESCRIPTION
Follow-up to the Scrubber activation (#1307): propagate the write hook to Claude's native hook config.

Claude Code reads hooks from `settings.json` (merged by `claude-settings-hooks.js`), not from the shared `hooks.json` runtime registry, so the Fase 6 registration alone did not reach Claude. This adds the Scrubber `PreToolUse` hook for `Edit`, `Write`, and `MultiEdit` to Claude's settings **alongside** the write validator, mirroring its exact merge-operation pattern.

- **Additive and minimal**: the `scrubber-hook.js` script already ships with the hooks runtime, so only a settings-merge operation is added (no new copy). The generic PreToolUse handler makes apply/remove/inspect idempotent.
- **Verified**: a planning test asserts the three matchers are wired into `.claude/settings.json`; the reinstall-idempotency test's expected layout is updated to 11 PreToolUse groups and still guards against duplication (a double install produces exactly 11, proven by the passing assertion). Full suite 4340/4340, install/doctor/harness suites green.

With this, the Scrubber reaches every tool the write validator reaches (the shared runtime registry plus Claude's native settings).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates the Scrubber to Claude Code’s native `settings.json` and conditionally copies its hook files so installs without `hooks-runtime` still scrub invisible Unicode and long dashes before writes hit disk. Previously Claude could register a missing command via the shared registry; now `Edit`, `Write`, and `MultiEdit` invoke the Scrubber through `PreToolUse` entries.

- Adds `createPreToolUseScrubberHookMergeOperation` using `scripts/hooks/scrubber-hook.js` (`claude-scrubber-hook`) and registers `PreToolUse` for `Edit`, `Write`, and `MultiEdit`.
- Copies `scripts/hooks/scrubber-hook.js` and scrubber-lib deps (`engine.js`, `binary-guard.js`, `unicode-marks.js`, `dash-normalize.js`) only when `hooks-runtime` is absent to avoid dual ownership; otherwise rely on `hooks-runtime`’s shipped files.
- Wires the merge and conditional copy in `scripts/lib/install-targets/claude-home.js`; the hook remains fail-open.
- Updates tests: planning asserts three Scrubber merges and the copies when `hooks-runtime` is not selected; reinstall idempotency expects 11 `PreToolUse` groups in order with no duplication.

**Rollout**
- No manual migration. Run the installer to update `.claude/settings.json`; reinstall is safe.

<sup>Written for commit a8d2762fa6eb2b7474043a0716d2636b6d048396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

