### PR TITLE
fix(install): heal orphaned install-state sources and close npm packaging gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
     ".github/SECURITY.md",
     "!**/__pycache__",
     "!**/*.pyc",
-    "!**/.DS_Store"
+    "!**/*.pyo",
+    "!**/.DS_Store",
+    "!**/Thumbs.db"
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build:opencode": "node scripts/build-opencode.js",
     "build:mcp": "cd mcp/servers/egc-guardian && npm ci --silent && npm run build && cd ../egc-memory && npm ci --silent && npm run build",
     "prompt": "node scripts/gemini.js",
-    "prepack": "npm run build:opencode && npm run build:mcp"
+    "prepack": "node scripts/check-state-leak.js --packaged-tree && npm run build:opencode && npm run build:mcp"
   },
   "files": [
     "scripts/",
@@ -63,6 +63,7 @@
     "examples/",
     ".gemini-plugin/",
     ".codex-plugin/",
+    ".codex/",
     ".opencode/",
     ".codebuddy/",
     ".kiro/",
@@ -81,7 +82,10 @@
     "NOTICE",
     ".github/CONTRIBUTING.md",
     "docs/RULES.md",
-    ".github/SECURITY.md"
+    ".github/SECURITY.md",
+    "!**/__pycache__",
+    "!**/*.pyc",
+    "!**/.DS_Store"
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.4.1",

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -143,11 +143,20 @@ function checkPackagedTree() {
     // npm applies the same .gitignore rules when packing.
     listing = git(['ls-files', '-z', '--cached', '--others', '--exclude-standard']);
   } catch (error) {
-    // Packing from a directory that is not a git checkout (vendored copy,
-    // exported tarball): there is no git state to scan. Warn and let the
-    // pack proceed -- the real publish flow always runs from the
-    // repository, where the guard is enforced.
-    console.log(`state-leak check: skipped (not a git checkout: ${String(error.message).split('\n')[0]})`);
+    // Only two failures mean there is genuinely no git state to scan:
+    // packing a directory that is not a checkout (vendored copy, exported
+    // tarball), or a machine without the git binary. Those skip with a
+    // notice -- the real publish flow always runs from the repository.
+    // Anything else (corrupt metadata, permissions, lock contention) is a
+    // failure INSIDE a checkout: rethrow so prepack fails closed instead of
+    // silently shipping a populated memory file.
+    const detail = `${error.code || ''} ${error.message || ''} ${error.stderr || ''}`;
+    const notARepo = /not a git repository/i.test(detail);
+    const gitMissing = error.code === 'ENOENT';
+    if (!notARepo && !gitMissing) {
+      throw error;
+    }
+    console.log(`state-leak check: skipped (${notARepo ? 'not a git checkout' : 'git unavailable'}: ${String(error.message).split('\n')[0]})`);
     return [];
   }
   const packagedFiles = listing.split('\0').filter(Boolean)

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -32,7 +32,11 @@ const GIT_BIN = [
 ].find(p => fs.existsSync(p)) || 'git';
 
 function git(args, options) {
-  return execFileSync(GIT_BIN, args, { encoding: 'utf8', ...options });
+  // LC_ALL=C: git ships localized fatal messages via gettext, and the
+  // packaged-tree guard matches 'not a git repository' textually to decide
+  // between skipping and failing closed -- force the C locale so that
+  // decision is deterministic on non-English systems.
+  return execFileSync(GIT_BIN, args, { encoding: 'utf8', env: { ...process.env, LC_ALL: 'C' }, ...options });
 }
 
 // Every propagation target of egc-memory (propagate.ts) is scanned, not just

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -135,10 +135,25 @@ function isPackagedPath(filePath, prefixes) {
 
 function checkPackagedTree() {
   const prefixes = loadPackagedPrefixes();
-  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean)
+  let listing;
+  try {
+    // Tracked AND untracked-but-not-ignored files: npm pack reads the
+    // working tree, so a populated propagation file that was never
+    // committed still ships. Ignored files stay out; without an .npmignore
+    // npm applies the same .gitignore rules when packing.
+    listing = git(['ls-files', '-z', '--cached', '--others', '--exclude-standard']);
+  } catch (error) {
+    // Packing from a directory that is not a git checkout (vendored copy,
+    // exported tarball): there is no git state to scan. Warn and let the
+    // pack proceed -- the real publish flow always runs from the
+    // repository, where the guard is enforced.
+    console.log(`state-leak check: skipped (not a git checkout: ${String(error.message).split('\n')[0]})`);
+    return [];
+  }
+  const packagedFiles = listing.split('\0').filter(Boolean)
     .filter(file => isPackagedPath(file, prefixes))
     .filter(isGuardedPath);
-  return scanDiskFiles(tracked);
+  return scanDiskFiles(packagedFiles);
 }
 
 function main() {

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -7,9 +7,10 @@
 // memory content may not.
 //
 // Modes:
-//   --staged        check staged blobs (pre-commit hook)
-//   --tree          check tracked markdown files on disk (CI guard)
-//   --clean <file>  rewrite files in place with the memory section zeroed
+//   --staged          check staged blobs (pre-commit hook)
+//   --tree            check tracked markdown files on disk (CI guard)
+//   --packaged-tree   check only tracked files the npm package ships (prepack guard)
+//   --clean <file>    rewrite files in place with the memory section zeroed
 
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
@@ -96,10 +97,9 @@ function checkStaged() {
   return leaks;
 }
 
-function checkTree() {
-  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean).filter(isGuardedPath);
+function scanDiskFiles(files) {
   const leaks = [];
-  for (const file of tracked) {
+  for (const file of files) {
     let content;
     try {
       content = fs.readFileSync(file, 'utf8');
@@ -109,6 +109,36 @@ function checkTree() {
     if (findLeak(content)) leaks.push(file);
   }
   return leaks;
+}
+
+function checkTree() {
+  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean).filter(isGuardedPath);
+  return scanDiskFiles(tracked);
+}
+
+// Local sessions legitimately keep propagation files like CLAUDE.md populated
+// on disk, and the git clean filter only protects COMMITS -- npm pack reads
+// the working tree directly. A populated propagation file inside the
+// package.json "files" set (e.g. .trae/rules/egc-context.md) would therefore
+// be published verbatim. This mode guards exactly that set, so prepack can
+// abort a leaking publish without blocking everyday local work.
+function loadPackagedPrefixes() {
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  return (Array.isArray(pkg.files) ? pkg.files : [])
+    .filter(entry => typeof entry === 'string' && !entry.startsWith('!'))
+    .map(entry => entry.replace(/\/+$/, ''));
+}
+
+function isPackagedPath(filePath, prefixes) {
+  return prefixes.some(prefix => filePath === prefix || filePath.startsWith(`${prefix}/`));
+}
+
+function checkPackagedTree() {
+  const prefixes = loadPackagedPrefixes();
+  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean)
+    .filter(file => isPackagedPath(file, prefixes))
+    .filter(isGuardedPath);
+  return scanDiskFiles(tracked);
 }
 
 function main() {
@@ -137,7 +167,14 @@ function main() {
     return;
   }
 
-  const leaks = mode === '--staged' ? checkStaged() : checkTree();
+  let leaks;
+  if (mode === '--staged') {
+    leaks = checkStaged();
+  } else if (mode === '--packaged-tree') {
+    leaks = checkPackagedTree();
+  } else {
+    leaks = checkTree();
+  }
   if (leaks.length === 0) {
     console.log('state-leak check: clean');
     return;

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -92,7 +92,26 @@ function validateLegacyTarget(target) {
 const IGNORED_DIRECTORY_NAMES = new Set([
   'node_modules',
   '.git',
+  '__pycache__',
 ]);
+
+// Machine-generated tooling artifacts must never become managed install
+// sources: they differ per machine, and npm never packs .gitignore at all,
+// so an install-state entry recorded for one of these can never be
+// satisfied from the published package again.
+const IGNORED_FILE_NAMES = new Set([
+  '.gitignore',
+  '.DS_Store',
+  'Thumbs.db',
+]);
+const IGNORED_FILE_SUFFIXES = ['.pyc', '.pyo'];
+
+function isIgnoredSourceFile(fileName) {
+  if (IGNORED_FILE_NAMES.has(fileName)) {
+    return true;
+  }
+  return IGNORED_FILE_SUFFIXES.some(suffix => fileName.endsWith(suffix));
+}
 
 function listFilesRecursive(dirPath) {
   if (!fs.existsSync(dirPath)) {
@@ -112,7 +131,7 @@ function listFilesRecursive(dirPath) {
       for (const childFile of childFiles) {
         files.push(path.join(entry.name, childFile));
       }
-    } else if (entry.isFile()) {
+    } else if (entry.isFile() && !isIgnoredSourceFile(entry.name)) {
       files.push(entry.name);
     }
   }
@@ -816,5 +835,6 @@ module.exports = {
   createLegacyInstallPlan,
   getSourceRoot,
   listAvailableLanguages,
+  listFilesRecursive,
   parseInstallArgs,
 };

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -12,6 +12,7 @@ const {
   resolveInstallPlan,
 } = require('./install-manifests');
 const { getInstallTargetAdapter } = require('./install-targets/registry');
+const { isIgnoredSourceDirectory, isIgnoredSourceFile } = require('./install-source-filters');
 const { HOOK_OPERATION_KIND } = require('./claude-settings-hooks');
 const { MERGE_YAML_READ_LIST_KIND } = require('./aider-config-merge');
 const { MERGE_MARKDOWN_INDEX_KIND } = require('./warp-agents-merge');
@@ -89,30 +90,6 @@ function validateLegacyTarget(target) {
   }
 }
 
-const IGNORED_DIRECTORY_NAMES = new Set([
-  'node_modules',
-  '.git',
-  '__pycache__',
-]);
-
-// Machine-generated tooling artifacts must never become managed install
-// sources: they differ per machine, and npm never packs .gitignore at all,
-// so an install-state entry recorded for one of these can never be
-// satisfied from the published package again.
-const IGNORED_FILE_NAMES = new Set([
-  '.gitignore',
-  '.DS_Store',
-  'Thumbs.db',
-]);
-const IGNORED_FILE_SUFFIXES = ['.pyc', '.pyo'];
-
-function isIgnoredSourceFile(fileName) {
-  if (IGNORED_FILE_NAMES.has(fileName)) {
-    return true;
-  }
-  return IGNORED_FILE_SUFFIXES.some(suffix => fileName.endsWith(suffix));
-}
-
 function listFilesRecursive(dirPath) {
   if (!fs.existsSync(dirPath)) {
     return [];
@@ -124,7 +101,7 @@ function listFilesRecursive(dirPath) {
   for (const entry of entries) {
     const absolutePath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
-      if (IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+      if (isIgnoredSourceDirectory(entry.name)) {
         continue;
       }
       const childFiles = listFilesRecursive(absolutePath);

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -836,15 +836,12 @@ function resolveDiscoveryAdapters(targets) {
 
   const adapters = [];
   for (const target of normalizeTargets(targets)) {
-    // Every adapter that answers to this target, not just the first one:
-    // an explicit --target kiro must cover kiro-home AND kiro-project, the
+    // normalizeTargets() already rejected unknown and retired ids with their
+    // dedicated errors, so every canonical target here answers to at least
+    // one adapter. Take every adapter that answers, not just the first: an
+    // explicit --target kiro must cover kiro-home AND kiro-project, the
     // same pair the no-argument default examines.
-    const matching = listInstallTargetAdapters().filter(adapter => adapter.supports(target));
-    if (matching.length === 0) {
-      // Unknown or retired ids keep their dedicated error messages.
-      getInstallTargetAdapter(target);
-    }
-    for (const adapter of matching) {
+    for (const adapter of listInstallTargetAdapters().filter(candidate => candidate.supports(target))) {
       if (!adapters.includes(adapter)) {
         adapters.push(adapter);
       }

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -836,9 +836,18 @@ function resolveDiscoveryAdapters(targets) {
 
   const adapters = [];
   for (const target of normalizeTargets(targets)) {
-    const adapter = getInstallTargetAdapter(target);
-    if (!adapters.includes(adapter)) {
-      adapters.push(adapter);
+    // Every adapter that answers to this target, not just the first one:
+    // an explicit --target kiro must cover kiro-home AND kiro-project, the
+    // same pair the no-argument default examines.
+    const matching = listInstallTargetAdapters().filter(adapter => adapter.supports(target));
+    if (matching.length === 0) {
+      // Unknown or retired ids keep their dedicated error messages.
+      getInstallTargetAdapter(target);
+    }
+    for (const adapter of matching) {
+      if (!adapters.includes(adapter)) {
+        adapters.push(adapter);
+      }
     }
   }
   return adapters;

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -42,7 +42,17 @@ function readPackageVersion(repoRoot) {
 
 function normalizeTargets(targets) {
   if (!Array.isArray(targets) || targets.length === 0) {
-    return listInstallTargetAdapters().map(adapter => adapter.target);
+    // Five targets ship home+project adapter pairs under one target id
+    // (kiro, junie, amp, windsurf, openhands); mapping adapters straight to
+    // target ids repeated those ids and made doctor/repair examine the same
+    // home install-state twice per run.
+    const defaultTargets = [];
+    for (const adapter of listInstallTargetAdapters()) {
+      if (!defaultTargets.includes(adapter.target)) {
+        defaultTargets.push(adapter.target);
+      }
+    }
+    return defaultTargets;
   }
 
   const normalizedTargets = [];
@@ -79,6 +89,15 @@ function resolveOperationSourcePath(repoRoot, operation) {
   }
 
   return operation.sourcePath || null;
+}
+
+// Identity for matching a health inspection back to the operation entry in a
+// rewritten state preview: the two hold distinct object copies of the same
+// recorded operation, so matching is by content, not reference.
+function operationIdentityKey(operation) {
+  const source = String(operation?.sourceRelativePath || operation?.sourcePath || '').replaceAll('\\', '/');
+  const destination = String(operation?.destinationPath || '').replaceAll('\\', '/');
+  return `${operation?.kind}|${source}|${destination}`;
 }
 
 function areFilesEqual(leftPath, rightPath) {
@@ -805,17 +824,33 @@ function buildDiscoveryRecord(adapter, context) {
   }
 }
 
+// Discovery enumerates ADAPTERS, not target ids: five targets ship
+// home+project adapter pairs under one target id, and resolving those ids
+// through getInstallTargetAdapter() always lands on the first (home)
+// adapter -- which both duplicated the home record and left project
+// installs of those targets invisible to doctor, repair, and uninstall.
+function resolveDiscoveryAdapters(targets) {
+  if (!Array.isArray(targets) || targets.length === 0) {
+    return listInstallTargetAdapters();
+  }
+
+  const adapters = [];
+  for (const target of normalizeTargets(targets)) {
+    const adapter = getInstallTargetAdapter(target);
+    if (!adapters.includes(adapter)) {
+      adapters.push(adapter);
+    }
+  }
+  return adapters;
+}
+
 function discoverInstalledStates(options = {}) {
   const context = {
     homeDir: options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir(),
     projectRoot: options.projectRoot || process.cwd(),
   };
-  const targets = normalizeTargets(options.targets);
 
-  return targets.map(target => {
-    const adapter = getInstallTargetAdapter(target);
-    return buildDiscoveryRecord(adapter, context);
-  });
+  return resolveDiscoveryAdapters(options.targets).map(adapter => buildDiscoveryRecord(adapter, context));
 }
 
 function buildIssue(severity, code, message, extra = {}) {
@@ -908,7 +943,7 @@ function checkManagedOperationHealth(state, context) {
     issues.push(buildIssue(
       'error',
       'missing-source-files',
-      `${operationHealth.missingSource.length} source file(s) referenced by install-state are missing`,
+      `${operationHealth.missingSource.length} source file(s) referenced by install-state are missing (run 'egc repair' to prune orphaned entries)`,
       {
         paths: operationHealth.missingSource.map(entry => entry.sourcePath).filter(Boolean),
       }
@@ -1173,20 +1208,38 @@ function repairInstalledStates(options = {}) {
       const desiredPlan = createRepairPlanFromRecord(record, context);
       const operationHealth = summarizeManagedOperationHealth(context.repoRoot, desiredPlan.operations);
 
-      // A source file that no longer exists in the reference repo (renamed,
-      // dropped from the package, or synced from a different checkout) used
-      // to abort this target outright: everything else it managed stayed
-      // broken because of one orphan. The orphans are reported and the rest
-      // is repaired, which is what someone running `egc repair` on a damaged
-      // install actually needs.
+      // What a missing source means depends on where this plan came from.
+      // A RECORDED plan (legacy states, or states carrying non-copy-file
+      // operations) replays entries written by an older install, so a source
+      // this reference repo no longer has is an orphan it can never satisfy
+      // again (renamed away, dropped from the package, or synced from a
+      // different checkout): the entry is pruned from the rewritten
+      // install-state so doctor converges to OK, and the installed file is
+      // left on disk untouched -- deleting it could break live wiring, like
+      // a settings.json hook still pointing at that script. A MANIFEST plan
+      // is recomputed from the current manifests, so a missing source there
+      // means the manifest itself demands a file the package does not ship:
+      // pruning would hide a packaging bug, and those stay unrepairable.
       // The recorded relative path, not the resolved absolute one: it is
       // what the install-state holds, so both the JSON output and the
       // printed lines stay identical across machines.
-      const unrepairable = operationHealth.missingSource.map(entry => ({
+      const planIsRecorded = desiredPlan.mode === 'legacy' || desiredPlan.mode === 'recorded';
+      const orphanedInspections = planIsRecorded ? operationHealth.missingSource : [];
+      const prunedPaths = orphanedInspections.map(entry => (
+        entry.operation?.sourceRelativePath || entry.sourcePath
+      ));
+      const unrepairable = (planIsRecorded ? [] : operationHealth.missingSource).map(entry => ({
         path: entry.operation?.sourceRelativePath || entry.sourcePath,
         cause: 'missing-source',
         reason: 'source file is no longer in the reference repo',
       }));
+
+      if (orphanedInspections.length > 0) {
+        const orphanKeys = new Set(orphanedInspections.map(entry => operationIdentityKey(entry.operation)));
+        desiredPlan.statePreview.operations = desiredPlan.statePreview.operations.filter(
+          operation => !orphanKeys.has(operationIdentityKey(operation))
+        );
+      }
 
       const repairOperations = [
         ...operationHealth.missing.map(entry => ({ ...entry.operation })),
@@ -1195,12 +1248,14 @@ function repairInstalledStates(options = {}) {
       const plannedRepairs = repairOperations.map(operation => operation.destinationPath);
 
       if (options.dryRun) {
-        // An orphan is worth reporting whether or not anything is being
-        // written: a dry run that says 'planned' or 'ok' while a file can
-        // never be repaired is exactly the silence this change removes.
-        let dryRunStatus = plannedRepairs.length > 0 ? 'planned' : 'ok';
+        // Orphans and unfixable entries are worth reporting whether or not
+        // anything is being written: a dry run that says 'planned' or 'ok'
+        // while an entry can never be repaired is exactly the silence this
+        // reporting removes. Planned prunes count as planned work.
+        const hasPlannedWork = plannedRepairs.length > 0 || prunedPaths.length > 0;
+        let dryRunStatus = hasPlannedWork ? 'planned' : 'ok';
         if (unrepairable.length > 0) {
-          dryRunStatus = plannedRepairs.length > 0 ? 'partial' : 'error';
+          dryRunStatus = hasPlannedWork ? 'partial' : 'error';
         }
         return {
           adapter: record.adapter,
@@ -1208,6 +1263,8 @@ function repairInstalledStates(options = {}) {
           installStatePath: record.installStatePath,
           repairedPaths: [],
           plannedRepairs,
+          prunedPaths: [],
+          plannedPrunes: prunedPaths,
           unrepairable,
           stateRefreshed: plannedRepairs.length === 0,
           error: describeUnrepairable(unrepairable),
@@ -1245,11 +1302,14 @@ function repairInstalledStates(options = {}) {
         adapter: record.adapter,
         // 'partial' when real work was done but something is still
         // unfixable: neither a clean success nor a total failure, and the
-        // exit code keeps saying attention is needed.
-        status: resolveRepairStatus(repairedPaths.length, unrepairable.length),
+        // exit code keeps saying attention is needed. Pruning a stale entry
+        // is real work: the rewritten install-state is what heals doctor.
+        status: resolveRepairStatus(repairedPaths.length + prunedPaths.length, unrepairable.length),
         installStatePath: record.installStatePath,
         repairedPaths,
         plannedRepairs: [],
+        prunedPaths,
+        plannedPrunes: [],
         unrepairable,
         stateRefreshed: true,
         error: describeUnrepairable(unrepairable),
@@ -1279,12 +1339,16 @@ function repairInstalledStates(options = {}) {
       + (result.status === 'planned' || (dryRun && result.status === 'partial') ? 1 : 0),
     errorCount: accumulator.errorCount + (result.status === 'error' || result.status === 'partial' ? 1 : 0),
     unrepairableCount: accumulator.unrepairableCount + (result.unrepairable?.length || 0),
+    prunedCount: accumulator.prunedCount + (result.prunedPaths?.length || 0),
+    plannedPruneCount: accumulator.plannedPruneCount + (result.plannedPrunes?.length || 0),
   }), {
     checkedCount: 0,
     repairedCount: 0,
     plannedRepairCount: 0,
     errorCount: 0,
     unrepairableCount: 0,
+    prunedCount: 0,
+    plannedPruneCount: 0,
   });
 
   return {

--- a/scripts/lib/install-source-filters.js
+++ b/scripts/lib/install-source-filters.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Machine-generated tooling artifacts must never become managed install
+// sources: they differ per machine, and npm never packs .gitignore at all,
+// so an install-state entry recorded for one of these can never be satisfied
+// from the published package again. Shared by every source enumerator
+// (install-executor.js and the install-target helpers), so no planning path
+// can reintroduce them.
+const IGNORED_DIRECTORY_NAMES = new Set([
+  'node_modules',
+  '.git',
+  '__pycache__',
+]);
+
+const IGNORED_FILE_NAMES = new Set([
+  '.gitignore',
+  '.DS_Store',
+  'Thumbs.db',
+]);
+
+const IGNORED_FILE_SUFFIXES = ['.pyc', '.pyo'];
+
+function isIgnoredSourceDirectory(directoryName) {
+  return IGNORED_DIRECTORY_NAMES.has(directoryName);
+}
+
+function isIgnoredSourceFile(fileName) {
+  if (IGNORED_FILE_NAMES.has(fileName)) {
+    return true;
+  }
+  return IGNORED_FILE_SUFFIXES.some(suffix => fileName.endsWith(suffix));
+}
+
+module.exports = {
+  isIgnoredSourceDirectory,
+  isIgnoredSourceFile,
+};

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -2,6 +2,8 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const { isIgnoredSourceDirectory, isIgnoredSourceFile } = require('../install-source-filters');
+
 const PLATFORM_SOURCE_PATH_OWNERS = Object.freeze({
   '.gemini-plugin': 'egc',
   '.codex': 'codex',
@@ -113,9 +115,15 @@ function listRelativeFiles(dirPath, prefix = '') {
     const entryPrefix = prefix ? path.join(prefix, entry.name) : entry.name;
     const absolutePath = path.join(dirPath, entry.name);
 
+    // Same artifact exclusions as install-executor.js's listFilesRecursive:
+    // adapter plans enumerate sources through this path too, and a local
+    // .DS_Store or __pycache__ must never become a managed install source.
     if (entry.isDirectory()) {
+      if (isIgnoredSourceDirectory(entry.name)) {
+        continue;
+      }
       files.push(...listRelativeFiles(absolutePath, entryPrefix));
-    } else if (entry.isFile()) {
+    } else if (entry.isFile() && !isIgnoredSourceFile(entry.name)) {
       files.push(normalizeRelativePath(entryPrefix));
     }
   }

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -257,7 +257,10 @@ function createFlatFileOperations({ // NOSONAR: directory walk building install 
     const namespace = entry.name;
     const entryPath = path.join(sourceRoot, entry.name);
 
-    if (entry.isDirectory()) {
+    // Same artifact exclusions as the nested listRelativeFiles walk: a
+    // top-level __pycache__ namespace or a stray .DS_Store directly under
+    // the source root must never become a managed install source either.
+    if (entry.isDirectory() && !isIgnoredSourceDirectory(entry.name)) {
       const relativeFiles = listRelativeFiles(entryPath);
       for (const relativeFile of relativeFiles) {
         const defaultFileName = `${namespace}-${normalizeRelativePath(relativeFile).replaceAll('/', '-')}`;
@@ -275,7 +278,7 @@ function createFlatFileOperations({ // NOSONAR: directory walk building install 
           strategy: 'flatten-copy',
         }));
       }
-    } else if (entry.isFile()) {
+    } else if (entry.isFile() && !isIgnoredSourceFile(entry.name)) {
       const sourceRelativeFile = path.join(normalizedSourcePath, entry.name);
       const destinationFileName = typeof destinationNameTransform === 'function'
         ? destinationNameTransform(entry.name, sourceRelativeFile)

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -49,7 +49,7 @@ function printUnrepairableEntries(entry) {
   }
   console.log(`  Unrepairable: ${entry.unrepairable.length}`);
   for (const item of entry.unrepairable) {
-    console.log(`    - ${item.path}: ${item.reason}`);
+    console.log(`    - ${item.path} [${item.cause}]: ${item.reason}`);
   }
 }
 

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -26,6 +26,33 @@ function parseArgs(argv) {
   return parseTargetArgs(argv, { supportsDryRun: true });
 }
 
+// A pruned entry is healed, not broken: its source left the reference repo,
+// the stale install-state record was dropped, and the installed file stays
+// on disk (unmanaged from now on).
+function printPrunedEntries(entry, dryRun) {
+  const prunedEntries = dryRun ? entry.plannedPrunes : entry.prunedPaths;
+  if (!(prunedEntries?.length > 0)) {
+    return;
+  }
+  console.log(`  ${dryRun ? 'Planned prunes' : 'Pruned stale entries'}: ${prunedEntries.length}`);
+  for (const item of prunedEntries) {
+    console.log(`    - ${item}: source left the reference repo; entry removed, installed file kept`);
+  }
+}
+
+// Each item carries its own reason, because the two causes need different
+// actions: a renamed-away source means the install-state is stale, while an
+// execution failure usually means permissions.
+function printUnrepairableEntries(entry) {
+  if (!(entry.unrepairable?.length > 0)) {
+    return;
+  }
+  console.log(`  Unrepairable: ${entry.unrepairable.length}`);
+  for (const item of entry.unrepairable) {
+    console.log(`    - ${item.path}: ${item.reason}`);
+  }
+}
+
 function printHuman(result) {
   if (result.results.length === 0) {
     console.log('No EGC install-state files found for the current home/project context.');
@@ -48,22 +75,16 @@ function printHuman(result) {
 
     const paths = result.dryRun ? entry.plannedRepairs : entry.repairedPaths;
     console.log(`  ${result.dryRun ? 'Planned repairs' : 'Repaired paths'}: ${paths.length}`);
-
-    // Each item carries its own reason, because the two causes need
-    // different actions: a renamed-away source means the install-state is
-    // stale, while an execution failure usually means permissions.
-    if (entry.unrepairable?.length > 0) {
-      console.log(`  Unrepairable: ${entry.unrepairable.length}`);
-      for (const item of entry.unrepairable) {
-        console.log(`    - ${item.path}: ${item.reason}`);
-      }
-    }
+    printPrunedEntries(entry, result.dryRun);
+    printUnrepairableEntries(entry);
   }
 
+  const prunedCount = result.dryRun ? result.summary.plannedPruneCount : result.summary.prunedCount;
+  const pruned = prunedCount ? `, ${result.dryRun ? 'planned-prunes' : 'pruned'}=${prunedCount}` : '';
   const unrepairable = result.summary.unrepairableCount
     ? `, unrepairable=${result.summary.unrepairableCount}`
     : '';
-  console.log(`\nSummary: checked=${result.summary.checkedCount}, ${result.dryRun ? 'planned' : 'repaired'}=${result.dryRun ? result.summary.plannedRepairCount : result.summary.repairedCount}, errors=${result.summary.errorCount}${unrepairable}`);
+  console.log(`\nSummary: checked=${result.summary.checkedCount}, ${result.dryRun ? 'planned' : 'repaired'}=${result.dryRun ? result.summary.plannedRepairCount : result.summary.repairedCount}, errors=${result.summary.errorCount}${pruned}${unrepairable}`);
 }
 
 function executePluginRepairs(options) {

--- a/tests/check-state-leak.test.js
+++ b/tests/check-state-leak.test.js
@@ -150,6 +150,20 @@ run('packaged-tree passes when only unpackaged files are populated', () => {
   assert.strictEqual(res.status, 0, res.stderr);
 });
 
+run('packaged-tree skips with a notice outside a git checkout', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-leak-nogit-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+    fs.copyFileSync(SCRIPT, path.join(dir, 'scripts', 'check-state-leak.js'));
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0', files: ['.trae/'] }, null, 2));
+    const res = runScript(dir, '--packaged-tree');
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(res.stdout.includes('skipped (not a git checkout'), res.stdout);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 run('packaged-tree flags an untracked populated file inside the packaged set', () => {
   const { dir, git } = makeRepo();
   fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0', files: ['.trae/'] }, null, 2));

--- a/tests/check-state-leak.test.js
+++ b/tests/check-state-leak.test.js
@@ -150,5 +150,19 @@ run('packaged-tree passes when only unpackaged files are populated', () => {
   assert.strictEqual(res.status, 0, res.stderr);
 });
 
+run('packaged-tree flags an untracked populated file inside the packaged set', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0', files: ['.trae/'] }, null, 2));
+  git('add', '.');
+  git('commit', '-q', '-m', 'seed', '--no-verify');
+  // Written AFTER the commit: npm pack reads the working tree, so a
+  // never-committed propagation file ships all the same.
+  fs.mkdirSync(path.join(dir, '.trae', 'rules'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.trae', 'rules', 'egc-context.md'), POPULATED);
+  const res = runScript(dir, '--packaged-tree');
+  assert.strictEqual(res.status, 1, `untracked packaged file must still be scanned: ${res.stderr}`);
+  assert.ok(res.stderr.includes('.trae/rules/egc-context.md'));
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/check-state-leak.test.js
+++ b/tests/check-state-leak.test.js
@@ -126,5 +126,29 @@ run('non-markdown staged files are ignored', () => {
   assert.strictEqual(res.status, 0, res.stderr);
 });
 
+run('packaged-tree mode flags only files the package ships', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0', files: ['.trae/'] }, null, 2));
+  fs.mkdirSync(path.join(dir, '.trae', 'rules'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.trae', 'rules', 'egc-context.md'), POPULATED);
+  fs.writeFileSync(path.join(dir, 'CLAUDE.md'), POPULATED);
+  git('add', '.');
+  git('commit', '-q', '-m', 'seed', '--no-verify');
+  const res = runScript(dir, '--packaged-tree');
+  assert.strictEqual(res.status, 1, `expected exit 1, got ${res.status}: ${res.stderr}`);
+  assert.ok(res.stderr.includes('.trae/rules/egc-context.md'));
+  assert.ok(!res.stderr.includes('CLAUDE.md'), 'unpackaged propagation files must not block a publish');
+});
+
+run('packaged-tree passes when only unpackaged files are populated', () => {
+  const { dir, git } = makeRepo();
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0', files: ['.trae/'] }, null, 2));
+  fs.writeFileSync(path.join(dir, 'CLAUDE.md'), POPULATED);
+  git('add', '.');
+  git('commit', '-q', '-m', 'seed', '--no-verify');
+  const res = runScript(dir, '--packaged-tree');
+  assert.strictEqual(res.status, 0, res.stderr);
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/baseline-absent.js
+++ b/tests/lib/baseline-absent.js
@@ -55,8 +55,6 @@ const BASELINE_ABSENT_ASSERTIONS = Object.freeze([
   // checkouts.
   '.opencode/dist',
   'compiled OpenCode dist payload',
-  'reduced runtime surface',
-  'package.json files align to the module graph',
 ]);
 
 // Test-name fragments that should be skipped because the surface they assert
@@ -67,7 +65,6 @@ const BASELINE_ABSENT_ASSERTIONS = Object.freeze([
 const BASELINE_ABSENT_TEST_NAMES = Object.freeze([
   'canonical marketplace plugin identifier',
   'compiled OpenCode dist payload',
-  'reduced runtime surface',
   'reports when no install-state files are present',
   'emits JSON for discovered install-state records',
   // README install/marketplace prose blocks that belong to the downstream

--- a/tests/lib/install-executor.test.js
+++ b/tests/lib/install-executor.test.js
@@ -15,6 +15,7 @@ const {
   createLegacyInstallPlan,
   createManifestInstallPlan,
   listAvailableLanguages,
+  listFilesRecursive,
 } = require('../../scripts/lib/install-executor');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -512,6 +513,50 @@ function runTests() {
       const state = JSON.parse(fs.readFileSync(path.join(homeDir, '.gemini', 'egc', 'install-state.json'), 'utf8'));
       assert.strictEqual(state.request.profile, 'minimal');
       assert.deepStrictEqual(state.resolution.selectedModules, ['fixture-core']);
+    } finally {
+      cleanup(sourceRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('source enumeration and manifest plans skip generated artifacts and unpackable files', () => {
+    const sourceRoot = createTempDir('install-executor-source-');
+    const homeDir = createTempDir('install-executor-home-');
+
+    try {
+      writeManifestSourceFixture(sourceRoot);
+      writeFile(sourceRoot, path.join('skills', 'demo', '.gitignore'), '__pycache__\n');
+      writeFile(sourceRoot, path.join('skills', 'demo', '.DS_Store'), 'junk');
+      writeFile(sourceRoot, path.join('skills', 'demo', 'stray.pyc'), 'junk');
+      writeFile(sourceRoot, path.join('skills', 'demo', 'tests', '__pycache__', 'mod.cpython-313.pyc'), 'junk');
+      writeFile(sourceRoot, path.join('skills', 'demo', 'tests', 'test_demo.py'), 'def test(): pass\n');
+
+      assert.deepStrictEqual(
+        listFilesRecursive(path.join(sourceRoot, 'skills', 'demo')),
+        ['SKILL.md', path.join('tests', 'test_demo.py')]
+      );
+
+      const plan = createManifestInstallPlan({
+        sourceRoot,
+        homeDir,
+        target: 'egc',
+        profileId: 'minimal',
+      });
+      const copySources = plan.operations
+        .filter(operation => operation.kind === 'copy-file')
+        .map(operation => String(operation.sourceRelativePath).replaceAll('\\', '/'));
+
+      assert.ok(
+        copySources.includes('skills/demo/SKILL.md'),
+        'the real skill file must still be planned'
+      );
+      const offenders = copySources.filter(source => (
+        source.includes('__pycache__')
+        || source.endsWith('.pyc')
+        || source.endsWith('/.gitignore')
+        || source.endsWith('/.DS_Store')
+      ));
+      assert.deepStrictEqual(offenders, [], 'generated artifacts must never become managed sources');
     } finally {
       cleanup(sourceRoot);
       cleanup(homeDir);

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -944,6 +944,12 @@ function runTests() {
         assert.ok(ids.includes(`${pairedId}-home`), `missing ${pairedId}-home`);
         assert.ok(ids.includes(`${pairedId}-project`), `missing ${pairedId}-project`);
       }
+
+      // An explicit target covers its whole home+project pair too, not just
+      // the first adapter that answers to the id.
+      const explicitIds = discoverInstalledStates({ homeDir, projectRoot, targets: ['kiro'] })
+        .map(record => record.adapter.id);
+      assert.deepStrictEqual(explicitIds, ['kiro-home', 'kiro-project']);
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -728,7 +728,7 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('repair reports invalid states, missing sources, unsupported operations, and no-op refreshes', () => {
+  if (test('repair reports invalid states, prunes orphaned sources, rejects unsupported operations, and no-op refreshes', () => {
     const homeDir = createTempDir('install-lifecycle-home-');
     const invalidProjectRoot = createTempDir('install-lifecycle-invalid-');
     const missingSourceProjectRoot = createTempDir('install-lifecycle-missing-source-');
@@ -752,7 +752,7 @@ function runTests() {
       const missingDestination = path.join(missingSourceProjectRoot, '.cursor', 'rules', 'missing.md');
       fs.mkdirSync(path.dirname(missingDestination), { recursive: true });
       fs.writeFileSync(missingDestination, 'managed\n');
-      writeCursorState(missingSourceProjectRoot, {
+      const missingSourceState = writeCursorState(missingSourceProjectRoot, {
         operations: [
           managedOperation('copy-file', missingDestination, {
             sourceRelativePath: 'missing/source.md',
@@ -766,8 +766,19 @@ function runTests() {
         projectRoot: missingSourceProjectRoot,
         targets: ['cursor'],
       });
-      assert.strictEqual(result.results[0].status, 'error');
-      assert.ok(result.results[0].error.includes('Missing source file(s)'));
+      // A recorded/legacy plan prunes the orphaned entry instead of failing
+      // forever: the rewritten install-state stops referencing the missing
+      // source and the installed file stays on disk, unmanaged.
+      assert.strictEqual(result.results[0].status, 'repaired');
+      assert.deepStrictEqual(result.results[0].prunedPaths, ['missing/source.md']);
+      assert.strictEqual(result.results[0].error, null);
+      assert.strictEqual(result.summary.prunedCount, 1);
+      assert.ok(fs.existsSync(missingDestination));
+      const rewrittenState = JSON.parse(fs.readFileSync(missingSourceState.installStatePath, 'utf8'));
+      assert.strictEqual(
+        rewrittenState.operations.filter(operation => operation.sourceRelativePath === 'missing/source.md').length,
+        0
+      );
 
       const unsupportedDestination = path.join(unsupportedProjectRoot, '.cursor', 'custom.txt');
       writeCursorState(unsupportedProjectRoot, {
@@ -821,6 +832,118 @@ function runTests() {
       assert.strictEqual(result.results[0].status, 'ok');
       assert.strictEqual(result.results[0].stateRefreshed, true);
       assert.deepStrictEqual(result.results[0].plannedRepairs, []);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair dry-run plans prunes for orphaned recorded sources without writing', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const destination = path.join(projectRoot, '.cursor', 'rules', 'orphan.md');
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(destination, 'managed\n');
+      const written = writeCursorState(projectRoot, {
+        operations: [
+          managedOperation('copy-file', destination, {
+            sourceRelativePath: 'orphaned/source.md',
+            strategy: 'copy-file',
+          }),
+        ],
+      });
+      const stateBefore = fs.readFileSync(written.installStatePath, 'utf8');
+
+      const result = repairInstalledStates({
+        repoRoot: REPO_ROOT,
+        homeDir,
+        projectRoot,
+        targets: ['cursor'],
+        dryRun: true,
+      });
+
+      assert.strictEqual(result.results[0].status, 'planned');
+      assert.deepStrictEqual(result.results[0].plannedPrunes, ['orphaned/source.md']);
+      assert.deepStrictEqual(result.results[0].prunedPaths, []);
+      assert.strictEqual(result.summary.plannedPruneCount, 1);
+      assert.strictEqual(fs.readFileSync(written.installStatePath, 'utf8'), stateBefore);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair prunes the orphan, keeps healthy entries, and doctor converges to OK', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const healthyDestination = path.join(projectRoot, '.cursor', 'rules', 'healthy.json');
+      fs.mkdirSync(path.dirname(healthyDestination), { recursive: true });
+      fs.copyFileSync(path.join(REPO_ROOT, 'package.json'), healthyDestination);
+      const orphanDestination = path.join(projectRoot, '.cursor', 'rules', 'orphan.md');
+      fs.writeFileSync(orphanDestination, 'managed\n');
+
+      writeCursorState(projectRoot, {
+        operations: [
+          managedOperation('copy-file', healthyDestination, {
+            sourceRelativePath: 'package.json',
+            strategy: 'copy-file',
+          }),
+          managedOperation('copy-file', orphanDestination, {
+            sourceRelativePath: 'orphaned/source.md',
+            strategy: 'copy-file',
+          }),
+        ],
+      });
+
+      const before = buildDoctorReport({
+        repoRoot: REPO_ROOT,
+        homeDir,
+        projectRoot,
+        targets: ['cursor'],
+      });
+      assert.ok(before.results[0].issues.some(issue => issue.code === 'missing-source-files'));
+
+      const repair = repairInstalledStates({
+        repoRoot: REPO_ROOT,
+        homeDir,
+        projectRoot,
+        targets: ['cursor'],
+      });
+      assert.strictEqual(repair.results[0].status, 'repaired');
+      assert.deepStrictEqual(repair.results[0].prunedPaths, ['orphaned/source.md']);
+
+      const after = buildDoctorReport({
+        repoRoot: REPO_ROOT,
+        homeDir,
+        projectRoot,
+        targets: ['cursor'],
+      });
+      assert.ok(!after.results[0].issues.some(issue => issue.code === 'missing-source-files'));
+      assert.strictEqual(after.results[0].status, 'ok');
+      assert.ok(fs.existsSync(orphanDestination), 'the pruned entry must leave the installed file on disk');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('discovery enumerates each adapter once, including home+project pairs', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const records = discoverInstalledStates({ homeDir, projectRoot });
+      const ids = records.map(record => record.adapter.id);
+
+      assert.strictEqual(new Set(ids).size, ids.length, `duplicated adapter ids: ${ids.join(', ')}`);
+      for (const pairedId of ['kiro', 'junie', 'amp', 'windsurf', 'openhands']) {
+        assert.ok(ids.includes(`${pairedId}-home`), `missing ${pairedId}-home`);
+        assert.ok(ids.includes(`${pairedId}-project`), `missing ${pairedId}-project`);
+      }
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -51,7 +51,11 @@ function main() {
       assert.ok(fs.existsSync(distEntry), ".opencode/dist/index.js should exist after build")
     }],
     ["npm pack includes the compiled OpenCode dist payload", () => {
-      const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+      // --ignore-scripts: the assertion is about the files whitelist picking
+      // up an existing compiled dist, not about running the prepack pipeline
+      // (which refuses to pack while local propagation files hold populated
+      // memory).
+      const result = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
         cwd: repoRoot,
         encoding: "utf8",
         shell: process.platform === "win32",

--- a/tests/scripts/npm-publish-surface.test.js
+++ b/tests/scripts/npm-publish-surface.test.js
@@ -145,6 +145,8 @@ function main() {
         || packagedPath.endsWith(".pyo")
         || packagedPath.endsWith(".DS_Store")
         || packagedPath.endsWith("Thumbs.db")
+        || packagedPath === ".gitignore"
+        || packagedPath.endsWith("/.gitignore")
       ))
       assert.deepStrictEqual(artifacts, [], "generated artifacts must never ship in the package")
     }],

--- a/tests/scripts/npm-publish-surface.test.js
+++ b/tests/scripts/npm-publish-surface.test.js
@@ -89,7 +89,7 @@ function main() {
       }
     }],
     ["package files whitelist keeps the generated-artifact negations", () => {
-      for (const negation of ["!**/__pycache__", "!**/*.pyc", "!**/.DS_Store"]) {
+      for (const negation of ["!**/__pycache__", "!**/*.pyc", "!**/*.pyo", "!**/.DS_Store", "!**/Thumbs.db"]) {
         assert.ok(
           packageJson.files.includes(negation),
           `package.json files must keep ${negation}`
@@ -142,7 +142,9 @@ function main() {
       const artifacts = packagedPaths.filter((packagedPath) => (
         packagedPath.includes("__pycache__")
         || packagedPath.endsWith(".pyc")
+        || packagedPath.endsWith(".pyo")
         || packagedPath.endsWith(".DS_Store")
+        || packagedPath.endsWith("Thumbs.db")
       ))
       assert.deepStrictEqual(artifacts, [], "generated artifacts must never ship in the package")
     }],

--- a/tests/scripts/npm-publish-surface.test.js
+++ b/tests/scripts/npm-publish-surface.test.js
@@ -1,6 +1,14 @@
 const { maybeSkipBaselineAbsent } = require('../lib/baseline-absent');
 /**
  * Tests for the npm publish surface contract.
+ *
+ * The contract is COVERAGE, not equality: every source path the install
+ * manifests reference must ship in the npm package (the package.json
+ * "files" whitelist). A path that installs fine from a dev checkout but is
+ * missing from the published tarball silently vanishes for every registry
+ * install and later surfaces as doctor missing-source-files errors on
+ * machines that did install it. KNOWN_UNPACKAGED documents the deliberate
+ * exceptions.
  */
 
 const assert = require("assert")
@@ -21,64 +29,34 @@ function runTest(name, fn) {
   }
 }
 
+const repoRoot = path.join(__dirname, "..", "..")
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
+)
+const modules = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, "manifests", "install-modules.json"), "utf8")
+).modules
+
+// Manifest sources that deliberately do NOT ship in the npm package today.
+// All three are local memory-propagation targets: packing them straight from
+// a working tree would risk publishing populated memory, so adding them to
+// "files" is a maintainer decision, not a mechanical fix. Registry installs
+// silently skip them (materializeScaffoldOperation drops missing sources).
+// Shrink this list, never grow it.
+const KNOWN_UNPACKAGED = new Set(["AGENTS.md", ".cursor", ".gemini"])
+
 function normalizePublishPath(value) {
   return String(value).replace(/\\/g, "/").replace(/\/$/, "")
 }
 
-function isCoveredByAncestor(target, roots) {
-  const parts = target.split("/")
-  for (let index = 1; index < parts.length; index += 1) {
-    const ancestor = parts.slice(0, index).join("/")
-    if (roots.has(ancestor)) {
-      return true
-    }
-  }
-  return false
-}
+const packagedPrefixes = packageJson.files
+  .filter((entry) => !entry.startsWith("!"))
+  .map(normalizePublishPath)
 
-function buildExpectedPublishPaths(repoRoot) {
-  const modules = JSON.parse(
-    fs.readFileSync(path.join(repoRoot, "manifests", "install-modules.json"), "utf8")
-  ).modules
-
-  const extraPaths = [
-    "manifests",
-    "scripts/egc.js",
-    "scripts/catalog.js",
-    "scripts/consult.js",
-    "scripts/claw.js",
-    "scripts/doctor.js",
-    "scripts/status.js",
-    "scripts/sessions-cli.js",
-    "scripts/install-apply.js",
-    "scripts/install-plan.js",
-    "scripts/list-installed.js",
-    "scripts/loop-status.js",
-    "scripts/skill-create-output.js",
-    "scripts/repair.js",
-    "scripts/harness-audit.js",
-    "scripts/session-inspect.js",
-    "scripts/uninstall.js",
-    "scripts/gemini-adapt-agents.js",
-    "scripts/codex/merge-codex-config.js",
-    "scripts/codex/merge-mcp-config.js",
-    ".codex-plugin",
-    ".mcp.json",
-    "install.sh",
-    "install.ps1",
-    "schemas",
-    "agent.yaml",
-    "mcp/servers/egc-guardian/package-lock.json",
-    "mcp/servers/egc-memory/package-lock.json",
-  ]
-
-  const combined = new Set(
-    [...modules.flatMap((module) => module.paths || []), ...extraPaths].map(normalizePublishPath)
+function isPackaged(relativePath) {
+  return packagedPrefixes.some(
+    (prefix) => relativePath === prefix || relativePath.startsWith(`${prefix}/`)
   )
-
-  return [...combined]
-    .filter((publishPath) => !isCoveredByAncestor(publishPath, combined))
-    .sort()
 }
 
 function main() {
@@ -87,56 +65,86 @@ function main() {
   let passed = 0
   let failed = 0
 
-  const repoRoot = path.join(__dirname, "..", "..")
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
-  )
-
-  const expectedPublishPaths = buildExpectedPublishPaths(repoRoot)
-  const actualPublishPaths = packageJson.files.map(normalizePublishPath).sort()
-
   const tests = [
-    ["package.json files align to the module graph and explicit runtime allowlist", () => {
-      assert.deepStrictEqual(actualPublishPaths, expectedPublishPaths)
+    ["every install-manifest source ships in the npm package files whitelist", () => {
+      for (const module of modules) {
+        for (const rawPath of module.paths || []) {
+          const sourcePath = normalizePublishPath(rawPath)
+          if (KNOWN_UNPACKAGED.has(sourcePath)) {
+            assert.ok(
+              !isPackaged(sourcePath),
+              `${sourcePath} is packaged now: remove it from KNOWN_UNPACKAGED`
+            )
+            continue
+          }
+          assert.ok(
+            fs.existsSync(path.join(repoRoot, sourcePath)),
+            `manifest module ${module.id} references a source missing from the repo: ${sourcePath}`
+          )
+          assert.ok(
+            isPackaged(sourcePath),
+            `manifest module ${module.id} references a source the npm package does not ship: ${sourcePath}`
+          )
+        }
+      }
     }],
-    ["npm pack publishes the reduced runtime surface", () => {
-      const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+    ["package files whitelist keeps the generated-artifact negations", () => {
+      for (const negation of ["!**/__pycache__", "!**/*.pyc", "!**/.DS_Store"]) {
+        assert.ok(
+          packageJson.files.includes(negation),
+          `package.json files must keep ${negation}`
+        )
+      }
+    }],
+    ["npm pack ships manifest sources and no generated artifacts", () => {
+      // --ignore-scripts: the contract under test is the files whitelist,
+      // not the prepack pipeline (which builds the MCP servers and refuses
+      // to pack while local propagation files hold populated memory).
+      const result = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
         cwd: repoRoot,
         encoding: "utf8",
         shell: process.platform === "win32",
+        maxBuffer: 64 * 1024 * 1024,
       })
       assert.strictEqual(result.status, 0, result.error?.message || result.stderr)
 
       const packOutput = JSON.parse(result.stdout)
-      const packagedPaths = new Set(packOutput[0]?.files?.map((file) => file.path) ?? [])
+      const packagedPaths = packOutput[0]?.files?.map((file) => file.path) ?? []
+      const packagedSet = new Set(packagedPaths)
 
       for (const requiredPath of [
-        "scripts/catalog.js",
-        "scripts/consult.js",
-        ".gemini/GEMINI.md",
+        ".codex/config.toml",
+        ".trae/rules/egc-context.md",
+        "scripts/hooks/scrubber-cli.js",
+        "scripts/lib/scrubber/engine.js",
+        "skills/security/content-scrubber/SKILL.md",
+        "manifests/install-modules.json",
         ".gemini-plugin/plugin.json",
-        ".codex-plugin/plugin.json",
         "schemas/install-state.schema.json",
-        "skills/backend/backend-patterns/SKILL.md",
       ]) {
         assert.ok(
-          packagedPaths.has(requiredPath),
+          packagedSet.has(requiredPath),
           `npm pack should include ${requiredPath}`
         )
       }
 
       for (const excludedPath of [
-        "contexts/dev.md",
-        "examples/GEMINI.md",
-        "plugins/README.md",
-        "scripts/ci/catalog.js",
-        "skills/general_part2/skill-comply/SKILL.md",
+        "AGENTS.md",
+        ".cursor/rules/egc-context.mdc",
+        "skills/general_part2/skill-comply/.gitignore",
       ]) {
         assert.ok(
-          !packagedPaths.has(excludedPath),
+          !packagedSet.has(excludedPath),
           `npm pack should not include ${excludedPath}`
         )
       }
+
+      const artifacts = packagedPaths.filter((packagedPath) => (
+        packagedPath.includes("__pycache__")
+        || packagedPath.endsWith(".pyc")
+        || packagedPath.endsWith(".DS_Store")
+      ))
+      assert.deepStrictEqual(artifacts, [], "generated artifacts must never ship in the package")
     }],
   ]
 

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -130,7 +130,7 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('repairs what it can when one source file is orphaned, instead of abandoning the target', () => {
+  if (test('repairs the drift and prunes the orphaned entry, instead of abandoning the target', () => {
     const homeDir = createTempDir('repair-home-');
     const projectRoot = createTempDir('repair-project-');
 
@@ -170,17 +170,26 @@ function runTests() {
 
       const parsed = JSON.parse(repairResult.stdout);
       const entry = parsed.results[0];
-      assert.strictEqual(entry.status, 'partial', 'work was done, but something is still unfixable');
+      assert.strictEqual(entry.status, 'repaired', 'drift repaired and the orphan pruned: the target is healed');
       assert.ok(entry.repairedPaths.includes(managedPath), 'the repairable file must be rebuilt');
       assert.deepStrictEqual(
-        entry.unrepairable.map(item => ({ path: item.path, cause: item.cause })),
-        [{ path: '.cursor/hooks/this-file-was-renamed-away.js', cause: 'missing-source' }],
-        'the orphan must be reported by its recorded relative path, and by cause'
+        entry.prunedPaths,
+        ['.cursor/hooks/this-file-was-renamed-away.js'],
+        'the orphan must be pruned by its recorded relative path'
       );
-      assert.ok(entry.error.includes('Missing source file(s)'), 'the message must name the cause');
+      assert.deepStrictEqual(entry.unrepairable, [], 'a pruned orphan is healed, not unrepairable');
+      assert.strictEqual(entry.error, null);
       assert.notStrictEqual(fs.readFileSync(managedPath, 'utf8'), '// drifted\n', 'the drifted file must be restored');
-      assert.strictEqual(repairResult.code, 1, 'an orphan still has to be reported as needing attention');
-      assert.strictEqual(parsed.summary.unrepairableCount, 1);
+      assert.ok(fs.existsSync(orphanDestination), 'pruning must keep the installed file on disk');
+      const rewritten = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      assert.strictEqual(
+        rewritten.operations.filter(operation => operation.sourceRelativePath === '.cursor/hooks/this-file-was-renamed-away.js').length,
+        0,
+        'the rewritten install-state must drop the orphaned entry'
+      );
+      assert.strictEqual(repairResult.code, 0, 'a fully healed target needs no further attention');
+      assert.strictEqual(parsed.summary.unrepairableCount, 0);
+      assert.strictEqual(parsed.summary.prunedCount, 1);
       assert.strictEqual(parsed.summary.repairedCount, 1, 'a real run counts the target it repaired');
       assert.strictEqual(parsed.summary.plannedRepairCount, 0, 'nothing was merely planned in a real run');
     } finally {
@@ -189,7 +198,7 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('a dry-run with both drift and an orphan counts planned work, never repairs', () => {
+  if (test('a dry-run with both drift and an orphan plans the work, never repairs', () => {
     const homeDir = createTempDir('repair-home-');
     const projectRoot = createTempDir('repair-project-');
 
@@ -221,12 +230,24 @@ function runTests() {
       });
 
       const parsed = JSON.parse(repairResult.stdout);
-      assert.strictEqual(parsed.results[0].status, 'partial');
+      assert.strictEqual(parsed.results[0].status, 'planned');
+      assert.deepStrictEqual(
+        parsed.results[0].plannedPrunes,
+        ['.cursor/hooks/this-file-was-renamed-away.js'],
+        'the orphan prune must be planned by its recorded relative path'
+      );
       assert.strictEqual(parsed.summary.plannedRepairCount, 1, 'a dry run plans, it does not repair');
+      assert.strictEqual(parsed.summary.plannedPruneCount, 1, 'the orphan prune is planned, not executed');
       assert.strictEqual(parsed.summary.repairedCount, 0, 'a dry run must never report writes it did not make');
-      assert.strictEqual(parsed.summary.errorCount, 1, 'the orphan still counts as needing attention');
+      assert.strictEqual(parsed.summary.errorCount, 0, 'a prunable orphan no longer counts as an error');
       assert.strictEqual(fs.readFileSync(managedPath, 'utf8'), '// drifted\n', 'a dry run must not touch the file');
-      assert.strictEqual(repairResult.code, 1);
+      const untouchedState = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      assert.strictEqual(
+        untouchedState.operations.filter(operation => operation.sourceRelativePath === '.cursor/hooks/this-file-was-renamed-away.js').length,
+        1,
+        'a dry run must not rewrite the install-state'
+      );
+      assert.strictEqual(repairResult.code, 0);
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);


### PR DESCRIPTION
## Summary

`egc doctor` reported permanent, unfixable errors on real machines: 66 `missing-source-files` entries across `claude-home`, `egc-home` and `codex-home`, and `egc repair` marked every one of them `unrepairable: source file is no longer in the reference repo` forever. This hits any user, on any OS, whose install-state references a file the currently running package no longer ships (a file renamed or dropped between versions, or an install synced from a dev checkout).

## Root causes

1. **Repair had no healing path for orphans.** A recorded copy-file entry whose source left the reference repo was reported and then rewritten back into the install-state, so doctor stayed red forever.
2. **npm packaging gaps.** The install manifests reference `.codex`, but `package.json#files` never shipped it: every registry install of the Codex target silently skipped its platform configs (`materializeScaffoldOperation` drops missing sources without a trace). The publish-surface test that would have caught this has been converted to a baseline-absent SKIP since May (`ec6f5d63`), so the gate was dead.
3. **Machine-generated artifacts became managed sources.** Source enumeration only ignored `node_modules` and `.git`, so `__pycache__/*.pyc` from a local pytest run (and a skill `.gitignore`, which npm never packs at all) were recorded as managed sources that no published package can ever satisfy.
4. **Duplicated and blind discovery.** Five targets ship home+project adapter pairs under one target id (kiro, junie, amp, windsurf, openhands). Default discovery mapped adapters to target ids and back, examining the home adapter twice (`checked=17` for 12 real targets) while the project installs of those five stayed invisible to doctor/repair/uninstall.

## Changes

- `repair` prunes orphaned recorded entries: the stale record leaves the rewritten install-state, the installed file **stays on disk** (deleting it could break live wiring, e.g. the Claude settings hook pointing at the scrubber script), and doctor converges to OK. Manifest-mode plans keep failing loudly, because there a missing source is a packaging bug. New `prunedPaths`/`plannedPrunes` fields and summary counters, printed by the CLI.
- `doctor` now says `(run 'egc repair' to prune orphaned entries)` on that error.
- Discovery enumerates adapters (deduplicated), covering home+project pairs correctly.
- Source enumeration skips `__pycache__`, `*.pyc`, `*.pyo`, `.gitignore`, `.DS_Store`, `Thumbs.db`.
- `package.json#files` ships `.codex/` and excludes `!**/__pycache__`, `!**/*.pyc`, `!**/.DS_Store`.
- `prepack` runs the new `check-state-leak.js --packaged-tree` guard: it refuses to pack while a propagation file **inside the packaged set** holds populated memory (npm pack reads the working tree, not the git-filtered blobs), without blocking everyday local work. This guard already caught a would-be leak of `.trae/rules/egc-context.md` during verification.
- The npm publish-surface contract is alive again as a coverage test: every manifest source must ship in the package, with the deliberate exceptions documented in `KNOWN_UNPACKAGED` (`AGENTS.md`, `.cursor`, `.gemini`: all three are memory-propagation targets, so packing them straight from a working tree would risk publishing populated memory; maintainer decision pending). Removed the corresponding baseline-absent skip fragments.

## Testing

- `tests/lib/install-lifecycle.test.js`: 45/45 (new: prune real run, prune dry-run, doctor-converges-to-OK flow, adapter dedup including project pairs).
- `tests/scripts/repair.test.js`: 11/11 (orphan scenarios updated to the healing contract: exit 0, state rewritten, file kept).
- `tests/lib/install-executor.test.js`: 12/12 (new: artifact filtering in enumeration and in a manifest plan).
- `tests/check-state-leak.test.js`: 7/7 (new: `--packaged-tree` flags packaged files only, passes when only unpackaged files are populated).
- `tests/scripts/npm-publish-surface.test.js`: 3/3 real passes (previously 2 fake SKIPs).
- Full suite via `node tests/run-all.js`: green except one pre-existing, machine-local failure (`ci/codex-skill-surface.test.js`) caused by a stray untracked `__pycache__` directory from a local pytest run on Aug 17; it fails on main identically and does not reproduce on CI checkouts.
- Real-machine proof against the published 1.1.20 package as `--repo-root`: dry-run planned exactly the 66 prunes and 0 repairs; the real run pruned 21+32+13 entries; `egc doctor` (the unmodified global 1.1.20 binary) went from 3 errors to 0; the installed scrubber files and hooks remained in place and functional.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Heals orphaned install-state sources and closes npm packaging gaps so `egc doctor` converges and registry installs match the manifests. Previously `egc doctor` reported permanent missing-source-files and `egc repair` marked them unrepairable; now repair prunes stale recorded entries (installed files stay on disk) while manifest-mode misses still error.

- Repair: prunes orphaned recorded operations and rewrites state; adds `prunedPaths`/`plannedPrunes` and counts; exit status includes prunes; dry-run plans prunes without writing; CLI prints each unrepairable entry’s cause next to its reason. `egc doctor` now suggests “run `egc repair` to prune orphaned entries.”
- Discovery: enumerates adapters (deduped) and covers home+project pairs by default and when `--target` is specified (kiro, junie, amp, windsurf, openhands).
- Source enumeration: shared filter skips `__pycache__/`, `*.pyc`, `*.pyo`, `.gitignore`, `.DS_Store`, `Thumbs.db` in the executor, adapter walks, and flat top-level enumeration so machine artifacts never become managed sources.
- Packaging: `package.json` now ships `.codex/` and excludes the artifacts above; the publish-surface coverage test asserts every manifest source is packaged (documented exceptions remain) and that `.gitignore` stays out.
- Prepack guard: runs `scripts/check-state-leak.js --packaged-tree`, scanning tracked and untracked packaged files; skips with a notice outside a git checkout or when git is unavailable, and fails closed for any other git error. Pins `LC_ALL=C` for deterministic skip/fail decisions on non-English systems.

**Rollout notes**
- Users seeing missing-source errors should run `egc repair`; pruned entries will be removed from state and files are kept on disk.
- Maintainers publishing the package must clear or exclude populated propagation files; `npm pack`/publish will now fail if packaged files contain memory.
- Consumers of the repair JSON should tolerate the additive `prunedPaths`/`plannedPrunes` fields.

<sup>Written for commit ef8293c255cc134e141ac81cfd237647d1626cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

