### PR TITLE
fix(guardian): run the per-command checks before the metacharacter advisory and read combined short flags

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -34,7 +34,11 @@ export const FIND_ACTION_FLAGS = ['-delete', '-exec', '-execdir', '-ok', '-okdir
 const NO_SHORT_FLAG_CLUSTERS = new Set(['pwsh', 'powershell', 'powershell.exe']);
 const SHORT_FLAG_CLUSTER = /^-[A-Za-z]+$/;
 
-function matchesEvalFlag(arg: string, flags: string[], clusters = true): boolean {
+// `arg` is the lowercased token the exact and glued comparisons always used;
+// `casedArg` keeps the letter case, because inside a cluster -c and -C are
+// different options (bash -xC is noclobber, not eval), so the cluster check
+// must not inherit the lowercasing. Pass null to skip the cluster check.
+function matchesEvalFlag(arg: string, flags: string[], casedArg: string | null): boolean {
   for (const flag of flags) {
     if (arg === flag) return true;
     if (arg.startsWith(flag + '=') || arg.startsWith(flag + ':')) return true;
@@ -44,7 +48,7 @@ function matchesEvalFlag(arg: string, flags: string[], clusters = true): boolean
     // letter anywhere in a pure letter cluster (-xc, -lc, -Bc, -pe, -ne)
     // still switches on eval. Matching only the exact token or the glued
     // value form let `bash -xc "..."` through with no warning at all.
-    if (clusters && SHORT_FLAG_CLUSTER.test(arg) && arg.includes(flag[1])) return true;
+    if (casedArg !== null && SHORT_FLAG_CLUSTER.test(casedArg) && casedArg.includes(flag[1])) return true;
   }
   return false;
 }
@@ -1344,10 +1348,13 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   // Args are bareToken()'d before matching so a quoted/glued flag (e.g.
   // "--eval=code" with the whole flag=value inside one pair of quotes)
   // can't dodge the exact/prefix comparisons in matchesEvalFlag.
-  const evalFlagsForBase = INLINE_EVAL_COMMANDS[baseCommand]
-    ?? INLINE_EVAL_COMMANDS[bareInterpreterName(baseCommand)];
-  const clusters = !NO_SHORT_FLAG_CLUSTERS.has(baseCommand);
-  if (evalFlagsForBase && args.map(bareToken).some(a => matchesEvalFlag(a, evalFlagsForBase, clusters))) {
+  // The name the eval table answers to (bare, or version-stripped) is also
+  // the name the cluster exclusion is keyed on, so `pwsh7 -NonInteractive`
+  // is judged as PowerShell just like `pwsh`.
+  const evalName = INLINE_EVAL_COMMANDS[baseCommand] ? baseCommand : bareInterpreterName(baseCommand);
+  const evalFlagsForBase = INLINE_EVAL_COMMANDS[evalName];
+  const clusters = !NO_SHORT_FLAG_CLUSTERS.has(evalName);
+  if (evalFlagsForBase && args.some(a => matchesEvalFlag(bareToken(a), evalFlagsForBase, clusters ? stripQuotes(a) : null))) {
     return {
       allowed: false,
       reason: `inline code execution via '${baseCommand}' eval flag is forbidden — write the code to a file and run it instead`,

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -1238,7 +1238,7 @@ function validateDevToolArgs(baseCommand: string, args: string[], cwd?: string):
   // validateCommand, but a defense-in-depth check here means this branch
   // is still safe even if it's ever reached directly.
   const evalFlags = INLINE_EVAL_COMMANDS[baseCommand];
-  if (evalFlags && args.some(a => matchesEvalFlag(a, evalFlags))) {
+  if (evalFlags && args.some(a => matchesEvalFlag(bareToken(a), evalFlags, stripQuotes(a)))) {
 return {
   allowed: false,
   reason: `inline code execution via '${baseCommand}' eval flag is forbidden`,

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -29,11 +29,22 @@ export const FIND_ACTION_FLAGS = ['-delete', '-exec', '-execdir', '-ok', '-okdir
 // Matches an eval flag given exactly, glued to its value (-e'code', -ccode),
 // or joined with = or : (--eval=code, -Command:code). Exact membership alone
 // misses every glued form, which the underlying interpreters all accept.
-function matchesEvalFlag(arg: string, flags: string[]): boolean {
+// Interpreters whose single-dash options are long words (-NonInteractive,
+// -Command): a letter inside one of those is not a combined short flag.
+const NO_SHORT_FLAG_CLUSTERS = new Set(['pwsh', 'powershell', 'powershell.exe']);
+const SHORT_FLAG_CLUSTER = /^-[A-Za-z]+$/;
+
+function matchesEvalFlag(arg: string, flags: string[], clusters = true): boolean {
   for (const flag of flags) {
     if (arg === flag) return true;
     if (arg.startsWith(flag + '=') || arg.startsWith(flag + ':')) return true;
-    if (!flag.startsWith('--') && flag.length === 2 && arg.startsWith(flag) && arg.length > 2) return true;
+    if (flag.startsWith('--') || flag.length !== 2) continue;
+    if (arg.startsWith(flag) && arg.length > 2) return true;
+    // getopt-style interpreters accept combined short options, so the eval
+    // letter anywhere in a pure letter cluster (-xc, -lc, -Bc, -pe, -ne)
+    // still switches on eval. Matching only the exact token or the glued
+    // value form let `bash -xc "..."` through with no warning at all.
+    if (clusters && SHORT_FLAG_CLUSTER.test(arg) && arg.includes(flag[1])) return true;
   }
   return false;
 }
@@ -1335,7 +1346,8 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   // can't dodge the exact/prefix comparisons in matchesEvalFlag.
   const evalFlagsForBase = INLINE_EVAL_COMMANDS[baseCommand]
     ?? INLINE_EVAL_COMMANDS[bareInterpreterName(baseCommand)];
-  if (evalFlagsForBase && args.map(bareToken).some(a => matchesEvalFlag(a, evalFlagsForBase))) {
+  const clusters = !NO_SHORT_FLAG_CLUSTERS.has(baseCommand);
+  if (evalFlagsForBase && args.map(bareToken).some(a => matchesEvalFlag(a, evalFlagsForBase, clusters))) {
     return {
       allowed: false,
       reason: `inline code execution via '${baseCommand}' eval flag is forbidden — write the code to a file and run it instead`,
@@ -1352,14 +1364,20 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
   const destructiveDenial = destructiveVerdict(baseCommand, args);
   if (destructiveDenial) return destructiveDenial;
 
-  // 6. Shell metacharacters: an advisory-only signal (see ADVISORY_REASONS
-  // in the enforcement hook), checked only after every hard check above has
-  // had a chance to run against the real, unwrapped base command. Checking
-  // this first (as before) let a stray $/`/pipe elsewhere in the command —
-  // routinely present in legitimate quoted arguments, e.g. `git commit -m
-  // "fix: a && b"` — short-circuit the function before DANGEROUS/inline-eval
-  // ever ran, silently downgrading a real hard-block into an advisory-only
-  // verdict the hook does not act on.
+  // 6. Per-command checks (protected paths, destructive git/find forms,
+  // dev-tool targets) and the allowlist verdict, always. They used to sit
+  // behind the metacharacter step below, so any `2>/dev/null`, pipe or `$`
+  // in the command made that advisory-only step return first and the
+  // protected-path denial for `cat ~/.ssh/id_rsa 2>/dev/null` never ran.
+  const verdict = validateAgainstAllowlist(baseCommand, args, cwd);
+  if (!verdict.allowed && !isAllowlistMissVerdict(verdict)) return verdict;
+
+  // 7. Shell metacharacters: an advisory-only signal (see ADVISORY_REASONS
+  // in the enforcement hook), reported only once every hard check above has
+  // had its say. Checking this first (as before) let a stray $/`/pipe
+  // elsewhere in the command — routinely present in legitimate quoted
+  // arguments, e.g. `git commit -m "fix: a && b"` — short-circuit the
+  // function before the real denials ever ran.
   if (SHELL_META_REGEX.test(command)) {
     return {
       allowed: false,
@@ -1368,52 +1386,54 @@ export function validateCommand(command: string, cwd?: string): ValidationResult
     };
   }
 
-  // 7. Not in any allowlist: advisory-only at the hook layer (see
-  // ADVISORY_REASONS in pre-bash-guardian-validate.js) -- UNLESS the command
-  // targets a protected file, in which case it hard-blocks here instead
-  // (EGC-494). Catalogued commands (SAFE_READONLY/SAFE_DEV) already get
-  // their own protected-path checks per-command in validateCommandArgs
-  // below (step 8); this only runs for commands outside both lists (wget,
-  // curl, cp, sed -i, tee, ...), which previously had zero protected-path
-  // coverage since validateCommandArgs is never reached for them -- the
-  // generic "not in the allowlist" advisory swallowed every case, including
-  // `wget -O ~/.bashrc <url>`. Flag values (--output=path) are unwrapped so
-  // a protected target glued to its flag isn't skipped as a non-path arg.
-  if (!SAFE_READONLY.includes(baseCommand) && !SAFE_DEV.includes(baseCommand)) {
-    const candidatePaths = args.flatMap(rawArg => {
-      const arg = bareToken(rawArg);
-      if (!arg.startsWith('-')) {
-        // A URI operand (http://..., ftp://...) is a download/read target,
-        // not a local path -- passing it to isProtectedPath would resolve it
-        // relative to cwd and could false-positive hard-block a benign
-        // download whose URL happens to end in a protected-looking name.
-        return /^[a-z][a-z\d+.-]*:\/\//i.test(arg) ? [] : [arg];
-      }
-      const eq = arg.indexOf('=');
-      if (eq > 0) return [arg.slice(eq + 1)];
-      // A short option's value can be glued directly to its flag with no
-      // separator (`-o~/.bashrc`, equivalent to `-o ~/.bashrc`) -- without
-      // this, that form never produces a candidate and stays advisory-only.
-      if (!arg.startsWith('--') && arg.length > 2) return [arg.slice(2)];
-      return [];
-    });
-    const protectedTarget = candidatePaths.find(arg => isProtectedPath(arg, cwd));
-    if (protectedTarget) {
-      return {
-        allowed: false,
-        reason: `'${baseCommand}' targets a protected file (${protectedTarget}) and is always denied, regardless of allowlist status`,
-        trust_level: 'DANGEROUS',
-      };
+  return verdict;
+}
+
+const ALLOWLIST_MISS_MARKER = 'is not in the allowlist';
+
+function isAllowlistMissVerdict(verdict: ValidationResult): boolean {
+  return !verdict.allowed && String(verdict.reason ?? '').includes(ALLOWLIST_MISS_MARKER);
+}
+
+// Filesystem targets an argument can carry: a bare operand (URIs excluded,
+// they are download targets, not local paths), a --flag=value value, or a
+// value glued to a short flag (`-o~/.bashrc`).
+function pathCandidatesOf(args: string[]): string[] {
+  return args.flatMap(rawArg => {
+    const arg = bareToken(rawArg);
+    if (!arg.startsWith('-')) {
+      return /^[a-z][a-z\d+.-]*:\/\//i.test(arg) ? [] : [arg];
     }
+    const eq = arg.indexOf('=');
+    if (eq > 0) return [arg.slice(eq + 1)];
+    if (!arg.startsWith('--') && arg.length > 2) return [arg.slice(2)];
+    return [];
+  });
+}
+
+// Catalogued commands (SAFE_READONLY/SAFE_DEV) get their own per-command
+// checks in validateCommandArgs. Everything else is advisory-only at the
+// hook layer (ADVISORY_REASONS in pre-bash-guardian-validate.js), UNLESS it
+// targets a protected file, which hard-blocks here (EGC-494): without this,
+// `wget -O ~/.bashrc <url>` had zero protected-path coverage because the
+// generic allowlist-miss advisory swallowed every case.
+function validateAgainstAllowlist(baseCommand: string, args: string[], cwd?: string): ValidationResult {
+  if (SAFE_READONLY.includes(baseCommand) || SAFE_DEV.includes(baseCommand)) {
+    return validateCommandArgs(baseCommand, args, cwd);
+  }
+  const protectedTarget = pathCandidatesOf(args).find(arg => isProtectedPath(arg, cwd));
+  if (protectedTarget) {
     return {
       allowed: false,
-      reason: `Command '${baseCommand}' is not in the allowlist`,
-      trust_level: 'BLOCKED',
+      reason: `'${baseCommand}' targets a protected file (${protectedTarget}) and is always denied, regardless of allowlist status`,
+      trust_level: 'DANGEROUS',
     };
   }
-
-  // 8. In allowlist: validate args
-  return validateCommandArgs(baseCommand, args, cwd);
+  return {
+    allowed: false,
+    reason: `Command '${baseCommand}' ${ALLOWLIST_MISS_MARKER}`,
+    trust_level: 'BLOCKED',
+  };
 }
 
 export function validateWrite(filepath: string): ValidationResult {

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -475,6 +475,16 @@ async function runTests() {
     assert.ok(!String(result.reason || '').includes('inline code execution'), JSON.stringify(result));
   });
   run('pwsh -c is still hard-blocking', () => assertHardBlocking(`pwsh -c "Get-Process"`));
+  run('bash -xC script.sh (uppercase C is noclobber, not eval)', () => {
+    const result = validateCommand('bash -xC script.sh');
+    assert.ok(!String(result.reason || '').includes('inline code execution'), JSON.stringify(result));
+  });
+  run('perl -nE (uppercase E is eval) is hard-blocking', () => assertHardBlocking(`perl -nE "say 1" file.txt`));
+  run('pwsh7 -NonInteractive resolves as PowerShell and is not a cluster', () => {
+    const result = validateCommand('pwsh7 -NonInteractive -File build.ps1');
+    assert.ok(!String(result.reason || '').includes('inline code execution'), JSON.stringify(result));
+  });
+  run('pwsh7 -c is still hard-blocking', () => assertHardBlocking(`pwsh7 -c "Get-Process"`));
 
   // ── Summary ───────────────────────────────────────────────────────────────
 

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -427,6 +427,55 @@ async function runTests() {
   run('node -e is hard-blocking',      () => assertHardBlocking(`node -e "1"`));
   run('find -delete is hard-blocking', () => assertHardBlocking('find . -delete'));
 
+  // ── Security audit 2026-08-17, P1: the two bypasses reproduced live ────────
+  // A: any shell metacharacter (a trailing `2>/dev/null` counts) used to make
+  // the advisory metacharacter step return before the per-command checks, so
+  // the protected-path denial never ran and the hook saw only a warning.
+  console.log('\n=== audit P1-A: per-command checks survive metacharacters ===');
+  run('cat protected path with 2>/dev/null still hard-blocks', () => assertHardBlocking(`cat ${home}/.ssh/id_rsa 2>/dev/null`));
+  run('grep protected path with 2>/dev/null still hard-blocks', () => assertHardBlocking(`grep -r secret ${home}/.aws/config 2>/dev/null`));
+  run('head protected path piped still hard-blocks',          () => assertHardBlocking(`head -n 5 ${home}/.ssh/id_rsa | wc -l`));
+  run('git push --force with 2>/dev/null still hard-blocks',   () => assertHardBlocking('git push --force 2>/dev/null'));
+  run('find -delete with 2>/dev/null still hard-blocks',       () => assertHardBlocking('find . -delete 2>/dev/null'));
+  run('wget onto protected path with $ still hard-blocks',     () => assertHardBlocking(`wget -O ${home}/.bashrc "https://x.tld/$RANDOM"`));
+  run('cat of a plain file with 2>/dev/null stays advisory',   () => {
+    const result = validateCommand('cat README.md 2>/dev/null');
+    assert.strictEqual(result.allowed, false);
+    assert.ok(String(result.reason).includes('Shell chaining/metacharacters are forbidden'), JSON.stringify(result));
+  });
+  run('unknown command with $ stays advisory (metacharacter reason wins)', () => {
+    const result = validateCommand('cargo build --features "$FEATURES"');
+    assert.strictEqual(result.allowed, false);
+    assert.ok(String(result.reason).includes('Shell chaining/metacharacters are forbidden'), JSON.stringify(result));
+  });
+  run('unknown command without metacharacters stays an allowlist miss', () => {
+    const result = validateCommand('cargo build --release');
+    assert.strictEqual(result.allowed, false);
+    assert.ok(String(result.reason).includes('is not in the allowlist'), JSON.stringify(result));
+  });
+
+  // B: combined short flags (-xc, -lc, -Bc, -pe, -ne) switch on eval in every
+  // getopt-style interpreter, but only the exact token and the glued-value
+  // form were recognized, so `bash -xc "..."` ran with no warning at all.
+  console.log('\n=== audit P1-B: combined short flags reach the eval denial ===');
+  run('bash -xc is hard-blocking',     () => assertHardBlocking(`bash -xc "echo guardian-flag-test"`));
+  run('bash -lc is hard-blocking',     () => assertHardBlocking(`bash -lc "id"`));
+  run('sh -ec is hard-blocking',       () => assertHardBlocking(`sh -ec "id"`));
+  run('zsh -ic is hard-blocking',      () => assertHardBlocking(`zsh -ic "id"`));
+  run('python3 -Bc is hard-blocking',  () => assertHardBlocking(`python3 -Bc "print(1)"`));
+  run('node -pe is hard-blocking',     () => assertHardBlocking(`node -pe "1+1"`));
+  run('perl -ne is hard-blocking',     () => assertHardBlocking(`perl -ne "print" file.txt`));
+  run('su -lc is hard-blocking',       () => assertHardBlocking(`su -lc "id" root`));
+  run('bash -x script.sh (no eval letter) is not an eval denial', () => {
+    const result = validateCommand('bash -x script.sh');
+    assert.ok(!String(result.reason || '').includes('inline code execution'), JSON.stringify(result));
+  });
+  run('pwsh -NonInteractive is not read as a short-flag cluster', () => {
+    const result = validateCommand('pwsh -NonInteractive -File build.ps1');
+    assert.ok(!String(result.reason || '').includes('inline code execution'), JSON.stringify(result));
+  });
+  run('pwsh -c is still hard-blocking', () => assertHardBlocking(`pwsh -c "Get-Process"`));
+
   // ── Summary ───────────────────────────────────────────────────────────────
 
   console.log(`\n${'─'.repeat(50)}`);


### PR DESCRIPTION
## What

Day 1 of the security schedule: the two Guardian bypasses reproduced live against the production hook in the 17/08 audit.

- **Bypass A, `cat ~/.ssh/id_rsa 2>/dev/null` went through.** Any shell metacharacter made the advisory-only metacharacter step return before the per-command checks, so the protected-path denial for `cat`, `grep`, `head`, `ls` and the destructive `git`/`find` forms never ran. The per-command checks and the allowlist verdict now always run first; the metacharacter advisory is reported only when nothing harder applied (an allowlist miss keeps the metacharacter reason, as before, so nothing that was advisory becomes a hard block).
- **Bypass B, `bash -xc "..."` went through.** Only the exact eval flag and the glued-value form were matched. A pure letter cluster carrying the eval letter (`-xc`, `-lc`, `-Bc`, `-pe`, `-ne`) now counts for every getopt-style interpreter; PowerShell is excluded because its single-dash options are words (`-NonInteractive` contains a c and must not match).

Step 7's body moved into `validateAgainstAllowlist` and `pathCandidatesOf`, unchanged in behavior.

## Proof

- Live, through `scripts/hooks/pre-bash-guardian-validate.js` with the rebuilt validator: both bypass idioms are now blocked, the two controls stay blocked, and `cat README.md 2>/dev/null`, `git commit -m "fix: a && b"` and `bash -x script.sh` still pass.
- `tests/scripts/egc-guardian.test.js`: 20 new cases (146/146), including the negative ones (plain file with `2>/dev/null` stays advisory, `cargo build` stays an allowlist miss, `bash -x script.sh` and `pwsh -NonInteractive` are not eval). Hook suites 25/25 and 8/8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Guardian bypasses reproduced against the production hook in the 17/08 audit: protected-path denials no longer get skipped when a shell metacharacter is present, and combined short eval flags like `bash -xc "..."` are now blocked.

- Per-command checks and the allowlist verdict always run first; the metacharacter advisory is reported only when nothing harder applied, so advisory behavior is unchanged.
- Eval flag matching now recognizes pure letter clusters (`-xc`, `-lc`, `-Bc`, `-pe`, `-ne`) for getopt-style interpreters, preserving letter case so `bash -xC` (noclobber) is not read as eval; PowerShell is excluded via the resolved interpreter name, so `pwsh7 -NonInteractive` behaves like `pwsh`.
- The dev-tool defense-in-depth eval check now uses the same cased cluster matching, blocking `node -pe` and similar.
- Extracted `validateAgainstAllowlist` and `pathCandidatesOf` from the old step 7 with no behavior change.

<sup>Written for commit 1d7cc359c77bf4e09748f431d256a5ba784d77af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

