### PR TITLE
ci: give the npm-bound jobs a budget that fits their measured worst case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.pm }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -156,7 +156,7 @@ jobs:
   validate:
     name: Validate Components
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -10,7 +10,7 @@ jobs:
   audit:
     name: npm audit
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

Tonight every open PR lost the same lanes to `##[error]The operation was canceled.` at exactly the job limit, with the tests already green in the log (macOS Node 22 npm: 3868/3868 passed, then cancelled at 10:00). Measured on the last green main run today, the slowest Test lane took 7 minutes (Windows Node 20 npm); tonight the npm lanes on Windows and macOS ran past 10. Validate Components and the npm audit were cancelled at 5 minutes inside their npm install.

- Test job: `timeout-minutes` 10 → 15
- Validate Components: 5 → 10
- Reusable security audit job: 5 → 10

The budgets now cover the measured worst case with headroom instead of sitting 2 minutes above the normal Windows npm lane.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the CI job timeouts for npm-bound jobs so passing runs aren't cancelled at the job limit.

- Test job goes from 10 to 15 minutes; Validate Components and the npm audit go from 5 to 10.
- Windows and macOS npm lanes previously hit the 10-minute limit with tests already green, and the 5-minute jobs were cancelled inside `npm install`.

<sup>Written for commit c6e32b8a5e5f11295777e7c3f99e847c0768fcdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

