### PR TITLE
chore(ci): group github-actions bumps into one weekly Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,10 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      # One PR per weekly sweep: actions that must move in lockstep (the
+      # codeql-action init/analyze pair refuses mixed versions) otherwise
+      # arrive as separate PRs that each fail their own CI.
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Actions that must move in lockstep (the codeql-action `init`/`analyze` pair refuses mixed versions) were arriving as separate Dependabot PRs that each failed their own CI: #1317 and #1318 both died on `Loaded a configuration file for version '4.37.6', but running version '4.37.7'` and had to be superseded by a manual combined bump (#1320).

With a `groups` entry on the `github-actions` ecosystem, the weekly sweep arrives as one PR, keeping paired actions consistent in every intermediate state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups all `github-actions` Dependabot updates into a single weekly PR to keep lockstep actions (e.g., `github/codeql-action` `init`/`analyze`) on matching versions and avoid CI failures from mixed versions. Old: multiple PRs per action often failed when versions diverged. New: one grouped PR per weekly run keeps paired actions consistent.

- Adds `groups.github-actions.patterns: ["*"]` under the `github-actions` ecosystem in `.github/dependabot.yml`.
- Expect one weekly grouped PR covering all actions; if any action breaks CI, the group will fail as a unit and can be temporarily narrowed if needed.

<sup>Written for commit d51773db0267e0e129bf3e71bcaa2a9803b20e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

