### PR TITLE
fix(install): probe the sqlite3 binary EGC ships instead of warning about better-sqlite3

### DIFF
--- a/scripts/check-native-sqlite.js
+++ b/scripts/check-native-sqlite.js
@@ -11,7 +11,7 @@ function main() {
   try {
     require('sqlite3');
   } catch (error) {
-    const reason = String(error && error.message ? error.message : error).split('\n')[0];
+    const reason = String(error?.message ?? error).split('\n')[0];
     console.error(reason);
     process.exit(1);
   }

--- a/scripts/check-native-sqlite.js
+++ b/scripts/check-native-sqlite.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict';
+
+// Tells the installers whether the native sqlite3 binary loads on this
+// machine. EGC keeps working without it (the CLI and the MCP servers fall
+// back to the portable sql.js engine, with full-text search degraded to
+// substring matching), so the answer is a note, not an error: exit 0 when
+// the binary loads, 1 with the reason on stderr when it does not.
+
+function main() {
+  try {
+    require('sqlite3');
+  } catch (error) {
+    const reason = String(error && error.message ? error.message : error).split('\n')[0];
+    console.error(reason);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -194,21 +194,12 @@ if (-not $DryRun) {
         }
     }
 
-    # Verify native modules (better-sqlite3 requires Build Tools on Windows)
-    $nativeOk = $true
-    try {
-        node -e "require('better-sqlite3')" 2>$null
-    } catch {
-        $nativeOk = $false
-    }
-    if (-not $nativeOk) {
-        Write-Host ""
-        Write-Host "  WARNING: better-sqlite3 native module unavailable." -ForegroundColor Yellow
-        Write-Host "    SQLite CLI features (egc status, egc sessions) will be disabled." -ForegroundColor Yellow
-        Write-Host "    Core memory features via egc-memory MCP server are unaffected." -ForegroundColor Yellow
-        Write-Host "    To enable full SQLite, install Visual Studio Build Tools:" -ForegroundColor Yellow
-        Write-Host "    https://visualstudio.microsoft.com/visual-cpp-build-tools/" -ForegroundColor Yellow
-        Write-Host ""
+    # The native sqlite3 binary is a prebuilt download; when it cannot load
+    # here, EGC runs on its portable engine (full-text search degrades to
+    # substring matching), so this is a note rather than a warning.
+    node (Join-Path (Join-Path $RootDir "scripts") "check-native-sqlite.js") 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  note: native sqlite3 unavailable on this machine; EGC uses its portable engine (search falls back to substring matching)."
     }
 
     # egc-guardian

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,10 +111,15 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 
 if [[ "$DRY_RUN" = false ]]; then
-  # Root dependencies (better-sqlite3 etc.)
+  # Root dependencies (sqlite3 etc.)
   echo "  installing root dependencies..."
   cd "$ROOT_DIR"
   install_deps
+  # The native sqlite3 binary is a prebuilt download; when it cannot load
+  # here, EGC runs on its portable engine, so say so once and carry on.
+  if ! node "$ROOT_DIR/scripts/check-native-sqlite.js" 2>/dev/null; then
+    echo "  note: native sqlite3 unavailable on this machine; EGC uses its portable engine (search falls back to substring matching)."
+  fi
 
   # Point the "egc" command at this checkout, so the "egc doctor" the message
   # at the end of this script tells the user to run (and anything else they

--- a/tests/scripts/check-native-sqlite.test.js
+++ b/tests/scripts/check-native-sqlite.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'check-native-sqlite.js');
 
@@ -26,7 +27,7 @@ function runTests() {
   if (test('exits 0 quietly when the native sqlite3 binary loads', () => {
     let native = true;
     try { require('sqlite3'); } catch { native = false; }
-    const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8', timeout: CLI_TIMEOUT_MS });
     if (native) {
       assert.strictEqual(result.status, 0, result.stderr);
       assert.strictEqual(result.stdout, '');
@@ -46,7 +47,7 @@ function runTests() {
     try {
       const copy = path.join(dir, 'check-native-sqlite.js');
       fs.copyFileSync(SCRIPT, copy);
-      const result = spawnSync(process.execPath, [copy], { encoding: 'utf8', env: { ...process.env, NODE_PATH: '' } });
+      const result = spawnSync(process.execPath, [copy], { encoding: 'utf8', env: { ...process.env, NODE_PATH: '' }, timeout: CLI_TIMEOUT_MS });
       assert.strictEqual(result.status, 1);
       assert.ok(result.stderr.includes("Cannot find module 'sqlite3'"), result.stderr);
     } finally {

--- a/tests/scripts/check-native-sqlite.test.js
+++ b/tests/scripts/check-native-sqlite.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'check-native-sqlite.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing check-native-sqlite.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  if (test('exits 0 quietly when the native sqlite3 binary loads', () => {
+    let native = true;
+    try { require('sqlite3'); } catch { native = false; }
+    const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    if (native) {
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.strictEqual(result.stdout, '');
+    } else {
+      assert.strictEqual(result.status, 1);
+      assert.ok(result.stderr.trim().length > 0, 'the reason must be printed');
+    }
+  })) passed++; else failed++;
+
+  if (test('reports the load failure on stderr with exit 1 when the binary is unusable', () => {
+    // NODE_PATH cannot hide sqlite3 from a checkout that has it, so the
+    // failure branch is exercised by pointing the probe at a copy of the
+    // script placed where sqlite3 does not resolve.
+    const os = require('os');
+    const fs = require('fs');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-native-sqlite-'));
+    try {
+      const copy = path.join(dir, 'check-native-sqlite.js');
+      fs.copyFileSync(SCRIPT, copy);
+      const result = spawnSync(process.execPath, [copy], { encoding: 'utf8', env: { ...process.env, NODE_PATH: '' } });
+      assert.strictEqual(result.status, 1);
+      assert.ok(result.stderr.includes("Cannot find module 'sqlite3'"), result.stderr);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/install-ps1.test.js
+++ b/tests/scripts/install-ps1.test.js
@@ -141,6 +141,16 @@ function runTests() {
     assert.ok(bashSource.includes('skipping the prompt-library step'), 'install.sh must announce the skip too');
   })) passed++; else failed++;
 
+  if (test('probes the native sqlite3 binary EGC actually depends on, as a note rather than a warning', () => {
+    assert.ok(!scriptSource.includes('better-sqlite3 native module unavailable'), 'install.ps1 must not warn about better-sqlite3, which EGC no longer uses');
+    assert.ok(!/require\('better-sqlite3'\)/.test(scriptSource), 'install.ps1 must not probe better-sqlite3');
+    assert.ok(scriptSource.includes('check-native-sqlite.js'), 'install.ps1 must probe sqlite3 through scripts/check-native-sqlite.js');
+    assert.ok(bashSource.includes('check-native-sqlite.js'), 'install.sh must run the same probe');
+    for (const source of [scriptSource, bashSource]) {
+      assert.ok(source.includes('native sqlite3 unavailable on this machine; EGC uses its portable engine'), 'both installers print the same portable-engine note');
+    }
+  })) passed++; else failed++;
+
   if (test('installs dependencies via a lockfile-aware helper matching install.sh exactly (no npm install fallback)', () => {
     assert.ok(scriptSource.includes('function Install-Deps'), 'should define the lockfile-aware helper');
     assert.ok(scriptSource.includes('Test-Path "package-lock.json"'));


### PR DESCRIPTION
## What

Every Windows install of v1.1.20 and main prints:

```
WARNING: better-sqlite3 native module unavailable.
  SQLite CLI features (egc status, egc sessions) will be disabled.
  To enable full SQLite, install Visual Studio Build Tools
```

because `install.ps1` still probes `better-sqlite3`, a dependency EGC dropped; the probe can never succeed and the advice is wrong (the CLI features work, on the portable engine when needed). Seen on every Windows run of the end-to-end pass.

- Both installers now probe the `sqlite3` binary the package actually ships through `scripts/check-native-sqlite.js` (exit 0 when it loads, the reason on stderr otherwise).
- When it cannot load, they print one note: EGC uses its portable engine and search falls back to substring matching. install.sh gains the same note for parity.

## Proof

`tests/scripts/check-native-sqlite.test.js` (both outcomes), a parity assertion in the install.ps1 suite; installer suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows installs warning about `better-sqlite3`, a dependency EGC dropped, so installs no longer falsely claim SQLite CLI features are disabled.

- Both installers now probe the native `sqlite3` binary via `scripts/check-native-sqlite.js` and print one note when it cannot load, saying EGC falls back to its portable engine with substring search.
- Adds tests covering the probe's success and failure outcomes and installer parity.

<sup>Written for commit 3c5c1bb967bd3836f178a44012a81669636f364f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

