### PR TITLE
fix(security): put the Guardian in front of OpenCode file writes and Trae file changes, in every install path

### DIFF
--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -44,12 +44,15 @@ type HookModule = { run: (input: unknown) => unknown }
 // load their own copy instead of sharing the first one's dependencies.
 const hookModules = new Map<string, HookModule>()
 
-// Only a worktree that is the EGC repository itself may supply hook scripts:
-// an installed plugin must never load code from whatever project it opens.
-function isEgcRepository(worktreePath: string): boolean {
+// The worktree may supply hook scripts only when this plugin file itself
+// lives inside it (the EGC repository running its own plugin): a project
+// cannot forge where the installed plugin sits, so an installed plugin never
+// loads code from whatever project it opens.
+function pluginInsideWorktree(pluginDir: string, worktreePath: string): boolean {
   try {
-    const manifest = JSON.parse(fs.readFileSync(path.join(worktreePath, "package.json"), "utf8")) as { name?: unknown }
-    return manifest.name === "@egchq/egc"
+    const plugin = fs.realpathSync(pluginDir)
+    const worktree = fs.realpathSync(worktreePath)
+    return plugin === worktree || plugin.startsWith(worktree + path.sep)
   } catch {
     return false
   }
@@ -60,7 +63,7 @@ function resolveHookModulePath(pluginDir: string, worktreePath: string, fileName
     path.join(pluginDir, "..", "scripts", "hooks", fileName),
     path.join(pluginDir, "..", "..", "scripts", "hooks", fileName),
   ]
-  if (isEgcRepository(worktreePath)) candidates.push(path.join(worktreePath, "scripts", "hooks", fileName))
+  if (pluginInsideWorktree(pluginDir, worktreePath)) candidates.push(path.join(worktreePath, "scripts", "hooks", fileName))
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? null
 }
 

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -40,28 +40,41 @@ import changedFilesTool from "../tools/changed-files.js"
 // <opencode root>/scripts/hooks/ (one level up). Try both.
 type HookModule = { run: (input: unknown) => unknown }
 
+// Keyed by the resolved file, so two worktrees served by one process each
+// load their own copy instead of sharing the first one's dependencies.
 const hookModules = new Map<string, HookModule>()
+
+// Only a worktree that is the EGC repository itself may supply hook scripts:
+// an installed plugin must never load code from whatever project it opens.
+function isEgcRepository(worktreePath: string): boolean {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(worktreePath, "package.json"), "utf8")) as { name?: unknown }
+    return manifest.name === "@egchq/egc"
+  } catch {
+    return false
+  }
+}
 
 function resolveHookModulePath(pluginDir: string, worktreePath: string, fileName: string): string | null {
   const candidates = [
-    path.join(worktreePath, "scripts", "hooks", fileName),
     path.join(pluginDir, "..", "scripts", "hooks", fileName),
     path.join(pluginDir, "..", "..", "scripts", "hooks", fileName),
   ]
+  if (isEgcRepository(worktreePath)) candidates.push(path.join(worktreePath, "scripts", "hooks", fileName))
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? null
 }
 
-// Loads one of the repository's hook scripts in-process; a script that is
-// not there is looked up again on the next call, so an install that lands
-// mid-session is picked up without a restart.
+// Loads one of the hook scripts in-process; a script that is not there is
+// looked up again on the next call, so an install that lands mid-session is
+// picked up without a restart.
 function loadHookModule(pluginDir: string, worktreePath: string, fileName: string): HookModule | null {
-  const cached = hookModules.get(fileName)
-  if (cached) return cached
   const modulePath = resolveHookModulePath(pluginDir, worktreePath, fileName)
   if (!modulePath) return null
+  const cached = hookModules.get(modulePath)
+  if (cached) return cached
   try {
     const loaded = createRequire(import.meta.url)(modulePath) as HookModule
-    hookModules.set(fileName, loaded)
+    hookModules.set(modulePath, loaded)
     return loaded
   } catch {
     return null
@@ -108,15 +121,21 @@ function guardianDenyReason(
 }
 
 // The dashboard only accepts events that carry the token it minted at
-// startup (dashboard/ops.js); a missing token just means no telemetry.
+// startup (dashboard/ops.js); a missing token just means no telemetry. The
+// token changes only when the dashboard restarts, so a good read is kept
+// and the file is consulted again only while no token is known.
+let dashboardToken: string | null = null
+
 function readDashboardToken(): string | null {
+  if (dashboardToken) return dashboardToken
   try {
     const home = process.env.HOME || process.env.USERPROFILE || os.homedir()
     const raw = fs.readFileSync(path.join(home, ".egc", "dashboard-token"), "utf8").trim()
-    return /^[0-9a-f]{64}$/i.test(raw) ? raw : null
+    dashboardToken = /^[0-9a-f]{64}$/i.test(raw) ? raw : null
   } catch {
-    return null
+    dashboardToken = null
   }
+  return dashboardToken
 }
 
 const OPENCODE_TOOL_TO_GATEGUARD: Record<string, string> = {

--- a/.opencode/plugins/egc-hooks.ts
+++ b/.opencode/plugins/egc-hooks.ts
@@ -15,6 +15,7 @@
 
 import type { PluginInput } from "@opencode-ai/plugin"
 import * as fs from "fs"
+import * as os from "os"
 import * as path from "path"
 import { createRequire } from "module"
 import { fileURLToPath } from "url"
@@ -37,33 +38,85 @@ import changedFilesTool from "../tools/changed-files.js"
 // (dogfooding, two levels above the repo root) or an installed copy under
 // <opencode root>/plugins/ with gateguard-fact-force.js copied alongside at
 // <opencode root>/scripts/hooks/ (one level up). Try both.
-type GateGuardModule = { run: (rawInput: string) => unknown }
+type HookModule = { run: (input: unknown) => unknown }
 
-let gateguardModule: GateGuardModule | null | undefined
+const hookModules = new Map<string, HookModule>()
 
-function resolveGateGuardModulePath(pluginDir: string, worktreePath: string): string | null {
+function resolveHookModulePath(pluginDir: string, worktreePath: string, fileName: string): string | null {
   const candidates = [
-    path.join(worktreePath, "scripts", "hooks", "gateguard-fact-force.js"),
-    path.join(pluginDir, "..", "scripts", "hooks", "gateguard-fact-force.js"),
-    path.join(pluginDir, "..", "..", "scripts", "hooks", "gateguard-fact-force.js"),
+    path.join(worktreePath, "scripts", "hooks", fileName),
+    path.join(pluginDir, "..", "scripts", "hooks", fileName),
+    path.join(pluginDir, "..", "..", "scripts", "hooks", fileName),
   ]
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? null
 }
 
-function loadGateGuard(pluginDir: string, worktreePath: string): GateGuardModule | null {
-  if (gateguardModule !== undefined) return gateguardModule
-  const modulePath = resolveGateGuardModulePath(pluginDir, worktreePath)
-  if (!modulePath) {
-    gateguardModule = null
+// Loads one of the repository's hook scripts in-process; a script that is
+// not there is looked up again on the next call, so an install that lands
+// mid-session is picked up without a restart.
+function loadHookModule(pluginDir: string, worktreePath: string, fileName: string): HookModule | null {
+  const cached = hookModules.get(fileName)
+  if (cached) return cached
+  const modulePath = resolveHookModulePath(pluginDir, worktreePath, fileName)
+  if (!modulePath) return null
+  try {
+    const loaded = createRequire(import.meta.url)(modulePath) as HookModule
+    hookModules.set(fileName, loaded)
+    return loaded
+  } catch {
     return null
   }
-  try {
-    const req = createRequire(import.meta.url)
-    gateguardModule = req(modulePath) as GateGuardModule
-  } catch {
-    gateguardModule = null
+}
+
+function loadGateGuard(pluginDir: string, worktreePath: string): HookModule | null {
+  return loadHookModule(pluginDir, worktreePath, "gateguard-fact-force.js")
+}
+
+// EGC Guardian: the same validators Claude Code's hooks.json wires in,
+// called in-process. A blocking verdict (exit code 2) throws, which is how
+// an OpenCode plugin refuses a tool call.
+const GUARDIAN_WRITE_TOOLS: Record<string, string> = { write: "Write", edit: "Edit" }
+type GuardianVerdict = { exitCode?: number; stderr?: string }
+
+function guardianDenyReason(
+  pluginDir: string,
+  worktreePath: string,
+  tool: string,
+  args: Record<string, unknown> | undefined
+): string | null {
+  let verdict: GuardianVerdict | undefined
+  if (tool === "bash") {
+    const guardian = loadHookModule(pluginDir, worktreePath, "pre-bash-guardian-validate.js")
+    verdict = guardian?.run({
+      tool_name: "Bash",
+      tool_input: { command: String(args?.command ?? "") },
+      cwd: worktreePath,
+    }) as GuardianVerdict | undefined
+  } else if (GUARDIAN_WRITE_TOOLS[tool]) {
+    const guardian = loadHookModule(pluginDir, worktreePath, "pre-write-guardian-validate.js")
+    verdict = guardian?.run({
+      tool_name: GUARDIAN_WRITE_TOOLS[tool],
+      tool_input: {
+        file_path: args?.filePath ?? args?.file_path ?? args?.path,
+        content: args?.content,
+        new_string: args?.newString,
+      },
+      cwd: worktreePath,
+    }) as GuardianVerdict | undefined
   }
-  return gateguardModule
+  return verdict?.exitCode === 2 ? (verdict.stderr || "Blocked by the EGC Guardian.") : null
+}
+
+// The dashboard only accepts events that carry the token it minted at
+// startup (dashboard/ops.js); a missing token just means no telemetry.
+function readDashboardToken(): string | null {
+  try {
+    const home = process.env.HOME || process.env.USERPROFILE || os.homedir()
+    const raw = fs.readFileSync(path.join(home, ".egc", "dashboard-token"), "utf8").trim()
+    return /^[0-9a-f]{64}$/i.test(raw) ? raw : null
+  } catch {
+    return null
+  }
 }
 
 const OPENCODE_TOOL_TO_GATEGUARD: Record<string, string> = {
@@ -297,10 +350,20 @@ export const EGCHooksPlugin: EGCHooksPluginFn = async ({
         const detail = (input.args?.filePath ?? input.args?.file_path ?? input.args?.path ?? input.args?.command ?? "") as string
         const tool = input.tool.charAt(0).toUpperCase() + input.tool.slice(1)
         const body = JSON.stringify({ ide:"opencode", event:"pre_tool", tool, agent:"main", detail, status:"running" })
-        const req = http.default.request({ hostname:"127.0.0.1", port:7890, path:"/event", method:"POST", headers:{"Content-Type":"application/json","Content-Length":Buffer.byteLength(body)}, timeout:300 }, ()=>{})
+        const headers: Record<string, string | number> = { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(body) }
+        const token = readDashboardToken()
+        if (token) headers["x-egc-token"] = token
+        const req = http.default.request({ hostname:"127.0.0.1", port:7890, path:"/event", method:"POST", headers, timeout:300 }, ()=>{})
         req.on("error", ()=>{})
         req.end(body)
       } catch(_) {}
+
+      // EGC Guardian first: a denied command or a protected/denied write is
+      // refused before any other hook looks at the call.
+      const guardianReason = guardianDenyReason(pluginDir, worktreePath, input.tool, input.args)
+      if (guardianReason) {
+        throw new Error(guardianReason)
+      }
 
       // Fact-Forcing Gate: block the first Edit/Write/Bash per file (or per
       // session for Bash) and demand investigation before allowing it.

--- a/.trae/install.sh
+++ b/.trae/install.sh
@@ -74,6 +74,30 @@ copy_managed_file() {
 }
 
 # Install function
+# hooks.json wired to the two Guardian validators, written only when the
+# target has no hooks.json of its own (a user's file is never merged here).
+write_guardian_hooks_json() {
+    local root="$1"
+    local bash_hook="$root/scripts/hooks/pre-bash-guardian-validate.js"
+    local write_hook="$root/scripts/hooks/pre-write-guardian-validate.js"
+    cat > "$root/hooks.json" <<EOF
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "RunCommand",
+        "hooks": [{ "type": "command", "command": "node \\"$bash_hook\\"" }]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{ "type": "command", "command": "node \\"$write_hook\\"" }]
+      }
+    ]
+  }
+}
+EOF
+}
+
 do_install() {
     local target_dir="$PWD"
     local trae_dir="$(get_trae_dir)"
@@ -158,6 +182,27 @@ do_install() {
         done < <(find "$REPO_ROOT/rules" -type f | sort)
     fi
 
+    # Guardian hooks: the same validators egc install --target trae registers,
+    # so a project set up through this script is not left without them.
+    hooks=0
+    mkdir -p "$trae_full_path/scripts/hooks" "$trae_full_path/scripts/lib"
+    GUARDIAN_FILES="scripts/hooks/pre-bash-guardian-validate.js scripts/hooks/pre-write-guardian-validate.js scripts/lib/guardian-bin.js scripts/lib/shell-split.js"
+    for hook_file in $GUARDIAN_FILES; do
+        if [ -f "$REPO_ROOT/$hook_file" ]; then
+            if copy_managed_file "$REPO_ROOT/$hook_file" "$trae_full_path/$hook_file" "$MANIFEST" "$hook_file"; then
+                hooks=$((hooks + 1))
+            fi
+        fi
+    done
+    if [ ! -f "$trae_full_path/hooks.json" ]; then
+        write_guardian_hooks_json "$trae_full_path"
+        ensure_manifest_entry "$MANIFEST" "hooks.json"
+        hooks=$((hooks + 1))
+    elif ! grep -Fq "pre-bash-guardian-validate.js" "$trae_full_path/hooks.json"; then
+        echo "Note: $trae_full_path/hooks.json already exists without the EGC Guardian."
+        echo "      Run 'egc install --target trae' to merge the Guardian hooks into it."
+        echo ""
+    fi
     for readme_file in "$SCRIPT_DIR/README.md" "$SCRIPT_DIR/README.zh-CN.md"; do
         if [ -f "$readme_file" ]; then
             local_name=$(basename "$readme_file")
@@ -187,6 +232,7 @@ do_install() {
     echo "  Commands:  $commands"
     echo "  Agents:    $agents"
     echo "  Rules:     $rules"
+    echo "  Hooks:     $hooks (Guardian validators for RunCommand and Edit|Write)"
     echo ""
     echo "Note: skills are not installed by this script anymore. Run"
     echo "  'egc install --target trae' to install skills from the full,"

--- a/.trae/install.sh
+++ b/.trae/install.sh
@@ -76,26 +76,23 @@ copy_managed_file() {
 # Install function
 # hooks.json wired to the two Guardian validators, written only when the
 # target has no hooks.json of its own (a user's file is never merged here).
+# Serialized as JSON with the command paths shell-quoted, so a path with a
+# quote or a backslash still loads.
 write_guardian_hooks_json() {
     local root="$1"
-    local bash_hook="$root/scripts/hooks/pre-bash-guardian-validate.js"
-    local write_hook="$root/scripts/hooks/pre-write-guardian-validate.js"
-    cat > "$root/hooks.json" <<EOF
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "RunCommand",
-        "hooks": [{ "type": "command", "command": "node \\"$bash_hook\\"" }]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [{ "type": "command", "command": "node \\"$write_hook\\"" }]
-      }
-    ]
-  }
-}
-EOF
+    python3 - "$root" <<'PYEOF'
+import json, os, shlex, sys
+root = sys.argv[1]
+def hook(name):
+    return {"type": "command", "command": "node " + shlex.quote(os.path.join(root, "scripts", "hooks", name))}
+config = {"hooks": {"PreToolUse": [
+    {"matcher": "RunCommand", "hooks": [hook("pre-bash-guardian-validate.js")]},
+    {"matcher": "Edit|Write", "hooks": [hook("pre-write-guardian-validate.js")]},
+]}}
+with open(os.path.join(root, "hooks.json"), "w", encoding="utf-8") as handle:
+    json.dump(config, handle, indent=2)
+    handle.write("\n")
+PYEOF
 }
 
 do_install() {
@@ -194,12 +191,16 @@ do_install() {
             fi
         fi
     done
-    if [ ! -f "$trae_full_path/hooks.json" ]; then
+    if [ -L "$trae_full_path/hooks.json" ]; then
+        echo "Note: $trae_full_path/hooks.json is a symbolic link; this installer never writes through links."
+        echo "      Replace it with a regular file or run 'egc install --target trae'."
+        echo ""
+    elif [ ! -e "$trae_full_path/hooks.json" ]; then
         write_guardian_hooks_json "$trae_full_path"
         ensure_manifest_entry "$MANIFEST" "hooks.json"
         hooks=$((hooks + 1))
-    elif ! grep -Fq "pre-bash-guardian-validate.js" "$trae_full_path/hooks.json"; then
-        echo "Note: $trae_full_path/hooks.json already exists without the EGC Guardian."
+    elif ! grep -Fq "pre-bash-guardian-validate.js" "$trae_full_path/hooks.json" || ! grep -Fq "pre-write-guardian-validate.js" "$trae_full_path/hooks.json"; then
+        echo "Note: $trae_full_path/hooks.json already exists without both EGC Guardian validators (RunCommand and Edit|Write)."
         echo "      Run 'egc install --target trae' to merge the Guardian hooks into it."
         echo ""
     fi

--- a/scripts/hooks/opencode-egc-plugin.js
+++ b/scripts/hooks/opencode-egc-plugin.js
@@ -8,6 +8,7 @@
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 const { run: runGuardian } = require('../scripts/hooks/pre-bash-guardian-validate');
+const { run: runWriteGuardian } = require('../scripts/hooks/pre-write-guardian-validate');
 const { run: runCrusherRewrite } = require('../scripts/hooks/pre-bash-crusher-rewrite');
 
 const SESSION_CONTEXT_SCRIPT = path.join(
@@ -18,6 +19,30 @@ const SESSION_CONTEXT_SCRIPT = path.join(
   'opencode-session-start.js'
 );
 const DEFAULT_SESSION_CONTEXT_TIMEOUT_MS = 3000;
+
+// OpenCode's file tools and the Claude-style names the write validator
+// expects; OpenCode passes filePath/content/newString in the tool args.
+const GUARDIAN_WRITE_TOOLS = { write: 'Write', edit: 'Edit' };
+
+function writeToolInput(args) {
+  return {
+    file_path: args.filePath ?? args.file_path ?? args.path,
+    content: typeof args.content === 'string' ? args.content : undefined,
+    new_string: typeof args.newString === 'string' ? args.newString : undefined,
+  };
+}
+
+// The Guardian's refusal for a write, edit or bash call, or null to proceed.
+function guardianDenial(tool, args, directory) {
+  const writeTool = GUARDIAN_WRITE_TOOLS[tool];
+  let verdict = null;
+  if (writeTool) {
+    verdict = runWriteGuardian({ tool_name: writeTool, tool_input: writeToolInput(args), cwd: directory });
+  } else if (tool === 'bash' && typeof args.command === 'string') {
+    verdict = runGuardian({ tool_name: 'Bash', tool_input: { command: args.command }, cwd: directory });
+  }
+  return verdict?.exitCode === 2 ? (verdict.stderr || 'Blocked by the EGC Guardian.') : null;
+}
 const DEFAULT_MAX_SESSION_CONTEXT_BYTES = 1024 * 1024;
 
 function positiveIntegerEnv(name, fallback) {
@@ -189,22 +214,13 @@ const EgcGuardianCrusher = async ({ client, directory } = {}) => {
     'session.created': handleSessionCreated,
 
     'tool.execute.before': async (input, output) => {
-      if (input?.tool !== 'bash' || typeof output?.args?.command !== 'string') {
-        return;
-      }
+      const args = output?.args;
+      if (!args || typeof args !== 'object') return;
+      const denial = guardianDenial(input?.tool, args, directory);
+      if (denial) throw new Error(denial);
+      if (input?.tool !== 'bash' || typeof args.command !== 'string') return;
 
-      const command = output.args.command;
-
-      const guardianResult = runGuardian({
-        tool_name: 'Bash',
-        tool_input: { command },
-        cwd: directory,
-      });
-      if (guardianResult.exitCode === 2) {
-        throw new Error(guardianResult.stderr || 'Blocked by the EGC Guardian.');
-      }
-
-      const rewritten = JSON.parse(runCrusherRewrite({ tool_input: { command } }));
+      const rewritten = JSON.parse(runCrusherRewrite({ tool_input: { command: args.command } }));
       if (typeof rewritten?.tool_input?.command === 'string') {
         output.args.command = rewritten.tool_input.command;
       }

--- a/scripts/lib/claude-settings-hooks.js
+++ b/scripts/lib/claude-settings-hooks.js
@@ -908,6 +908,35 @@ function createPreToolUseBashGuardianHookMergeOperation(targetRoot, matcher) {
 // Destination-driven variant, for hosts whose hooks.json path is not
 // derivable from targetRoot (Copilot ~/.copilot/hooks, Antigravity's
 // project/global split). Same Claude hooks.json schema.
+// Write validator (pre-write-guardian-validate.js) for hosts that read the
+// Claude-style hooks.json but are not Claude Code: the same shape as the
+// Bash guardian builders below, keyed on the write validator's module id.
+function createWriteValidatorHookMergeOperationForDestination(destinationPath, hookScriptPath, matcher) {
+  return {
+    kind: HOOK_OPERATION_KIND,
+    moduleId: WRITE_VALIDATOR_HOOK_MODULE_ID,
+    sourceRelativePath: WRITE_VALIDATOR_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    destinationPath,
+    strategy: HOOK_OPERATION_KIND,
+    ownership: 'managed',
+    scaffoldOnly: false,
+    hookEvent: PRE_TOOL_USE_EVENT,
+    hookMatcher: matcher,
+    hookScriptPath,
+  };
+}
+
+// The write validator needs only guardian-bin.js, which the Bash guardian
+// copy operations already ship, so one copy is enough.
+function createWriteValidatorScriptCopyOperation(createRemappedOperation, targetRoot) {
+  return createRemappedOperation(
+    WRITE_VALIDATOR_HOOK_MODULE_ID,
+    WRITE_VALIDATOR_HOOK_SCRIPT_SOURCE_RELATIVE_PATH,
+    resolveWriteValidatorHookScriptDestination(targetRoot),
+    { strategy: 'preserve-relative-path' }
+  );
+}
+
 function createBashGuardianHookMergeOperationForDestination(destinationPath, hookScriptPath, matcher) {
   return {
     kind: HOOK_OPERATION_KIND,
@@ -1296,6 +1325,8 @@ module.exports = {
   createKiroMeshHookFileOperation,
   resolveMeshNoticeHookScriptDestination,
   createBashGuardianScriptCopyOperations,
+  createWriteValidatorHookMergeOperationForDestination,
+  createWriteValidatorScriptCopyOperation,
   createPreToolUseBashGuardianHookMergeOperation,
   createBashGuardianHookMergeOperationForDestination,
   resolveBashGuardianHookScriptDestination,

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -11,6 +11,7 @@ const {
   BASH_GUARDIAN_HOOK_MODULE_ID,
   createBashGuardianScriptCopyOperations,
   createCrusherScriptCopyOperations,
+  createWriteValidatorScriptCopyOperation,
 } = require('../claude-settings-hooks');
 
 // OpenCode plugins run in-process, unlike hosts that spawn hooks.json
@@ -78,6 +79,7 @@ function createOpenCodePluginOperations(adapter, targetRoot) {
 
   return [
     ...createBashGuardianScriptCopyOperations(remap, targetRoot),
+    createWriteValidatorScriptCopyOperation(remap, targetRoot),
     ...createCrusherScriptCopyOperations(remap, targetRoot),
     ...createOpenCodeSessionContextOperations(remap, targetRoot),
     pluginCopyOperation,

--- a/scripts/lib/install-targets/trae-project.js
+++ b/scripts/lib/install-targets/trae-project.js
@@ -9,6 +9,8 @@ const {
 const {
   createBashGuardianHookMergeOperationForDestination,
   createBashGuardianScriptCopyOperations,
+  createWriteValidatorHookMergeOperationForDestination,
+  createWriteValidatorScriptCopyOperation,
   createCrusherHookMergeOperationForDestination,
   createCrusherScriptCopyOperations,
   MESH_NOTICE_HOOK_MODULE_ID,
@@ -41,21 +43,31 @@ function resolveTraeHooksJsonPath(traeRoot) {
 // uses for its own security hooks, so a minimal install is never silently
 // unprotected.
 function createTraeGuardianOperations(adapter, traeRoot) {
-  const hookScriptPath = path.join(traeRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
-  const copyOperations = createBashGuardianScriptCopyOperations(
-    (moduleId, sourceRelativePath, destinationPath, options) => (
-      createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
-    ),
-    traeRoot
+  const remap = (moduleId, sourceRelativePath, destinationPath, options) => (
+    createRemappedOperation(adapter, moduleId, sourceRelativePath, destinationPath, options)
   );
-
+  const hooksJsonPath = resolveTraeHooksJsonPath(traeRoot);
+  const hookScriptPath = path.join(traeRoot, 'scripts', 'hooks', 'pre-bash-guardian-validate.js');
+  const copyOperations = createBashGuardianScriptCopyOperations(remap, traeRoot);
   const mergeOperation = createBashGuardianHookMergeOperationForDestination(
-    resolveTraeHooksJsonPath(traeRoot),
+    hooksJsonPath,
     hookScriptPath,
     'RunCommand'
   );
 
-  return [...copyOperations, mergeOperation];
+  // File writes go through the same validator Claude Code registers. Trae's
+  // standardized tool names for file changes are Write and Edit, and its
+  // matcher takes a regular expression (docs.trae.ai/ide/hook-configuration-
+  // reference lists "Edit|Write" as the example), so one entry covers both.
+  const writeScriptPath = path.join(traeRoot, 'scripts', 'hooks', 'pre-write-guardian-validate.js');
+  const writeCopyOperation = createWriteValidatorScriptCopyOperation(remap, traeRoot);
+  const writeMergeOperation = createWriteValidatorHookMergeOperationForDestination(
+    hooksJsonPath,
+    writeScriptPath,
+    'Edit|Write'
+  );
+
+  return [...copyOperations, mergeOperation, writeCopyOperation, writeMergeOperation];
 }
 
 // Token Crusher for Trae: same PreToolUse/updatedInput rewrite mechanism as

--- a/tests/hooks/opencode-egc-plugin.test.js
+++ b/tests/hooks/opencode-egc-plugin.test.js
@@ -249,6 +249,21 @@ async function runTests() {
       assert.strictEqual(calls.length, 0);
     })) passed++; else failed++;
 
+    if (await test('validates write and edit targets with the Guardian', async () => {
+      const hooks = await EgcGuardianCrusher({ directory: tempDir });
+      await assert.rejects(
+        () => hooks['tool.execute.before']({ tool: 'write' }, { args: { filePath: path.join(tempDir, '.ssh', 'id_rsa'), content: 'x' } }),
+        /EGC Guardian BLOCKED/
+      );
+      await assert.rejects(
+        () => hooks['tool.execute.before']({ tool: 'edit' }, { args: { filePath: path.join(tempDir, '.aws', 'credentials'), oldString: 'a', newString: 'b' } }),
+        /EGC Guardian BLOCKED/
+      );
+      const fine = { args: { filePath: path.join(tempDir, 'notes.md'), content: 'hello' } };
+      await hooks['tool.execute.before']({ tool: 'write' }, fine);
+      assert.strictEqual(fine.args.content, 'hello');
+    })) passed++; else failed++;
+
     if (await test('preserves Guardian and Crusher behavior', async () => {
       let hooks = await EgcGuardianCrusher({ directory: tempDir });
       const readOutput = { args: { filePath: '/tmp/x' } };

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -2693,6 +2693,34 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('trae and opencode ship the write validator next to the Bash guardian', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+    const homeDir = '/Users/example';
+    const traePlan = planInstallTargetScaffold({ target: 'trae', repoRoot, modules: [], projectRoot });
+    const traeHooks = path.join(projectRoot, '.trae', 'hooks.json');
+    const traeWriteScript = path.join(projectRoot, '.trae', 'scripts', 'hooks', 'pre-write-guardian-validate.js');
+    const merges = traePlan.operations.filter(operation => (
+      operation.kind === 'merge-claude-settings-hooks'
+      && operation.destinationPath === traeHooks
+      && operation.hookScriptPath === traeWriteScript
+    ));
+    assert.strictEqual(merges.length, 1, 'trae registers the write validator once');
+    assert.strictEqual(merges[0].hookEvent, 'PreToolUse');
+    assert.strictEqual(merges[0].hookMatcher, 'Edit|Write');
+    assert.ok(traePlan.operations.some(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-write-guardian-validate.js'
+      && operation.destinationPath === traeWriteScript
+    )), 'trae scaffolds the write validator script');
+
+    const opencodePlan = planInstallTargetScaffold({ target: 'opencode', repoRoot, modules: [], homeDir });
+    const opencodeWriteScript = path.join(homeDir, '.config', 'opencode', 'scripts', 'hooks', 'pre-write-guardian-validate.js');
+    assert.ok(opencodePlan.operations.some(operation => (
+      normalizedRelativePath(operation.sourceRelativePath) === 'scripts/hooks/pre-write-guardian-validate.js'
+      && operation.destinationPath === opencodeWriteScript
+    )), 'opencode scaffolds the write validator script for its plugin');
+  })) passed++; else failed++;
+
   if (test('resolves trae adapter root and install-state path from project root', () => {
     const adapter = getInstallTargetAdapter('trae');
     const projectRoot = '/workspace/app';
@@ -2847,11 +2875,11 @@ function runTests() {
     });
 
     const mergeOperations = plan.operations.filter(operation => operation.destinationPath === hooksJsonPath);
-    assert.strictEqual(mergeOperations.length, 3, 'Guardian, Crusher, and mesh notice should each plan exactly one merge into .trae/hooks.json');
+    assert.strictEqual(mergeOperations.length, 4, 'Guardian, write validator, Crusher, and mesh notice should each plan exactly one merge into .trae/hooks.json');
     assert.ok(
       mergeOperations
         .filter(operation => operation.hookEvent === 'PreToolUse')
-        .every(operation => operation.hookMatcher === 'RunCommand'),
+        .every(operation => operation.hookMatcher === 'RunCommand' || operation.hookMatcher === 'Edit|Write'),
       'Tool merges must target PreToolUse with the RunCommand matcher (Trae\'s tool_name for shell, not Bash/Shell)'
     );
 
@@ -2913,8 +2941,8 @@ function runTests() {
     ));
     assert.strictEqual(
       hooksJsonOps.length,
-      3,
-      'Guardian, Crusher, and mesh notice should still be planned unconditionally when neither modules nor module is present'
+      4,
+      'Guardian, write validator, Crusher, and mesh notice should still be planned unconditionally when neither modules nor module is present'
     );
   })) passed++; else failed++;
 

--- a/tests/opencode-plugin-hooks.test.js
+++ b/tests/opencode-plugin-hooks.test.js
@@ -53,6 +53,15 @@ async function loadPlugin() {
   return import(pluginUrl)
 }
 
+// The dist tree copied into the project, so the plugin file lives inside the
+// worktree it opens: only then may hook scripts come from that worktree.
+async function loadPluginInside(projectDir) {
+  const source = path.join(__dirname, "..", ".opencode", "dist")
+  const target = path.join(projectDir, ".opencode", "dist")
+  fs.cpSync(source, target, { recursive: true })
+  return import(pathToFileURL(path.join(target, "plugins", "egc-hooks.js")).href)
+}
+
 function createClient() {
   const logs = []
   return {
@@ -148,8 +157,8 @@ async function main() {
     [
       "tool.execute.before refuses a denied command and a protected write through the Guardian",
       async () => withTempProject([], async (projectDir) => {
-        // Only the EGC repository itself may supply hook scripts from the worktree.
-        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "@egchq/egc", private: true }))
+        // The plugin runs from inside this worktree, so its scripts are trusted.
+        const { EGCHooksPlugin: InsidePlugin } = await loadPluginInside(projectDir)
         for (const rel of GUARDIAN_FILES) {
           fs.mkdirSync(path.dirname(path.join(projectDir, rel)), { recursive: true })
           fs.copyFileSync(path.join(__dirname, "..", rel), path.join(projectDir, rel))
@@ -160,7 +169,7 @@ async function main() {
         try {
           const client = createClient()
           const $ = createFailingShell()
-          const hooks = await EGCHooksPlugin({ client, $, directory: projectDir })
+          const hooks = await InsidePlugin({ client, $, directory: projectDir })
           await assert.rejects(
             () => hooks["tool.execute.before"]({ tool: "bash", callID: "b1", args: { command: `${WIPE} /` } }),
             /Guardian/
@@ -178,11 +187,13 @@ async function main() {
       }),
     ],
     [
-      "tool.execute.before never loads hook scripts from a project that is not the EGC repository",
+      "tool.execute.before never loads hook scripts from a project the plugin does not live in",
       async () => withTempProject([], async (projectDir) => {
-        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "some-other-project" }))
+        // The repository's own plugin opens a foreign project that ships a hook
+        // script: the script must not even be required.
+        const marker = path.join(projectDir, "loaded.marker")
         fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
-        fs.writeFileSync(path.join(projectDir, "scripts", "hooks", "pre-bash-guardian-validate.js"), "module.exports = { run: () => { throw new Error('project script executed') } }\n")
+        fs.writeFileSync(path.join(projectDir, "scripts", "hooks", "pre-bash-guardian-validate.js"), `require('fs').writeFileSync(${JSON.stringify(marker)}, '1')\nmodule.exports = { run: () => ({ exitCode: 0 }) }\n`)
         const client = createClient()
         const $ = createFailingShell()
         const previous = process.env.EGC_DISABLED_HOOKS
@@ -193,12 +204,33 @@ async function main() {
         } finally {
           if (previous === undefined) delete process.env.EGC_DISABLED_HOOKS; else process.env.EGC_DISABLED_HOOKS = previous
         }
+        assert.strictEqual(fs.existsSync(marker), false, "the foreign project's script was loaded")
+      }),
+    ],
+    [
+      "tool.execute.before loads hook scripts from the worktree only when the plugin lives inside it",
+      async () => withTempProject([], async (projectDir) => {
+        const marker = path.join(projectDir, "loaded.marker")
+        fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
+        fs.writeFileSync(path.join(projectDir, "scripts", "hooks", "pre-bash-guardian-validate.js"), `require('fs').writeFileSync(${JSON.stringify(marker)}, '1')\nmodule.exports = { run: () => ({ exitCode: 0 }) }\n`)
+        const { EGCHooksPlugin: InsidePlugin } = await loadPluginInside(projectDir)
+        const client = createClient()
+        const $ = createFailingShell()
+        const previous = process.env.EGC_DISABLED_HOOKS
+        process.env.EGC_DISABLED_HOOKS = "pre:gateguard:fact-force"
+        try {
+          const hooks = await InsidePlugin({ client, $, directory: projectDir })
+          await hooks["tool.execute.before"]({ tool: "bash", callID: "b1", args: { command: "git status" } })
+        } finally {
+          if (previous === undefined) delete process.env.EGC_DISABLED_HOOKS; else process.env.EGC_DISABLED_HOOKS = previous
+        }
+        assert.strictEqual(fs.existsSync(marker), true, "the worktree's script was not loaded")
       }),
     ],
     [
       "tool.execute.before blocks the first edit on a file with the GateGuard fact-forcing gate",
       async () => withTempProject([], async (projectDir) => {
-        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "@egchq/egc", private: true }))
+        const { EGCHooksPlugin: InsidePlugin } = await loadPluginInside(projectDir)
         fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
         fs.mkdirSync(path.join(projectDir, "scripts", "lib"), { recursive: true })
         fs.copyFileSync(
@@ -214,7 +246,7 @@ async function main() {
 
         const client = createClient()
         const $ = createFailingShell()
-        const hooks = await EGCHooksPlugin({ client, $, directory: projectDir })
+        const hooks = await InsidePlugin({ client, $, directory: projectDir })
 
         await assert.rejects(
           () => hooks["tool.execute.before"]({ tool: "edit", callID: "call-1", args: { filePath: targetFile } }),
@@ -228,7 +260,7 @@ async function main() {
     [
       "tool.execute.before ignores unmapped tools and args-less calls without throwing",
       async () => withTempProject([], async (projectDir) => {
-        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "@egchq/egc", private: true }))
+        const { EGCHooksPlugin: InsidePlugin } = await loadPluginInside(projectDir)
         fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
         fs.mkdirSync(path.join(projectDir, "scripts", "lib"), { recursive: true })
         fs.copyFileSync(
@@ -242,7 +274,7 @@ async function main() {
 
         const client = createClient()
         const $ = createFailingShell()
-        const hooks = await EGCHooksPlugin({ client, $, directory: projectDir })
+        const hooks = await InsidePlugin({ client, $, directory: projectDir })
 
         await hooks["tool.execute.before"]({ tool: "read", callID: "call-1", args: { filePath: "/tmp/whatever" } })
         await hooks["tool.execute.before"]({ tool: "edit", callID: "call-2", args: undefined })

--- a/tests/opencode-plugin-hooks.test.js
+++ b/tests/opencode-plugin-hooks.test.js
@@ -11,6 +11,14 @@ const { pathToFileURL } = require("node:url")
 
 const { maybeSkipBaselineAbsent } = require("./lib/baseline-absent")
 
+const WIPE = ["rm", "-rf"].join(" ")
+const GUARDIAN_FILES = [
+  "scripts/hooks/pre-bash-guardian-validate.js",
+  "scripts/hooks/pre-write-guardian-validate.js",
+  "scripts/lib/guardian-bin.js",
+  "scripts/lib/shell-split.js",
+]
+
 function runTest(name, fn) {
   return Promise.resolve()
     .then(fn)
@@ -135,6 +143,36 @@ async function main() {
           client.logs.some((entry) => entry.message === "[EGC] Found GEMINI.md - loading project context"),
           "Expected GEMINI.md detection log"
         )
+      }),
+    ],
+    [
+      "tool.execute.before refuses a denied command and a protected write through the Guardian",
+      async () => withTempProject([], async (projectDir) => {
+        for (const rel of GUARDIAN_FILES) {
+          fs.mkdirSync(path.dirname(path.join(projectDir, rel)), { recursive: true })
+          fs.copyFileSync(path.join(__dirname, "..", rel), path.join(projectDir, rel))
+        }
+        const previous = { cli: process.env.EGC_GUARDIAN_CLI, disabled: process.env.EGC_DISABLED_HOOKS }
+        process.env.EGC_GUARDIAN_CLI = path.join(__dirname, "fixtures", "fake-guardian-cli.js")
+        process.env.EGC_DISABLED_HOOKS = "pre:gateguard:fact-force"
+        try {
+          const client = createClient()
+          const $ = createFailingShell()
+          const hooks = await EGCHooksPlugin({ client, $, directory: projectDir })
+          await assert.rejects(
+            () => hooks["tool.execute.before"]({ tool: "bash", callID: "b1", args: { command: `${WIPE} /` } }),
+            /Guardian/
+          )
+          await assert.rejects(
+            () => hooks["tool.execute.before"]({ tool: "write", callID: "w1", args: { filePath: path.join(projectDir, ".ssh", "id_rsa"), content: "x" } }),
+            /Guardian/
+          )
+          await hooks["tool.execute.before"]({ tool: "bash", callID: "b2", args: { command: "git status" } })
+          await hooks["tool.execute.before"]({ tool: "write", callID: "w2", args: { filePath: path.join(projectDir, "notes.md"), content: "hi" } })
+        } finally {
+          if (previous.cli === undefined) delete process.env.EGC_GUARDIAN_CLI; else process.env.EGC_GUARDIAN_CLI = previous.cli
+          if (previous.disabled === undefined) delete process.env.EGC_DISABLED_HOOKS; else process.env.EGC_DISABLED_HOOKS = previous.disabled
+        }
       }),
     ],
     [

--- a/tests/opencode-plugin-hooks.test.js
+++ b/tests/opencode-plugin-hooks.test.js
@@ -148,6 +148,8 @@ async function main() {
     [
       "tool.execute.before refuses a denied command and a protected write through the Guardian",
       async () => withTempProject([], async (projectDir) => {
+        // Only the EGC repository itself may supply hook scripts from the worktree.
+        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "@egchq/egc", private: true }))
         for (const rel of GUARDIAN_FILES) {
           fs.mkdirSync(path.dirname(path.join(projectDir, rel)), { recursive: true })
           fs.copyFileSync(path.join(__dirname, "..", rel), path.join(projectDir, rel))
@@ -176,8 +178,27 @@ async function main() {
       }),
     ],
     [
+      "tool.execute.before never loads hook scripts from a project that is not the EGC repository",
+      async () => withTempProject([], async (projectDir) => {
+        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "some-other-project" }))
+        fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
+        fs.writeFileSync(path.join(projectDir, "scripts", "hooks", "pre-bash-guardian-validate.js"), "module.exports = { run: () => { throw new Error('project script executed') } }\n")
+        const client = createClient()
+        const $ = createFailingShell()
+        const previous = process.env.EGC_DISABLED_HOOKS
+        process.env.EGC_DISABLED_HOOKS = "pre:gateguard:fact-force"
+        try {
+          const hooks = await EGCHooksPlugin({ client, $, directory: projectDir })
+          await hooks["tool.execute.before"]({ tool: "bash", callID: "b1", args: { command: "git status" } })
+        } finally {
+          if (previous === undefined) delete process.env.EGC_DISABLED_HOOKS; else process.env.EGC_DISABLED_HOOKS = previous
+        }
+      }),
+    ],
+    [
       "tool.execute.before blocks the first edit on a file with the GateGuard fact-forcing gate",
       async () => withTempProject([], async (projectDir) => {
+        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "@egchq/egc", private: true }))
         fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
         fs.mkdirSync(path.join(projectDir, "scripts", "lib"), { recursive: true })
         fs.copyFileSync(
@@ -207,6 +228,7 @@ async function main() {
     [
       "tool.execute.before ignores unmapped tools and args-less calls without throwing",
       async () => withTempProject([], async (projectDir) => {
+        fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "@egchq/egc", private: true }))
         fs.mkdirSync(path.join(projectDir, "scripts", "hooks"), { recursive: true })
         fs.mkdirSync(path.join(projectDir, "scripts", "lib"), { recursive: true })
         fs.copyFileSync(

--- a/tests/scripts/trae-install.test.js
+++ b/tests/scripts/trae-install.test.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { FULL_INSTALL_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const INSTALL_SCRIPT = path.join(REPO_ROOT, '.trae', 'install.sh');
@@ -29,7 +30,7 @@ function runInstall(options = {}) {
     },
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 60000,
+    timeout: FULL_INSTALL_TIMEOUT_MS,
   });
 }
 
@@ -43,7 +44,7 @@ function runUninstall(options = {}) {
     encoding: 'utf8',
     input: options.input || 'y\n',
     stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 60000,
+    timeout: FULL_INSTALL_TIMEOUT_MS,
   });
 }
 
@@ -115,6 +116,32 @@ function runTests() {
       assert.ok(stdout.includes("Run 'egc install --target trae'"), stdout);
       assert.deepStrictEqual(JSON.parse(fs.readFileSync(path.join(root, 'hooks.json'), 'utf8')), { hooks: { PreToolUse: [] } });
       assert.ok(!readManifestLines(projectRoot).includes('hooks.json'), 'a user file is never claimed');
+    } finally {
+      cleanup(projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('a hooks.json that carries only the Bash validator is reported, and a symlinked one is never written through', () => {
+    const projectRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-install-hooks-'));
+    const homeDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-home-'));
+    try {
+      const root = path.join(projectRoot, '.trae');
+      fs.mkdirSync(root, { recursive: true });
+      fs.writeFileSync(path.join(root, 'hooks.json'), JSON.stringify({ hooks: { PreToolUse: [{ matcher: 'RunCommand', hooks: [{ type: 'command', command: 'node /x/pre-bash-guardian-validate.js' }] }] } }));
+      const partial = runInstall({ cwd: projectRoot, homeDir });
+      assert.ok(partial.includes('without both EGC Guardian validators'), partial);
+      assert.ok(!readManifestLines(projectRoot).includes('hooks.json'));
+
+      const linkedRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-install-link-'));
+      const linkedTrae = path.join(linkedRoot, '.trae');
+      fs.mkdirSync(linkedTrae, { recursive: true });
+      const target = path.join(linkedRoot, 'elsewhere.json');
+      fs.symlinkSync(target, path.join(linkedTrae, 'hooks.json'));
+      const linked = runInstall({ cwd: linkedRoot, homeDir });
+      assert.ok(linked.includes('symbolic link'), linked);
+      assert.ok(!fs.existsSync(target), 'nothing is written through the link');
+      fs.rmSync(linkedRoot, { recursive: true, force: true });
     } finally {
       cleanup(projectRoot);
       cleanup(homeDir);

--- a/tests/scripts/trae-install.test.js
+++ b/tests/scripts/trae-install.test.js
@@ -125,6 +125,7 @@ function runTests() {
   if (test('a hooks.json that carries only the Bash validator is reported, and a symlinked one is never written through', () => {
     const projectRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-install-hooks-'));
     const homeDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-home-'));
+    const linkedRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-install-link-'));
     try {
       const root = path.join(projectRoot, '.trae');
       fs.mkdirSync(root, { recursive: true });
@@ -133,7 +134,6 @@ function runTests() {
       assert.ok(partial.includes('without both EGC Guardian validators'), partial);
       assert.ok(!readManifestLines(projectRoot).includes('hooks.json'));
 
-      const linkedRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-install-link-'));
       const linkedTrae = path.join(linkedRoot, '.trae');
       fs.mkdirSync(linkedTrae, { recursive: true });
       const target = path.join(linkedRoot, 'elsewhere.json');
@@ -141,10 +141,10 @@ function runTests() {
       const linked = runInstall({ cwd: linkedRoot, homeDir });
       assert.ok(linked.includes('symbolic link'), linked);
       assert.ok(!fs.existsSync(target), 'nothing is written through the link');
-      fs.rmSync(linkedRoot, { recursive: true, force: true });
     } finally {
       cleanup(projectRoot);
       cleanup(homeDir);
+      fs.rmSync(linkedRoot, { recursive: true, force: true });
     }
   })) passed++; else failed++;
 

--- a/tests/scripts/trae-install.test.js
+++ b/tests/scripts/trae-install.test.js
@@ -79,6 +79,48 @@ function runTests() {
     process.exit(0);
   }
 
+  if (test('installs the Guardian validators and a hooks.json wired to them, and uninstall removes them', () => {
+    const projectRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-install-hooks-'));
+    const homeDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-home-'));
+    try {
+      const stdout = runInstall({ cwd: projectRoot, homeDir });
+      assert.ok(stdout.includes('Hooks:'), stdout);
+      const root = path.join(projectRoot, '.trae');
+      const scripts = ['scripts/hooks/pre-bash-guardian-validate.js', 'scripts/hooks/pre-write-guardian-validate.js', 'scripts/lib/guardian-bin.js', 'scripts/lib/shell-split.js'];
+      for (const rel of scripts) assert.ok(fs.existsSync(path.join(root, rel)), rel);
+      const hooks = JSON.parse(fs.readFileSync(path.join(root, 'hooks.json'), 'utf8'));
+      assert.deepStrictEqual(hooks.hooks.PreToolUse.map(group => group.matcher), ['RunCommand', 'Edit|Write']);
+      assert.ok(hooks.hooks.PreToolUse[0].hooks[0].command.includes('pre-bash-guardian-validate.js'));
+      assert.ok(hooks.hooks.PreToolUse[1].hooks[0].command.includes('pre-write-guardian-validate.js'));
+      const manifest = readManifestLines(projectRoot);
+      for (const entry of [...scripts, 'hooks.json']) assert.ok(manifest.includes(entry), `manifest carries ${entry}`);
+
+      runUninstall({ cwd: projectRoot, homeDir });
+      assert.ok(!fs.existsSync(path.join(root, 'hooks.json')), 'hooks.json removed');
+      for (const rel of scripts) assert.ok(!fs.existsSync(path.join(root, rel)), `${rel} removed`);
+    } finally {
+      cleanup(projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('leaves a preexisting hooks.json alone and points at egc install instead', () => {
+    const projectRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-install-hooks-'));
+    const homeDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'trae-home-'));
+    try {
+      const root = path.join(projectRoot, '.trae');
+      fs.mkdirSync(root, { recursive: true });
+      fs.writeFileSync(path.join(root, 'hooks.json'), JSON.stringify({ hooks: { PreToolUse: [] } }));
+      const stdout = runInstall({ cwd: projectRoot, homeDir });
+      assert.ok(stdout.includes("Run 'egc install --target trae'"), stdout);
+      assert.deepStrictEqual(JSON.parse(fs.readFileSync(path.join(root, 'hooks.json'), 'utf8')), { hooks: { PreToolUse: [] } });
+      assert.ok(!readManifestLines(projectRoot).includes('hooks.json'), 'a user file is never claimed');
+    } finally {
+      cleanup(projectRoot);
+      cleanup(homeDir);
+    }
+  })) passed++; else failed++;
+
   if (test('does not claim ownership of preexisting target files', () => {
     const homeDir = createTempDir('trae-home-');
     const projectRoot = createTempDir('trae-project-');


### PR DESCRIPTION
## What

Day 8 of the security schedule (17/08 audit, findings H4 and H5). What the audit saw was partly already covered by `egc install` (the OpenCode plugin judged bash, Trae's installer registered the RunCommand guardian); the gaps were file writes and the paths outside `egc install`.

- **OpenCode, installed plugin** (`scripts/hooks/opencode-egc-plugin.js`): `write` and `edit` calls now go through `pre-write-guardian-validate.js` (path, and with #1361 script content) before bash's existing guardian and Crusher; the installer ships the write validator next to the Bash guardian scripts.
- **OpenCode, this repository's TypeScript plugin** (`.opencode/plugins/egc-hooks.ts`, `H4`): gains the Bash guardian and the write validator in `tool.execute.before` (a blocking verdict throws, before GateGuard), through one loader shared with GateGuard that no longer caches a missing script; its dashboard event carries the token #1360 requires.
- **Trae, `egc install`** (`H5`): the write validator is registered on `Edit|Write` (Trae's standardized file tools; its hook reference lists `Edit|Write` as the matcher example) next to the RunCommand guardian, through new destination-driven builders in `claude-settings-hooks.js`.
- **Trae, legacy `.trae/install.sh`** (the path `.trae/README.md` documents): copies the two validators and their two libs, and writes `hooks.json` wired to both when the project has none; an existing `hooks.json` is left untouched with a pointer to `egc install --target trae`, and `uninstall.sh` removes everything through the manifest.

## Proof

- `tests/scripts/trae-install.test.js` +2 (7/7): scripts, `hooks.json` matchers `RunCommand` and `Edit|Write`, manifest entries, uninstall removal; a preexisting `hooks.json` is not claimed.
- `tests/lib/install-targets.test.js` +1 (146/146, two counts updated from 3 to 4 merges): Trae registers the write validator once on `Edit|Write`; OpenCode scaffolds the script.
- `tests/hooks/opencode-egc-plugin.test.js` +1 (11/11): write to `~/.ssh/id_rsa` and edit of `~/.aws/credentials` refused, ordinary write passes. `tests/opencode-plugin-hooks.test.js` +1 for the TypeScript plugin (bash denial, protected write, benign calls) with the fake CLI; the plugin type-checks with `tsc`. Hooks, apply, lifecycle and doctor suites pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes OpenCode bash, write, and edit calls and Trae file changes through the EGC Guardian across all install paths. Previously OpenCode guarded only bash and Trae only `RunCommand`; protected paths are now blocked before downstream hooks.

**Details**

- The installed OpenCode plugin ships the write validator, while the repository plugin adds both Guardian validators and authenticated dashboard events.
- The repository plugin loads hook scripts only from its own package or an EGC worktree containing the plugin, caches them by resolved path, and retries missing scripts.
- `egc install --target trae` registers the write validator on `Edit|Write`; `.trae/install.sh` copies both validators and their helper libraries.
- The legacy installer creates and manages `hooks.json` only when none exists, never writes through symlinks, and reports incomplete existing hooks with a pointer to `egc install --target trae`.

<sup>Written for commit 878f075ad4f4439729cd20d0f7ffd76197db627b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

