### PR TITLE
test(install): lock the clean-environment detection gating

### DIFF
--- a/tests/scripts/clean-environment-gating.test.js
+++ b/tests/scripts/clean-environment-gating.test.js
@@ -49,10 +49,18 @@ function runWithSyntheticHome(scriptPath, args, homeDir, cwd) {
       PATH: RESTRICTED_PATH,
     },
   });
+  // A timed-out subprocess has a null status and (usually) an empty stderr;
+  // folding that into a bare exit 1 would make the assertion failure mute,
+  // the exact failure shape that hid today's CI flake. Name the hang.
+  const timedOut = result.error?.code === 'ETIMEDOUT'
+    || (result.status === null && result.signal !== null);
+  const stderr = timedOut
+    ? `subprocess timed out after ${FULL_INSTALL_TIMEOUT_MS}ms (${result.signal || result.error?.code})\n${result.stderr || ''}`
+    : (result.stderr || '');
   return {
     code: result.status ?? 1,
     stdout: result.stdout || '',
-    stderr: result.stderr || '',
+    stderr,
   };
 }
 

--- a/tests/scripts/clean-environment-gating.test.js
+++ b/tests/scripts/clean-environment-gating.test.js
@@ -1,0 +1,154 @@
+/**
+ * Locks the clean-environment detection contract proven by hand on
+ * 2026-08-19 (synthetic-HOME matrix plus a virgin docker container):
+ * EGC only ever touches harnesses that actually exist on the machine.
+ *
+ * - The cognitive bootstrap creates NOTHING in an empty home, and only the
+ *   detected harness's context file when exactly one tool is present.
+ * - An explicit install for an absent tool warns loudly instead of
+ *   installing silently (adapter.validate() detection warning).
+ *
+ * PATH is pinned to /usr/bin:/bin in every subprocess so commandExists()
+ * probes cannot see tools installed on the developer machine: the gates
+ * must decide from the synthetic HOME alone (on Windows the pinned POSIX
+ * PATH simply resolves nothing, which is exactly the point).
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { FULL_INSTALL_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const BOOTSTRAP_SCRIPT = path.join(REPO_ROOT, 'scripts', 'bootstrap-cognitive.js');
+const INSTALL_SCRIPT = path.join(REPO_ROOT, 'scripts', 'install-apply.js');
+const RESTRICTED_PATH = '/usr/bin:/bin';
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function runWithSyntheticHome(scriptPath, args, homeDir, cwd) {
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: cwd || homeDir,
+    encoding: 'utf8',
+    timeout: FULL_INSTALL_TIMEOUT_MS,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      PATH: RESTRICTED_PATH,
+    },
+  });
+  return {
+    code: result.status ?? 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function listHomeEntries(homeDir) {
+  return fs.readdirSync(homeDir).sort((a, b) => a.localeCompare(b));
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing clean-environment detection gating ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('cognitive bootstrap creates nothing in an empty home', () => {
+    const homeDir = createTempDir('clean-env-empty-');
+
+    try {
+      const result = runWithSyntheticHome(BOOTSTRAP_SCRIPT, [], homeDir);
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.deepStrictEqual(
+        listHomeEntries(homeDir),
+        [],
+        'an empty home must stay empty: no harness may be conjured'
+      );
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('cognitive bootstrap touches only the one detected harness', () => {
+    const homeDir = createTempDir('clean-env-claude-');
+
+    try {
+      fs.mkdirSync(path.join(homeDir, '.claude'));
+      const result = runWithSyntheticHome(BOOTSTRAP_SCRIPT, [], homeDir);
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.deepStrictEqual(
+        listHomeEntries(homeDir),
+        ['.claude'],
+        'only the detected harness directory may exist afterwards'
+      );
+      const protocolFile = path.join(homeDir, '.claude', 'CLAUDE.md');
+      assert.ok(fs.existsSync(protocolFile), 'the detected harness receives its protocol file');
+      assert.ok(
+        fs.readFileSync(protocolFile, 'utf8').includes('egc-memory-protocol'),
+        'the written file carries the versioned protocol marker'
+      );
+    } finally {
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('an explicit install for an absent tool warns instead of installing silently', () => {
+    const homeDir = createTempDir('clean-env-absent-tool-');
+    const projectRoot = createTempDir('clean-env-project-');
+
+    try {
+      const result = runWithSyntheticHome(
+        INSTALL_SCRIPT,
+        ['--target', 'kiro', '--profile', 'core', '--dry-run'],
+        homeDir,
+        projectRoot
+      );
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(
+        result.stdout.includes('does not appear to be installed'),
+        'the plan must carry the tool-not-detected warning'
+      );
+      assert.deepStrictEqual(
+        listHomeEntries(homeDir),
+        [],
+        'a dry-run plan must not write anything into the home'
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
Locks the clean-environment contract verified today in two live audits: a synthetic-HOME matrix on this machine and a genuinely virgin `node:20-slim` container installing `@egchq/egc@1.1.20` from the registry (result: only `~/.egc` and the npm cache were created; zero ghost harnesses).

Three permanent assertions, all green locally:
- the cognitive bootstrap creates **nothing** in an empty home;
- with exactly one tool present (`~/.claude`), only that harness receives its protocol file;
- `install-apply --target kiro --dry-run` on a machine without Kiro carries the `does not appear to be installed` detection warning and writes nothing.

Subprocesses pin `PATH=/usr/bin:/bin` so `commandExists` probes cannot see tools installed on the developer machine: the gates must decide from the synthetic HOME alone (on Windows the pinned POSIX PATH resolves nothing, which is the point).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks clean-environment detection with a new test suite so bootstrap and installs only act on detected harnesses and never write to an empty HOME. Also surfaces subprocess timeouts to make CI hangs diagnosable.

- Cognitive bootstrap: does nothing in an empty HOME; with only ~/.claude, writes only CLAUDE.md containing the protocol marker.
- Install: running install-apply --target kiro --profile core --dry-run for an absent tool exits 0, includes the “does not appear to be installed” warning, and writes nothing.
- Subprocesses pin PATH to /usr/bin:/bin so detection relies only on the synthetic HOME (on Windows, this PATH resolves nothing by design).
- Timeout diagnostics: the helper prefixes stderr with the timeout duration and signal when a subprocess hangs, avoiding mute failures.
- Test-only; no runtime code changes.

<sup>Written for commit 78bd40ab7186f847a3ee92b1864b175c8544fe52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

