### PR TITLE
fix(doctor): print the state-db consolidation hint as an absolute path

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -8,6 +8,11 @@ const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { getEGCDir, getKnownHarnessDirs } = require('./lib/utils');
 const { parseTargetArgs } = require('./lib/cli-target-args');
 
+// Printed as an absolute path: the hint is read from wherever the person ran
+// egc doctor (a project folder, a global npm install on Windows), and a
+// repo-relative command only works from the package root (#1292).
+const CONSOLIDATE_SCRIPT = path.join(__dirname, 'maintenance', 'merge-fragmented-state-dbs.js');
+
 function showHelp(exitCode = 0) {
   console.log(`
 Usage: node scripts/doctor.js [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--repo-root <path>] [--json]
@@ -174,7 +179,7 @@ function main() {
           console.log(`    ${stateDb.dbPath}`);
           console.log('  It belongs in the shared ~/.egc store; in a harness directory its');
           console.log('  history is invisible to the rest of EGC. Consolidate it with:');
-          console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
+          console.log(`    node "${CONSOLIDATE_SCRIPT}"`);
         }
         if (stateDb.fragments.length > 0) {
           const plural = stateDb.fragments.length === 1 ? 'copy' : 'copies';
@@ -184,7 +189,7 @@ function main() {
           }
           console.log('  Nothing is lost, but new sessions no longer write there. Consolidate');
           console.log('  them into the main store (dry-run by default) with:');
-          console.log('    node scripts/maintenance/merge-fragmented-state-dbs.js');
+          console.log(`    node "${CONSOLIDATE_SCRIPT}"`);
         }
         if (stateDb.hasHarnessDb && !stateDb.hasMemoryDb) {
           // "Nothing to do." only when no warning printed above it in this

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -667,7 +667,8 @@ function runTests() {
       assert.ok(result.stdout.includes('State store:'));
       assert.ok(result.stdout.includes('1 stray state.db copy'));
       assert.ok(result.stdout.includes(strayPath));
-      assert.ok(result.stdout.includes('merge-fragmented-state-dbs.js'), 'must point at the consolidation script');
+      const consolidateScript = path.join(__dirname, '..', '..', 'scripts', 'maintenance', 'merge-fragmented-state-dbs.js');
+      assert.ok(result.stdout.includes(`node "${consolidateScript}"`), 'must point at the consolidation script by absolute path, runnable from any cwd');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);


### PR DESCRIPTION
## Why

The stray `state.db` and misplaced-store warnings in `egc doctor` end with `node scripts/maintenance/merge-fragmented-state-dbs.js`, a repo-relative command that only works when the current directory is the package root. On a global npm install (the Windows report in #1292 ran doctor from a project folder under `AppData\Roaming\npm\node_modules\@egchq\egc`) the hint points nowhere.

## What

The hint now prints the absolute path of the script that sits next to the running `doctor.js`, quoted, so it can be pasted from any directory on any platform. No behavior change beyond the printed text.

## Verification

- `tests/scripts/doctor.test.js` now asserts the absolute, quoted path (19 passed, 0 failed)
- Lint clean on the changed files (pre-existing complexity warnings only)

## Credit

Reported by @Akisolu in the v1.1.20 Windows upgrade mission (#1292).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `egc doctor`'s state-db consolidation hint so it prints the absolute path to the consolidation script instead of a repo-relative command, which pointed nowhere when doctor was run from a global npm install on Windows (#1292). The hint is quoted so it can be pasted from any directory; no behavior changes beyond the printed text.

<sup>Written for commit 39d4579107482950043bdd3a859b7fe1916ca897. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

