### PR TITLE
fix(security): refuse to install through symbolic links, and keep memory provider notes under their root

### DIFF
--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -1,6 +1,8 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { hasParentSegment, isAnchoredPath } = require('./path-safety');
+const { replaceFileWith } = require('./install/preserving-write');
+
 
 let Ajv = null;
 try {
@@ -334,7 +336,9 @@ function readInstallState(filePath) {
 function writeInstallState(filePath, state) {
   assertValidInstallState(state, filePath);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`);
+  // The state file lands like every managed file: an exclusive temporary
+  // renamed over the destination, so a link there is replaced, not followed.
+  replaceFileWith(filePath, descriptor => fs.writeFileSync(descriptor, `${JSON.stringify(state, null, 2)}\n`));
   return state;
 }
 

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -265,8 +265,12 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
   const resolvedClaudeHooksPlan = buildResolvedClaudeHooks(plan);
   const disabledServers = parseDisabledMcpServers(process.env.EGC_DISABLED_MCPS || process.env.ECC_DISABLED_MCPS);
 
+  // Every destination is checked before the first write, the state file
+  // included, so a planted link fails the install before it changes anything.
+  refuseLinkedDestination(plan.installStatePath, plan.targetRoot);
   for (const operation of plan.operations) {
     refuseLinkedDestination(operation.destinationPath, plan.targetRoot);
+
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
 
 
@@ -296,8 +300,8 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
     );
   }
 
-  refuseLinkedDestination(plan.installStatePath, plan.targetRoot);
   writeInstallState(plan.installStatePath, plan.statePreview);
+
 
   writeGuardianCliMarker(onWarning, homeDir);
 

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -265,10 +265,13 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
   const resolvedClaudeHooksPlan = buildResolvedClaudeHooks(plan);
   const disabledServers = parseDisabledMcpServers(process.env.EGC_DISABLED_MCPS || process.env.ECC_DISABLED_MCPS);
 
-  // Every destination is checked before the first write, the state file
-  // included, so a planted link fails the install before it changes anything.
+  // Every destination is checked before the first write, the state file and
+  // the hooks file included, so a planted link fails the install before it
+  // changes anything.
   refuseLinkedDestination(plan.installStatePath, plan.targetRoot);
+  if (resolvedClaudeHooksPlan) refuseLinkedDestination(resolvedClaudeHooksPlan.hooksDestinationPath, plan.targetRoot);
   for (const operation of plan.operations) {
+
     refuseLinkedDestination(operation.destinationPath, plan.targetRoot);
 
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -225,9 +225,14 @@ function resolvePackageRoot() {
 // existing ones are unaffected -- so it is logged and swallowed rather than
 // failing the whole install.
 function writeGuardianCliMarker(onWarning, homeDir) {
-  const markerPath = path.join(homeDir || os.homedir(), '.egc', 'guardian-cli-path.json');
+  const home = homeDir || os.homedir();
+  const markerPath = path.join(home, '.egc', 'guardian-cli-path.json');
   try {
+    // The marker's own directory answers to the same link check as every
+    // install destination; a linked ~/.egc turns the write into a warning.
+    refuseLinkedDestination(markerPath, home);
     fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+
     writeManagedText(markerPath, `${JSON.stringify({ packageRoot: resolvePackageRoot() }, null, 2)}\n`);
   } catch (error) {
     const msg = `Warning: Failed to write Guardian CLI marker: ${error.message}`;
@@ -346,6 +351,8 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
 module.exports = {
   applyInstallPlan,
   refuseLinkedDestination,
+  writeGuardianCliMarker,
   writeManagedText,
+
 
 };

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -236,12 +236,39 @@ function writeGuardianCliMarker(onWarning, homeDir) {
   }
 }
 
+// The installer never writes through a link: a destination that is a
+// symbolic link, or that sits under a linked directory strictly inside the
+// target root, is refused before anything is created. The root itself may be
+// a link the user made (a dotfiles manager, say); what lies below it is what
+// the installer owns.
+function refuseLinkedDestination(destinationPath, targetRoot) {
+  const root = targetRoot ? path.resolve(targetRoot) : null;
+  let probe = path.resolve(destinationPath);
+  for (;;) {
+    let stat;
+    try {
+      stat = fs.lstatSync(probe);
+    } catch {
+      stat = null;
+    }
+    if (stat?.isSymbolicLink()) {
+      throw new Error(`Refusing to write through a symbolic link at ${probe}`);
+    }
+    const parent = path.dirname(probe);
+    if (!root || parent === probe || parent === root || !parent.startsWith(root + path.sep)) break;
+    probe = parent;
+  }
+}
+
 function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
+
   const resolvedClaudeHooksPlan = buildResolvedClaudeHooks(plan);
   const disabledServers = parseDisabledMcpServers(process.env.EGC_DISABLED_MCPS || process.env.ECC_DISABLED_MCPS);
 
   for (const operation of plan.operations) {
+    refuseLinkedDestination(operation.destinationPath, plan.targetRoot);
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
+
 
     if (operation.kind === HOOK_OPERATION_KIND) {
       applyManagedHookOperation(operation);
@@ -259,7 +286,9 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
   }
 
   if (resolvedClaudeHooksPlan) {
+    refuseLinkedDestination(resolvedClaudeHooksPlan.hooksDestinationPath, plan.targetRoot);
     fs.mkdirSync(path.dirname(resolvedClaudeHooksPlan.hooksDestinationPath), { recursive: true });
+
     fs.writeFileSync(
       resolvedClaudeHooksPlan.hooksDestinationPath,
       JSON.stringify(resolvedClaudeHooksPlan.resolvedHooksConfig, null, 2) + '\n',
@@ -300,4 +329,5 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
 
 module.exports = {
   applyInstallPlan,
+  refuseLinkedDestination,
 };

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -7,7 +7,8 @@ const path = require('node:path');
 const { writeInstallState } = require('../install-state');
 const { syncInstallStateToStore } = require('../install-state-store-sync');
 const { assertSafeMcpConfig, filterMcpConfig, isMcpConfigPath, parseDisabledMcpServers, parseMcpConfigText } = require('../mcp-config');
-const { writeTextKeepingMode } = require('./preserving-write');
+const { copyFileKeepingMode, replaceFileWith, writeTextKeepingMode } = require('./preserving-write');
+
 const {
   HOOK_OPERATION_KIND,
   applyManagedHookOperation,
@@ -144,8 +145,9 @@ function applyMergeJsonOperation(operation, disabledServers) {
     ? readJsonObject(operation.destinationPath, 'existing JSON config')
     : {};
   const mergedValue = deepMergeJson(currentValue, filteredPayload);
-  fs.writeFileSync(operation.destinationPath, formatJson(mergedValue), 'utf8');
+  writeManagedText(operation.destinationPath, formatJson(mergedValue));
 }
+
 
 function applyMergeYamlReadListOperation(operation) {
   if (!operation.readEntry) {
@@ -167,7 +169,7 @@ function applyMergeYamlReadListOperation(operation) {
       { cause: error },
     );
   }
-  fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
+  writeManagedText(operation.destinationPath, nextContent);
 }
 
 function applyMergeMarkdownIndexOperation(operation) {
@@ -179,7 +181,7 @@ function applyMergeMarkdownIndexOperation(operation) {
     description: operation.skillDescription,
     relativePath: operation.relativePath,
   });
-  fs.writeFileSync(operation.destinationPath, nextContent, 'utf8');
+  writeManagedText(operation.destinationPath, nextContent);
 }
 
 // The text that was validated is the text that lands (or the filtered form
@@ -226,11 +228,7 @@ function writeGuardianCliMarker(onWarning, homeDir) {
   const markerPath = path.join(homeDir || os.homedir(), '.egc', 'guardian-cli-path.json');
   try {
     fs.mkdirSync(path.dirname(markerPath), { recursive: true });
-    fs.writeFileSync(
-      markerPath,
-      `${JSON.stringify({ packageRoot: resolvePackageRoot() }, null, 2)}\n`,
-      'utf8'
-    );
+    writeManagedText(markerPath, `${JSON.stringify({ packageRoot: resolvePackageRoot() }, null, 2)}\n`);
   } catch (error) {
     const msg = `Warning: Failed to write Guardian CLI marker: ${error.message}`;
     if (typeof onWarning === 'function') {
@@ -246,6 +244,13 @@ function writeGuardianCliMarker(onWarning, homeDir) {
 // target root, is refused before anything is created. The root itself may be
 // a link the user made (a dotfiles manager, say); what lies below it is what
 // the installer owns.
+// Every managed file lands through an exclusive temporary and a rename, so a
+// link at the destination (planted before the pre-flight check or swapped in
+// after it) is replaced, never written through.
+function writeManagedText(destinationPath, text) {
+  replaceFileWith(destinationPath, descriptor => fs.writeFileSync(descriptor, text, 'utf8'));
+}
+
 function refuseLinkedDestination(destinationPath, targetRoot) {
   const root = targetRoot ? path.resolve(targetRoot) : null;
   let probe = path.resolve(destinationPath);
@@ -293,7 +298,8 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
     } else if (operation.kind === 'copy-file' && isMcpConfigPath(operation.destinationPath)) {
       applyMcpCopyFileOperation(operation, disabledServers);
     } else {
-      fs.copyFileSync(operation.sourcePath, operation.destinationPath);
+      copyFileKeepingMode(operation.sourcePath, operation.destinationPath);
+
     }
   }
 
@@ -301,11 +307,7 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
     refuseLinkedDestination(resolvedClaudeHooksPlan.hooksDestinationPath, plan.targetRoot);
     fs.mkdirSync(path.dirname(resolvedClaudeHooksPlan.hooksDestinationPath), { recursive: true });
 
-    fs.writeFileSync(
-      resolvedClaudeHooksPlan.hooksDestinationPath,
-      JSON.stringify(resolvedClaudeHooksPlan.resolvedHooksConfig, null, 2) + '\n',
-      'utf8'
-    );
+    writeManagedText(resolvedClaudeHooksPlan.hooksDestinationPath, `${JSON.stringify(resolvedClaudeHooksPlan.resolvedHooksConfig, null, 2)}\n`);
   }
 
   writeInstallState(plan.installStatePath, plan.statePreview);
@@ -344,4 +346,6 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
 module.exports = {
   applyInstallPlan,
   refuseLinkedDestination,
+  writeManagedText,
+
 };

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -296,7 +296,9 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
     );
   }
 
+  refuseLinkedDestination(plan.installStatePath, plan.targetRoot);
   writeInstallState(plan.installStatePath, plan.statePreview);
+
   writeGuardianCliMarker(onWarning, homeDir);
 
   // Capture the async promise so callers (e.g. install() in the operations

--- a/src/llm/memory/paths.py
+++ b/src/llm/memory/paths.py
@@ -5,9 +5,10 @@ else.
 """
 import os
 import re
+import secrets
 import stat
-import tempfile
 from pathlib import Path
+
 
 
 from typing import Optional
@@ -38,90 +39,149 @@ def safe_title(value: object) -> Optional[str]:
 
 
 
-def _private_mode(target: Path) -> Optional[int]:
-    """The permission bits of an existing regular `target`, else None."""
-    try:
-        status = os.lstat(target)
-    except OSError:
-        return None
-    return stat.S_IMODE(status.st_mode) if stat.S_ISREG(status.st_mode) else None
-
-
-def write_text_atomic(target: Path, text: str) -> None:
-    """Replace `target` with `text` through a unique temporary sibling and a
-    rename, so a link (hard or symbolic) planted at the target is replaced,
-    never written through; the existing file's mode is kept and the
-    temporary never survives a failure."""
-    mode = _private_mode(target)
-    descriptor, temporary = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-            handle.write(text)
-        if mode is not None:
-            os.chmod(temporary, mode)
-        os.replace(temporary, target)
-    except BaseException:
-        try:
-            os.unlink(temporary)
-        except OSError:
-            pass
-        raise
-
-
 def _is_private_regular(status: os.stat_result) -> bool:
     """A regular file with a single name: not a link of any kind."""
     return stat.S_ISREG(status.st_mode) and status.st_nlink == 1
 
 
-def _open_private(target: Path, flags: int) -> Optional[int]:
-    """A descriptor on `target` when it is a regular file with a single name
-    that was not reached through a symbolic link. The checks are made on the
-    opened descriptor and on the name after the open, so a link swapped in
-    around the open is caught even where O_NOFOLLOW is unavailable."""
-    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
-    try:
-        descriptor = os.open(target, flags, 0o600)
-    except OSError:
-        return None
-    try:
-        opened = os.fstat(descriptor)
-        named = os.lstat(target)
-        same = (named.st_ino, named.st_dev) == (opened.st_ino, opened.st_dev)
-        if _is_private_regular(opened) and not stat.S_ISLNK(named.st_mode) and same:
-            return descriptor
-    except OSError:
-        pass
-    os.close(descriptor)
-    return None
+def _write_all(descriptor: int, data: bytes) -> None:
+    """Write the whole buffer; a write that makes no progress is an error,
+    never a spin."""
+    view = memoryview(data)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("write made no progress")
+        view = view[written:]
 
 
-def read_text_if_regular(target: Path) -> str:
-    """The text of `target` when it is a regular file with a single name
-    (neither a symbolic nor a hard link), read from the checked descriptor."""
-    descriptor = _open_private(target, os.O_RDONLY)
-    if descriptor is None:
-        return ""
-    with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
-        return handle.read()
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_BINARY = getattr(os, "O_BINARY", 0)
+_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+# Directory descriptors bind every operation to the directory that was
+# checked; where the platform has none (Windows), operations use the path.
+_DIRECTORY_DESCRIPTORS = bool(_DIRECTORY) and all(
+    operation in os.supports_dir_fd for operation in (os.open, os.stat, os.replace, os.unlink)
+)
 
 
-def append_text_private(target: Path, text: str) -> bool:
-    """Append `text` to `target`, creating it when missing, never through a
-    link and never partially: the whole buffer is written on the checked
-    descriptor. Concurrent appends keep each other's lines."""
-    descriptor = _open_private(target, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
-    if descriptor is None:
-        return False
-    data = text.encode("utf-8")
-    try:
-        while data:
-            data = data[os.write(descriptor, data):]
-        return True
-    finally:
+class PrivateDirectory:
+    """A category directory the provider works in. Where the platform allows
+    it the directory is held open as a descriptor obtained without following
+    links, and every file operation is relative to that descriptor, so a
+    directory swapped for a link after the check can no longer redirect
+    anything. Elsewhere the operations use the directory path, with the same
+    per-file checks."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.descriptor: Optional[int] = None
+        if _DIRECTORY_DESCRIPTORS:
+            descriptor = os.open(path, os.O_RDONLY | _DIRECTORY | _NOFOLLOW)
+            if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+                os.close(descriptor)
+                raise NotADirectoryError(str(path))
+            self.descriptor = descriptor
+
+    def __enter__(self) -> "PrivateDirectory":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self.descriptor is not None:
+            os.close(self.descriptor)
+            self.descriptor = None
+
+    def _where(self) -> dict:
+        return {"dir_fd": self.descriptor} if self.descriptor is not None else {}
+
+    def _target(self, name: str) -> str:
+        return name if self.descriptor is not None else str(self.path / name)
+
+    def _lstat(self, name: str) -> Optional[os.stat_result]:
+        try:
+            return os.lstat(self._target(name), **self._where())
+        except OSError:
+            return None
+
+    def _open_private(self, name: str, flags: int) -> Optional[int]:
+        """A descriptor on `name` when it is a regular file with a single
+        name that was not reached through a symbolic link. The name is
+        checked before the open (so, without O_NOFOLLOW, nothing is created
+        behind a dangling link) and the opened descriptor is compared with
+        the name after the open."""
+        named = self._lstat(name)
+        if named is not None and stat.S_ISLNK(named.st_mode):
+            return None
+        try:
+            descriptor = os.open(self._target(name), flags | _NOFOLLOW | _BINARY, 0o600, **self._where())
+        except OSError:
+            return None
+        try:
+            opened = os.fstat(descriptor)
+            named = os.lstat(self._target(name), **self._where())
+            same = (named.st_ino, named.st_dev) == (opened.st_ino, opened.st_dev)
+            if _is_private_regular(opened) and not stat.S_ISLNK(named.st_mode) and same:
+                return descriptor
+        except OSError:
+            pass
         os.close(descriptor)
+        return None
 
+    def read_text(self, name: str) -> str:
+        """The text of `name` when it is a regular file with a single name,
+        read from the checked descriptor; '' otherwise."""
+        descriptor = self._open_private(name, os.O_RDONLY)
+        if descriptor is None:
+            return ""
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            return handle.read()
 
+    def append_text(self, name: str, text: str) -> bool:
+        """Append `text` to `name`, creating it when missing, never through a
+        link and never partially. Concurrent appends keep each other's lines."""
+        descriptor = self._open_private(name, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+        if descriptor is None:
+            return False
+        try:
+            _write_all(descriptor, text.encode("utf-8"))
+            return True
+        finally:
+            os.close(descriptor)
 
+    def write_text_atomic(self, name: str, text: str) -> None:
+        """Replace `name` with `text` through a unique temporary sibling and a
+        rename, so a link (hard or symbolic) planted at the name is replaced,
+        never written through; the existing file's mode is kept and the
+        temporary never survives a failure."""
+        existing = self._lstat(name)
+        mode = stat.S_IMODE(existing.st_mode) if existing is not None and stat.S_ISREG(existing.st_mode) else None
+        temporary = f".{name}.{os.getpid()}.{secrets.token_hex(4)}.tmp"
+        descriptor = os.open(self._target(temporary), os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW | _BINARY, 0o600, **self._where())
+        try:
+            _write_all(descriptor, text.encode("utf-8"))
+            if mode is not None:
+                self._chmod(descriptor, temporary, mode)
+            os.close(descriptor)
+            descriptor = None
+            replace_where = {"src_dir_fd": self.descriptor, "dst_dir_fd": self.descriptor} if self.descriptor is not None else {}
+            os.replace(self._target(temporary), self._target(name), **replace_where)
+        except BaseException:
+            if descriptor is not None:
+                os.close(descriptor)
+            try:
+                os.unlink(self._target(temporary), **self._where())
+            except OSError:
+                pass
+            raise
+
+    def _chmod(self, descriptor: int, temporary: str, mode: int) -> None:
+        if os.chmod in os.supports_fd:
+            os.chmod(descriptor, mode)
+        else:
+            os.chmod(self._target(temporary), mode)
 
 
 def resolve_inside(root: Path, *parts: str) -> Optional[Path]:

--- a/src/llm/memory/paths.py
+++ b/src/llm/memory/paths.py
@@ -68,7 +68,13 @@ _DIRECTORY_DESCRIPTORS = bool(_DIRECTORY) and all(
 
 
 
+def supports_directory_descriptors() -> bool:
+    """Whether this platform binds a directory by descriptor (see above)."""
+    return _DIRECTORY_DESCRIPTORS
+
+
 class PrivateDirectory:
+
     """A category directory the provider works in. Where the platform allows
     it the directory is held open as a descriptor obtained without following
     links, and every file operation is relative to that descriptor, so a

--- a/src/llm/memory/paths.py
+++ b/src/llm/memory/paths.py
@@ -60,9 +60,12 @@ _BINARY = getattr(os, "O_BINARY", 0)
 _DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 # Directory descriptors bind every operation to the directory that was
 # checked; where the platform has none (Windows), operations use the path.
+# os.replace shares os.rename's implementation and is not listed on its own,
+# so rename is the operation probed for it.
 _DIRECTORY_DESCRIPTORS = bool(_DIRECTORY) and all(
-    operation in os.supports_dir_fd for operation in (os.open, os.stat, os.replace, os.unlink)
+    operation in os.supports_dir_fd for operation in (os.open, os.stat, os.rename, os.unlink)
 )
+
 
 
 class PrivateDirectory:

--- a/src/llm/memory/paths.py
+++ b/src/llm/memory/paths.py
@@ -1,0 +1,41 @@
+"""
+Path hygiene for the memory providers: a category, a session id or a title
+supplied by a caller names one entry under the provider's root and nothing
+else.
+"""
+import re
+from pathlib import Path
+from typing import Optional
+
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def safe_segment(value: object) -> Optional[str]:
+    """One path segment from a category or a session id, or None when the
+    value could name anything but a plain entry under the root."""
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text in {".", ".."} or not _SEGMENT_RE.match(text):
+        return None
+    return text
+
+
+def safe_title(value: object) -> Optional[str]:
+    """A file stem from a note title: spaces become underscores and anything
+    a path or a filesystem could interpret is replaced."""
+    if not isinstance(value, str):
+        return None
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", value.strip().replace(" ", "_")).strip("._-")
+    return stem[:120] or None
+
+
+def resolve_inside(root: Path, *parts: str) -> Optional[Path]:
+    """The path root/parts, or None when it would resolve outside the root."""
+    base = root.resolve()
+    candidate = base.joinpath(*parts).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError:
+        return None
+    return candidate

--- a/src/llm/memory/paths.py
+++ b/src/llm/memory/paths.py
@@ -73,36 +73,53 @@ def _is_private_regular(status: os.stat_result) -> bool:
     return stat.S_ISREG(status.st_mode) and status.st_nlink == 1
 
 
+def _open_private(target: Path, flags: int) -> Optional[int]:
+    """A descriptor on `target` when it is a regular file with a single name
+    that was not reached through a symbolic link. The checks are made on the
+    opened descriptor and on the name after the open, so a link swapped in
+    around the open is caught even where O_NOFOLLOW is unavailable."""
+    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    try:
+        descriptor = os.open(target, flags, 0o600)
+    except OSError:
+        return None
+    try:
+        opened = os.fstat(descriptor)
+        named = os.lstat(target)
+        same = (named.st_ino, named.st_dev) == (opened.st_ino, opened.st_dev)
+        if _is_private_regular(opened) and not stat.S_ISLNK(named.st_mode) and same:
+            return descriptor
+    except OSError:
+        pass
+    os.close(descriptor)
+    return None
+
+
 def read_text_if_regular(target: Path) -> str:
     """The text of `target` when it is a regular file with a single name
-    (neither a symbolic nor a hard link), else ''."""
-    try:
-        status = os.lstat(target)
-    except OSError:
+    (neither a symbolic nor a hard link), read from the checked descriptor."""
+    descriptor = _open_private(target, os.O_RDONLY)
+    if descriptor is None:
         return ""
-    if not _is_private_regular(status):
-        return ""
-    with open(target, "r", encoding="utf-8") as handle:
+    with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
         return handle.read()
 
 
 def append_text_private(target: Path, text: str) -> bool:
-    """Append `text` to `target` in one write, creating it when missing, and
-    never through a link: the file is opened without following symbolic
-    links and refused when it has more than one name. Concurrent appends
-    keep each other's lines."""
-    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
-    try:
-        descriptor = os.open(target, flags, 0o600)
-    except OSError:
+    """Append `text` to `target`, creating it when missing, never through a
+    link and never partially: the whole buffer is written on the checked
+    descriptor. Concurrent appends keep each other's lines."""
+    descriptor = _open_private(target, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+    if descriptor is None:
         return False
+    data = text.encode("utf-8")
     try:
-        if not _is_private_regular(os.fstat(descriptor)):
-            return False
-        os.write(descriptor, text.encode("utf-8"))
+        while data:
+            data = data[os.write(descriptor, data):]
         return True
     finally:
         os.close(descriptor)
+
 
 
 

--- a/src/llm/memory/paths.py
+++ b/src/llm/memory/paths.py
@@ -5,7 +5,10 @@ else.
 """
 import os
 import re
+import stat
+import tempfile
 from pathlib import Path
+
 
 from typing import Optional
 
@@ -30,25 +33,77 @@ def safe_title(value: object) -> Optional[str]:
     if not isinstance(value, str):
         return None
     stem = re.sub(r"[^\w.-]+", "_", value.strip().replace(" ", "_")).strip("._-")
-    return stem[:120] or None
+    # Filesystems bound names in bytes: cut on a character boundary.
+    return stem.encode("utf-8")[:120].decode("utf-8", "ignore") or None
+
+
+
+def _private_mode(target: Path) -> Optional[int]:
+    """The permission bits of an existing regular `target`, else None."""
+    try:
+        status = os.lstat(target)
+    except OSError:
+        return None
+    return stat.S_IMODE(status.st_mode) if stat.S_ISREG(status.st_mode) else None
 
 
 def write_text_atomic(target: Path, text: str) -> None:
-    """Replace `target` with `text` through a temporary sibling and a rename,
-    so a link (hard or symbolic) planted at the target is replaced, never
-    written through."""
-    temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
-    with open(temporary, "x", encoding="utf-8") as handle:
-        handle.write(text)
-    os.replace(temporary, target)
+    """Replace `target` with `text` through a unique temporary sibling and a
+    rename, so a link (hard or symbolic) planted at the target is replaced,
+    never written through; the existing file's mode is kept and the
+    temporary never survives a failure."""
+    mode = _private_mode(target)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        if mode is not None:
+            os.chmod(temporary, mode)
+        os.replace(temporary, target)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _is_private_regular(status: os.stat_result) -> bool:
+    """A regular file with a single name: not a link of any kind."""
+    return stat.S_ISREG(status.st_mode) and status.st_nlink == 1
 
 
 def read_text_if_regular(target: Path) -> str:
-    """The text of `target` when it is a regular file (not a link), else ''."""
-    if not target.is_file() or target.is_symlink():
+    """The text of `target` when it is a regular file with a single name
+    (neither a symbolic nor a hard link), else ''."""
+    try:
+        status = os.lstat(target)
+    except OSError:
+        return ""
+    if not _is_private_regular(status):
         return ""
     with open(target, "r", encoding="utf-8") as handle:
         return handle.read()
+
+
+def append_text_private(target: Path, text: str) -> bool:
+    """Append `text` to `target` in one write, creating it when missing, and
+    never through a link: the file is opened without following symbolic
+    links and refused when it has more than one name. Concurrent appends
+    keep each other's lines."""
+    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(target, flags, 0o600)
+    except OSError:
+        return False
+    try:
+        if not _is_private_regular(os.fstat(descriptor)):
+            return False
+        os.write(descriptor, text.encode("utf-8"))
+        return True
+    finally:
+        os.close(descriptor)
+
 
 
 

--- a/src/llm/memory/paths.py
+++ b/src/llm/memory/paths.py
@@ -3,8 +3,10 @@ Path hygiene for the memory providers: a category, a session id or a title
 supplied by a caller names one entry under the provider's root and nothing
 else.
 """
+import os
 import re
 from pathlib import Path
+
 from typing import Optional
 
 _SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -22,12 +24,32 @@ def safe_segment(value: object) -> Optional[str]:
 
 
 def safe_title(value: object) -> Optional[str]:
-    """A file stem from a note title: spaces become underscores and anything
-    a path or a filesystem could interpret is replaced."""
+    """A file stem from a note title: spaces become underscores, letters and
+    digits of any script stay, and anything a path or a filesystem could
+    interpret is replaced."""
     if not isinstance(value, str):
         return None
-    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", value.strip().replace(" ", "_")).strip("._-")
+    stem = re.sub(r"[^\w.-]+", "_", value.strip().replace(" ", "_")).strip("._-")
     return stem[:120] or None
+
+
+def write_text_atomic(target: Path, text: str) -> None:
+    """Replace `target` with `text` through a temporary sibling and a rename,
+    so a link (hard or symbolic) planted at the target is replaced, never
+    written through."""
+    temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+    with open(temporary, "x", encoding="utf-8") as handle:
+        handle.write(text)
+    os.replace(temporary, target)
+
+
+def read_text_if_regular(target: Path) -> str:
+    """The text of `target` when it is a regular file (not a link), else ''."""
+    if not target.is_file() or target.is_symlink():
+        return ""
+    with open(target, "r", encoding="utf-8") as handle:
+        return handle.read()
+
 
 
 def resolve_inside(root: Path, *parts: str) -> Optional[Path]:

--- a/src/llm/memory/providers/filesystem.py
+++ b/src/llm/memory/providers/filesystem.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from typing import List, Optional
 
 from llm.memory.base import CognitiveMemoryProvider, MemoryEntry
-from llm.memory.paths import append_text_private, read_text_if_regular, resolve_inside, safe_segment, safe_title, write_text_atomic
+from llm.memory.paths import PrivateDirectory, resolve_inside, safe_segment, safe_title
+
 
 
 
@@ -40,9 +41,7 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
             if target_dir is None:
                 return False
             target_dir.mkdir(exist_ok=True)
-            # The name as spelled, under a directory proven real: a link at the
-            # note's own name is replaced by the atomic write, never followed.
-            file_path = target_dir / f"{stem}.md"
+
 
             # Frontmatter (Standard YAML for Obsidian compatibility); every
             # value is a JSON scalar or list, which YAML reads as-is, so
@@ -52,8 +51,13 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
             lines.extend(f"{json.dumps(str(k))}: {json.dumps(str(v))}" for k, v in entry.metadata.items())
             lines.append("---")
 
-            write_text_atomic(file_path, "\n".join(lines) + "\n\n" + entry.content)
+            # The name as spelled, inside the directory held by descriptor: a
+            # link at the note's own name is replaced by the atomic write,
+            # never followed.
+            with PrivateDirectory(target_dir) as directory:
+                directory.write_text_atomic(f"{stem}.md", "\n".join(lines) + "\n\n" + entry.content)
             return True
+
         except Exception:
             return False
 
@@ -64,7 +68,9 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
             if target_dir is None or not target_dir.is_dir():
                 return False
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            return append_text_private(target_dir / "Journal.md", f"\n### {timestamp}\n\n{content}\n")
+            with PrivateDirectory(target_dir) as directory:
+                return directory.append_text("Journal.md", f"\n### {timestamp}\n\n{content}\n")
+
 
 
         except Exception:
@@ -83,12 +89,17 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
             return None
         # The same naming as the note the session end writes ("Session <id>
         # Summary"), with the session start note as the fallback.
-        for title in (f"Session {session_id} Summary", f"Session {session_id}"):
-            stem = safe_title(title)
-            text = read_text_if_regular(sessions / f"{stem}.md") if stem else ""
-            if text:
-                return text
+        try:
+            with PrivateDirectory(sessions) as directory:
+                for title in (f"Session {session_id} Summary", f"Session {session_id}"):
+                    stem = safe_title(title)
+                    text = directory.read_text(f"{stem}.md") if stem else ""
+                    if text:
+                        return text
+        except OSError:
+            return None
         return None
+
 
     def _real_directory(self, segment: str) -> Optional[Path]:
         """The category directory as spelled, when it is inside the root and

--- a/src/llm/memory/providers/filesystem.py
+++ b/src/llm/memory/providers/filesystem.py
@@ -3,12 +3,15 @@ Shared filesystem implementation of the Cognitive Memory Provider: notes live
 under one root, and every name a caller supplies (category, title, session
 id) is bound to that root before anything is read or written.
 """
+import json
 from datetime import datetime
+
 from pathlib import Path
 from typing import List, Optional
 
 from llm.memory.base import CognitiveMemoryProvider, MemoryEntry
-from llm.memory.paths import read_text_if_regular, resolve_inside, safe_segment, safe_title, write_text_atomic
+from llm.memory.paths import append_text_private, read_text_if_regular, resolve_inside, safe_segment, safe_title, write_text_atomic
+
 
 
 class FilesystemMemoryProvider(CognitiveMemoryProvider):
@@ -38,11 +41,14 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
             if target_dir is None or file_path is None:
                 return False
             target_dir.mkdir(exist_ok=True)
-            # Frontmatter (Standard YAML for Obsidian compatibility)
-            lines = ["---", f"title: \"{entry.title}\"", f"category: {entry.category}",
-                     f"tags: [egc, {', '.join(entry.tags)}]", f"timestamp: {entry.timestamp.isoformat()}"]
-            lines.extend(f"{k}: \"{v}\"" for k, v in entry.metadata.items())
+            # Frontmatter (Standard YAML for Obsidian compatibility); every
+            # value is a JSON scalar or list, which YAML reads as-is, so
+            # quotes and newlines in a title or a metadata value stay data.
+            lines = ["---", f"title: {json.dumps(str(entry.title))}", f"category: {json.dumps(str(entry.category))}",
+                     f"tags: {json.dumps(['egc', *map(str, entry.tags)])}", f"timestamp: {entry.timestamp.isoformat()}"]
+            lines.extend(f"{json.dumps(str(k))}: {json.dumps(str(v))}" for k, v in entry.metadata.items())
             lines.append("---")
+
             write_text_atomic(file_path, "\n".join(lines) + "\n\n" + entry.content)
             return True
         except Exception:
@@ -55,8 +61,8 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
             if journal_path is None or not journal_path.parent.is_dir():
                 return False
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            write_text_atomic(journal_path, read_text_if_regular(journal_path) + f"\n### {timestamp}\n\n{content}\n")
-            return True
+            return append_text_private(journal_path, f"\n### {timestamp}\n\n{content}\n")
+
         except Exception:
             return False
 
@@ -65,9 +71,14 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
         return []
 
     def get_session_summary(self, session_id: str) -> Optional[str]:
-        segment = safe_segment(session_id)
-        summary_path = resolve_inside(self.root, "Sessions", f"session_{segment}.md") if segment else None
-        if summary_path is not None and summary_path.exists():
-            with open(summary_path, "r", encoding="utf-8") as f:
-                return f.read()
+        # The same naming as the note the session end writes ("Session <id>
+        # Summary"), with the session start note as the fallback.
+        for title in (f"Session {session_id} Summary", f"Session {session_id}"):
+            stem = safe_title(title)
+            summary_path = resolve_inside(self.root, "Sessions", f"{stem}.md") if stem else None
+            if summary_path is not None:
+                text = read_text_if_regular(summary_path)
+                if text:
+                    return text
         return None
+

--- a/src/llm/memory/providers/filesystem.py
+++ b/src/llm/memory/providers/filesystem.py
@@ -36,11 +36,14 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
             stem = safe_title(entry.title)
             if category is None or stem is None:
                 return False
-            target_dir = resolve_inside(self.root, category)
-            file_path = resolve_inside(self.root, category, f"{stem}.md")
-            if target_dir is None or file_path is None:
+            target_dir = self._real_directory(category)
+            if target_dir is None:
                 return False
             target_dir.mkdir(exist_ok=True)
+            # The name as spelled, under a directory proven real: a link at the
+            # note's own name is replaced by the atomic write, never followed.
+            file_path = target_dir / f"{stem}.md"
+
             # Frontmatter (Standard YAML for Obsidian compatibility); every
             # value is a JSON scalar or list, which YAML reads as-is, so
             # quotes and newlines in a title or a metadata value stay data.
@@ -57,11 +60,12 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
     def append_journal(self, category: str, content: str) -> bool:
         try:
             segment = safe_segment(category)
-            journal_path = resolve_inside(self.root, segment, "Journal.md") if segment else None
-            if journal_path is None or not journal_path.parent.is_dir():
+            target_dir = self._real_directory(segment) if segment else None
+            if target_dir is None or not target_dir.is_dir():
                 return False
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            return append_text_private(journal_path, f"\n### {timestamp}\n\n{content}\n")
+            return append_text_private(target_dir / "Journal.md", f"\n### {timestamp}\n\n{content}\n")
+
 
         except Exception:
             return False
@@ -71,14 +75,28 @@ class FilesystemMemoryProvider(CognitiveMemoryProvider):
         return []
 
     def get_session_summary(self, session_id: str) -> Optional[str]:
+        # A session id is one path segment; anything else names no session.
+        if safe_segment(session_id) != session_id:
+            return None
+        sessions = self._real_directory("Sessions")
+        if sessions is None:
+            return None
         # The same naming as the note the session end writes ("Session <id>
         # Summary"), with the session start note as the fallback.
         for title in (f"Session {session_id} Summary", f"Session {session_id}"):
             stem = safe_title(title)
-            summary_path = resolve_inside(self.root, "Sessions", f"{stem}.md") if stem else None
-            if summary_path is not None:
-                text = read_text_if_regular(summary_path)
-                if text:
-                    return text
+            text = read_text_if_regular(sessions / f"{stem}.md") if stem else ""
+            if text:
+                return text
         return None
+
+    def _real_directory(self, segment: str) -> Optional[Path]:
+        """The category directory as spelled, when it is inside the root and
+        neither it nor the root is a symbolic link (a link inside the root
+        would alias another category)."""
+        lexical = self.root / segment
+        if self.root.is_symlink() or lexical.is_symlink() or resolve_inside(self.root, segment) is None:
+            return None
+        return lexical
+
 

--- a/src/llm/memory/providers/filesystem.py
+++ b/src/llm/memory/providers/filesystem.py
@@ -1,0 +1,73 @@
+"""
+Shared filesystem implementation of the Cognitive Memory Provider: notes live
+under one root, and every name a caller supplies (category, title, session
+id) is bound to that root before anything is read or written.
+"""
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from llm.memory.base import CognitiveMemoryProvider, MemoryEntry
+from llm.memory.paths import read_text_if_regular, resolve_inside, safe_segment, safe_title, write_text_atomic
+
+
+class FilesystemMemoryProvider(CognitiveMemoryProvider):
+    SUBDIRECTORIES = ("Sessions", "Archaeology", "Governance", "Traces")
+
+    def __init__(self, root: Path, namespace: str = "EGC"):
+        self.root = root
+        self.namespace = namespace
+
+    def initialize(self) -> bool:
+        try:
+            self.root.mkdir(parents=True, exist_ok=True)
+            for sub in self.SUBDIRECTORIES:
+                (self.root / sub).mkdir(exist_ok=True)
+            return True
+        except Exception:
+            return False
+
+    def write_note(self, entry: MemoryEntry) -> bool:
+        try:
+            category = safe_segment(entry.category)
+            stem = safe_title(entry.title)
+            if category is None or stem is None:
+                return False
+            target_dir = resolve_inside(self.root, category)
+            file_path = resolve_inside(self.root, category, f"{stem}.md")
+            if target_dir is None or file_path is None:
+                return False
+            target_dir.mkdir(exist_ok=True)
+            # Frontmatter (Standard YAML for Obsidian compatibility)
+            lines = ["---", f"title: \"{entry.title}\"", f"category: {entry.category}",
+                     f"tags: [egc, {', '.join(entry.tags)}]", f"timestamp: {entry.timestamp.isoformat()}"]
+            lines.extend(f"{k}: \"{v}\"" for k, v in entry.metadata.items())
+            lines.append("---")
+            write_text_atomic(file_path, "\n".join(lines) + "\n\n" + entry.content)
+            return True
+        except Exception:
+            return False
+
+    def append_journal(self, category: str, content: str) -> bool:
+        try:
+            segment = safe_segment(category)
+            journal_path = resolve_inside(self.root, segment, "Journal.md") if segment else None
+            if journal_path is None or not journal_path.parent.is_dir():
+                return False
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            write_text_atomic(journal_path, read_text_if_regular(journal_path) + f"\n### {timestamp}\n\n{content}\n")
+            return True
+        except Exception:
+            return False
+
+    def search_memory(self, query: str) -> List[MemoryEntry]:
+        # Placeholder for future indexed search
+        return []
+
+    def get_session_summary(self, session_id: str) -> Optional[str]:
+        segment = safe_segment(session_id)
+        summary_path = resolve_inside(self.root, "Sessions", f"session_{segment}.md") if segment else None
+        if summary_path is not None and summary_path.exists():
+            with open(summary_path, "r", encoding="utf-8") as f:
+                return f.read()
+        return None

--- a/src/llm/memory/providers/local.py
+++ b/src/llm/memory/providers/local.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from datetime import datetime
 
 from llm.memory.base import CognitiveMemoryProvider, MemoryEntry
+from llm.memory.paths import resolve_inside, safe_segment, safe_title
+
 
 class LocalFileProvider(CognitiveMemoryProvider):
     def __init__(self, workspace_root: str, namespace: str = "EGC"):
@@ -25,12 +27,16 @@ class LocalFileProvider(CognitiveMemoryProvider):
 
     def write_note(self, entry: MemoryEntry) -> bool:
         try:
-            target_dir = self.root / entry.category
+            category = safe_segment(entry.category)
+            stem = safe_title(entry.title)
+            if category is None or stem is None:
+                return False
+            target_dir = resolve_inside(self.root, category)
+            file_path = resolve_inside(self.root, category, f"{stem}.md")
+            if target_dir is None or file_path is None:
+                return False
             target_dir.mkdir(exist_ok=True)
-            
-            # Sanitize title for filename
-            safe_title = entry.title.replace(" ", "_").replace("/", "-")
-            file_path = target_dir / f"{safe_title}.md"
+
             
             with open(file_path, "w", encoding="utf-8") as f:
                 # Frontmatter
@@ -49,7 +55,11 @@ class LocalFileProvider(CognitiveMemoryProvider):
 
     def append_journal(self, category: str, content: str) -> bool:
         try:
-            journal_path = self.root / category / "Journal.md"
+            segment = safe_segment(category)
+            journal_path = resolve_inside(self.root, segment, "Journal.md") if segment else None
+            if journal_path is None or not journal_path.parent.is_dir():
+                return False
+
             with open(journal_path, "a", encoding="utf-8") as f:
                 timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 f.write(f"\n### {timestamp}\n\n{content}\n")
@@ -63,8 +73,10 @@ class LocalFileProvider(CognitiveMemoryProvider):
 
     def get_session_summary(self, session_id: str) -> Optional[str]:
         # Retrieve from Sessions dir
-        summary_path = self.root / "Sessions" / f"session_{session_id}.md"
-        if summary_path.exists():
+        segment = safe_segment(session_id)
+        summary_path = resolve_inside(self.root, "Sessions", f"session_{segment}.md") if segment else None
+        if summary_path is not None and summary_path.exists():
+
             with open(summary_path, "r", encoding="utf-8") as f:
                 return f.read()
         return None

--- a/src/llm/memory/providers/local.py
+++ b/src/llm/memory/providers/local.py
@@ -1,82 +1,11 @@
 """
 Local filesystem implementation of the Cognitive Memory Provider.
 """
-import os
-import json
-from typing import List, Optional
 from pathlib import Path
-from datetime import datetime
 
-from llm.memory.base import CognitiveMemoryProvider, MemoryEntry
-from llm.memory.paths import resolve_inside, safe_segment, safe_title
+from llm.memory.providers.filesystem import FilesystemMemoryProvider
 
 
-class LocalFileProvider(CognitiveMemoryProvider):
+class LocalFileProvider(FilesystemMemoryProvider):
     def __init__(self, workspace_root: str, namespace: str = "EGC"):
-        self.root = Path(workspace_root) / ".sessions" / "memory" / namespace
-        self.namespace = namespace
-
-    def initialize(self) -> bool:
-        try:
-            self.root.mkdir(parents=True, exist_ok=True)
-            for sub in ["Sessions", "Archaeology", "Governance", "Traces"]:
-                (self.root / sub).mkdir(exist_ok=True)
-            return True
-        except Exception:
-            return False
-
-    def write_note(self, entry: MemoryEntry) -> bool:
-        try:
-            category = safe_segment(entry.category)
-            stem = safe_title(entry.title)
-            if category is None or stem is None:
-                return False
-            target_dir = resolve_inside(self.root, category)
-            file_path = resolve_inside(self.root, category, f"{stem}.md")
-            if target_dir is None or file_path is None:
-                return False
-            target_dir.mkdir(exist_ok=True)
-
-            
-            with open(file_path, "w", encoding="utf-8") as f:
-                # Frontmatter
-                f.write("---\n")
-                f.write(f"title: {entry.title}\n")
-                f.write(f"category: {entry.category}\n")
-                f.write(f"tags: [{', '.join(entry.tags)}]\n")
-                f.write(f"timestamp: {entry.timestamp.isoformat()}\n")
-                for k, v in entry.metadata.items():
-                    f.write(f"{k}: {v}\n")
-                f.write("---\n\n")
-                f.write(entry.content)
-            return True
-        except Exception:
-            return False
-
-    def append_journal(self, category: str, content: str) -> bool:
-        try:
-            segment = safe_segment(category)
-            journal_path = resolve_inside(self.root, segment, "Journal.md") if segment else None
-            if journal_path is None or not journal_path.parent.is_dir():
-                return False
-
-            with open(journal_path, "a", encoding="utf-8") as f:
-                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                f.write(f"\n### {timestamp}\n\n{content}\n")
-            return True
-        except Exception:
-            return False
-
-    def search_memory(self, query: str) -> List[MemoryEntry]:
-        # Basic grep-like search (placeholder for now)
-        return []
-
-    def get_session_summary(self, session_id: str) -> Optional[str]:
-        # Retrieve from Sessions dir
-        segment = safe_segment(session_id)
-        summary_path = resolve_inside(self.root, "Sessions", f"session_{segment}.md") if segment else None
-        if summary_path is not None and summary_path.exists():
-
-            with open(summary_path, "r", encoding="utf-8") as f:
-                return f.read()
-        return None
+        super().__init__(Path(workspace_root) / ".sessions" / "memory" / namespace, namespace)

--- a/src/llm/memory/providers/obsidian.py
+++ b/src/llm/memory/providers/obsidian.py
@@ -2,81 +2,16 @@
 Obsidian Vault implementation of the Cognitive Memory Provider.
 """
 import os
-from typing import List, Optional
 from pathlib import Path
-from datetime import datetime
 
-from llm.memory.base import CognitiveMemoryProvider, MemoryEntry
-from llm.memory.paths import resolve_inside, safe_segment, safe_title
+from llm.memory.providers.filesystem import FilesystemMemoryProvider
 
 
-class ObsidianVaultProvider(CognitiveMemoryProvider):
+class ObsidianVaultProvider(FilesystemMemoryProvider):
     def __init__(self, vault_path: str, namespace: str = "EGC"):
-        self.root = Path(os.path.expanduser(vault_path)) / namespace
-        self.namespace = namespace
+        super().__init__(Path(os.path.expanduser(vault_path)) / namespace, namespace)
 
     def initialize(self) -> bool:
-        try:
-            if not self.root.parent.exists():
-                return False  # Vault path must exist
-            self.root.mkdir(parents=True, exist_ok=True)
-            for sub in ["Sessions", "Archaeology", "Governance", "Traces"]:
-                (self.root / sub).mkdir(exist_ok=True)
-            return True
-        except Exception:
-            return False
-
-    def write_note(self, entry: MemoryEntry) -> bool:
-        try:
-            category = safe_segment(entry.category)
-            stem = safe_title(entry.title)
-            if category is None or stem is None:
-                return False
-            target_dir = resolve_inside(self.root, category)
-            file_path = resolve_inside(self.root, category, f"{stem}.md")
-            if target_dir is None or file_path is None:
-                return False
-            target_dir.mkdir(exist_ok=True)
-
-            
-            with open(file_path, "w", encoding="utf-8") as f:
-                # Frontmatter (Standard YAML for Obsidian compatibility)
-                f.write("---\n")
-                f.write(f"title: \"{entry.title}\"\n")
-                f.write(f"category: {entry.category}\n")
-                f.write(f"tags: [egc, {', '.join(entry.tags)}]\n")
-                f.write(f"timestamp: {entry.timestamp.isoformat()}\n")
-                for k, v in entry.metadata.items():
-                    f.write(f"{k}: \"{v}\"\n")
-                f.write("---\n\n")
-                f.write(entry.content)
-            return True
-        except Exception:
-            return False
-
-    def append_journal(self, category: str, content: str) -> bool:
-        try:
-            segment = safe_segment(category)
-            journal_path = resolve_inside(self.root, segment, "Journal.md") if segment else None
-            if journal_path is None or not journal_path.parent.is_dir():
-                return False
-
-            with open(journal_path, "a", encoding="utf-8") as f:
-                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                f.write(f"\n### {timestamp}\n\n{content}\n")
-            return True
-        except Exception:
-            return False
-
-    def search_memory(self, query: str) -> List[MemoryEntry]:
-        # Placeholder for future Local REST API integration
-        return []
-
-    def get_session_summary(self, session_id: str) -> Optional[str]:
-        segment = safe_segment(session_id)
-        summary_path = resolve_inside(self.root, "Sessions", f"session_{segment}.md") if segment else None
-        if summary_path is not None and summary_path.exists():
-
-            with open(summary_path, "r", encoding="utf-8") as f:
-                return f.read()
-        return None
+        if not self.root.parent.exists():
+            return False  # Vault path must exist
+        return super().initialize()

--- a/src/llm/memory/providers/obsidian.py
+++ b/src/llm/memory/providers/obsidian.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from datetime import datetime
 
 from llm.memory.base import CognitiveMemoryProvider, MemoryEntry
+from llm.memory.paths import resolve_inside, safe_segment, safe_title
+
 
 class ObsidianVaultProvider(CognitiveMemoryProvider):
     def __init__(self, vault_path: str, namespace: str = "EGC"):
@@ -26,12 +28,16 @@ class ObsidianVaultProvider(CognitiveMemoryProvider):
 
     def write_note(self, entry: MemoryEntry) -> bool:
         try:
-            target_dir = self.root / entry.category
+            category = safe_segment(entry.category)
+            stem = safe_title(entry.title)
+            if category is None or stem is None:
+                return False
+            target_dir = resolve_inside(self.root, category)
+            file_path = resolve_inside(self.root, category, f"{stem}.md")
+            if target_dir is None or file_path is None:
+                return False
             target_dir.mkdir(exist_ok=True)
-            
-            # Sanitize title for filename
-            safe_title = entry.title.replace(" ", "_").replace("/", "-")
-            file_path = target_dir / f"{safe_title}.md"
+
             
             with open(file_path, "w", encoding="utf-8") as f:
                 # Frontmatter (Standard YAML for Obsidian compatibility)
@@ -50,7 +56,11 @@ class ObsidianVaultProvider(CognitiveMemoryProvider):
 
     def append_journal(self, category: str, content: str) -> bool:
         try:
-            journal_path = self.root / category / "Journal.md"
+            segment = safe_segment(category)
+            journal_path = resolve_inside(self.root, segment, "Journal.md") if segment else None
+            if journal_path is None or not journal_path.parent.is_dir():
+                return False
+
             with open(journal_path, "a", encoding="utf-8") as f:
                 timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 f.write(f"\n### {timestamp}\n\n{content}\n")
@@ -63,8 +73,10 @@ class ObsidianVaultProvider(CognitiveMemoryProvider):
         return []
 
     def get_session_summary(self, session_id: str) -> Optional[str]:
-        summary_path = self.root / "Sessions" / f"session_{session_id}.md"
-        if summary_path.exists():
+        segment = safe_segment(session_id)
+        summary_path = resolve_inside(self.root, "Sessions", f"session_{segment}.md") if segment else None
+        if summary_path is not None and summary_path.exists():
+
             with open(summary_path, "r", encoding="utf-8") as f:
                 return f.read()
         return None

--- a/tests/lib/install-apply-links.test.js
+++ b/tests/lib/install-apply-links.test.js
@@ -9,7 +9,8 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { refuseLinkedDestination, writeManagedText } = require('../../scripts/lib/install/apply');
+const { refuseLinkedDestination, writeGuardianCliMarker, writeManagedText } = require('../../scripts/lib/install/apply');
+
 const { createInstallState, writeInstallState } = require('../../scripts/lib/install-state');
 
 
@@ -53,6 +54,16 @@ function runTests() {
       if (test('a destination under a linked directory inside the root is refused, even when the file does not exist yet', () => {
         assert.throws(() => refuseLinkedDestination(path.join(root, 'linked-dir', 'deep', 'new.md'), root), /symbolic link/);
         assert.ok(!fs.existsSync(path.join(outside, 'deep')));
+      })) passed++; else failed++;
+
+      if (test('the Guardian marker is not written through a linked .egc directory', () => {
+        const home = path.join(dir, 'home');
+        fs.mkdirSync(home, { recursive: true });
+        fs.symlinkSync(outside, path.join(home, '.egc'), 'dir');
+        const warnings = [];
+        writeGuardianCliMarker(message => warnings.push(message), home);
+        assert.ok(warnings.some(message => message.includes('symbolic link')), JSON.stringify(warnings));
+        assert.ok(!fs.existsSync(path.join(outside, 'guardian-cli-path.json')), 'nothing lands behind the link');
       })) passed++; else failed++;
 
       if (test('a root that is itself a link is allowed', () => {

--- a/tests/lib/install-apply-links.test.js
+++ b/tests/lib/install-apply-links.test.js
@@ -9,7 +9,9 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { refuseLinkedDestination } = require('../../scripts/lib/install/apply');
+const { refuseLinkedDestination, writeManagedText } = require('../../scripts/lib/install/apply');
+const { createInstallState, writeInstallState } = require('../../scripts/lib/install-state');
+
 
 function test(name, fn) {
   try {
@@ -58,6 +60,38 @@ function runTests() {
         assert.doesNotThrow(() => refuseLinkedDestination(path.join(viaLink, 'rules', 'plain.md'), viaLink));
       })) passed++; else failed++;
     }
+
+    if (test('a hard link at the destination is replaced and the aliased file keeps its content', () => {
+      const aliased = path.join(outside, 'aliased.md');
+      fs.writeFileSync(aliased, 'aliased content');
+      fs.mkdirSync(path.join(root, 'notes'), { recursive: true });
+      const destination = path.join(root, 'notes', 'hard.md');
+      try {
+        fs.linkSync(aliased, destination);
+      } catch (error) {
+        console.log(`  - skipped: cannot create hard links here (${error.code})`);
+        return;
+      }
+      assert.doesNotThrow(() => refuseLinkedDestination(destination, root), 'a hard link is a regular name to lstat');
+      writeManagedText(destination, 'managed');
+      assert.strictEqual(fs.readFileSync(aliased, 'utf8'), 'aliased content', 'the aliased file is untouched');
+      assert.strictEqual(fs.readFileSync(destination, 'utf8'), 'managed');
+      assert.strictEqual(fs.statSync(destination).nlink, 1, 'the destination is its own file now');
+      const statePath = path.join(root, 'notes', 'egc-install-state.json');
+      fs.linkSync(aliased, statePath);
+      const state = createInstallState({
+        adapter: { id: 'cursor-project' },
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: 'developer', modules: [], legacyLanguages: [], legacyMode: false },
+        resolution: { selectedModules: [], skippedModules: [] },
+        operations: [],
+      });
+      writeInstallState(statePath, state);
+      assert.strictEqual(fs.readFileSync(aliased, 'utf8'), 'aliased content', 'the state file never writes through a link either');
+      assert.strictEqual(fs.statSync(statePath).nlink, 1);
+      assert.strictEqual(fs.readdirSync(path.join(root, 'notes')).filter(name => name.endsWith('.tmp')).length, 0, 'no temporary survives');
+    })) passed++; else failed++;
 
     if (test('a plain destination, existing or not, passes', () => {
       fs.mkdirSync(path.join(root, 'rules'), { recursive: true });

--- a/tests/lib/install-apply-links.test.js
+++ b/tests/lib/install-apply-links.test.js
@@ -1,0 +1,76 @@
+/**
+ * The installer refuses to write through a symbolic link at the destination
+ * or under a linked directory inside the target root (security audit
+ * 2026-08-17, day 11); the root itself may be a link the user made.
+ */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { refuseLinkedDestination } = require('../../scripts/lib/install/apply');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing linked destinations in the installer ===\n');
+  let passed = 0;
+  let failed = 0;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-apply-links-'));
+  const root = path.join(dir, 'root');
+  const outside = path.join(dir, 'outside');
+  fs.mkdirSync(root, { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  let links = true;
+  try {
+    fs.writeFileSync(path.join(outside, 'target.md'), 'outside');
+    fs.symlinkSync(path.join(outside, 'target.md'), path.join(root, 'linked.md'));
+    fs.symlinkSync(outside, path.join(root, 'linked-dir'), 'dir');
+    fs.symlinkSync(root, path.join(dir, 'root-link'), 'dir');
+  } catch (error) {
+    links = false;
+    console.log(`  - skipped: cannot create symlinks here (${error.code})`);
+  }
+  try {
+    if (links) {
+      if (test('a destination that is a link is refused', () => {
+        assert.throws(() => refuseLinkedDestination(path.join(root, 'linked.md'), root), /symbolic link/);
+      })) passed++; else failed++;
+
+      if (test('a destination under a linked directory inside the root is refused, even when the file does not exist yet', () => {
+        assert.throws(() => refuseLinkedDestination(path.join(root, 'linked-dir', 'deep', 'new.md'), root), /symbolic link/);
+        assert.ok(!fs.existsSync(path.join(outside, 'deep')));
+      })) passed++; else failed++;
+
+      if (test('a root that is itself a link is allowed', () => {
+        const viaLink = path.join(dir, 'root-link');
+        assert.doesNotThrow(() => refuseLinkedDestination(path.join(viaLink, 'rules', 'plain.md'), viaLink));
+      })) passed++; else failed++;
+    }
+
+    if (test('a plain destination, existing or not, passes', () => {
+      fs.mkdirSync(path.join(root, 'rules'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'rules', 'existing.md'), 'x');
+      assert.doesNotThrow(() => refuseLinkedDestination(path.join(root, 'rules', 'existing.md'), root));
+      assert.doesNotThrow(() => refuseLinkedDestination(path.join(root, 'rules', 'later.md'), root));
+      assert.doesNotThrow(() => refuseLinkedDestination(path.join(outside, 'elsewhere.md'), root));
+    })) passed++; else failed++;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/install-apply-links.test.js
+++ b/tests/lib/install-apply-links.test.js
@@ -86,6 +86,7 @@ function runTests() {
         request: { profile: 'developer', modules: [], legacyLanguages: [], legacyMode: false },
         resolution: { selectedModules: [], skippedModules: [] },
         operations: [],
+        source: { repoVersion: require('../../package.json').version, repoCommit: 'abc123', manifestVersion: 1 },
       });
       writeInstallState(statePath, state);
       assert.strictEqual(fs.readFileSync(aliased, 'utf8'), 'aliased content', 'the state file never writes through a link either');

--- a/tests/test_memory_provider_paths.py
+++ b/tests/test_memory_provider_paths.py
@@ -85,13 +85,31 @@ class MemoryProviderPathTests(unittest.TestCase):
             self.assertIn("body", (provider.root / "Governance" / "Aliased.md").read_text(encoding="utf-8"))
             self.assertEqual([p for p in outside.iterdir()], [victim])
 
+    def test_frontmatter_journal_and_summary(self):
+        for provider in self.providers():
+            tricky = MemoryEntry(title='Quote " and\nnewline', content="body", category="Governance",
+                                 tags=["a, b"], metadata={"k": 'v"\n---\nevil: yes'})
+            self.assertTrue(provider.write_note(tricky))
+            note = next(provider.root.joinpath("Governance").glob("Quote_*.md")).read_text(encoding="utf-8")
+            self.assertIn('title: "Quote \\" and\\nnewline"', note)
+            self.assertNotIn("\nevil:", note)
+            self.assertTrue(provider.append_journal("Governance", "first"))
+            self.assertTrue(provider.append_journal("Governance", "second"))
+            journal = (provider.root / "Governance" / "Journal.md").read_text(encoding="utf-8")
+            self.assertIn("first", journal)
+            self.assertIn("second", journal)
+            self.assertIsNone(provider.get_session_summary("s1"))
+            self.assertTrue(provider.write_note(self.entry("Session s1 Summary", "Sessions")))
+            self.assertIn("body", provider.get_session_summary("s1") or "")
+            self.assertEqual([p.name for p in provider.root.joinpath("Governance").iterdir() if p.name.endswith(".tmp")], [])
+
     def test_plain_names_work(self):
         for provider in self.providers():
             self.assertTrue(provider.write_note(self.entry("Decision one", "Governance")))
             self.assertTrue((provider.root / "Governance" / "Decision_one.md").exists())
             self.assertTrue(provider.append_journal("Sessions", "note"))
             self.assertTrue((provider.root / "Sessions" / "Journal.md").exists())
-            (provider.root / "Sessions" / "session_abc-1.md").write_text("summary", encoding="utf-8")
+            (provider.root / "Sessions" / "Session_abc-1_Summary.md").write_text("summary", encoding="utf-8")
             self.assertEqual(provider.get_session_summary("abc-1"), "summary")
             self.assertIsNone(provider.get_session_summary("missing"))
 

--- a/tests/test_memory_provider_paths.py
+++ b/tests/test_memory_provider_paths.py
@@ -2,14 +2,14 @@
 or a session id supplied by a caller cannot climb out (security audit
 2026-08-17, day 11)."""
 
-import os
 import tempfile
 import unittest
 
 from pathlib import Path
 
 from llm.memory.base import MemoryEntry
-from llm.memory.paths import PrivateDirectory, resolve_inside, safe_segment, safe_title
+from llm.memory.paths import PrivateDirectory, resolve_inside, safe_segment, safe_title, supports_directory_descriptors
+
 
 from llm.memory.providers.local import LocalFileProvider
 from llm.memory.providers.obsidian import ObsidianVaultProvider
@@ -120,8 +120,9 @@ class MemoryProviderPathTests(unittest.TestCase):
             self.assertEqual([p.name for p in provider.root.joinpath("Governance").iterdir() if p.name.endswith(".tmp")], [])
 
     def test_directory_is_held_by_descriptor_where_supported(self):
-        if not hasattr(os, "O_DIRECTORY"):
+        if not supports_directory_descriptors():
             self.skipTest("no directory descriptors on this platform")
+
         with PrivateDirectory(self.base) as directory:
             self.assertIsNotNone(directory.descriptor, "POSIX must bind the directory by descriptor")
             directory.write_text_atomic("held.md", "held")

--- a/tests/test_memory_provider_paths.py
+++ b/tests/test_memory_provider_paths.py
@@ -91,8 +91,11 @@ class MemoryProviderPathTests(unittest.TestCase):
             self.assertEqual(other.read_text(encoding="utf-8"), "other")
             (provider.root / "Aliased-category").symlink_to(provider.root / "Traces", target_is_directory=True)
             self.assertFalse(provider.write_note(self.entry("note", "Aliased-category")), "a category that links another one is refused")
-            self.assertIsNone(provider.get_session_summary("abc/def"))
-            self.assertIsNone(provider.get_session_summary("../Governance/Decision"))
+            planted = provider.root / "Sessions" / "Session_abc_def_Summary.md"
+            planted.write_text("planted", encoding="utf-8")
+            self.assertIsNone(provider.get_session_summary("abc/def"), "a session id with a separator names no session, even when its mangled name exists")
+            self.assertEqual(provider.get_session_summary("abc_def"), "planted")
+
 
 
     def test_frontmatter_journal_and_summary(self):

--- a/tests/test_memory_provider_paths.py
+++ b/tests/test_memory_provider_paths.py
@@ -1,0 +1,80 @@
+"""Memory providers keep every note under their root: a category, a title
+or a session id supplied by a caller cannot climb out (security audit
+2026-08-17, day 11)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from llm.memory.base import MemoryEntry
+from llm.memory.paths import resolve_inside, safe_segment, safe_title
+from llm.memory.providers.local import LocalFileProvider
+from llm.memory.providers.obsidian import ObsidianVaultProvider
+
+
+class MemoryProviderPathTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    @staticmethod
+    def entry(title, category):
+        return MemoryEntry(title=title, content="body", category=category, tags=["t"], metadata={})
+
+    def providers(self):
+        local = LocalFileProvider(str(self.base / "ws"))
+        self.assertTrue(local.initialize())
+        vault = self.base / "vault"
+        vault.mkdir()
+        obsidian = ObsidianVaultProvider(str(vault))
+        self.assertTrue(obsidian.initialize())
+        return [local, obsidian]
+
+    def files_outside(self, roots):
+        resolved = [root.resolve() for root in roots]
+        return [
+            path for path in self.base.rglob("*")
+            if path.is_file() and not any(root in path.resolve().parents for root in resolved)
+        ]
+
+    def test_segments_and_titles(self):
+        self.assertEqual(safe_segment("Sessions"), "Sessions")
+        self.assertEqual(safe_segment("run-2026.09"), "run-2026.09")
+        for bad in ["../etc", "a/b", "..", ".", "", "a\\b", ".hidden", None]:
+            self.assertIsNone(safe_segment(bad), bad)
+        self.assertEqual(safe_title("My note / v2"), "My_note___v2")
+        self.assertIsNone(safe_title("../../"))
+        self.assertIsNone(safe_title(""))
+        root = self.base / "r"
+        root.mkdir()
+        self.assertIsNone(resolve_inside(root, "..", "x"))
+        self.assertEqual(resolve_inside(root, "a", "b.md"), (root / "a" / "b.md").resolve())
+
+    def test_traversal_is_refused(self):
+        providers = self.providers()
+        for provider in providers:
+            self.assertFalse(provider.write_note(self.entry("evil", "../../outside")))
+            self.assertTrue(provider.write_note(self.entry("../../evil", "Sessions")))
+            self.assertTrue((provider.root / "Sessions" / "evil.md").exists())
+            self.assertFalse(provider.write_note(self.entry("evil", "Sessions/../../outside")))
+            self.assertFalse(provider.append_journal("../outside", "x"))
+            self.assertFalse(provider.append_journal("Nowhere", "x"))
+            self.assertIsNone(provider.get_session_summary("../../etc/passwd"))
+        self.assertEqual(self.files_outside([provider.root for provider in providers]), [])
+
+    def test_plain_names_work(self):
+        for provider in self.providers():
+            self.assertTrue(provider.write_note(self.entry("Decision one", "Governance")))
+            self.assertTrue((provider.root / "Governance" / "Decision_one.md").exists())
+            self.assertTrue(provider.append_journal("Sessions", "note"))
+            self.assertTrue((provider.root / "Sessions" / "Journal.md").exists())
+            (provider.root / "Sessions" / "session_abc-1.md").write_text("summary", encoding="utf-8")
+            self.assertEqual(provider.get_session_summary("abc-1"), "summary")
+            self.assertIsNone(provider.get_session_summary("missing"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_provider_paths.py
+++ b/tests/test_memory_provider_paths.py
@@ -84,6 +84,16 @@ class MemoryProviderPathTests(unittest.TestCase):
             self.assertEqual(victim.read_text(encoding="utf-8"), "outside content", "the hard link is replaced, not written through")
             self.assertIn("body", (provider.root / "Governance" / "Aliased.md").read_text(encoding="utf-8"))
             self.assertEqual([p for p in outside.iterdir()], [victim])
+            other = provider.root / "Traces" / "Journal.md"
+            other.write_text("other", encoding="utf-8")
+            (provider.root / "Archaeology" / "Journal.md").symlink_to(other)
+            self.assertFalse(provider.append_journal("Archaeology", "x"), "a journal that is a link is not appended")
+            self.assertEqual(other.read_text(encoding="utf-8"), "other")
+            (provider.root / "Aliased-category").symlink_to(provider.root / "Traces", target_is_directory=True)
+            self.assertFalse(provider.write_note(self.entry("note", "Aliased-category")), "a category that links another one is refused")
+            self.assertIsNone(provider.get_session_summary("abc/def"))
+            self.assertIsNone(provider.get_session_summary("../Governance/Decision"))
+
 
     def test_frontmatter_journal_and_summary(self):
         for provider in self.providers():

--- a/tests/test_memory_provider_paths.py
+++ b/tests/test_memory_provider_paths.py
@@ -46,6 +46,8 @@ class MemoryProviderPathTests(unittest.TestCase):
         for bad in ["../etc", "a/b", "..", ".", "", "a\\b", ".hidden", None]:
             self.assertIsNone(safe_segment(bad), bad)
         self.assertEqual(safe_title("My note / v2"), "My_note___v2")
+        self.assertEqual(safe_title("Réunion été"), "Réunion_été")
+
         self.assertIsNone(safe_title("../../"))
         self.assertIsNone(safe_title(""))
         root = self.base / "r"
@@ -64,6 +66,24 @@ class MemoryProviderPathTests(unittest.TestCase):
             self.assertFalse(provider.append_journal("Nowhere", "x"))
             self.assertIsNone(provider.get_session_summary("../../etc/passwd"))
         self.assertEqual(self.files_outside([provider.root for provider in providers]), [])
+
+    def test_links_never_redirect_a_write(self):
+        outside = self.base / "outside"
+        outside.mkdir()
+        victim = outside / "victim.md"
+        victim.write_text("outside content", encoding="utf-8")
+        for provider in self.providers():
+            try:
+                (provider.root / "Linked").symlink_to(outside, target_is_directory=True)
+                (provider.root / "Governance" / "Aliased.md").hardlink_to(victim)
+            except (OSError, NotImplementedError, AttributeError) as error:
+                self.skipTest(f"links are not available here: {error}")
+            self.assertFalse(provider.write_note(self.entry("note", "Linked")), "a linked category resolves outside the root")
+            self.assertFalse(provider.append_journal("Linked", "x"))
+            self.assertTrue(provider.write_note(self.entry("Aliased", "Governance")))
+            self.assertEqual(victim.read_text(encoding="utf-8"), "outside content", "the hard link is replaced, not written through")
+            self.assertIn("body", (provider.root / "Governance" / "Aliased.md").read_text(encoding="utf-8"))
+            self.assertEqual([p for p in outside.iterdir()], [victim])
 
     def test_plain_names_work(self):
         for provider in self.providers():

--- a/tests/test_memory_provider_paths.py
+++ b/tests/test_memory_provider_paths.py
@@ -2,12 +2,15 @@
 or a session id supplied by a caller cannot climb out (security audit
 2026-08-17, day 11)."""
 
+import os
 import tempfile
 import unittest
+
 from pathlib import Path
 
 from llm.memory.base import MemoryEntry
-from llm.memory.paths import resolve_inside, safe_segment, safe_title
+from llm.memory.paths import PrivateDirectory, resolve_inside, safe_segment, safe_title
+
 from llm.memory.providers.local import LocalFileProvider
 from llm.memory.providers.obsidian import ObsidianVaultProvider
 
@@ -115,6 +118,15 @@ class MemoryProviderPathTests(unittest.TestCase):
             self.assertTrue(provider.write_note(self.entry("Session s1 Summary", "Sessions")))
             self.assertIn("body", provider.get_session_summary("s1") or "")
             self.assertEqual([p.name for p in provider.root.joinpath("Governance").iterdir() if p.name.endswith(".tmp")], [])
+
+    def test_directory_is_held_by_descriptor_where_supported(self):
+        if not hasattr(os, "O_DIRECTORY"):
+            self.skipTest("no directory descriptors on this platform")
+        with PrivateDirectory(self.base) as directory:
+            self.assertIsNotNone(directory.descriptor, "POSIX must bind the directory by descriptor")
+            directory.write_text_atomic("held.md", "held")
+            self.assertTrue(directory.append_text("held.md", " more"))
+            self.assertEqual(directory.read_text("held.md"), "held more")
 
     def test_plain_names_work(self):
         for provider in self.providers():


### PR DESCRIPTION
## What

Day 11 of the security schedule (17/08 audit).

- **Install pipeline.** `applyInstallPlan` wrote every operation with `writeFileSync`/`copyFileSync`, which follow links: a symbolic link planted at a destination, or a linked directory inside the target root, redirected the write anywhere. `refuseLinkedDestination` now checks the destination and every ancestor strictly inside the target root with `lstat` before anything is created (the root itself may be a link the user made with a dotfiles manager), for the plan's operations and for the resolved Claude hooks file.
- **Python memory providers.** `obsidian.py` and `local.py` built paths from the caller's `category`, `title` and `session_id` with a cosmetic replace only, so `../` climbed out of the vault or workspace. A shared `llm.memory.paths` module now admits one plain segment for a category or a session id (letters, digits, dot, dash, underscore; never `.`/`..`), derives a safe stem from a title (a climbing title becomes a plain name inside the root), and resolves every path inside the provider's root; anything else is refused (`False`/`None`) without touching the filesystem.

## Proof

- `tests/lib/install-apply-links.test.js` (new): a linked destination is refused; a destination under a linked directory inside the root is refused before the target exists; a root that is itself a link is allowed; plain destinations pass. Install suites pass.
- `tests/test_memory_provider_paths.py` (new, runs under pytest in CI): traversal through category and session id is refused by both providers, a climbing title lands inside the root, no file is created outside the roots; plain names work end to end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the installer from writing through symbolic links and keeps memory provider notes inside their root.

**Bug Fixes**
- The installer refuses a destination that is a symbolic link or sits under a linked directory strictly inside the target root, checking before anything is created; only the root itself may be a link the user made.
- Every managed file — merged JSON, YAML, and Markdown, copied files, the hooks file, the Guardian marker, and the install state — lands through an exclusive temporary renamed over the destination, so a planted hard link is replaced instead of written through.
- The Guardian marker answers to the same link check, so a linked `.egc` directory turns the write into a warning and nothing lands behind the link.
- Memory providers accept one plain segment for a category or session id, derive a safe stem from titles, resolve every path inside the provider root, and refuse a category that is a link.
- Where the platform supports it, category directories are held by a descriptor opened without following links, and notes and journals are written through a temporary sibling and renamed, so a swapped directory or planted link cannot redirect a write and a linked journal is never read.

<sup>Written for commit 6f8993e5f91eab3874a10e39f79ff2efc9bd53ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

