### PR TITLE
docs(installation): document the EGC Scrubber in the install guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -287,6 +287,16 @@ egc crusher-shim uninstall  # remove it
 
 ---
 
+## EGC Scrubber
+
+The Scrubber removes AI provenance marks from content you own, automatically. On hook-capable harnesses it registers a `PreToolUse` hook at `egc init` (the same way the Token Crusher and Guardian do), so files are cleaned as they are written: invisible Unicode carriers (zero-width family, BOM, tag characters, variation selectors, and more) and long dashes are stripped, while the invisibles that carry meaning (emoji joiners, complex-script joiners, flag tags, RTL marks) are preserved. A commit hook removes AI co-authorship from commit messages while keeping human co-authors.
+
+An opt-in `content-scrubber` skill and CLI cover on-demand and batch use, including metadata: they strip AI-provenance metadata from Markdown frontmatter, HTML head and SVG, from PNG and JPEG images, and from PDF Document Info dictionaries. Metadata cleaning is honest about partial coverage: compressed-stream and encrypted cases are reported, never altered.
+
+Everything is pure Node, deterministic, and fail-open: a parse error, an engine error, or binary input passes the original content through untouched, so the Scrubber can never block or corrupt a write. Opt out of the automatic write hook anytime with `EGC_DISABLED_HOOKS=pre:scrubber`.
+
+---
+
 ## Command reference
 
 You never need to type any of these. Talk to your AI naturally, in any language, and the auto-intuition protocol maps your intent to the right action: saying "how much did I save?" runs the savings report, saying "we are done for today" saves the session. The commands below exist for people who prefer explicit control, and every one of them is valid on its own:


### PR DESCRIPTION
Adds an EGC Scrubber section to docs/installation.md, next to the Token Crusher: what it strips (invisible Unicode, long dashes, commit co-authorship, opt-in metadata for text/images/PDF), that it turns on at egc init on hook-capable harnesses, that it is fail-open, and the EGC_DISABLED_HOOKS=pre:scrubber opt-out. Documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the EGC Scrubber in the installation guide so users understand default cleaning behavior, on-demand usage, and how to opt out. This clarifies write-hook activation at `egc init`, what is stripped vs preserved, and fail-open guarantees.

**Review notes**
- Confirm hook details: registers `PreToolUse` at `egc init`; opt-out via `EGC_DISABLED_HOOKS=pre:scrubber`.
- Validate scope and limits: strips invisible Unicode carriers and long dashes; preserves semantic invisibles; removes co-authorship in commit messages; covers Markdown/HTML/SVG, PNG/JPEG, PDF Document Info; reports compressed/encrypted cases without modification.
- No product behavior changes; docs only.

<sup>Written for commit 5b3bf767aaf684e7e01a9b252bf612e2eedab164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

