### PR TITLE
chore(ci): bump codeql-action init and analyze together to 4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -100,6 +100,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
CodeQL refuses mixed versions between `init` and `analyze`: the separate Dependabot bumps #1317 and #1318 each failed their own CI with `Loaded a configuration file for version '4.37.6', but running version '4.37.7'`, because each PR alone leaves the pair on different versions.

This lands both pins together (`5595ccaf` v4.37.6 -> `ff2f1c62` v4.37.7), keeping init and analyze consistent in every intermediate state. `upload-sarif` was already bumped by #1316.

Supersedes #1317 and #1318 (Dependabot will detect the applied versions and close them).

Follow-up suggestion for the maintainer: add a `github-actions` group to `.github/dependabot.yml` so codeql-action bumps arrive as one PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the CodeQL workflow to bump `github/codeql-action/init` and `github/codeql-action/analyze` together to v4.37.7, preventing CI failures from mixed versions.

- Previously, separate bumps left `init` and `analyze` on different versions and CodeQL failed with "Loaded a configuration file for version '4.37.6', but running version '4.37.7'".
- Now both steps use v4.37.7; `github/codeql-action/upload-sarif` was already on v4.37.7; no other workflow changes.
- Verify both references in `.github/workflows/codeql.yml` point to v4.37.7. No migration needed. Optional: add a `github-actions` group in `.github/dependabot.yml` to keep CodeQL sub-actions in one PR.

<sup>Written for commit c1a7f08c1effdfc27636051a8aa20d5e874f5959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

