### PR TITLE
fix(watch): point at what creates the watched files instead of at egc install

### DIFF
--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -77,7 +77,8 @@ function main() {
 
   if (count === 0) {
     console.log('[egc watch] No EGC-managed tool config files found in this project.');
-    console.log('            Run egc install --target <tool> to set up a target first.');
+    console.log('            They are written the first time a session saves state here');
+    console.log('            (update_state from any tool after egc init); run egc watch again then.');
     process.exit(0);
   }
 


### PR DESCRIPTION
## What

Running the documented sequence end to end (merged main, Linux root-owned prefix): after `egc install --target cursor --profile full` in a project, `egc watch` still reports no EGC-managed tool config files and tells the user to run `egc install --target <tool>`. That advice cannot help: `egc watch` follows the memory propagation files (`.cursor/rules/egc-context.mdc`, `AGENTS.md`, `llms.txt` and friends), which no install profile writes. They appear the first time a session saves state in the project.

The empty-project hint now says that. Message only; no test asserts the old text.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the empty-project hint in `egc watch` to explain that the watched files appear the first time a session saves state, instead of telling users to run `egc install --target <tool>`. The old advice couldn't help because no install profile writes those files.

<sup>Written for commit 8df58591a3ba3858374f079f5fa1a750a432caad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

