### PR TITLE
fix(tests): stop platform-splitting the subprocess timeout budget

### DIFF
--- a/tests/fixtures/subprocess-timeouts.js
+++ b/tests/fixtures/subprocess-timeouts.js
@@ -4,19 +4,26 @@
  * Timeouts for tests that spawn a real EGC command as a subprocess.
  *
  * A suite that runs a complete install-apply against a temp tree performs
- * dozens of file writes, and on a Windows runner each one also pays for
- * whatever the machine's antivirus does with it. A budget sized on a quiet
- * machine turns that into `spawnSync node ETIMEDOUT`, which reads as a flake
- * and is not one: the work genuinely takes longer there.
+ * dozens of file writes, and every runner environment adds its own tax: a
+ * Windows machine pays antivirus scanning per write, and a busy hosted
+ * Linux runner pays CPU contention and cold process starts (three ubuntu
+ * occurrences on 2026-08-19 alone: a cold pwsh start plus a full dry-run
+ * plan overran the old 10s budget, and the killed subprocess's null exit
+ * status surfaced as a mute `1 !== 0` failure). A budget sized on a quiet
+ * machine reads as a flake and is not one: the work genuinely takes longer
+ * there.
+ *
+ * The budget therefore no longer varies by platform: a timeout here is a
+ * last-resort hang detector, not a performance assertion.
  *
  * Kept in one place so the next adjustment is a single edit rather than a
  * hunt through every suite.
  */
 
 // For suites that install or uninstall a target end to end.
-const FULL_INSTALL_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 10000;
+const FULL_INSTALL_TIMEOUT_MS = 90000;
 
 // For suites that only spawn a CLI to read output (--help, --json probes).
-const CLI_TIMEOUT_MS = process.platform === 'win32' ? 30000 : 10000;
+const CLI_TIMEOUT_MS = 30000;
 
 module.exports = { FULL_INSTALL_TIMEOUT_MS, CLI_TIMEOUT_MS };


### PR DESCRIPTION
The non-Windows subprocess budget was a fixed 10s. On busy hosted ubuntu runners that is not enough for a cold pwsh start plus a complete dry-run install plan, and the killed subprocess's null exit status surfaces as a mute `1 !== 0` failure: it happened three times on 2026-08-19 alone (`install-ps1.test.js`, Node 20 npm / Node 22 npm / Node 20 bun), every re-run green.

This is the same class of failure already fixed three times for the Windows lane (#1203, #1209, #1212), which is why Windows sits at 90s. A timeout in these suites is a last-resort hang detector, not a performance assertion, so the budget no longer varies by platform: 90s for end-to-end installs, 30s for CLI probes.

Verified locally: `repair.test.js` 11/11, `uninstall.test.js` 3/3, `install-ps1.test.js` 10/10, `mesh-events-inject.test.js` 9/9.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies subprocess timeouts across platforms to prevent flaky test failures on busy Linux runners. Non-Windows full-install timeouts go from 10s to 90s; CLI probes from 10s to 30s. These timeouts act as hang detectors, not performance checks.

- Set `FULL_INSTALL_TIMEOUT_MS` to 90000 and `CLI_TIMEOUT_MS` to 30000 for all platforms in `tests/fixtures/subprocess-timeouts.js`.
- Removes mute “1 !== 0” failures from killed subprocesses in `install-ps1.test.js` on hosted Ubuntu (cold `pwsh` start + dry-run plan exceeded 10s).
- Side effect: true hangs on non-Windows may take longer to surface; budgets now match the Windows lane.

<sup>Written for commit e7f7360ad9579150fcfffe530111430436b4f435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

