### PR TITLE
fix(dashboard): authenticate POST /event, pin CORS and the WebSocket to the panel origin, and refuse unknown ide values

### DIFF
--- a/dashboard/accumulator.js
+++ b/dashboard/accumulator.js
@@ -11,6 +11,23 @@
  *   (e.g. the server's MODEL_PRICES object).  When omitted all cost
  *   calculations return null.
  */
+const CAPABILITIES = {
+  claude:    { tokenUsage:true,  model:true,  cost:true,  session:true,  workspace:true  },
+  gemini:    { tokenUsage:true,  model:true,  cost:false, session:true,  workspace:false },
+  cursor:    { tokenUsage:false, model:false, cost:false, session:true,  workspace:true  },
+  codex:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  vscode:    { tokenUsage:false, model:false, cost:false, session:false, workspace:true  },
+  kiro:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  trae:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  opencode:  { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  codebuddy: { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+  aider:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
+};
+
+// The ide values the dashboard knows how to render; the server refuses
+// events for anything else before they reach the panel.
+const KNOWN_IDES = Object.freeze(Object.keys(CAPABILITIES));
+
 function createAccumulator(externalPrices) {
   const providerState = {};
   const sessionHistory = [];
@@ -21,18 +38,6 @@ function createAccumulator(externalPrices) {
   // replayLog: Map<sessionId, { meta, events[] }>
   const replayLog = new Map();
 
-  const CAPABILITIES = {
-    claude:    { tokenUsage:true,  model:true,  cost:true,  session:true,  workspace:true  },
-    gemini:    { tokenUsage:true,  model:true,  cost:false, session:true,  workspace:false },
-    cursor:    { tokenUsage:false, model:false, cost:false, session:true,  workspace:true  },
-    codex:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-    vscode:    { tokenUsage:false, model:false, cost:false, session:false, workspace:true  },
-    kiro:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-    trae:      { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-    opencode:  { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-    codebuddy: { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-    aider:     { tokenUsage:false, model:false, cost:false, session:false, workspace:false },
-  };
 
   const IDE_PRICE_KEY = {
     claude:   '_default_claude',
@@ -190,4 +195,4 @@ function createAccumulator(externalPrices) {
   };
 }
 
-module.exports = { createAccumulator };
+module.exports = { KNOWN_IDES, createAccumulator };

--- a/dashboard/aider-watcher.js
+++ b/dashboard/aider-watcher.js
@@ -3,10 +3,10 @@
 
 const fs   = require('fs');
 const path = require('path');
-const http = require('http');
 const os   = require('os');
 const { readFileDelta } = require('./read-file-delta');
 const { PORT } = require('./port');
+const { postEvent } = require('./telemetry-client');
 
 const WATCH_PATHS = [
   path.join(os.homedir(), '.aider.chat.history.md'),
@@ -17,16 +17,7 @@ const WATCH_PATHS = [
 let lastSizes = {};
 
 function post(ev) {
-  const body = JSON.stringify(ev);
-  const req = http.request(
-    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
-      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
-      timeout:300 },
-    ()=>{}
-  );
-  req.on('error', ()=>{});
-  req.on('timeout', ()=>req.destroy());
-  req.end(body);
+  postEvent(ev, { port: PORT });
 }
 
 function watchFile(filePath) {

--- a/dashboard/codebuddy-adapter.js
+++ b/dashboard/codebuddy-adapter.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 'use strict';
-const http = require('http');
 const fs   = require('fs');
 const path = require('path');
 const os   = require('os');
 const { PORT } = require('./port');
+const { postEvent } = require('./telemetry-client');
 const WATCH_PATHS = [
   path.join(os.homedir(), '.codebuddy', 'logs'),
   path.join(os.homedir(), '.config', 'codebuddy', 'logs'),
@@ -15,16 +15,7 @@ const IGNORED_EXTENSIONS = new Set(['.tmp', '.swp', '.lock', '.bak', '.orig']);
 const DEBOUNCE_MS = 200;
 
 function post(ev) {
-  const body = JSON.stringify(ev);
-  const req = http.request(
-    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
-      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
-      timeout:300 },
-    ()=>{}
-  );
-  req.on('error', ()=>{});
-  req.on('timeout', ()=>req.destroy());
-  req.end(body);
+  postEvent(ev, { port: PORT });
 }
 
 function watchLogDir(dir) {

--- a/dashboard/ops.js
+++ b/dashboard/ops.js
@@ -604,7 +604,10 @@ module.exports = {
   TOKEN_FILE_NAME,
   TOKEN_HEADER,
   createOpsHandler,
+  isPanelOrigin,
   listOpsOperations,
   loadOrCreateOpsToken,
+  panelOrigins,
   resolveTokenPath,
+  tokensMatch,
 };

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1948,7 +1948,7 @@ const costStr =
     : `<strong style="color:${col}">${fmtCost(v.totalCost)}</strong>`;
           return `<div class="cost-bar-row">
             <div class="cost-bar-head">
-              <span class="cost-bar-ide" style="color:${col}">${ide}</span>
+              <span class="cost-bar-ide" style="color:${col}">${esc(ide)}</span>
              <span class="cost-bar-meta">
   ${inpTok}↑ ${outTok}↓ ·
   ${totalTok} total ·
@@ -1972,7 +1972,7 @@ const costStr =
       sessEl.innerHTML = data.recentSessions.map(s => {
         const col = IDE_COLORS[s.ide] || '#8b949e';
         return `<div class="cost-sess-row">
-          <span class="cost-sess-ide" style="color:${col}">${s.ide}</span>
+          <span class="cost-sess-ide" style="color:${col}">${esc(s.ide)}</span>
           <span class="cost-sess-tok">${fmtTokens(s.input_tokens || 0)}↑ ${fmtTokens(s.output_tokens || 0)}↓</span>
           <span class="cost-sess-cost">${fmtCost(s.cost)}</span>
           <span class="cost-sess-time">${fmtTimeAgo(s.timestamp)}</span>

--- a/dashboard/public/replay.html
+++ b/dashboard/public/replay.html
@@ -184,7 +184,7 @@ function renderSessionList() {
   el.innerHTML = sessions.map((s, i) => `
     <div class="sl-item ${currentSession && currentSession.id === s.id ? 'active' : ''}"
          onclick="selectSession(sessions[${i}])">
-      <div class="sl-ide">${s.ide || 'unknown'}</div>
+      <div class="sl-ide">${escHtml(s.ide || 'unknown')}</div>
       <div class="sl-time">${formatTs(s.timestamp)}</div>
       <div class="sl-meta">
         <span>${s.eventCount || 0} events</span>

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -6,8 +6,9 @@ const path    = require('path');
 const fs      = require('fs');
 const os      = require('os');
 const { execSync, execFileSync } = require('child_process');
-const { createAccumulator } = require('./accumulator');
-const { createOpsHandler, loadOrCreateOpsToken } = require('./ops');
+const { KNOWN_IDES, createAccumulator } = require('./accumulator');
+const { TOKEN_HEADER, createOpsHandler, isPanelOrigin, loadOrCreateOpsToken, tokensMatch } = require('./ops');
+const { SUPPORTED_INSTALL_TARGETS } = require('../scripts/lib/install-manifests');
 const { PORT } = require('./port');
 const PUBLIC = path.join(__dirname, 'public');
 const CFG    = path.join(__dirname, 'config.json');
@@ -16,6 +17,38 @@ const CFG    = path.join(__dirname, 'config.json');
 // not present it, and the panel receives it the same way it receives the port.
 const OPS = loadOrCreateOpsToken();
 const OPS_TOKEN = OPS.token;
+
+// Every ide an event may name: what the panel renders plus every install
+// target a hook can announce itself as. Anything else is refused server-side.
+const ACCEPTED_IDES = new Set([...KNOWN_IDES, ...SUPPORTED_INSTALL_TARGETS]);
+const IDE_ID_RE = /^[a-z][a-z0-9-]{0,31}$/;
+function isAcceptedIde(value) {
+  return typeof value === 'string' && IDE_ID_RE.test(value) && ACCEPTED_IDES.has(value);
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+// POST /event is for the local senders only: they present the dashboard
+// token, send JSON, and never carry a browser Origin other than the panel's.
+function rejectEventRequest(req, res, reqOrigin) {
+  const presented = req.headers[TOKEN_HEADER];
+  if (!tokensMatch(typeof presented === 'string' ? presented : '', OPS_TOKEN)) {
+    sendJson(res, 401, { error: 'Missing or invalid dashboard token' });
+    return true;
+  }
+  if (!/^application\/json\b/i.test(String(req.headers['content-type'] || ''))) {
+    sendJson(res, 415, { error: 'Content-Type must be application/json' });
+    return true;
+  }
+  if (reqOrigin && !isPanelOrigin(reqOrigin, PORT)) {
+    sendJson(res, 403, { error: 'Origin not allowed' });
+    return true;
+  }
+  return false;
+}
 const handleOps = createOpsHandler({ token: OPS_TOKEN, port: PORT });
 
 const MIME = {
@@ -161,15 +194,21 @@ const server = http.createServer((req, res) => {
   // permissive any-loopback-port ones the telemetry routes below carry.
   if (handleOps(req, res)) return;
 
+  // CORS is pinned to the panel's own origin: another local web origin gets
+  // the canonical origin back, never its own reflected.
   const reqOrigin = req.headers.origin || '';
   res.setHeader('Access-Control-Allow-Origin',
-    /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(reqOrigin) ? reqOrigin : `http://localhost:${PORT}`);
+    isPanelOrigin(reqOrigin, PORT) ? reqOrigin : `http://localhost:${PORT}`);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
 
   // ── POST /event ─────────────────────────────────────────
   if (req.method === 'POST' && req.url === '/event') {
+    if (rejectEventRequest(req, res, reqOrigin)) {
+      req.resume();
+      return;
+    }
     const chunks = [];
     let currentSize = 0;
     const MAX_SIZE = 256 * 1024; // 256 KB cap
@@ -201,6 +240,11 @@ const server = http.createServer((req, res) => {
       } catch (_) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+
+      if (!isAcceptedIde(ev?.ide)) {
+        sendJson(res, 400, { error: 'Unknown ide' });
         return;
       }
 
@@ -474,7 +518,10 @@ const grandTotal = Object.values(byIde).reduce(
 // ── WebSocket ────────────────────────────────────────────────
 try {
   const { WebSocketServer } = require('ws');
-  const wss = new WebSocketServer({ server });
+  // Only the panel this server serves may join the live broadcast: the
+  // upgrade must carry the panel's own origin, so a page elsewhere in the
+  // same browser cannot read commands, paths and URLs off the stream.
+  const wss = new WebSocketServer({ server, verifyClient: info => isPanelOrigin(info.origin, PORT) });
   wss.on('connection', ws => {
     clients.add(ws);
     ws.on('close', () => clients.delete(ws));

--- a/dashboard/shim-session.js
+++ b/dashboard/shim-session.js
@@ -1,41 +1,15 @@
 #!/usr/bin/env node
 'use strict';
 
-const http = require('http');
 const { PORT } = require('./port');
+const { postEvent } = require('./telemetry-client');
 
 const IDE   = process.argv[2] || 'trae';
 const EVENT = process.argv[3] || 'session_start';
 
 function post(ev) {
-  const body = JSON.stringify(ev);
-  const req = http.request(
-    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
-      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
-      timeout:300 },
-    (res) => {
-      res.resume();
-      
-      res.on('end', () => {
-        process.exit(0);
-      });
-
-      res.on('error', () => {
-        process.exit(0);
-      });
-    }
-  );
-  
-  req.on('error', () => {
-    process.exit(0);
-  });
-  
-  req.on('timeout', () => {
-    req.destroy();
-    process.exit(0);
-  });
-  
-  req.end(body);
+  // One shot: the process ends as soon as the dashboard answers or fails.
+  postEvent(ev, { port: PORT, onDone: () => process.exit(0) });
 }
 
 post({ ide:IDE, event:EVENT, agent:'main', status:'running', detail:'' });

--- a/dashboard/shim.js
+++ b/dashboard/shim.js
@@ -1,22 +1,13 @@
 #!/usr/bin/env node
 'use strict';
 
-const http = require('http');
 const { PORT } = require('./port');
+const { postEvent } = require('./telemetry-client');
 
 const IDE = process.env.EGC_IDE || process.argv[2] || 'claude';
 
 function post(ev) {
-  const body = JSON.stringify(ev);
-  const req = http.request(
-    { hostname: '127.0.0.1', port: PORT, path: '/event', method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
-      timeout: 300 },
-    () => {}
-  );
-  req.on('error', () => {});
-  req.on('timeout', () => req.destroy());
-  req.end(body);
+  postEvent(ev, { port: PORT });
 }
 
 function fileFrom(input) {

--- a/dashboard/telemetry-client.js
+++ b/dashboard/telemetry-client.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+const TOKEN_HEADER = 'x-egc-token';
+
+// The dashboard mints this token at startup (dashboard/ops.js) and keeps it
+// private to the user; every local telemetry sender presents it, so a web
+// page in the same browser cannot post events blind.
+function readDashboardToken(homeDir) {
+  const home = homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
+  try {
+    const raw = fs.readFileSync(path.join(home, '.egc', 'dashboard-token'), 'utf8').trim();
+    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function postEvent(ev, { port, timeout = 300, onDone } = {}) {
+  const body = JSON.stringify(ev);
+  const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) };
+  const token = readDashboardToken();
+  if (token) headers[TOKEN_HEADER] = token;
+  const done = typeof onDone === 'function' ? onDone : () => {};
+  const req = http.request(
+    { hostname: '127.0.0.1', port, path: '/event', method: 'POST', headers, timeout },
+    res => {
+      res.resume();
+      done();
+    }
+  );
+  req.on('error', () => done());
+  req.on('timeout', () => {
+    req.destroy();
+    done();
+  });
+  req.end(body);
+  return req;
+}
+
+module.exports = { TOKEN_HEADER, postEvent, readDashboardToken };

--- a/dashboard/telemetry-client.js
+++ b/dashboard/telemetry-client.js
@@ -1,31 +1,24 @@
 'use strict';
 
-const fs = require('fs');
 const http = require('http');
-const os = require('os');
-const path = require('path');
+
+const { readDashboardToken } = require('../scripts/lib/dashboard-token');
 
 const TOKEN_HEADER = 'x-egc-token';
-
-// The dashboard mints this token at startup (dashboard/ops.js) and keeps it
-// private to the user; every local telemetry sender presents it, so a web
-// page in the same browser cannot post events blind.
-function readDashboardToken(homeDir) {
-  const home = homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
-  try {
-    const raw = fs.readFileSync(path.join(home, '.egc', 'dashboard-token'), 'utf8').trim();
-    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
-  } catch {
-    return null;
-  }
-}
 
 function postEvent(ev, { port, timeout = 300, onDone } = {}) {
   const body = JSON.stringify(ev);
   const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) };
   const token = readDashboardToken();
   if (token) headers[TOKEN_HEADER] = token;
-  const done = typeof onDone === 'function' ? onDone : () => {};
+  // A timed-out request also raises an error when it is destroyed: the
+  // completion callback fires once regardless.
+  let finished = false;
+  const done = () => {
+    if (finished) return;
+    finished = true;
+    if (typeof onDone === 'function') onDone();
+  };
   const req = http.request(
     { hostname: '127.0.0.1', port, path: '/event', method: 'POST', headers, timeout },
     res => {

--- a/dashboard/vscode-adapter.js
+++ b/dashboard/vscode-adapter.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 'use strict';
 
-const http = require('http');
 const fs   = require('fs');
 const path = require('path');
 const os   = require('os');
 const { readFileDelta } = require('./read-file-delta');
 const { PORT } = require('./port');
+const { postEvent } = require('./telemetry-client');
 
 const LOG_PATHS = [
   path.join(os.homedir(), '.vscode', 'logs'),
@@ -14,16 +14,7 @@ const LOG_PATHS = [
 ];
 
 function post(ev) {
-  const body = JSON.stringify(ev);
-  const req = http.request(
-    { hostname:'127.0.0.1', port:PORT, path:'/event', method:'POST',
-      headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)},
-      timeout:300 },
-    ()=>{}
-  );
-  req.on('error', ()=>{});
-  req.on('timeout', ()=>req.destroy());
-  req.end(body);
+  postEvent(ev, { port: PORT });
 }
 
 function findCopilotLog(dir) {

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -19,7 +19,8 @@ const path = require('node:path');
 // goes out without a token instead of the hook failing to load.
 let readDashboardToken = () => null;
 try {
-  ({ readDashboardToken } = require('../lib/dashboard-token'));
+  const loaded = require('../lib/dashboard-token');
+  if (typeof loaded.readDashboardToken === 'function') readDashboardToken = loaded.readDashboardToken;
 } catch {
   // an older install without the helper: no token, no crash
 }

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -14,7 +14,15 @@ const fs = require('node:fs');
 const http = require('node:http');
 const os = require('node:os');
 const path = require('node:path');
-const { readDashboardToken } = require('../lib/dashboard-token');
+// The token reader ships with the hooks runtime; an install recorded before
+// it existed has no copy until egc repair refreshes it, and then the event
+// goes out without a token instead of the hook failing to load.
+let readDashboardToken = () => null;
+try {
+  ({ readDashboardToken } = require('../lib/dashboard-token'));
+} catch {
+  // an older install without the helper: no token, no crash
+}
 const _egcRaw = process.env.EGC_PORT;
 const _egcParsed = (_egcRaw && /^\d+$/.test(_egcRaw)) ? Number(_egcRaw) : Number.NaN;
 const DASHBOARD_PORT = (!Number.isNaN(_egcParsed) && _egcParsed >= 1 && _egcParsed <= 65535) ? _egcParsed : 7890;

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -61,12 +61,25 @@ function shouldPromptSave(input, nowMs) {
   return true;
 }
 
+// The dashboard keeps a private token next to its state (dashboard/ops.js);
+// presenting it is what separates a local sender from a web page.
+function readDashboardToken() {
+  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+  try {
+    const raw = fs.readFileSync(path.join(home, '.egc', 'dashboard-token'), 'utf8').trim();
+    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
 function post(ev, done) {
   const body = JSON.stringify(ev);
+  const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) };
+  const token = readDashboardToken();
+  if (token) headers['x-egc-token'] = token;
   const req = http.request(
-    { hostname: '127.0.0.1', port: DASHBOARD_PORT, path: '/event', method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
-      timeout: 300 },
+    { hostname: '127.0.0.1', port: DASHBOARD_PORT, path: '/event', method: 'POST', headers, timeout: 300 },
     () => done()
   );
   req.on('error', () => done());

--- a/scripts/hooks/claude-session-stop.js
+++ b/scripts/hooks/claude-session-stop.js
@@ -14,6 +14,7 @@ const fs = require('node:fs');
 const http = require('node:http');
 const os = require('node:os');
 const path = require('node:path');
+const { readDashboardToken } = require('../lib/dashboard-token');
 const _egcRaw = process.env.EGC_PORT;
 const _egcParsed = (_egcRaw && /^\d+$/.test(_egcRaw)) ? Number(_egcRaw) : Number.NaN;
 const DASHBOARD_PORT = (!Number.isNaN(_egcParsed) && _egcParsed >= 1 && _egcParsed <= 65535) ? _egcParsed : 7890;
@@ -59,18 +60,6 @@ function shouldPromptSave(input, nowMs) {
     // Marker is best-effort; still prompt.
   }
   return true;
-}
-
-// The dashboard keeps a private token next to its state (dashboard/ops.js);
-// presenting it is what separates a local sender from a web page.
-function readDashboardToken() {
-  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
-  try {
-    const raw = fs.readFileSync(path.join(home, '.egc', 'dashboard-token'), 'utf8').trim();
-    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
-  } catch {
-    return null;
-  }
 }
 
 function post(ev, done) {

--- a/scripts/lib/dashboard-token.js
+++ b/scripts/lib/dashboard-token.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// The dashboard mints exactly this shape at startup (dashboard/ops.js,
+// TOKEN_BYTES hex characters); anything else is a partial write and counts
+// as no token, so a sender retries next time instead of posting a token
+// the dashboard is sure to refuse.
+const DASHBOARD_TOKEN_RE = /^[0-9a-f]{64}$/i;
+const DASHBOARD_TOKEN_FILE = 'dashboard-token';
+
+function resolveDashboardTokenPath(homeDir) {
+  const home = homeDir || process.env.HOME || process.env.USERPROFILE || os.homedir();
+  return path.join(home, '.egc', DASHBOARD_TOKEN_FILE);
+}
+
+function readDashboardToken(homeDir) {
+  try {
+    const raw = fs.readFileSync(resolveDashboardTokenPath(homeDir), 'utf8').trim();
+    return DASHBOARD_TOKEN_RE.test(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { DASHBOARD_TOKEN_FILE, DASHBOARD_TOKEN_RE, readDashboardToken, resolveDashboardTokenPath };

--- a/scripts/lib/install-targets/claude-home.js
+++ b/scripts/lib/install-targets/claude-home.js
@@ -44,6 +44,7 @@ const {
 
 const HOOK_LIB_SOURCES = [
   'scripts/lib/session-start-adapter.js',
+  'scripts/lib/dashboard-token.js',
   // Flattens next to the adapter; its require falls back from
   // ./crusher/session-marker to ./session-marker for exactly this layout.
   'scripts/lib/crusher/session-marker.js',

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -27,6 +27,7 @@ const OPENCODE_SESSION_CONTEXT_MODULE_ID = 'opencode-session-context-hook';
 // restoration on both hosts.
 const SESSION_CONTEXT_LIB_SOURCES = [
   'scripts/lib/session-start-adapter.js',
+  'scripts/lib/dashboard-token.js',
   'scripts/lib/session-context-loader.js',
   'scripts/lib/branch-state.js',
   'scripts/lib/global-state.js',

--- a/scripts/lib/session-start-adapter.js
+++ b/scripts/lib/session-start-adapter.js
@@ -11,7 +11,8 @@ const http = require('node:http');
 // goes out without a token instead of the hook failing to load.
 let readDashboardToken = () => null;
 try {
-  ({ readDashboardToken } = require('./dashboard-token'));
+  const loaded = require('./dashboard-token');
+  if (typeof loaded.readDashboardToken === 'function') readDashboardToken = loaded.readDashboardToken;
 } catch {
   // an older install without the helper: no token, no crash
 }

--- a/scripts/lib/session-start-adapter.js
+++ b/scripts/lib/session-start-adapter.js
@@ -6,7 +6,15 @@
 
 const fs = require('node:fs');
 const http = require('node:http');
-const { readDashboardToken } = require('./dashboard-token');
+// The token reader ships with the hooks runtime; an install recorded before
+// it existed has no copy until egc repair refreshes it, and then the event
+// goes out without a token instead of the hook failing to load.
+let readDashboardToken = () => null;
+try {
+  ({ readDashboardToken } = require('./dashboard-token'));
+} catch {
+  // an older install without the helper: no token, no crash
+}
 
 const DEFAULT_DASHBOARD_PORT = 7890;
 const DASHBOARD_TIMEOUT_MS = 200;

--- a/scripts/lib/session-start-adapter.js
+++ b/scripts/lib/session-start-adapter.js
@@ -6,8 +6,7 @@
 
 const fs = require('node:fs');
 const http = require('node:http');
-const os = require('node:os');
-const path = require('node:path');
+const { readDashboardToken } = require('./dashboard-token');
 
 const DEFAULT_DASHBOARD_PORT = 7890;
 const DASHBOARD_TIMEOUT_MS = 200;
@@ -49,18 +48,6 @@ function resolveDashboardPort() {
   return Number.isInteger(port) && port >= 1 && port <= 65535
     ? port
     : DEFAULT_DASHBOARD_PORT;
-}
-
-// The dashboard keeps a private token next to its state (dashboard/ops.js);
-// presenting it is what separates a local sender from a web page.
-function readDashboardToken() {
-  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
-  try {
-    const raw = fs.readFileSync(path.join(home, '.egc', 'dashboard-token'), 'utf8').trim();
-    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
-  } catch {
-    return null;
-  }
 }
 
 function postSessionStart(host, sessionId) {

--- a/scripts/lib/session-start-adapter.js
+++ b/scripts/lib/session-start-adapter.js
@@ -6,6 +6,8 @@
 
 const fs = require('node:fs');
 const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 
 const DEFAULT_DASHBOARD_PORT = 7890;
 const DASHBOARD_TIMEOUT_MS = 200;
@@ -49,18 +51,30 @@ function resolveDashboardPort() {
     : DEFAULT_DASHBOARD_PORT;
 }
 
+// The dashboard keeps a private token next to its state (dashboard/ops.js);
+// presenting it is what separates a local sender from a web page.
+function readDashboardToken() {
+  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+  try {
+    const raw = fs.readFileSync(path.join(home, '.egc', 'dashboard-token'), 'utf8').trim();
+    return /^[0-9a-f]{32,}$/i.test(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
 function postSessionStart(host, sessionId) {
   const body = JSON.stringify({ ide: host, event: 'session_start', session_id: sessionId });
+  const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) };
+  const token = readDashboardToken();
+  if (token) headers['x-egc-token'] = token;
   const request = http.request(
     {
       hostname: '127.0.0.1',
       port: resolveDashboardPort(),
       path: '/event',
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
-      },
+      headers,
       timeout: DASHBOARD_TIMEOUT_MS,
     },
     response => response.resume()

--- a/tests/dashboard-server.test.js
+++ b/tests/dashboard-server.test.js
@@ -10,8 +10,23 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('http');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+
+// Point HOME at a scratch directory before the server resolves it, so the
+// dashboard token it mints never touches the real ~/.egc.
+const SANDBOX_HOME = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'egc-dashboard-home-')));
+process.env.HOME = SANDBOX_HOME;
+process.env.USERPROFILE = SANDBOX_HOME;
+
 const { createAccumulator } = require('../dashboard/accumulator');
+const { TOKEN_HEADER, resolveTokenPath } = require('../dashboard/ops');
+const { PORT: PANEL_PORT } = require('../dashboard/port');
+const WebSocket = require(require.resolve('ws', { paths: [path.join(__dirname, '..', 'dashboard')] }));
+
+function dashboardToken() {
+  return fs.readFileSync(resolveTokenPath(), 'utf8').trim();
+}
 
 // ---------------------------------------------------------------------------
 // Tests — every scenario that should be caught by the guard clause
@@ -122,9 +137,12 @@ function runWithDashboardServer(testFn, done) {
   const activeIntervals = [];
   const watchedFiles = [];
 
+  // Listeners the server attaches to its http.Server (the WebSocket upgrade
+  // among them) are replayed onto the real test server below.
+  const serverListeners = [];
   http.createServer = (handler) => {
     serverHandler = handler;
-    return { listen: () => {}, on: () => {} };
+    return { listen: () => {}, on: (event, listener) => { serverListeners.push([event, listener]); } };
   };
 
   global.setInterval = (cb, ms) => {
@@ -167,6 +185,7 @@ function runWithDashboardServer(testFn, done) {
   }
 
   const testServer = http.createServer(serverHandler);
+  for (const [event, listener] of serverListeners) testServer.on(event, listener);
   let finished = false;
 
   const cleanup = (err) => {
@@ -208,7 +227,8 @@ test('POST /event rejects payloads larger than 256 KB with 413 status code', (t,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(largePayload)
+        'Content-Length': Buffer.byteLength(largePayload),
+        [TOKEN_HEADER]: dashboardToken()
       }
     };
 
@@ -252,7 +272,8 @@ test('POST /event rejects malformed JSON with 400 status code', (t, done) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(malformedPayload)
+        'Content-Length': Buffer.byteLength(malformedPayload),
+        [TOKEN_HEADER]: dashboardToken()
       }
     };
 
@@ -293,7 +314,8 @@ test('POST /event still accepts valid JSON with 200 status code', (t, done) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(validPayload)
+        'Content-Length': Buffer.byteLength(validPayload),
+        [TOKEN_HEADER]: dashboardToken()
       }
     };
 
@@ -341,7 +363,8 @@ test('POST /event handles multi-byte UTF-8 character split across TCP chunks', (
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': buf.length
+        'Content-Length': buf.length,
+        [TOKEN_HEADER]: dashboardToken()
       }
     };
 
@@ -465,3 +488,105 @@ test('debounce: burst of misses triggers at most one rebuild per interval (EGC#9
     })();
   }, done);
 });
+
+// ---------------------------------------------------------------------------
+// POST /event authentication, ide allowlist, CORS pin, WebSocket origin
+// (security audit 2026-08-17, F1/F4/F9/F10)
+// ---------------------------------------------------------------------------
+
+function requestDashboard(port, { body, headers = {}, method = 'POST', path: reqPath = '/event' } = {}) {
+  return new Promise((resolve, reject) => {
+    const payload = body === undefined ? '' : body;
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port,
+      path: reqPath,
+      method,
+      headers: { 'Content-Length': Buffer.byteLength(payload), ...headers },
+    }, res => {
+      let data = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: data }));
+    });
+    req.on('error', reject);
+    req.end(payload);
+  });
+}
+
+function withDashboardServer(fn) {
+  return new Promise((resolve, reject) => {
+    runWithDashboardServer((port, cleanup) => {
+      fn(port).then(() => cleanup(), err => cleanup(err));
+    }, err => (err ? reject(err) : resolve()));
+  });
+}
+
+function eventHeaders(extra = {}) {
+  return { 'Content-Type': 'application/json', [TOKEN_HEADER]: dashboardToken(), ...extra };
+}
+
+const EVENT = JSON.stringify({ ide: 'claude', event: 'pre_tool', tool: 'Bash', detail: 'git status' });
+
+test('POST /event without the dashboard token is refused with 401', () => withDashboardServer(async port => {
+  const res = await requestDashboard(port, { body: EVENT, headers: { 'Content-Type': 'application/json' } });
+  assert.equal(res.status, 401);
+  assert.match(JSON.parse(res.body).error, /token/i);
+}));
+
+test('POST /event with a wrong token is refused with 401', () => withDashboardServer(async port => {
+  const res = await requestDashboard(port, { body: EVENT, headers: eventHeaders({ [TOKEN_HEADER]: 'f'.repeat(64) }) });
+  assert.equal(res.status, 401);
+}));
+
+test('POST /event with a non-JSON Content-Type is refused with 415', () => withDashboardServer(async port => {
+  const res = await requestDashboard(port, { body: EVENT, headers: eventHeaders({ 'Content-Type': 'text/plain' }) });
+  assert.equal(res.status, 415);
+}));
+
+test('POST /event carrying a browser Origin other than the panel is refused with 403', () => withDashboardServer(async port => {
+  const res = await requestDashboard(port, { body: EVENT, headers: eventHeaders({ Origin: 'http://localhost:9999' }) });
+  assert.equal(res.status, 403);
+}));
+
+test('POST /event with the token, JSON and the panel origin (or none) is accepted', () => withDashboardServer(async port => {
+  const plain = await requestDashboard(port, { body: EVENT, headers: eventHeaders() });
+  assert.equal(plain.status, 200);
+  assert.equal(JSON.parse(plain.body).ok, true);
+  const panel = await requestDashboard(port, { body: EVENT, headers: eventHeaders({ Origin: `http://localhost:${PANEL_PORT}` }) });
+  assert.equal(panel.status, 200);
+}));
+
+test('POST /event refuses an ide the dashboard does not know, including markup', () => withDashboardServer(async port => {
+  for (const ide of ['<img src=x onerror=alert(1)>', 'not-a-real-tool', 'CLAUDE', '']) {
+    const res = await requestDashboard(port, { body: JSON.stringify({ ide, event: 'pre_tool' }), headers: eventHeaders() });
+    assert.equal(res.status, 400, `ide ${JSON.stringify(ide)} must be refused`);
+    assert.equal(JSON.parse(res.body).error, 'Unknown ide');
+  }
+}));
+
+test('CORS is pinned to the panel origin instead of reflecting any localhost origin', () => withDashboardServer(async port => {
+  const foreign = await requestDashboard(port, { method: 'GET', path: '/ping', headers: { Origin: 'http://localhost:9999' } });
+  assert.equal(foreign.headers['access-control-allow-origin'], `http://localhost:${PANEL_PORT}`);
+  const panel = await requestDashboard(port, { method: 'GET', path: '/ping', headers: { Origin: `http://127.0.0.1:${PANEL_PORT}` } });
+  assert.equal(panel.headers['access-control-allow-origin'], `http://127.0.0.1:${PANEL_PORT}`);
+}));
+
+function connectWebSocket(port, origin) {
+  return new Promise(resolve => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, { origin });
+    ws.on('open', () => { ws.close(); resolve({ opened: true }); });
+    ws.on('unexpected-response', (req, res) => { req.destroy(); resolve({ opened: false, status: res.statusCode }); });
+    ws.on('error', error => resolve({ opened: false, error: error.message }));
+  });
+}
+
+test('WebSocket upgrade is refused without the panel origin and accepted with it', () => withDashboardServer(async port => {
+  const foreign = await connectWebSocket(port, 'http://localhost:9999');
+  assert.equal(foreign.opened, false, 'a foreign origin must not join the broadcast');
+  assert.equal(foreign.status, 401);
+  const none = await connectWebSocket(port, undefined);
+  assert.equal(none.opened, false, 'an upgrade without an origin must not join either');
+  const panel = await connectWebSocket(port, `http://localhost:${PANEL_PORT}`);
+  assert.equal(panel.opened, true, 'the panel itself must connect');
+}));

--- a/tests/dashboard-server.test.js
+++ b/tests/dashboard-server.test.js
@@ -18,6 +18,13 @@ const path = require('path');
 const SANDBOX_HOME = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'egc-dashboard-home-')));
 process.env.HOME = SANDBOX_HOME;
 process.env.USERPROFILE = SANDBOX_HOME;
+process.on('exit', () => {
+  try {
+    fs.rmSync(SANDBOX_HOME, { recursive: true, force: true });
+  } catch {
+    // best effort: a leftover scratch directory is not a test failure
+  }
+});
 
 const { createAccumulator } = require('../dashboard/accumulator');
 const { TOKEN_HEADER, resolveTokenPath } = require('../dashboard/ops');
@@ -185,7 +192,11 @@ function runWithDashboardServer(testFn, done) {
   }
 
   const testServer = http.createServer(serverHandler);
-  for (const [event, listener] of serverListeners) testServer.on(event, listener);
+  // Only the WebSocket upgrade is replayed: the server's own 'error'
+  // listener exits the process, which would hide a failing test.
+  for (const [event, listener] of serverListeners) {
+    if (event === 'upgrade') testServer.on(event, listener);
+  }
   let finished = false;
 
   const cleanup = (err) => {
@@ -589,4 +600,23 @@ test('WebSocket upgrade is refused without the panel origin and accepted with it
   assert.equal(none.opened, false, 'an upgrade without an origin must not join either');
   const panel = await connectWebSocket(port, `http://localhost:${PANEL_PORT}`);
   assert.equal(panel.opened, true, 'the panel itself must connect');
+}));
+
+test('postEvent reports completion once even when a timeout also raises an error', () => new Promise((resolve, reject) => {
+  const { postEvent } = require('../dashboard/telemetry-client');
+  const net = require('net');
+  const silent = net.createServer(() => {});
+  silent.listen(0, '127.0.0.1', () => {
+    let calls = 0;
+    postEvent({ ide: 'claude', event: 'pre_tool' }, { port: silent.address().port, timeout: 50, onDone: () => { calls += 1; } });
+    setTimeout(() => {
+      silent.close();
+      try {
+        assert.equal(calls, 1);
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    }, 400);
+  });
 }));


### PR DESCRIPTION
## What

Days 5 and 6 of the security schedule (17/08 audit, findings F1, F4, F9, F10).

- **WebSocket** (`F1`): the upgrade now requires the panel's own origin (`verifyClient` with `isPanelOrigin`), so a page elsewhere in the same browser cannot join the live broadcast of commands, paths and URLs.
- **POST /event** (`F9`): requires the dashboard token (`x-egc-token`, the same token `/ops` already uses, minted at startup and kept private to the user), a JSON `Content-Type` (415 otherwise) and no browser Origin other than the panel's (403). Every local sender presents the token through one shared client, `dashboard/telemetry-client.js` (shim, session shim, codebuddy/aider/vscode adapters); the two session hooks that are copied alone into targets read the token inline.
- **ide allowlist and escaping** (`F4`): the server refuses an `ide` that is neither a value the panel renders nor an install target (400 `Unknown ide`, format-checked first), and the panel escapes `ide` in the cost bars, the session list and the replay page.
- **CORS** (`F10`): answers with the panel origin instead of reflecting any localhost-shaped origin.

## Proof

- Live against the real server on a test port: `POST /event` without token 401, wrong Content-Type 415, foreign Origin 403, with token 200, markup ide 400; `GET /ping` with a foreign localhost origin gets the canonical origin back; WebSocket with a foreign origin or no origin is refused (401), with the panel origin it opens.
- `tests/dashboard-server.test.js` +8 (25/25) driving the intercepted server, including a real `ws` client against the replayed upgrade listener; the harness now sandboxes HOME so the token never touches the real `~/.egc`. Dashboard suites (ops, session-bus, watcher-rotation, export, ping-polling, port) and every suite referencing the senders pass.

## Note

An installed copy of `claude-session-stop.js` or the session-start adapters from before this change posts without the token and is answered 401 until `egc repair` or `egc install` refreshes it; the dashboard is optional telemetry, and the sender already ignores the answer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops other pages in the same browser from reading or writing the dashboard's live telemetry: previously any local web page could join the WebSocket broadcast, post events, and store markup in the `ide` field. The WebSocket upgrade now requires the panel's own origin, `POST /event` requires the dashboard token, a JSON `Content-Type`, and no foreign browser Origin, CORS reflects only the panel origin, and `ide` values are allowlisted and escaped wherever the panel renders them.

All local senders read the token from the shared `scripts/lib/dashboard-token.js`, and dashboard-side senders post through the shared `dashboard/telemetry-client.js`. When the shared reader is missing or does not export a token reader, senders fall back to posting without a token instead of failing to load, and the reader now ships with OpenCode installs too.

**Migration**
- Previously installed copies of `claude-session-stop.js` or the session-start adapters get 401 until `egc repair` or `egc install` refreshes them.
- The dashboard is optional telemetry and the senders already ignore the answer, so a 401 is silent.

<sup>Written for commit 9dc06b2f516968a933eabd7f408ba4dd54253463. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

