### PR TITLE
fix(tests): give the InsAIts monitor test the shared subprocess budget

### DIFF
--- a/tests/hooks/insaits-security-monitor.test.js
+++ b/tests/hooks/insaits-security-monitor.test.js
@@ -10,13 +10,19 @@ const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
+const { FULL_INSTALL_TIMEOUT_MS, CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
+
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'insaits-security-monitor.py');
-const MONITOR_TIMEOUT_MS = 30000;
+// A monitor run pays a cold interpreter start plus the SDK import; on a busy
+// Windows runner the first run overran a private 30s budget and surfaced as
+// spawnSync ETIMEDOUT (2026-09-03, PR #1334). Same doctrine as the shared
+// fixture: a timeout here is a hang detector, not a performance assertion,
+// so both budgets come from there instead of a platform split.
+const MONITOR_TIMEOUT_MS = FULL_INSTALL_TIMEOUT_MS;
 // Probing `python --version` pays the same cold interpreter start the monitor
-// itself does, which on Windows regularly costs more than a few seconds. A
-// budget too small here reports "no Python on this machine" and the suite
-// fails with spawnSync ETIMEDOUT instead of skipping or running.
-const PYTHON_PROBE_TIMEOUT_MS = process.platform === 'win32' ? 20000 : 5000;
+// itself does. A budget too small here reports "no Python on this machine"
+// and the suite fails with spawnSync ETIMEDOUT instead of skipping or running.
+const PYTHON_PROBE_TIMEOUT_MS = CLI_TIMEOUT_MS;
 
 function createTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'insaits-monitor-'));


### PR DESCRIPTION
## Why

The Windows yarn lane on #1334 failed a single test out of 3783: `hooks/insaits-security-monitor.test.js` reported `spawnSync python3 ETIMEDOUT` on "clean scan exits 0", the first monitor run of the file. That run pays a cold interpreter start plus the SDK import, and on a busy runner it overran the file's private 30s budget; the killed subprocess then surfaced as a mute `null !== 0` failure.

## What

Both budgets in the test now come from `tests/fixtures/subprocess-timeouts.js` instead of private constants: the monitor run uses the full-install budget (90s) and the interpreter probe the CLI budget (30s), with no platform split. Same doctrine as #1321: a timeout is a hang detector, not a performance assertion.

## Verification

- `node tests/hooks/insaits-security-monitor.test.js`: 5 passed, 0 failed
- Lint clean on the changed file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the InsAIts monitor test flakiness on Windows by replacing private timeout constants with shared budgets from `tests/fixtures/subprocess-timeouts.js`. The monitor run now uses the full-install budget (90s) and the interpreter probe uses the CLI budget (30s), so a busy runner no longer kills the subprocess and surfaces a misleading `null !== 0` failure.

<sup>Written for commit 6d165723acc95039dc5e628b41ecb2fbf30a787a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

