### PR TITLE
ci: skip the install-time advisory request in every lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ concurrency:
 permissions:
   contents: read
 
+# Every npm install here would otherwise end with an advisory request to
+# the registry; when that endpoint stalls, each lane waits out npm's fetch
+# timeout before running a single test. The dedicated security audit job
+# (reusable-security-audit.yml) is the one place that consults it.
+env:
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
+
 jobs:
   test:
     name: Test (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.pm }})
@@ -261,7 +269,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -291,7 +299,7 @@ jobs:
   runtime-cli-smoke:
     name: Runtime CLI Smoke (informational)
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 6
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# The install-time advisory lookup is skipped here for the same reason as
+# in ci.yml: the dedicated security audit job is the one that consults it.
+env:
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
+
 jobs:
   coverage:
     name: Coverage


### PR DESCRIPTION
## What

`npm ci` ends with an advisory lookup unless audit is off. Tonight that registry endpoint stalls (a local `npm audit` hangs past 120 s while `npm ping` answers in 2 s), so every lane waited out npm's fetch timeout before its first test: Lint, Validate Components and the informational smoke job were cancelled inside `Install dependencies` on every open PR, while the yarn and bun lanes, which do not consult it, passed.

- Workflow-level `NPM_CONFIG_AUDIT=false` and `NPM_CONFIG_FUND=false` for the CI workflow. The dedicated security audit job (`reusable-security-audit.yml`) keeps consulting the advisory database; the other lanes no longer depend on it.
- Lint job timeout 5 → 10 and the informational smoke job 3 → 6, the same headroom #1353 gave the test lanes.

Configuration only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips npm's install-time advisory lookup in the CI and coverage workflows so stalled registry endpoints no longer hold up test lanes.

- Sets `NPM_CONFIG_AUDIT=false` and `NPM_CONFIG_FUND=false` for both workflows; only the dedicated security audit job still consults the advisory database.
- The coverage job previously waited out the same fetch timeout and was cancelled at 20 minutes; it now skips the lookup too.
- Doubles lint and informational smoke job timeouts to match test lanes' headroom.

<sup>Written for commit 427628df91f6f80a3ff2d8322474ed7813ce06a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

