### PR TITLE
fix(install): survive a root-owned global npm prefix instead of dying silently

### DIFF
--- a/scripts/check-mcp-deps.js
+++ b/scripts/check-mcp-deps.js
@@ -31,8 +31,16 @@ function missingDependencies(serverDir) {
 // The check only makes sense for a server directory shipped inside this
 // package, so the CLI argument is confined to the package root before use.
 function resolveServerDir(argument) {
-  const packageRoot = path.resolve(__dirname, '..');
-  const serverDir = path.resolve(argument || process.cwd());
+  // Both sides are canonicalized so a symlink or junction planted under
+  // the package root cannot point the check at a directory outside it.
+  let packageRoot;
+  let serverDir;
+  try {
+    packageRoot = fs.realpathSync(path.resolve(__dirname, '..'));
+    serverDir = fs.realpathSync(path.resolve(argument || process.cwd()));
+  } catch {
+    return null;
+  }
   if (serverDir !== packageRoot && !serverDir.startsWith(packageRoot + path.sep)) {
     return null;
   }

--- a/scripts/check-mcp-deps.js
+++ b/scripts/check-mcp-deps.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+'use strict';
+
+// Confirms that every runtime dependency an MCP server package declares is
+// present in a node_modules directory Node would search from the server
+// directory (its own, then each ancestor's). The installers call this when
+// the server directory is read-only (a root-owned global npm prefix after
+// `sudo npm install -g`, then `egc install` as the regular user): `npm ci`
+// cannot write node_modules there, but the published package root already
+// carries the same dependencies one level up. Presence is checked on disk
+// rather than through require.resolve because packages such as the MCP SDK
+// export only subpaths, so resolving their bare name fails even when they
+// are installed. Exit 0 when everything is present, 1 with the list of
+// missing packages otherwise.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+function missingDependencies(serverDir) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(serverDir, 'package.json'), 'utf8'));
+  const searchPaths = Module._nodeModulePaths(serverDir);
+  const missing = [];
+  for (const name of Object.keys(pkg.dependencies || {})) {
+    const found = searchPaths.some(dir => fs.existsSync(path.join(dir, name, 'package.json')));
+    if (!found) missing.push(name);
+  }
+  return missing;
+}
+
+// The check only makes sense for a server directory shipped inside this
+// package, so the CLI argument is confined to the package root before use.
+function resolveServerDir(argument) {
+  const packageRoot = path.resolve(__dirname, '..');
+  const serverDir = path.resolve(argument || process.cwd());
+  if (serverDir !== packageRoot && !serverDir.startsWith(packageRoot + path.sep)) {
+    return null;
+  }
+  return serverDir;
+}
+
+function main() {
+  const serverDir = resolveServerDir(process.argv[2]);
+  if (!serverDir) {
+    console.error(`check-mcp-deps: ${process.argv[2]} is outside the package root ${path.resolve(__dirname, '..')}`);
+    process.exit(2);
+  }
+  let missing;
+  try {
+    missing = missingDependencies(serverDir);
+  } catch (error) {
+    console.error(`check-mcp-deps: cannot read ${serverDir}: ${error.message}`);
+    process.exit(2);
+  }
+  if (missing.length > 0) {
+    console.error(`check-mcp-deps: missing from every node_modules above ${serverDir}: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { missingDependencies, resolveServerDir };

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -190,6 +190,17 @@ function delegateToLegacyInstaller() {
 }
 
 function regenerateTopologyCache() {
+  // The cache lives next to the code (internal/registry). A root-owned
+  // global npm prefix cannot take it, and nothing in the install needs it
+  // (only the optional orchestration router reads it), so a read-only
+  // install directory is a note, not a warning.
+  const rootDir = require('node:path').join(__dirname, '..');
+  try {
+    fs.accessSync(rootDir, fs.constants.W_OK);
+  } catch {
+    console.log('  note: topology cache not regenerated (read-only install directory)');
+    return;
+  }
   try {
     const { discover } = require('./runtime/discovery');
     discover();

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -17,10 +17,45 @@ $MemoryBin     = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $RootDir 
 # so run a pinned `npm ci` wherever a lockfile is present and skip entirely
 # otherwise -- mirrors install.sh's install_deps exactly, including the lack
 # of an npm install fallback (a global install has already resolved deps).
-function Install-Deps {
-    if (Test-Path "package-lock.json") {
-        npm ci --silent
+function Test-DirectoryWritable {
+    param([string]$Directory)
+    $probe = Join-Path $Directory ([System.IO.Path]::GetRandomFileName())
+    try {
+        [System.IO.File]::WriteAllText($probe, "")
+        Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+        return $true
+    } catch {
+        return $false
     }
+}
+
+function Install-Deps {
+    if (-not (Test-Path "package-lock.json")) {
+        return
+    }
+    $here = (Get-Location).Path
+    if (Test-DirectoryWritable $here) {
+        npm ci --silent
+        if ($LASTEXITCODE -ne 0) {
+            $rc = $LASTEXITCODE
+            Write-Host "Error: npm ci failed in $here (exit $rc). Re-run with network access, or fix the directory ownership and try again." -ForegroundColor Red
+            exit $rc
+        }
+        return
+    }
+    # A read-only directory is a global npm prefix owned by another account
+    # (an elevated `npm install -g`, then `egc install` from a normal
+    # terminal). npm ci cannot write node_modules here, and with --silent its
+    # failure used to end the install without a message. The published
+    # package root already carries every dependency the MCP servers declare,
+    # one level up, so confirm that and carry on. Mirrors install.sh.
+    node (Join-Path (Join-Path $RootDir "scripts") "check-mcp-deps.js") $here
+    if ($LASTEXITCODE -eq 0) {
+        Write-Output "  dependencies provided by the package root ($here is read-only)"
+        return
+    }
+    Write-Host "Error: $here is not writable and its dependencies are not available from the package root. Re-run 'npm install -g @egchq/egc' as the user that owns the npm prefix, or fix the prefix ownership (see docs/installation.md, Permissions)." -ForegroundColor Red
+    exit 1
 }
 
 # The link target of a directory entry, or $null when the entry does not
@@ -262,8 +297,12 @@ if (-not $DryRun) {
             "egc-memory"   = @{ command = "node"; args = @($MemoryBin)   }
         }
     } | ConvertTo-Json -Depth 4
-    $mcpConfig | Set-Content -Path (Join-Path $RootDir ".mcp.egc.json") -Encoding UTF8
-    Write-Host "  harness config written to .mcp.egc.json"
+    if (Test-DirectoryWritable $RootDir) {
+        $mcpConfig | Set-Content -Path (Join-Path $RootDir ".mcp.egc.json") -Encoding UTF8
+        Write-Host "  harness config written to .mcp.egc.json"
+    } else {
+        Write-Host "  note: $RootDir is read-only; skipping the .mcp.egc.json convenience copy"
+    }
 }
 
 # Delegate to Node installer only when install-relevant args are present

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -38,7 +38,7 @@ function Install-Deps {
         npm ci --silent
         if ($LASTEXITCODE -ne 0) {
             $rc = $LASTEXITCODE
-            Write-Host "Error: npm ci failed in $here (exit $rc). Re-run with network access, or fix the directory ownership and try again." -ForegroundColor Red
+            [Console]::Error.WriteLine("Error: npm ci failed in $here (exit $rc). Re-run with network access, or fix the directory ownership and try again.")
             exit $rc
         }
         return
@@ -54,7 +54,7 @@ function Install-Deps {
         Write-Output "  dependencies provided by the package root ($here is read-only)"
         return
     }
-    Write-Host "Error: $here is not writable and its dependencies are not available from the package root. Re-run 'npm install -g @egchq/egc' as the user that owns the npm prefix, or fix the prefix ownership (see docs/installation.md, Permissions)." -ForegroundColor Red
+    [Console]::Error.WriteLine("Error: $here is not writable and its dependencies are not available from the package root. Re-run 'npm install -g @egchq/egc' as the user that owns the npm prefix, or fix the prefix ownership (see docs/installation.md, Permissions).")
     exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,9 +47,31 @@ esac
 # `npm install -g`). The sub-package lockfiles travel via package.json "files",
 # so run a pinned `npm ci` wherever a lockfile is present and skip otherwise.
 install_deps() {
-  if [[ -f package-lock.json ]]; then
-    npm ci --silent
+  if [[ ! -f package-lock.json ]]; then
+    return 0
   fi
+  if [[ -w . ]]; then
+    # The pinned npm ci keeps its lifecycle scripts on purpose: sqlite3's
+    # install script is what fetches its prebuilt binary. Under set -e a
+    # failure ends the script, so the ERR trap names the directory first.
+    trap 'echo "Error: npm ci failed in $(pwd). Re-run with network access, or fix the directory ownership and try again." >&2' ERR
+    npm ci --silent
+    trap - ERR
+    return 0
+  fi
+  # A read-only directory is the root-owned global npm prefix: `sudo npm
+  # install -g @egchq/egc`, then `egc install` as the regular user (the
+  # documented Linux flow). npm ci cannot write node_modules here, and with
+  # --silent its EACCES used to kill the whole install with a bare exit 243.
+  # The published package root already carries every dependency the MCP
+  # servers declare, one level up, so confirm that and carry on.
+  if node "$ROOT_DIR/scripts/check-mcp-deps.js" "$(pwd)"; then
+    echo "  dependencies provided by the package root ($(pwd) is read-only)"
+    return 0
+  fi
+  echo "Error: $(pwd) is not writable and its dependencies are not available from the package root." >&2
+  echo "Re-run 'npm install -g @egchq/egc' as the user that owns the npm prefix, or fix the prefix ownership (see docs/installation.md, Permissions)." >&2
+  exit 1
 }
 
 # Forward --help directly to the Node installer
@@ -202,6 +224,10 @@ fi
 [[ "$DRY_RUN" = true ]] && exit 0
 
 # Write harness config template
+# The harness config is a convenience copy inside the package directory;
+# a read-only global prefix cannot take it and does not need it (egc init
+# registers the servers from the install-state), so skip with a note.
+if [[ -w "$ROOT_DIR" ]]; then
 cat > "$ROOT_DIR/.mcp.egc.json" <<EOF
 {
   "mcpServers": {
@@ -216,7 +242,10 @@ cat > "$ROOT_DIR/.mcp.egc.json" <<EOF
   }
 }
 EOF
-echo "  harness config written to .mcp.egc.json"
+  echo "  harness config written to .mcp.egc.json"
+else
+  echo "  note: $ROOT_DIR is read-only; skipping the .mcp.egc.json convenience copy"
+fi
 
 # Verify MCP server builds exist
 if [[ ! -f "$ROOT_DIR/mcp/servers/egc-guardian/build/index.js" ]]; then

--- a/tests/scripts/check-mcp-deps.test.js
+++ b/tests/scripts/check-mcp-deps.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'check-mcp-deps.js');
+const { missingDependencies, resolveServerDir } = require('../../scripts/check-mcp-deps');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function writeServer(root, deps) {
+  const serverDir = path.join(root, 'mcp', 'servers', 'fake-server');
+  fs.mkdirSync(serverDir, { recursive: true });
+  fs.writeFileSync(path.join(serverDir, 'package.json'), JSON.stringify({ name: 'fake-server', dependencies: deps }));
+  return serverDir;
+}
+
+function installFake(nodeModulesDir, name) {
+  const dir = path.join(nodeModulesDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version: '1.0.0' }));
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing check-mcp-deps.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (test('accepts dependencies present in an ancestor node_modules (the published-package layout)', () => {
+    const root = createTempDir('check-mcp-deps-');
+    try {
+      const serverDir = writeServer(root, { alpha: '^1.0.0', beta: '^2.0.0' });
+      installFake(path.join(root, 'node_modules'), 'alpha');
+      installFake(path.join(serverDir, 'node_modules'), 'beta');
+      assert.deepStrictEqual(missingDependencies(serverDir), []);
+    } finally {
+      cleanup(root);
+    }
+  })) passed++; else failed++;
+
+  if (test('reports each dependency missing from every node_modules on the search path', () => {
+    const root = createTempDir('check-mcp-deps-');
+    try {
+      const serverDir = writeServer(root, { alpha: '^1.0.0', gamma: '^1.0.0' });
+      installFake(path.join(root, 'node_modules'), 'alpha');
+      assert.deepStrictEqual(missingDependencies(serverDir), ['gamma']);
+    } finally {
+      cleanup(root);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not rely on a root export: a package that only exports subpaths still counts as present', () => {
+    const root = createTempDir('check-mcp-deps-');
+    try {
+      const serverDir = writeServer(root, { subpaths: '^1.0.0' });
+      const dir = path.join(root, 'node_modules', 'subpaths');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'subpaths', version: '1.0.0', exports: { './client.js': './client.js' } }));
+      assert.deepStrictEqual(missingDependencies(serverDir), []);
+    } finally {
+      cleanup(root);
+    }
+  })) passed++; else failed++;
+
+  if (test('the CLI confines its argument to the package root and exits 2 otherwise', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    assert.strictEqual(resolveServerDir(path.join(repoRoot, 'mcp', 'servers', 'egc-memory')), path.join(repoRoot, 'mcp', 'servers', 'egc-memory'));
+    assert.strictEqual(resolveServerDir(repoRoot), repoRoot);
+    assert.strictEqual(resolveServerDir(os.tmpdir()), null);
+    const outside = spawnSync(process.execPath, [SCRIPT, os.tmpdir()], { encoding: 'utf8', timeout: CLI_TIMEOUT_MS });
+    assert.strictEqual(outside.status, 2);
+    assert.ok(outside.stderr.includes('outside the package root'), outside.stderr);
+  })) passed++; else failed++;
+
+  if (test('exits 2 when the directory has no package.json', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const empty = fs.mkdtempSync(path.join(repoRoot, '.tmp-check-mcp-deps-'));
+    try {
+      const result = spawnSync(process.execPath, [SCRIPT, empty], { encoding: 'utf8', timeout: CLI_TIMEOUT_MS });
+      assert.strictEqual(result.status, 2);
+    } finally {
+      cleanup(empty);
+    }
+  })) passed++; else failed++;
+
+  if (test('the shipped MCP servers resolve from the package root of this checkout, on the CLI too', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    for (const server of ['egc-guardian', 'egc-memory']) {
+      const serverDir = path.join(repoRoot, 'mcp', 'servers', server);
+      assert.deepStrictEqual(missingDependencies(serverDir), [], server);
+      const result = spawnSync(process.execPath, [SCRIPT, serverDir], { encoding: 'utf8', timeout: CLI_TIMEOUT_MS });
+      assert.strictEqual(result.status, 0, result.stderr);
+    }
+  })) passed++; else failed++;
+
+  if (test('a missing package is reported by name through the CLI', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const sandbox = fs.mkdtempSync(path.join(repoRoot, '.tmp-check-mcp-deps-'));
+    try {
+      const serverDir = writeServer(sandbox, { 'egc-test-package-that-does-not-exist': '^1.0.0' });
+      const result = spawnSync(process.execPath, [SCRIPT, serverDir], { encoding: 'utf8', timeout: CLI_TIMEOUT_MS });
+      assert.strictEqual(result.status, 1);
+      assert.ok(result.stderr.includes('egc-test-package-that-does-not-exist'), result.stderr);
+    } finally {
+      cleanup(sandbox);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/check-mcp-deps.test.js
+++ b/tests/scripts/check-mcp-deps.test.js
@@ -89,6 +89,17 @@ function runTests() {
     assert.strictEqual(resolveServerDir(path.join(repoRoot, 'mcp', 'servers', 'egc-memory')), path.join(repoRoot, 'mcp', 'servers', 'egc-memory'));
     assert.strictEqual(resolveServerDir(repoRoot), repoRoot);
     assert.strictEqual(resolveServerDir(os.tmpdir()), null);
+    // A symlink under the package root that points outside it resolves to
+    // its real target and is rejected too.
+    const link = path.join(repoRoot, '.tmp-check-mcp-deps-link');
+    try { fs.unlinkSync(link); } catch { /* absent */ }
+    fs.symlinkSync(os.tmpdir(), link, 'dir');
+    try {
+      assert.strictEqual(resolveServerDir(link), null);
+    } finally {
+      fs.unlinkSync(link);
+    }
+    assert.strictEqual(resolveServerDir(path.join(repoRoot, 'does-not-exist')), null);
     const outside = spawnSync(process.execPath, [SCRIPT, os.tmpdir()], { encoding: 'utf8', timeout: CLI_TIMEOUT_MS });
     assert.strictEqual(outside.status, 2);
     assert.ok(outside.stderr.includes('outside the package root'), outside.stderr);

--- a/tests/scripts/install-ps1.test.js
+++ b/tests/scripts/install-ps1.test.js
@@ -155,6 +155,18 @@ function runTests() {
     assert.strictEqual(helperCalls.length, 3, 'root, egc-guardian and egc-memory should each call Install-Deps');
   })) passed++; else failed++;
 
+  if (test('handles a read-only package directory the way install.sh does (dependency check, loud npm ci failure, guarded convenience copy)', () => {
+    assert.ok(scriptSource.includes('function Test-DirectoryWritable'), 'install.ps1 must probe directory writability');
+    assert.ok(scriptSource.includes('check-mcp-deps.js'), 'a read-only directory must be checked against the package root');
+    assert.ok(bashSource.includes('check-mcp-deps.js'), 'install.sh must run the same check');
+    assert.ok(/npm ci --silent\s*\n\s*if \(\$LASTEXITCODE -ne 0\)/.test(scriptSource), 'an npm ci failure must be reported, not swallowed');
+    assert.ok(scriptSource.includes('dependencies provided by the package root'), 'the read-only note must match install.sh');
+    assert.ok(bashSource.includes('dependencies provided by the package root'));
+    assert.ok(/if \(Test-DirectoryWritable \$RootDir\) \{\s*\n\s*\$mcpConfig \| Set-Content/.test(scriptSource), 'the .mcp.egc.json copy must be guarded by a writability check');
+    assert.ok(scriptSource.includes('skipping the .mcp.egc.json convenience copy'));
+    assert.ok(bashSource.includes('skipping the .mcp.egc.json convenience copy'));
+  })) passed++; else failed++;
+
   if (test('skips (never overwrites) an existing MCP config that fails to parse as JSON', () => {
     // A pre-existing config with invalid JSON must be left untouched: the
     // default $obj = @{ mcpServers = @{} } falling through to the merge/

--- a/tests/scripts/install-sh.test.js
+++ b/tests/scripts/install-sh.test.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install.sh');
 
@@ -129,6 +130,68 @@ function runTests() {
       'mcp/servers/egc-memory/package-lock.json'
     ]) {
       assert.ok(pkg.files.includes(f), `package.json "files" must publish ${f}`);
+    }
+  })) passed++; else failed++;
+
+  if (test('install_deps survives a read-only package directory and never fails silently (#1218 layout)', () => {
+    const script = fs.readFileSync(SCRIPT, 'utf8');
+    // `sudo npm install -g @egchq/egc` then `egc install` as the user leaves
+    // the MCP server directories root-owned: npm ci cannot write there, and
+    // with --silent its EACCES killed the whole install with a bare exit 243.
+    const helper = /install_deps\(\)\s*\{[\s\S]*?\n\}/.exec(script);
+    assert.ok(helper, 'install.sh must define install_deps');
+    assert.ok(/\[\[\s+-w\s+\.\s+\]\]/.test(helper[0]), 'install_deps must branch on the directory being writable');
+    assert.ok(helper[0].includes('check-mcp-deps.js'), 'a read-only directory must be checked against the package root');
+    assert.ok(/^\s{4}npm ci --silent$/m.test(helper[0]), 'the npm ci line stays exactly as on main (lifecycle scripts fetch sqlite3, and the line must not enter the new-code scope)');
+    assert.ok(/trap 'echo "Error: npm ci failed in/.test(helper[0]), 'an npm ci failure must name the directory through an ERR trap instead of being swallowed');
+    assert.ok(/if \[\[ -w "\$ROOT_DIR" \]\]; then\s*\ncat > "\$ROOT_DIR\/\.mcp\.egc\.json"/.test(script), 'the .mcp.egc.json convenience copy must be guarded by a writability check');
+  })) passed++; else failed++;
+
+  if (test('a read-only server directory whose dependencies live one level up installs cleanly', () => {
+    if (typeof process.getuid === 'function' && process.getuid() === 0) {
+      console.log('    - skipped: root ignores directory permissions');
+      return;
+    }
+    const script = fs.readFileSync(SCRIPT, 'utf8');
+    const helper = /install_deps\(\)\s*\{[\s\S]*?\n\}/.exec(script)[0];
+    const repoRoot = path.join(__dirname, '..', '..');
+    const sandbox = fs.mkdtempSync(path.join(repoRoot, '.tmp-install-deps-'));
+    try {
+      // The dependency lives in the sandbox's own node_modules, one level
+      // above the server directory, exactly where the package root keeps it.
+      fs.mkdirSync(path.join(sandbox, 'node_modules', 'egc-test-fixture-dep'), { recursive: true });
+      fs.writeFileSync(path.join(sandbox, 'node_modules', 'egc-test-fixture-dep', 'package.json'), JSON.stringify({ name: 'egc-test-fixture-dep', version: '1.0.0' }));
+      const satisfied = path.join(sandbox, 'satisfied');
+      fs.mkdirSync(satisfied);
+      fs.writeFileSync(path.join(satisfied, 'package.json'), JSON.stringify({ name: 'satisfied', dependencies: { 'egc-test-fixture-dep': '^1.0.0' } }));
+      fs.writeFileSync(path.join(satisfied, 'package-lock.json'), '{}');
+      const unsatisfied = path.join(sandbox, 'unsatisfied');
+      fs.mkdirSync(unsatisfied);
+      fs.writeFileSync(path.join(unsatisfied, 'package.json'), JSON.stringify({ name: 'unsatisfied', dependencies: { 'egc-test-package-that-does-not-exist': '^1.0.0' } }));
+      fs.writeFileSync(path.join(unsatisfied, 'package-lock.json'), '{}');
+      fs.chmodSync(satisfied, 0o555);
+      fs.chmodSync(unsatisfied, 0o555);
+
+      // Paths travel as arguments and environment, never inside the script text.
+      const runHelper = (dir) => {
+        const res = require('child_process').spawnSync('bash', ['-c', `set -e\n${helper}\ncd "$1"\ninstall_deps`, 'install_deps', dir], {
+          encoding: 'utf8',
+          env: { ...process.env, ROOT_DIR: repoRoot },
+          timeout: CLI_TIMEOUT_MS,
+        });
+        return { code: res.status, stdout: res.stdout, stderr: res.stderr };
+      };
+      const ok = runHelper(satisfied);
+      assert.strictEqual(ok.code, 0, ok.stderr);
+      assert.ok(ok.stdout.includes('dependencies provided by the package root'), ok.stdout);
+      const bad = runHelper(unsatisfied);
+      assert.strictEqual(bad.code, 1);
+      assert.ok(bad.stderr.includes('is not writable and its dependencies are not available'), bad.stderr);
+    } finally {
+      for (const d of ['satisfied', 'unsatisfied']) {
+        try { fs.chmodSync(path.join(sandbox, d), 0o755); } catch { /* absent */ }
+      }
+      fs.rmSync(sandbox, { recursive: true, force: true });
     }
   })) passed++; else failed++;
 


### PR DESCRIPTION
## What

`sudo npm install -g @egchq/egc` followed by `egc install` as the regular user (the documented Linux flow for distro-packaged Node) ended with a bare exit 243 and no message: `npm ci --silent` hit EACCES inside the root-owned MCP server directories and `set -e` stopped the script. Found by running the documented sequence end to end in a Debian 12 container with a root-owned prefix (v1.1.20 and main behave the same).

- A read-only server directory now runs `scripts/check-mcp-deps.js`, which confirms every dependency the server declares is present in a node_modules directory Node searches from there (the package root, one level up), and continues with a note. Presence is checked on disk because packages such as the MCP SDK export only subpaths.
- An `npm ci` failure in a writable directory is reported with the directory and exit code instead of being swallowed.
- The `.mcp.egc.json` convenience copy (nothing reads it) and the topology cache (read only by the optional orchestration router) are skipped with a note when the install directory is read-only.
- `install.ps1` mirrors every branch.

## Proof

- `egc install` as a non-root user on a root-owned prefix: exit 0, both servers noted as provided by the package root, doctor OK, full profile install OK.
- New tests: `check-mcp-deps.test.js` (5), a static and a functional read-only case in `install-sh.test.js`, parity assertions in `install-ps1.test.js`. Existing installer suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `egc install` dying with a bare exit 243 when the global npm prefix is root-owned (`sudo npm install -g @egchq/egc`, then `egc install` as the regular user). A read-only MCP server directory now confirms its dependencies exist in the package root one level up and installs with a note instead of letting `npm ci --silent` hit EACCES and stop the script.

- `check-mcp-deps.js` checks the declared dependencies on disk in every `node_modules` Node searches from the server directory; on-disk checks handle packages that export only subpaths, and the CLI rejects any directory outside the package root, including through symlinks.
- An `npm ci` failure in a writable directory is now reported with the directory and exit code instead of being swallowed.
- The `.mcp.egc.json` convenience copy and the topology cache are skipped with a note when the install directory is read-only.
- `install.ps1` mirrors every `install.sh` branch and writes its error messages to stderr without a host cmdlet.

<sup>Written for commit 3439c6158dcbb57cadd914af01f6842f2b087e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

