### PR TITLE
fix(security): seal team sync state with a team key, and make GateGuard check the facts before accepting a retry

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -260,8 +260,11 @@ With a provider API key (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`
 
 ---
 
-## Global memory and parallel sessions
+## Team sync
 
+`egc team init --backend git --remote <url>` creates the team and prints a team key (64 hexadecimal characters); every other member joins with `egc team init ... --key <that key>`. State never enters the shared repository in the clear or under a personal key: each file is sealed with the team key (AES-256-GCM plus an HMAC-SHA256 signature) before it is pushed, and `egc team sync` merges only files that open with that key and an intact signature. A file that was altered in the repository, or written without the key, is reported as rejected and leaves local state untouched.
+
+## Global memory and parallel sessions
 Since v1.1.12 memory has two scopes. Project scope works exactly as before (one state per project branch). The new user-wide global scope is shared across every project: save transversal preferences and lessons once with `update_state` and `scope: "global"`, and every `get_state` in every project appends a deduplicated `Global Memory` section after the project state. Project and branch entries always take precedence, and global memory is only ever written by an explicit global call, never derived from project data.
 
 Parallel sessions coordinate through the session bus. A session announces itself with `session_announce` (presence plus an optional territory, doubling as heartbeat), inspects who else is active with `session_peers`, and takes cooperative locks with `claim_path` before editing shared files. Claims are fail-fast: a conflicting live lock is refused with the holder's identity instead of queued. Sessions silent for 10 minutes are swept and their locks released, so a crashed session never blocks the others.

--- a/mcp/servers/egc-memory/src/index.ts
+++ b/mcp/servers/egc-memory/src/index.ts
@@ -900,7 +900,8 @@ const CompressObservationsSchema = z.object({
 const TeamInitSchema = z.object({
   backend: z.string().min(1).default('git'),
   remote: z.string().min(1),
-  branch: z.string().min(1).default('main')
+  branch: z.string().min(1).default('main'),
+  team_key: z.string().regex(/^[0-9a-f]{64}$/i, 'team_key must be 64 hexadecimal characters').optional()
 });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -1144,7 +1145,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             backend: { type: "string", description: "Sync backend type. Currently only 'git' is supported.", default: "git" },
             remote: { type: "string", description: "Remote URL for the sync storage (e.g. git@github.com:org/egc-memory)." },
-            branch: { type: "string", description: "Git branch to use for syncing. Defaults to 'main'.", default: "main" }
+            branch: { type: "string", description: "Git branch to use for syncing. Defaults to 'main'.", default: "main" },
+            team_key: { type: "string", description: "64 hexadecimal characters: the team key shared out of band by the member who initialized the team. Omit to generate a new key (first member)." }
           },
           required: ["remote"]
         }
@@ -1901,10 +1903,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "compress_observations": return await handleCompressObservations(db, request.params.arguments);
 
       case "team_init": {
-        const { backend, remote, branch } = TeamInitSchema.parse(request.params.arguments || {});
-        const config = await teamInit(backend, remote, branch);
-        log('INFO', 'Team sync initialized', { backend, remote, branch });
-        return { content: [{ type: "text", text: JSON.stringify({ success: true, config }, null, 2) }] };
+        const { backend, remote, branch, team_key } = TeamInitSchema.parse(request.params.arguments || {});
+        const config = await teamInit(backend, remote, branch, team_key);
+        log('INFO', 'Team sync initialized', { backend, remote, branch, joined: team_key !== undefined });
+        const { teamKey, ...shown } = config;
+        return { content: [{ type: "text", text: JSON.stringify({ success: true, config: shown, teamKey, note: 'State travels sealed with this team key (AES-256-GCM plus HMAC). Share it out of band; teammates join with team_init and the same team_key.' }, null, 2) }] };
       }
 
       case "team_sync": {

--- a/mcp/servers/egc-memory/src/sync/GitBackend.ts
+++ b/mcp/servers/egc-memory/src/sync/GitBackend.ts
@@ -77,14 +77,8 @@ export class GitBackend extends SyncBackend {
   async push(): Promise<boolean> {
     if (!this.config) throw new Error('GitBackend not initialized. Call init() first.');
 
-    // Copy the current state files into the sync repo.
-    const stateDir = path.join(os.homedir(), '.egc', 'state');
-    const syncStateDir = path.join(this.repoDir, 'state');
-
-    if (fs.existsSync(stateDir)) {
-      this.mirrorCopy(stateDir, syncStateDir);
-    }
-
+    // State files are staged by TeamSync as sealed team envelopes before
+    // push() runs; the raw (personally encrypted) files never enter the repo.
     // Also copy lessons/decisions from the memory DB as JSON.
     const memoryDir = path.join(os.homedir(), '.egc', 'memory');
     const syncMemoryDir = path.join(this.repoDir, 'memory');

--- a/mcp/servers/egc-memory/src/sync/SyncBackend.ts
+++ b/mcp/servers/egc-memory/src/sync/SyncBackend.ts
@@ -9,12 +9,14 @@ export interface SyncConfig {
   backend: string;
   remote: string;
   branch: string;
+  teamKey?: string;
 }
 
 export interface SyncResult {
   pulledCount: number;
   pushedCount: number;
   conflictCount: number;
+  rejectedCount: number;
   errors: string[];
 }
 

--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -213,6 +213,27 @@ function hasLinkedAncestor(filePath: string, root: string): boolean {
   return false;
 }
 
+// The roots below which every directory of ours must be real: the home
+// directory and the temporary directory (where tests place their trees).
+// Above them the system's own layout (a linked /tmp, say) is not ours to judge.
+function trustedRoots(): string[] {
+  return [os.homedir(), os.tmpdir()].map(root => path.resolve(root));
+}
+
+// The first directory between a trusted root (exclusive) and `dir`
+// (inclusive) that is a link, or null when the whole chain is real.
+function linkedDirectoryTowards(dir: string): string | null {
+  const resolved = path.resolve(dir);
+  const root = trustedRoots().find(candidate => resolved.startsWith(candidate + path.sep));
+  if (!root) return isLink(resolved) ? resolved : null;
+  let probe = resolved;
+  while (probe !== root) {
+    if (isLink(probe)) return probe;
+    probe = path.dirname(probe);
+  }
+  return null;
+}
+
 function removeSyncFile(filePath: string): void {
   try {
     fs.rmSync(filePath, { force: true });
@@ -271,19 +292,22 @@ export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, 
   // The state tree of the repository must be a real directory: a link there
   // (dangling or not) would make the merge read, reject and remove whatever
   // it points at.
-  if (isLink(syncStateDir)) {
-    outcome.rejected.push('state (the sync tree is a link)');
-    removeSyncFile(syncStateDir);
+  const linkedSync = linkedDirectoryTowards(syncStateDir);
+  if (linkedSync) {
+    outcome.rejected.push(`state (the sync tree is a link at ${linkedSync})`);
+    if (linkedSync === path.resolve(syncStateDir)) removeSyncFile(syncStateDir);
     return outcome;
   }
   if (!fs.existsSync(syncStateDir)) return outcome;
-  // The local tree must be a real directory too, or the merge would write
-  // wherever the link points.
-  if (isLink(localStateDir)) {
-    outcome.rejected.push('local state (the local tree is a link)');
+  // The local tree and every directory above it must be real too, or the
+  // merge would write wherever a link points.
+  const linkedLocal = linkedDirectoryTowards(localStateDir);
+  if (linkedLocal) {
+    outcome.rejected.push(`local state (the local tree is a link at ${linkedLocal})`);
     return outcome;
   }
   fs.mkdirSync(localStateDir, { recursive: true });
+
 
   const entries = walkEntries(syncStateDir);
   // A link in the repository is refused and removed, so it is neither
@@ -304,9 +328,12 @@ export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, 
 // Local state leaves the machine only as sealed envelopes; a local file that
 // cannot be decrypted is left out rather than shipped opaque.
 export function stageTeamState(localStateDir: string, syncStateDir: string, teamKey: Buffer, personalKey: Buffer): number {
-  if (isLink(localStateDir)) throw new Error('the local state tree is a link and is not staged');
-  if (isLink(syncStateDir)) throw new Error('the sync state tree is a link and is not written');
+  const linkedLocal = linkedDirectoryTowards(localStateDir);
+  if (linkedLocal) throw new Error(`the local state tree is a link at ${linkedLocal} and is not staged`);
+  const linkedSync = linkedDirectoryTowards(syncStateDir);
+  if (linkedSync) throw new Error(`the sync state tree is a link at ${linkedSync} and is not written`);
   if (!fs.existsSync(localStateDir)) return 0;
+
 
   let staged = 0;
   for (const localFile of walkEntries(localStateDir).files) {
@@ -319,7 +346,9 @@ export function stageTeamState(localStateDir: string, syncStateDir: string, team
     const relativePath = path.relative(localStateDir, localFile);
     const target = path.join(syncStateDir, relativePath);
     if (isLink(target)) removeSyncFile(target);
+    if (hasLinkedAncestor(target, syncStateDir)) throw new Error(`the sync state tree has a linked directory above ${relativePath} and is not written`);
     fs.mkdirSync(path.dirname(target), { recursive: true });
+
     fs.writeFileSync(target, sealEnvelope(plaintext, teamKey, relativePath), 'utf-8');
     staged += 1;
   }

--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -4,8 +4,9 @@ import fs from 'node:fs';
 import { SyncBackend } from './SyncBackend';
 import { GitBackend } from './GitBackend';
 import type { SyncConfig, SyncStatus, SyncResult } from './SyncBackend';
-import { loadOrCreateEncKey, readStateFile, writeStateFile } from '../encryption';
+import { isEncrypted, loadOrCreateEncKey, readStateFile, writeStateFile } from '../encryption';
 import { generateTeamKey, openEnvelope, parseTeamKey, sealEnvelope } from './envelope';
+
 const TEAM_CONFIG_PATH = path.join(os.homedir(), '.egc', 'team.json');
 
 const BACKEND_REGISTRY: Record<string, new () => SyncBackend> = {
@@ -22,12 +23,18 @@ export function getTeamConfig(): SyncConfig | null {
   }
 }
 
+// The config carries the team key, so it is private to the user.
 export function writeTeamConfig(config: SyncConfig): void {
   const egcDir = path.join(os.homedir(), '.egc');
   if (!fs.existsSync(egcDir)) {
-    fs.mkdirSync(egcDir, { recursive: true });
+    fs.mkdirSync(egcDir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+  fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 });
+  try {
+    fs.chmodSync(TEAM_CONFIG_PATH, 0o600);
+  } catch {
+    // modes are not supported on this filesystem
+  }
 }
 
 export async function teamInit(backend: string, remote: string, branch: string = 'main', teamKey?: string): Promise<SyncConfig> {
@@ -99,7 +106,10 @@ export async function teamSync(): Promise<SyncResult> {
     const merge = mergeTeamStateFrom(SYNC_STATE_DIR, LOCAL_STATE_DIR, teamKey, personalKey);
     result.rejectedCount = merge.rejected.length;
     for (const rejected of merge.rejected) {
-      result.errors.push(`Rejected sync file (not a verified team envelope): ${rejected}`);
+      result.errors.push(`Rejected sync file (not a verified team envelope for its path): ${rejected}`);
+    }
+    for (const unreadable of merge.unreadable) {
+      result.errors.push(`Local state file could not be decrypted and was left untouched: ${unreadable}`);
     }
     // Step 3: Stage local state as sealed envelopes and push.
     try {
@@ -152,6 +162,42 @@ const LOCAL_STATE_DIR = path.join(os.homedir(), '.egc', 'state');
 export interface TeamMergeOutcome {
   merged: number;
   rejected: string[];
+  unreadable: string[];
+}
+
+// Regular files and links under a directory, links kept apart: a link in
+// the shared repository or at a local state path is never followed.
+function walkEntries(dir: string): { files: string[]; links: string[] } {
+  const found: { files: string[]; links: string[] } = { files: [], links: [] };
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      found.links.push(fullPath);
+    } else if (entry.isDirectory()) {
+      const nested = walkEntries(fullPath);
+      found.files.push(...nested.files);
+      found.links.push(...nested.links);
+    } else if (entry.isFile()) {
+      found.files.push(fullPath);
+    }
+  }
+  return found;
+}
+
+function isLink(filePath: string): boolean {
+  try {
+    return fs.lstatSync(filePath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function removeSyncFile(filePath: string): void {
+  try {
+    fs.rmSync(filePath, { force: true });
+  } catch {
+    // a file that cannot be removed is still refused for local state
+  }
 }
 
 // Every sync file must open as a team envelope (right key, intact signature)
@@ -159,29 +205,49 @@ export interface TeamMergeOutcome {
 // Local files are read and written through the personal key, so the merge
 // compares plaintext timestamps and the result stays encrypted at rest.
 export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, teamKey: Buffer, personalKey: Buffer): TeamMergeOutcome {
-  const outcome: TeamMergeOutcome = { merged: 0, rejected: [] };
+  const outcome: TeamMergeOutcome = { merged: 0, rejected: [], unreadable: [] };
   if (!fs.existsSync(syncStateDir)) return outcome;
   if (!fs.existsSync(localStateDir)) {
     fs.mkdirSync(localStateDir, { recursive: true });
   }
-  for (const syncFile of getAllFiles(syncStateDir)) {
+  const entries = walkEntries(syncStateDir);
+  // A link in the repository is refused and removed, so it is neither
+  // followed here nor pushed back to the team.
+  for (const link of entries.links) {
+    outcome.rejected.push(path.relative(syncStateDir, link));
+    removeSyncFile(link);
+  }
+  for (const syncFile of entries.files) {
     const relativePath = path.relative(syncStateDir, syncFile);
-    const remoteContent = openEnvelope(fs.readFileSync(syncFile, 'utf-8'), teamKey);
+    const remoteContent = openEnvelope(fs.readFileSync(syncFile, 'utf-8'), teamKey, relativePath);
     if (remoteContent === null) {
+      // Refused for local state and removed from the working tree, so the
+      // next push does not carry it back into the shared repository.
       outcome.rejected.push(relativePath);
+      removeSyncFile(syncFile);
       continue;
     }
     const localFile = path.join(localStateDir, relativePath);
+    if (isLink(localFile)) {
+      outcome.rejected.push(`${relativePath} (local path is a link)`);
+      continue;
+    }
     let localContent = '';
+    let legacyPlaintext = false;
     if (fs.existsSync(localFile)) {
       try {
+        const raw = fs.readFileSync(localFile);
+        legacyPlaintext = !isEncrypted(raw);
         localContent = readStateFile(localFile, personalKey);
       } catch {
-        localContent = '';
+        // A local file that does not open with the personal key (rotated
+        // key, damaged bytes) is left exactly as it is.
+        outcome.unreadable.push(relativePath);
+        continue;
       }
     }
     const merged = localContent ? mergeStateDocs(localContent, remoteContent) : remoteContent;
-    if (merged === localContent) continue;
+    if (merged === localContent && !legacyPlaintext) continue;
     fs.mkdirSync(path.dirname(localFile), { recursive: true });
     writeStateFile(localFile, merged, personalKey);
     outcome.merged += 1;
@@ -198,34 +264,23 @@ export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, 
 export function stageTeamState(localStateDir: string, syncStateDir: string, teamKey: Buffer, personalKey: Buffer): number {
   if (!fs.existsSync(localStateDir)) return 0;
   let staged = 0;
-  for (const localFile of getAllFiles(localStateDir)) {
+  for (const localFile of walkEntries(localStateDir).files) {
     let plaintext: string;
     try {
       plaintext = readStateFile(localFile, personalKey);
     } catch {
       continue;
     }
-    const target = path.join(syncStateDir, path.relative(localStateDir, localFile));
+    const relativePath = path.relative(localStateDir, localFile);
+    const target = path.join(syncStateDir, relativePath);
+    if (isLink(target)) removeSyncFile(target);
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, sealEnvelope(plaintext, teamKey), 'utf-8');
+    fs.writeFileSync(target, sealEnvelope(plaintext, teamKey, relativePath), 'utf-8');
     staged += 1;
   }
   return staged;
 }
 
-function getAllFiles(dir: string): string[] {
-  const results: string[] = [];
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...getAllFiles(fullPath));
-    } else if (entry.isFile()) {
-      results.push(fullPath);
-    }
-  }
-  return results;
-}
 
 function mergeStateDocs(localContent: string, remoteContent: string): string {
   const localUpdated = extractTimestamp(localContent);

--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -220,11 +220,19 @@ function trustedRoots(): string[] {
   return [os.homedir(), os.tmpdir()].map(root => path.resolve(root));
 }
 
+// The prefix every descendant of `root` starts with; a root that is the
+// filesystem root already ends with the separator.
+function descendantPrefix(root: string): string {
+  return root.endsWith(path.sep) ? root : root + path.sep;
+}
+
+
 // The first directory between a trusted root (exclusive) and `dir`
 // (inclusive) that is a link, or null when the whole chain is real.
 function linkedDirectoryTowards(dir: string): string | null {
   const resolved = path.resolve(dir);
-  const root = trustedRoots().find(candidate => resolved.startsWith(candidate + path.sep));
+  const root = trustedRoots().find(candidate => resolved.startsWith(descendantPrefix(candidate)));
+
   if (!root) return isLink(resolved) ? resolved : null;
   let probe = resolved;
   while (probe !== root) {

--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -1,4 +1,6 @@
+import crypto from 'node:crypto';
 import path from 'node:path';
+
 import os from 'node:os';
 import fs from 'node:fs';
 import { SyncBackend } from './SyncBackend';
@@ -26,15 +28,22 @@ export function getTeamConfig(): SyncConfig | null {
 // The config carries the team key, so it is private to the user.
 export function writeTeamConfig(config: SyncConfig): void {
   const egcDir = path.join(os.homedir(), '.egc');
-  if (!fs.existsSync(egcDir)) {
-    fs.mkdirSync(egcDir, { recursive: true, mode: 0o700 });
-  }
-  fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 });
+  fs.mkdirSync(egcDir, { recursive: true, mode: 0o700 });
   try {
-    fs.chmodSync(TEAM_CONFIG_PATH, 0o600);
+    fs.chmodSync(egcDir, 0o700);
   } catch {
     // modes are not supported on this filesystem
   }
+  // Written next to its place and renamed over it, so an interrupted write
+  // never leaves a truncated config that would look like a missing team.
+  const temporary = `${TEAM_CONFIG_PATH}.${process.pid}.${crypto.randomBytes(4).toString('hex')}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 });
+  try {
+    fs.chmodSync(temporary, 0o600);
+  } catch {
+    // modes are not supported on this filesystem
+  }
+  fs.renameSync(temporary, TEAM_CONFIG_PATH);
 }
 
 export async function teamInit(backend: string, remote: string, branch: string = 'main', teamKey?: string): Promise<SyncConfig> {
@@ -192,6 +201,18 @@ function isLink(filePath: string): boolean {
   }
 }
 
+// Whether any directory between `root` (exclusive) and `filePath`
+// (exclusive) is a link: a write there would land elsewhere.
+function hasLinkedAncestor(filePath: string, root: string): boolean {
+  let probe = path.dirname(filePath);
+  const top = path.resolve(root);
+  while (probe !== top && probe.startsWith(top + path.sep)) {
+    if (isLink(probe)) return true;
+    probe = path.dirname(probe);
+  }
+  return false;
+}
+
 function removeSyncFile(filePath: string): void {
   try {
     fs.rmSync(filePath, { force: true });
@@ -204,12 +225,58 @@ function removeSyncFile(filePath: string): void {
 // before it can touch local state; anything else is reported and skipped.
 // Local files are read and written through the personal key, so the merge
 // compares plaintext timestamps and the result stays encrypted at rest.
+type MergeContext = { syncStateDir: string; localStateDir: string; teamKey: Buffer; personalKey: Buffer; outcome: TeamMergeOutcome };
+
+// The local document as it stands, or null when it must not be touched
+// (a link, or a file that does not open with the personal key).
+function currentLocal(localFile: string, relativePath: string, context: MergeContext): { content: string; legacyPlaintext: boolean } | null {
+  if (isLink(localFile) || hasLinkedAncestor(localFile, context.localStateDir)) {
+    context.outcome.rejected.push(`${relativePath} (local path goes through a link)`);
+    return null;
+  }
+  if (!fs.existsSync(localFile)) return { content: '', legacyPlaintext: false };
+  try {
+    const raw = fs.readFileSync(localFile);
+    return { content: readStateFile(localFile, context.personalKey), legacyPlaintext: !isEncrypted(raw) };
+  } catch {
+    // A local file that does not open with the personal key (rotated key,
+    // damaged bytes) is left exactly as it is.
+    context.outcome.unreadable.push(relativePath);
+    return null;
+  }
+}
+
+function mergeOneSyncFile(syncFile: string, context: MergeContext): void {
+  const relativePath = path.relative(context.syncStateDir, syncFile);
+  const remoteContent = openEnvelope(fs.readFileSync(syncFile, 'utf-8'), context.teamKey, relativePath);
+  if (remoteContent === null) {
+    // Refused for local state and removed from the working tree, so the
+    // next push does not carry it back into the shared repository.
+    context.outcome.rejected.push(relativePath);
+    removeSyncFile(syncFile);
+    return;
+  }
+  const localFile = path.join(context.localStateDir, relativePath);
+  const local = currentLocal(localFile, relativePath, context);
+  if (local === null) return;
+  const merged = local.content ? mergeStateDocs(local.content, remoteContent) : remoteContent;
+  if (merged === local.content && !local.legacyPlaintext) return;
+  fs.mkdirSync(path.dirname(localFile), { recursive: true });
+  writeStateFile(localFile, merged, context.personalKey);
+  context.outcome.merged += 1;
+}
+
 export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, teamKey: Buffer, personalKey: Buffer): TeamMergeOutcome {
   const outcome: TeamMergeOutcome = { merged: 0, rejected: [], unreadable: [] };
   if (!fs.existsSync(syncStateDir)) return outcome;
-  if (!fs.existsSync(localStateDir)) {
-    fs.mkdirSync(localStateDir, { recursive: true });
+  // The state tree of the repository must be a real directory: a link there
+  // would make the merge read, reject and remove whatever it points at.
+  if (isLink(syncStateDir)) {
+    outcome.rejected.push('state (the sync tree is a link)');
+    removeSyncFile(syncStateDir);
+    return outcome;
   }
+  fs.mkdirSync(localStateDir, { recursive: true });
   const entries = walkEntries(syncStateDir);
   // A link in the repository is refused and removed, so it is neither
   // followed here nor pushed back to the team.
@@ -217,41 +284,8 @@ export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, 
     outcome.rejected.push(path.relative(syncStateDir, link));
     removeSyncFile(link);
   }
-  for (const syncFile of entries.files) {
-    const relativePath = path.relative(syncStateDir, syncFile);
-    const remoteContent = openEnvelope(fs.readFileSync(syncFile, 'utf-8'), teamKey, relativePath);
-    if (remoteContent === null) {
-      // Refused for local state and removed from the working tree, so the
-      // next push does not carry it back into the shared repository.
-      outcome.rejected.push(relativePath);
-      removeSyncFile(syncFile);
-      continue;
-    }
-    const localFile = path.join(localStateDir, relativePath);
-    if (isLink(localFile)) {
-      outcome.rejected.push(`${relativePath} (local path is a link)`);
-      continue;
-    }
-    let localContent = '';
-    let legacyPlaintext = false;
-    if (fs.existsSync(localFile)) {
-      try {
-        const raw = fs.readFileSync(localFile);
-        legacyPlaintext = !isEncrypted(raw);
-        localContent = readStateFile(localFile, personalKey);
-      } catch {
-        // A local file that does not open with the personal key (rotated
-        // key, damaged bytes) is left exactly as it is.
-        outcome.unreadable.push(relativePath);
-        continue;
-      }
-    }
-    const merged = localContent ? mergeStateDocs(localContent, remoteContent) : remoteContent;
-    if (merged === localContent && !legacyPlaintext) continue;
-    fs.mkdirSync(path.dirname(localFile), { recursive: true });
-    writeStateFile(localFile, merged, personalKey);
-    outcome.merged += 1;
-  }
+  const context: MergeContext = { syncStateDir, localStateDir, teamKey, personalKey, outcome };
+  for (const syncFile of entries.files) mergeOneSyncFile(syncFile, context);
   // A team sync never removes local state files: a file absent from the sync
   // repo may be one this machine created and has not pushed yet, and deleting
   // it would be silent, unrecoverable memory loss. Remote deletions therefore

--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -268,15 +268,23 @@ function mergeOneSyncFile(syncFile: string, context: MergeContext): void {
 
 export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, teamKey: Buffer, personalKey: Buffer): TeamMergeOutcome {
   const outcome: TeamMergeOutcome = { merged: 0, rejected: [], unreadable: [] };
-  if (!fs.existsSync(syncStateDir)) return outcome;
   // The state tree of the repository must be a real directory: a link there
-  // would make the merge read, reject and remove whatever it points at.
+  // (dangling or not) would make the merge read, reject and remove whatever
+  // it points at.
   if (isLink(syncStateDir)) {
     outcome.rejected.push('state (the sync tree is a link)');
     removeSyncFile(syncStateDir);
     return outcome;
   }
+  if (!fs.existsSync(syncStateDir)) return outcome;
+  // The local tree must be a real directory too, or the merge would write
+  // wherever the link points.
+  if (isLink(localStateDir)) {
+    outcome.rejected.push('local state (the local tree is a link)');
+    return outcome;
+  }
   fs.mkdirSync(localStateDir, { recursive: true });
+
   const entries = walkEntries(syncStateDir);
   // A link in the repository is refused and removed, so it is neither
   // followed here nor pushed back to the team.
@@ -296,7 +304,10 @@ export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, 
 // Local state leaves the machine only as sealed envelopes; a local file that
 // cannot be decrypted is left out rather than shipped opaque.
 export function stageTeamState(localStateDir: string, syncStateDir: string, teamKey: Buffer, personalKey: Buffer): number {
+  if (isLink(localStateDir)) throw new Error('the local state tree is a link and is not staged');
+  if (isLink(syncStateDir)) throw new Error('the sync state tree is a link and is not written');
   if (!fs.existsSync(localStateDir)) return 0;
+
   let staged = 0;
   for (const localFile of walkEntries(localStateDir).files) {
     let plaintext: string;

--- a/mcp/servers/egc-memory/src/sync/TeamSync.ts
+++ b/mcp/servers/egc-memory/src/sync/TeamSync.ts
@@ -4,7 +4,8 @@ import fs from 'node:fs';
 import { SyncBackend } from './SyncBackend';
 import { GitBackend } from './GitBackend';
 import type { SyncConfig, SyncStatus, SyncResult } from './SyncBackend';
-
+import { loadOrCreateEncKey, readStateFile, writeStateFile } from '../encryption';
+import { generateTeamKey, openEnvelope, parseTeamKey, sealEnvelope } from './envelope';
 const TEAM_CONFIG_PATH = path.join(os.homedir(), '.egc', 'team.json');
 
 const BACKEND_REGISTRY: Record<string, new () => SyncBackend> = {
@@ -29,13 +30,17 @@ export function writeTeamConfig(config: SyncConfig): void {
   fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
 }
 
-export async function teamInit(backend: string, remote: string, branch: string = 'main'): Promise<SyncConfig> {
+export async function teamInit(backend: string, remote: string, branch: string = 'main', teamKey?: string): Promise<SyncConfig> {
   const BackendClass = BACKEND_REGISTRY[backend];
   if (!BackendClass) {
     throw new Error(`Unknown sync backend: "${backend}". Supported backends: ${Object.keys(BACKEND_REGISTRY).join(', ')}`);
   }
-
-  const config: SyncConfig = { backend, remote, branch };
+  // The first member generates the team key; the others join with the same
+  // key (64 hex characters) shared out of band.
+  if (teamKey !== undefined && !parseTeamKey(teamKey)) {
+    throw new Error('The team key must be 64 hexadecimal characters (32 bytes).');
+  }
+  const config: SyncConfig = { backend, remote, branch, teamKey: teamKey ?? generateTeamKey() };
   const instance = new BackendClass();
   try {
     await instance.init(config);
@@ -61,9 +66,15 @@ export async function teamSync(): Promise<SyncResult> {
     pulledCount: 0,
     pushedCount: 0,
     conflictCount: 0,
+    rejectedCount: 0,
     errors: [],
   };
-
+  const teamKey = parseTeamKey(config.teamKey);
+  if (!teamKey) {
+    result.errors.push('Team key missing or invalid in team.json: run team init again (with the shared key to join an existing team). Nothing was synced.');
+    return result;
+  }
+  const personalKey = loadOrCreateEncKey();
   const instance = new BackendClass();
   try {
     // A missing or unreachable remote must degrade to an offline no-op with
@@ -84,11 +95,15 @@ export async function teamSync(): Promise<SyncResult> {
       result.errors.push(`Pull failed: ${String(err)}`);
     }
 
-    // Step 2: Merge into local state.
-    await mergeTeamState();
-
-    // Step 3: Push local changes.
+    // Step 2: Merge into local state; only verified team envelopes count.
+    const merge = mergeTeamStateFrom(SYNC_STATE_DIR, LOCAL_STATE_DIR, teamKey, personalKey);
+    result.rejectedCount = merge.rejected.length;
+    for (const rejected of merge.rejected) {
+      result.errors.push(`Rejected sync file (not a verified team envelope): ${rejected}`);
+    }
+    // Step 3: Stage local state as sealed envelopes and push.
     try {
+      stageTeamState(LOCAL_STATE_DIR, SYNC_STATE_DIR, teamKey, personalKey);
       const pushed = await instance.push();
       if (pushed) {
         result.pushedCount = 1;
@@ -131,44 +146,71 @@ export async function teamStatus(): Promise<SyncStatus> {
   }
 }
 
-async function mergeTeamState(): Promise<void> {
-  const syncStateDir = path.join(os.homedir(), '.egc', 'team-sync', 'state');
-  const localStateDir = path.join(os.homedir(), '.egc', 'state');
+const SYNC_STATE_DIR = path.join(os.homedir(), '.egc', 'team-sync', 'state');
+const LOCAL_STATE_DIR = path.join(os.homedir(), '.egc', 'state');
 
-  if (!fs.existsSync(syncStateDir)) return;
+export interface TeamMergeOutcome {
+  merged: number;
+  rejected: string[];
+}
+
+// Every sync file must open as a team envelope (right key, intact signature)
+// before it can touch local state; anything else is reported and skipped.
+// Local files are read and written through the personal key, so the merge
+// compares plaintext timestamps and the result stays encrypted at rest.
+export function mergeTeamStateFrom(syncStateDir: string, localStateDir: string, teamKey: Buffer, personalKey: Buffer): TeamMergeOutcome {
+  const outcome: TeamMergeOutcome = { merged: 0, rejected: [] };
+  if (!fs.existsSync(syncStateDir)) return outcome;
   if (!fs.existsSync(localStateDir)) {
     fs.mkdirSync(localStateDir, { recursive: true });
   }
-
-  const syncFiles = getAllFiles(syncStateDir);
-  if (syncFiles.length === 0) {
-    return; // No remote state yet; preserve local files.
-  }
-  for (const syncFile of syncFiles) {
+  for (const syncFile of getAllFiles(syncStateDir)) {
     const relativePath = path.relative(syncStateDir, syncFile);
-    const localFile = path.join(localStateDir, relativePath);
-
-    const syncContent = fs.readFileSync(syncFile, 'utf-8');
-    const localContent = fs.existsSync(localFile) ? fs.readFileSync(localFile, 'utf-8') : '';
-
-    if (!localContent) {
-      // New file from team: copy it over.
-      const localDir = path.dirname(localFile);
-      if (!fs.existsSync(localDir)) {
-        fs.mkdirSync(localDir, { recursive: true });
-      }
-      fs.writeFileSync(localFile, syncContent, 'utf-8');
-    } else {
-      // Both exist: merge with last-write-wins per section.
-      const merged = mergeStateDocs(localContent, syncContent);
-      fs.writeFileSync(localFile, merged, 'utf-8');
+    const remoteContent = openEnvelope(fs.readFileSync(syncFile, 'utf-8'), teamKey);
+    if (remoteContent === null) {
+      outcome.rejected.push(relativePath);
+      continue;
     }
+    const localFile = path.join(localStateDir, relativePath);
+    let localContent = '';
+    if (fs.existsSync(localFile)) {
+      try {
+        localContent = readStateFile(localFile, personalKey);
+      } catch {
+        localContent = '';
+      }
+    }
+    const merged = localContent ? mergeStateDocs(localContent, remoteContent) : remoteContent;
+    if (merged === localContent) continue;
+    fs.mkdirSync(path.dirname(localFile), { recursive: true });
+    writeStateFile(localFile, merged, personalKey);
+    outcome.merged += 1;
   }
-
   // A team sync never removes local state files: a file absent from the sync
   // repo may be one this machine created and has not pushed yet, and deleting
   // it would be silent, unrecoverable memory loss. Remote deletions therefore
   // do not propagate automatically.
+  return outcome;
+}
+
+// Local state leaves the machine only as sealed envelopes; a local file that
+// cannot be decrypted is left out rather than shipped opaque.
+export function stageTeamState(localStateDir: string, syncStateDir: string, teamKey: Buffer, personalKey: Buffer): number {
+  if (!fs.existsSync(localStateDir)) return 0;
+  let staged = 0;
+  for (const localFile of getAllFiles(localStateDir)) {
+    let plaintext: string;
+    try {
+      plaintext = readStateFile(localFile, personalKey);
+    } catch {
+      continue;
+    }
+    const target = path.join(syncStateDir, path.relative(localStateDir, localFile));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, sealEnvelope(plaintext, teamKey), 'utf-8');
+    staged += 1;
+  }
+  return staged;
 }
 
 function getAllFiles(dir: string): string[] {

--- a/mcp/servers/egc-memory/src/sync/envelope.ts
+++ b/mcp/servers/egc-memory/src/sync/envelope.ts
@@ -1,4 +1,6 @@
 import crypto from 'node:crypto';
+import path from 'node:path';
+
 import { decryptState, encryptState } from '../encryption';
 
 // State that leaves the machine travels sealed with the team key: the
@@ -19,9 +21,11 @@ export function generateTeamKey(): string {
   return crypto.randomBytes(32).toString('hex');
 }
 
-// The repository path of a state file, the same on every platform.
+// The repository path of a state file: the host's separator becomes the
+// repository's, and nothing else is rewritten, so two distinct local names
+// never share one authenticated path.
 export function envelopePath(relativePath: string): string {
-  return relativePath.split('\\').join('/');
+  return path.sep === '/' ? relativePath : relativePath.replaceAll(path.sep, '/');
 }
 
 function derivedKey(teamKey: Buffer, purpose: 'encrypt' | 'sign'): Buffer {

--- a/mcp/servers/egc-memory/src/sync/envelope.ts
+++ b/mcp/servers/egc-memory/src/sync/envelope.ts
@@ -38,7 +38,7 @@ export function openEnvelope(text: string, teamKey: Buffer): string | null {
   } catch {
     return null;
   }
-  if (!parsed || parsed.egcTeamEnvelope !== TEAM_ENVELOPE_VERSION) return null;
+  if (parsed?.egcTeamEnvelope !== TEAM_ENVELOPE_VERSION) return null;
   if (typeof parsed.data !== 'string' || typeof parsed.mac !== 'string' || !TEAM_KEY_HEX_RE.test(parsed.mac)) return null;
   const data = Buffer.from(parsed.data, 'base64');
   const expected = signature(teamKey, data);

--- a/mcp/servers/egc-memory/src/sync/envelope.ts
+++ b/mcp/servers/egc-memory/src/sync/envelope.ts
@@ -3,10 +3,12 @@ import { decryptState, encryptState } from '../encryption';
 
 // State that leaves the machine travels sealed with the team key: the
 // plaintext is encrypted (AES-256-GCM, the same primitive as the state at
-// rest) and the ciphertext carries an HMAC-SHA256 signature made with the
-// same team key, so a sync file that was not produced by a holder of the
-// key, or was altered in the shared repository, opens as nothing.
-export const TEAM_ENVELOPE_VERSION = 1;
+// rest) under a key derived for encryption, and the ciphertext together with
+// the file's path in the shared repository is signed (HMAC-SHA256) under a
+// key derived for signing, so a sync file that was not produced by a holder
+// of the team key, was altered in the repository, or was copied to another
+// path opens as nothing.
+export const TEAM_ENVELOPE_VERSION = 2;
 export const TEAM_KEY_HEX_RE = /^[0-9a-f]{64}$/i;
 
 export function parseTeamKey(value: unknown): Buffer | null {
@@ -17,35 +19,50 @@ export function generateTeamKey(): string {
   return crypto.randomBytes(32).toString('hex');
 }
 
-function signature(teamKey: Buffer, data: Buffer): Buffer {
-  return crypto.createHmac('sha256', teamKey).update(data).digest();
+// The repository path of a state file, the same on every platform.
+export function envelopePath(relativePath: string): string {
+  return relativePath.split('\\').join('/');
 }
 
-export function sealEnvelope(plaintext: string, teamKey: Buffer): string {
-  const data = encryptState(plaintext, teamKey);
+function derivedKey(teamKey: Buffer, purpose: 'encrypt' | 'sign'): Buffer {
+  return Buffer.from(crypto.hkdfSync('sha256', teamKey, '', `egc-team-envelope-${purpose}`, 32));
+}
+
+function signature(teamKey: Buffer, envelopeRelativePath: string, data: Buffer): Buffer {
+  return crypto.createHmac('sha256', derivedKey(teamKey, 'sign'))
+    .update(envelopeRelativePath, 'utf8')
+    .update(Buffer.from([0]))
+    .update(data)
+    .digest();
+}
+
+export function sealEnvelope(plaintext: string, teamKey: Buffer, relativePath: string): string {
+  const boundPath = envelopePath(relativePath);
+  const data = encryptState(plaintext, derivedKey(teamKey, 'encrypt'));
   const envelope = {
     egcTeamEnvelope: TEAM_ENVELOPE_VERSION,
+    path: boundPath,
     data: data.toString('base64'),
-    mac: signature(teamKey, data).toString('hex'),
+    mac: signature(teamKey, boundPath, data).toString('hex'),
   };
   return `${JSON.stringify(envelope)}\n`;
 }
 
-export function openEnvelope(text: string, teamKey: Buffer): string | null {
-  let parsed: { egcTeamEnvelope?: unknown; data?: unknown; mac?: unknown };
+export function openEnvelope(text: string, teamKey: Buffer, relativePath: string): string | null {
+  let parsed: { egcTeamEnvelope?: unknown; path?: unknown; data?: unknown; mac?: unknown };
   try {
     parsed = JSON.parse(text) as typeof parsed;
   } catch {
     return null;
   }
-  if (parsed?.egcTeamEnvelope !== TEAM_ENVELOPE_VERSION) return null;
+  if (parsed?.egcTeamEnvelope !== TEAM_ENVELOPE_VERSION || parsed.path !== envelopePath(relativePath)) return null;
   if (typeof parsed.data !== 'string' || typeof parsed.mac !== 'string' || !TEAM_KEY_HEX_RE.test(parsed.mac)) return null;
   const data = Buffer.from(parsed.data, 'base64');
-  const expected = signature(teamKey, data);
+  const expected = signature(teamKey, parsed.path, data);
   const given = Buffer.from(parsed.mac, 'hex');
   if (given.length !== expected.length || !crypto.timingSafeEqual(given, expected)) return null;
   try {
-    return decryptState(data, teamKey);
+    return decryptState(data, derivedKey(teamKey, 'encrypt'));
   } catch {
     return null;
   }

--- a/mcp/servers/egc-memory/src/sync/envelope.ts
+++ b/mcp/servers/egc-memory/src/sync/envelope.ts
@@ -1,0 +1,52 @@
+import crypto from 'node:crypto';
+import { decryptState, encryptState } from '../encryption';
+
+// State that leaves the machine travels sealed with the team key: the
+// plaintext is encrypted (AES-256-GCM, the same primitive as the state at
+// rest) and the ciphertext carries an HMAC-SHA256 signature made with the
+// same team key, so a sync file that was not produced by a holder of the
+// key, or was altered in the shared repository, opens as nothing.
+export const TEAM_ENVELOPE_VERSION = 1;
+export const TEAM_KEY_HEX_RE = /^[0-9a-f]{64}$/i;
+
+export function parseTeamKey(value: unknown): Buffer | null {
+  return typeof value === 'string' && TEAM_KEY_HEX_RE.test(value) ? Buffer.from(value, 'hex') : null;
+}
+
+export function generateTeamKey(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+function signature(teamKey: Buffer, data: Buffer): Buffer {
+  return crypto.createHmac('sha256', teamKey).update(data).digest();
+}
+
+export function sealEnvelope(plaintext: string, teamKey: Buffer): string {
+  const data = encryptState(plaintext, teamKey);
+  const envelope = {
+    egcTeamEnvelope: TEAM_ENVELOPE_VERSION,
+    data: data.toString('base64'),
+    mac: signature(teamKey, data).toString('hex'),
+  };
+  return `${JSON.stringify(envelope)}\n`;
+}
+
+export function openEnvelope(text: string, teamKey: Buffer): string | null {
+  let parsed: { egcTeamEnvelope?: unknown; data?: unknown; mac?: unknown };
+  try {
+    parsed = JSON.parse(text) as typeof parsed;
+  } catch {
+    return null;
+  }
+  if (!parsed || parsed.egcTeamEnvelope !== TEAM_ENVELOPE_VERSION) return null;
+  if (typeof parsed.data !== 'string' || typeof parsed.mac !== 'string' || !TEAM_KEY_HEX_RE.test(parsed.mac)) return null;
+  const data = Buffer.from(parsed.data, 'base64');
+  const expected = signature(teamKey, data);
+  const given = Buffer.from(parsed.mac, 'hex');
+  if (given.length !== expected.length || !crypto.timingSafeEqual(given, expected)) return null;
+  try {
+    return decryptState(data, teamKey);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -43,6 +43,106 @@ const ROUTINE_BASH_SESSION_KEY = '__bash_session__';
 const EDIT_WRITE_HOOK_ID = 'pre:edit-write:gateguard-fact-force';
 const BASH_HOOK_ID = 'pre:bash:gateguard-fact-force';
 const EGC_DISABLE_VALUES = new Set(['0', 'false', 'off', 'disabled', 'disable']);
+const TRANSCRIPT_TAIL_BYTES = 512 * 1024;
+
+// The hook input of the current call, kept for the transcript lookup.
+let hookInput = null;
+
+function pendingKey(key) {
+  return `pending:${key}`;
+}
+
+function presentedKey(key) {
+  return `presented:${key}`;
+}
+
+// The assistant text written since the last user turn, read from the
+// harness transcript when one is named in the hook input: that is the
+// message that precedes a retried tool call. Null when no transcript can be
+// read, so a harness without transcripts keeps the identical-retry rule.
+function readTranscriptTail(transcriptPath) {
+  try {
+    const descriptor = fs.openSync(transcriptPath, 'r');
+    try {
+      const size = fs.fstatSync(descriptor).size;
+      const start = Math.max(0, size - TRANSCRIPT_TAIL_BYTES);
+      const buffer = Buffer.alloc(size - start);
+      fs.readSync(descriptor, buffer, 0, buffer.length, start);
+      return buffer.toString('utf8');
+    } finally {
+      fs.closeSync(descriptor);
+    }
+  } catch (_) { // NOSONAR: an unreadable transcript keeps the identical-retry rule
+    return null;
+  }
+}
+
+function parseTranscriptLine(line) {
+  try {
+    const entry = JSON.parse(line);
+    return entry && typeof entry === 'object' ? entry : null;
+  } catch (_) { // NOSONAR: a partial first line or a non-JSON line is skipped
+    return null;
+  }
+}
+
+function assistantTextBlocks(entry) {
+  const content = entry.message && Array.isArray(entry.message.content) ? entry.message.content : [];
+  return content.filter(block => block && block.type === 'text' && typeof block.text === 'string').map(block => block.text);
+}
+
+function recentAssistantText(data) {
+  const transcriptPath = data && (data.transcript_path || data.transcriptPath);
+  if (!transcriptPath || typeof transcriptPath !== 'string') return null;
+  const tail = readTranscriptTail(transcriptPath);
+  if (tail === null) return null;
+  let texts = [];
+  for (const line of tail.split('\n')) {
+    const entry = parseTranscriptLine(line);
+    if (!entry) continue;
+    if (entry.type === 'user') texts = [];
+    else if (entry.type === 'assistant') texts.push(...assistantTextBlocks(entry));
+  }
+  return texts.join('\n');
+}
+
+function missingFacts(text, required) {
+  const lower = text.toLowerCase();
+  return required.filter(term => term && !lower.includes(term.toLowerCase()));
+}
+
+function factsMissingMsg(missing) {
+  return [
+    '[Fact-Forcing Gate]',
+    '',
+    `The retry was refused: the message before it does not present the required facts (missing: ${missing.join(', ')}).`,
+    'Write the facts in your reply, then retry the same operation.'
+  ].join('\n');
+}
+
+function commandWord(command) {
+  const first = String(command || '').trim().split(/\s+/)[0] || '';
+  return first.split(/[\\/]/).pop();
+}
+
+// The first retry after a denial is accepted only when the message before
+// it presents the facts (when a transcript is there to read); later
+// operations on the same target stay free, as before.
+function refuseUnpresentedFacts(key, required, traceMeta) {
+  if (!isChecked(pendingKey(key)) || isChecked(presentedKey(key))) return null;
+  const text = recentAssistantText(hookInput);
+  if (text === null) {
+    markChecked(presentedKey(key));
+    return null;
+  }
+  const missing = missingFacts(text, required);
+  if (missing.length === 0) {
+    markChecked(presentedKey(key));
+    return null;
+  }
+  trace('governance:denied:facts_missing', { ...traceMeta, missing });
+  return denyResult(factsMissingMsg(missing), { includeRecoveryHint: false });
+}
 
 // One pattern per destructive command; each keeps the same word boundaries
 // the former single alternation applied around the matched command.
@@ -369,7 +469,7 @@ function withRecoveryHint(message, hookIds = [EDIT_WRITE_HOOK_ID]) {
   return [
     message,
     '',
-    `Recovery: if GateGuard is blocking setup or repair work, run this session with \`EGC_GATEGUARD=off\` or add ${disableTargets} to \`EGC_DISABLED_HOOKS\`.`
+    `Recovery: a human doing setup or repair work can lift this gate by adding ${disableTargets} to \`EGC_DISABLED_HOOKS\`.`
   ].join('\n');
 }
 
@@ -417,14 +517,15 @@ function handleEditWrite(rawInput, toolName, toolInput) {
   }
 
   if (!isChecked(filePath)) {
-    if (!markChecked(filePath)) {
+    if (!markChecked(filePath) || !markChecked(pendingKey(filePath))) {
       trace('governance:allowed:state_error', { toolName, filePath });
       return allowWithStateWarning();
     }
     trace('governance:denied:fact_force', { toolName, filePath });
     return denyResult(toolName === 'Edit' ? editGateMsg(filePath) : writeGateMsg(filePath));
   }
-
+  const refused = refuseUnpresentedFacts(filePath, [path.basename(filePath)], { toolName, filePath });
+  if (refused) return refused;
   trace('governance:allowed:checked', { toolName, filePath });
   return rawInput;
 }
@@ -441,14 +542,17 @@ function handleMultiEdit(rawInput, toolName, toolInput) {
   const edits = toolInput.edits || [];
   for (const edit of edits) {
     const filePath = edit.file_path || '';
-    if (filePath && !isClaudeSettingsPath(filePath) && !isChecked(filePath)) {
-      if (!markChecked(filePath)) {
+    if (!filePath || isClaudeSettingsPath(filePath)) continue;
+    if (!isChecked(filePath)) {
+      if (!markChecked(filePath) || !markChecked(pendingKey(filePath))) {
         trace('governance:allowed:state_error', { toolName, filePath });
         return allowWithStateWarning();
       }
       trace('governance:denied:fact_force', { toolName, filePath });
       return denyResult(editGateMsg(filePath));
     }
+    const refused = refuseUnpresentedFacts(filePath, [path.basename(filePath)], { toolName, filePath });
+    if (refused) return refused;
   }
   trace('governance:allowed:multiedit');
   return rawInput;
@@ -499,7 +603,7 @@ function handleApplyPatch(rawInput, rawPatchInput) {
     if (isClaudeSettingsPath(filePath) || isChecked(filePath)) {
       continue;
     }
-    if (!markChecked(filePath)) {
+    if (!markChecked(filePath) || !markChecked(pendingKey(filePath))) {
       trace('governance:allowed:state_error', { toolName: 'apply_patch', filePath });
       return allowWithStateWarning();
     }
@@ -529,13 +633,15 @@ function handleBash(rawInput, toolName, toolInput) {
   if (isDestructiveBash(command)) {
     const key = '__destructive__' + crypto.createHash('sha256').update(command).digest('hex').slice(0, 16);
     if (!isChecked(key)) {
-      if (!markChecked(key)) {
+      if (!markChecked(key) || !markChecked(pendingKey(key))) {
         trace('governance:allowed:state_error', { toolName, command });
         return allowWithStateWarning();
       }
       trace('governance:denied:destructive', { command });
       return denyResult(destructiveBashMsg(), { includeRecoveryHint: false });
     }
+    const refused = refuseUnpresentedFacts(key, ['rollback', commandWord(command)], { command });
+    if (refused) return refused;
     trace('governance:allowed:destructive_retry', { command });
     return rawInput;
   }
@@ -569,6 +675,7 @@ function run(rawInput) {
   }
 
   activeStateFile = null;
+  hookInput = data;
   getStateFile(data);
 
   const rawToolName = data.tool_name || '';

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -27,7 +27,8 @@
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
-const os = require('os');
+const os = require('node:os');
+
 
 // Session state: scoped per session to avoid cross-session races.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
@@ -64,17 +65,14 @@ function presentedKey(key) {
 // A transcript named by the hook input is read only when it is an absolute
 // .jsonl file under the home directory or the temporary directory, with no
 // parent segments: the harness writes transcripts there and nowhere else.
-function allowedTranscriptPath(candidate) {
+function readTranscriptTail(candidate) {
   if (typeof candidate !== 'string' || !candidate.endsWith('.jsonl') || !path.isAbsolute(candidate)) return null;
   if (candidate.split(/[\\/]/).includes('..')) return null;
   const resolved = path.resolve(candidate);
   const roots = [os.homedir(), os.tmpdir()].map(root => path.resolve(root));
-  return roots.some(root => resolved === root || resolved.startsWith(root + path.sep)) ? resolved : null;
-}
-
-function readTranscriptTail(transcriptPath) {
+  if (!roots.some(root => resolved === root || resolved.startsWith(root + path.sep))) return null;
   try {
-    const descriptor = fs.openSync(transcriptPath, 'r');
+    const descriptor = fs.openSync(resolved, 'r');
     try {
       const size = fs.fstatSync(descriptor).size;
       const start = Math.max(0, size - TRANSCRIPT_TAIL_BYTES);
@@ -104,9 +102,7 @@ function assistantTextBlocks(entry) {
 }
 
 function recentAssistantText(data) {
-  const transcriptPath = allowedTranscriptPath(data?.transcript_path || data?.transcriptPath);
-  if (!transcriptPath) return null;
-  const tail = readTranscriptTail(transcriptPath);
+  const tail = readTranscriptTail(data?.transcript_path || data?.transcriptPath);
   if (tail === null) return null;
   let texts = [];
   for (const line of tail.split('\n')) {

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -65,6 +65,16 @@ function presentedKey(key) {
 // A transcript named by the hook input is read only when it is an absolute
 // .jsonl file under the home directory or the temporary directory, with no
 // parent segments: the harness writes transcripts there and nowhere else.
+// A root as the filesystem knows it; a root that cannot be resolved admits
+// nothing (the sentinel never prefixes a real path).
+function realRoot(root) {
+  try {
+    return fs.realpathSync(root);
+  } catch (_) { // NOSONAR: see above
+    return '\0';
+  }
+}
+
 function readTranscriptTail(candidate) {
   if (typeof candidate !== 'string' || !candidate.endsWith('.jsonl') || !path.isAbsolute(candidate)) return null;
   if (candidate.split(/[\\/]/).includes('..')) return null;
@@ -76,16 +86,12 @@ function readTranscriptTail(candidate) {
   } catch (_) { // NOSONAR: a transcript that cannot be resolved is not read
     return null;
   }
-  const roots = [os.homedir(), os.tmpdir()].map(root => {
-    try {
-      return fs.realpathSync(root);
-    } catch (_) { // NOSONAR: a root that cannot be resolved admits nothing
-      return null;
-    }
-  }).filter(Boolean);
-  if (!roots.some(root => real === root || real.startsWith(root + path.sep))) return null;
+  const home = realRoot(os.homedir());
+  const temporary = realRoot(os.tmpdir());
+  const transcriptPath = path.resolve(real);
+  if (!transcriptPath.startsWith(home + path.sep) && !transcriptPath.startsWith(temporary + path.sep)) return null;
   try {
-    const descriptor = fs.openSync(real, 'r');
+    const descriptor = fs.openSync(transcriptPath, 'r');
     try {
       const size = fs.fstatSync(descriptor).size;
       const start = Math.max(0, size - TRANSCRIPT_TAIL_BYTES);

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -68,11 +68,24 @@ function presentedKey(key) {
 function readTranscriptTail(candidate) {
   if (typeof candidate !== 'string' || !candidate.endsWith('.jsonl') || !path.isAbsolute(candidate)) return null;
   if (candidate.split(/[\\/]/).includes('..')) return null;
-  const resolved = path.resolve(candidate);
-  const roots = [os.homedir(), os.tmpdir()].map(root => path.resolve(root));
-  if (!roots.some(root => resolved === root || resolved.startsWith(root + path.sep))) return null;
+  // The real location is what is read: a link under an allowed root that
+  // points elsewhere is refused.
+  let real;
   try {
-    const descriptor = fs.openSync(resolved, 'r');
+    real = fs.realpathSync(path.resolve(candidate));
+  } catch (_) { // NOSONAR: a transcript that cannot be resolved is not read
+    return null;
+  }
+  const roots = [os.homedir(), os.tmpdir()].map(root => {
+    try {
+      return fs.realpathSync(root);
+    } catch (_) { // NOSONAR: a root that cannot be resolved admits nothing
+      return null;
+    }
+  }).filter(Boolean);
+  if (!roots.some(root => real === root || real.startsWith(root + path.sep))) return null;
+  try {
+    const descriptor = fs.openSync(real, 'r');
     try {
       const size = fs.fstatSync(descriptor).size;
       const start = Math.max(0, size - TRANSCRIPT_TAIL_BYTES);

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -27,6 +27,7 @@
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('os');
 
 // Session state: scoped per session to avoid cross-session races.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
@@ -60,6 +61,17 @@ function presentedKey(key) {
 // harness transcript when one is named in the hook input: that is the
 // message that precedes a retried tool call. Null when no transcript can be
 // read, so a harness without transcripts keeps the identical-retry rule.
+// A transcript named by the hook input is read only when it is an absolute
+// .jsonl file under the home directory or the temporary directory, with no
+// parent segments: the harness writes transcripts there and nowhere else.
+function allowedTranscriptPath(candidate) {
+  if (typeof candidate !== 'string' || !candidate.endsWith('.jsonl') || !path.isAbsolute(candidate)) return null;
+  if (candidate.split(/[\\/]/).includes('..')) return null;
+  const resolved = path.resolve(candidate);
+  const roots = [os.homedir(), os.tmpdir()].map(root => path.resolve(root));
+  return roots.some(root => resolved === root || resolved.startsWith(root + path.sep)) ? resolved : null;
+}
+
 function readTranscriptTail(transcriptPath) {
   try {
     const descriptor = fs.openSync(transcriptPath, 'r');
@@ -88,12 +100,12 @@ function parseTranscriptLine(line) {
 
 function assistantTextBlocks(entry) {
   const content = entry.message && Array.isArray(entry.message.content) ? entry.message.content : [];
-  return content.filter(block => block && block.type === 'text' && typeof block.text === 'string').map(block => block.text);
+  return content.filter(block => block?.type === 'text' && typeof block.text === 'string').map(block => block.text);
 }
 
 function recentAssistantText(data) {
-  const transcriptPath = data && (data.transcript_path || data.transcriptPath);
-  if (!transcriptPath || typeof transcriptPath !== 'string') return null;
+  const transcriptPath = allowedTranscriptPath(data?.transcript_path || data?.transcriptPath);
+  if (!transcriptPath) return null;
   const tail = readTranscriptTail(transcriptPath);
   if (tail === null) return null;
   let texts = [];

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -176,6 +176,12 @@ function handleInit(args) {
 
   const config = { backend, remote, branch, teamKey };
   fs.mkdirSync(path.dirname(TEAM_CONFIG_PATH), { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(path.dirname(TEAM_CONFIG_PATH), 0o700);
+  } catch {
+    // modes are not supported on this filesystem
+  }
+
   fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 });
   try {
     fs.chmodSync(TEAM_CONFIG_PATH, 0o600);

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 const path = require('node:path');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
+
 const os = require('node:os');
 const { spawnSync, execFileSync } = require('node:child_process');
 
@@ -158,33 +160,42 @@ function handleInit(args) {
   const backend = optionValue(args, '--backend', 'git');
   const remote = optionValue(args, '--remote', null);
   const branch = optionValue(args, '--branch', 'main');
-  const teamKey = optionValue(args, '--key', undefined);
-  if (teamKey !== undefined && !/^[0-9a-f]{64}$/i.test(teamKey)) {
-    console.error('Error: --key must be 64 hexadecimal characters (the key shared by the member who initialized the team)');
+  const keyIndex = args.indexOf('--key');
+  const provided = keyIndex === -1 ? undefined : args[keyIndex + 1];
+  if (keyIndex !== -1 && (provided === undefined || provided.startsWith('--') || !/^[0-9a-f]{64}$/i.test(provided))) {
+    console.error('Error: --key must be followed by 64 hexadecimal characters (the key shared by the member who initialized the team)');
     process.exit(1);
   }
+  // The first member's key is made here, so the config is complete even
+  // when the memory server cannot be reached right now.
+  const teamKey = provided ?? crypto.randomBytes(32).toString('hex');
   if (!remote) {
     console.error('Error: --remote is required for team init');
     process.exit(1);
   }
 
-  const config = teamKey ? { backend, remote, branch, teamKey } : { backend, remote, branch };
-  fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+  const config = { backend, remote, branch, teamKey };
+  fs.mkdirSync(path.dirname(TEAM_CONFIG_PATH), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 });
+  try {
+    fs.chmodSync(TEAM_CONFIG_PATH, 0o600);
+  } catch {
+    // modes are not supported on this filesystem
+  }
   console.log(`Team initialized:
   Backend: ${backend}
   Remote:  ${remote}
   Branch:  ${branch}
   Config:  ${TEAM_CONFIG_PATH}`);
+  if (provided === undefined) {
+    console.log(`Team key (share it out of band; teammates join with --key):\n  ${teamKey}`);
+  }
 
   // Now try to connect and set up via MCP tool.
   try {
-    const result = callMcpTool('team_init', teamKey ? { backend, remote, branch, team_key: teamKey } : { backend, remote, branch });
+    const result = callMcpTool('team_init', { backend, remote, branch, team_key: teamKey });
     if (result) {
       console.log('Sync backend configured successfully.');
-      const generated = result && typeof result === 'object' && typeof result.teamKey === 'string' ? result.teamKey : null;
-      if (generated && !teamKey) {
-        console.log(`Team key (share it out of band; teammates join with --key):\n  ${generated}`);
-      }
     }
   } catch (err) {
     console.log(`Note: Memory server setup returned: ${err.message}`);
@@ -212,10 +223,10 @@ async function handleSync() {
       console.log(`  Errors: ${result.errors.join(', ')}`);
     }
   } catch (err) {
-    // Fallback: use direct git operations.
-    console.log(`MCP tool failed: ${err.message}`);
-    console.log('Falling back to direct sync...');
-    await directSync(config);
+    // State leaves this machine only sealed by the memory server; the old
+    // direct git fallback pushed the state directory in the clear.
+    console.error(`Error: team sync needs the memory server (${err.message}). Run "egc doctor" and try again.`);
+    process.exit(1);
   }
 }
 
@@ -283,105 +294,6 @@ async function main() {
       showHelp();
       process.exit(1);
   }
-}
-
-function ensureRemote(syncDir, remoteUrl) {
-  try {
-    const current = safeGit(['remote', 'get-url', 'origin'], syncDir);
-    if (current !== remoteUrl) {
-      safeGit(['remote', 'set-url', 'origin', remoteUrl], syncDir);
-    }
-  } catch {
-    safeGit(['remote', 'add', 'origin', remoteUrl], syncDir);
-  }
-}
-
-function mirrorCopy(src, dest) {
-  if (fs.existsSync(dest)) {
-    fs.rmSync(dest, { recursive: true, force: true });
-  }
-  fs.mkdirSync(dest, { recursive: true });
-  fs.cpSync(src, dest, { recursive: true });
-}
-
-function initializeSyncRepo(syncDir, config) {
-  const isRepo = fs.existsSync(path.join(syncDir, '.git'));
-  if (!isRepo) {
-    safeGit(['init'], syncDir);
-    safeGit(['remote', 'add', 'origin', config.remote], syncDir);
-  } else {
-    ensureRemote(syncDir, config.remote);
-  }
-}
-
-function pullRemoteChanges(syncDir, config) {
-  try {
-    safeGit(['pull', 'origin', config.branch, '--allow-unrelated-histories', '--no-rebase'], syncDir);
-    console.log('  Pulled remote changes.');
-  } catch (err) {
-    const msg = err.stderr ? err.stderr.toString().trim() : err.message;
-    console.log(`  Pull: ${msg.includes('no upstream') ? 'first sync, no upstream yet' : msg}`);
-  }
-}
-
-function commitAndPushChanges(syncDir, config) {
-  safeGit(['add', '-A'], syncDir);
-  try {
-    safeGit(['config', 'user.email', `${process.env.USER || process.env.USERNAME || 'egc'}@egc.local`], syncDir);
-    safeGit(['config', 'user.name', process.env.USER || process.env.USERNAME || 'egc'], syncDir);
-  } catch {
-    // identity may already be configured
-  }
-  try {
-    const staged = safeGit(['diff', '--cached', '--name-only'], syncDir);
-    if (!staged.trim()) {
-      console.log('  Nothing new to push.');
-      return false;
-    }
-    const author = process.env.USER || process.env.USERNAME || 'unknown';
-    safeGit(['commit', '-m', `sync: team memory update from ${author}`], syncDir);
-    safeGit(['push', 'origin', config.branch], syncDir);
-    console.log('  Pushed local changes.');
-    return true;
-  } catch (err) {
-    const msg = err.stderr ? err.stderr.toString() : err.message;
-    if (msg.includes('nothing to commit')) {
-      console.log('  Nothing new to push.');
-    } else {
-      console.log(`  Push: ${msg.trim().split('\n').pop() || 'unknown error'}`);
-    }
-    return false;
-  }
-}
-
-async function directSync(config) {
-  const syncDir = path.join(os.homedir(), '.egc', 'team-sync');
-  const stateDir = path.join(os.homedir(), '.egc', 'state');
-
-  if (!fs.existsSync(syncDir)) {
-    fs.mkdirSync(syncDir, { recursive: true });
-  }
-
-  initializeSyncRepo(syncDir, config);
-
-  // Discard uncommitted sync-repo changes before pull.
-  try {
-    safeGit(['reset', '--hard'], syncDir);
-  } catch {
-    // empty repo on first sync
-  }
-
-  pullRemoteChanges(syncDir, config);
-
-  // Copy state files into sync repo (mirror to avoid resurrecting deleted files).
-  const syncStateDir = path.join(syncDir, 'state');
-  if (fs.existsSync(stateDir)) {
-    mirrorCopy(stateDir, syncStateDir);
-  }
-
-  commitAndPushChanges(syncDir, config);
-
-  console.log('Sync complete.');
 }
 
 main().catch(err => {

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -39,7 +39,7 @@ function showHelp() {
 EGC Team Memory — Sync state across teammates
 
 Usage:
-  egc team init --backend <backend> --remote <url> [--branch <branch>]
+  egc team init --backend <backend> --remote <url> [--branch <branch>] [--key <hex>]
   egc team sync
   egc team status
 
@@ -51,6 +51,7 @@ Commands:
 Options:
   --backend   Sync backend type (default: git)
   --remote    Remote URL for the sync storage
+  --key       Team key (64 hex) shared by the member who initialized the team; omit to create a new team
   --branch    Git branch to use (default: main)
 
 Examples:
@@ -148,21 +149,26 @@ function callMcpTool(toolName, args) {
   return parseMcpResponse(result.stdout);
 }
 
+function optionValue(args, name, fallback) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+
 function handleInit(args) {
-  const backendIdx = args.indexOf('--backend');
-  const remoteIdx = args.indexOf('--remote');
-  const branchIdx = args.indexOf('--branch');
-
-  const backend = backendIdx !== -1 ? args[backendIdx + 1] : 'git';
-  const remote = remoteIdx !== -1 ? args[remoteIdx + 1] : null;
-  const branch = branchIdx !== -1 ? args[branchIdx + 1] : 'main';
-
+  const backend = optionValue(args, '--backend', 'git');
+  const remote = optionValue(args, '--remote', null);
+  const branch = optionValue(args, '--branch', 'main');
+  const teamKey = optionValue(args, '--key', undefined);
+  if (teamKey !== undefined && !/^[0-9a-f]{64}$/i.test(teamKey)) {
+    console.error('Error: --key must be 64 hexadecimal characters (the key shared by the member who initialized the team)');
+    process.exit(1);
+  }
   if (!remote) {
     console.error('Error: --remote is required for team init');
     process.exit(1);
   }
 
-  const config = { backend, remote, branch };
+  const config = teamKey ? { backend, remote, branch, teamKey } : { backend, remote, branch };
   fs.writeFileSync(TEAM_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
   console.log(`Team initialized:
   Backend: ${backend}
@@ -172,9 +178,13 @@ function handleInit(args) {
 
   // Now try to connect and set up via MCP tool.
   try {
-    const result = callMcpTool('team_init', { backend, remote, branch });
+    const result = callMcpTool('team_init', teamKey ? { backend, remote, branch, team_key: teamKey } : { backend, remote, branch });
     if (result) {
       console.log('Sync backend configured successfully.');
+      const generated = result && typeof result === 'object' && typeof result.teamKey === 'string' ? result.teamKey : null;
+      if (generated && !teamKey) {
+        console.log(`Team key (share it out of band; teammates join with --key):\n  ${generated}`);
+      }
     }
   } catch (err) {
     console.log(`Note: Memory server setup returned: ${err.message}`);

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -489,7 +489,7 @@ function runTests() {
     const output = parseOutput(result.stdout);
 
     assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
-    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('EGC_GATEGUARD=off'),
+    assert.ok(!output.hookSpecificOutput.permissionDecisionReason.includes('GATEGUARD=off'),
       'denial reason should show the canonical direct recovery env toggle');
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('EGC_DISABLED_HOOKS'),
       'denial reason should mention the canonical hook-id disable control');
@@ -497,6 +497,68 @@ function runTests() {
 
   // --- Test 14: routine Bash denial messages show the Bash hook escape hatch ---
   clearState();
+  if (test('a destructive retry is accepted only when the facts message names a rollback and the command', () => {
+    const transcript = path.join(stateDir, 'destructive-transcript.jsonl');
+    const session = 'facts-destructive-' + Date.now();
+    const call = { tool_name: 'Bash', tool_input: { command: 'rm -rf /tmp/egc-facts-target' }, transcript_path: transcript };
+    const first = runBashHook(call, { EGC_SESSION_ID: session });
+    assert.strictEqual(JSON.parse(first.stdout).hookSpecificOutput.permissionDecision, 'deny');
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'go' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Retrying now.' }] } }),
+    ].join('\n') + '\n');
+    const bare = runBashHook(call, { EGC_SESSION_ID: session });
+    const bareOut = JSON.parse(bare.stdout);
+    assert.strictEqual(bareOut.hookSpecificOutput.permissionDecision, 'deny', bare.stdout);
+    assert.ok(bareOut.hookSpecificOutput.permissionDecisionReason.includes('does not present'), bare.stdout);
+    assert.ok(!bareOut.hookSpecificOutput.permissionDecisionReason.includes('GATEGUARD=off'));
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'go' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Facts: this removes the scratch directory only. Rollback: recreate it from git. Instruction: "clean it up". The command is rm.' }] } }),
+    ].join('\n') + '\n');
+    const withFacts = runBashHook(call, { EGC_SESSION_ID: session });
+    assert.strictEqual(withFacts.code, 0, withFacts.stderr);
+    assert.ok(!withFacts.stdout.includes('"deny"'), withFacts.stdout);
+  })) passed++; else failed++;
+
+  if (test('an edit retry is accepted only when the facts message names the file, and later edits stay free', () => {
+    const transcript = path.join(stateDir, 'edit-transcript.jsonl');
+    const session = 'facts-edit-' + Date.now();
+    const target = path.join(stateDir, 'src', 'billing.js');
+    const call = { tool_name: 'Edit', tool_input: { file_path: target, old_string: 'a', new_string: 'b' }, transcript_path: transcript };
+    const first = runHook(call, { EGC_SESSION_ID: session });
+    assert.strictEqual(JSON.parse(first.stdout).hookSpecificOutput.permissionDecision, 'deny');
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'go' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Here are some facts about nothing in particular.' }] } }),
+    ].join('\n') + '\n');
+    const bare = runHook(call, { EGC_SESSION_ID: session });
+    assert.strictEqual(JSON.parse(bare.stdout).hookSpecificOutput.permissionDecision, 'deny', bare.stdout);
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'go' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'billing.js is imported by checkout.js; it exposes charge(); no data files.' }] } }),
+    ].join('\n') + '\n');
+    const withFacts = runHook(call, { EGC_SESSION_ID: session });
+    assert.strictEqual(withFacts.code, 0, withFacts.stderr);
+    assert.ok(!withFacts.stdout.includes('"deny"'), withFacts.stdout);
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'next' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Continuing.' }] } }),
+    ].join('\n') + '\n');
+    const later = runHook(call, { EGC_SESSION_ID: session });
+    assert.strictEqual(later.code, 0, later.stderr);
+    assert.ok(!later.stdout.includes('"deny"'), later.stdout);
+  })) passed++; else failed++;
+
+  if (test('a retry without a readable transcript keeps the identical-retry rule', () => {
+    const session = 'facts-none-' + Date.now();
+    const call = { tool_name: 'Bash', tool_input: { command: 'rm -rf /tmp/egc-facts-none' }, transcript_path: path.join(stateDir, 'missing.jsonl') };
+    runBashHook(call, { EGC_SESSION_ID: session });
+    const retry = runBashHook(call, { EGC_SESSION_ID: session });
+    assert.strictEqual(retry.code, 0, retry.stderr);
+    assert.ok(!retry.stdout.includes('"deny"'), retry.stdout);
+  })) passed++; else failed++;
+
   if (test('routine Bash denials include Bash hook disable id', () => {
     const input = {
       tool_name: 'Bash',

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -564,14 +564,14 @@ function runTests() {
     try {
       fs.writeFileSync(target, [
         JSON.stringify({ type: 'user', message: { role: 'user', content: 'go' } }),
-        JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Rollback: none needed. rm is fine.' }] } }),
+        JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Nothing to present here.' }] } }),
       ].join('\n') + '\n');
       fs.symlinkSync(target, link);
       const call = { tool_name: 'Bash', tool_input: { command: 'rm -rf /tmp/egc-facts-link' }, transcript_path: link };
       runBashHook(call, { EGC_SESSION_ID: session });
       const retry = runBashHook(call, { EGC_SESSION_ID: session });
       assert.strictEqual(retry.code, 0, retry.stderr);
-      assert.ok(!retry.stdout.includes('"deny"'), 'without a readable transcript the identical-retry rule applies, the planted facts are never read');
+      assert.ok(!retry.stdout.includes('"deny"'), 'the link is not followed: the identical-retry rule applies instead of the planted transcript, whose text would fail the facts');
     } finally {
       fs.rmSync(outside, { recursive: true, force: true });
     }

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -550,6 +550,33 @@ function runTests() {
     assert.ok(!later.stdout.includes('"deny"'), later.stdout);
   })) passed++; else failed++;
 
+  if (test('a transcript link that points outside the allowed roots is not read', () => {
+    let outside;
+    try {
+      outside = fs.mkdtempSync('/var/tmp/egc-gateguard-');
+    } catch (_) {
+      console.log('  - skipped: no writable directory outside the home and temp roots');
+      return;
+    }
+    const session = 'facts-link-' + Date.now();
+    const target = path.join(outside, 'planted.jsonl');
+    const link = path.join(stateDir, 'linked-transcript.jsonl');
+    try {
+      fs.writeFileSync(target, [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'go' } }),
+        JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Rollback: none needed. rm is fine.' }] } }),
+      ].join('\n') + '\n');
+      fs.symlinkSync(target, link);
+      const call = { tool_name: 'Bash', tool_input: { command: 'rm -rf /tmp/egc-facts-link' }, transcript_path: link };
+      runBashHook(call, { EGC_SESSION_ID: session });
+      const retry = runBashHook(call, { EGC_SESSION_ID: session });
+      assert.strictEqual(retry.code, 0, retry.stderr);
+      assert.ok(!retry.stdout.includes('"deny"'), 'without a readable transcript the identical-retry rule applies, the planted facts are never read');
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('a retry without a readable transcript keeps the identical-retry rule', () => {
     const session = 'facts-none-' + Date.now();
     const call = { tool_name: 'Bash', tool_input: { command: 'rm -rf /tmp/egc-facts-none' }, transcript_path: path.join(stateDir, 'missing.jsonl') };

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -490,7 +490,7 @@ function runTests() {
 
     assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
     assert.ok(!output.hookSpecificOutput.permissionDecisionReason.includes('GATEGUARD=off'),
-      'denial reason should show the canonical direct recovery env toggle');
+      'denial reason should no longer advertise the GATEGUARD=off recovery toggle');
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('EGC_DISABLED_HOOKS'),
       'denial reason should mention the canonical hook-id disable control');
   })) passed++; else failed++;

--- a/tests/team-sync-envelope.test.js
+++ b/tests/team-sync-envelope.test.js
@@ -101,6 +101,13 @@ async function runTests() {
       }
       const outcome = teamSync.mergeTeamStateFrom(syncDir, localDir, teamKey, personalKey);
       if (linkedParent) {
+        const linkedLocalRoot = path.join(dir, 'linked-local-root');
+        fs.symlinkSync(path.join(dir, 'parent-target'), linkedLocalRoot, 'dir');
+        const viaLink = teamSync.mergeTeamStateFrom(syncDir, linkedLocalRoot, teamKey, personalKey);
+        assert.strictEqual(viaLink.merged, 0, 'nothing is merged into a local tree that is a link');
+        assert.ok(viaLink.rejected.some(entry => entry.includes('local tree is a link')), JSON.stringify(viaLink.rejected));
+        assert.throws(() => teamSync.stageTeamState(linkedLocalRoot, syncDir, teamKey, personalKey), /local state tree is a link/);
+        assert.strictEqual(fs.readdirSync(path.join(dir, 'parent-target')).length, 0, 'nothing is written through the linked root');
         assert.ok(outcome.rejected.some(entry => entry.startsWith(path.join('linked-parent', 'note.md'))), 'a local parent that is a link is refused');
         assert.strictEqual(fs.readdirSync(path.join(dir, 'parent-target')).length, 0, 'nothing is written through the linked parent');
         outcome.rejected = outcome.rejected.filter(entry => !entry.startsWith(path.join('linked-parent', 'note.md')));

--- a/tests/team-sync-envelope.test.js
+++ b/tests/team-sync-envelope.test.js
@@ -50,31 +50,55 @@ async function runTests() {
   const doc = (updated, body) => `# Project State\nupdated: ${updated}\n\n${body}\n`;
   try {
     if (test('an envelope opens with the team key and with nothing else', () => {
-      const sealed = envelope.sealEnvelope('hello team', teamKey);
-      assert.strictEqual(envelope.openEnvelope(sealed, teamKey), 'hello team');
-      assert.strictEqual(envelope.openEnvelope(sealed, otherKey), null);
+      const sealed = envelope.sealEnvelope('hello team', teamKey, 'proj/main.md');
+      assert.strictEqual(envelope.openEnvelope(sealed, teamKey, 'proj/main.md'), 'hello team');
+      assert.strictEqual(envelope.openEnvelope(sealed, teamKey, path.join('proj', 'main.md')), 'hello team', 'the platform separator is normalized');
+      assert.strictEqual(envelope.openEnvelope(sealed, otherKey, 'proj/main.md'), null);
+      assert.strictEqual(envelope.openEnvelope(sealed, teamKey, 'other/main.md'), null, 'an envelope copied to another path is refused');
       const parsed = JSON.parse(sealed);
+      assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, path: 'other/main.md' }), teamKey, 'other/main.md'), null, 'a rewritten path breaks the signature');
       const flipped = Buffer.from(parsed.data, 'base64');
       flipped[flipped.length - 1] ^= 0x01;
-      assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, data: flipped.toString('base64') }), teamKey), null);
-      assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, mac: parsed.mac.replace(/^./, c => (c === 'a' ? 'b' : 'a')) }), teamKey), null);
-      assert.strictEqual(envelope.openEnvelope('# Project State\nupdated: 2026-01-01\n', teamKey), null);
-      assert.strictEqual(envelope.openEnvelope('{"egcTeamEnvelope":1}', teamKey), null);
+      assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, data: flipped.toString('base64') }), teamKey, 'proj/main.md'), null);
+      assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, mac: parsed.mac.replace(/^./, c => (c === 'a' ? 'b' : 'a')) }), teamKey, 'proj/main.md'), null);
+      assert.strictEqual(envelope.openEnvelope('# Project State\nupdated: 2026-01-01\n', teamKey, 'proj/main.md'), null);
+      assert.strictEqual(envelope.openEnvelope('{"egcTeamEnvelope":1}', teamKey, 'proj/main.md'), null);
     })) passed++; else failed++;
 
     if (test('the merge takes a newer verified envelope, keeps newer local state, and rejects everything else', () => {
       fs.mkdirSync(path.join(syncDir, 'proj'), { recursive: true });
       fs.mkdirSync(path.join(localDir, 'proj'), { recursive: true });
-      fs.writeFileSync(path.join(syncDir, 'proj', 'newer.md'), envelope.sealEnvelope(doc('2026-09-04T12:00:00.000Z', 'remote wins'), teamKey));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'newer.md'), envelope.sealEnvelope(doc('2026-09-04T12:00:00.000Z', 'remote wins'), teamKey, 'proj/newer.md'));
       encryption.writeStateFile(path.join(localDir, 'proj', 'newer.md'), doc('2026-09-01T12:00:00.000Z', 'local old'), personalKey);
-      fs.writeFileSync(path.join(syncDir, 'proj', 'older.md'), envelope.sealEnvelope(doc('2026-08-01T12:00:00.000Z', 'remote old'), teamKey));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'older.md'), envelope.sealEnvelope(doc('2026-08-01T12:00:00.000Z', 'remote old'), teamKey, 'proj/older.md'));
       encryption.writeStateFile(path.join(localDir, 'proj', 'older.md'), doc('2026-09-03T12:00:00.000Z', 'local wins'), personalKey);
-      fs.writeFileSync(path.join(syncDir, 'proj', 'fresh.md'), envelope.sealEnvelope(doc('2026-09-02T12:00:00.000Z', 'brand new'), teamKey));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'fresh.md'), envelope.sealEnvelope(doc('2026-09-02T12:00:00.000Z', 'brand new'), teamKey, 'proj/fresh.md'));
       fs.writeFileSync(path.join(syncDir, 'proj', 'plain.md'), doc('2026-09-09T12:00:00.000Z', 'injected in the clear'));
-      fs.writeFileSync(path.join(syncDir, 'proj', 'foreign.md'), envelope.sealEnvelope(doc('2026-09-09T12:00:00.000Z', 'sealed with another key'), otherKey));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'foreign.md'), envelope.sealEnvelope(doc('2026-09-09T12:00:00.000Z', 'sealed with another key'), otherKey, 'proj/foreign.md'));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'moved.md'), envelope.sealEnvelope(doc('2026-09-09T12:00:00.000Z', 'copied from elsewhere'), teamKey, 'proj/newer.md'));
+      fs.writeFileSync(path.join(localDir, 'proj', 'legacy.md'), doc('2026-09-08T12:00:00.000Z', 'legacy plaintext, newer than the team'));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'legacy.md'), envelope.sealEnvelope(doc('2026-08-08T12:00:00.000Z', 'older remote'), teamKey, 'proj/legacy.md'));
+      encryption.writeStateFile(path.join(localDir, 'proj', 'locked.md'), doc('2026-01-01T12:00:00.000Z', 'sealed under a rotated key'), otherKey);
+      fs.writeFileSync(path.join(syncDir, 'proj', 'locked.md'), envelope.sealEnvelope(doc('2026-09-09T12:00:00.000Z', 'would replace it'), teamKey, 'proj/locked.md'));
+      let linked;
+      try {
+        fs.symlinkSync(path.join(dir, 'elsewhere.md'), path.join(syncDir, 'proj', 'link.md'));
+        linked = true;
+      } catch {
+        linked = false;
+      }
       const outcome = teamSync.mergeTeamStateFrom(syncDir, localDir, teamKey, personalKey);
-      assert.deepStrictEqual(outcome.rejected.sort(), ['proj/foreign.md', 'proj/plain.md'].map(p => p.split('/').join(path.sep)));
-      assert.strictEqual(outcome.merged, 2);
+      const expectedRejected = ['proj/foreign.md', 'proj/moved.md', 'proj/plain.md'].concat(linked ? ['proj/link.md'] : []).map(p => p.split('/').join(path.sep)).sort();
+      assert.deepStrictEqual(outcome.rejected.sort(), expectedRejected);
+      assert.deepStrictEqual(outcome.unreadable, [path.join('proj', 'locked.md')]);
+      assert.strictEqual(outcome.merged, 3, 'newer, fresh and the legacy plaintext rewrite');
+      for (const name of ['foreign.md', 'moved.md', 'plain.md'].concat(linked ? ['link.md'] : [])) {
+        assert.ok(!fs.existsSync(path.join(syncDir, 'proj', name)), `${name} is removed from the sync tree`);
+      }
+      assert.ok(fs.existsSync(path.join(syncDir, 'proj', 'locked.md')), 'a verified envelope stays in the sync tree');
+      assert.ok(encryption.isEncrypted(fs.readFileSync(path.join(localDir, 'proj', 'legacy.md'))), 'legacy plaintext is rewritten encrypted');
+      assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'legacy.md'), personalKey).includes('legacy plaintext'));
+      assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'locked.md'), otherKey).includes('rotated key'), 'the unreadable local file is untouched');
       assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'newer.md'), personalKey).includes('remote wins'));
       assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'older.md'), personalKey).includes('local wins'));
       assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'fresh.md'), personalKey).includes('brand new'));
@@ -86,13 +110,14 @@ async function runTests() {
     if (test('staging seals every local file with the team key and nothing leaves in the clear', () => {
       const stagedDir = path.join(dir, 'staged');
       const count = teamSync.stageTeamState(localDir, stagedDir, teamKey, personalKey);
-      assert.strictEqual(count, 3);
-      for (const name of ['newer.md', 'older.md', 'fresh.md']) {
+      assert.strictEqual(count, 4, 'newer, older, fresh and the rewritten legacy file; the unreadable one is left out');
+      for (const name of ['newer.md', 'older.md', 'fresh.md', 'legacy.md']) {
         const raw = fs.readFileSync(path.join(stagedDir, 'proj', name), 'utf8');
         assert.ok(!raw.includes('Project State'), `${name} is not in the clear`);
-        assert.ok(envelope.openEnvelope(raw, teamKey).includes('Project State'), `${name} opens with the team key`);
-        assert.strictEqual(envelope.openEnvelope(raw, otherKey), null);
+        assert.ok(envelope.openEnvelope(raw, teamKey, `proj/${name}`).includes('Project State'), `${name} opens with the team key at its path`);
+        assert.strictEqual(envelope.openEnvelope(raw, otherKey, `proj/${name}`), null);
       }
+      assert.ok(!fs.existsSync(path.join(stagedDir, 'proj', 'locked.md')), 'an undecryptable local file is not staged');
     })) passed++; else failed++;
 
     if (test('the team key is validated and generated as 64 hex characters', () => {

--- a/tests/team-sync-envelope.test.js
+++ b/tests/team-sync-envelope.test.js
@@ -45,6 +45,14 @@ async function runTests() {
   const otherKey = crypto.randomBytes(32);
   const personalKey = crypto.randomBytes(32);
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-team-envelope-'));
+  const isLinkPath = (candidate) => {
+    try {
+      return fs.lstatSync(candidate).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  };
+
   const syncDir = path.join(dir, 'sync');
   const localDir = path.join(dir, 'local');
   const doc = (updated, body) => `# Project State\nupdated: ${updated}\n\n${body}\n`;
@@ -107,6 +115,22 @@ async function runTests() {
         assert.strictEqual(viaLink.merged, 0, 'nothing is merged into a local tree that is a link');
         assert.ok(viaLink.rejected.some(entry => entry.includes('local tree is a link')), JSON.stringify(viaLink.rejected));
         assert.throws(() => teamSync.stageTeamState(linkedLocalRoot, syncDir, teamKey, personalKey), /local state tree is a link/);
+        const linkedLocalParent = path.join(dir, 'linked-parent-of-local', 'state');
+        fs.symlinkSync(path.join(dir, 'parent-target'), path.join(dir, 'linked-parent-of-local'), 'dir');
+        const viaParent = teamSync.mergeTeamStateFrom(syncDir, linkedLocalParent, teamKey, personalKey);
+        assert.strictEqual(viaParent.merged, 0, 'nothing is merged below a linked parent');
+        assert.throws(() => teamSync.stageTeamState(linkedLocalParent, syncDir, teamKey, personalKey), /local state tree is a link/);
+        fs.mkdirSync(path.join(dir, 'sync-target'), { recursive: true });
+        const linkedSyncRoot = path.join(dir, 'linked-sync-root');
+        fs.symlinkSync(path.join(dir, 'sync-target'), linkedSyncRoot, 'dir');
+        const viaSyncLink = teamSync.mergeTeamStateFrom(linkedSyncRoot, localDir, teamKey, personalKey);
+        assert.ok(viaSyncLink.rejected.some(entry => entry.includes('sync tree is a link')), JSON.stringify(viaSyncLink.rejected));
+        assert.ok(!fs.existsSync(linkedSyncRoot) && !isLinkPath(linkedSyncRoot), 'the linked sync tree is removed from the checkout');
+        assert.ok(fs.existsSync(path.join(dir, 'sync-target')), 'the target of the link is untouched');
+        fs.symlinkSync(path.join(dir, 'sync-target'), linkedSyncRoot, 'dir');
+        assert.throws(() => teamSync.stageTeamState(localDir, linkedSyncRoot, teamKey, personalKey), /sync state tree is a link/);
+        assert.strictEqual(fs.readdirSync(path.join(dir, 'sync-target')).length, 0, 'nothing is staged through the linked sync tree');
+
         assert.strictEqual(fs.readdirSync(path.join(dir, 'parent-target')).length, 0, 'nothing is written through the linked root');
         assert.ok(outcome.rejected.some(entry => entry.startsWith(path.join('linked-parent', 'note.md'))), 'a local parent that is a link is refused');
         assert.strictEqual(fs.readdirSync(path.join(dir, 'parent-target')).length, 0, 'nothing is written through the linked parent');

--- a/tests/team-sync-envelope.test.js
+++ b/tests/team-sync-envelope.test.js
@@ -1,0 +1,111 @@
+/**
+ * Team sync envelopes: state leaves the machine sealed with the team key and
+ * only verified envelopes reach local state (security audit 2026-08-17,
+ * day 10 of the schedule). Runs against the built memory server modules.
+ */
+'use strict';
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const BUILD = path.join(__dirname, '..', 'mcp', 'servers', 'egc-memory', 'build');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+async function runTests() {
+  console.log('\n=== Testing team sync envelopes ===\n');
+  let envelope;
+  let teamSync;
+  let encryption;
+  try {
+    envelope = await import(pathToFileURL(path.join(BUILD, 'sync', 'envelope.js')).href);
+    teamSync = await import(pathToFileURL(path.join(BUILD, 'sync', 'TeamSync.js')).href);
+    encryption = await import(pathToFileURL(path.join(BUILD, 'encryption.js')).href);
+  } catch (error) {
+    console.error(`[SKIP] Could not import the memory server build: ${error.message}. Run 'npm run build' in mcp/servers/egc-memory first.`);
+    process.exit(0);
+  }
+  let passed = 0;
+  let failed = 0;
+  const teamKey = crypto.randomBytes(32);
+  const otherKey = crypto.randomBytes(32);
+  const personalKey = crypto.randomBytes(32);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-team-envelope-'));
+  const syncDir = path.join(dir, 'sync');
+  const localDir = path.join(dir, 'local');
+  const doc = (updated, body) => `# Project State\nupdated: ${updated}\n\n${body}\n`;
+  try {
+    if (test('an envelope opens with the team key and with nothing else', () => {
+      const sealed = envelope.sealEnvelope('hello team', teamKey);
+      assert.strictEqual(envelope.openEnvelope(sealed, teamKey), 'hello team');
+      assert.strictEqual(envelope.openEnvelope(sealed, otherKey), null);
+      const parsed = JSON.parse(sealed);
+      const flipped = Buffer.from(parsed.data, 'base64');
+      flipped[flipped.length - 1] ^= 0x01;
+      assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, data: flipped.toString('base64') }), teamKey), null);
+      assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, mac: parsed.mac.replace(/^./, c => (c === 'a' ? 'b' : 'a')) }), teamKey), null);
+      assert.strictEqual(envelope.openEnvelope('# Project State\nupdated: 2026-01-01\n', teamKey), null);
+      assert.strictEqual(envelope.openEnvelope('{"egcTeamEnvelope":1}', teamKey), null);
+    })) passed++; else failed++;
+
+    if (test('the merge takes a newer verified envelope, keeps newer local state, and rejects everything else', () => {
+      fs.mkdirSync(path.join(syncDir, 'proj'), { recursive: true });
+      fs.mkdirSync(path.join(localDir, 'proj'), { recursive: true });
+      fs.writeFileSync(path.join(syncDir, 'proj', 'newer.md'), envelope.sealEnvelope(doc('2026-09-04T12:00:00.000Z', 'remote wins'), teamKey));
+      encryption.writeStateFile(path.join(localDir, 'proj', 'newer.md'), doc('2026-09-01T12:00:00.000Z', 'local old'), personalKey);
+      fs.writeFileSync(path.join(syncDir, 'proj', 'older.md'), envelope.sealEnvelope(doc('2026-08-01T12:00:00.000Z', 'remote old'), teamKey));
+      encryption.writeStateFile(path.join(localDir, 'proj', 'older.md'), doc('2026-09-03T12:00:00.000Z', 'local wins'), personalKey);
+      fs.writeFileSync(path.join(syncDir, 'proj', 'fresh.md'), envelope.sealEnvelope(doc('2026-09-02T12:00:00.000Z', 'brand new'), teamKey));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'plain.md'), doc('2026-09-09T12:00:00.000Z', 'injected in the clear'));
+      fs.writeFileSync(path.join(syncDir, 'proj', 'foreign.md'), envelope.sealEnvelope(doc('2026-09-09T12:00:00.000Z', 'sealed with another key'), otherKey));
+      const outcome = teamSync.mergeTeamStateFrom(syncDir, localDir, teamKey, personalKey);
+      assert.deepStrictEqual(outcome.rejected.sort(), ['proj/foreign.md', 'proj/plain.md'].map(p => p.split('/').join(path.sep)));
+      assert.strictEqual(outcome.merged, 2);
+      assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'newer.md'), personalKey).includes('remote wins'));
+      assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'older.md'), personalKey).includes('local wins'));
+      assert.ok(encryption.readStateFile(path.join(localDir, 'proj', 'fresh.md'), personalKey).includes('brand new'));
+      assert.ok(!fs.existsSync(path.join(localDir, 'proj', 'plain.md')));
+      assert.ok(!fs.existsSync(path.join(localDir, 'proj', 'foreign.md')));
+      assert.ok(encryption.isEncrypted(fs.readFileSync(path.join(localDir, 'proj', 'fresh.md'))), 'local state stays encrypted at rest');
+    })) passed++; else failed++;
+
+    if (test('staging seals every local file with the team key and nothing leaves in the clear', () => {
+      const stagedDir = path.join(dir, 'staged');
+      const count = teamSync.stageTeamState(localDir, stagedDir, teamKey, personalKey);
+      assert.strictEqual(count, 3);
+      for (const name of ['newer.md', 'older.md', 'fresh.md']) {
+        const raw = fs.readFileSync(path.join(stagedDir, 'proj', name), 'utf8');
+        assert.ok(!raw.includes('Project State'), `${name} is not in the clear`);
+        assert.ok(envelope.openEnvelope(raw, teamKey).includes('Project State'), `${name} opens with the team key`);
+        assert.strictEqual(envelope.openEnvelope(raw, otherKey), null);
+      }
+    })) passed++; else failed++;
+
+    if (test('the team key is validated and generated as 64 hex characters', () => {
+      assert.ok(/^[0-9a-f]{64}$/.test(envelope.generateTeamKey()));
+      assert.strictEqual(envelope.parseTeamKey('not-a-key'), null);
+      assert.strictEqual(envelope.parseTeamKey(undefined), null);
+      assert.strictEqual(envelope.parseTeamKey(teamKey.toString('hex')).equals(teamKey), true);
+    })) passed++; else failed++;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/team-sync-envelope.test.js
+++ b/tests/team-sync-envelope.test.js
@@ -55,6 +55,8 @@ async function runTests() {
       assert.strictEqual(envelope.openEnvelope(sealed, teamKey, path.join('proj', 'main.md')), 'hello team', 'the platform separator is normalized');
       assert.strictEqual(envelope.openEnvelope(sealed, otherKey, 'proj/main.md'), null);
       assert.strictEqual(envelope.openEnvelope(sealed, teamKey, 'other/main.md'), null, 'an envelope copied to another path is refused');
+      if (path.sep === '/') assert.strictEqual(envelope.openEnvelope(envelope.sealEnvelope('x', teamKey, 'a\\b.md'), teamKey, 'a/b.md'), null, 'a backslash in a POSIX name is not a separator');
+
       const parsed = JSON.parse(sealed);
       assert.strictEqual(envelope.openEnvelope(JSON.stringify({ ...parsed, path: 'other/main.md' }), teamKey, 'other/main.md'), null, 'a rewritten path breaks the signature');
       const flipped = Buffer.from(parsed.data, 'base64');
@@ -87,7 +89,22 @@ async function runTests() {
       } catch {
         linked = false;
       }
+      let linkedParent;
+      try {
+        fs.mkdirSync(path.join(dir, 'parent-target'), { recursive: true });
+        fs.symlinkSync(path.join(dir, 'parent-target'), path.join(localDir, 'linked-parent'), 'dir');
+        fs.mkdirSync(path.join(syncDir, 'linked-parent'), { recursive: true });
+        fs.writeFileSync(path.join(syncDir, 'linked-parent', 'note.md'), envelope.sealEnvelope(doc('2026-09-09T12:00:00.000Z', 'through a linked parent'), teamKey, 'linked-parent/note.md'));
+        linkedParent = true;
+      } catch {
+        linkedParent = false;
+      }
       const outcome = teamSync.mergeTeamStateFrom(syncDir, localDir, teamKey, personalKey);
+      if (linkedParent) {
+        assert.ok(outcome.rejected.some(entry => entry.startsWith(path.join('linked-parent', 'note.md'))), 'a local parent that is a link is refused');
+        assert.strictEqual(fs.readdirSync(path.join(dir, 'parent-target')).length, 0, 'nothing is written through the linked parent');
+        outcome.rejected = outcome.rejected.filter(entry => !entry.startsWith(path.join('linked-parent', 'note.md')));
+      }
       const expectedRejected = ['proj/foreign.md', 'proj/moved.md', 'proj/plain.md'].concat(linked ? ['proj/link.md'] : []).map(p => p.split('/').join(path.sep)).sort();
       assert.deepStrictEqual(outcome.rejected.sort(), expectedRejected);
       assert.deepStrictEqual(outcome.unreadable, [path.join('proj', 'locked.md')]);


### PR DESCRIPTION
## What

Day 10 of the security schedule (17/08 audit).

- **TeamSync.** `team_sync` mirrored the personally encrypted state files into the shared repository and merged whatever came back, so anyone who could write to the repository could plant state, and files sealed under another member's personal key were opaque anyway. Each file is now decrypted locally, sealed with the **team key** (AES-256-GCM plus an HMAC-SHA256 signature over the ciphertext) and pushed as a JSON envelope; the merge opens only envelopes that verify with the key and an intact signature, keeps the newer document by its `updated` timestamp, writes local state through the personal key, and reports every other file as rejected. The key is generated at `team_init` (returned once, to be shared out of band) and teammates join with `team_key` / `egc team init --key`. Without a valid key nothing is synced.
- **GateGuard.** The recovery hint no longer names `EGC_GATEGUARD=off`. The first retry after a denial is accepted only when the assistant message written before it presents the required facts (a rollback procedure and the command word for destructive Bash; the file name for edits, multi-edits and Codex patches), read from the harness transcript named in the hook input; later operations on the same target stay free as before, and a harness without a readable transcript keeps the identical-retry rule.

## Proof

- `tests/team-sync-envelope.test.js` (new, 4/4, against the built server): an envelope opens only with the team key and only when intact; the merge takes a newer verified envelope, keeps newer local state, rejects a file in the clear and one sealed with another key, and leaves local state encrypted at rest; staging seals every file and nothing leaves in the clear; key validation.
- `tests/hooks/gateguard-fact-force.test.js` +3 (52/52): a destructive retry is refused until the message names a rollback and the command; an edit retry is refused until the message names the file, and later edits stay free; a retry without a readable transcript keeps the identical-retry rule; the hint no longer contains the switch. Cursor and Windsurf GateGuard suites pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes team sync so shared state can't be tampered with in the repository, and makes GateGuard require the preceding message to state facts before accepting a retry after a denial.

**Bug Fixes**
- Team sync decrypts state locally, seals it with the team key (AES-256-GCM plus HMAC-SHA256) into envelopes bound to their repository path, and merges only envelopes that verify; anything unverified is rejected and removed from the working tree, and a link anywhere between the home or temp root and a sync or local state tree blocks that side's merge or staging.
- The key is generated at `team_init` and shown once; teammates join with `--key` or `team_key`, and without a valid key nothing syncs.
- State stays encrypted at rest (legacy plaintext is rewritten), undecryptable local files are left untouched, the config directory is 0700 and `team.json` is 0600 written atomically via temp-and-rename, and the CLI no longer falls back to pushing the state directory directly.
- GateGuard's recovery hint no longer names `EGC_GATEGUARD=off`, and the first retry after a denial is accepted only when the prior assistant message names the required facts (rollback and command word for destructive Bash; file name for edits), read from the harness transcript when available.
- Transcripts are resolved to their real location and read only from an absolute `.jsonl` path under the home or temp directory, so a symlink pointing elsewhere is never read; harnesses without a readable transcript keep the previous identical-retry rule.
- Teams syncing under the old scheme must re-initialize with a team key; existing repo state won't open with it.

<sup>Written for commit caba82d58423d592d5af008fbdbe1be50a56502a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

