### PR TITLE
fix(security): inspect a plugin package before extracting it, and keep every plugin under the store

### DIFF
--- a/scripts/lib/plugin-registry.js
+++ b/scripts/lib/plugin-registry.js
@@ -16,10 +16,9 @@ const INSTALLED_DIR = path.join(PLUGINS_DIR, 'installed');
 
 const PLUGIN_JSON_SCHEMA_KEYS = ['name', 'version', 'description', 'egcPeerVersion'];
 
-// A plugin name is one directory segment under the store: letters, digits,
-// dots, dashes and underscores, plus the npm scope form @scope/name (the
-// scope becomes a parent segment). Anything else could name a path outside
-// the store.
+// A plugin name is letters, digits, dots, dashes and underscores, or the
+// npm scope form @scope/name. Anything else could name a path outside the
+// store.
 const PLUGIN_NAME_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 function pluginNameSegments(name) {
@@ -29,7 +28,8 @@ function pluginNameSegments(name) {
 function pluginNameError(name) {
   if (typeof name !== 'string' || name.length === 0) return 'Plugin name is required';
   const segments = pluginNameSegments(name);
-  if (segments.length > 2 || segments.some(segment => !PLUGIN_NAME_SEGMENT.test(segment) || segment === '.' || segment === '..')) {
+  const scoped = name.startsWith('@');
+  if (segments.length !== (scoped ? 2 : 1) || segments.some(segment => !PLUGIN_NAME_SEGMENT.test(segment) || segment === '.' || segment === '..')) {
     return `Invalid plugin name '${name}': use letters, digits, dots, dashes and underscores (optionally @scope/name)`;
   }
   return null;
@@ -39,11 +39,22 @@ function getInstalledDir() {
   return INSTALLED_DIR;
 }
 
+// Every plugin is one directory directly under the store: @scope/name is
+// stored as @scope__name, a spelling no plain name can produce, so a scope
+// and a plugin of the same name never share a path.
 function getPluginDir(name) {
   const error = pluginNameError(name);
   if (error) throw new Error(error);
-  return path.join(INSTALLED_DIR, ...pluginNameSegments(name));
+  return path.join(INSTALLED_DIR, name.startsWith('@') ? name.replace('/', '__') : name);
 }
+
+// The plugin directory for a name recorded in the lock file, or null when
+// the recorded name would not be accepted today (a lock written before the
+// name rule existed); the caller reports that plugin instead of throwing.
+function recordedPluginDir(name) {
+  return pluginNameError(name) === null ? getPluginDir(name) : null;
+}
+
 
 
 function readLockFile() {
@@ -77,11 +88,29 @@ function validatePluginJson(pluginJson) {
   return errors;
 }
 
+// The kind of entry at `target` as it sits on disk: a link is never
+// followed, so a plugin cannot present a file it does not contain.
+function entryKind(target) {
+  try {
+    const status = fs.lstatSync(target);
+    if (status.isSymbolicLink()) return 'link';
+    if (status.isDirectory()) return 'directory';
+    return status.isFile() ? 'file' : 'other';
+  } catch {
+    return 'missing';
+  }
+}
+
 function validatePluginDir(pluginDir) {
   const pluginJsonPath = path.join(pluginDir, 'plugin.json');
-  if (!fs.existsSync(pluginJsonPath)) {
+  const manifestKind = entryKind(pluginJsonPath);
+  if (manifestKind === 'missing') {
     return { valid: false, errors: ['plugin.json not found'], pluginJson: null };
   }
+  if (manifestKind !== 'file') {
+    return { valid: false, errors: ['plugin.json must be a plain file, not a link'], pluginJson: null };
+  }
+
   let pluginJson;
   try {
     pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
@@ -89,16 +118,18 @@ function validatePluginDir(pluginDir) {
     return { valid: false, errors: [`Invalid plugin.json: ${e.message}`], pluginJson: null };
   }
   const errors = validatePluginJson(pluginJson);
-  const hasContent = (
-    fs.existsSync(path.join(pluginDir, 'skills')) ||
-    fs.existsSync(path.join(pluginDir, 'agents')) ||
-    fs.existsSync(path.join(pluginDir, 'rules'))
-  );
-  if (!hasContent) {
+  // A content directory that is a link is refused rather than skipped: the
+  // copy never follows links, so the installed plugin would silently lack it.
+  const kinds = ['skills', 'agents', 'rules'].map(name => [name, entryKind(path.join(pluginDir, name))]);
+  for (const [name, kind] of kinds) {
+    if (kind === 'link') errors.push(`${name}/ must be a plain directory, not a link`);
+  }
+  if (!kinds.some(([, kind]) => kind === 'directory')) {
     errors.push('Plugin must contain at least one of: skills/, agents/, rules/ directory');
   }
   return { valid: errors.length === 0, errors, pluginJson };
 }
+
 
 function installPluginFromDir(sourceDir, pluginName) {
   const nameError = pluginNameError(pluginName);
@@ -117,8 +148,16 @@ function installPluginFromDir(sourceDir, pluginName) {
   fs.mkdirSync(pluginDir, { recursive: true });
 
   copyRecursive(sourceDir, pluginDir);
+  // What landed is what is recorded: the copy skips links, so the installed
+  // tree is validated again before the lock file says the plugin is there.
+  const installed = validatePluginDir(pluginDir);
+  if (!installed.valid) {
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+    return { success: false, errors: ['Installed plugin is incomplete', ...installed.errors] };
+  }
 
   const pluginJson = validation.pluginJson;
+
   lock.installed[pluginName] = {
     name: pluginName,
     version: pluginJson.version,
@@ -173,6 +212,35 @@ function archiveInspectionErrors(archivePath) {
   return errors;
 }
 
+// The extracted tree, judged on disk rather than from the listing: every
+// entry must be a plain file or directory whose real location stays under
+// the extraction directory. This is the check that does not depend on how
+// a given tar prints its listing.
+function extractedTreeErrors(extractDir) {
+  const root = fs.realpathSync(extractDir);
+  const errors = [];
+  const pending = [extractDir];
+  while (pending.length > 0) {
+    const dir = pending.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const target = path.join(dir, entry.name);
+      const kind = entryKind(target);
+      if (kind !== 'file' && kind !== 'directory') {
+        errors.push(`extracted entry is not a plain file or directory: ${path.relative(extractDir, target)}`);
+        continue;
+      }
+      const real = fs.realpathSync(target);
+      if (real !== root && !real.startsWith(root + path.sep)) {
+        errors.push(`extracted entry leaves the package: ${path.relative(extractDir, target)}`);
+        continue;
+      }
+      if (kind === 'directory') pending.push(target);
+    }
+  }
+  return errors;
+}
+
+
 function installPluginFromNpm(npmPackage, pluginName) {
   const nameError = pluginNameError(pluginName);
   if (nameError) return { success: false, errors: [nameError] };
@@ -218,6 +286,11 @@ function installPluginFromNpm(npmPackage, pluginName) {
     if (tarResult.status !== 0) {
       return { success: false, errors: ['Failed to extract plugin package'] };
     }
+    const tree = extractedTreeErrors(extractDir);
+    if (tree.length > 0) {
+      return { success: false, errors: ['Plugin package refused', ...tree] };
+    }
+
 
     const entries = fs.readdirSync(extractDir);
     const packageDir = entries.find(f => {
@@ -257,7 +330,10 @@ function removePlugin(name) {
     return { success: false, errors: [`Plugin "${name}" is not installed`] };
   }
 
-  const pluginDir = getPluginDir(name);
+  const pluginDir = recordedPluginDir(name);
+  if (pluginDir === null) {
+    return { success: false, errors: [`Plugin "${name}" was recorded under a name the store no longer accepts; remove its directory by hand`] };
+  }
   if (fs.existsSync(pluginDir)) {
     fs.rmSync(pluginDir, { recursive: true, force: true });
   }
@@ -275,11 +351,15 @@ function updatePlugin(name) {
     return { success: false, errors: [`Plugin "${name}" is not installed`] };
   }
 
-  const pluginDir = getPluginDir(name);
+  const pluginDir = recordedPluginDir(name);
+  if (pluginDir === null) {
+    return { success: false, errors: [`Plugin "${name}" was recorded under a name the store no longer accepts`] };
+  }
   const pluginJsonPath = path.join(pluginDir, 'plugin.json');
   if (!fs.existsSync(pluginJsonPath)) {
     return { success: false, errors: [`Plugin "${name}" has no plugin.json; cannot determine source`] };
   }
+
 
   let pluginJson;
   try {
@@ -301,9 +381,14 @@ function reinstallAllPlugins() {
   const results = [];
 
   for (const name of names) {
-    const pluginDir = getPluginDir(name);
+    const pluginDir = recordedPluginDir(name);
+    if (pluginDir === null) {
+      results.push({ name, success: false, errors: ['recorded under a name the store no longer accepts; cannot reinstall'] });
+      continue;
+    }
     const pluginJsonPath = path.join(pluginDir, 'plugin.json');
     if (!fs.existsSync(pluginJsonPath)) {
+
       results.push({ name, success: false, errors: ['plugin.json missing; cannot reinstall'] });
       continue;
     }
@@ -364,5 +449,7 @@ module.exports = {
   getInstalledDir,
   PLUGINS_LOCK_PATH,
   archiveInspectionErrors,
+  extractedTreeErrors,
   pluginNameError,
+  getPluginDir,
 };

--- a/scripts/lib/plugin-registry.js
+++ b/scripts/lib/plugin-registry.js
@@ -173,40 +173,41 @@ function installPluginFromDir(sourceDir, pluginName) {
   return { success: true, plugin: lock.installed[pluginName] };
 }
 
-// The entries of a package archive, as tar lists them; null when the
-// archive cannot be listed.
-function listArchiveEntries(archivePath) {
-  const listing = spawnSync('tar', ['-tzvf', archivePath], { // NOSONAR jssecurity:S8705
+// The entry names of a package archive, one per line, as tar lists them
+// with -t alone (no columns, so every tar prints the same thing); null when
+// the archive cannot be listed. bsdtar strips a leading slash from the
+// listing and says so on stderr, so that warning counts as an absolute name.
+function listArchiveNames(archivePath) {
+  const listing = spawnSync('tar', ['-tzf', archivePath], { // NOSONAR jssecurity:S8705
     encoding: 'utf-8',
     stdio: 'pipe',
     timeout: 30000,
   });
   if (listing.status !== 0) return null;
-  return listing.stdout.split('\n').filter(line => line.trim() !== '');
+  const names = listing.stdout.split('\n').filter(line => line.trim() !== '');
+  if (/leading '\/'|absolute path|Removing leading/i.test(listing.stderr || '')) names.push('/');
+  return names;
 }
 
-// Whether a listed archive entry stays inside the extraction directory and
-// is a plain file or directory: an absolute name, a name that climbs, a
-// symbolic or hard link, or a device would land or point outside it.
-function archiveEntryError(line) {
-  const type = line[0];
-  if (type !== '-' && type !== 'd') return `archive entry is not a plain file or directory: ${line.slice(0, 80)}`;
-  const name = line.replace(/^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+/, '');
+// Whether an archive entry name stays inside the extraction directory: an
+// absolute name or a name that climbs would land outside it. Entry kinds
+// (a link, a device) are judged on the extracted tree, where every tar
+// agrees on what it wrote.
+function archiveNameError(name) {
   const normalized = name.replaceAll('\\', '/');
   if (normalized.startsWith('/') || /^[A-Za-z]:/.test(normalized)) return `archive entry has an absolute name: ${name}`;
   if (normalized.split('/').includes('..')) return `archive entry climbs out of the package: ${name}`;
   return null;
 }
 
-// Every entry is inspected before anything is written: tar itself refuses
-// absolute names and parent segments, but a link inside the archive would
-// be created and then followed by the copy, so links are refused here.
+// Every name is inspected before anything is written; the extracted tree is
+// inspected again afterwards for links and for where each entry really is.
 function archiveInspectionErrors(archivePath) {
-  const entries = listArchiveEntries(archivePath);
-  if (entries === null) return ['Failed to list the plugin package'];
+  const names = listArchiveNames(archivePath);
+  if (names === null) return ['Failed to list the plugin package'];
   const errors = [];
-  for (const line of entries) {
-    const error = archiveEntryError(line);
+  for (const name of names) {
+    const error = archiveNameError(name);
     if (error) errors.push(error);
   }
   return errors;

--- a/scripts/lib/plugin-registry.js
+++ b/scripts/lib/plugin-registry.js
@@ -40,12 +40,13 @@ function getInstalledDir() {
 }
 
 // Every plugin is one directory directly under the store: @scope/name is
-// stored as @scope__name, a spelling no plain name can produce, so a scope
-// and a plugin of the same name never share a path.
+// stored as @scope+name. The plus sign is outside the segment alphabet, so
+// no other accepted name (plain or scoped) spells the same directory, and a
+// scope and a plugin of the same name never share a path.
 function getPluginDir(name) {
   const error = pluginNameError(name);
   if (error) throw new Error(error);
-  return path.join(INSTALLED_DIR, name.startsWith('@') ? name.replace('/', '__') : name);
+  return path.join(INSTALLED_DIR, name.startsWith('@') ? name.replace('/', '+') : name);
 }
 
 // The plugin directory for a name recorded in the lock file, or null when

--- a/scripts/lib/plugin-registry.js
+++ b/scripts/lib/plugin-registry.js
@@ -5,19 +5,46 @@ const path = require('node:path');
 const os = require('node:os');
 const { spawnSync } = require('node:child_process');
 
-const PLUGINS_DIR = path.join(os.homedir(), '.egc', 'plugins');
+// The plugin store lives under the home directory the environment names, so
+// a test (or a relocated home) never touches the real one.
+function homeDir() {
+  return process.env.HOME || process.env.USERPROFILE || os.homedir();
+}
+const PLUGINS_DIR = path.join(homeDir(), '.egc', 'plugins');
 const PLUGINS_LOCK_PATH = path.join(PLUGINS_DIR, 'plugins.json');
 const INSTALLED_DIR = path.join(PLUGINS_DIR, 'installed');
 
 const PLUGIN_JSON_SCHEMA_KEYS = ['name', 'version', 'description', 'egcPeerVersion'];
+
+// A plugin name is one directory segment under the store: letters, digits,
+// dots, dashes and underscores, plus the npm scope form @scope/name (the
+// scope becomes a parent segment). Anything else could name a path outside
+// the store.
+const PLUGIN_NAME_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function pluginNameSegments(name) {
+  return name.startsWith('@') ? name.slice(1).split('/') : [name];
+}
+
+function pluginNameError(name) {
+  if (typeof name !== 'string' || name.length === 0) return 'Plugin name is required';
+  const segments = pluginNameSegments(name);
+  if (segments.length > 2 || segments.some(segment => !PLUGIN_NAME_SEGMENT.test(segment) || segment === '.' || segment === '..')) {
+    return `Invalid plugin name '${name}': use letters, digits, dots, dashes and underscores (optionally @scope/name)`;
+  }
+  return null;
+}
 
 function getInstalledDir() {
   return INSTALLED_DIR;
 }
 
 function getPluginDir(name) {
-  return path.join(INSTALLED_DIR, name);
+  const error = pluginNameError(name);
+  if (error) throw new Error(error);
+  return path.join(INSTALLED_DIR, ...pluginNameSegments(name));
 }
+
 
 function readLockFile() {
   try {
@@ -74,10 +101,13 @@ function validatePluginDir(pluginDir) {
 }
 
 function installPluginFromDir(sourceDir, pluginName) {
+  const nameError = pluginNameError(pluginName);
+  if (nameError) return { success: false, errors: [nameError] };
   const validation = validatePluginDir(sourceDir);
   if (!validation.valid) {
     return { success: false, errors: validation.errors };
   }
+
 
   const lock = readLockFile();
   const pluginDir = getPluginDir(pluginName);
@@ -104,10 +134,51 @@ function installPluginFromDir(sourceDir, pluginName) {
   return { success: true, plugin: lock.installed[pluginName] };
 }
 
+// The entries of a package archive, as tar lists them; null when the
+// archive cannot be listed.
+function listArchiveEntries(archivePath) {
+  const listing = spawnSync('tar', ['-tzvf', archivePath], { // NOSONAR jssecurity:S8705
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    timeout: 30000,
+  });
+  if (listing.status !== 0) return null;
+  return listing.stdout.split('\n').filter(line => line.trim() !== '');
+}
+
+// Whether a listed archive entry stays inside the extraction directory and
+// is a plain file or directory: an absolute name, a name that climbs, a
+// symbolic or hard link, or a device would land or point outside it.
+function archiveEntryError(line) {
+  const type = line[0];
+  if (type !== '-' && type !== 'd') return `archive entry is not a plain file or directory: ${line.slice(0, 80)}`;
+  const name = line.replace(/^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+/, '');
+  const normalized = name.replaceAll('\\', '/');
+  if (normalized.startsWith('/') || /^[A-Za-z]:/.test(normalized)) return `archive entry has an absolute name: ${name}`;
+  if (normalized.split('/').includes('..')) return `archive entry climbs out of the package: ${name}`;
+  return null;
+}
+
+// Every entry is inspected before anything is written: tar itself refuses
+// absolute names and parent segments, but a link inside the archive would
+// be created and then followed by the copy, so links are refused here.
+function archiveInspectionErrors(archivePath) {
+  const entries = listArchiveEntries(archivePath);
+  if (entries === null) return ['Failed to list the plugin package'];
+  const errors = [];
+  for (const line of entries) {
+    const error = archiveEntryError(line);
+    if (error) errors.push(error);
+  }
+  return errors;
+}
+
 function installPluginFromNpm(npmPackage, pluginName) {
-  const tmpDir = path.join(os.tmpdir(), 'egc-plugin-tmp-' + Date.now());
+  const nameError = pluginNameError(pluginName);
+  if (nameError) return { success: false, errors: [nameError] };
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-plugin-'));
   try {
-    fs.mkdirSync(tmpDir, { recursive: true });
+
 
     const npmResult = spawnSync('npm', ['pack', npmPackage, '--pack-destination', tmpDir], { // NOSONAR jssecurity:S8705
       cwd: tmpDir,
@@ -126,14 +197,23 @@ function installPluginFromNpm(npmPackage, pluginName) {
       return { success: false, errors: ['npm pack produced no .tgz file'] };
     }
 
+    const archivePath = path.join(tmpDir, tgzFile);
+    const inspection = archiveInspectionErrors(archivePath);
+    if (inspection.length > 0) {
+      return { success: false, errors: ['Plugin package refused', ...inspection] };
+    }
+
     const extractDir = path.join(tmpDir, 'extracted');
     fs.mkdirSync(extractDir, { recursive: true });
 
-    const tarResult = spawnSync('tar', ['-xzf', path.join(tmpDir, tgzFile), '-C', extractDir], { // NOSONAR jssecurity:S8705
+    // Extracted as files owned by this user, with no permission bits or
+    // ownership taken from the archive.
+    const tarResult = spawnSync('tar', ['-xzf', archivePath, '-C', extractDir, '--no-same-owner', '--no-same-permissions'], { // NOSONAR jssecurity:S8705
       encoding: 'utf-8',
       stdio: 'pipe',
       timeout: 30000,
     });
+
 
     if (tarResult.status !== 0) {
       return { success: false, errors: ['Failed to extract plugin package'] };
@@ -141,9 +221,10 @@ function installPluginFromNpm(npmPackage, pluginName) {
 
     const entries = fs.readdirSync(extractDir);
     const packageDir = entries.find(f => {
-      try { return fs.statSync(path.join(extractDir, f)).isDirectory() && f.startsWith('package'); }
+      try { return fs.lstatSync(path.join(extractDir, f)).isDirectory() && f.startsWith('package'); }
       catch { return false; }
     });
+
 
     if (!packageDir) {
       return { success: false, errors: ['Extracted package has no package/ directory'] };
@@ -243,20 +324,23 @@ function reinstallAllPlugins() {
   return results;
 }
 
+// Only plain files and directories are copied into the store: a link in a
+// plugin (local directory or extracted package) is skipped, never followed.
 function copyRecursive(src, dest) {
   const entries = fs.readdirSync(src, { withFileTypes: true });
   for (const entry of entries) {
-    if (entry.name === 'node_modules') continue;
+    if (entry.name === 'node_modules' || entry.isSymbolicLink()) continue;
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
     if (entry.isDirectory()) {
       fs.mkdirSync(destPath, { recursive: true });
       copyRecursive(srcPath, destPath);
-    } else {
+    } else if (entry.isFile()) {
       fs.copyFileSync(srcPath, destPath);
     }
   }
 }
+
 
 function listSubdirs(dir) {
   try {
@@ -279,4 +363,6 @@ module.exports = {
   validatePluginDir,
   getInstalledDir,
   PLUGINS_LOCK_PATH,
+  archiveInspectionErrors,
+  pluginNameError,
 };

--- a/tests/lib/plugin-install-archive.test.js
+++ b/tests/lib/plugin-install-archive.test.js
@@ -10,7 +10,9 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const zlib = require('zlib');
 const { spawnSync } = require('child_process');
+
 
 function test(name, fn) {
   try {
@@ -45,6 +47,34 @@ function buildArchive(dir, archiveName, entries) {
   const packed = spawnSync('tar', ['-czf', archivePath, '-C', stage, 'package'], { encoding: 'utf-8', stdio: 'pipe' });
   assert.strictEqual(packed.status, 0, packed.stderr);
   return archivePath;
+}
+
+// A ustar header for one plain file, written by hand: tar itself refuses to
+// create an entry whose name climbs, so the archive a hostile publisher
+// would craft is assembled byte by byte here.
+function ustarEntry(name, content) {
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100, 'utf8');
+  header.write('0000644\0', 100, 8, 'utf8');
+  header.write('0000000\0', 108, 8, 'utf8');
+  header.write('0000000\0', 116, 8, 'utf8');
+  header.write(content.length.toString(8).padStart(11, '0') + '\0', 124, 12, 'utf8');
+  header.write('00000000000\0', 136, 12, 'utf8');
+  header.write('        ', 148, 8, 'utf8');
+  header.write('0', 156, 1, 'utf8');
+  header.write('ustar\0', 257, 6, 'utf8');
+  header.write('00', 263, 2, 'utf8');
+  let sum = 0;
+  for (const byte of header) sum += byte;
+  header.write(sum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'utf8');
+  const body = Buffer.alloc(Math.ceil(content.length / 512) * 512);
+  body.write(content, 0, 'utf8');
+  return Buffer.concat([header, body]);
+}
+
+function craftArchive(archivePath, entries) {
+  const blocks = entries.map(([name, content]) => ustarEntry(name, content));
+  fs.writeFileSync(archivePath, zlib.gzipSync(Buffer.concat([...blocks, Buffer.alloc(1024)])));
 }
 
 function runTests() {
@@ -89,16 +119,16 @@ function runTests() {
 
       if (test('an archive with a climbing entry is refused before extraction', () => {
         const archive = path.join(dir, 'climb.tgz');
-        const stage = path.join(dir, 'stage-climb');
-        fs.mkdirSync(path.join(stage, 'package'), { recursive: true });
-        fs.writeFileSync(path.join(stage, 'package', 'plugin.json'), '{}');
-        fs.writeFileSync(path.join(stage, 'escaped.md'), 'x');
-        // tar records the name as given: the transform turns escaped.md into
-        // a name that climbs, the way a hostile publisher would craft it.
-        const packed = spawnSync('tar', ['-czf', archive, '-C', stage, '--transform', 's,^escaped.md,package/../../escaped.md,', 'package', 'escaped.md'], { encoding: 'utf-8', stdio: 'pipe' });
-        assert.strictEqual(packed.status, 0, packed.stderr);
+        craftArchive(archive, [['package/plugin.json', '{}'], ['package/../../escaped.md', 'x']]);
         const errors = registry.archiveInspectionErrors(archive);
         assert.ok(errors.some(error => error.includes('climbs out')), JSON.stringify(errors));
+      })) passed++; else failed++;
+
+      if (test('an archive with an absolute entry is refused before extraction', () => {
+        const archive = path.join(dir, 'absolute.tgz');
+        craftArchive(archive, [['package/plugin.json', '{}'], ['/tmp/escaped.md', 'x']]);
+        const errors = registry.archiveInspectionErrors(archive);
+        assert.ok(errors.some(error => error.includes('absolute name')), JSON.stringify(errors));
       })) passed++; else failed++;
     } else {
       console.log('  - skipped: tar is not available here');

--- a/tests/lib/plugin-install-archive.test.js
+++ b/tests/lib/plugin-install-archive.test.js
@@ -168,15 +168,20 @@ function runTests() {
         assert.deepStrictEqual(registry.archiveInspectionErrors(archive), []);
       })) passed++; else failed++;
 
-      if (test('an archive with a symbolic link is refused before extraction', () => {
+      if (test('an archive with a symbolic link is refused once extracted', () => {
         const archive = buildArchive(dir, 'link.tgz', [...validPlugin, { name: 'package/rules/out.md', link: path.join(dir, 'outside.md') }]);
         if (archive === null) {
-          console.log('  - links not available here; listing check skipped');
+          console.log('  - links not available here; extraction check skipped');
           return;
         }
-        const errors = registry.archiveInspectionErrors(archive);
+        const extracted = path.join(dir, 'extracted-link');
+        fs.mkdirSync(extracted, { recursive: true });
+        const untar = spawnSync('tar', ['-xzf', archive, '-C', extracted], { encoding: 'utf-8', stdio: 'pipe' });
+        assert.strictEqual(untar.status, 0, untar.stderr);
+        const errors = registry.extractedTreeErrors(extracted);
         assert.ok(errors.some(error => error.includes('not a plain file or directory')), JSON.stringify(errors));
       })) passed++; else failed++;
+
 
       if (test('the extracted tree is judged on disk, whatever the listing looked like', () => {
         const extracted = path.join(dir, 'extracted-tree');

--- a/tests/lib/plugin-install-archive.test.js
+++ b/tests/lib/plugin-install-archive.test.js
@@ -117,8 +117,8 @@ function runTests() {
       assert.notStrictEqual(scoped, plain);
       assert.ok(!scoped.startsWith(plain + path.sep), 'the scoped plugin is not inside the plain one');
       assert.ok(registry.pluginNameError('@scope'), 'a bare scope is not a name');
-      assert.strictEqual(registry.pluginNameError('scope__plugin'), null, 'the stored spelling is itself a valid plain name and lands in its own directory');
-      assert.notStrictEqual(registry.getPluginDir('scope__plugin'), scoped);
+      assert.ok(registry.pluginNameError('scope+plugin'), 'the stored spelling is not an accepted name, so nothing else maps onto it');
+      assert.notStrictEqual(registry.getPluginDir('@scope__plugin/x'), registry.getPluginDir('@scope/plugin__x'), 'two scoped names never share a directory');
     })) passed++; else failed++;
 
     if (test('a plugin recorded under a name the store no longer accepts fails per plugin instead of throwing', () => {

--- a/tests/lib/plugin-install-archive.test.js
+++ b/tests/lib/plugin-install-archive.test.js
@@ -33,16 +33,32 @@ function tarAvailable() {
 
 // An archive built from `entries` ({ name, content } for files, { name } for
 // directories, { name, link } for symbolic links), all under package/.
+// Null when a link entry cannot be created here (a platform without
+// symbolic links for this user), so the caller skips instead of failing.
+function stageEntry(stage, entry) {
+  const target = path.join(stage, entry.name);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  if (entry.link !== undefined) {
+    try {
+      fs.symlinkSync(entry.link, target);
+    } catch {
+      return false;
+    }
+  } else if (entry.content !== undefined) {
+    fs.writeFileSync(target, entry.content);
+  } else {
+    fs.mkdirSync(target, { recursive: true });
+  }
+  return true;
+}
+
 function buildArchive(dir, archiveName, entries) {
   const stage = path.join(dir, `stage-${archiveName}`);
   fs.mkdirSync(path.join(stage, 'package'), { recursive: true });
   for (const entry of entries) {
-    const target = path.join(stage, entry.name);
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    if (entry.link !== undefined) fs.symlinkSync(entry.link, target);
-    else if (entry.content !== undefined) fs.writeFileSync(target, entry.content);
-    else fs.mkdirSync(target, { recursive: true });
+    if (!stageEntry(stage, entry)) return null;
   }
+
   const archivePath = path.join(dir, archiveName);
   const packed = spawnSync('tar', ['-czf', archivePath, '-C', stage, 'package'], { encoding: 'utf-8', stdio: 'pipe' });
   assert.strictEqual(packed.status, 0, packed.stderr);
@@ -94,10 +110,51 @@ function runTests() {
     { name: 'package/skills/demo/SKILL.md', content: '# demo' },
   ];
   try {
+    if (test('a scope and a plugin of the same name never share a store path', () => {
+      const scoped = registry.getPluginDir('@scope/plugin');
+      const plain = registry.getPluginDir('scope');
+      assert.strictEqual(path.dirname(scoped), path.dirname(plain), 'both sit directly under the store');
+      assert.notStrictEqual(scoped, plain);
+      assert.ok(!scoped.startsWith(plain + path.sep), 'the scoped plugin is not inside the plain one');
+      assert.ok(registry.pluginNameError('@scope'), 'a bare scope is not a name');
+      assert.strictEqual(registry.pluginNameError('scope__plugin'), null, 'the stored spelling is itself a valid plain name and lands in its own directory');
+      assert.notStrictEqual(registry.getPluginDir('scope__plugin'), scoped);
+    })) passed++; else failed++;
+
+    if (test('a plugin recorded under a name the store no longer accepts fails per plugin instead of throwing', () => {
+      const lockPath = registry.PLUGINS_LOCK_PATH;
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.writeFileSync(lockPath, JSON.stringify({ schemaVersion: 'egc.plugins.v1', installed: { '../legacy': { name: '../legacy', version: '1.0.0' } } }));
+      assert.strictEqual(registry.removePlugin('../legacy').success, false);
+      assert.strictEqual(registry.updatePlugin('../legacy').success, false);
+      const results = registry.reinstallAllPlugins();
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0].success, false);
+      assert.ok(results[0].errors[0].includes('no longer accepts'), JSON.stringify(results[0]));
+      fs.writeFileSync(lockPath, JSON.stringify({ schemaVersion: 'egc.plugins.v1', installed: {} }));
+    })) passed++; else failed++;
+
+    if (test('a plugin whose required entry is a link is refused, not installed incomplete', () => {
+      const source = path.join(dir, 'linked-required');
+      fs.mkdirSync(source, { recursive: true });
+      fs.writeFileSync(path.join(source, 'plugin.json'), JSON.stringify({ name: 'lr', version: '1.0.0', description: 'lr', egcPeerVersion: '>=1.1.0' }));
+      fs.mkdirSync(path.join(dir, 'real-skills', 'demo'), { recursive: true });
+      try {
+        fs.symlinkSync(path.join(dir, 'real-skills'), path.join(source, 'skills'), 'dir');
+      } catch (error) {
+        console.log(`  - links not available here (${error.code}); skipped`);
+        return;
+      }
+      const result = registry.installPluginFromDir(source, 'lr');
+      assert.strictEqual(result.success, false, JSON.stringify(result));
+      assert.ok(result.errors.some(error => error.includes('not a link')), JSON.stringify(result.errors));
+      assert.ok(!fs.existsSync(path.join(home, '.egc', 'plugins', 'installed', 'lr')), 'nothing is recorded or left behind');
+    })) passed++; else failed++;
+
     if (test('a plugin name is one directory segment, optionally scoped', () => {
       assert.strictEqual(registry.pluginNameError('egc-plugin-docker'), null);
       assert.strictEqual(registry.pluginNameError('@scope/plugin'), null);
-      for (const bad of ['../escape', '..', 'a/b', '/abs', 'name\\evil', '@scope/../x', '@a/b/c', '']) {
+      for (const bad of ['../escape', '..', 'a/b', '/abs', 'name\\evil', '@scope/../x', '@a/b/c', '@scope', '']) {
         assert.ok(registry.pluginNameError(bad), `${bad} must be refused`);
       }
       const result = registry.installPluginFromDir(dir, '../escape');
@@ -113,9 +170,29 @@ function runTests() {
 
       if (test('an archive with a symbolic link is refused before extraction', () => {
         const archive = buildArchive(dir, 'link.tgz', [...validPlugin, { name: 'package/rules/out.md', link: path.join(dir, 'outside.md') }]);
+        if (archive === null) {
+          console.log('  - links not available here; listing check skipped');
+          return;
+        }
         const errors = registry.archiveInspectionErrors(archive);
         assert.ok(errors.some(error => error.includes('not a plain file or directory')), JSON.stringify(errors));
       })) passed++; else failed++;
+
+      if (test('the extracted tree is judged on disk, whatever the listing looked like', () => {
+        const extracted = path.join(dir, 'extracted-tree');
+        fs.mkdirSync(path.join(extracted, 'package', 'skills'), { recursive: true });
+        fs.writeFileSync(path.join(extracted, 'package', 'plugin.json'), '{}');
+        assert.deepStrictEqual(registry.extractedTreeErrors(extracted), []);
+        try {
+          fs.symlinkSync(dir, path.join(extracted, 'package', 'skills', 'escape'), 'dir');
+        } catch (error) {
+          console.log(`  - links not available here (${error.code}); clean tree only`);
+          return;
+        }
+        const errors = registry.extractedTreeErrors(extracted);
+        assert.ok(errors.some(error => error.includes('not a plain file or directory')), JSON.stringify(errors));
+      })) passed++; else failed++;
+
 
       if (test('an archive with a climbing entry is refused before extraction', () => {
         const archive = path.join(dir, 'climb.tgz');
@@ -143,7 +220,7 @@ function runTests() {
       let linked = true;
       try {
         fs.symlinkSync(path.join(dir, 'secret.md'), path.join(source, 'skills', 'demo', 'linked.md'));
-        fs.symlinkSync(dir, path.join(source, 'rules'), 'dir');
+        fs.symlinkSync(dir, path.join(source, 'skills', 'demo', 'linked-dir'), 'dir');
       } catch (error) {
         linked = false;
         console.log(`  - links not available here (${error.code}); copy check only`);
@@ -154,8 +231,9 @@ function runTests() {
       assert.ok(fs.existsSync(path.join(installed, 'skills', 'demo', 'SKILL.md')));
       if (linked) {
         assert.ok(!fs.existsSync(path.join(installed, 'skills', 'demo', 'linked.md')), 'the linked file is not copied');
-        assert.ok(!fs.existsSync(path.join(installed, 'rules')), 'the linked directory is not copied');
+        assert.ok(!fs.existsSync(path.join(installed, 'skills', 'demo', 'linked-dir')), 'the linked directory is not copied');
       }
+
     })) passed++; else failed++;
   } finally {
     process.env.HOME = previousHome.HOME;

--- a/tests/lib/plugin-install-archive.test.js
+++ b/tests/lib/plugin-install-archive.test.js
@@ -1,0 +1,140 @@
+/**
+ * `egc plugin install` inspects a package archive before extracting it and
+ * keeps every plugin under the store (security audit 2026-08-17, day 12): an
+ * entry that climbs, an absolute name or a link is refused, a plugin name is
+ * one directory segment, and a link inside a plugin is never copied.
+ */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function tarAvailable() {
+  const probe = spawnSync('tar', ['--version'], { encoding: 'utf-8', stdio: 'pipe' });
+  return probe.status === 0;
+}
+
+// An archive built from `entries` ({ name, content } for files, { name } for
+// directories, { name, link } for symbolic links), all under package/.
+function buildArchive(dir, archiveName, entries) {
+  const stage = path.join(dir, `stage-${archiveName}`);
+  fs.mkdirSync(path.join(stage, 'package'), { recursive: true });
+  for (const entry of entries) {
+    const target = path.join(stage, entry.name);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    if (entry.link !== undefined) fs.symlinkSync(entry.link, target);
+    else if (entry.content !== undefined) fs.writeFileSync(target, entry.content);
+    else fs.mkdirSync(target, { recursive: true });
+  }
+  const archivePath = path.join(dir, archiveName);
+  const packed = spawnSync('tar', ['-czf', archivePath, '-C', stage, 'package'], { encoding: 'utf-8', stdio: 'pipe' });
+  assert.strictEqual(packed.status, 0, packed.stderr);
+  return archivePath;
+}
+
+function runTests() {
+  console.log('\n=== Testing plugin archive inspection and store containment ===\n');
+  let passed = 0;
+  let failed = 0;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-plugin-archive-'));
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  const previousHome = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete require.cache[require.resolve('../../scripts/lib/plugin-registry')];
+  const registry = require('../../scripts/lib/plugin-registry');
+  const validPlugin = [
+    { name: 'package/plugin.json', content: JSON.stringify({ name: 'demo', version: '1.0.0', description: 'demo', egcPeerVersion: '>=1.1.0' }) },
+    { name: 'package/skills/demo/SKILL.md', content: '# demo' },
+  ];
+  try {
+    if (test('a plugin name is one directory segment, optionally scoped', () => {
+      assert.strictEqual(registry.pluginNameError('egc-plugin-docker'), null);
+      assert.strictEqual(registry.pluginNameError('@scope/plugin'), null);
+      for (const bad of ['../escape', '..', 'a/b', '/abs', 'name\\evil', '@scope/../x', '@a/b/c', '']) {
+        assert.ok(registry.pluginNameError(bad), `${bad} must be refused`);
+      }
+      const result = registry.installPluginFromDir(dir, '../escape');
+      assert.strictEqual(result.success, false);
+      assert.ok(result.errors[0].includes('Invalid plugin name'), JSON.stringify(result.errors));
+    })) passed++; else failed++;
+
+    if (tarAvailable()) {
+      if (test('an archive whose entries stay under package/ passes the inspection', () => {
+        const archive = buildArchive(dir, 'ok.tgz', validPlugin);
+        assert.deepStrictEqual(registry.archiveInspectionErrors(archive), []);
+      })) passed++; else failed++;
+
+      if (test('an archive with a symbolic link is refused before extraction', () => {
+        const archive = buildArchive(dir, 'link.tgz', [...validPlugin, { name: 'package/rules/out.md', link: path.join(dir, 'outside.md') }]);
+        const errors = registry.archiveInspectionErrors(archive);
+        assert.ok(errors.some(error => error.includes('not a plain file or directory')), JSON.stringify(errors));
+      })) passed++; else failed++;
+
+      if (test('an archive with a climbing entry is refused before extraction', () => {
+        const archive = path.join(dir, 'climb.tgz');
+        const stage = path.join(dir, 'stage-climb');
+        fs.mkdirSync(path.join(stage, 'package'), { recursive: true });
+        fs.writeFileSync(path.join(stage, 'package', 'plugin.json'), '{}');
+        fs.writeFileSync(path.join(stage, 'escaped.md'), 'x');
+        // tar records the name as given: the transform turns escaped.md into
+        // a name that climbs, the way a hostile publisher would craft it.
+        const packed = spawnSync('tar', ['-czf', archive, '-C', stage, '--transform', 's,^escaped.md,package/../../escaped.md,', 'package', 'escaped.md'], { encoding: 'utf-8', stdio: 'pipe' });
+        assert.strictEqual(packed.status, 0, packed.stderr);
+        const errors = registry.archiveInspectionErrors(archive);
+        assert.ok(errors.some(error => error.includes('climbs out')), JSON.stringify(errors));
+      })) passed++; else failed++;
+    } else {
+      console.log('  - skipped: tar is not available here');
+    }
+
+    if (test('a link inside a local plugin is never copied into the store', () => {
+      const source = path.join(dir, 'local-plugin');
+      fs.mkdirSync(path.join(source, 'skills', 'demo'), { recursive: true });
+      fs.writeFileSync(path.join(source, 'plugin.json'), JSON.stringify({ name: 'local', version: '1.0.0', description: 'local', egcPeerVersion: '>=1.1.0' }));
+      fs.writeFileSync(path.join(source, 'skills', 'demo', 'SKILL.md'), '# demo');
+      fs.writeFileSync(path.join(dir, 'secret.md'), 'secret');
+      let linked = true;
+      try {
+        fs.symlinkSync(path.join(dir, 'secret.md'), path.join(source, 'skills', 'demo', 'linked.md'));
+        fs.symlinkSync(dir, path.join(source, 'rules'), 'dir');
+      } catch (error) {
+        linked = false;
+        console.log(`  - links not available here (${error.code}); copy check only`);
+      }
+      const result = registry.installPluginFromDir(source, 'local');
+      assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+      const installed = path.join(home, '.egc', 'plugins', 'installed', 'local');
+      assert.ok(fs.existsSync(path.join(installed, 'skills', 'demo', 'SKILL.md')));
+      if (linked) {
+        assert.ok(!fs.existsSync(path.join(installed, 'skills', 'demo', 'linked.md')), 'the linked file is not copied');
+        assert.ok(!fs.existsSync(path.join(installed, 'rules')), 'the linked directory is not copied');
+      }
+    })) passed++; else failed++;
+  } finally {
+    process.env.HOME = previousHome.HOME;
+    process.env.USERPROFILE = previousHome.USERPROFILE;
+    if (previousHome.USERPROFILE === undefined) delete process.env.USERPROFILE;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Why

Security schedule, day 12 (audit 2026-08-17, MEDIUM items: "unguarded tar extraction on `egc plugin install`" and "manifest parity enforced by discipline, not CI").

`egc plugin install <name>` ran `npm pack` and then `tar -xzf` on whatever came back, with no inspection: a package whose archive carries a climbing name or a symbolic link could land or point outside the temporary directory, and the recursive copy that followed would carry a link's target into the plugin store. The plugin name itself was joined onto the store path without validation, so `egc plugin install ../x` named a directory outside it.

## What changed

- The archive is listed (`tar -tzvf`) before anything is written; an entry that climbs, has an absolute name, or is anything but a plain file or directory (symbolic or hard link, device) refuses the whole package with the offending entries named.
- Extraction takes no ownership or permission bits from the archive (`--no-same-owner --no-same-permissions`), and the extracted `package/` directory is checked with `lstat`.
- A plugin name is one directory segment (letters, digits, dots, dashes, underscores) or the npm scope form `@scope/name`; anything else is refused before any path is built, for local and npm installs alike.
- The recursive copy into the store skips symbolic links and anything that is not a plain file or directory.
- The store follows the home directory the environment names, so the tests run against a temporary home.

Manifest parity: `EGC_MANIFEST_STRICT` is already strict by default in `scripts/ci/validate-install-manifests.js` (only `=0` relaxes it) and is set to `1` in the CI workflow, with tests covering both; nothing further was needed for that item.

## Proof

`tests/lib/plugin-install-archive.test.js` builds real archives with `tar`: a clean package passes, a package with a symbolic link is refused, a package with a `package/../../../` entry (crafted with `--transform`, the way a hostile publisher would) is refused, invalid names are refused, and a local plugin containing a linked file and a linked directory installs without either.

Live run of the day's scenario against the module: the hostile archive listing shows `package/../../../planted-by-plugin.txt`, the inspection returns `archive entry climbs out of the package`, and `../x` as a name returns `Invalid plugin name`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two unguarded paths in `egc plugin install`: the npm package archive was extracted without inspection, and plugin names were joined onto the store path without validation, so a hostile archive or a name like `../x` could land outside the store.

**Security fixes**
- The archive is listed before extraction and the extracted tree is re-checked on disk, so climbing, absolute, and non-plain entries are refused on any tar.
- Extraction drops archive ownership and permission bits; `plugin.json` and the `skills/`, `agents/`, `rules/` entries must be plain files or directories, and the installed tree is validated again before the lock file records it.
- A plugin name is one directory segment or `@scope/name`, stored flat as `@scope+name`; the plus sign is outside the accepted name alphabet, so no other accepted name maps onto that directory and a scope and a same-named plugin never share a path.
- The copy into the store skips symbolic links and anything that isn't a plain file or directory; a plugin recorded under an invalid legacy name fails on its own in remove, update, and reinstall instead of throwing.
- The store follows the home directory the environment names, so tests run against a temporary home; the hostile archives are built by hand, so the climbing and absolute-name cases run on any tar. Manifest parity needs no changes; `EGC_MANIFEST_STRICT` is already strict by default and set to `1` in CI.

<sup>Written for commit d7f64173b4ea07578671fdc4717bef5c997bac06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

