### PR TITLE
fix(security): escape single quotes in the dashboard's inline handlers, and refuse untrusted event text inside run: steps

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -750,7 +750,10 @@ const IDES=[
   {id:'vscode',    label:'VS Code',    c:'#007acc',e:'🔷'},
   {id:'aider',     label:'Aider',      c:'#f57c00',e:'⚡'},
 ];
-function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
+// Every character that could end an attribute or a quoted string inside
+// an inline handler is escaped, single quotes included, so a value is
+// text wherever it lands in the markup.
+function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
 
 const EGC_AGENTS=[
   {id:'memory',    name:'Memory',        icon:'🧠',node:'memory',    c:'#00d992',tools:['Read','Grep','Glob','Search'],   thoughts:{Read:'🧠 Reading memory',Grep:'🔎 Searching history',Glob:'📂 Scanning directory',Search:'🔎 Searching knowledge base'}},
@@ -1238,8 +1241,8 @@ startTimer();
 /* ── IDE PILLS ──────────────────────────────────────────── */
 function iconf(id){return IDES.find(i=>i.id===id)||{label:id,c:'#888',e:'🔧'};}
 document.getElementById('idePills').innerHTML=IDES.map(i=>
-  `<div class="ide-pill" id="pill-${i.id}" style="--pill-c:${i.c}" onclick="selIde('${i.id}')" title="${i.label}">
-    <div class="ide-dot"></div><span class="ide-ico">${i.e}</span><span class="ide-lbl">${i.label}</span></div>`
+  `<div class="ide-pill" id="pill-${esc(i.id)}" style="--pill-c:${esc(i.c)}" onclick="selIde('${esc(i.id)}')" title="${esc(i.label)}">
+    <div class="ide-dot"></div><span class="ide-ico">${esc(i.e)}</span><span class="ide-lbl">${esc(i.label)}</span></div>`
 ).join('');
 function selIde(id){
   S.filter=S.filter===id?null:id;

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -909,7 +909,7 @@ function docResultBlock(result){
     .map(i=>`<div class="doc-issue">[${esc(i.severity)}] ${esc(i.code)}: ${esc(i.message)}</div>`)
     .join('');
   const action=status==='ok'?'':`<div class="doc-action">
-        <button class="btn-sm" onclick="opRepair('${esc(target)}')">Repair</button>
+        <button class="btn-sm" data-op="repair" data-target="${esc(target)}">Repair</button>
         <code class="doc-cmd">egc repair --target ${esc(target)}</code>
       </div>`;
   return `<div class="doc-item">
@@ -932,7 +932,7 @@ function docInstallBlock(row){
         <span class="doc-kind">${esc(row.kinds.join(' · '))}</span>
       </div>
       <div class="doc-action">
-        <button class="btn-sm" onclick="opInstall('${esc(row.target)}')">Install</button>
+        <button class="btn-sm" data-op="install" data-target="${esc(row.target)}">Install</button>
         <code class="doc-cmd">egc install --target ${esc(row.target)} --profile full</code>
       </div>
     </div>`;
@@ -1241,9 +1241,22 @@ startTimer();
 /* ── IDE PILLS ──────────────────────────────────────────── */
 function iconf(id){return IDES.find(i=>i.id===id)||{label:id,c:'#888',e:'🔧'};}
 document.getElementById('idePills').innerHTML=IDES.map(i=>
-  `<div class="ide-pill" id="pill-${esc(i.id)}" style="--pill-c:${esc(i.c)}" onclick="selIde('${esc(i.id)}')" title="${esc(i.label)}">
+  `<div class="ide-pill" id="pill-${esc(i.id)}" style="--pill-c:${esc(i.c)}" data-ide="${esc(i.id)}" title="${esc(i.label)}">
     <div class="ide-dot"></div><span class="ide-ico">${esc(i.e)}</span><span class="ide-lbl">${esc(i.label)}</span></div>`
 ).join('');
+// Values never land inside handler code: a click is read from the element's
+// data attribute, which the HTML parser hands over as plain text whatever
+// characters it carries.
+document.getElementById('idePills').addEventListener('click',e=>{
+  const pill=e.target.closest('.ide-pill[data-ide]');
+  if(pill)selIde(pill.dataset.ide);
+});
+document.getElementById('docBody').addEventListener('click',e=>{
+  const btn=e.target.closest('button[data-op][data-target]');
+  if(!btn)return;
+  if(btn.dataset.op==='repair')opRepair(btn.dataset.target);
+  else if(btn.dataset.op==='install')opInstall(btn.dataset.target);
+});
 function selIde(id){
   S.filter=S.filter===id?null:id;
   document.querySelectorAll('.ide-pill').forEach(e=>e.classList.remove('selected'));

--- a/dashboard/public/replay.html
+++ b/dashboard/public/replay.html
@@ -187,9 +187,9 @@ function renderSessionList() {
       <div class="sl-ide">${escHtml(s.ide || 'unknown')}</div>
       <div class="sl-time">${formatTs(s.timestamp)}</div>
       <div class="sl-meta">
-        <span>${s.eventCount || 0} events</span>
+        <span>${escHtml(s.eventCount || 0)} events</span>
         ${s.duration ? '<span>' + formatDur(s.duration) + '</span>' : ''}
-        ${s.model ? '<span>' + s.model + '</span>' : ''}
+        ${s.model ? '<span>' + escHtml(s.model) + '</span>' : ''}
       </div>
     </div>
   `).join('');
@@ -410,7 +410,7 @@ function formatRelTime(ms) {
 
 function escHtml(s) {
   if (s == null) return '';
-  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
 
 // Wire up scrub bar after DOM ready

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -72,11 +72,12 @@ function isWordChar(ch) {
 }
 
 // One bracketed segment starting at the `[` at `from`: a quoted name, an
-// index or a `*`, with spaces allowed inside the brackets. Returns the
+// index or a `*`, with expression whitespace (spaces or tabs) allowed
+// inside the brackets. Returns the
 // segment and the index after the `]`, or null when the text is not one.
 function bracketSegment(text, from) {
   let i = from + 1;
-  while (text[i] === ' ') i += 1;
+  while (isBlank(text[i])) i += 1;
   let value;
   const quote = text[i];
   if (quote === "'" || quote === '"') {
@@ -90,7 +91,7 @@ function bracketSegment(text, from) {
     if (i === start) return null;
     value = text.slice(start, i);
   }
-  while (text[i] === ' ') i += 1;
+  while (isBlank(text[i])) i += 1;
   return text[i] === ']' ? { value, next: i + 1 } : null;
 }
 

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -38,19 +38,70 @@ const RULES = [
 // inside a run: step is a shell injection whatever the triggering event.
 // A field is matched anywhere inside an expression (`|| ''`, `format()`,
 // a ternary), not only as the whole expression.
-const UNTRUSTED_EVENT_FIELDS = [
-  /\bgithub\.event\.pull_request\.(?:title|body)\b/,
-  /\bgithub\.event\.pull_request\.head\.(?:ref|label)\b/,
-  /\bgithub\.event\.pull_request\.user\.(?:login|email)\b/,
-  /\bgithub\.event\.issue\.(?:title|body)\b/,
-  /\bgithub\.event\.(?:comment|review|review_comment)\.body\b/,
-  /\bgithub\.event\.discussion\.(?:title|body)\b/,
-  /\bgithub\.event\.commits\[\d+\]\.message\b/,
-  /\bgithub\.event\.commits\[\d+\]\.(?:author|committer)\.(?:name|email)\b/,
-  /\bgithub\.event\.head_commit\.message\b/,
-  /\bgithub\.event\.head_commit\.(?:author|committer)\.(?:name|email)\b/,
-  /\bgithub\.head_ref\b/,
+const UNTRUSTED_EVENT_PATHS = [
+  ['github', 'event', 'pull_request', 'title'],
+  ['github', 'event', 'pull_request', 'body'],
+  ['github', 'event', 'pull_request', 'head', 'ref'],
+  ['github', 'event', 'pull_request', 'head', 'label'],
+  ['github', 'event', 'pull_request', 'user', 'login'],
+  ['github', 'event', 'pull_request', 'user', 'email'],
+  ['github', 'event', 'issue', 'title'],
+  ['github', 'event', 'issue', 'body'],
+  ['github', 'event', 'comment', 'body'],
+  ['github', 'event', 'review', 'body'],
+  ['github', 'event', 'review_comment', 'body'],
+  ['github', 'event', 'discussion', 'title'],
+  ['github', 'event', 'discussion', 'body'],
+  ['github', 'event', 'commits', '*', 'message'],
+  ['github', 'event', 'commits', '*', 'author', 'name'],
+  ['github', 'event', 'commits', '*', 'author', 'email'],
+  ['github', 'event', 'commits', '*', 'committer', 'name'],
+  ['github', 'event', 'commits', '*', 'committer', 'email'],
+  ['github', 'event', 'head_commit', 'message'],
+  ['github', 'event', 'head_commit', 'author', 'name'],
+  ['github', 'event', 'head_commit', 'author', 'email'],
+  ['github', 'event', 'head_commit', 'committer', 'name'],
+  ['github', 'event', 'head_commit', 'committer', 'email'],
+  ['github', 'head_ref'],
 ];
+
+// The context paths referenced in an expression, each as its segments, read
+// from dotted (`a.b`), bracketed (`a['b']`, `a["b"]`) and indexed (`a[0]`)
+// spellings alike, so the spelling cannot hide the field.
+function contextPathsIn(expression) {
+  const paths = [];
+  const reader = /\bgithub((?:\.[A-Za-z_][\w-]*|\[\s*(?:'[^']*'|"[^"]*"|\d+|\*)\s*\])+)/g;
+  for (const match of expression.matchAll(reader)) {
+    const segments = ['github'];
+    const tail = match[1];
+    const segment = /\.([A-Za-z_][\w-]*)|\[\s*(?:'([^']*)'|"([^"]*)"|(\d+|\*))\s*\]/g;
+    for (const piece of tail.matchAll(segment)) segments.push(piece[1] ?? piece[2] ?? piece[3] ?? piece[4]);
+    paths.push(segments);
+  }
+  return paths;
+}
+
+function isUntrustedPath(segments) {
+  return UNTRUSTED_EVENT_PATHS.some(known => known.length === segments.length && known.every((part, index) => part === '*' ? /^\d+$|^\*$/.test(segments[index]) : part === segments[index]));
+}
+
+// The end of the expression opened at `from`: the first `}}` outside a
+// quoted string, so a brace pair inside a string literal is not a closer.
+function expressionEnd(text, from) {
+  let quote = null;
+  for (let i = from + 3; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = text[i + 1] === quote ? (i += 1, quote) : null;
+    } else if (ch === "'" || ch === '"') {
+      quote = ch;
+    } else if (ch === '}' && text[i + 1] === '}') {
+      return i + 2;
+    }
+  }
+  return -1;
+}
+
 
 // The untrusted fields found inside the `${{ ... }}` expressions of `text`,
 // each with its offset in the text. Expressions are found by a plain scan
@@ -60,14 +111,13 @@ function untrustedFieldsIn(text) {
   const found = [];
   let from = text.indexOf('${{');
   while (from !== -1) {
-    const close = text.indexOf('}}', from + 3);
-    if (close === -1) break;
-    const expression = text.slice(from, close + 2);
-    for (const field of UNTRUSTED_EVENT_FIELDS) {
-      const match = field.exec(expression);
-      if (match) found.push({ index: from, expression: expression.length > 120 ? `${expression.slice(0, 117)}...` : expression, field: match[0] });
+    const end = expressionEnd(text, from);
+    if (end === -1) break;
+    const expression = text.slice(from, end);
+    for (const segments of contextPathsIn(expression)) {
+      if (isUntrustedPath(segments)) found.push({ index: from, expression: expression.length > 120 ? `${expression.slice(0, 117)}...` : expression, field: segments.join('.') });
     }
-    from = text.indexOf('${{', close + 2);
+    from = text.indexOf('${{', end);
   }
   return found;
 }

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -66,15 +66,15 @@ const UNTRUSTED_EVENT_PATHS = [
 ];
 
 // The context paths referenced in an expression, each as its segments, read
-// from dotted (`a.b`), bracketed (`a['b']`, `a["b"]`) and indexed (`a[0]`)
-// spellings alike, so the spelling cannot hide the field.
+// from dotted (`a.b`), bracketed (`a['b']`, `a["b"]`), indexed (`a[0]`) and
+// filtered (`a.*.b`) spellings alike, so the spelling cannot hide the field.
 function contextPathsIn(expression) {
   const paths = [];
-  const reader = /\bgithub((?:\.[A-Za-z_][\w-]*|\[\s*(?:'[^']*'|"[^"]*"|\d+|\*)\s*\])+)/g;
+  const reader = /\bgithub((?:\.(?:[A-Za-z_][\w-]*|\*)|\[\s*(?:'[^']*'|"[^"]*"|\d+|\*)\s*\])+)/g;
   for (const match of expression.matchAll(reader)) {
     const segments = ['github'];
     const tail = match[1];
-    const segment = /\.([A-Za-z_][\w-]*)|\[\s*(?:'([^']*)'|"([^"]*)"|(\d+|\*))\s*\]/g;
+    const segment = /\.([A-Za-z_][\w-]*|\*)|\[\s*(?:'([^']*)'|"([^"]*)"|(\d+|\*))\s*\]/g;
     for (const piece of tail.matchAll(segment)) segments.push(piece[1] ?? piece[2] ?? piece[3] ?? piece[4]);
     paths.push(segments);
   }

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 /**
  * Reject unsafe GitHub Actions patterns that execute or checkout untrusted PR code
- * from privileged events such as workflow_run or pull_request_target.
+ * from privileged events such as workflow_run or pull_request_target, and
+ * any `run:` step that splices attacker-controlled event text (a pull
+ * request title or body, an issue or comment body, a branch name) into the
+ * shell: the runner expands the expression before the shell reads it, so
+ * the text is code.
  */
 
 const fs = require('node:fs');
@@ -28,6 +32,50 @@ const RULES = [
     ],
   },
 ];
+
+// Event fields whose text is written by whoever opened the pull request,
+// issue or comment, or named the branch; any of them inside a run: step is
+// a shell injection whatever the triggering event.
+const UNTRUSTED_TEXT_EXPRESSION = /\$\{\{\s*github\.(?:event\.(?:pull_request\.(?:title|body|head\.(?:ref|label)|user\.(?:login|email))|issue\.(?:title|body)|comment\.body|review\.body|review_comment\.body|discussion\.(?:title|body)|commits\[\d+\]\.(?:message|author\.(?:name|email))|head_commit\.(?:message|author\.(?:name|email)))|head_ref)\s*\}\}/g;
+
+// The run: blocks of a workflow, with the line each one starts on: the
+// scalar after `run:` and, for a block scalar (| or >), every following
+// line indented deeper than the key.
+function extractRunBlocks(source) {
+  const blocks = [];
+  const lines = source.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = /^(\s*)(?:-\s+)?run:\s*(.*)$/.exec(lines[i]);
+    if (!match) continue;
+    const indent = match[1].length;
+    const text = [match[2]];
+    if (/^[|>]/.test(match[2].trim())) {
+      let j = i + 1;
+      while (j < lines.length && (lines[j].trim() === '' || lines[j].search(/\S/) > indent)) {
+        text.push(lines[j]);
+        j += 1;
+      }
+    }
+    blocks.push({ startLine: i + 1, text: text.join('\n') });
+  }
+  return blocks;
+}
+
+function findRunInjections(filePath, source) {
+  const violations = [];
+  for (const block of extractRunBlocks(source)) {
+    for (const match of block.text.matchAll(UNTRUSTED_TEXT_EXPRESSION)) {
+      violations.push({
+        filePath,
+        event: 'run',
+        description: 'run: must not splice untrusted event text into the shell; pass it through an env: variable and quote it',
+        expression: match[0],
+        line: block.startLine + getLineNumber(block.text, match.index) - 1,
+      });
+    }
+  }
+  return violations;
+}
 
 function getWorkflowFiles(workflowsDir) {
   if (!fs.existsSync(workflowsDir)) {
@@ -109,6 +157,7 @@ function findViolations(filePath, source) {
     }
   }
 
+  violations.push(...findRunInjections(filePath, source));
   return violations;
 }
 
@@ -144,6 +193,8 @@ if (require.main === module) {
 module.exports = {
   DEFAULT_WORKFLOWS_DIR,
   extractCheckoutSteps,
+  extractRunBlocks,
+  findRunInjections,
   findViolations,
   validateWorkflowSecurity,
 };

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -34,24 +34,61 @@ const RULES = [
 ];
 
 // Event fields whose text is written by whoever opened the pull request,
-// issue or comment, or named the branch; any of them inside a run: step is
-// a shell injection whatever the triggering event.
-const UNTRUSTED_TEXT_EXPRESSION = /\$\{\{\s*github\.(?:event\.(?:pull_request\.(?:title|body|head\.(?:ref|label)|user\.(?:login|email))|issue\.(?:title|body)|comment\.body|review\.body|review_comment\.body|discussion\.(?:title|body)|commits\[\d+\]\.(?:message|author\.(?:name|email))|head_commit\.(?:message|author\.(?:name|email)))|head_ref)\s*\}\}/g;
+// issue or comment, named the branch or authored the commit; any of them
+// inside a run: step is a shell injection whatever the triggering event.
+// A field is matched anywhere inside an expression (`|| ''`, `format()`,
+// a ternary), not only as the whole expression.
+const UNTRUSTED_EVENT_FIELDS = [
+  /\bgithub\.event\.pull_request\.(?:title|body)\b/,
+  /\bgithub\.event\.pull_request\.head\.(?:ref|label)\b/,
+  /\bgithub\.event\.pull_request\.user\.(?:login|email)\b/,
+  /\bgithub\.event\.issue\.(?:title|body)\b/,
+  /\bgithub\.event\.(?:comment|review|review_comment)\.body\b/,
+  /\bgithub\.event\.discussion\.(?:title|body)\b/,
+  /\bgithub\.event\.commits\[\d+\]\.message\b/,
+  /\bgithub\.event\.commits\[\d+\]\.(?:author|committer)\.(?:name|email)\b/,
+  /\bgithub\.event\.head_commit\.message\b/,
+  /\bgithub\.event\.head_commit\.(?:author|committer)\.(?:name|email)\b/,
+  /\bgithub\.head_ref\b/,
+];
+
+// The untrusted fields found inside the `${{ ... }}` expressions of `text`,
+// each with its offset in the text. Expressions are found by a plain scan
+// (no nested braces in the expression syntax), so a malformed one cannot
+// make the scan backtrack.
+function untrustedFieldsIn(text) {
+  const found = [];
+  let from = text.indexOf('${{');
+  while (from !== -1) {
+    const close = text.indexOf('}}', from + 3);
+    if (close === -1) break;
+    const expression = text.slice(from, close + 2);
+    for (const field of UNTRUSTED_EVENT_FIELDS) {
+      const match = field.exec(expression);
+      if (match) found.push({ index: from, expression: expression.length > 120 ? `${expression.slice(0, 117)}...` : expression, field: match[0] });
+    }
+    from = text.indexOf('${{', close + 2);
+  }
+  return found;
+}
 
 // The run: blocks of a workflow, with the line each one starts on: the
-// scalar after `run:` and, for a block scalar (| or >), every following
-// line indented deeper than the key.
+// scalar after the `run` key (spaces before the colon allowed, as YAML
+// does) and, for a block scalar (| or >), every following line indented
+// deeper than the key itself. The key's column, not the dash's, bounds the
+// block, so a sibling key (env:, shell:) after a block-scalar run: is not
+// swallowed into it.
 function extractRunBlocks(source) {
   const blocks = [];
   const lines = source.split(/\r?\n/);
   for (let i = 0; i < lines.length; i += 1) {
-    const match = /^(\s*)(?:-\s+)?run:\s*(.*)$/.exec(lines[i]);
+    const match = /^(\s*(?:-\s+)?)run\s*:\s*(.*)$/.exec(lines[i]);
     if (!match) continue;
-    const indent = match[1].length;
+    const keyColumn = match[1].length;
     const text = [match[2]];
     if (/^[|>]/.test(match[2].trim())) {
       let j = i + 1;
-      while (j < lines.length && (lines[j].trim() === '' || lines[j].search(/\S/) > indent)) {
+      while (j < lines.length && (lines[j].trim() === '' || lines[j].search(/\S/) > keyColumn)) {
         text.push(lines[j]);
         j += 1;
       }
@@ -64,13 +101,13 @@ function extractRunBlocks(source) {
 function findRunInjections(filePath, source) {
   const violations = [];
   for (const block of extractRunBlocks(source)) {
-    for (const match of block.text.matchAll(UNTRUSTED_TEXT_EXPRESSION)) {
+    for (const found of untrustedFieldsIn(block.text)) {
       violations.push({
         filePath,
         event: 'run',
-        description: 'run: must not splice untrusted event text into the shell; pass it through an env: variable and quote it',
-        expression: match[0],
-        line: block.startLine + getLineNumber(block.text, match.index) - 1,
+        description: `run: must not splice untrusted event text (${found.field}) into the shell; pass it through an env: variable and quote it`,
+        expression: found.expression,
+        line: block.startLine + getLineNumber(block.text, found.index) - 1,
       });
     }
   }
@@ -195,6 +232,8 @@ module.exports = {
   extractCheckoutSteps,
   extractRunBlocks,
   findRunInjections,
+  untrustedFieldsIn,
+
   findViolations,
   validateWorkflowSecurity,
 };

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -65,18 +65,70 @@ const UNTRUSTED_EVENT_PATHS = [
   ['github', 'head_ref'],
 ];
 
+const IDENTIFIER_CHARS = /^[A-Za-z0-9_-]$/;
+
+function isWordChar(ch) {
+  return ch !== undefined && IDENTIFIER_CHARS.test(ch);
+}
+
+// One bracketed segment starting at the `[` at `from`: a quoted name, an
+// index or a `*`, with spaces allowed inside the brackets. Returns the
+// segment and the index after the `]`, or null when the text is not one.
+function bracketSegment(text, from) {
+  let i = from + 1;
+  while (text[i] === ' ') i += 1;
+  let value;
+  const quote = text[i];
+  if (quote === "'" || quote === '"') {
+    const close = text.indexOf(quote, i + 1);
+    if (close === -1) return null;
+    value = text.slice(i + 1, close);
+    i = close + 1;
+  } else {
+    const start = i;
+    while (text[i] === '*' || (text[i] >= '0' && text[i] <= '9')) i += 1;
+    if (i === start) return null;
+    value = text.slice(start, i);
+  }
+  while (text[i] === ' ') i += 1;
+  return text[i] === ']' ? { value, next: i + 1 } : null;
+}
+
+// One dotted segment starting at the `.` at `from`: an identifier or the
+// `*` object filter. Returns the segment and the index after it, or null.
+function dottedSegment(text, from) {
+  let i = from + 1;
+  if (text[i] === '*') return { value: '*', next: i + 1 };
+  const start = i;
+  while (isWordChar(text[i])) i += 1;
+  return i === start ? null : { value: text.slice(start, i), next: i };
+}
+
+function nextSegment(text, at) {
+  if (text[at] === '.') return dottedSegment(text, at);
+  return text[at] === '[' ? bracketSegment(text, at) : null;
+}
+
 // The context paths referenced in an expression, each as its segments, read
 // from dotted (`a.b`), bracketed (`a['b']`, `a["b"]`), indexed (`a[0]`) and
 // filtered (`a.*.b`) spellings alike, so the spelling cannot hide the field.
+// A plain index walk, so no pattern can make the read backtrack.
 function contextPathsIn(expression) {
   const paths = [];
-  const reader = /\bgithub((?:\.(?:[A-Za-z_][\w-]*|\*)|\[\s*(?:'[^']*'|"[^"]*"|\d+|\*)\s*\])+)/g;
-  for (const match of expression.matchAll(reader)) {
+  let from = expression.indexOf('github');
+  while (from !== -1) {
+    let i = from + 'github'.length;
     const segments = ['github'];
-    const tail = match[1];
-    const segment = /\.([A-Za-z_][\w-]*|\*)|\[\s*(?:'([^']*)'|"([^"]*)"|(\d+|\*))\s*\]/g;
-    for (const piece of tail.matchAll(segment)) segments.push(piece[1] ?? piece[2] ?? piece[3] ?? piece[4]);
-    paths.push(segments);
+    if (!isWordChar(expression[from - 1])) {
+      let segment = nextSegment(expression, i);
+      while (segment) {
+        segments.push(segment.value);
+        i = segment.next;
+        segment = nextSegment(expression, i);
+      }
+      if (segments.length > 1) paths.push(segments);
+    }
+    from = expression.indexOf('github', i);
   }
   return paths;
 }
@@ -128,15 +180,41 @@ function untrustedFieldsIn(text) {
 // deeper than the key itself. The key's column, not the dash's, bounds the
 // block, so a sibling key (env:, shell:) after a block-scalar run: is not
 // swallowed into it.
+function isBlank(ch) {
+  return ch === ' ' || ch === '\t';
+}
+
+// The `run` key on a line, with the column the key starts on (after the
+// indentation and an optional list dash) and the scalar after the colon;
+// spaces before the colon are allowed, as YAML does. Read by index, so no
+// pattern can make the read backtrack.
+function runKeyOn(line) {
+  let i = 0;
+  while (isBlank(line[i])) i += 1;
+  if (line[i] === '-') {
+    i += 1;
+    if (!isBlank(line[i])) return null;
+    while (isBlank(line[i])) i += 1;
+  }
+  const column = i;
+  if (!line.startsWith('run', i)) return null;
+  i += 'run'.length;
+  while (isBlank(line[i])) i += 1;
+  if (line[i] !== ':') return null;
+  i += 1;
+  while (isBlank(line[i])) i += 1;
+  return { column, value: line.slice(i) };
+}
+
 function extractRunBlocks(source) {
   const blocks = [];
   const lines = source.split(/\r?\n/);
   for (let i = 0; i < lines.length; i += 1) {
-    const match = /^(\s*(?:-\s+)?)run\s*:\s*(.*)$/.exec(lines[i]);
-    if (!match) continue;
-    const keyColumn = match[1].length;
-    const text = [match[2]];
-    if (/^[|>]/.test(match[2].trim())) {
+    const key = runKeyOn(lines[i]);
+    if (!key) continue;
+    const keyColumn = key.column;
+    const text = [key.value];
+    if (/^[|>]/.test(key.value.trim())) {
       let j = i + 1;
       while (j < lines.length && (lines[j].trim() === '' || lines[j].search(/\S/) > keyColumn)) {
         text.push(lines[j]);

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -76,14 +76,16 @@ function run() {
     assert.ok(result.stderr.includes('committer.name'), result.stderr);
   })) passed++; else failed++;
 
-  if (test('rejects bracket spellings and a field placed after a string that carries }}', () => {
+  if (test('rejects bracket and filter spellings, and a field placed after a string that carries }}', () => {
     const result = runValidator({
-      'spelling.yml': 'name: X\non:\n  push:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event[\'pull_request\'][\'title\'] }}"\n      - run: echo "${{ format(\'}}\', github.event.issue.body) }}"\n      - run: echo "${{ github.event.commits[3][\'message\'] }}"\n',
+      'spelling.yml': 'name: X\non:\n  push:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event[\'pull_request\'][\'title\'] }}"\n      - run: echo "${{ format(\'}}\', github.event.issue.body) }}"\n      - run: echo "${{ github.event.commits[3][\'message\'] }}"\n      - run: echo "${{ join(github.event.commits.*.message, \', \') }}"\n',
     });
     assert.notStrictEqual(result.status, 0);
     assert.ok(result.stderr.includes('spelling.yml:8'), result.stderr);
     assert.ok(result.stderr.includes('spelling.yml:9'), result.stderr);
     assert.ok(result.stderr.includes('spelling.yml:10'), result.stderr);
+    assert.ok(result.stderr.includes('spelling.yml:11'), result.stderr);
+
   })) passed++; else failed++;
 
   if (test('allows an env: sibling that follows a block-scalar run:', () => {

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -66,6 +66,23 @@ function run() {
     assert.ok(result.stderr.includes('body.yml:13'), result.stderr);
   })) passed++; else failed++;
 
+  if (test('rejects a field wrapped in a larger expression, a spaced run key, and committer fields', () => {
+    const result = runValidator({
+      'wrapped.yml': 'name: W\non:\n  push:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run : echo "${{ github.event.pull_request.title || \'none\' }}"\n      - run: echo "${{ format(\'{0}\', github.event.head_commit.committer.name) }}"\n',
+    });
+    assert.notStrictEqual(result.status, 0);
+    assert.ok(result.stderr.includes('wrapped.yml:8'), result.stderr);
+    assert.ok(result.stderr.includes('wrapped.yml:9'), result.stderr);
+    assert.ok(result.stderr.includes('committer.name'), result.stderr);
+  })) passed++; else failed++;
+
+  if (test('allows an env: sibling that follows a block-scalar run:', () => {
+    const result = runValidator({
+      'sibling.yml': 'name: S\non:\n  issues:\n    types: [opened]\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          echo "$BODY"\n          echo done\n        env:\n          BODY: ${{ github.event.issue.body }}\n',
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  })) passed++; else failed++;
+
   if (test('allows the same text passed through an env: variable', () => {
     const result = runValidator({
       'env.yml': 'name: E\non:\n  pull_request:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - env:\n          TITLE: ${{ github.event.pull_request.title }}\n        run: echo "$TITLE"\n',

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -76,6 +76,16 @@ function run() {
     assert.ok(result.stderr.includes('committer.name'), result.stderr);
   })) passed++; else failed++;
 
+  if (test('rejects bracket spellings and a field placed after a string that carries }}', () => {
+    const result = runValidator({
+      'spelling.yml': 'name: X\non:\n  push:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event[\'pull_request\'][\'title\'] }}"\n      - run: echo "${{ format(\'}}\', github.event.issue.body) }}"\n      - run: echo "${{ github.event.commits[3][\'message\'] }}"\n',
+    });
+    assert.notStrictEqual(result.status, 0);
+    assert.ok(result.stderr.includes('spelling.yml:8'), result.stderr);
+    assert.ok(result.stderr.includes('spelling.yml:9'), result.stderr);
+    assert.ok(result.stderr.includes('spelling.yml:10'), result.stderr);
+  })) passed++; else failed++;
+
   if (test('allows an env: sibling that follows a block-scalar run:', () => {
     const result = runValidator({
       'sibling.yml': 'name: S\non:\n  issues:\n    types: [opened]\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          echo "$BODY"\n          echo done\n        env:\n          BODY: ${{ github.event.issue.body }}\n',

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -48,6 +48,39 @@ function run() {
   let passed = 0;
   let failed = 0;
 
+  if (test('rejects a run: step that splices the pull request title into the shell', () => {
+    const result = runValidator({
+      'title.yml': 'name: T\non:\n  pull_request:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event.pull_request.title }}"\n',
+    });
+    assert.notStrictEqual(result.status, 0, 'a title inside run: is a violation');
+    assert.ok(result.stderr.includes('github.event.pull_request.title'), result.stderr);
+    assert.ok(result.stderr.includes('title.yml:8'), result.stderr);
+  })) passed++; else failed++;
+
+  if (test('rejects a block-scalar run: with an issue body or a branch name on a later line', () => {
+    const result = runValidator({
+      'body.yml': 'name: B\non:\n  issues:\n    types: [opened]\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - name: show\n        run: |\n          echo start\n          echo "${{ github.event.issue.body }}"\n          git checkout "${{ github.head_ref }}"\n',
+    });
+    assert.notStrictEqual(result.status, 0);
+    assert.ok(result.stderr.includes('body.yml:12'), result.stderr);
+    assert.ok(result.stderr.includes('body.yml:13'), result.stderr);
+  })) passed++; else failed++;
+
+  if (test('allows the same text passed through an env: variable', () => {
+    const result = runValidator({
+      'env.yml': 'name: E\non:\n  pull_request:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - env:\n          TITLE: ${{ github.event.pull_request.title }}\n        run: echo "$TITLE"\n',
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  })) passed++; else failed++;
+
+  if (test('allows run: steps that use trusted context only', () => {
+    const result = runValidator({
+      'ok.yml': 'name: O\non:\n  pull_request:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          echo "${{ github.sha }} ${{ github.event.pull_request.number }}"\n          echo "${{ runner.os }}"\n',
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  })) passed++; else failed++;
+
+
   if (test('allows safe workflow_run workflow that only checks out the base repository', () => {
     const result = runValidator({
       'safe.yml': `name: Safe\non:\n  workflow_run:\n    workflows: ["CI"]\n    types: [completed]\njobs:\n  repair:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: echo safe\n`,

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -78,13 +78,15 @@ function run() {
 
   if (test('rejects bracket and filter spellings, and a field placed after a string that carries }}', () => {
     const result = runValidator({
-      'spelling.yml': 'name: X\non:\n  push:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event[\'pull_request\'][\'title\'] }}"\n      - run: echo "${{ format(\'}}\', github.event.issue.body) }}"\n      - run: echo "${{ github.event.commits[3][\'message\'] }}"\n      - run: echo "${{ join(github.event.commits.*.message, \', \') }}"\n',
+      'spelling.yml': 'name: X\non:\n  push:\njobs:\n  echo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event[\'pull_request\'][\'title\'] }}"\n      - run: echo "${{ format(\'}}\', github.event.issue.body) }}"\n      - run: echo "${{ github.event.commits[3][\'message\'] }}"\n      - run: echo "${{ join(github.event.commits.*.message, \', \') }}"\n      - run: echo "${{ github.event[\t\'pull_request\'\t][\t\'title\'\t] }}"\n',
     });
     assert.notStrictEqual(result.status, 0);
     assert.ok(result.stderr.includes('spelling.yml:8'), result.stderr);
     assert.ok(result.stderr.includes('spelling.yml:9'), result.stderr);
     assert.ok(result.stderr.includes('spelling.yml:10'), result.stderr);
     assert.ok(result.stderr.includes('spelling.yml:11'), result.stderr);
+    assert.ok(result.stderr.includes('spelling.yml:12'), result.stderr);
+
 
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Why

Security schedule, day 14 (audit 2026-08-17, MEDIUM items): "fragile escaping in dashboard onclick handlers (single-quote not escaped by `esc()`), safe today only because the interpolated values come from a small enumerated set", and "CI's own workflow-security linter has a documented blind spot: it catches the pwn-request checkout but not `github.event.pull_request.title/body` spliced into `run:`".

## What changed

Dashboard (`dashboard/public/index.html`, `dashboard/public/replay.html`):
- `esc()` and `escHtml()` also escape the single quote (`&#39;`), so a value interpolated into `onclick="fn('...')"` ends as text instead of closing the JavaScript string. The existing handlers already route their value through `esc()`; the IDE pill (id, colour, label, icon) and the replay session list (event count, model) now do too.

Workflow linter (`scripts/ci/validate-workflow-security.js`):
- A rule over every `run:` step, whatever the triggering event: `${{ github.event.pull_request.title | body | head.ref | head.label | user.login | user.email }}`, `github.event.issue.title | body`, `github.event.comment.body`, `github.event.review.body`, `github.event.review_comment.body`, `github.event.discussion.title | body`, commit messages and authors from `github.event.commits[n]` and `github.event.head_commit`, and `github.head_ref` are refused inside the step text, with the line of the expression in the report. The accepted form is the `env:` variable, which the runner passes as data.
- The run block reader takes the scalar after `run:` and, for a block scalar, every following line indented deeper than the key, so a directive on a later line of a `run: |` block is found at its own line.

The repository's 23 workflows pass the new rule unchanged.

## Proof

- `tests/ci/validate-workflow-security.test.js`: the PR title in a one-line `run:` (reported at its line), an issue body and a branch name on later lines of a block scalar (both reported), the same text through `env:` (accepted), and trusted context only (accepted).
- Live run: a value crafted to break out of `opRepair('...')` comes back as `x&#39;);fetch(&#39;...` and stays inside the string; the linter reports `${{ github.event.pull_request.title }}` at line 8 of a sample workflow.
- Full suite green locally; every dashboard suite included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two security gaps from the August audit: dashboard values can no longer break out of inline handlers, and the workflow linter rejects untrusted event text inside `run:` steps.

- Dashboard controls (Repair, Install, IDE pills) now carry their value in a data attribute read by a delegated listener, so values are never compiled as JavaScript; the escaper still covers markup and now also escapes single quotes.
- The replay session fields route interpolated values through the escaper.
- The linter flags untrusted event text (PR titles/bodies, issue/comment/review bodies, branch names, commit and committer messages/authors) anywhere inside a `run:` expression, across block scalars, wrapped expressions, and fallbacks, whatever the spelling — dotted, bracketed (with spaces or tabs inside the brackets), indexed, or filtered (`commits.*.message`) — and closes an expression only outside a quoted string; a spaced `run :` key is covered too.
- Passing the text through an `env:` variable is the accepted alternative; the repo's existing 23 workflows pass unchanged.

<sup>Written for commit 4cbc5b27db97ce84e573af0f00cf019d515a08b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

