### PR TITLE
fix(cli): answer --help with exit 0 in crusher-shim, session-inspect, prompt and claw

### DIFF
--- a/scripts/claw.js
+++ b/scripts/claw.js
@@ -412,7 +412,28 @@ function handleReplCommand(line, state, rl) {
   return 'send';
 }
 
+function printUsage() {
+  console.log([
+    'Usage: egc claw',
+    '',
+    'NanoClaw: a persistent, session-aware agent REPL with Markdown history.',
+    'Sessions live in ~/.gemini/claw/<name>.md; type /help inside the REPL for',
+    'the session commands and exit to quit.',
+    '',
+    'Environment:',
+    '  CLAW_SESSION   session name to open (default: default)',
+    '  CLAW_MODEL     model passed to the backend (default: gemini-2.0-flash)',
+    '  CLAW_SKILLS    comma-separated skills loaded as context',
+  ].join('\n'));
+}
+
 function main() {
+  // `egc help claw` forwards --help; answer it instead of opening the REPL.
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    printUsage();
+    return;
+  }
+
   const initialSessionName = process.env.CLAW_SESSION || 'default';
   if (!isValidSessionName(initialSessionName)) {
     console.error(`Error: Invalid session name "${initialSessionName}". Use alphanumeric characters and hyphens only.`);

--- a/scripts/crusher-shim.js
+++ b/scripts/crusher-shim.js
@@ -62,7 +62,10 @@ function main() {
   console.log('\nInstalls a PATH-level binary shim (git, npm, pip, gh, ...) that compresses');
   console.log('noisy output for any tool that shells out to run them, independent of any');
   console.log('AI harness\'s hook support. Requires a new shell session after install.');
-  process.exit(action ? 1 : 0);
+  // `egc help crusher-shim` arrives here as --help: asking for the usage is
+  // not a usage error.
+  const helpRequested = action === '--help' || action === '-h';
+  process.exit(action && !helpRequested ? 1 : 0);
 }
 
 main();

--- a/scripts/gemini.js
+++ b/scripts/gemini.js
@@ -9,8 +9,20 @@
 'use strict';
 
 const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+
+function bridgeUsage(pythonBin) {
+  return [
+    'Usage: egc prompt [-p <text>] [options]',
+    '',
+    'Runs the Python LLM bridge (src/llm/cli/prompt.py) with the package\'s own',
+    `virtualenv (${pythonBin}). That virtualenv is not present on this machine, so`,
+    'the backend options are unavailable; with it in place, egc prompt --help',
+    'prints the full option list from the Python entry point.',
+  ].join('\n');
+}
 
 function main() {
   const pluginRoot = path.resolve(__dirname, '..');
@@ -22,7 +34,21 @@ function main() {
     : path.join(venvPath, 'bin', 'python3');
 
   const args = process.argv.slice(2);
-  
+  const helpRequested = args.includes('--help') || args.includes('-h');
+
+  // The bridge needs the package's own virtualenv. Without it, `egc help
+  // prompt` used to die with a spawn ENOENT: answer the help request from
+  // here, and make the missing-venv failure say what is missing.
+  if (!fs.existsSync(pythonBin)) {
+    if (helpRequested) {
+      console.log(bridgeUsage(pythonBin));
+      return;
+    }
+    console.error(`Error: Python bridge not available: ${pythonBin} is missing.`);
+    console.error('egc prompt runs src/llm/cli/prompt.py through the package\'s .venv; create that virtualenv with the backend dependencies (src/llm) before using it.');
+    process.exit(1);
+  }
+
   // Session propagation (MANDATORY per directive)
   const env = { ...process.env };
   const sessionId = env.EGC_SESSION_ID || env.ECC_SESSION_ID || `egc-session-${Date.now()}`;

--- a/scripts/session-inspect.js
+++ b/scripts/session-inspect.js
@@ -98,6 +98,13 @@ function inspectSkillLoopTarget(target, options = {}) {
 }
 
 function main() {
+  // `egc help session-inspect` forwards --help: print the usage and exit 0,
+  // unlike a missing target, which stays a usage error.
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    usage();
+    return;
+  }
+
   const { target, adapterId, targetType, writePath, listAdapters, skillId, amendmentId, observationsPath } = parseArgs(process.argv);
 
   if (listAdapters) {

--- a/tests/scripts/cli-help-exit.test.js
+++ b/tests/scripts/cli-help-exit.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const DISPATCHER = path.join(REPO_ROOT, 'scripts', 'egc.js');
@@ -12,11 +13,15 @@ function runNode(args, options = {}) {
     cwd: REPO_ROOT,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 20000,
+    timeout: CLI_TIMEOUT_MS,
     input: options.input,
     env: { ...process.env, ...(options.env || {}) },
   });
   return { code: result.status, stdout: result.stdout || '', stderr: result.stderr || '' };
+}
+
+function hasMarker(output, marker) {
+  return (Array.isArray(marker) ? marker : [marker]).some(m => output.includes(m));
 }
 
 function test(name, fn) {
@@ -37,7 +42,9 @@ function test(name, fn) {
 const CASES = [
   { command: 'crusher-shim', script: 'crusher-shim.js', marker: 'Usage: egc crusher-shim' },
   { command: 'session-inspect', script: 'session-inspect.js', marker: 'Usage:' },
-  { command: 'prompt', script: 'gemini.js', marker: 'Usage: egc prompt' },
+  // With the Python virtualenv present, prompt --help is answered by the
+  // Python entry point (usage: prompt.py); without it, by the bridge itself.
+  { command: 'prompt', script: 'gemini.js', marker: ['Usage: egc prompt', 'usage: prompt.py'] },
   { command: 'claw', script: 'claw.js', marker: 'Usage: egc claw' },
 ];
 
@@ -51,14 +58,14 @@ function runTests() {
       for (const flag of ['--help', '-h']) {
         const result = runNode([path.join(REPO_ROOT, 'scripts', c.script), flag], { input: 'exit\n' });
         assert.strictEqual(result.code, 0, `${flag}: ${result.stderr}`);
-        assert.ok(result.stdout.includes(c.marker), `${flag}: expected "${c.marker}" in: ${result.stdout.slice(0, 200)}`);
+        assert.ok(hasMarker(result.stdout, c.marker), `${flag}: expected ${JSON.stringify(c.marker)} in: ${result.stdout.slice(0, 200)}`);
       }
     })) passed++; else failed++;
 
     if (test(`egc help ${c.command} exits 0 through the dispatcher`, () => {
       const result = runNode([DISPATCHER, 'help', c.command], { input: 'exit\n' });
       assert.strictEqual(result.code, 0, result.stderr);
-      assert.ok(result.stdout.includes(c.marker), result.stdout.slice(0, 200));
+      assert.ok(hasMarker(result.stdout, c.marker), result.stdout.slice(0, 200));
     })) passed++; else failed++;
   }
 

--- a/tests/scripts/cli-help-exit.test.js
+++ b/tests/scripts/cli-help-exit.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const DISPATCHER = path.join(REPO_ROOT, 'scripts', 'egc.js');
+
+function runNode(args, options = {}) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 20000,
+    input: options.input,
+    env: { ...process.env, ...(options.env || {}) },
+  });
+  return { code: result.status, stdout: result.stdout || '', stderr: result.stderr || '' };
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+// Every subcommand `egc help <name>` reaches must answer --help with exit 0
+// and a usage text. These four used to exit 1 (or start a REPL, or die on a
+// missing Python virtualenv) when asked for help.
+const CASES = [
+  { command: 'crusher-shim', script: 'crusher-shim.js', marker: 'Usage: egc crusher-shim' },
+  { command: 'session-inspect', script: 'session-inspect.js', marker: 'Usage:' },
+  { command: 'prompt', script: 'gemini.js', marker: 'Usage: egc prompt' },
+  { command: 'claw', script: 'claw.js', marker: 'Usage: egc claw' },
+];
+
+function runTests() {
+  console.log('\n=== Testing help exit codes ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  for (const c of CASES) {
+    if (test(`${c.script} --help exits 0 with its usage`, () => {
+      for (const flag of ['--help', '-h']) {
+        const result = runNode([path.join(REPO_ROOT, 'scripts', c.script), flag], { input: 'exit\n' });
+        assert.strictEqual(result.code, 0, `${flag}: ${result.stderr}`);
+        assert.ok(result.stdout.includes(c.marker), `${flag}: expected "${c.marker}" in: ${result.stdout.slice(0, 200)}`);
+      }
+    })) passed++; else failed++;
+
+    if (test(`egc help ${c.command} exits 0 through the dispatcher`, () => {
+      const result = runNode([DISPATCHER, 'help', c.command], { input: 'exit\n' });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes(c.marker), result.stdout.slice(0, 200));
+    })) passed++; else failed++;
+  }
+
+  if (test('a real usage error still exits 1', () => {
+    const shim = runNode([path.join(REPO_ROOT, 'scripts', 'crusher-shim.js'), 'bogus']);
+    assert.strictEqual(shim.code, 1);
+    const inspect = runNode([path.join(REPO_ROOT, 'scripts', 'session-inspect.js')]);
+    assert.strictEqual(inspect.code, 1);
+    assert.ok(inspect.stdout.includes('Usage:'));
+  })) passed++; else failed++;
+
+  if (test('claw --help does not open the REPL', () => {
+    const result = runNode([path.join(REPO_ROOT, 'scripts', 'claw.js'), '--help'], { input: 'exit\n' });
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(!result.stdout.includes('claw>'), 'the REPL prompt must not appear');
+    assert.ok(!result.stdout.includes('NanoClaw v2: Session'), 'no session banner for a help request');
+  })) passed++; else failed++;
+
+  if (test('the prompt bridge names the missing virtualenv instead of a bare spawn error', () => {
+    const result = runNode([path.join(REPO_ROOT, 'scripts', 'gemini.js'), '--prompt', 'hi']);
+    if (result.code === 0) {
+      console.log('    - a virtualenv is present on this machine; the missing-venv message is not exercised');
+      return;
+    }
+    assert.strictEqual(result.code, 1);
+    assert.ok(result.stderr.includes('Python bridge not available'), result.stderr);
+    assert.ok(!result.stderr.includes('ENOENT'), result.stderr);
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/session-inspect.test.js
+++ b/tests/scripts/session-inspect.test.js
@@ -70,6 +70,14 @@ function runTests() {
     assert.ok(result.stdout.includes('Usage:'));
   })) passed++; else failed++;
 
+  if (test('answers --help with the usage and exit 0', () => {
+    for (const flag of ['--help', '-h']) {
+      const result = run([flag]);
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('Usage:'));
+    }
+  })) passed++; else failed++;
+
   if (test('lists registered adapters', () => {
     const result = run(['--list-adapters']);
     assert.strictEqual(result.code, 0, result.stderr);


### PR DESCRIPTION
## What

`egc help <command>` forwards `--help` to the subcommand script. Running every documented command end to end on Linux, macOS and Windows (v1.1.20 and main) showed four of them mishandling it:

- `crusher-shim` and `session-inspect` printed their usage and exited 1.
- `prompt` died with a spawn ENOENT because the Python bridge's virtualenv was missing.
- `claw` opened the REPL instead of answering.

Each now prints its usage and exits 0. A real usage error (unknown action, missing target) still exits 1, and a missing virtualenv is reported by name with what it needs instead of a bare ENOENT. When the virtualenv exists, `prompt --help` still forwards to the Python entry point, so the existing bridge test keeps its meaning.

## Proof

New `tests/scripts/cli-help-exit.test.js` (11 cases: both flags per script, the dispatcher path, the negative cases) plus a `--help` case in the session-inspect suite. Existing suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `egc help <command>` for `crusher-shim`, `session-inspect`, `prompt`, and `claw` so they answer `--help` with their usage and exit 0.

- `crusher-shim` and `session-inspect` previously printed usage and exited 1; `prompt` died on a missing virtualenv with a bare ENOENT; `claw` opened the REPL instead.
- Real usage errors still exit 1, and a missing virtualenv is now reported by name with what it needs.
- Adds `tests/scripts/cli-help-exit.test.js` covering both flags per script, the dispatcher path, and the negative cases; the `prompt` case accepts the Python entry point's usage when the virtualenv exists.
- Adds a `--help` case to the session-inspect suite.

<sup>Written for commit cae05eb896a721cb821fc569affa8cb72125362d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

