### PR TITLE
fix(install): register the content-scrubber skill in the security module

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -265,6 +265,7 @@
       "kind": "skills",
       "description": "Security review and security-focused framework guidance.",
       "paths": [
+        "skills/security/content-scrubber",
         "skills/security/defi-amm-security",
         "skills/backend/django-security",
         "skills/security/healthcare-phi-compliance",


### PR DESCRIPTION
The content-scrubber skill (Scrubber's manual mode: Layer A docs plus the Layer B rewrite workflow, ethics, and coverage references) shipped under skills/security but was never listed in the security module of manifests/install-modules.json. As a result no egc install placed the skill into any tool, even though the write hook (Layer A) installed fine. This registers the skill path so it installs alongside the other security skills. Verified: the install dry-run now includes skills/security/content-scrubber and its references; the install/manifest test suite stays green. Manifest-only, no version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the `skills/security/content-scrubber` skill in the security module so `egc install` includes it. Previously the skill was not listed in `manifests/install-modules.json`, so installs skipped it; now it installs with the other security skills.

**Review and rollout**
- Adds `skills/security/content-scrubber` to the security module `paths` in `manifests/install-modules.json`.
- Action: re-run `egc install` to include the skill in existing tools that use the security module.

<sup>Written for commit ff70e715310e31e0632a57e5bea166f2602d5102. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

