### PR TITLE
Add knos to .mcp.json so agents share one decision record

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,11 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
 }

--- a/examples/knos-decisions.example.md
+++ b/examples/knos-decisions.example.md
@@ -5,8 +5,8 @@
 
 ## Decisions
 
-- **rule 1** - `egc-guardian`: `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task` _(source: CLAUDE.md)_
-- **rule 2** - `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`, `session_announce`, `session_peers`, `claim_path`, `release_path` _(source: CLAUDE.md)_
+- `egc-guardian`: `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task` _(source: CLAUDE.md)_
+- `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`, `session_announce`, `session_peers`, `claim_path`, `release_path` _(source: CLAUDE.md)_
 
 ## Being worked on right now
 

--- a/examples/knos-decisions.example.md
+++ b/examples/knos-decisions.example.md
@@ -1,0 +1,17 @@
+# Decisions and current work
+
+<!-- Example record. `knos export` writes this file in an adopting repo; it is
+     plain markdown, so a fresh clone reads it with nothing installed. -->
+
+## Decisions
+
+- **rule 1** - `egc-guardian`: `validate_command`, `validate_write`, `reduce_context`, `orchestrate_task` _(source: CLAUDE.md)_
+- **rule 2** - `egc-memory`: `get_state`, `update_state`, `store_decision`, `query_history`, `search_history`, `session_announce`, `session_peers`, `claim_path`, `release_path` _(source: CLAUDE.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>One record every agent working in this repo reads. Claims lapse after 30
+minutes or on `knos done`.</sub>


### PR DESCRIPTION
Fmarzochi/EGC runs more than one coding agent over the same tree. Agents do not
see each other's decisions, so two of them can reach opposite conclusions about
the same file in the same hour, and neither one knows.

**What this adds**

- `knos` in added to the existing `.mcp.json` - a local MCP server (`pip install knos`, Python 3.10+).
  No network, no account, no model download; one SQLite file.
- `examples/knos-decisions.example.md` - the shape of the record it writes,
  seeded with two rules taken from this repo's own CLAUDE.md, so the format is
  visible without installing anything.

**What it does**

When one agent claims a piece of work, another agent asking about that topic is
told who holds it instead of being handed the answer. Claims lapse after 30
minutes, so a crashed agent cannot hold work forever.

**Runtime note:** the server needs Python 3.10+ and `pip install knos`. Nothing
else in the repo depends on it - if it is absent, the example file still reads
normally and no other tooling changes.

Disclosure: I wrote knos. Happy to drop either half, or close this, if it is not
a fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for the Knos MCP server, enabling it to launch through the Python module interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `knos` to `.mcp.json` so all coding agents in this repo share one decision record. Previously agents had no visibility into each other's decisions; now they read and write to a single local record, and a claimed piece of work is visible to other agents until the claim lapses after 30 minutes.

**New Features**
- Adds `examples/knos-decisions.example.md` showing the record format, seeded with rules from this repo's `CLAUDE.md`.
- Requires Python 3.10+ and `pip install knos`; without it, the example file reads normally and no other tooling changes.

<sup>Written for commit 222c6f047ada213065e8861b11556a5548690ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

