### PR TITLE
fix(security): confine replayed install-state operations to roots the adapter derives, and check the path inside file:// URIs

### DIFF
--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -618,6 +618,10 @@ const INLINE_EVAL_COMMANDS: Record<string, string[]> = {
 // tool's official docs, verified 2026-07-11 (see docs/architecture or the
 // PR that introduced this comment for the full per-tool research).
 export const PROTECTED_FILE_PATTERNS: RegExp[] = [
+  // EGC install-state: egc repair and uninstall replay what it records, so a
+  // planted entry would turn either into a write or delete of its choosing.
+  /(^|[\\/])egc[\\/][\w-]*install-state\.json$/,
+  /(^|[\\/])egc-install-state\.json$/,
   /\.env$/,
   // .env.example/.sample/.template are conventionally committed templates
   // with placeholder values, never real secrets — excluded so they're
@@ -1405,15 +1409,37 @@ function isAllowlistMissVerdict(verdict: ValidationResult): boolean {
 // Filesystem targets an argument can carry: a bare operand (URIs excluded,
 // they are download targets, not local paths), a --flag=value value, or a
 // value glued to a short flag (`-o~/.bashrc`).
+// file:///path and file://localhost/path name a local file, so the path
+// inside gets the same protected-path check as a bare operand would; every
+// other scheme is a download/read target with no local path in it.
+const FILE_URI_RE = /^file:\/\/(?:localhost)?(?=\/)/i;
+
+function unwrapFileUri(arg: string): string {
+  const match = FILE_URI_RE.exec(arg);
+  if (!match) return arg;
+  const rest = arg.slice(match[0].length);
+  let decoded = rest;
+  try {
+    decoded = decodeURIComponent(rest);
+  } catch {
+    // A malformed escape keeps the raw text; the check still sees the path.
+  }
+  // file:///C:/Users/x carries a slash before the drive letter.
+  return /^\/[A-Za-z]:/.test(decoded) ? decoded.slice(1) : decoded;
+}
+
 function pathCandidatesOf(args: string[]): string[] {
   return args.flatMap(rawArg => {
     const arg = bareToken(rawArg);
+    const cased = stripQuotes(rawArg);
     if (!arg.startsWith('-')) {
-      return /^[a-z][a-z\d+.-]*:\/\//i.test(arg) ? [] : [arg];
+      const unwrapped = unwrapFileUri(cased);
+      if (unwrapped !== cased) return [unwrapped];
+      return /^[a-z][a-z\d+.-]*:\/\//i.test(arg) ? [] : [cased];
     }
-    const eq = arg.indexOf('=');
-    if (eq > 0) return [arg.slice(eq + 1)];
-    if (!arg.startsWith('--') && arg.length > 2) return [arg.slice(2)];
+    const eq = cased.indexOf('=');
+    if (eq > 0) return [unwrapFileUri(cased.slice(eq + 1))];
+    if (!arg.startsWith('--') && arg.length > 2) return [unwrapFileUri(cased.slice(2))];
     return [];
   });
 }

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -1418,7 +1418,9 @@ function unwrapFileUri(arg: string): string {
   const match = FILE_URI_RE.exec(arg);
   if (!match) return arg;
   // A query or fragment is not part of the file a client opens.
-  const rest = arg.slice(match[0].length).replace(/[?#].*$/, '');
+  const tail = arg.slice(match[0].length);
+  const cut = tail.search(/[?#]/);
+  const rest = cut === -1 ? tail : tail.slice(0, cut);
   let decoded = rest;
   try {
     decoded = decodeURIComponent(rest);

--- a/mcp/servers/egc-guardian/src/validator.ts
+++ b/mcp/servers/egc-guardian/src/validator.ts
@@ -1417,7 +1417,8 @@ const FILE_URI_RE = /^file:\/\/(?:localhost)?(?=\/)/i;
 function unwrapFileUri(arg: string): string {
   const match = FILE_URI_RE.exec(arg);
   if (!match) return arg;
-  const rest = arg.slice(match[0].length);
+  // A query or fragment is not part of the file a client opens.
+  const rest = arg.slice(match[0].length).replace(/[?#].*$/, '');
   let decoded = rest;
   try {
     decoded = decodeURIComponent(rest);

--- a/schemas/install-state.schema.json
+++ b/schemas/install-state.schema.json
@@ -186,11 +186,13 @@
           },
           "sourceRelativePath": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^(?![/\\\\]|[A-Za-z]:)(?!(?:.*[/\\\\])?\\.\\.(?:[/\\\\]|$)).+$"
           },
           "destinationPath": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^(?=/|[A-Za-z]:[\\\\/]|\\\\\\\\)(?!(?:.*[/\\\\])?\\.\\.(?:[/\\\\]|$)).+$"
           },
           "strategy": {
             "type": "string",

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -433,7 +433,7 @@ function repairMergeJson(operation) {
   const mergedValue = deepMergeJson(currentValue, payload);
 
   ensureParentDir(operation.destinationPath);
-  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, formatJson(mergedValue)));
+  replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, formatJson(mergedValue)));
 }
 
 function repairRemove(operation) {
@@ -461,7 +461,7 @@ function repairMergeYamlReadList(operation) {
     );
   }
   ensureParentDir(operation.destinationPath);
-  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
+  replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, nextContent));
 }
 
 function repairMergeMarkdownIndex(operation) {
@@ -474,7 +474,7 @@ function repairMergeMarkdownIndex(operation) {
     relativePath: operation.relativePath,
   });
   ensureParentDir(operation.destinationPath);
-  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
+  replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, nextContent));
 }
 
 function executeRepairOperation(repoRoot, operation) {
@@ -499,14 +499,14 @@ function restorePreviousContent(operation) {
   const previousContent = getOperationPreviousContent(operation);
   if (previousContent !== null) {
     ensureParentDir(operation.destinationPath);
-    replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, previousContent));
+    replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, previousContent));
     return { removedPaths: [], cleanupTargets: [] };
   }
 
   const previousJson = getOperationPreviousJson(operation);
   if (previousJson !== undefined) {
     ensureParentDir(operation.destinationPath);
-    replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, formatJson(previousJson)));
+    replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, formatJson(previousJson)));
     return { removedPaths: [], cleanupTargets: [] };
   }
 
@@ -548,7 +548,7 @@ function uninstallMergeJson(operation) {
   }
 
   ensureParentDir(operation.destinationPath);
-  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, formatJson(nextValue)));
+  replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, formatJson(nextValue)));
   return { removedPaths: [], cleanupTargets: [] };
 }
 
@@ -577,7 +577,7 @@ function uninstallAiderConfigReadList(operation) {
   }
 
   ensureParentDir(operation.destinationPath);
-  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
+  replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, nextContent));
   return { removedPaths: [], cleanupTargets: [] };
 }
 
@@ -593,7 +593,7 @@ function uninstallWarpAgentsIndexEntry(operation) {
   const existingContent = fs.readFileSync(operation.destinationPath, 'utf8');
   const nextContent = removeSkillIndexEntry(existingContent, operation.skillName);
   ensureParentDir(operation.destinationPath);
-  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
+  replaceFileWith(operation.destinationPath, descriptor => fs.writeFileSync(descriptor, nextContent));
   return { removedPaths: [], cleanupTargets: [] };
 }
 

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const { resolveInstallPlan, loadInstallManifests } = require('./install-manifests');
 const { readInstallState, writeInstallState } = require('./install-state');
 const { hasParentSegment, isAnchoredPath, isInsideReal, realizePath } = require('./path-safety');
+const { copyFileKeepingMode, replaceFileWith } = require('./install/preserving-write');
 const { syncInstallStateToStore } = require('./install-state-store-sync');
 const {
   createManifestInstallPlan,
@@ -417,7 +418,7 @@ function repairCopyFile(repoRoot, operation) {
   }
 
   ensureParentDir(operation.destinationPath);
-  fs.copyFileSync(sourcePath, operation.destinationPath);
+  copyFileKeepingMode(sourcePath, operation.destinationPath);
 }
 
 function repairMergeJson(operation) {
@@ -432,7 +433,7 @@ function repairMergeJson(operation) {
   const mergedValue = deepMergeJson(currentValue, payload);
 
   ensureParentDir(operation.destinationPath);
-  fs.writeFileSync(operation.destinationPath, formatJson(mergedValue));
+  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, formatJson(mergedValue)));
 }
 
 function repairRemove(operation) {
@@ -460,7 +461,7 @@ function repairMergeYamlReadList(operation) {
     );
   }
   ensureParentDir(operation.destinationPath);
-  fs.writeFileSync(operation.destinationPath, nextContent);
+  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
 }
 
 function repairMergeMarkdownIndex(operation) {
@@ -473,7 +474,7 @@ function repairMergeMarkdownIndex(operation) {
     relativePath: operation.relativePath,
   });
   ensureParentDir(operation.destinationPath);
-  fs.writeFileSync(operation.destinationPath, nextContent);
+  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
 }
 
 function executeRepairOperation(repoRoot, operation) {
@@ -498,14 +499,14 @@ function restorePreviousContent(operation) {
   const previousContent = getOperationPreviousContent(operation);
   if (previousContent !== null) {
     ensureParentDir(operation.destinationPath);
-    fs.writeFileSync(operation.destinationPath, previousContent);
+    replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, previousContent));
     return { removedPaths: [], cleanupTargets: [] };
   }
 
   const previousJson = getOperationPreviousJson(operation);
   if (previousJson !== undefined) {
     ensureParentDir(operation.destinationPath);
-    fs.writeFileSync(operation.destinationPath, formatJson(previousJson));
+    replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, formatJson(previousJson)));
     return { removedPaths: [], cleanupTargets: [] };
   }
 
@@ -547,7 +548,7 @@ function uninstallMergeJson(operation) {
   }
 
   ensureParentDir(operation.destinationPath);
-  fs.writeFileSync(operation.destinationPath, formatJson(nextValue));
+  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, formatJson(nextValue)));
   return { removedPaths: [], cleanupTargets: [] };
 }
 
@@ -576,7 +577,7 @@ function uninstallAiderConfigReadList(operation) {
   }
 
   ensureParentDir(operation.destinationPath);
-  fs.writeFileSync(operation.destinationPath, nextContent);
+  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
   return { removedPaths: [], cleanupTargets: [] };
 }
 
@@ -592,7 +593,7 @@ function uninstallWarpAgentsIndexEntry(operation) {
   const existingContent = fs.readFileSync(operation.destinationPath, 'utf8');
   const nextContent = removeSkillIndexEntry(existingContent, operation.skillName);
   ensureParentDir(operation.destinationPath);
-  fs.writeFileSync(operation.destinationPath, nextContent);
+  replaceFileWith(operation.destinationPath, temporary => fs.writeFileSync(temporary, nextContent));
   return { removedPaths: [], cleanupTargets: [] };
 }
 

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -83,12 +83,80 @@ function getManagedOperations(state) {
     : [];
 }
 
-function resolveOperationSourcePath(repoRoot, operation) {
-  if (operation.sourceRelativePath) {
-    return path.join(repoRoot, operation.sourceRelativePath);
-  }
+function hasParentSegment(value) {
+  return String(value).split(/[\\/]/).includes('..');
+}
 
-  return operation.sourcePath || null;
+// Only the manifest-relative path recorded at install time is joined onto
+// the reference repository; the absolute sourcePath stored next to it is
+// never replayed, so a planted entry cannot make repair copy from anywhere.
+function resolveOperationSourcePath(repoRoot, operation) {
+  const relative = operation.sourceRelativePath;
+  if (typeof relative !== 'string' || relative.trim() === '' || path.isAbsolute(relative) || hasParentSegment(relative)) {
+    return null;
+  }
+  return path.join(repoRoot, relative);
+}
+
+function isPathInside(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+// Destinations this adapter would produce today, derived from the current
+// manifest rather than read back from the state file. The recorded request
+// is tried first; a request the manifest can no longer plan falls back to the
+// full profile, and with no plan at all only the derived target root counts.
+function collectPlannedDestinations(record, context) {
+  const request = record.state?.request || {};
+  const attempts = [
+    { profileId: request.profile || null, moduleIds: request.modules || [], includeComponentIds: request.includeComponents || [], excludeComponentIds: request.excludeComponents || [] },
+    { profileId: 'full', moduleIds: [], includeComponentIds: [], excludeComponentIds: [] },
+  ];
+  for (const attempt of attempts) {
+    try {
+      const plan = createManifestInstallPlan({
+        sourceRoot: context.repoRoot,
+        target: record.adapter.target,
+        projectRoot: context.projectRoot,
+        homeDir: context.homeDir,
+        ...attempt,
+      });
+      const operations = Array.isArray(plan.operations) ? plan.operations : [];
+      return {
+        files: new Set(operations.map(operation => path.resolve(operation.destinationPath))),
+        dirs: new Set(operations.filter(operation => operation.kind === 'copy-path').map(operation => path.resolve(operation.destinationPath))),
+      };
+    } catch (_error) { // NOSONAR: a request the current manifest cannot plan falls through to the next attempt
+      continue;
+    }
+  }
+  return { files: new Set(), dirs: new Set() };
+}
+
+// A recorded operation may only touch the derived target root, a file the
+// current manifest plans for this adapter, or a directory that plan copies.
+function operationEscapes(operation, root, planned) {
+  const destination = operation.destinationPath;
+  if (typeof destination !== 'string' || !path.isAbsolute(destination) || hasParentSegment(destination)) return true;
+  const resolved = path.resolve(destination);
+  if (operation.kind === 'remove' && resolved === root) return true;
+  if (isPathInside(resolved, root)) return false;
+  if (planned.files.has(resolved)) return false;
+  return ![...planned.dirs].some(dir => isPathInside(resolved, dir));
+}
+
+function findEscapingOperation(operations, record, context) {
+  const root = path.resolve(record.targetRoot);
+  const planned = collectPlannedDestinations(record, context);
+  return operations.find(operation => operationEscapes(operation, root, planned)) || null;
+}
+
+function assertRecordedOperationsContained(record, context, operations) {
+  const escaping = findEscapingOperation(operations, record, context);
+  if (escaping) {
+    throw new Error(`Recorded operation escapes the managed roots for ${record.adapter.id}: ${escaping.destinationPath}`);
+  }
 }
 
 // Identity for matching a health inspection back to the operation entry in a
@@ -1119,15 +1187,17 @@ function createRepairPlanFromRecord(record, context) {
 
   if (state.request.legacyMode || shouldRepairFromRecordedOperations(state)) {
     const operations = hydrateRecordedOperations(context.repoRoot, getManagedOperations(state));
+    assertRecordedOperationsContained(record, context, operations);
     const statePreview = buildRecordedStatePreview(state, context, operations);
 
+    // Roots come from the adapter (record), never from the state file.
     return {
       mode: state.request.legacyMode ? 'legacy' : 'recorded',
       target: record.adapter.target,
       adapter: record.adapter,
-      targetRoot: state.target.root,
-      installRoot: state.target.root,
-      installStatePath: state.target.installStatePath,
+      targetRoot: record.targetRoot,
+      installRoot: record.targetRoot,
+      installStatePath: record.installStatePath,
       warnings: [],
       languages: Array.isArray(state.request.legacyLanguages)
         ? [...state.request.legacyLanguages]
@@ -1408,9 +1478,14 @@ function cleanupEmptyParentDirs(filePath, stopAt) {
 }
 
 function uninstallInstalledStates(options = {}) {
+  const context = {
+    repoRoot: options.repoRoot || DEFAULT_REPO_ROOT,
+    homeDir: options.homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir(),
+    projectRoot: options.projectRoot || process.cwd(),
+  };
   const records = discoverInstalledStates({
-    homeDir: options.homeDir,
-    projectRoot: options.projectRoot,
+    homeDir: context.homeDir,
+    projectRoot: context.projectRoot,
     targets: options.targets,
   }).filter(record => record.exists);
 
@@ -1427,9 +1502,23 @@ function uninstallInstalledStates(options = {}) {
     }
 
     const state = record.state;
+    const operations = getManagedOperations(state);
+    // Every recorded path is checked against the roots the adapter derives
+    // today before anything is removed; one planted entry refuses the target.
+    const escaping = findEscapingOperation(operations, record, context);
+    if (escaping) {
+      return {
+        adapter: record.adapter,
+        status: 'error',
+        installStatePath: record.installStatePath,
+        removedPaths: [],
+        plannedRemovals: [],
+        error: `Recorded operation escapes the managed roots for ${record.adapter.id}: ${escaping.destinationPath}`,
+      };
+    }
     const plannedRemovals = Array.from(new Set([
-      ...getManagedOperations(state).map(operation => operation.destinationPath),
-      state.target.installStatePath,
+      ...operations.map(operation => operation.destinationPath),
+      record.installStatePath,
     ]));
 
     if (options.dryRun) {
@@ -1446,7 +1535,6 @@ function uninstallInstalledStates(options = {}) {
     try {
       const removedPaths = [];
       const cleanupTargets = [];
-      const operations = getManagedOperations(state);
 
       for (const operation of operations) {
         const outcome = executeUninstallOperation(operation);
@@ -1454,14 +1542,14 @@ function uninstallInstalledStates(options = {}) {
         cleanupTargets.push(...outcome.cleanupTargets);
       }
 
-      if (fs.existsSync(state.target.installStatePath)) {
-        fs.rmSync(state.target.installStatePath, { force: true });
-        removedPaths.push(state.target.installStatePath);
-        cleanupTargets.push(state.target.installStatePath);
+      if (fs.existsSync(record.installStatePath)) {
+        fs.rmSync(record.installStatePath, { force: true });
+        removedPaths.push(record.installStatePath);
+        cleanupTargets.push(record.installStatePath);
       }
 
       for (const cleanupTarget of cleanupTargets) {
-        cleanupEmptyParentDirs(cleanupTarget, state.target.root);
+        cleanupEmptyParentDirs(cleanupTarget, record.targetRoot);
       }
 
       return {

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -4,6 +4,7 @@ const path = require('node:path');
 
 const { resolveInstallPlan, loadInstallManifests } = require('./install-manifests');
 const { readInstallState, writeInstallState } = require('./install-state');
+const { hasParentSegment, isAnchoredPath, isInsideReal, realizePath } = require('./path-safety');
 const { syncInstallStateToStore } = require('./install-state-store-sync');
 const {
   createManifestInstallPlan,
@@ -83,24 +84,17 @@ function getManagedOperations(state) {
     : [];
 }
 
-function hasParentSegment(value) {
-  return String(value).split(/[\\/]/).includes('..');
-}
-
 // Only the manifest-relative path recorded at install time is joined onto
 // the reference repository; the absolute sourcePath stored next to it is
-// never replayed, so a planted entry cannot make repair copy from anywhere.
+// never replayed, so a planted entry cannot make repair copy from anywhere,
+// and a source that leaves the repository through a link is refused too.
 function resolveOperationSourcePath(repoRoot, operation) {
   const relative = operation.sourceRelativePath;
-  if (typeof relative !== 'string' || relative.trim() === '' || path.isAbsolute(relative) || hasParentSegment(relative)) {
+  if (typeof relative !== 'string' || relative.trim() === '' || isAnchoredPath(relative) || hasParentSegment(relative)) {
     return null;
   }
-  return path.join(repoRoot, relative);
-}
-
-function isPathInside(candidate, root) {
-  const relative = path.relative(root, candidate);
-  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+  const joined = path.join(repoRoot, relative);
+  return isInsideReal(joined, repoRoot) ? joined : null;
 }
 
 // Destinations this adapter would produce today, derived from the current
@@ -124,8 +118,8 @@ function collectPlannedDestinations(record, context) {
       });
       const operations = Array.isArray(plan.operations) ? plan.operations : [];
       return {
-        files: new Set(operations.map(operation => path.resolve(operation.destinationPath))),
-        dirs: new Set(operations.filter(operation => operation.kind === 'copy-path').map(operation => path.resolve(operation.destinationPath))),
+        files: new Set(operations.map(operation => realizePath(operation.destinationPath))),
+        dirs: new Set(operations.filter(operation => operation.kind === 'copy-path').map(operation => realizePath(operation.destinationPath))),
       };
     } catch (_error) { // NOSONAR: a request the current manifest cannot plan falls through to the next attempt
       continue;
@@ -136,18 +130,20 @@ function collectPlannedDestinations(record, context) {
 
 // A recorded operation may only touch the derived target root, a file the
 // current manifest plans for this adapter, or a directory that plan copies.
+// Every comparison is made on real locations (links followed, missing tails
+// kept), so a link inside the root cannot point the replay outside it.
 function operationEscapes(operation, root, planned) {
   const destination = operation.destinationPath;
-  if (typeof destination !== 'string' || !path.isAbsolute(destination) || hasParentSegment(destination)) return true;
-  const resolved = path.resolve(destination);
+  if (typeof destination !== 'string' || !isAnchoredPath(destination) || hasParentSegment(destination)) return true;
+  const resolved = realizePath(destination);
   if (operation.kind === 'remove' && resolved === root) return true;
-  if (isPathInside(resolved, root)) return false;
+  if (isInsideReal(resolved, root)) return false;
   if (planned.files.has(resolved)) return false;
-  return ![...planned.dirs].some(dir => isPathInside(resolved, dir));
+  return ![...planned.dirs].some(dir => isInsideReal(resolved, dir));
 }
 
 function findEscapingOperation(operations, record, context) {
-  const root = path.resolve(record.targetRoot);
+  const root = realizePath(record.targetRoot);
   const planned = collectPlannedDestinations(record, context);
   return operations.find(operation => operationEscapes(operation, root, planned)) || null;
 }

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -142,12 +142,30 @@ const OPERATION_STRING_FIELDS = [
   'ownership',
 ];
 
+function hasParentSegment(value) {
+  return String(value).split(/[\\/]/).includes('..');
+}
+
+// A recorded destination is replayed verbatim by repair and uninstall, and
+// the source is joined onto the reference repository: neither may climb.
+function validateOperationPaths(operation, instancePath, pushError) {
+  const destination = operation.destinationPath;
+  if (isNonEmptyString(destination) && (!path.isAbsolute(destination) || hasParentSegment(destination))) {
+    pushError(`${instancePath}/destinationPath`, 'must be an absolute path without ".." segments');
+  }
+  const source = operation.sourceRelativePath;
+  if (isNonEmptyString(source) && (path.isAbsolute(source) || hasParentSegment(source))) {
+    pushError(`${instancePath}/sourceRelativePath`, 'must be a relative path without ".." segments');
+  }
+}
+
 function validateOperation(operation, instancePath, pushError) {
   for (const field of OPERATION_STRING_FIELDS) {
     if (!isNonEmptyString(operation[field])) {
       pushError(`${instancePath}/${field}`, 'must be non-empty string');
     }
   }
+  validateOperationPaths(operation, instancePath, pushError);
   if (typeof operation.scaffoldOnly !== 'boolean') {
     pushError(`${instancePath}/scaffoldOnly`, 'must be boolean');
   }

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -1,5 +1,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { hasParentSegment, isAnchoredPath } = require('./path-safety');
 
 let Ajv = null;
 try {
@@ -142,19 +143,17 @@ const OPERATION_STRING_FIELDS = [
   'ownership',
 ];
 
-function hasParentSegment(value) {
-  return String(value).split(/[\\/]/).includes('..');
-}
-
-// A recorded destination is replayed verbatim by repair and uninstall, and
-// the source is joined onto the reference repository: neither may climb.
+// A recorded destination is replayed by repair and uninstall, and the source
+// is joined onto the reference repository: neither may climb. "Absolute"
+// means anchored on either platform family, the same rule the JSON schema
+// applies, so both validators agree whatever host wrote the file.
 function validateOperationPaths(operation, instancePath, pushError) {
   const destination = operation.destinationPath;
-  if (isNonEmptyString(destination) && (!path.isAbsolute(destination) || hasParentSegment(destination))) {
+  if (isNonEmptyString(destination) && (!isAnchoredPath(destination) || hasParentSegment(destination))) {
     pushError(`${instancePath}/destinationPath`, 'must be an absolute path without ".." segments');
   }
   const source = operation.sourceRelativePath;
-  if (isNonEmptyString(source) && (path.isAbsolute(source) || hasParentSegment(source))) {
+  if (isNonEmptyString(source) && (isAnchoredPath(source) || hasParentSegment(source))) {
     pushError(`${instancePath}/sourceRelativePath`, 'must be a relative path without ".." segments');
   }
 }

--- a/scripts/lib/install/preserving-write.js
+++ b/scripts/lib/install/preserving-write.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const fs = require('node:fs');
+
+// Files the installer and its repair replay manage land in one atomic
+// replacement: the content is written next to the destination and renamed
+// over it, so a hard link at the destination is replaced instead of written
+// through, and nothing outside the managed location is modified.
+function replaceFileWith(destinationPath, writeTemporary) {
+  let existingMode;
+  try {
+    existingMode = fs.statSync(destinationPath).mode & 0o777;
+  } catch {
+    existingMode = null;
+  }
+  const temporary = `${destinationPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeTemporary(temporary);
+    if (existingMode !== null) fs.chmodSync(temporary, existingMode);
+    fs.renameSync(temporary, destinationPath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
+}
+
+// A destination created here takes the source's permission bits (an MCP
+// file may carry credentials and be mode-restricted); one that already
+// exists keeps the mode its owner chose.
+function writeTextKeepingMode(destinationPath, text, sourcePath) {
+  const sourceMode = fs.statSync(sourcePath).mode & 0o777;
+  replaceFileWith(destinationPath, temporary => {
+    fs.writeFileSync(temporary, text);
+    fs.chmodSync(temporary, sourceMode);
+  });
+}
+
+function copyFileKeepingMode(sourcePath, destinationPath) {
+  replaceFileWith(destinationPath, temporary => fs.copyFileSync(sourcePath, temporary));
+}
+
+module.exports = { copyFileKeepingMode, replaceFileWith, writeTextKeepingMode };

--- a/scripts/lib/install/preserving-write.js
+++ b/scripts/lib/install/preserving-write.js
@@ -1,42 +1,50 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 
 // Files the installer and its repair replay manage land in one atomic
-// replacement: the content is written next to the destination and renamed
-// over it, so a hard link at the destination is replaced instead of written
-// through, and nothing outside the managed location is modified.
-function replaceFileWith(destinationPath, writeTemporary) {
+// replacement: the content is written to a temporary sibling that is created
+// exclusively (a link planted at that name is refused, never followed) and
+// renamed over the destination, so a hard link or a symlink at the
+// destination is replaced instead of written through, and nothing outside
+// the managed location is modified. An existing destination keeps the mode
+// its owner chose.
+function replaceFileWith(destinationPath, writeContent) {
   let existingMode;
   try {
     existingMode = fs.statSync(destinationPath).mode & 0o777;
   } catch {
     existingMode = null;
   }
-  const temporary = `${destinationPath}.${process.pid}.${Date.now()}.tmp`;
+  const temporary = `${destinationPath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  const descriptor = fs.openSync(temporary, 'wx', existingMode ?? 0o644);
+  let open = true;
   try {
-    writeTemporary(temporary);
-    if (existingMode !== null) fs.chmodSync(temporary, existingMode);
+    writeContent(descriptor);
+    if (existingMode !== null) fs.fchmodSync(descriptor, existingMode);
+    open = false;
+    fs.closeSync(descriptor);
     fs.renameSync(temporary, destinationPath);
   } catch (error) {
-    fs.rmSync(temporary, { force: true });
+    if (open) fs.closeSync(descriptor);
+    try {
+      fs.unlinkSync(temporary);
+    } catch {
+      // nothing was left to remove
+    }
     throw error;
   }
 }
 
-// A destination created here takes the source's permission bits (an MCP
-// file may carry credentials and be mode-restricted); one that already
-// exists keeps the mode its owner chose.
-function writeTextKeepingMode(destinationPath, text, sourcePath) {
+// A destination created here takes the source's permission bits.
+function copyFileKeepingMode(sourcePath, destinationPath) {
   const sourceMode = fs.statSync(sourcePath).mode & 0o777;
-  replaceFileWith(destinationPath, temporary => {
-    fs.writeFileSync(temporary, text);
-    fs.chmodSync(temporary, sourceMode);
+  const existed = fs.existsSync(destinationPath);
+  replaceFileWith(destinationPath, descriptor => {
+    fs.writeFileSync(descriptor, fs.readFileSync(sourcePath));
+    if (!existed) fs.fchmodSync(descriptor, sourceMode);
   });
 }
 
-function copyFileKeepingMode(sourcePath, destinationPath) {
-  replaceFileWith(destinationPath, temporary => fs.copyFileSync(sourcePath, temporary));
-}
-
-module.exports = { copyFileKeepingMode, replaceFileWith, writeTextKeepingMode };
+module.exports = { copyFileKeepingMode, replaceFileWith };

--- a/scripts/lib/install/preserving-write.js
+++ b/scripts/lib/install/preserving-write.js
@@ -3,31 +3,40 @@
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 
+const COPY_CHUNK_BYTES = 64 * 1024;
+
 // Files the installer and its repair replay manage land in one atomic
 // replacement: the content is written to a temporary sibling that is created
-// exclusively (a link planted at that name is refused, never followed) and
-// renamed over the destination, so a hard link or a symlink at the
-// destination is replaced instead of written through, and nothing outside
-// the managed location is modified. An existing destination keeps the mode
-// its owner chose.
-function replaceFileWith(destinationPath, writeContent) {
+// exclusively (a link planted at that name is refused, never followed), with
+// its final mode from the start, and renamed over the destination, so a hard
+// link or a symlink at the destination is replaced instead of written
+// through, and nothing outside the managed location is modified. An existing
+// destination keeps the mode its owner chose; a new one takes `createMode`.
+function replaceFileWith(destinationPath, writeContent, createMode = 0o644) {
   let existingMode;
   try {
     existingMode = fs.statSync(destinationPath).mode & 0o777;
   } catch {
     existingMode = null;
   }
+  const mode = existingMode ?? createMode;
   const temporary = `${destinationPath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
-  const descriptor = fs.openSync(temporary, 'wx', existingMode ?? 0o644);
+  const descriptor = fs.openSync(temporary, 'wx', mode);
   let open = true;
   try {
     writeContent(descriptor);
-    if (existingMode !== null) fs.fchmodSync(descriptor, existingMode);
-    open = false;
+    fs.fchmodSync(descriptor, mode);
     fs.closeSync(descriptor);
+    open = false;
     fs.renameSync(temporary, destinationPath);
   } catch (error) {
-    if (open) fs.closeSync(descriptor);
+    if (open) {
+      try {
+        fs.closeSync(descriptor);
+      } catch {
+        // the descriptor is gone already
+      }
+    }
     try {
       fs.unlinkSync(temporary);
     } catch {
@@ -37,14 +46,24 @@ function replaceFileWith(destinationPath, writeContent) {
   }
 }
 
+function copyThroughDescriptor(sourcePath, descriptor) {
+  const source = fs.openSync(sourcePath, 'r');
+  try {
+    const buffer = Buffer.alloc(COPY_CHUNK_BYTES);
+    for (;;) {
+      const read = fs.readSync(source, buffer, 0, buffer.length, null);
+      if (read === 0) break;
+      fs.writeSync(descriptor, buffer, 0, read);
+    }
+  } finally {
+    fs.closeSync(source);
+  }
+}
+
 // A destination created here takes the source's permission bits.
 function copyFileKeepingMode(sourcePath, destinationPath) {
   const sourceMode = fs.statSync(sourcePath).mode & 0o777;
-  const existed = fs.existsSync(destinationPath);
-  replaceFileWith(destinationPath, descriptor => {
-    fs.writeFileSync(descriptor, fs.readFileSync(sourcePath));
-    if (!existed) fs.fchmodSync(descriptor, sourceMode);
-  });
+  replaceFileWith(destinationPath, descriptor => copyThroughDescriptor(sourcePath, descriptor), sourceMode);
 }
 
 module.exports = { copyFileKeepingMode, replaceFileWith };

--- a/scripts/lib/install/preserving-write.js
+++ b/scripts/lib/install/preserving-write.js
@@ -53,7 +53,13 @@ function copyThroughDescriptor(sourcePath, descriptor) {
     for (;;) {
       const read = fs.readSync(source, buffer, 0, buffer.length, null);
       if (read === 0) break;
-      fs.writeSync(descriptor, buffer, 0, read);
+      let offset = 0;
+      while (offset < read) {
+        const written = fs.writeSync(descriptor, buffer, offset, read - offset);
+        if (written <= 0) throw new Error(`Short write while copying ${sourcePath}`);
+        offset += written;
+      }
+
     }
   } finally {
     fs.closeSync(source);

--- a/scripts/lib/path-safety.js
+++ b/scripts/lib/path-safety.js
@@ -31,7 +31,7 @@ function realizePath(target) {
     tail.unshift(path.basename(probe));
     probe = parent;
   }
-  let real = probe;
+  let real;
   try {
     real = fs.realpathSync(probe);
   } catch {

--- a/scripts/lib/path-safety.js
+++ b/scripts/lib/path-safety.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Path predicates shared by the install-state validator and the replay
+// containment in the lifecycle, so the two cannot drift apart.
+
+function hasParentSegment(value) {
+  return String(value).split(/[\\/]/).includes('..');
+}
+
+// Absolute on either platform family: a POSIX root, a drive letter or a UNC
+// share. The state file may have been written on another host.
+const ANCHORED_RE = /^(?:[\\/]|[A-Za-z]:[\\/])/;
+
+function isAnchoredPath(value) {
+  return typeof value === 'string' && ANCHORED_RE.test(value);
+}
+
+// Where a write or delete of `target` would actually land: the real location
+// of its deepest existing ancestor, joined with the tail that does not exist
+// yet, so a link anywhere along the path is followed the way the filesystem
+// would follow it.
+function realizePath(target) {
+  let probe = path.resolve(target);
+  const tail = [];
+  while (!fs.existsSync(probe)) {
+    const parent = path.dirname(probe);
+    if (parent === probe) break;
+    tail.unshift(path.basename(probe));
+    probe = parent;
+  }
+  let real = probe;
+  try {
+    real = fs.realpathSync(probe);
+  } catch {
+    real = probe;
+  }
+  return path.join(real, ...tail);
+}
+
+function isInsideReal(target, root) {
+  const relative = path.relative(realizePath(root), realizePath(target));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+module.exports = { hasParentSegment, isAnchoredPath, isInsideReal, realizePath };

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -2472,6 +2472,42 @@ function runTests() {
     cleanup(outside);
   }
 
+  // A hard link inside the root that aliases a file outside it: the replay
+  // replaces the link instead of writing through it.
+  {
+    const homeDir = createTempDir('lifecycle-home-');
+    const projectRoot = createTempDir('lifecycle-project-');
+    const outside = createTempDir('lifecycle-outside-');
+    const victim = path.join(outside, 'aliased.md');
+    const destinationPath = path.join(projectRoot, '.cursor', 'rules', 'coding-style.md');
+    let linked = false;
+    try {
+      fs.writeFileSync(victim, 'outside content');
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+      fs.linkSync(victim, destinationPath);
+      linked = true;
+    } catch (error) {
+      console.log(`  - skipped (hard link): cannot create hard links here (${error.code})`);
+    }
+    if (linked) {
+      if (test('repair replaces a hard-linked destination without touching the file it aliased', () => {
+        writeCursorState(projectRoot, {
+          operations: [
+            managedOperation('copy-file', destinationPath, { sourceRelativePath: 'rules/common/coding-style.md', strategy: 'copy-file' }),
+          ],
+        });
+        const result = repairInstalledStates({ repoRoot: REPO_ROOT, homeDir, projectRoot, targets: ['cursor'] });
+        assert.strictEqual(result.results[0].status, 'repaired', JSON.stringify(result.results[0]));
+        assert.strictEqual(fs.readFileSync(victim, 'utf8'), 'outside content');
+        assert.ok(fs.readFileSync(destinationPath).equals(fs.readFileSync(path.join(REPO_ROOT, 'rules', 'common', 'coding-style.md'))));
+        assert.notStrictEqual(fs.statSync(destinationPath).ino, fs.statSync(victim).ino);
+      })) passed++; else failed++;
+    }
+    cleanup(homeDir);
+    cleanup(projectRoot);
+    cleanup(outside);
+  }
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -2399,6 +2399,79 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // Containment follows links: a directory inside the root that points
+  // outside, or a source that leaves the repository through a link, is refused.
+  {
+    const homeDir = createTempDir('lifecycle-home-');
+    const projectRoot = createTempDir('lifecycle-project-');
+    const outside = createTempDir('lifecycle-outside-');
+    let linked = false;
+    try {
+      fs.mkdirSync(path.join(projectRoot, '.cursor'), { recursive: true });
+      fs.symlinkSync(outside, path.join(projectRoot, '.cursor', 'escape'), 'dir');
+      linked = true;
+    } catch (error) {
+      console.log(`  - skipped (link containment): cannot create symlinks here (${error.code})`);
+    }
+    if (linked) {
+      if (test('uninstall refuses a destination that leaves the root through a linked directory', () => {
+        const victim = path.join(outside, 'keep.txt');
+        fs.writeFileSync(victim, 'keep me');
+        writeCursorState(projectRoot, {
+          operations: [
+            { kind: 'copy-file', moduleId: 'rules-core', sourceRelativePath: 'rules/x.md', destinationPath: path.join(projectRoot, '.cursor', 'escape', 'keep.txt'), strategy: 'overwrite', ownership: 'managed', scaffoldOnly: false },
+          ],
+        });
+        const result = uninstallInstalledStates({ homeDir, projectRoot, targets: ['cursor'] });
+        const outcome = (result.results || result)[0];
+        assert.strictEqual(outcome.status, 'error', JSON.stringify(outcome));
+        assert.ok(fs.existsSync(victim), 'the file outside the root must survive');
+      })) passed++; else failed++;
+    }
+    cleanup(homeDir);
+    cleanup(projectRoot);
+    cleanup(outside);
+  }
+
+  {
+    const homeDir = createTempDir('lifecycle-home-');
+    const projectRoot = createTempDir('lifecycle-project-');
+    const repoRoot = createTempDir('lifecycle-repo-');
+    const outside = createTempDir('lifecycle-outside-');
+    let linked = false;
+    try {
+      fs.symlinkSync(outside, path.join(repoRoot, 'rules'), 'dir');
+      linked = true;
+    } catch (error) {
+      console.log(`  - skipped (source link): cannot create symlinks here (${error.code})`);
+    }
+    if (linked) {
+      if (test('repair refuses a source that leaves the repository through a link', () => {
+        const realRepo = path.join(__dirname, '..', '..');
+        fs.mkdirSync(path.join(repoRoot, 'manifests'), { recursive: true });
+        for (const name of fs.readdirSync(path.join(realRepo, 'manifests'))) {
+          fs.copyFileSync(path.join(realRepo, 'manifests', name), path.join(repoRoot, 'manifests', name));
+        }
+        fs.writeFileSync(path.join(repoRoot, 'package.json'), JSON.stringify({ name: 'egc-test', version: CURRENT_PACKAGE_VERSION }));
+        fs.writeFileSync(path.join(outside, 'secret.md'), 'private');
+        const destination = path.join(projectRoot, '.cursor', 'rules', 'secret.md');
+        writeCursorState(projectRoot, {
+          operations: [
+            { kind: 'copy-file', moduleId: 'rules-core', sourceRelativePath: 'rules/secret.md', destinationPath: destination, strategy: 'overwrite', ownership: 'managed', scaffoldOnly: false },
+          ],
+        });
+        const result = repairInstalledStates({ homeDir, projectRoot, targets: ['cursor'], repoRoot });
+        const outcome = result.results[0];
+        assert.notStrictEqual(outcome.status, 'repaired', JSON.stringify(outcome));
+        assert.ok(!fs.existsSync(destination), 'nothing is copied from outside the repository');
+      })) passed++; else failed++;
+    }
+    cleanup(homeDir);
+    cleanup(projectRoot);
+    cleanup(repoRoot);
+    cleanup(outside);
+  }
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -2326,6 +2326,79 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // audit 2026-08-17, C5: a state file is data, not authority. A recorded
+  // destination outside the roots the adapter derives today is refused
+  // before anything is written or removed.
+  if (test('uninstall refuses a target whose recorded operation escapes the managed roots', () => {
+    const homeDir = createTempDir('lifecycle-home-');
+    const projectRoot = createTempDir('lifecycle-project-');
+    try {
+      const planted = path.join(homeDir, 'planted-by-attacker.txt');
+      fs.writeFileSync(planted, 'keep me');
+      const managed = path.join(projectRoot, '.cursor', 'rules', 'managed.md');
+      fs.mkdirSync(path.dirname(managed), { recursive: true });
+      fs.writeFileSync(managed, 'managed');
+      const { installStatePath } = writeCursorState(projectRoot, {
+        operations: [
+          { kind: 'copy-file', moduleId: 'rules-core', sourceRelativePath: 'rules/managed.md', destinationPath: managed, strategy: 'overwrite', ownership: 'managed', scaffoldOnly: false },
+          { kind: 'copy-file', moduleId: 'rules-core', sourceRelativePath: 'rules/managed.md', destinationPath: planted, strategy: 'overwrite', ownership: 'managed', scaffoldOnly: false },
+        ],
+      });
+      const result = uninstallInstalledStates({ homeDir, projectRoot, targets: ['cursor'] });
+      const outcome = (result.results || result)[0];
+      assert.strictEqual(outcome.status, 'error', JSON.stringify(outcome));
+      assert.ok(outcome.error.includes('escapes the managed roots'), outcome.error);
+      assert.ok(fs.existsSync(planted), 'the planted path must survive');
+      assert.ok(fs.existsSync(managed), 'nothing is removed when one entry escapes');
+      assert.ok(fs.existsSync(installStatePath), 'the state file stays for inspection');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('repair refuses a recorded plan whose operation escapes the managed roots', () => {
+    const homeDir = createTempDir('lifecycle-home-');
+    const projectRoot = createTempDir('lifecycle-project-');
+    try {
+      const planted = path.join(homeDir, '.bashrc');
+      writeCursorState(projectRoot, {
+        operations: [
+          { kind: 'copy-file', moduleId: 'rules-core', sourceRelativePath: 'rules/typescript.md', destinationPath: planted, strategy: 'overwrite', ownership: 'managed', scaffoldOnly: false },
+        ],
+      });
+      const result = repairInstalledStates({ homeDir, projectRoot, targets: ['cursor'] });
+      const outcome = result.results[0];
+      assert.strictEqual(outcome.status, 'error', JSON.stringify(outcome));
+      assert.ok(String(outcome.error).includes('escapes the managed roots'), String(outcome.error));
+      assert.ok(!fs.existsSync(planted), 'nothing is written outside the roots');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('a stored absolute sourcePath is never replayed: only the manifest-relative path counts', () => {
+    const homeDir = createTempDir('lifecycle-home-');
+    const projectRoot = createTempDir('lifecycle-project-');
+    try {
+      const destination = path.join(projectRoot, '.cursor', 'rules', 'x.md');
+      writeCursorState(projectRoot, {
+        operations: [
+          { kind: 'copy-file', moduleId: 'rules-core', sourceRelativePath: 'rules/does-not-exist.md', sourcePath: path.join(homeDir, 'secret.txt'), destinationPath: destination, strategy: 'overwrite', ownership: 'managed', scaffoldOnly: false },
+        ],
+      });
+      fs.writeFileSync(path.join(homeDir, 'secret.txt'), 'private');
+      const result = repairInstalledStates({ homeDir, projectRoot, targets: ['cursor'] });
+      const outcome = result.results[0];
+      assert.notStrictEqual(outcome.status, 'repaired', JSON.stringify(outcome));
+      assert.ok(!fs.existsSync(destination), 'the stored absolute source must not be copied');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/lib/install-state.test.js
+++ b/tests/lib/install-state.test.js
@@ -215,6 +215,11 @@ function runTests() {
       const clean = createInstallState({ ...base, operations: [operation] });
       fs.writeFileSync(statePath, JSON.stringify(clean, null, 2));
       assert.strictEqual(readInstallState(statePath).operations.length, 1);
+      // Anchored on the other platform family is still anchored: a state file
+      // written on Windows validates the same way on POSIX and the reverse.
+      for (const destinationPath of ['C:\\repo\\.cursor\\x.md', '\\\\server\\share\\x.md']) {
+        assert.doesNotThrow(() => createInstallState({ ...base, operations: [{ ...operation, destinationPath }] }), destinationPath);
+      }
     } finally {
       cleanupTestDir(testDir);
     }

--- a/tests/lib/install-state.test.js
+++ b/tests/lib/install-state.test.js
@@ -185,6 +185,41 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('rejects operations whose paths climb or are not anchored where they must be', () => {
+    const base = {
+      adapter: { id: 'cursor-project' },
+      targetRoot: '/repo/.cursor',
+      installStatePath: '/repo/.cursor/egc-install-state.json',
+      request: { profile: null, modules: [], includeComponents: [], excludeComponents: [], legacyLanguages: [], legacyMode: false },
+      resolution: { selectedModules: [], skippedModules: [] },
+      source: { repoVersion: '1.0.0', repoCommit: 'abc', manifestVersion: 1 },
+    };
+    const operation = { kind: 'copy-file', moduleId: 'rules-core', sourceRelativePath: 'rules/x.md', destinationPath: '/repo/.cursor/rules/x.md', strategy: 'overwrite', ownership: 'managed', scaffoldOnly: false };
+    const testDir = createTestDir();
+    const statePath = path.join(testDir, 'egc-install-state.json');
+    try {
+      for (const tampered of [
+        { sourceRelativePath: '../../home/user/.ssh/id_rsa' },
+        { sourceRelativePath: '/etc/passwd' },
+        { destinationPath: '/repo/.cursor/../../home/user/.bashrc' },
+        { destinationPath: 'relative/path' },
+      ]) {
+        // createInstallState validates on creation, so the tampered operation
+        // never even becomes a state object; a hand-written file is refused on read.
+        assert.throws(() => createInstallState({ ...base, operations: [{ ...operation, ...tampered }] }), /Invalid install-state/, JSON.stringify(tampered));
+        const clean = createInstallState({ ...base, operations: [operation] });
+        const handWritten = { ...clean, operations: [{ ...clean.operations[0], ...tampered }] };
+        fs.writeFileSync(statePath, JSON.stringify(handWritten, null, 2));
+        assert.throws(() => readInstallState(statePath), /Invalid install-state/, JSON.stringify(tampered));
+      }
+      const clean = createInstallState({ ...base, operations: [operation] });
+      fs.writeFileSync(statePath, JSON.stringify(clean, null, 2));
+      assert.strictEqual(readInstallState(statePath).operations.length, 1);
+    } finally {
+      cleanupTestDir(testDir);
+    }
+  })) passed++; else failed++;
+
   if (test('rejects unexpected properties and missing required request fields', () => {
     const testDir = createTestDir();
     const statePath = path.join(testDir, 'egc-install-state.json');

--- a/tests/lib/preserving-write.test.js
+++ b/tests/lib/preserving-write.test.js
@@ -1,0 +1,81 @@
+/**
+ * The atomic replacement used by the install replay: a destination that is
+ * a link is replaced, never written through; modes are kept; a failed write
+ * leaves nothing behind.
+ */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { copyFileKeepingMode, replaceFileWith } = require('../../scripts/lib/install/preserving-write');
+
+const modes = process.platform !== 'win32';
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing the atomic file replacement ===\n');
+  let passed = 0;
+  let failed = 0;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-preserving-write-'));
+  try {
+    if (test('a symlinked destination is replaced and its target is untouched', () => {
+      const target = path.join(dir, 'target.txt');
+      const link = path.join(dir, 'link.txt');
+      fs.writeFileSync(target, 'target content');
+      let linked = true;
+      try {
+        fs.symlinkSync(target, link);
+      } catch (error) {
+        linked = false;
+        console.log(`    - skipped: cannot create symlinks here (${error.code})`);
+      }
+      if (!linked) return;
+      replaceFileWith(link, descriptor => fs.writeFileSync(descriptor, 'replaced'));
+      assert.strictEqual(fs.readFileSync(target, 'utf8'), 'target content');
+      assert.strictEqual(fs.readFileSync(link, 'utf8'), 'replaced');
+      assert.ok(!fs.lstatSync(link).isSymbolicLink(), 'the destination is a regular file now');
+    })) passed++; else failed++;
+
+    if (test('an existing destination keeps its mode, a new copy takes the source mode', () => {
+      const existing = path.join(dir, 'existing.txt');
+      fs.writeFileSync(existing, 'old');
+      if (modes) fs.chmodSync(existing, 0o600);
+      replaceFileWith(existing, descriptor => fs.writeFileSync(descriptor, 'new'));
+      assert.strictEqual(fs.readFileSync(existing, 'utf8'), 'new');
+      if (modes) assert.strictEqual(fs.statSync(existing).mode & 0o777, 0o600);
+      const source = path.join(dir, 'source.json');
+      fs.writeFileSync(source, '{}');
+      if (modes) fs.chmodSync(source, 0o640);
+      const created = path.join(dir, 'created.json');
+      copyFileKeepingMode(source, created);
+      assert.strictEqual(fs.readFileSync(created, 'utf8'), '{}');
+      if (modes) assert.strictEqual(fs.statSync(created).mode & 0o777, 0o640);
+    })) passed++; else failed++;
+
+    if (test('a failed write leaves no temporary file and no destination', () => {
+      const destination = path.join(dir, 'never.txt');
+      assert.throws(() => replaceFileWith(destination, () => { throw new Error('writer failed'); }), /writer failed/);
+      assert.ok(!fs.existsSync(destination));
+      assert.deepStrictEqual(fs.readdirSync(dir).filter(name => name.endsWith('.tmp')), []);
+    })) passed++; else failed++;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -490,6 +490,10 @@ async function runTests() {
   const userHome = require('os').homedir();
   run('curl file:///~/.ssh/id_rsa is hard-blocking (file URI unwrapped)', () => assertHardBlocking(`curl file://${userHome}/.ssh/id_rsa`));
   run('curl --url=file:///etc/shadow is hard-blocking', () => assertHardBlocking('curl --url=file:///etc/shadow'));
+  run('a query or fragment on a file URI does not hide the protected path', () => {
+    assertHardBlocking(`curl file://${userHome}/.ssh/id_rsa?raw=1`);
+    assertHardBlocking(`curl file://${userHome}/.bashrc#top`);
+  });
   run('wget -O out file://localhost/etc/passwd is hard-blocking', () => assertHardBlocking('wget -O out file://localhost/etc/passwd'));
   run('curl file:///tmp/notes.txt is not a protected-path denial', () => {
     const result = validateCommand('curl file:///tmp/notes.txt');

--- a/tests/scripts/egc-guardian.test.js
+++ b/tests/scripts/egc-guardian.test.js
@@ -486,6 +486,24 @@ async function runTests() {
   });
   run('pwsh7 -c is still hard-blocking', () => assertHardBlocking(`pwsh7 -c "Get-Process"`));
 
+  // audit 2026-08-17, C2 second bypass and C5: file:// and install-state
+  const userHome = require('os').homedir();
+  run('curl file:///~/.ssh/id_rsa is hard-blocking (file URI unwrapped)', () => assertHardBlocking(`curl file://${userHome}/.ssh/id_rsa`));
+  run('curl --url=file:///etc/shadow is hard-blocking', () => assertHardBlocking('curl --url=file:///etc/shadow'));
+  run('wget -O out file://localhost/etc/passwd is hard-blocking', () => assertHardBlocking('wget -O out file://localhost/etc/passwd'));
+  run('curl file:///tmp/notes.txt is not a protected-path denial', () => {
+    const result = validateCommand('curl file:///tmp/notes.txt');
+    assert.ok(!String(result.reason || '').includes('protected'), JSON.stringify(result));
+  });
+  run('curl https://example.com stays as before (no protected-path denial)', () => {
+    const result = validateCommand('curl https://example.com');
+    assert.ok(!String(result.reason || '').includes('protected'), JSON.stringify(result));
+  });
+  run('write to ~/.claude/egc/install-state.json is denied', () => assertWriteDenied(`${userHome}/.claude/egc/install-state.json`));
+  run('write to ~/.agents/egc/codex-install-state.json is denied', () => assertWriteDenied(`${userHome}/.agents/egc/codex-install-state.json`));
+  run('write to project .cursor/egc-install-state.json is denied', () => assertWriteDenied('.cursor/egc-install-state.json'));
+  run('write to a sibling egc/notes.json stays allowed', () => assertWriteAllowed(`${userHome}/.claude/egc/notes.json`));
+
   // ── Summary ───────────────────────────────────────────────────────────────
 
   console.log(`\n${'─'.repeat(50)}`);

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -119,6 +119,36 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('uninstalls a home target that writes outside its own root (copilot: ~/.github and ~/.copilot)', () => {
+    const homeDir = createTempDir('uninstall-home-');
+    const projectRoot = createTempDir('uninstall-project-');
+
+    try {
+      execFileSync('node', [INSTALL_SCRIPT, '--target', 'copilot', '--profile', 'full'], {
+        cwd: projectRoot,
+        env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: SUBPROCESS_TIMEOUT_MS,
+      });
+      const hooksFile = path.join(fs.realpathSync(homeDir), '.copilot', 'hooks', 'hooks.json');
+      assert.ok(fs.existsSync(hooksFile), 'the install must have written outside the target root');
+      assert.ok(fs.readFileSync(hooksFile, 'utf8').includes('scripts/hooks'), 'the merged file carries the EGC hook entries');
+
+      // The recorded entries live outside ~/.github; they are still accepted
+      // because the current manifest plans them, so the merge is reversed
+      // (the file itself is the user's and stays) and nothing errors.
+      const uninstallResult = run(['--target', 'copilot'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+      assert.ok(uninstallResult.stdout.includes('Status: UNINSTALLED'), uninstallResult.stdout);
+      assert.ok(uninstallResult.stdout.includes('errors=0'), uninstallResult.stdout);
+      assert.ok(!fs.readFileSync(hooksFile, 'utf8').includes('scripts/hooks'), 'the EGC hook entries are reversed out of the merged file');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   if (test('reverses non-copy operations and keeps unrelated files', () => {
     const homeDir = createTempDir('uninstall-home-');
     const projectRoot = createTempDir('uninstall-project-');

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -133,7 +133,9 @@ function runTests() {
       });
       const hooksFile = path.join(fs.realpathSync(homeDir), '.copilot', 'hooks', 'hooks.json');
       assert.ok(fs.existsSync(hooksFile), 'the install must have written outside the target root');
-      assert.ok(fs.readFileSync(hooksFile, 'utf8').includes('scripts/hooks'), 'the merged file carries the EGC hook entries');
+      // Windows writes these paths with backslashes (escaped once more in JSON).
+      const carriesEgcHooks = content => /scripts[\\/]+hooks/.test(content);
+      assert.ok(carriesEgcHooks(fs.readFileSync(hooksFile, 'utf8')), 'the merged file carries the EGC hook entries');
 
       // The recorded entries live outside ~/.github; they are still accepted
       // because the current manifest plans them, so the merge is reversed
@@ -142,7 +144,7 @@ function runTests() {
       assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
       assert.ok(uninstallResult.stdout.includes('Status: UNINSTALLED'), uninstallResult.stdout);
       assert.ok(uninstallResult.stdout.includes('errors=0'), uninstallResult.stdout);
-      assert.ok(!fs.readFileSync(hooksFile, 'utf8').includes('scripts/hooks'), 'the EGC hook entries are reversed out of the merged file');
+      assert.ok(!carriesEgcHooks(fs.readFileSync(hooksFile, 'utf8')), 'the EGC hook entries are reversed out of the merged file');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);


### PR DESCRIPTION
## What

Day 4 of the security schedule (17/08 audit, findings C5 and the second C2 bypass).

- **install-state was replayed as authority.** `egc repair` and `egc uninstall` executed every recorded operation verbatim, so a planted `destinationPath` meant an arbitrary write or a recursive delete, a planted `sourcePath` let repair copy any readable file into place, and the stored `target.root` / `installStatePath` were used as-is. Now every recorded destination must sit inside the root the adapter derives today, or be a location the current manifest plans for that adapter (a directory it copies, or an exact file), otherwise the whole target is refused before anything runs. The source is only ever `repoRoot` joined with the recorded manifest-relative path; the root and state path come from the adapter's own resolution, never from the file.
- **Schema.** `destinationPath` must be absolute without `..` segments and `sourceRelativePath` relative without `..`, in the JSON schema and in the fallback validator; `createInstallState` refuses such entries at creation and `readInstallState` refuses a hand-written file.
- **Guardian.** Every install-state file (`egc/install-state.json`, `egc/<target>-install-state.json`, `egc-install-state.json`) is a protected path, so the Write tool and destructive commands cannot plant entries. `file:///path` and `file://localhost/path` (bare operand, `--url=`, `-o` forms) are unwrapped so the path inside gets the protected-path check; other schemes stay download targets as before.

## Proof

- Live, against the production hook with the fresh build: `curl file:///~/.ssh/id_rsa`, `curl --url=file:///etc/shadow` and `wget -O out file://localhost/etc/passwd` are BLOCKED as protected files; `curl https://example.com` and `curl file:///tmp/notes.txt` pass as before.
- `tests/lib/install-lifecycle.test.js` +3 (50/50): uninstall refuses a target with a planted destination under $HOME and touches nothing; repair refuses a planted `~/.bashrc`; a stored absolute `sourcePath` is never copied.
- `tests/scripts/uninstall.test.js` +1: a real `copilot` install (writes `~/.copilot/hooks/hooks.json` outside its `~/.github` root) still uninstalls cleanly, since the current manifest plans that location.
- `tests/lib/install-state.test.js` +1: climbing and unanchored paths refused on create and on read. `tests/scripts/egc-guardian.test.js` +9 (159/159). Every suite referencing the touched files passes (repair 11, doctor 19, install-apply 35, bypass-hardening 84, destructive-cli 73).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes arbitrary file access in `egc repair` and `egc uninstall` by treating install-state as untrusted data, and closes Guardian's `file://` path-check bypass. Replayed operations now stay within adapter-derived or manifest-planned locations, while file URI operands are checked like local paths.

- One escaping destination rejects the entire target before any write or delete; checks follow symlinks and missing path tails.
- Repair ignores stored absolute `sourcePath` values and only uses a validated repository-relative source.
- The adapter, not install-state data, supplies the target root and install-state path.
- Schema and fallback validation reject unanchored or climbing destination and source paths on either platform family.
- Replayed file writes use an exclusively-created atomic sibling replacement, preserve modes, and replace hard links instead of modifying the aliased file.
- The Guardian protects install-state files and strips queries, fragments, and supported `file://` prefixes before checking paths; other URI schemes keep their existing behavior.

<sup>Written for commit 1163b385d03d010320a4c1a21bea0ea359715490. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

