### PR TITLE
fix(scrubber): thread --lang through the rewrite CLI

### DIFF
--- a/scripts/hooks/scrubber-cli.js
+++ b/scripts/hooks/scrubber-cli.js
@@ -221,9 +221,16 @@ function main(argv) {
     }
     const lang = optionValue(rest, '--lang');
     const originalLang = optionValue(rest, '--original-lang');
-    if (lang === null || originalLang === null) {
-      process.stderr.write('error: --lang / --original-lang require a value\n');
+    if (lang === null) {
+      process.stderr.write('error: --lang requires a value\n');
       return 2;
+    }
+    if (originalLang === null) {
+      process.stderr.write('error: --original-lang requires a value\n');
+      return 2;
+    }
+    if (strength !== 'backtranslate' && (lang !== undefined || originalLang !== undefined)) {
+      process.stderr.write('note: --lang / --original-lang only affect the backtranslate strength; ignored here\n');
     }
     return runRewrite(source, strength, lang, originalLang);
   }

--- a/scripts/hooks/scrubber-cli.js
+++ b/scripts/hooks/scrubber-cli.js
@@ -14,7 +14,8 @@
 //   node scrubber-cli.js rewrite <file|-> [--strength NAME]  print a Layer B rewrite prompt
 // Flags: --aggressive (normalize cross-script look-alikes), --no-dashes,
 //        --json (clean prints the stats report to stderr),
-//        --strength paraphrase|humanize|code|backtranslate|structural (rewrite).
+//        --strength paraphrase|humanize|code|backtranslate|structural (rewrite),
+//        --lang / --original-lang (pivot languages for backtranslate).
 //
 // inspect/clean are deterministic Layer A (plus metadata). rewrite is the
 // best-effort Layer B for statistical marks: it only prints the prompt for the
@@ -170,27 +171,33 @@ function runClean(source, flags) {
   return 0;
 }
 
-// Absent --strength keeps the default; a present --strength with a missing
-// value or another flag next is an error, not a silent fallback.
-function parseStrength(args) {
-  const i = args.indexOf('--strength');
-  if (i < 0) return 'paraphrase';
+// Returns the value after `name`: undefined when the option is absent, null
+// when it is present but the next token is missing or another option (so a
+// malformed flag is an error, never a silent default).
+function optionValue(args, name) {
+  const i = args.indexOf(name);
+  if (i < 0) return undefined;
   const value = args[i + 1];
   if (!value || value.startsWith('-')) return null;
   return value;
+}
+
+function parseStrength(args) {
+  const value = optionValue(args, '--strength');
+  return value === undefined ? 'paraphrase' : value;
 }
 
 // Layer B: emit the rewrite instruction for the host agent to carry out (relay
 // mode, no network, no bundled model). The statistical mark rides in word
 // choice, so the operator's own model does the rewrite; the honest note goes to
 // stderr.
-function runRewrite(source, strength) {
+function runRewrite(source, strength, lang, originalLang) {
   const bytes = readBytes(source);
   const text = textFromBytes(bytes, source);
   if (text === null) return 2;
   let plan;
   try {
-    plan = buildRewrite(text, { strength });
+    plan = buildRewrite(text, { strength, lang, originalLang });
   } catch (err) {
     process.stderr.write(`${err.message} (valid: ${STRENGTH_LADDER.join(', ')}, code)\n`);
     return 2;
@@ -212,7 +219,13 @@ function main(argv) {
       process.stderr.write('error: --strength requires a value\n');
       return 2;
     }
-    return runRewrite(source, strength);
+    const lang = optionValue(rest, '--lang');
+    const originalLang = optionValue(rest, '--original-lang');
+    if (lang === null || originalLang === null) {
+      process.stderr.write('error: --lang / --original-lang require a value\n');
+      return 2;
+    }
+    return runRewrite(source, strength, lang, originalLang);
   }
 
   process.stderr.write('usage: scrubber-cli.js <inspect|clean|rewrite> <file|-> [-o OUT] [--in-place] [--aggressive] [--no-dashes] [--strength NAME] [--json]\n');

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -220,6 +220,16 @@ check('rewrite rejects --strength with no value instead of silently defaulting',
   assert.ok(/--strength requires a value/.test(shortOpt.err));
 });
 
+check('rewrite propagates --lang to the backtranslate prompt', () => {
+  const file = tmpFile('draft-l.md', 'some text to translate');
+  const r = runCli(['rewrite', file, '--strength', 'backtranslate', '--lang', 'German']);
+  assert.strictEqual(r.code, 0);
+  assert.ok(/into German/.test(r.out), 'the pivot language must follow --lang, not the default');
+  const missing = runCli(['rewrite', file, '--strength', 'backtranslate', '--lang']);
+  assert.strictEqual(missing.code, 2);
+  assert.ok(/--lang/.test(missing.err));
+});
+
 check('rewrite refuses binary input', () => {
   const png = tmpFile('x.png', Buffer.from('\x89PNG\r\n\x1a\n\x00\x00binary', 'latin1'));
   const r = runCli(['rewrite', png]);

--- a/tests/scrubber/cli.test.js
+++ b/tests/scrubber/cli.test.js
@@ -228,6 +228,12 @@ check('rewrite propagates --lang to the backtranslate prompt', () => {
   const missing = runCli(['rewrite', file, '--strength', 'backtranslate', '--lang']);
   assert.strictEqual(missing.code, 2);
   assert.ok(/--lang/.test(missing.err));
+  const oneMissing = runCli(['rewrite', file, '--strength', 'backtranslate', '--lang', 'German', '--original-lang']);
+  assert.strictEqual(oneMissing.code, 2);
+  assert.ok(/--original-lang requires a value/.test(oneMissing.err), 'names the specific malformed flag');
+  const noEffect = runCli(['rewrite', file, '--strength', 'paraphrase', '--lang', 'German']);
+  assert.strictEqual(noEffect.code, 0);
+  assert.ok(/only affect the backtranslate/.test(noEffect.err), 'warns pivot flags have no effect here');
 });
 
 check('rewrite refuses binary input', () => {


### PR DESCRIPTION
The rewrite subcommand only parsed --strength, so --lang and --original-lang were silently dropped and back-translate always used the French/English default. This adds a shared option parser (missing value is an error, not a silent default) and threads both pivot languages into buildRewrite. Verified end to end: rewrite --strength backtranslate --lang German now emits into German. Scrubber suite green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads `--lang` and `--original-lang` through the `rewrite` CLI and validates option values to avoid silent fallbacks or ignored flags. Previously only `--strength` was parsed, so back-translate always used the French/English default.

- **Behavior changes**
  - `rewrite` passes pivot languages to `buildRewrite`; back-translate uses the provided pivots.
  - Present flags without a value exit with code 2 and name the specific flag (`--strength`, `--lang`, `--original-lang`).
  - When strength is not `backtranslate`, pivot flags are ignored and the CLI prints a note to stderr.
  - Absent `--strength` still defaults to `paraphrase`.

<sup>Written for commit da25f6c675753acda65048b9ba4b9c4035fa9f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

