### PR TITLE
refactor: finish the quality sweep in the container scrubber and the installers

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -214,7 +214,7 @@ if (-not $DryRun) {
     # egc-guardian
     Write-Host "  building egc-guardian..."
     $GuardianDir = Join-Path (Join-Path (Join-Path $RootDir "mcp") "servers") "egc-guardian"
-    if (-Not (Test-Path $GuardianDir)) {
+    if (-not (Test-Path $GuardianDir)) {
         Write-Error "Not found: $GuardianDir"
         exit 1
     }
@@ -229,7 +229,7 @@ if (-not $DryRun) {
     # egc-memory
     Write-Host "  building egc-memory..."
     $MemoryDir = Join-Path (Join-Path (Join-Path $RootDir "mcp") "servers") "egc-memory"
-    if (-Not (Test-Path $MemoryDir)) {
+    if (-not (Test-Path $MemoryDir)) {
         Write-Error "Not found: $MemoryDir"
         exit 1
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,7 +53,7 @@ install_deps() {
 }
 
 # Forward --help directly to the Node installer
-if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+if [[ "$1" = "--help" || "$1" = "-h" ]]; then
   node "$ROOT_DIR/scripts/install-apply.js" "$@"
   exit $?
 fi
@@ -63,7 +63,7 @@ echo "EGC install"
 # Detect --dry-run flag
 DRY_RUN=false
 for _arg in "$@"; do
-  [ "$_arg" = "--dry-run" ] && DRY_RUN=true && break
+  [[ "$_arg" = "--dry-run" ]] && DRY_RUN=true && break
 done
 
 # Detect whether we'll delegate to the Node installer below (install-apply.js
@@ -110,7 +110,7 @@ if ! command -v python3 >/dev/null 2>&1; then
   echo "  note: python3 not found: evalview MCP server requires it"
 fi
 
-if [ "$DRY_RUN" = false ]; then
+if [[ "$DRY_RUN" = false ]]; then
   # Root dependencies (better-sqlite3 etc.)
   echo "  installing root dependencies..."
   cd "$ROOT_DIR"
@@ -140,8 +140,8 @@ if [ "$DRY_RUN" = false ]; then
   # egc-guardian
   echo "  building egc-guardian..."
   GUARDIAN_DIR="$ROOT_DIR/mcp/servers/egc-guardian"
-  if [ ! -d "$GUARDIAN_DIR" ]; then
-    echo "Error: $GUARDIAN_DIR not found"
+  if [[ ! -d "$GUARDIAN_DIR" ]]; then
+    echo "Error: $GUARDIAN_DIR not found" >&2
     exit 1
   fi
   cd "$GUARDIAN_DIR"
@@ -155,8 +155,8 @@ if [ "$DRY_RUN" = false ]; then
   # egc-memory
   echo "  building egc-memory..."
   MEMORY_DIR="$ROOT_DIR/mcp/servers/egc-memory"
-  if [ ! -d "$MEMORY_DIR" ]; then
-    echo "Error: $MEMORY_DIR not found"
+  if [[ ! -d "$MEMORY_DIR" ]]; then
+    echo "Error: $MEMORY_DIR not found" >&2
     exit 1
   fi
   cd "$MEMORY_DIR"
@@ -195,11 +195,11 @@ fi
 
 # Delegate to Node installer only when install-relevant args are present
 cd "$ROOT_DIR"
-if [ "$_has_install_args" = true ]; then
+if [[ "$_has_install_args" = true ]]; then
   node scripts/install-apply.js "$@"
 fi
 
-[ "$DRY_RUN" = true ] && exit 0
+[[ "$DRY_RUN" = true ]] && exit 0
 
 # Write harness config template
 cat > "$ROOT_DIR/.mcp.egc.json" <<EOF
@@ -219,13 +219,13 @@ EOF
 echo "  harness config written to .mcp.egc.json"
 
 # Verify MCP server builds exist
-if [ ! -f "$ROOT_DIR/mcp/servers/egc-guardian/build/index.js" ]; then
+if [[ ! -f "$ROOT_DIR/mcp/servers/egc-guardian/build/index.js" ]]; then
   echo "Error: egc-guardian build missing: run 'cd mcp/servers/egc-guardian && npm run build'" >&2
   exit 1
 fi
 echo "  ✓ egc-guardian build verified"
 
-if [ ! -f "$ROOT_DIR/mcp/servers/egc-memory/build/index.js" ]; then
+if [[ ! -f "$ROOT_DIR/mcp/servers/egc-memory/build/index.js" ]]; then
   echo "Error: egc-memory build missing: run 'cd mcp/servers/egc-memory && npm run build'" >&2
   exit 1
 fi
@@ -240,33 +240,33 @@ echo "  ✓ egc-memory build verified"
 node scripts/egc.js doctor --repo-root "$ROOT_DIR" || true
 
 # Interactive ecosystem install (skipped in CI/headless environments)
-if [ -t 0 ] && [ "$DRY_RUN" = false ]; then
+if [[ -t 0 && "$DRY_RUN" = false ]]; then
   printf "\n  Install prompt library? (61 agents, 232 skills, 77 commands) [Y/n] "
   read -r _install_ans
   _install_ans="${_install_ans:-Y}"
-  if [ "$_install_ans" = "Y" ] || [ "$_install_ans" = "y" ]; then
-    if [ -d "$HOME/.gemini" ] || command -v gemini >/dev/null 2>&1 || command -v agy >/dev/null 2>&1; then
+  if [[ "$_install_ans" = "Y" || "$_install_ans" = "y" ]]; then
+    if [[ -d "$HOME/.gemini" ]] || command -v gemini >/dev/null 2>&1 || command -v agy >/dev/null 2>&1; then
       echo "  installing to Gemini / AGY..."
       node "$ROOT_DIR/scripts/install-apply.js" --target egc --profile full
     fi
-    if [ -d "$HOME/.codex" ] || command -v codex >/dev/null 2>&1; then
+    if [[ -d "$HOME/.codex" ]] || command -v codex >/dev/null 2>&1; then
       echo "  installing to Codex..."
       node "$ROOT_DIR/scripts/install-apply.js" --target codex --profile full
     fi
-    if [ -d "$HOME/.opencode" ] || command -v opencode >/dev/null 2>&1; then
+    if [[ -d "$HOME/.opencode" ]] || command -v opencode >/dev/null 2>&1; then
       echo "  installing to OpenCode..."
       node "$ROOT_DIR/scripts/install-apply.js" --target opencode --profile full
     fi
-    if [ -d "$HOME/.kiro" ] || command -v kiro >/dev/null 2>&1; then
+    if [[ -d "$HOME/.kiro" ]] || command -v kiro >/dev/null 2>&1; then
       echo "  installing to Kiro..."
       node "$ROOT_DIR/scripts/install-apply.js" --target kiro --profile full
       bash "$ROOT_DIR/.kiro/install.sh" ~
     fi
-    if [ -d "$HOME/.trae" ] || [ -d "$HOME/.trae-cn" ] || command -v trae >/dev/null 2>&1; then
+    if [[ -d "$HOME/.trae" || -d "$HOME/.trae-cn" ]] || command -v trae >/dev/null 2>&1; then
       echo "  installing to Trae..."
       bash "$ROOT_DIR/.trae/install.sh" ~
     fi
-    if [ -d "$HOME/.codebuddy" ] || command -v codebuddy >/dev/null 2>&1; then
+    if [[ -d "$HOME/.codebuddy" ]] || command -v codebuddy >/dev/null 2>&1; then
       echo "  installing to CodeBuddy..."
       bash "$ROOT_DIR/.codebuddy/install.sh" ~
     fi

--- a/scripts/lib/scrubber/container-meta.js
+++ b/scripts/lib/scrubber/container-meta.js
@@ -115,8 +115,12 @@ function cleanMarkdown(text) {
 // unbalanced quote makes the tag unrecognizable (a safe miss) instead of
 // giving the engine an ambiguity to backtrack through.
 const TAG_BODY = `(?:"[^"]*"|'[^']*'|[^>"'])*`;
-const META_TAG = new RegExp(`<meta\\b${TAG_BODY}>\\s*`, 'gi');
-const SCRIPT_BLOCK = new RegExp(`<script\\b(${TAG_BODY})>([\\s\\S]*?)<\\/script>\\s*`, 'gi'); // NOSONAR: repo/local file content, never network-controlled input
+const META_TAG = new RegExp(String.raw`<meta\b${TAG_BODY}>\s*`, 'gi');
+// Only the opening tag is matched by pattern; the block body runs to the next
+// closing tag found by plain search, so no repetition ever competes with the
+// terminator.
+const SCRIPT_OPEN = new RegExp(String.raw`<script\b(${TAG_BODY})>`, 'gi');
+const SCRIPT_CLOSE = '</script>';
 const DATA_AI_ATTR = /\s+data-ai-[\w-]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi;
 // Explicit provenance FIELDS, not brand mentions: a JSON-LD block is only
 // stripped when it declares AI provenance, so a legitimate Article that merely
@@ -168,6 +172,33 @@ function isProvenanceMetaValue(value) {
   return v === 'generator' || /^ai[:-]/.test(v);
 }
 
+// Removes every <script type="application/ld+json"> block that declares AI
+// provenance, together with the whitespace that followed it; every other
+// script block is kept byte for byte.
+function stripProvenanceScripts(html, removed) {
+  const lower = html.toLowerCase();
+  let result = '';
+  let last = 0;
+  SCRIPT_OPEN.lastIndex = 0;
+  let m = SCRIPT_OPEN.exec(html);
+  while (m !== null) {
+    const bodyStart = m.index + m[0].length;
+    const close = lower.indexOf(SCRIPT_CLOSE, bodyStart);
+    if (close < 0) break;
+    let end = close + SCRIPT_CLOSE.length;
+    const parsed = parseAttrs(m[1]);
+    if (parsed.type?.toLowerCase() === 'application/ld+json' && LD_PROVENANCE.test(html.slice(bodyStart, close))) {
+      removed.push('json-ld');
+      while (end < html.length && /\s/.test(html[end])) end += 1;
+      result += html.slice(last, m.index);
+      last = end;
+    }
+    SCRIPT_OPEN.lastIndex = end;
+    m = SCRIPT_OPEN.exec(html);
+  }
+  return result + html.slice(last);
+}
+
 function cleanHtml(text) {
   const removed = [];
   let out = text;
@@ -182,14 +213,7 @@ function cleanHtml(text) {
     return tag;
   });
 
-  out = out.replace(SCRIPT_BLOCK, (whole, attrs, body) => {
-    const parsed = parseAttrs(attrs);
-    if (parsed.type?.toLowerCase() === 'application/ld+json' && LD_PROVENANCE.test(body)) {
-      removed.push('json-ld');
-      return '';
-    }
-    return whole;
-  });
+  out = stripProvenanceScripts(out, removed);
 
   out = out.replace(DATA_AI_ATTR, () => { removed.push('attr:data-ai'); return ''; });
 

--- a/scripts/lib/scrubber/container-meta.js
+++ b/scripts/lib/scrubber/container-meta.js
@@ -120,7 +120,9 @@ const META_TAG = new RegExp(String.raw`<meta\b${TAG_BODY}>\s*`, 'gi');
 // closing tag found by plain search, so no repetition ever competes with the
 // terminator.
 const SCRIPT_OPEN = new RegExp(String.raw`<script\b(${TAG_BODY})>`, 'gi');
-const SCRIPT_CLOSE = '</script>';
+// Searched in the original text (not a lowercased copy, whose length can
+// differ for some Unicode characters), so every index stays aligned.
+const SCRIPT_CLOSE = /<\/script>/gi;
 const DATA_AI_ATTR = /\s+data-ai-[\w-]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi;
 // Explicit provenance FIELDS, not brand mentions: a JSON-LD block is only
 // stripped when it declares AI provenance, so a legitimate Article that merely
@@ -176,16 +178,17 @@ function isProvenanceMetaValue(value) {
 // provenance, together with the whitespace that followed it; every other
 // script block is kept byte for byte.
 function stripProvenanceScripts(html, removed) {
-  const lower = html.toLowerCase();
   let result = '';
   let last = 0;
   SCRIPT_OPEN.lastIndex = 0;
   let m = SCRIPT_OPEN.exec(html);
   while (m !== null) {
     const bodyStart = m.index + m[0].length;
-    const close = lower.indexOf(SCRIPT_CLOSE, bodyStart);
-    if (close < 0) break;
-    let end = close + SCRIPT_CLOSE.length;
+    SCRIPT_CLOSE.lastIndex = bodyStart;
+    const closeMatch = SCRIPT_CLOSE.exec(html);
+    if (closeMatch === null) break;
+    const close = closeMatch.index;
+    let end = close + closeMatch[0].length;
     const parsed = parseAttrs(m[1]);
     if (parsed.type?.toLowerCase() === 'application/ld+json' && LD_PROVENANCE.test(html.slice(bodyStart, close))) {
       removed.push('json-ld');


### PR DESCRIPTION
## Why

After #1344 the quality report on main still listed 27 open findings: 2 in the new-code period (the HTML script-block regex in the container scrubber and its raw-string sibling) and 25 older ones in the installers that predate the period (17 single-bracket tests and 2 stdout error messages in install.sh, 2 uppercase -Not operators in install.ps1).

## What

- Container scrubber: the script scan matches only the opening tag by pattern and locates the closing tag by plain search, so no repetition competes with the terminator; provenance JSON-LD blocks are removed with the whitespace that followed them exactly as before, every other script block is kept byte for byte. Meta and script patterns are raw strings.
- install.sh: every remaining test uses [[ ]]; the two missing-directory errors go to stderr.
- install.ps1: -not in lowercase.

## Verification

- cleanHtml differential run of the main version against this one over 12 HTML samples (provenance JSON-LD, plain JSON-LD, nested script content, uppercase tags, unterminated blocks, whitespace after blocks): identical output.
- Suites: scrubber container-meta, library and cli; install-sh, install-onboarding and install-ps1. Lint clean; bash -n clean.
- No single-bracket test remains in install.sh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the Sonar quality sweep in the container scrubber and installer scripts, addressing 27 open findings without changing behavior.

- Rewrites the script-block scan in `container-meta.js` to match only the opening tag and find the closing tag by plain search on the original text, avoiding the lowercased-copy length mismatch that misaligns indices for some Unicode; meta and script patterns are now raw strings.
- Switches all remaining single-bracket tests in `install.sh` to `[[ ]]` and sends the two missing-directory errors to stderr.
- Uses lowercase `-not` in `install.ps1`.
- Verified via differential tests that the scrubber output is identical and all suites pass.

<sup>Written for commit 44fdc341c32c4b2a520472b08f44746ce55bb8f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

