### PR TITLE
feat(install): confirm before installing an undetected target

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -221,6 +221,16 @@ function promptYesNo(question) {
   return answer === 'y' || answer === 'yes';
 }
 
+// Strips already-surfaced not-detected issues from BOTH plan shapes: the
+// flattened warning strings printHumanPlan() renders, and the structured
+// validationIssues the --json output embeds verbatim. Missing either one
+// leaves the issue visible through the shape this call site does not touch.
+function silenceUndetectedIssues(plan, issues) {
+  const silenced = new Set(issues.map(issue => issue.message));
+  plan.warnings = (plan.warnings || []).filter(warning => !silenced.has(warning));
+  plan.validationIssues = (plan.validationIssues || []).filter(issue => !silenced.has(issue.message));
+}
+
 // The detection ladder for a target whose tool is absent from this machine:
 // --require-detected refuses outright (strict automation); --allow-undetected
 // installs silently (deliberate provisioning); a human at a real terminal is
@@ -237,8 +247,7 @@ function enforceTargetDetection(plan, options) {
   }
 
   if (options.allowUndetected) {
-    const silenced = new Set(issues.map(issue => issue.message));
-    plan.warnings = (plan.warnings || []).filter(warning => !silenced.has(warning));
+    silenceUndetectedIssues(plan, issues);
     return;
   }
 
@@ -248,6 +257,9 @@ function enforceTargetDetection(plan, options) {
       console.log('Aborted: the target tool was not detected and installation was declined.');
       process.exit(1);
     }
+    // Already shown above as part of the prompt: printHumanPlan() must not
+    // repeat it a second time under "Warnings:" once the user said yes.
+    silenceUndetectedIssues(plan, issues);
   }
 }
 

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -6,6 +6,7 @@
  * target-specific mutation logic into testable Node code.
  */
 
+const fs = require('node:fs');
 const os = require('node:os');
 
 
@@ -45,6 +46,12 @@ Options:
   --config <path>     Load install intent from egc-install.json
   --dry-run    Show the install plan without copying files
   --json       Emit machine-readable plan/result JSON
+  --require-detected
+               Fail instead of installing when the target tool is not
+               detected on this machine (strict automation)
+  --allow-undetected
+               Skip the not-detected warning and prompt entirely
+               (deliberate provisioning before the tool is installed)
   --help       Show this help text
 
 Available languages:
@@ -191,6 +198,59 @@ function regenerateTopologyCache() {
   }
 }
 
+const UNDETECTED_ISSUE_CODE = 'ide-not-detected';
+
+function undetectedTargetIssues(plan) {
+  return (plan.validationIssues || []).filter(issue => issue.code === UNDETECTED_ISSUE_CODE);
+}
+
+// Reads one line from the terminal, synchronously. The caller only reaches
+// this when stdin AND stdout are real TTYs, so this can never hang a pipe:
+// a prompt reading from a dead pipe is exactly the 1.1.17 doctor regression
+// this guard exists to never repeat.
+function promptYesNo(question) {
+  process.stdout.write(question);
+  const buffer = Buffer.alloc(256);
+  let bytesRead;
+  try {
+    bytesRead = fs.readSync(0, buffer, 0, buffer.length);
+  } catch (_error) { // NOSONAR: an unreadable stdin answers the safe default, no
+    return false;
+  }
+  const answer = buffer.toString('utf8', 0, bytesRead).trim().toLowerCase();
+  return answer === 'y' || answer === 'yes';
+}
+
+// The detection ladder for a target whose tool is absent from this machine:
+// --require-detected refuses outright (strict automation); --allow-undetected
+// installs silently (deliberate provisioning); a human at a real terminal is
+// asked once, defaulting to No; and a non-interactive run keeps the historic
+// behavior, warn and proceed, so no existing script changes behavior.
+function enforceTargetDetection(plan, options) {
+  const issues = undetectedTargetIssues(plan);
+  if (issues.length === 0) {
+    return;
+  }
+
+  if (options.requireDetected) {
+    throw new Error(`--require-detected: ${issues[0].message.split('\n')[0]}`);
+  }
+
+  if (options.allowUndetected) {
+    const silenced = new Set(issues.map(issue => issue.message));
+    plan.warnings = (plan.warnings || []).filter(warning => !silenced.has(warning));
+    return;
+  }
+
+  if (!options.dryRun && !options.json && process.stdin.isTTY && process.stdout.isTTY) {
+    console.log(`\n${issues[0].message}`);
+    if (!promptYesNo('Install anyway? [y/N] ')) {
+      console.log('Aborted: the target tool was not detected and installation was declined.');
+      process.exit(1);
+    }
+  }
+}
+
 function main() {
   try {
     const options = parseInstallArgs(process.argv);
@@ -220,6 +280,8 @@ function main() {
       homeDir: process.env.HOME || process.env.USERPROFILE || os.homedir(),
       claudeRulesDir: process.env.GEMINI_RULES_DIR || null,
     });
+
+    enforceTargetDetection(plan, options);
 
     if (options.dryRun) {
       if (options.json) {

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -695,6 +695,10 @@ function dedupeCopyFileDestinations(operations, nativeRootRelativePath) {
   return result;
 }
 
+function toValidationIssueArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
 function createManifestInstallPlan(options = {}) {
   const sourceRoot = options.sourceRoot || getSourceRoot();
   const projectRoot = options.projectRoot || process.cwd();
@@ -780,6 +784,10 @@ function createManifestInstallPlan(options = {}) {
     targetRoot: plan.targetRoot,
     installRoot: plan.targetRoot,
     installStatePath: plan.installStatePath,
+    // The structured issues ride along untouched: the CLI's detection gate
+    // needs the machine-readable code (ide-not-detected), not just the
+    // flattened warning strings below.
+    validationIssues: toValidationIssueArray(plan.validationIssues),
     warnings: [
       ...(Array.isArray(options.warnings) ? options.warnings : []),
       ...(Array.isArray(plan.validationIssues)

--- a/scripts/lib/install/request.js
+++ b/scripts/lib/install/request.js
@@ -44,6 +44,8 @@ const ARG_HANDLERS = {
   '--without':  (parsed, args, i) => applyWithoutComponent(parsed, args, i),
   '--dry-run':  (parsed) => { parsed.dryRun = true; return 0; },
   '--json':     (parsed) => { parsed.json = true; return 0; },
+  '--require-detected': (parsed) => { parsed.requireDetected = true; return 0; },
+  '--allow-undetected': (parsed) => { parsed.allowUndetected = true; return 0; },
   '--help':     (parsed) => { parsed.help = true; return 0; },
   '-h':         (parsed) => { parsed.help = true; return 0; },
 };
@@ -55,6 +57,8 @@ function parseInstallArgs(argv) {
     dryRun: false,
     json: false,
     help: false,
+    requireDetected: false,
+    allowUndetected: false,
     configPath: null,
     profileId: null,
     moduleIds: [],
@@ -74,6 +78,10 @@ function parseInstallArgs(argv) {
     } else {
       parsed.languages.push(arg);
     }
+  }
+
+  if (parsed.requireDetected && parsed.allowUndetected) {
+    throw new Error('--require-detected and --allow-undetected are mutually exclusive');
   }
 
   return parsed;

--- a/tests/scripts/clean-environment-gating.test.js
+++ b/tests/scripts/clean-environment-gating.test.js
@@ -127,6 +127,58 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('--require-detected fails fast for an absent tool and writes nothing', () => {
+    const homeDir = createTempDir('clean-env-require-');
+    const projectRoot = createTempDir('clean-env-require-project-');
+
+    try {
+      const result = runWithSyntheticHome(
+        INSTALL_SCRIPT,
+        ['--target', 'kiro', '--profile', 'core', '--require-detected'],
+        homeDir,
+        projectRoot
+      );
+
+      assert.strictEqual(result.code, 1, 'strict automation must refuse an undetected target');
+      assert.ok(
+        result.stderr.includes('--require-detected'),
+        `the refusal must name the flag: ${result.stderr}`
+      );
+      assert.deepStrictEqual(
+        listHomeEntries(homeDir),
+        [],
+        'a refused install must not write anything into the home'
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('--allow-undetected proceeds without the detection warning', () => {
+    const homeDir = createTempDir('clean-env-allow-');
+    const projectRoot = createTempDir('clean-env-allow-project-');
+
+    try {
+      const result = runWithSyntheticHome(
+        INSTALL_SCRIPT,
+        ['--target', 'kiro', '--profile', 'core', '--dry-run', '--allow-undetected'],
+        homeDir,
+        projectRoot
+      );
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('Dry-run install plan'), 'the plan must still print');
+      assert.ok(
+        !result.stdout.includes('does not appear to be installed'),
+        'deliberate provisioning must not carry the detection warning'
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('an explicit install for an absent tool warns instead of installing silently', () => {
     const homeDir = createTempDir('clean-env-absent-tool-');
     const projectRoot = createTempDir('clean-env-project-');

--- a/tests/scripts/clean-environment-gating.test.js
+++ b/tests/scripts/clean-environment-gating.test.js
@@ -179,6 +179,31 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('--allow-undetected --json omits the issue from machine-readable output too', () => {
+    const homeDir = createTempDir('clean-env-allow-json-');
+    const projectRoot = createTempDir('clean-env-allow-json-project-');
+
+    try {
+      const result = runWithSyntheticHome(
+        INSTALL_SCRIPT,
+        ['--target', 'kiro', '--profile', 'core', '--dry-run', '--json', '--allow-undetected'],
+        homeDir,
+        projectRoot
+      );
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      const rawJson = JSON.stringify(parsed);
+      assert.ok(
+        !rawJson.includes('ide-not-detected') && !rawJson.includes('does not appear to be installed'),
+        `structured plan.validationIssues must be silenced too, not just the flattened warnings: ${rawJson}`
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('an explicit install for an absent tool warns instead of installing silently', () => {
     const homeDir = createTempDir('clean-env-absent-tool-');
     const projectRoot = createTempDir('clean-env-project-');


### PR DESCRIPTION
## Summary

`egc install --target X` for a tool not detected on this machine already carried an actionable warning (`ide-not-detected`, since #113), but always proceeded and wrote files regardless of context. A typo'd `--target` (or a target picked from muscle memory) silently created a stray config directory, and there was no way to make automation refuse a mismatched target outright.

## Changes

The detection ladder for an undetected target, in order:

- `--require-detected` refuses outright (exit 1) before writing anything, for strict automation that wants to fail loud on a mismatched target.
- `--allow-undetected` installs silently with the warning suppressed, for deliberate provisioning of a tool ahead of the machine actually having it (dotfiles, container images).
- a human at a **real interactive terminal** (stdin AND stdout are TTYs) is asked once, defaulting to No on Enter or an unreadable prompt.
- everything else, scripts, CI, pipes, keeps the exact historic behavior: warn and proceed. No existing automation changes behavior.

The prompt reads a single line synchronously and only ever runs behind the TTY check, so a dead pipe can never hang it, the same regression class the doctor bug once stuck the install on 1.1.17 (#1228) came from. Detection stays on the single source of truth already used for the warning (`adapter.validate()`'s `ide-not-detected` issue), not a second lookup that could drift.

## Testing

- Two new cases in `tests/scripts/clean-environment-gating.test.js` (merged in #1323, whose synthetic-HOME + pinned-PATH harness this reuses): `--require-detected` refuses and writes nothing; `--allow-undetected` proceeds without the warning.
- Existing suites touching this path stay green: `install-request.test.js` 7/7, `selective-install.test.js` 41/41, `dashboard-ops.test.js` 33/33, `repair.test.js` 11/11, `egc.test.js` 20/20, `install-ps1.test.js` 10/10, `clean-environment-gating.test.js` 5/5.
- `eslint` clean on the changed files (the two complexity warnings in `install-executor.js` and `install/request.js` are pre-existing on `main`, unchanged by this diff).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Confirm before installing an undetected target and add flags to enforce or bypass detection. This prevents stray installs from typos and gives automation a strict-fail option without changing non-interactive defaults.

- Behavior change for undetected targets: old behavior warned and proceeded; new behavior: `--require-detected` exits 1 before writing; `--allow-undetected` proceeds and suppresses the warning in both human and `--json` output; interactive TTY prompts once (default No; disabled under `--dry-run` and `--json`); non-interactive runs keep warn-and-proceed.
- Reviewer notes: gate uses `validationIssues` with code `ide-not-detected`; plan now carries structured `validationIssues`; `silenceUndetectedIssues()` removes the detection warning from both `plan.warnings` and `plan.validationIssues` (also after an interactive Yes); `--require-detected` and `--allow-undetected` are mutually exclusive; prompt reads one line synchronously and only when stdin and stdout are TTYs.
- Tests: add clean-environment cases for `--require-detected` refusing and writing nothing and for `--allow-undetected` suppressing the warning, including under `--json`; existing install-path tests remain green.

<sup>Written for commit cb1cbda37c78a45966698219f355e0b5a0cf7c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

