### PR TITLE
fix(install): keep GateGuard and Guardian side by side on Windsurf pre_run_command

### DIFF
--- a/scripts/lib/flat-hooks-json-merge.js
+++ b/scripts/lib/flat-hooks-json-merge.js
@@ -49,14 +49,31 @@ function isEgcEntry(entry, command) {
   return isPlainObject(entry) && entry.command === command;
 }
 
+// The script a hook command runs: the last quoted argument of the
+// `"node" "script"` shape buildHookCommand emits, or the last bare token of
+// a hand-written command. Split on both separators so an entry written on
+// Windows still resolves when the same file is inspected under POSIX.
+function commandScriptBasename(command) {
+  const quoted = /"([^"]+)"\s*$/.exec(command);
+  const scriptPath = quoted ? quoted[1] : command.trim().split(/\s+/).pop();
+  return scriptPath.split(/[\\/]/).pop();
+}
+
 // isOwnBasename: (command: string) => boolean, lets each host decide which
 // basenames identify ITS OWN managed adapter scripts (Windsurf has two:
 // GateGuard + Guardian; Cursor has one: Guardian only).
+//
+// A stale entry is the SAME script registered at a different install path,
+// so the basename has to match as well. Treating any host-owned entry as
+// stale let the two Windsurf scripts that share pre_run_command migrate
+// each other away: whichever applied last replaced the other, every repair
+// swapped them back, and doctor reported hooks.json as drifted forever.
 function isStaleEgcEntry(entry, command, isOwnBasename) {
   if (!isPlainObject(entry) || typeof entry.command !== 'string' || entry.command === command) {
     return false;
   }
-  return isOwnBasename(entry.command);
+  const basename = commandScriptBasename(command);
+  return Boolean(basename) && isOwnBasename(entry.command) && entry.command.includes(basename);
 }
 
 // buildExtraTopLevel: (base: object) => object, merged into the result

--- a/scripts/lib/flat-hooks-json-merge.js
+++ b/scripts/lib/flat-hooks-json-merge.js
@@ -73,7 +73,7 @@ function isStaleEgcEntry(entry, command, isOwnBasename) {
     return false;
   }
   const basename = commandScriptBasename(command);
-  return Boolean(basename) && isOwnBasename(entry.command) && entry.command.includes(basename);
+  return Boolean(basename) && isOwnBasename(entry.command) && commandScriptBasename(entry.command) === basename;
 }
 
 // buildExtraTopLevel: (base: object) => object, merged into the result

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -34,9 +34,11 @@ const {
   mergeSkillIndexEntry,
 } = require('../../scripts/lib/warp-agents-merge');
 const {
+  ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
   GUARDIAN_ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
   PRE_RUN_COMMAND_EVENT,
   applyWindsurfGateGuardHookToFile,
+  resolveAdapterScriptDestination,
   resolveGuardianAdapterScriptDestination,
   resolveHooksJsonPath,
 } = require('../../scripts/lib/windsurf-gateguard-hooks');
@@ -181,6 +183,36 @@ function writeWindsurfGuardianHookState(homeDir, options = {}) {
   if (options.existingHooks) {
     fs.writeFileSync(hooksJsonPath, JSON.stringify(options.existingHooks, null, 2));
   }
+  // Mirrors the real adapter plan order: GateGuard registers on
+  // pre_run_command before the Guardian does.
+  const gateGuardOperations = [];
+  const gateGuardAdapterScriptPath = resolveAdapterScriptDestination(targetRoot);
+  if (options.withGateGuard) {
+    fs.copyFileSync(path.join(REPO_ROOT, ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH), gateGuardAdapterScriptPath);
+    applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, gateGuardAdapterScriptPath);
+    gateGuardOperations.push(
+      {
+        kind: 'copy-file',
+        moduleId: 'claude-gateguard-fact-force-hook',
+        sourceRelativePath: ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+        destinationPath: gateGuardAdapterScriptPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      },
+      {
+        kind: 'merge-claude-settings-hooks',
+        moduleId: 'claude-gateguard-fact-force-hook',
+        sourceRelativePath: ADAPTER_SCRIPT_SOURCE_RELATIVE_PATH,
+        destinationPath: hooksJsonPath,
+        strategy: 'merge-claude-settings-hooks',
+        ownership: 'managed',
+        scaffoldOnly: false,
+        hookEvent: PRE_RUN_COMMAND_EVENT,
+        hookScriptPath: gateGuardAdapterScriptPath,
+      }
+    );
+  }
   applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, guardianAdapterScriptPath);
 
   writeState(installStatePath, {
@@ -200,6 +232,7 @@ function writeWindsurfGuardianHookState(homeDir, options = {}) {
       skippedModules: [],
     },
     operations: [
+      ...gateGuardOperations,
       {
         kind: 'copy-file',
         moduleId: 'egc-bash-guardian-hook',
@@ -228,7 +261,7 @@ function writeWindsurfGuardianHookState(homeDir, options = {}) {
     },
   });
 
-  return { targetRoot, installStatePath, hooksJsonPath, guardianAdapterScriptPath };
+  return { targetRoot, installStatePath, hooksJsonPath, guardianAdapterScriptPath, gateGuardAdapterScriptPath };
 }
 
 function managedOperation(kind, destinationPath, overrides = {}) {
@@ -2202,6 +2235,65 @@ function runTests() {
       assert.strictEqual(hooksConfig.hooks.pre_run_command[0].command, 'echo third-party');
       assert.ok(hooksConfig.hooks.pre_run_command[1].command.includes(installed.guardianAdapterScriptPath));
       assert.strictEqual(hooksConfig.hooks.SessionStart, undefined, 'must never inject a Claude-schema SessionStart group into a Windsurf hooks.json');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  // GateGuard and Guardian both register on pre_run_command. Until
+  // flat-hooks-json-merge.js matched the script basename before migrating a
+  // stale entry, the Guardian merge replaced the GateGuard entry, so a fresh
+  // install reported hooks.json as drifted and repair only swapped the two
+  // entries back and forth without ever converging.
+  if (test('doctor accepts GateGuard and Guardian side by side on Windsurf pre_run_command and repair leaves them alone', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeWindsurfGuardianHookState(homeDir, { withGateGuard: true });
+
+      const commandsOf = () => JSON.parse(fs.readFileSync(installed.hooksJsonPath, 'utf8'))
+        .hooks[PRE_RUN_COMMAND_EVENT]
+        .map(entry => path.basename(entry.command.replaceAll('"', '')));
+      assert.deepStrictEqual(commandsOf(), ['windsurf-gateguard-adapter.js', 'windsurf-guardian-adapter.js']);
+
+      const report = buildDoctorReport({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(report.results[0].status, 'ok', JSON.stringify(report.results[0].issues));
+
+      const result = repairInstalledStates({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.notStrictEqual(result.results[0].status, 'repaired', 'a healthy dual registration must not be rewritten');
+      assert.deepStrictEqual(commandsOf(), ['windsurf-gateguard-adapter.js', 'windsurf-guardian-adapter.js']);
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair restores a GateGuard pre_run_command entry that the Guardian merge had displaced', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const installed = writeWindsurfGuardianHookState(homeDir, { withGateGuard: true });
+      const guardianOnly = JSON.parse(fs.readFileSync(installed.hooksJsonPath, 'utf8'));
+      guardianOnly.hooks[PRE_RUN_COMMAND_EVENT] = guardianOnly.hooks[PRE_RUN_COMMAND_EVENT]
+        .filter(entry => !entry.command.includes('windsurf-gateguard-adapter.js'));
+      fs.writeFileSync(installed.hooksJsonPath, JSON.stringify(guardianOnly, null, 2));
+
+      let report = buildDoctorReport({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(report.results[0].status, 'warning', 'the displaced GateGuard entry must surface as drift');
+
+      const result = repairInstalledStates({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(result.results[0].status, 'repaired');
+
+      const commands = JSON.parse(fs.readFileSync(installed.hooksJsonPath, 'utf8'))
+        .hooks[PRE_RUN_COMMAND_EVENT]
+        .map(entry => path.basename(entry.command.replaceAll('"', '')));
+      assert.deepStrictEqual(commands.sort(), ['windsurf-gateguard-adapter.js', 'windsurf-guardian-adapter.js'], 'repair must add GateGuard back without dropping the Guardian');
+
+      report = buildDoctorReport({ homeDir, projectRoot, targets: ['windsurf'] });
+      assert.strictEqual(report.results[0].status, 'ok', 'doctor must converge after one repair');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/lib/windsurf-gateguard-hooks.test.js
+++ b/tests/lib/windsurf-gateguard-hooks.test.js
@@ -18,6 +18,7 @@ const {
   PRE_WRITE_CODE_EVENT,
   addWindsurfHookEntry,
   applyWindsurfGateGuardHookToFile,
+  inspectWindsurfGateGuardHookFile,
   resolveAdapterScriptDestination,
   resolveHooksJsonPath,
 } = require('../../scripts/lib/windsurf-gateguard-hooks');
@@ -134,6 +135,79 @@ function runTests() {
       assert.deepStrictEqual(onDisk.hooks.pre_run_command, [{ command: 'bash /user/custom.sh', show_output: true }]);
       assert.strictEqual(onDisk.hooks[PRE_WRITE_CODE_EVENT].length, 1);
       assert.ok(onDisk.hooks[PRE_WRITE_CODE_EVENT][0].command.includes('adapter.js'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  // Windsurf registers two adapter scripts on pre_run_command (GateGuard
+  // first, Guardian after). The stale-entry migration used to treat ANY
+  // host-owned entry as the one being re-registered, so the Guardian merge
+  // replaced the GateGuard entry, every repair swapped them back, and doctor
+  // reported hooks.json as drifted on a healthy install.
+  if (test('addWindsurfHookEntry keeps the GateGuard entry when the Guardian joins the same event', () => {
+    const gateguard = 'node /abs/scripts/hooks/windsurf-gateguard-adapter.js';
+    const guardian = 'node /abs/scripts/hooks/windsurf-guardian-adapter.js';
+    const first = addWindsurfHookEntry({}, PRE_RUN_COMMAND_EVENT, gateguard);
+    const second = addWindsurfHookEntry(first.config, PRE_RUN_COMMAND_EVENT, guardian);
+    assert.strictEqual(second.changed, true);
+    assert.deepStrictEqual(
+      second.config.hooks[PRE_RUN_COMMAND_EVENT].map(entry => entry.command),
+      [gateguard, guardian],
+      'both adapters must coexist on pre_run_command, in registration order'
+    );
+    const third = addWindsurfHookEntry(second.config, PRE_RUN_COMMAND_EVENT, gateguard);
+    assert.strictEqual(third.changed, false, 're-registering GateGuard with the Guardian present must be a no-op, not a swap');
+  })) passed++; else failed++;
+
+  if (test('addWindsurfHookEntry migrates only the stale GateGuard entry when the Guardian shares the event', () => {
+    const guardian = 'node /abs/scripts/hooks/windsurf-guardian-adapter.js';
+    const base = {
+      hooks: {
+        [PRE_RUN_COMMAND_EVENT]: [
+          { command: 'node /old/path/windsurf-gateguard-adapter.js' },
+          { command: guardian },
+        ],
+      },
+    };
+    const { config, changed } = addWindsurfHookEntry(base, PRE_RUN_COMMAND_EVENT, 'node /new/path/windsurf-gateguard-adapter.js');
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(
+      config.hooks[PRE_RUN_COMMAND_EVENT].map(entry => entry.command),
+      ['node /new/path/windsurf-gateguard-adapter.js', guardian]
+    );
+  })) passed++; else failed++;
+
+  if (test('addWindsurfHookEntry recognises a stale entry written with Windows paths and quoting', () => {
+    const base = {
+      hooks: {
+        [PRE_RUN_COMMAND_EVENT]: [
+          { command: '"C:\\node\\node.exe" "C:\\old\\windsurf-gateguard-adapter.js"' },
+          { command: '"C:\\node\\node.exe" "C:\\old\\windsurf-guardian-adapter.js"' },
+        ],
+      },
+    };
+    const next = '"C:\\node\\node.exe" "C:\\new\\windsurf-guardian-adapter.js"';
+    const { config, changed } = addWindsurfHookEntry(base, PRE_RUN_COMMAND_EVENT, next);
+    assert.strictEqual(changed, true);
+    assert.deepStrictEqual(
+      config.hooks[PRE_RUN_COMMAND_EVENT].map(entry => entry.command),
+      ['"C:\\node\\node.exe" "C:\\old\\windsurf-gateguard-adapter.js"', next]
+    );
+  })) passed++; else failed++;
+
+  if (test('applyWindsurfGateGuardHookToFile leaves both adapters inspectable as ok on pre_run_command', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'windsurf-hooks-coexist-'));
+    const hooksJsonPath = path.join(tempDir, 'hooks.json');
+    try {
+      applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, '/abs/windsurf-gateguard-adapter.js');
+      applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, '/abs/windsurf-guardian-adapter.js');
+      assert.strictEqual(inspectWindsurfGateGuardHookFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, '/abs/windsurf-gateguard-adapter.js'), 'ok');
+      assert.strictEqual(inspectWindsurfGateGuardHookFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, '/abs/windsurf-guardian-adapter.js'), 'ok');
+      const onDisk = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
+      assert.strictEqual(onDisk.hooks[PRE_RUN_COMMAND_EVENT].length, 2);
+      const again = applyWindsurfGateGuardHookToFile(hooksJsonPath, PRE_RUN_COMMAND_EVENT, '/abs/windsurf-gateguard-adapter.js');
+      assert.strictEqual(again.changed, false, 'a repair pass over a healthy file must not rewrite it');
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Why

`egc doctor` reports `windsurf-home` as drifted (`1 managed file(s) differ from the source repo`, path `hooks.json`) on a healthy, freshly installed machine, and `egc repair` never converges. Reproduced end to end on a synthetic HOME with both the published 1.1.20 package and current main.

Root cause: Windsurf registers two adapter scripts on `pre_run_command` (GateGuard first, then the Guardian). The flat hooks.json merge treated any host-owned entry as the stale version of the script being registered, so the Guardian merge migrated the GateGuard entry away instead of appending. Doctor then flagged the missing GateGuard entry, repair re-added it (displacing the Guardian), and the next doctor flagged the Guardian, forever.

## What

`isStaleEgcEntry` now requires the existing entry to carry the same script basename as the incoming command before migrating it in place. Cursor, Kiro and Amazon Q register a single script each, so their behavior is unchanged (their suites pass untouched).

## Verification

- New regression tests in `tests/lib/windsurf-gateguard-hooks.test.js` (coexistence, no ping-pong, stale migration of the right script only, Windows quoting) and `tests/lib/install-lifecycle.test.js` (doctor accepts both entries, repair leaves them alone, repair restores a displaced GateGuard and converges). All five fail on main without the fix and pass with it.
- Synthetic HOME, main + this fix: fresh `install-apply --target windsurf` followed by `doctor` reports OK; on a HOME installed before the fix, one `repair` pass restores the GateGuard entry and `doctor` goes OK.
- Full local suite: 4387 passed, 0 failed.
- Lint clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windsurf hooks merge so GateGuard and Guardian adapters coexist on `pre_run_command` instead of replacing each other. Previously `egc doctor` flagged a healthy install as drifted and `egc repair` swapped the two entries forever; now stale entries only migrate when both commands parse to the same script basename, avoiding substring collisions.

**Bug Fixes**
- `isStaleEgcEntry` parses both commands and compares script basenames before migrating an entry in place.
- Cursor, Kiro, and Amazon Q are unaffected since they each register a single script.

<sup>Written for commit 34a85de3ae7301ac6f00a3ecdcf2c9bc95abc088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

