### PR TITLE
fix(scrubber): make the data-ai attribute pattern's value branches disjoint

### DIFF
--- a/scripts/lib/scrubber/container-meta.js
+++ b/scripts/lib/scrubber/container-meta.js
@@ -123,9 +123,11 @@ const SCRIPT_OPEN = new RegExp(String.raw`<script\b(${TAG_BODY})>`, 'gi');
 // Searched in the original text (not a lowercased copy, whose length can
 // differ for some Unicode characters), so every index stays aligned.
 const SCRIPT_CLOSE = /<\/script>/gi;
-// The unquoted value branch excludes quote characters so it never overlaps
-// the quoted branches (an unbalanced quote is a safe miss, not a backtrack).
-const DATA_AI_ATTR = /\s+data-ai-[\w-]+\s*=\s*("[^"]*"|'[^']*'|[^\s>"'][^\s>]*)/gi;
+// Anchored on the literal attribute name; the whitespace that precedes it is
+// consumed by stripDataAiAttributes so no repetition sits in front of the
+// scan. The unquoted value branch excludes quote characters so it never
+// overlaps the quoted branches (an unbalanced quote is a safe miss).
+const DATA_AI_ATTR = /data-ai-[\w-]+\s*=\s*("[^"]*"|'[^']*'|[^\s>"'][^\s>]*)/gi;
 // Explicit provenance FIELDS, not brand mentions: a JSON-LD block is only
 // stripped when it declares AI provenance, so a legitimate Article that merely
 // names a model or company survives.
@@ -204,6 +206,27 @@ function stripProvenanceScripts(html, removed) {
   return result + html.slice(last);
 }
 
+// Removes every data-ai-* attribute together with the whitespace run that
+// precedes it; a name not preceded by whitespace is not an attribute
+// boundary and is left alone.
+function stripDataAiAttributes(html, removed) {
+  let result = '';
+  let last = 0;
+  DATA_AI_ATTR.lastIndex = 0;
+  let m = DATA_AI_ATTR.exec(html);
+  while (m !== null) {
+    let start = m.index;
+    while (start > last && /\s/.test(html[start - 1])) start -= 1;
+    if (start < m.index) {
+      removed.push('attr:data-ai');
+      result += html.slice(last, start);
+      last = m.index + m[0].length;
+    }
+    m = DATA_AI_ATTR.exec(html);
+  }
+  return result + html.slice(last);
+}
+
 function cleanHtml(text) {
   const removed = [];
   let out = text;
@@ -220,7 +243,7 @@ function cleanHtml(text) {
 
   out = stripProvenanceScripts(out, removed);
 
-  out = out.replace(DATA_AI_ATTR, () => { removed.push('attr:data-ai'); return ''; });
+  out = stripDataAiAttributes(out, removed);
 
   return { cleaned: out, removed };
 }

--- a/scripts/lib/scrubber/container-meta.js
+++ b/scripts/lib/scrubber/container-meta.js
@@ -123,7 +123,9 @@ const SCRIPT_OPEN = new RegExp(String.raw`<script\b(${TAG_BODY})>`, 'gi');
 // Searched in the original text (not a lowercased copy, whose length can
 // differ for some Unicode characters), so every index stays aligned.
 const SCRIPT_CLOSE = /<\/script>/gi;
-const DATA_AI_ATTR = /\s+data-ai-[\w-]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi;
+// The unquoted value branch excludes quote characters so it never overlaps
+// the quoted branches (an unbalanced quote is a safe miss, not a backtrack).
+const DATA_AI_ATTR = /\s+data-ai-[\w-]+\s*=\s*("[^"]*"|'[^']*'|[^\s>"'][^\s>]*)/gi;
 // Explicit provenance FIELDS, not brand mentions: a JSON-LD block is only
 // stripped when it declares AI provenance, so a legitimate Article that merely
 // names a model or company survives.


### PR DESCRIPTION
## Why

The last open finding on main after #1345: the `data-ai-*` attribute pattern in the container scrubber let its unquoted value branch start with a quote character, overlapping the quoted branches (super-linear backtracking).

## What

The unquoted branch is `[^\s>"'][^\s>]*`, so the three branches are disjoint. Same shape as the tag-body class and the attribute tokenizer already use.

## Verification

- cleanHtml differential run of the main version against this one over 18 HTML samples including quoted, single-quoted, unquoted, repeated and empty `data-ai-*` values: identical, except one deliberate safe miss on malformed HTML (an attribute whose quote is never closed is now kept instead of stripped through the unquoted branch), the same trade-off documented in #1345.
- Scrubber suites (container-meta 24, library 12, cli 21) green; lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `data-ai-*` attribute scrubber so it no longer backtracks super-linearly on malformed HTML. The unquoted value branch now excludes quote characters, and the scan anchors on the literal attribute name while consuming the preceding whitespace procedurally.

- The only behavioral change is on malformed HTML: an attribute whose quote is never closed is now kept instead of stripped.
- This is the same safe-miss trade-off the tag-body class and attribute tokenizer already make.

<sup>Written for commit 70acda69a313974ec0ce8ea28c262d3fefa6a148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

