### PR TITLE
fix(security): skip prototype keys in merge-json, and refuse a key file that cannot be made private

### DIFF
--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -38,34 +38,96 @@ function defaultEncKeyPath(): string {
  * Throws if the key file exists but cannot be read or is malformed —
  * only generates a new key when the file genuinely does not exist.
  */
-// A key file must be private and must be the file itself. A link is refused
-// before anything is touched, so the permissions of an unrelated target are
-// never changed or trusted. The bits are then set and read back: where the
+// A key file must be private and must be the file itself. It is opened
+// without following links (O_NOFOLLOW where the platform has it) and every
+// check runs on that one descriptor: the object must be a regular file,
+// the mode is set and read back through the descriptor, and the content is
+// read from it, so the file that was checked is the file that is used and
+// a path swapped underneath the checks changes nothing. Where the
 // filesystem keeps POSIX bits (Linux, macOS, most network mounts) a file
 // still readable by the group or others after the chmod is a hard error,
 // because the key would sit exposed with nothing but a log line to say so,
-// and a mount that cannot hold 0600 at all (FAT, exFAT) is refused with the
-// advice to move the key. Windows has no bits to tighten, so the mode check
-// is skipped there.
-export function assertPrivateKeyFile(filePath: string): void {
-  let isLink: boolean;
+// and a mount that cannot hold 0600 at all (FAT, exFAT) is refused with
+// the advice to move the key. Windows has no bits to tighten, so the mode
+// step is skipped there.
+const NO_FOLLOW = fs.constants.O_NOFOLLOW ?? 0;
+
+function linkRefusal(filePath: string, cause?: unknown): Error {
+  return new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`, { cause });
+}
+
+function openPrivateKeyFile(filePath: string): number {
+  if (NO_FOLLOW === 0 && fs.lstatSync(filePath).isSymbolicLink()) throw linkRefusal(filePath);
+  let fd: number;
   try {
-    isLink = fs.lstatSync(filePath).isSymbolicLink();
-  } catch (statErr) {
-    throw new Error(`[EGC] Could not inspect ${filePath}: ${(statErr as Error).message}. The key file must exist and be a regular file.`, { cause: statErr });
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | NO_FOLLOW);
+  } catch (openErr) {
+    const code = (openErr as NodeJS.ErrnoException).code;
+    if (code === 'ELOOP') throw linkRefusal(filePath, openErr);
+    const error: NodeJS.ErrnoException = new Error(`[EGC] Could not open ${filePath}: ${(openErr as Error).message}. The key file must exist and be a regular file.`, { cause: openErr });
+    error.code = code;
+    throw error;
   }
-  if (isLink) {
-    throw new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`);
+  try {
+    checkPrivateDescriptor(fd, filePath);
+  } catch (checkErr) {
+    fs.closeSync(fd);
+    throw checkErr;
+  }
+  return fd;
+}
+
+function checkPrivateDescriptor(fd: number, filePath: string): void {
+  if (!fs.fstatSync(fd).isFile()) {
+    throw new Error(`[EGC] ${filePath} is not a regular file; the key must be a regular file. Replace it and restart.`);
   }
   if (process.platform === 'win32') return;
   try {
-    fs.chmodSync(filePath, 0o600);
+    fs.fchmodSync(fd, 0o600);
   } catch (chmodErr) {
     throw new Error(`[EGC] Could not set 0600 permissions on ${filePath}: ${(chmodErr as Error).message}. The key must not be readable by other users; fix the permissions and restart.`, { cause: chmodErr });
   }
-  const mode = fs.statSync(filePath).mode & 0o777;
+  const mode = fs.fstatSync(fd).mode & 0o777;
   if ((mode & 0o077) !== 0) {
     throw new Error(`[EGC] ${filePath} is readable by other users (mode ${mode.toString(8)}) and the filesystem did not accept 0600. Move the key to a filesystem with POSIX permissions.`);
+  }
+}
+
+export function assertPrivateKeyFile(filePath: string): void {
+  fs.closeSync(openPrivateKeyFile(filePath));
+}
+
+// The content of a key file, read from the descriptor the checks ran on.
+export function readPrivateKeyFile(filePath: string): string {
+  const fd = openPrivateKeyFile(filePath);
+  try {
+    return fs.readFileSync(fd, 'utf-8');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// Whether anything (a file, a link, even a dangling one) sits at the path:
+// a dangling link must be refused as a link, never treated as absent and
+// replaced.
+export function pathPresent(filePath: string): boolean {
+  try {
+    fs.lstatSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The temp file is created exclusively (wx): a link planted at the temp
+// path is never followed, so the key is written only into a file this call
+// created, private from the first byte.
+export function writePrivateTemp(tmpPath: string, content: string): void {
+  const fd = fs.openSync(tmpPath, 'wx', 0o600);
+  try {
+    fs.writeSync(fd, content);
+  } finally {
+    fs.closeSync(fd);
   }
 }
 
@@ -79,16 +141,16 @@ export function loadOrCreateEncKey(keyPath: string = defaultEncKeyPath()): Buffe
   }
 
   const readExistingKey = (): Buffer => {
-    const hex = fs.readFileSync(keyPath, 'utf-8').trim();
+    const hex = readPrivateKeyFile(keyPath).trim();
+
     const key = Buffer.from(hex, 'hex');
     if (key.length !== 32) {
       throw new Error(`[EGC encryption] Key file at ${keyPath} is malformed (expected 32 bytes, got ${key.length}). Remove it to regenerate.`);
     }
-    assertPrivateKeyFile(keyPath);
     return key;
   };
 
-  if (fs.existsSync(keyPath)) {
+  if (pathPresent(keyPath)) {
     // Key file exists — load it. Do NOT silently regenerate on error;
     // that would destroy access to all previously encrypted state files.
     return readExistingKey();
@@ -110,7 +172,8 @@ export function loadOrCreateEncKey(keyPath: string = defaultEncKeyPath()): Buffe
   const key = crypto.randomBytes(32);
   const tmpPath = `${keyPath}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
   try {
-    fs.writeFileSync(tmpPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    writePrivateTemp(tmpPath, key.toString('hex'));
+
     try {
       fs.linkSync(tmpPath, keyPath);
       assertPrivateKeyFile(keyPath);

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -38,6 +38,27 @@ function defaultEncKeyPath(): string {
  * Throws if the key file exists but cannot be read or is malformed —
  * only generates a new key when the file genuinely does not exist.
  */
+// A key file must be private. The permission bits are set and then read
+// back: where the filesystem keeps POSIX bits (Linux, macOS, most network
+// mounts) a file still readable by the group or others after the chmod is a
+// hard error, because the key would sit exposed with nothing but a log line
+// to say so; where the filesystem has no bits at all (FAT, exFAT, Windows)
+// the read-back shows the mode Node synthesizes and nothing can be
+// tightened, so the call is a no-op there.
+export function assertPrivateKeyFile(filePath: string): void {
+  if (process.platform === 'win32') return;
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch (chmodErr) {
+    throw new Error(`[EGC] Could not set 0600 permissions on ${filePath}: ${(chmodErr as Error).message}. The key must not be readable by other users; fix the permissions and restart.`, { cause: chmodErr });
+
+  }
+  const mode = fs.statSync(filePath).mode & 0o777;
+  if ((mode & 0o077) !== 0) {
+    throw new Error(`[EGC] ${filePath} is readable by other users (mode ${mode.toString(8)}) and the filesystem did not accept 0600. Move the key to a filesystem with POSIX permissions.`);
+  }
+}
+
 export function loadOrCreateEncKey(keyPath: string = defaultEncKeyPath()): Buffer {
   const dir = path.dirname(keyPath);
   try {
@@ -53,17 +74,7 @@ export function loadOrCreateEncKey(keyPath: string = defaultEncKeyPath()): Buffe
     if (key.length !== 32) {
       throw new Error(`[EGC encryption] Key file at ${keyPath} is malformed (expected 32 bytes, got ${key.length}). Remove it to regenerate.`);
     }
-    try {
-      fs.chmodSync(keyPath, 0o600);
-    } catch (chmodErr) {
-      // Best-effort: some filesystems (FAT/exFAT mounts, certain network
-      // shares) don't support Unix permission bits at all, and that's a
-      // legitimate no-op. But on a filesystem that DOES support them, a
-      // failure here means the encryption key may be sitting world- or
-      // group-readable with no signal to the user that it happened —
-      // worth a warning even though it's not worth failing the read over.
-      console.error(`[EGC encryption] Warning: could not set 0600 permissions on ${keyPath}: ${(chmodErr as Error).message}`);
-    }
+    assertPrivateKeyFile(keyPath);
     return key;
   };
 
@@ -92,11 +103,7 @@ export function loadOrCreateEncKey(keyPath: string = defaultEncKeyPath()): Buffe
     fs.writeFileSync(tmpPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
     try {
       fs.linkSync(tmpPath, keyPath);
-      try {
-        fs.chmodSync(keyPath, 0o600);
-      } catch (chmodErr) {
-        console.error(`[EGC encryption] Warning: could not set 0600 permissions on ${keyPath}: ${(chmodErr as Error).message}`);
-      }
+      assertPrivateKeyFile(keyPath);
       return key;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code === 'EEXIST') {

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -127,15 +127,17 @@ export function readPrivateKeyFile(filePath: string): string {
 
 // Whether anything (a file, a link, even a dangling one) sits at the path:
 // a dangling link must be refused as a link, never treated as absent and
-// replaced. Only a path with nothing at it is absent; a path that cannot
-// be inspected is an error, never a silent absence.
+// replaced. Only a path with nothing at it (ENOENT) is absent; a path that
+// cannot be inspected, a parent that is not a directory included, is an
+// error, never a silent absence.
 export function pathPresent(filePath: string): boolean {
   try {
     fs.lstatSync(filePath);
     return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT' || code === 'ENOTDIR') return false;
+    if (code === 'ENOENT') return false;
+
     throw new Error(`[EGC] Could not inspect ${filePath}: ${(err as Error).message}`, { cause: err });
   }
 }

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -39,9 +39,11 @@ function defaultEncKeyPath(): string {
  * only generates a new key when the file genuinely does not exist.
  */
 // A key file must be private and must be the file itself. It is opened
-// without following links (O_NOFOLLOW where the platform has it) and every
-// check runs on that one descriptor: the object must be a regular file,
-// the mode is set and read back through the descriptor, and the content is
+// without following links (O_NOFOLLOW where the platform has it, with an
+// identity check across the open where it does not) and without blocking
+// (so a FIFO planted at the path cannot stall the open), and every check
+// runs on that one descriptor: the object must be a regular file, the
+// mode is set and read back through the descriptor, and the content is
 // read from it, so the file that was checked is the file that is used and
 // a path swapped underneath the checks changes nothing. Where the
 // filesystem keeps POSIX bits (Linux, macOS, most network mounts) a file
@@ -51,16 +53,29 @@ function defaultEncKeyPath(): string {
 // the advice to move the key. Windows has no bits to tighten, so the mode
 // step is skipped there.
 const NO_FOLLOW = fs.constants.O_NOFOLLOW ?? 0;
+const NON_BLOCKING = fs.constants.O_NONBLOCK ?? 0;
 
 function linkRefusal(filePath: string, cause?: unknown): Error {
   return new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`, { cause });
 }
 
+// Without O_NOFOLLOW the link check happens before the open, so the object
+// that was opened must be the object that was checked: same device, same
+// inode. Anything else was swapped underneath and is refused.
+function sameObject(before: fs.Stats, fd: number): boolean {
+  const after = fs.fstatSync(fd);
+  return after.dev === before.dev && after.ino === before.ino;
+}
+
 function openPrivateKeyFile(filePath: string): number {
-  if (NO_FOLLOW === 0 && fs.lstatSync(filePath).isSymbolicLink()) throw linkRefusal(filePath);
+  let before: fs.Stats | null = null;
+  if (NO_FOLLOW === 0) {
+    before = fs.lstatSync(filePath);
+    if (before.isSymbolicLink()) throw linkRefusal(filePath);
+  }
   let fd: number;
   try {
-    fd = fs.openSync(filePath, fs.constants.O_RDONLY | NO_FOLLOW);
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | NO_FOLLOW | NON_BLOCKING);
   } catch (openErr) {
     const code = (openErr as NodeJS.ErrnoException).code;
     if (code === 'ELOOP') throw linkRefusal(filePath, openErr);
@@ -69,6 +84,9 @@ function openPrivateKeyFile(filePath: string): number {
     throw error;
   }
   try {
+    if (before !== null && !sameObject(before, fd)) {
+      throw new Error(`[EGC] ${filePath} changed while it was being opened; the key must be a regular file that stays put. Check for a link planted at the path and restart.`);
+    }
     checkPrivateDescriptor(fd, filePath);
   } catch (checkErr) {
     fs.closeSync(fd);
@@ -109,23 +127,38 @@ export function readPrivateKeyFile(filePath: string): string {
 
 // Whether anything (a file, a link, even a dangling one) sits at the path:
 // a dangling link must be refused as a link, never treated as absent and
-// replaced.
+// replaced. Only a path with nothing at it is absent; a path that cannot
+// be inspected is an error, never a silent absence.
 export function pathPresent(filePath: string): boolean {
   try {
     fs.lstatSync(filePath);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return false;
+    throw new Error(`[EGC] Could not inspect ${filePath}: ${(err as Error).message}`, { cause: err });
+  }
+}
+
+// Every byte of `bytes` written to `fd`: a short write continues from where
+// it stopped, and no progress at all is an error, so a file is never
+// published half written.
+function writeAll(fd: number, bytes: Buffer): void {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const written = fs.writeSync(fd, bytes, offset, bytes.length - offset);
+    if (written <= 0) throw new Error('[EGC] short write: no progress while writing the key file');
+    offset += written;
   }
 }
 
 // The temp file is created exclusively (wx): a link planted at the temp
 // path is never followed, so the key is written only into a file this call
-// created, private from the first byte.
+// created, private from the first byte and complete before it is published.
 export function writePrivateTemp(tmpPath: string, content: string): void {
   const fd = fs.openSync(tmpPath, 'wx', 0o600);
   try {
-    fs.writeSync(fd, content);
+    writeAll(fd, Buffer.from(content, 'utf-8'));
   } finally {
     fs.closeSync(fd);
   }

--- a/mcp/servers/egc-memory/src/encryption.ts
+++ b/mcp/servers/egc-memory/src/encryption.ts
@@ -38,20 +38,30 @@ function defaultEncKeyPath(): string {
  * Throws if the key file exists but cannot be read or is malformed —
  * only generates a new key when the file genuinely does not exist.
  */
-// A key file must be private. The permission bits are set and then read
-// back: where the filesystem keeps POSIX bits (Linux, macOS, most network
-// mounts) a file still readable by the group or others after the chmod is a
-// hard error, because the key would sit exposed with nothing but a log line
-// to say so; where the filesystem has no bits at all (FAT, exFAT, Windows)
-// the read-back shows the mode Node synthesizes and nothing can be
-// tightened, so the call is a no-op there.
+// A key file must be private and must be the file itself. A link is refused
+// before anything is touched, so the permissions of an unrelated target are
+// never changed or trusted. The bits are then set and read back: where the
+// filesystem keeps POSIX bits (Linux, macOS, most network mounts) a file
+// still readable by the group or others after the chmod is a hard error,
+// because the key would sit exposed with nothing but a log line to say so,
+// and a mount that cannot hold 0600 at all (FAT, exFAT) is refused with the
+// advice to move the key. Windows has no bits to tighten, so the mode check
+// is skipped there.
 export function assertPrivateKeyFile(filePath: string): void {
+  let isLink: boolean;
+  try {
+    isLink = fs.lstatSync(filePath).isSymbolicLink();
+  } catch (statErr) {
+    throw new Error(`[EGC] Could not inspect ${filePath}: ${(statErr as Error).message}. The key file must exist and be a regular file.`, { cause: statErr });
+  }
+  if (isLink) {
+    throw new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`);
+  }
   if (process.platform === 'win32') return;
   try {
     fs.chmodSync(filePath, 0o600);
   } catch (chmodErr) {
     throw new Error(`[EGC] Could not set 0600 permissions on ${filePath}: ${(chmodErr as Error).message}. The key must not be readable by other users; fix the permissions and restart.`, { cause: chmodErr });
-
   }
   const mode = fs.statSync(filePath).mode & 0o777;
   if ((mode & 0o077) !== 0) {

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -15,6 +15,8 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { assertPrivateKeyFile } from './encryption.js';
+
 
 const HMAC_ALGORITHM = 'sha256';
 
@@ -63,22 +65,24 @@ export function loadOrCreateKey(): Buffer {
     }
 
     const key = Buffer.from(hex, 'hex');
-    // Harden permissions even on existing key in case it was copied with wrong perms
-    try { fs.chmodSync(KEY_PATH, 0o600); } catch { /* best-effort */ }
+    // A key copied in with wide permissions is tightened, and the process
+    // refuses to run with it exposed.
+    assertPrivateKeyFile(KEY_PATH);
     try { fs.chmodSync(KEY_DIR, 0o700); } catch { /* best-effort */ }
     return key;
   }
 
-  // Generate a fresh key and persist it.
+  // Generate a fresh key and persist it. A key that cannot be persisted or
+  // kept private is not used: every state file signed with it would fail
+  // verification on the next start, and a key on disk with wide
+  // permissions would let another user forge the signatures.
   const key = crypto.randomBytes(32);
   try {
     fs.writeFileSync(KEY_PATH, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
-    fs.chmodSync(KEY_PATH, 0o600);
   } catch (e) {
-    console.error('[EGC integrity] Failed to persist HMAC key:', String(e));
-    // best-effort: if we cannot persist the key we still return it for
-    // this process lifetime (integrity checks will fail on next boot).
+    throw new Error(`[EGC integrity] Failed to persist HMAC key to ${KEY_PATH}: ${String(e)}. Fix the directory permissions and restart.`, { cause: e });
   }
+  assertPrivateKeyFile(KEY_PATH);
   return key;
 }
 

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -15,7 +15,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { assertPrivateKeyFile } from './encryption.js';
+import { assertPrivateKeyFile, pathPresent, readPrivateKeyFile, writePrivateTemp } from './encryption.js';
 
 
 const HMAC_ALGORITHM = 'sha256';
@@ -47,15 +47,11 @@ export function loadOrCreateKey(): Buffer {
   }
 
   const readExistingKey = (): Buffer => {
-    let hex: string;
-    try {
-      hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
-    } catch (readErr: unknown) {
-      throw new Error(
-        `HMAC key file at ${KEY_PATH} exists but could not be read: ${(readErr as Error).message}`,
-        { cause: readErr }
-      );
-    }
+    // Read from the descriptor the private-file checks ran on: a link, a
+    // non-regular object, a wide mode or an unreadable file is refused
+    // there with its own message.
+    const hex = readPrivateKeyFile(KEY_PATH).trim();
+
 
     if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
       throw new Error(
@@ -65,14 +61,11 @@ export function loadOrCreateKey(): Buffer {
     }
 
     const key = Buffer.from(hex, 'hex');
-    // A key copied in with wide permissions is tightened, and the process
-    // refuses to run with it exposed.
-    assertPrivateKeyFile(KEY_PATH);
     try { fs.chmodSync(KEY_DIR, 0o700); } catch { /* best-effort */ }
     return key;
   };
 
-  if (fs.existsSync(KEY_PATH)) return readExistingKey();
+  if (pathPresent(KEY_PATH)) return readExistingKey();
 
   // Generate a fresh key and publish it the way the encryption key is
   // published: written whole to a private temp file, then linked into place
@@ -86,7 +79,8 @@ export function loadOrCreateKey(): Buffer {
   const tmpPath = `${KEY_PATH}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
   let published: boolean;
   try {
-    fs.writeFileSync(tmpPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    writePrivateTemp(tmpPath, key.toString('hex'));
+
     published = linkExclusively(tmpPath, KEY_PATH);
   } catch (e) {
     throw new Error(`[EGC integrity] Failed to persist HMAC key to ${KEY_PATH}: ${String(e)}. Fix the directory permissions and restart.`, { cause: e });

--- a/mcp/servers/egc-memory/src/integrity.ts
+++ b/mcp/servers/egc-memory/src/integrity.ts
@@ -46,7 +46,7 @@ export function loadOrCreateKey(): Buffer {
     // directory may already exist
   }
 
-  if (fs.existsSync(KEY_PATH)) {
+  const readExistingKey = (): Buffer => {
     let hex: string;
     try {
       hex = fs.readFileSync(KEY_PATH, 'utf-8').trim();
@@ -70,20 +70,44 @@ export function loadOrCreateKey(): Buffer {
     assertPrivateKeyFile(KEY_PATH);
     try { fs.chmodSync(KEY_DIR, 0o700); } catch { /* best-effort */ }
     return key;
-  }
+  };
 
-  // Generate a fresh key and persist it. A key that cannot be persisted or
-  // kept private is not used: every state file signed with it would fail
+  if (fs.existsSync(KEY_PATH)) return readExistingKey();
+
+  // Generate a fresh key and publish it the way the encryption key is
+  // published: written whole to a private temp file, then linked into place
+  // exclusively, so a concurrent creator never reads a truncated key and
+  // the loser of the race adopts the key that landed instead of signing
+  // with one that is not on disk. A key that cannot be persisted or kept
+  // private is not used: every state file signed with it would fail
   // verification on the next start, and a key on disk with wide
   // permissions would let another user forge the signatures.
   const key = crypto.randomBytes(32);
+  const tmpPath = `${KEY_PATH}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
+  let published: boolean;
   try {
-    fs.writeFileSync(KEY_PATH, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    fs.writeFileSync(tmpPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    published = linkExclusively(tmpPath, KEY_PATH);
   } catch (e) {
     throw new Error(`[EGC integrity] Failed to persist HMAC key to ${KEY_PATH}: ${String(e)}. Fix the directory permissions and restart.`, { cause: e });
+  } finally {
+    try { fs.unlinkSync(tmpPath); } catch { /* already linked or never written */ }
   }
+  if (!published) return readExistingKey();
   assertPrivateKeyFile(KEY_PATH);
   return key;
+}
+
+// True when `target` was created by this call; false when another process
+// published it first.
+function linkExclusively(source: string, target: string): boolean {
+  try {
+    fs.linkSync(source, target);
+    return true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw e;
+  }
 }
 
 /**

--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -229,7 +229,12 @@ function performConsolidation(report, result, readPath, stateFile, homeDir, opti
     // Back up the file we actually read from -- for a first-time migration
     // (git project with only a flat legacy file so far) that's not the same
     // path as stateFile, which may not exist yet.
+    // The integrity key is loaded before anything is written: a key that
+    // cannot be persisted or kept private stops the rewrite instead of
+    // leaving a state file behind with a sidecar nobody can verify.
+    const integrityKey = loadOrCreateIntegrityKey();
     report.backup = backupStateFile(homeDir, readPath);
+
     const payload = encrypted ? encryptStateBuffer(result.output) : result.output;
     const tmpPath = `${stateFile}.tmp-${process.pid}-${crypto.randomUUID()}`;
     try {
@@ -242,7 +247,8 @@ function performConsolidation(report, result, readPath, stateFile, homeDir, opti
     // The sidecar HMAC covers the plaintext (matching writeHmac()'s use in
     // index.ts), computed over result.output regardless of `encrypted` --
     // leaving it stale here is exactly the mismatch this rewrite fixes.
-    writeHmac(stateFile, result.output, loadOrCreateIntegrityKey());
+    writeHmac(stateFile, result.output, integrityKey);
+
   }
 
   if (options.json) {

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -291,6 +291,11 @@ function ensureParentDir(filePath) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
+// Keys that name the prototype chain rather than data: a patch carrying
+// one of them is data from a manifest or a config file, never a request to
+// change what every object inherits.
+const PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function deepMergeJson(baseValue, patchValue) {
   if (!isPlainObject(baseValue) || !isPlainObject(patchValue)) {
     return cloneJsonValue(patchValue);
@@ -298,6 +303,7 @@ function deepMergeJson(baseValue, patchValue) {
 
   const merged = { ...baseValue };
   for (const [key, value] of Object.entries(patchValue)) {
+    if (PROTOTYPE_KEYS.has(key)) continue;
     if (isPlainObject(value) && isPlainObject(merged[key])) {
       merged[key] = deepMergeJson(merged[key], value);
     } else {

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -7,6 +7,8 @@ const { readInstallState, writeInstallState } = require('./install-state');
 const { hasParentSegment, isAnchoredPath, isInsideReal, realizePath } = require('./path-safety');
 const { copyFileKeepingMode, replaceFileWith, writeTextKeepingMode } = require('./install/preserving-write');
 const { assertSafeMcpConfig, isMcpConfigPath, parseMcpConfigText } = require('./mcp-config');
+const { cloneJsonValue, deepMergeJson, isPlainObject, withoutPrototypeKeys } = require('./json-merge');
+
 const { syncInstallStateToStore } = require('./install-state-store-sync');
 const {
   createManifestInstallPlan,
@@ -197,17 +199,7 @@ function readFileUtf8(filePath) {
   return content.codePointAt(0) === 0xFEFF ? content.slice(1) : content;
 }
 
-function isPlainObject(value) {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
 
-function cloneJsonValue(value) {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  return structuredClone(value);
-}
 
 function parseJsonLikeValue(value, label) {
   if (value === undefined) {
@@ -240,7 +232,10 @@ function getOperationJsonPayload(operation) {
 
   for (const key of candidateKeys) {
     if (operation[key] !== undefined) {
-      return parseJsonLikeValue(operation[key], `${operation.kind}.${key}`);
+      // The recorded payload is read without prototype keys for every use
+      // (merge, uninstall, inspection), so uninstall never removes a key EGC
+      // never installed and inspection never reports one as drift.
+      return withoutPrototypeKeys(parseJsonLikeValue(operation[key], `${operation.kind}.${key}`));
     }
   }
 
@@ -289,28 +284,6 @@ function readJsonFile(filePath) {
 
 function ensureParentDir(filePath) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-}
-
-// Keys that name the prototype chain rather than data: a patch carrying
-// one of them is data from a manifest or a config file, never a request to
-// change what every object inherits.
-const PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-function deepMergeJson(baseValue, patchValue) {
-  if (!isPlainObject(baseValue) || !isPlainObject(patchValue)) {
-    return cloneJsonValue(patchValue);
-  }
-
-  const merged = { ...baseValue };
-  for (const [key, value] of Object.entries(patchValue)) {
-    if (PROTOTYPE_KEYS.has(key)) continue;
-    if (isPlainObject(value) && isPlainObject(merged[key])) {
-      merged[key] = deepMergeJson(merged[key], value);
-    } else {
-      merged[key] = cloneJsonValue(value);
-    }
-  }
-  return merged;
 }
 
 function jsonContainsSubset(actualValue, expectedValue) {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -8,6 +8,8 @@ const { writeInstallState } = require('../install-state');
 const { syncInstallStateToStore } = require('../install-state-store-sync');
 const { assertSafeMcpConfig, filterMcpConfig, isMcpConfigPath, parseDisabledMcpServers, parseMcpConfigText } = require('../mcp-config');
 const { copyFileKeepingMode, replaceFileWith, writeTextKeepingMode } = require('./preserving-write');
+const { cloneJsonValue, deepMergeJson } = require('../json-merge');
+
 
 const {
   HOOK_OPERATION_KIND,
@@ -35,40 +37,6 @@ function readJsonObject(filePath, label) {
   }
 
   return parsed;
-}
-
-function cloneJsonValue(value) {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  return structuredClone(value);
-}
-
-function isPlainObject(value) {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
-
-// Keys that name the prototype chain rather than data: a patch carrying
-// one of them is data from a manifest or a config file, never a request to
-// change what every object inherits.
-const PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-function deepMergeJson(baseValue, patchValue) {
-  if (!isPlainObject(baseValue) || !isPlainObject(patchValue)) {
-    return cloneJsonValue(patchValue);
-  }
-
-  const merged = { ...baseValue };
-  for (const [key, value] of Object.entries(patchValue)) {
-    if (PROTOTYPE_KEYS.has(key)) continue;
-    if (isPlainObject(value) && isPlainObject(merged[key])) {
-      merged[key] = deepMergeJson(merged[key], value);
-    } else {
-      merged[key] = cloneJsonValue(value);
-    }
-  }
-  return merged;
 }
 
 function formatJson(value) {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -49,6 +49,11 @@ function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+// Keys that name the prototype chain rather than data: a patch carrying
+// one of them is data from a manifest or a config file, never a request to
+// change what every object inherits.
+const PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function deepMergeJson(baseValue, patchValue) {
   if (!isPlainObject(baseValue) || !isPlainObject(patchValue)) {
     return cloneJsonValue(patchValue);
@@ -56,6 +61,7 @@ function deepMergeJson(baseValue, patchValue) {
 
   const merged = { ...baseValue };
   for (const [key, value] of Object.entries(patchValue)) {
+    if (PROTOTYPE_KEYS.has(key)) continue;
     if (isPlainObject(value) && isPlainObject(merged[key])) {
       merged[key] = deepMergeJson(merged[key], value);
     } else {
@@ -350,9 +356,11 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
 
 module.exports = {
   applyInstallPlan,
+  deepMergeJson,
   refuseLinkedDestination,
   writeGuardianCliMarker,
   writeManagedText,
+
 
 
 };

--- a/scripts/lib/json-merge.js
+++ b/scripts/lib/json-merge.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// JSON merge helpers shared by the installer (install/apply.js) and the
+// lifecycle (install-lifecycle.js): one copy of the prototype-key invariant,
+// so a hardening change lands in both at once.
+
+// Keys that name the prototype chain rather than data: a payload carrying
+// one of them is data from a manifest or a config file, never a request to
+// change what every object inherits.
+const PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJsonValue(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return structuredClone(value);
+}
+
+// A deep copy of a JSON value with every prototype key dropped from every
+// plain object in it, arrays included, so no payload read from disk carries
+// one into a config file, a merge or an uninstall.
+function withoutPrototypeKeys(value) {
+  if (Array.isArray(value)) {
+    return value.map(withoutPrototypeKeys);
+  }
+  if (!isPlainObject(value)) {
+    return cloneJsonValue(value);
+  }
+  const clean = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (!PROTOTYPE_KEYS.has(key)) clean[key] = withoutPrototypeKeys(entry);
+  }
+  return clean;
+}
+
+function deepMergeJson(baseValue, patchValue) {
+  if (!isPlainObject(baseValue) || !isPlainObject(patchValue)) {
+    return withoutPrototypeKeys(patchValue);
+  }
+
+  const merged = { ...baseValue };
+  for (const [key, value] of Object.entries(patchValue)) {
+    if (PROTOTYPE_KEYS.has(key)) continue;
+    if (isPlainObject(value)) {
+      merged[key] = deepMergeJson(isPlainObject(merged[key]) ? merged[key] : {}, value);
+    } else {
+      merged[key] = withoutPrototypeKeys(value);
+    }
+  }
+  return merged;
+}
+
+module.exports = {
+  PROTOTYPE_KEYS,
+  cloneJsonValue,
+  deepMergeJson,
+  isPlainObject,
+  withoutPrototypeKeys,
+};

--- a/scripts/lib/state-crypto.js
+++ b/scripts/lib/state-crypto.js
@@ -53,6 +53,25 @@ function loadKey(keyPath) {
 // another hook invocation) can never observe a truncated key, and the same
 // "never silently regenerate an existing key" safety rule. Only the create
 // path is new here -- reads still go through loadKey() elsewhere in this file.
+// A key file must be private. The permission bits are set and then read
+// back: where the filesystem keeps POSIX bits a file still readable by the
+// group or others after the chmod is a hard error, because the key would
+// sit exposed with nothing but a log line to say so; on Windows there are
+// no bits to tighten, so the call is a no-op there.
+function assertPrivateKeyFile(filePath) {
+  if (process.platform === 'win32') return;
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch (chmodErr) {
+    throw new Error(`[EGC] Could not set 0600 permissions on ${filePath}: ${chmodErr.message}. The key must not be readable by other users; fix the permissions and restart.`, { cause: chmodErr });
+
+  }
+  const mode = fs.statSync(filePath).mode & 0o777;
+  if ((mode & 0o077) !== 0) {
+    throw new Error(`[EGC] ${filePath} is readable by other users (mode ${mode.toString(8)}) and the filesystem did not accept 0600. Move the key to a filesystem with POSIX permissions.`);
+  }
+}
+
 function loadOrCreateKeySync(keyPath) {
   const resolvedPath = keyPath || defaultKeyPath();
   const dir = path.dirname(resolvedPath);
@@ -60,7 +79,7 @@ function loadOrCreateKeySync(keyPath) {
 
   if (fs.existsSync(resolvedPath)) {
     const key = loadKey(resolvedPath);
-    try { fs.chmodSync(resolvedPath, 0o600); } catch { /* best-effort, not supported on Windows */ }
+    assertPrivateKeyFile(resolvedPath);
     return key;
   }
 
@@ -70,7 +89,7 @@ function loadOrCreateKeySync(keyPath) {
     fs.writeFileSync(tmpPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
     try {
       fs.linkSync(tmpPath, resolvedPath);
-      try { fs.chmodSync(resolvedPath, 0o600); } catch { /* best-effort */ }
+      assertPrivateKeyFile(resolvedPath);
       return key;
     } catch (e) {
       if (e?.code === 'EEXIST') return loadKey(resolvedPath);
@@ -124,6 +143,7 @@ function readStateFileDecrypted(filePath, keyPath) {
 }
 
 module.exports = {
+  assertPrivateKeyFile,
   MAGIC,
   isEncryptedBuffer,
   decryptStateBuffer,

--- a/scripts/lib/state-crypto.js
+++ b/scripts/lib/state-crypto.js
@@ -42,8 +42,53 @@ function isEncryptedBuffer(data) {
     && data.subarray(0, MAGIC_BYTES).toString('utf-8') === MAGIC;
 }
 
+// A key file must be private and must be the file itself. A link is refused
+// before anything is touched, so the permissions of an unrelated target are
+// never changed or trusted. The bits are then set and read back: where the
+// filesystem keeps POSIX bits a file still readable by the group or others
+// after the chmod is a hard error, because the key would sit exposed with
+// nothing but a log line to say so, and a mount that cannot hold 0600 at
+// all is refused with the advice to move the key. Windows has no bits to
+// tighten, so the mode check is skipped there.
+function refuseLinkedKey(filePath) {
+  let isLink;
+  try {
+    isLink = fs.lstatSync(filePath).isSymbolicLink();
+  } catch (statErr) {
+    throw new Error(`[EGC] Could not inspect ${filePath}: ${statErr.message}. The key file must exist and be a regular file.`, { cause: statErr });
+  }
+  if (isLink) {
+    throw new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`);
+  }
+}
+
+function tightenToOwner(filePath) {
+  let failure = null;
+  try { fs.chmodSync(filePath, 0o600); } catch (chmodErr) { failure = chmodErr; }
+  if (failure) {
+    throw new Error(`[EGC] Could not set 0600 permissions on ${filePath}: ${failure.message}. The key must not be readable by other users; fix the permissions and restart.`, { cause: failure });
+  }
+  const bits = fs.statSync(filePath).mode & 0o777;
+  const exposed = bits & 0o077;
+  if (exposed) {
+    throw new Error(`[EGC] ${filePath} is readable by other users (mode ${bits.toString(8)}) and the filesystem did not accept 0600. Move the key to a filesystem with POSIX permissions.`);
+  }
+}
+
+function assertPrivateKeyFile(filePath) {
+  refuseLinkedKey(filePath);
+  if (process.platform !== 'win32') tightenToOwner(filePath);
+}
+
+// The key at `keyPath`, or null when the file does not exist or is
+// malformed. Every read goes through the privacy check first, so a key left
+// readable by others is refused on read as well, and that refusal is an
+// error, never a silent null.
 function loadKey(keyPath) {
-  const hex = fs.readFileSync(keyPath || defaultKeyPath(), 'utf-8').trim();
+  const resolvedPath = keyPath || defaultKeyPath();
+  if (!fs.existsSync(resolvedPath)) return null;
+  assertPrivateKeyFile(resolvedPath);
+  const hex = fs.readFileSync(resolvedPath, 'utf-8').trim();
   const key = Buffer.from(hex, 'hex');
   return key.length === 32 ? key : null;
 }
@@ -53,34 +98,13 @@ function loadKey(keyPath) {
 // another hook invocation) can never observe a truncated key, and the same
 // "never silently regenerate an existing key" safety rule. Only the create
 // path is new here -- reads still go through loadKey() elsewhere in this file.
-// A key file must be private. The permission bits are set and then read
-// back: where the filesystem keeps POSIX bits a file still readable by the
-// group or others after the chmod is a hard error, because the key would
-// sit exposed with nothing but a log line to say so; on Windows there are
-// no bits to tighten, so the call is a no-op there.
-function assertPrivateKeyFile(filePath) {
-  if (process.platform === 'win32') return;
-  try {
-    fs.chmodSync(filePath, 0o600);
-  } catch (chmodErr) {
-    throw new Error(`[EGC] Could not set 0600 permissions on ${filePath}: ${chmodErr.message}. The key must not be readable by other users; fix the permissions and restart.`, { cause: chmodErr });
-
-  }
-  const mode = fs.statSync(filePath).mode & 0o777;
-  if ((mode & 0o077) !== 0) {
-    throw new Error(`[EGC] ${filePath} is readable by other users (mode ${mode.toString(8)}) and the filesystem did not accept 0600. Move the key to a filesystem with POSIX permissions.`);
-  }
-}
-
 function loadOrCreateKeySync(keyPath) {
   const resolvedPath = keyPath || defaultKeyPath();
   const dir = path.dirname(resolvedPath);
   try { fs.mkdirSync(dir, { recursive: true, mode: 0o700 }); } catch { /* may already exist */ }
 
   if (fs.existsSync(resolvedPath)) {
-    const key = loadKey(resolvedPath);
-    assertPrivateKeyFile(resolvedPath);
-    return key;
+    return loadKey(resolvedPath);
   }
 
   const key = crypto.randomBytes(32);
@@ -114,9 +138,11 @@ function encryptStateBuffer(plaintext, keyPath) {
 // Returns plaintext, or null when the payload cannot be authenticated and
 // decrypted (missing or malformed key, truncated or tampered ciphertext).
 function decryptStateBuffer(data, keyPath) {
+  // A missing or malformed key resolves to null; a key that cannot be kept
+  // private is an error that reaches the caller.
+  const key = loadKey(keyPath);
+  if (!key) return null;
   try {
-    const key = loadKey(keyPath);
-    if (!key) return null;
     const iv = data.subarray(MAGIC_BYTES, MAGIC_BYTES + IV_BYTES);
     const authTag = data.subarray(MAGIC_BYTES + IV_BYTES, MAGIC_BYTES + IV_BYTES + AUTH_TAG_BYTES);
     const ciphertext = data.subarray(MAGIC_BYTES + IV_BYTES + AUTH_TAG_BYTES);

--- a/scripts/lib/state-crypto.js
+++ b/scripts/lib/state-crypto.js
@@ -42,53 +42,82 @@ function isEncryptedBuffer(data) {
     && data.subarray(0, MAGIC_BYTES).toString('utf-8') === MAGIC;
 }
 
-// A key file must be private and must be the file itself. A link is refused
-// before anything is touched, so the permissions of an unrelated target are
-// never changed or trusted. The bits are then set and read back: where the
-// filesystem keeps POSIX bits a file still readable by the group or others
-// after the chmod is a hard error, because the key would sit exposed with
-// nothing but a log line to say so, and a mount that cannot hold 0600 at
-// all is refused with the advice to move the key. Windows has no bits to
-// tighten, so the mode check is skipped there.
-function refuseLinkedKey(filePath) {
-  let isLink;
+// A key file must be private and must be the file itself: it is opened
+// without following links (O_NOFOLLOW where the platform has it), the
+// object behind the descriptor must be a regular file, the mode is set and
+// read back through that descriptor, and the content is read from it, so
+// the file that was checked is the file that is used. Where the filesystem
+// keeps POSIX bits a file still readable by others after the chmod is a
+// hard error; on Windows there are no bits to tighten, so the mode step is
+// skipped there.
+const NO_FOLLOW_FLAG = fs.constants.O_NOFOLLOW || 0;
+
+function linkRefusal(filePath, cause) {
+  return new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`, { cause });
+}
+
+function keyDescriptor(filePath) {
+  if (!NO_FOLLOW_FLAG && fs.lstatSync(filePath).isSymbolicLink()) throw linkRefusal(filePath, null);
   try {
-    isLink = fs.lstatSync(filePath).isSymbolicLink();
-  } catch (statErr) {
-    throw new Error(`[EGC] Could not inspect ${filePath}: ${statErr.message}. The key file must exist and be a regular file.`, { cause: statErr });
-  }
-  if (isLink) {
-    throw new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`);
+    return fs.openSync(filePath, fs.constants.O_RDONLY | NO_FOLLOW_FLAG);
+  } catch (openErr) {
+    if (openErr.code === 'ELOOP') throw linkRefusal(filePath, openErr);
+    const error = new Error(`[EGC] Could not open ${filePath}: ${openErr.message}. The key file must exist and be a regular file.`, { cause: openErr });
+    error.code = openErr.code;
+    throw error;
   }
 }
 
-function tightenToOwner(filePath) {
+function refuseUnlessRegularAndPrivate(fd, filePath) {
+  if (!fs.fstatSync(fd).isFile()) {
+    throw new Error(`[EGC] ${filePath} is not a regular file; the key must be a regular file. Replace it and restart.`);
+  }
+  if (process.platform === 'win32') return;
   let failure = null;
-  try { fs.chmodSync(filePath, 0o600); } catch (chmodErr) { failure = chmodErr; }
+  try { fs.fchmodSync(fd, 0o600); } catch (chmodErr) { failure = chmodErr; }
   if (failure) {
     throw new Error(`[EGC] Could not set 0600 permissions on ${filePath}: ${failure.message}. The key must not be readable by other users; fix the permissions and restart.`, { cause: failure });
   }
-  const bits = fs.statSync(filePath).mode & 0o777;
-  const exposed = bits & 0o077;
-  if (exposed) {
+  const bits = fs.fstatSync(fd).mode & 0o777;
+  if (bits & 0o077) {
     throw new Error(`[EGC] ${filePath} is readable by other users (mode ${bits.toString(8)}) and the filesystem did not accept 0600. Move the key to a filesystem with POSIX permissions.`);
   }
 }
 
-function assertPrivateKeyFile(filePath) {
-  refuseLinkedKey(filePath);
-  if (process.platform !== 'win32') tightenToOwner(filePath);
+// Runs `use(fd)` on the checked descriptor of the key file, then closes it.
+function withPrivateKeyFile(filePath, use) {
+  const fd = keyDescriptor(filePath);
+  try {
+    refuseUnlessRegularAndPrivate(fd, filePath);
+    return use(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
-// The key at `keyPath`, or null when the file does not exist or is
-// malformed. Every read goes through the privacy check first, so a key left
-// readable by others is refused on read as well, and that refusal is an
-// error, never a silent null.
+function assertPrivateKeyFile(filePath) {
+  withPrivateKeyFile(filePath, () => undefined);
+}
+
+// Whether anything (a file, a link, even a dangling one) sits at the path:
+// a dangling link is refused as a link, never treated as absent.
+function present(filePath) {
+  try {
+    fs.lstatSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The key at `keyPath`, or null when nothing sits at the path or the file
+// is malformed. Every read goes through the checks on the descriptor it
+// reads from, and any refusal (a link, a wide mode, a non-regular object,
+// an unreadable file) is an error, never a silent null.
 function loadKey(keyPath) {
   const resolvedPath = keyPath || defaultKeyPath();
-  if (!fs.existsSync(resolvedPath)) return null;
-  assertPrivateKeyFile(resolvedPath);
-  const hex = fs.readFileSync(resolvedPath, 'utf-8').trim();
+  if (!present(resolvedPath)) return null;
+  const hex = withPrivateKeyFile(resolvedPath, fd => fs.readFileSync(fd, 'utf-8')).trim();
   const key = Buffer.from(hex, 'hex');
   return key.length === 32 ? key : null;
 }
@@ -103,14 +132,18 @@ function loadOrCreateKeySync(keyPath) {
   const dir = path.dirname(resolvedPath);
   try { fs.mkdirSync(dir, { recursive: true, mode: 0o700 }); } catch { /* may already exist */ }
 
-  if (fs.existsSync(resolvedPath)) {
+  if (present(resolvedPath)) {
     return loadKey(resolvedPath);
   }
 
   const key = crypto.randomBytes(32);
   const tmpPath = `${resolvedPath}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
   try {
-    fs.writeFileSync(tmpPath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
+    // Created exclusively (wx): a link planted at the temp path is never
+    // followed, so the key lands only in a file this call created.
+    const tmpFd = fs.openSync(tmpPath, 'wx', 0o600);
+    try { fs.writeSync(tmpFd, key.toString('hex')); } finally { fs.closeSync(tmpFd); }
+
     try {
       fs.linkSync(tmpPath, resolvedPath);
       assertPrivateKeyFile(resolvedPath);

--- a/scripts/lib/state-crypto.js
+++ b/scripts/lib/state-crypto.js
@@ -72,8 +72,15 @@ function keyDescriptor(filePath) {
     throw error;
   }
   if (before) {
-    const after = fs.fstatSync(fd);
-    if (after.dev !== before.dev || after.ino !== before.ino) {
+    let swapped;
+    try {
+      const after = fs.fstatSync(fd);
+      swapped = after.dev !== before.dev || after.ino !== before.ino;
+    } catch (statErr) {
+      fs.closeSync(fd);
+      throw statErr;
+    }
+    if (swapped) {
       fs.closeSync(fd);
       throw new Error(`[EGC] ${filePath} changed while it was being opened; the key must be a regular file that stays put. Check for a link planted at the path and restart.`);
     }
@@ -113,14 +120,16 @@ function assertPrivateKeyFile(filePath) {
 }
 
 // Whether anything (a file, a link, even a dangling one) sits at the path.
-// Only a path with nothing at it is absent; a path that cannot be
-// inspected is an error, never a silent absence.
+// Only a path with nothing at it (ENOENT) is absent; a path that cannot be
+// inspected, a parent that is not a directory included, is an error, never
+// a silent absence.
 function present(filePath) {
   try {
     fs.lstatSync(filePath);
     return true;
   } catch (err) {
-    if (err.code === 'ENOENT' || err.code === 'ENOTDIR') return false;
+    if (err.code === 'ENOENT') return false;
+
     throw new Error(`[EGC] Could not inspect ${filePath}: ${err.message}`, { cause: err });
   }
 }

--- a/scripts/lib/state-crypto.js
+++ b/scripts/lib/state-crypto.js
@@ -43,29 +43,42 @@ function isEncryptedBuffer(data) {
 }
 
 // A key file must be private and must be the file itself: it is opened
-// without following links (O_NOFOLLOW where the platform has it), the
-// object behind the descriptor must be a regular file, the mode is set and
-// read back through that descriptor, and the content is read from it, so
-// the file that was checked is the file that is used. Where the filesystem
-// keeps POSIX bits a file still readable by others after the chmod is a
-// hard error; on Windows there are no bits to tighten, so the mode step is
+// without following links (O_NOFOLLOW where the platform has it, with an
+// identity check across the open where it does not) and without blocking
+// (a FIFO planted at the path cannot stall the open), the object behind
+// the descriptor must be a regular file, the mode is set and read back
+// through that descriptor, and the content is read from it, so the file
+// that was checked is the file that is used. Where the filesystem keeps
+// POSIX bits a file still readable by others after the chmod is a hard
+// error; on Windows there are no bits to tighten, so the mode step is
 // skipped there.
 const NO_FOLLOW_FLAG = fs.constants.O_NOFOLLOW || 0;
+const NON_BLOCKING_FLAG = fs.constants.O_NONBLOCK || 0;
 
 function linkRefusal(filePath, cause) {
   return new Error(`[EGC] ${filePath} is a symbolic link; the key must be a regular file. Replace the link and restart.`, { cause });
 }
 
 function keyDescriptor(filePath) {
-  if (!NO_FOLLOW_FLAG && fs.lstatSync(filePath).isSymbolicLink()) throw linkRefusal(filePath, null);
+  const before = NO_FOLLOW_FLAG ? null : fs.lstatSync(filePath);
+  if (before?.isSymbolicLink()) throw linkRefusal(filePath, null);
+  let fd;
   try {
-    return fs.openSync(filePath, fs.constants.O_RDONLY | NO_FOLLOW_FLAG);
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | NO_FOLLOW_FLAG | NON_BLOCKING_FLAG);
   } catch (openErr) {
     if (openErr.code === 'ELOOP') throw linkRefusal(filePath, openErr);
     const error = new Error(`[EGC] Could not open ${filePath}: ${openErr.message}. The key file must exist and be a regular file.`, { cause: openErr });
     error.code = openErr.code;
     throw error;
   }
+  if (before) {
+    const after = fs.fstatSync(fd);
+    if (after.dev !== before.dev || after.ino !== before.ino) {
+      fs.closeSync(fd);
+      throw new Error(`[EGC] ${filePath} changed while it was being opened; the key must be a regular file that stays put. Check for a link planted at the path and restart.`);
+    }
+  }
+  return fd;
 }
 
 function refuseUnlessRegularAndPrivate(fd, filePath) {
@@ -99,14 +112,27 @@ function assertPrivateKeyFile(filePath) {
   withPrivateKeyFile(filePath, () => undefined);
 }
 
-// Whether anything (a file, a link, even a dangling one) sits at the path:
-// a dangling link is refused as a link, never treated as absent.
+// Whether anything (a file, a link, even a dangling one) sits at the path.
+// Only a path with nothing at it is absent; a path that cannot be
+// inspected is an error, never a silent absence.
 function present(filePath) {
   try {
     fs.lstatSync(filePath);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    if (err.code === 'ENOENT' || err.code === 'ENOTDIR') return false;
+    throw new Error(`[EGC] Could not inspect ${filePath}: ${err.message}`, { cause: err });
+  }
+}
+
+// Every byte written, a short write resumed, no progress refused: a key
+// file is never published half written.
+function writeAllBytes(fd, bytes) {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const written = fs.writeSync(fd, bytes, offset, bytes.length - offset);
+    if (written <= 0) throw new Error('[EGC] short write: no progress while writing the key file');
+    offset += written;
   }
 }
 
@@ -142,7 +168,8 @@ function loadOrCreateKeySync(keyPath) {
     // Created exclusively (wx): a link planted at the temp path is never
     // followed, so the key lands only in a file this call created.
     const tmpFd = fs.openSync(tmpPath, 'wx', 0o600);
-    try { fs.writeSync(tmpFd, key.toString('hex')); } finally { fs.closeSync(tmpFd); }
+    try { writeAllBytes(tmpFd, Buffer.from(key.toString('hex'), 'utf-8')); } finally { fs.closeSync(tmpFd); }
+
 
     try {
       fs.linkSync(tmpPath, resolvedPath);

--- a/scripts/lib/state-integrity.js
+++ b/scripts/lib/state-integrity.js
@@ -23,23 +23,12 @@ function keyPath() {
 // state-crypto.js's loadOrCreateKeySync() is already a general 32-byte
 // hex-key-file load-or-create (atomic write-tmp-then-link) -- reused here
 // with the integrity key's own path instead of re-implementing the same
-// routine a second time. Its persistence failures are intentionally fatal
-// for the encryption key (losing it makes existing ciphertext unreadable),
-// but the integrity key has no such stakes: on failure, loadOrCreateKey()
-// in integrity.ts falls back to an unpersisted key held "for this process
-// lifetime" -- every sidecar in that run still gets signed consistently,
-// just with a key that won't survive the process. Cache the same way here:
-// a fresh crypto.randomBytes() on every call would make consecutive
-// writeHmac() calls in one run disagree with each other, not just with a
-// future process.
-let fallbackKey = null;
+// routine a second time. Its failures are as fatal here as they are for
+// the encryption key: a key that cannot be persisted would sign sidecars
+// that fail verification on the next start, and a key that cannot be kept
+// private would let another local user forge them, so neither is used.
 function loadOrCreateIntegrityKey() {
-  try {
-    return loadOrCreateKeySync(keyPath());
-  } catch {
-    if (!fallbackKey) fallbackKey = crypto.randomBytes(32);
-    return fallbackKey;
-  }
+  return loadOrCreateKeySync(keyPath());
 }
 
 function computeHmac(content, key) {

--- a/scripts/lib/state-snapshot.js
+++ b/scripts/lib/state-snapshot.js
@@ -129,6 +129,10 @@ function loadState(projectPath) {
 // atomically via temp-file-then-rename so a reader never observes a
 // partially-written file.
 function saveState(filePath, content) {
+  // The integrity key is loaded before anything is written: a key that
+  // cannot be persisted or kept private stops the write instead of leaving
+  // a state file behind with a sidecar nobody can verify.
+  const integrityKey = loadOrCreateIntegrityKey();
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const encrypted = encryptStateBuffer(content);
   const tmpPath = `${filePath}.tmp-${process.pid}-${crypto.randomUUID()}`;
@@ -142,7 +146,8 @@ function saveState(filePath, content) {
   // Same sidecar contract as writeHmac() in index.ts: without this, a hook
   // write here (PreCompact snapshot, mined-memory apply) leaves the old HMAC
   // in place and the next get_state reports a false tamper mismatch.
-  writeHmac(filePath, content, loadOrCreateIntegrityKey());
+  writeHmac(filePath, content, integrityKey);
+
 }
 
 function writeSnapshotToDisk(projectPath = process.env.PWD || process.cwd()) {

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -151,7 +151,9 @@ if (test('loadOrCreateEncKey: refuses a key whose permissions cannot be tightene
     assert.ok(!fs.existsSync(keyPath) || (fs.statSync(keyPath).mode & 0o077) === 0, 'no exposed key is left behind as the process key');
   } finally {
     fs.chmodSync = originalChmodSync;
+    fs.fchmodSync = originalFchmodSync;
     console.error = originalConsoleError;
+
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 })) passed++; else failed++;
@@ -191,8 +193,17 @@ if (test('loadOrCreateEncKey: TOCTOU race — a concurrent winner\'s key is read
   const winnerKey = crypto.randomBytes(32);
   fs.writeFileSync(keyPath, winnerKey.toString('hex'), { encoding: 'utf-8', mode: 0o600 });
 
-  const origExistsSync = fs.existsSync;
-  fs.existsSync = (p) => (p === keyPath ? false : origExistsSync(p));
+  // Presence is decided with lstat: the loser's view is an lstat that says
+  // nothing is there while the winner's key already sits on disk.
+  const origLstatSync = fs.lstatSync;
+  fs.lstatSync = (p, ...rest) => {
+    if (p === keyPath) {
+      const missing = new Error('ENOENT: simulated loser view');
+      missing.code = 'ENOENT';
+      throw missing;
+    }
+    return origLstatSync(p, ...rest);
+  };
   try {
     const result = loadOrCreateEncKey(keyPath);
     assert.ok(
@@ -202,7 +213,8 @@ if (test('loadOrCreateEncKey: TOCTOU race — a concurrent winner\'s key is read
     const onDisk = Buffer.from(fs.readFileSync(keyPath, 'utf-8').trim(), 'hex');
     assert.ok(onDisk.equals(winnerKey), 'the winner\'s key on disk must remain untouched');
   } finally {
-    fs.existsSync = origExistsSync;
+    fs.lstatSync = origLstatSync;
+
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 })) passed++; else failed++;

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -44,6 +44,22 @@ const { loadOrCreateEncKey, encryptState, decryptState, isEncrypted, writeStateF
 
 console.log('\n=== Testing egc-memory encryption ===\n');
 
+if (test('loadOrCreateEncKey: a key file left readable by others is tightened, and refused when it cannot be', () => {
+  if (process.platform === 'win32') return;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-key-mode-'));
+  try {
+    const keyPath = path.join(dir, 'encryption.key');
+    fs.writeFileSync(keyPath, crypto.randomBytes(32).toString('hex'), { mode: 0o644 });
+    assert.strictEqual(fs.statSync(keyPath).mode & 0o077, 0o044, 'planted wide');
+    loadOrCreateEncKey(keyPath);
+    assert.strictEqual(fs.statSync(keyPath).mode & 0o077, 0, 'tightened to owner only');
+    const { assertPrivateKeyFile } = require(buildPath);
+    assert.throws(() => assertPrivateKeyFile(path.join(dir, 'missing.key')), /Could not set 0600/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+})) passed++; else failed++;
+
 // ── encrypt/decrypt round-trip ──────────────────────────────────────────────
 
 if (test('encryptState/decryptState: round-trips plaintext', () => {
@@ -92,7 +108,7 @@ if (test('loadOrCreateEncKey: returns a 32-byte Buffer and creates the file with
   }
 })) passed++; else failed++;
 
-if (test('loadOrCreateEncKey: warns (does not throw) when chmod on the key file fails (audit EGC-128, low)', () => {
+if (test('loadOrCreateEncKey: refuses a key whose permissions cannot be tightened (audit 2026-08-17, day 16; supersedes EGC-128)', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-encryption-test-'));
   const keyPath = path.join(tmpDir, 'encryption.key');
   const originalChmodSync = fs.chmodSync;
@@ -106,13 +122,9 @@ if (test('loadOrCreateEncKey: warns (does not throw) when chmod on the key file 
     return originalChmodSync(target, mode);
   };
   try {
-    const key = loadOrCreateEncKey(keyPath);
-    assert.ok(Buffer.isBuffer(key), 'should still return a usable key despite the chmod failure');
-    assert.strictEqual(key.length, 32);
-    assert.ok(
-      errorLines.some(line => line.includes(keyPath) && line.includes('0600')),
-      `expected a warning naming the key path and the intended mode, got: ${JSON.stringify(errorLines)}`
-    );
+    if (process.platform === 'win32') return;
+    assert.throws(() => loadOrCreateEncKey(keyPath), error => error.message.includes(keyPath) && error.message.includes('0600'), 'a key that cannot be made private is refused, not used');
+    assert.ok(!fs.existsSync(keyPath) || (fs.statSync(keyPath).mode & 0o077) === 0, 'no exposed key is left behind as the process key');
   } finally {
     fs.chmodSync = originalChmodSync;
     console.error = originalConsoleError;

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -195,9 +195,14 @@ if (test('loadOrCreateEncKey: TOCTOU race — a concurrent winner\'s key is read
 
   // Presence is decided with lstat: the loser's view is an lstat that says
   // nothing is there while the winner's key already sits on disk.
+  // Only the presence check (the first lstat of the key path) sees the
+  // stale view; the recovery read that follows must see the real file, on
+  // platforms that open with an lstat pre-check too.
   const origLstatSync = fs.lstatSync;
+  let staleView = true;
   fs.lstatSync = (p, ...rest) => {
-    if (p === keyPath) {
+    if (p === keyPath && staleView) {
+      staleView = false;
       const missing = new Error('ENOENT: simulated loser view');
       missing.code = 'ENOENT';
       throw missing;

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -47,20 +47,31 @@ console.log('\n=== Testing egc-memory encryption ===\n');
 if (test('loadOrCreateEncKey: a key file left readable by others is tightened, and refused when it cannot be', () => {
   if (process.platform === 'win32') return;
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-key-mode-'));
+  const { assertPrivateKeyFile } = require(buildPath);
+  const originalChmodSync = fs.chmodSync;
   try {
     const keyPath = path.join(dir, 'encryption.key');
-    fs.writeFileSync(keyPath, crypto.randomBytes(32).toString('hex'), { mode: 0o644 });
+    fs.writeFileSync(keyPath, crypto.randomBytes(32).toString('hex'));
+    fs.chmodSync(keyPath, 0o644);
     assert.strictEqual(fs.statSync(keyPath).mode & 0o077, 0o044, 'planted wide');
     loadOrCreateEncKey(keyPath);
     assert.strictEqual(fs.statSync(keyPath).mode & 0o077, 0, 'tightened to owner only');
-    const { assertPrivateKeyFile } = require(buildPath);
-    assert.throws(() => assertPrivateKeyFile(path.join(dir, 'missing.key')), /Could not set 0600/);
+    fs.chmodSync(keyPath, 0o644);
+    fs.chmodSync = (target, mode) => {
+      if (target === keyPath) throw new Error('EPERM: simulated filesystem that cannot hold 0600');
+      return originalChmodSync(target, mode);
+    };
+    assert.throws(() => assertPrivateKeyFile(keyPath), /Could not set 0600/, 'an existing key that resists tightening is refused');
+    fs.chmodSync = originalChmodSync;
+    const linkPath = path.join(dir, 'linked.key');
+    fs.symlinkSync(keyPath, linkPath);
+    assert.throws(() => assertPrivateKeyFile(linkPath), /symbolic link/, 'a link is refused before anything is touched');
+    assert.throws(() => assertPrivateKeyFile(path.join(dir, 'missing.key')), /Could not inspect/, 'a missing file is an error, not a pass');
   } finally {
+    fs.chmodSync = originalChmodSync;
     fs.rmSync(dir, { recursive: true, force: true });
   }
 })) passed++; else failed++;
-
-// ── encrypt/decrypt round-trip ──────────────────────────────────────────────
 
 if (test('encryptState/decryptState: round-trips plaintext', () => {
   const key = crypto.randomBytes(32);

--- a/tests/egc-memory-encryption.test.js
+++ b/tests/egc-memory-encryption.test.js
@@ -57,16 +57,27 @@ if (test('loadOrCreateEncKey: a key file left readable by others is tightened, a
     loadOrCreateEncKey(keyPath);
     assert.strictEqual(fs.statSync(keyPath).mode & 0o077, 0, 'tightened to owner only');
     fs.chmodSync(keyPath, 0o644);
-    fs.chmodSync = (target, mode) => {
-      if (target === keyPath) throw new Error('EPERM: simulated filesystem that cannot hold 0600');
-      return originalChmodSync(target, mode);
+    // The mode is set through the descriptor, so the descriptor call is the
+    // one to fail; it restores itself on the first call.
+    const originalFchmodSync = fs.fchmodSync;
+    fs.fchmodSync = () => {
+      fs.fchmodSync = originalFchmodSync;
+      throw new Error('EPERM: simulated filesystem that cannot hold 0600');
     };
     assert.throws(() => assertPrivateKeyFile(keyPath), /Could not set 0600/, 'an existing key that resists tightening is refused');
-    fs.chmodSync = originalChmodSync;
+    fs.fchmodSync = originalFchmodSync;
     const linkPath = path.join(dir, 'linked.key');
     fs.symlinkSync(keyPath, linkPath);
     assert.throws(() => assertPrivateKeyFile(linkPath), /symbolic link/, 'a link is refused before anything is touched');
-    assert.throws(() => assertPrivateKeyFile(path.join(dir, 'missing.key')), /Could not inspect/, 'a missing file is an error, not a pass');
+    assert.throws(() => assertPrivateKeyFile(path.join(dir, 'missing.key')), /Could not open/, 'a missing file is an error, not a pass');
+    const dangling = path.join(dir, 'dangling.key');
+    fs.symlinkSync(path.join(dir, 'nowhere.key'), dangling);
+    assert.throws(() => assertPrivateKeyFile(dangling), /symbolic link/, 'a dangling link is refused as a link');
+    assert.throws(() => loadOrCreateEncKey(dangling), /symbolic link/, 'a dangling link at the key path is never replaced by a fresh key');
+    const folder = path.join(dir, 'folder.key');
+    fs.mkdirSync(folder);
+    assert.throws(() => assertPrivateKeyFile(folder), /not a regular file/, 'a directory is not a key');
+
   } finally {
     fs.chmodSync = originalChmodSync;
     fs.rmSync(dir, { recursive: true, force: true });
@@ -126,11 +137,13 @@ if (test('loadOrCreateEncKey: refuses a key whose permissions cannot be tightene
   const originalConsoleError = console.error;
   const errorLines = [];
   console.error = (...args) => errorLines.push(args.join(' '));
-  fs.chmodSync = (target, mode) => {
-    if (target === keyPath) {
-      throw new Error('EPERM: simulated filesystem without permission bit support');
-    }
-    return originalChmodSync(target, mode);
+  // The mode is set through the descriptor of the key file, so the
+  // descriptor call is the one to fail; it restores itself on the first
+  // call, and the path-based chmod stays real for the temp file.
+  const originalFchmodSync = fs.fchmodSync;
+  fs.fchmodSync = () => {
+    fs.fchmodSync = originalFchmodSync;
+    throw new Error('EPERM: simulated filesystem without permission bit support');
   };
   try {
     if (process.platform === 'win32') return;

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -1669,6 +1669,35 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('uninstall never removes a prototype key EGC never installed', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-proto-');
+
+    try {
+      const targetRoot = path.join(projectRoot, '.cursor');
+      const destinationPath = path.join(targetRoot, 'settings.json');
+      fs.mkdirSync(targetRoot, { recursive: true });
+      fs.writeFileSync(destinationPath, '{"keep": true, "managed": true, "__proto__": {"user": true}}');
+      writeCursorState(projectRoot, {
+        operations: [
+          managedOperation('merge-json', destinationPath, {
+            mergePayload: JSON.parse('{"managed": true, "__proto__": {"user": true}}'),
+          }),
+        ],
+      });
+
+      const result = uninstallInstalledStates({ homeDir, projectRoot, targets: ['cursor'] });
+      assert.strictEqual(result.results[0].status, 'uninstalled');
+      const remaining = JSON.parse(fs.readFileSync(destinationPath, 'utf8'));
+      assert.strictEqual(remaining.keep, true);
+      assert.ok(!Object.hasOwn(remaining, 'managed'), 'the managed key is removed');
+      assert.ok(Object.hasOwn(remaining, '__proto__'), 'the user-owned prototype key is untouched');
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('uninstall handles merge-json subset removal and full-file deletion', () => {
     const homeDir = createTempDir('install-lifecycle-home-');
     const partialProjectRoot = createTempDir('install-lifecycle-partial-');

--- a/tests/lib/state-crypto.test.js
+++ b/tests/lib/state-crypto.test.js
@@ -105,6 +105,13 @@ function runTests() {
       fs.symlinkSync(keyPath, linkPath);
       assert.throws(() => assertPrivateKeyFile(linkPath), /symbolic link/);
       assert.throws(() => decryptStateBuffer(Buffer.alloc(64), linkPath), /symbolic link/, 'a read never silently resolves to null on a refused key');
+      const dangling = path.join(dir, 'dangling.key');
+      fs.symlinkSync(path.join(dir, 'nowhere.key'), dangling);
+      assert.throws(() => decryptStateBuffer(Buffer.alloc(64), dangling), /symbolic link/, 'a dangling link is refused as a link, never treated as absent');
+      const folder = path.join(dir, 'folder.key');
+      fs.mkdirSync(folder);
+      assert.throws(() => assertPrivateKeyFile(folder), /not a regular file/, 'a directory is not a key');
+
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/lib/state-crypto.test.js
+++ b/tests/lib/state-crypto.test.js
@@ -14,6 +14,8 @@ const {
   decryptStateBuffer,
   readStateFileDecrypted,
 } = require('../../scripts/lib/state-crypto');
+const { assertPrivateKeyFile } = require('../../scripts/lib/state-crypto');
+
 
 function test(name, fn) {
   try {
@@ -90,6 +92,21 @@ function runTests() {
       );
     } finally {
       cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('refuses a key reached through a link, on the read path as well', () => {
+    if (process.platform === 'win32') return;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-state-crypto-link-'));
+    try {
+      const keyPath = path.join(dir, 'encryption.key');
+      fs.writeFileSync(keyPath, crypto.randomBytes(32).toString('hex'), { mode: 0o600 });
+      const linkPath = path.join(dir, 'linked.key');
+      fs.symlinkSync(keyPath, linkPath);
+      assert.throws(() => assertPrivateKeyFile(linkPath), /symbolic link/);
+      assert.throws(() => decryptStateBuffer(Buffer.alloc(64), linkPath), /symbolic link/, 'a read never silently resolves to null on a refused key');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   })) passed++; else failed++;
 

--- a/tests/lib/state-crypto.test.js
+++ b/tests/lib/state-crypto.test.js
@@ -111,6 +111,19 @@ function runTests() {
       const folder = path.join(dir, 'folder.key');
       fs.mkdirSync(folder);
       assert.throws(() => assertPrivateKeyFile(folder), /not a regular file/, 'a directory is not a key');
+      if (typeof process.getuid === 'function' && process.getuid() !== 0) {
+        const locked = path.join(dir, 'locked');
+        fs.mkdirSync(locked);
+        const lockedKey = path.join(locked, 'encryption.key');
+        fs.writeFileSync(lockedKey, crypto.randomBytes(32).toString('hex'), { mode: 0o600 });
+        fs.chmodSync(locked, 0o000);
+        try {
+          assert.throws(() => decryptStateBuffer(Buffer.alloc(64), lockedKey), /Could not inspect/, 'an inaccessible key is an error, never an absence');
+        } finally {
+          fs.chmodSync(locked, 0o700);
+        }
+      }
+
 
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/tests/scripts/consolidate.test.js
+++ b/tests/scripts/consolidate.test.js
@@ -226,6 +226,27 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('a refused integrity key stops the rewrite before the state file or a backup is touched', () => {
+    if (process.platform === 'win32') return;
+    const homeDir = createTempDir('consolidate-home-');
+    const projectDir = createTempDir('consolidate-project-');
+
+    try {
+      const filePath = writeState(homeDir, projectDir, sampleState(projectDir));
+      const before = fs.readFileSync(filePath, 'utf8');
+      fs.mkdirSync(path.join(homeDir, '.egc', 'integrity.key'), { recursive: true });
+
+      const result = run(['--project', projectDir, '--threshold', '10'], { homeDir, cwd: projectDir });
+      assert.notStrictEqual(result.code, 0, 'the rewrite is refused');
+      assert.ok(result.stderr.includes('not a regular file'), result.stderr);
+      assert.strictEqual(fs.readFileSync(filePath, 'utf8'), before, 'the state file is untouched');
+      assert.ok(!fs.existsSync(archiveDir(homeDir)) || fs.readdirSync(archiveDir(homeDir)).length === 0, 'no backup was written');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('emits a JSON report with stats and backup path', () => {
     const homeDir = createTempDir('consolidate-home-');
     const projectDir = createTempDir('consolidate-project-');

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -70,6 +70,16 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
+  if (test('merge-json never carries a prototype key into the config', () => {
+    const { deepMergeJson } = require('../../scripts/lib/install/apply');
+    const merged = deepMergeJson({ mcpServers: { a: { command: 'x' } } }, JSON.parse('{"__proto__": {"polluted": true}, "constructor": {"prototype": {"p": 1}}, "mcpServers": {"b": {"command": "y"}}}'));
+    assert.strictEqual(Object.prototype.polluted, undefined, 'the global prototype is untouched');
+    assert.strictEqual(merged.polluted, undefined);
+    assert.ok(!Object.hasOwn(merged, 'constructor'), 'constructor is not a data key');
+    assert.deepStrictEqual(Object.keys(merged.mcpServers).sort(), ['a', 'b']);
+  })) passed++; else failed++;
+
+
   if (test('shows help with --help', () => {
     const result = run(['--help']);
     assert.strictEqual(result.code, 0);

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -77,6 +77,12 @@ function runTests() {
     assert.strictEqual(merged.polluted, undefined);
     assert.ok(!Object.hasOwn(merged, 'constructor'), 'constructor is not a data key');
     assert.deepStrictEqual(Object.keys(merged.mcpServers).sort(), ['a', 'b']);
+    const nested = deepMergeJson({}, JSON.parse('{"new": {"__proto__": {"p": 1}, "keep": 1}, "list": [{"__proto__": {"q": 2}, "ok": true}]}'));
+    assert.ok(!Object.hasOwn(nested.new, '__proto__'), 'a new subtree is filtered too');
+    assert.strictEqual(nested.new.keep, 1);
+    assert.ok(!Object.hasOwn(nested.list[0], '__proto__'), 'objects inside arrays are filtered');
+    assert.strictEqual(nested.list[0].ok, true);
+
   })) passed++; else failed++;
 
 


### PR DESCRIPTION
## Why

Security schedule, day 16 (audit 2026-08-17, MEDIUM items): "`deepMergeJson` unhardened against `__proto__` (not exploitable today, but the pattern is duplicated unhardened in two places)", and "encryption and integrity key chmod failures are soft-fail (logged only) on filesystems without POSIX permission bits".

## What changed

merge-json (`scripts/lib/install/apply.js`, `scripts/lib/install-lifecycle.js`):
- Both copies of `deepMergeJson` skip `__proto__`, `constructor` and `prototype` in the patch, so a payload from a manifest or a config file is data only and never reaches the prototype chain, whatever the base object is.

Key files (`mcp/servers/egc-memory/src/encryption.ts`, `mcp/servers/egc-memory/src/integrity.ts`, `scripts/lib/state-crypto.js`):
- One helper per side sets 0600 and reads the mode back. Where the filesystem keeps POSIX bits, a chmod that fails or a key still readable by the group or others is a hard error naming the file and the fix, instead of a warning the user never sees; on Windows, where there are no bits to tighten, the helper is a no-op.
- The HMAC integrity key is no longer used for one process lifetime when it cannot be persisted: every state file signed with an ephemeral key would fail verification on the next start, and a key on disk with wide permissions would let another local user forge signatures, so both cases stop the server with a clear message.

## Proof

- `tests/scripts/install-apply.test.js`: a patch with `__proto__` and `constructor.prototype` leaves the global prototype untouched and only its data keys are merged.
- `tests/egc-memory-encryption.test.js`: a key planted with mode 644 is tightened to 600 on load; a key whose chmod fails is refused (this replaces the earlier test that expected a warning).
- Live run: a patch with a prototype key merges to `["mcpServers"]` with `Object.prototype.polluted` undefined; a key planted at 644 reads back at 600 after the load.
- Full suite green locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two security issues: install-state merges strip prototype keys so payloads never reach the prototype chain, and encryption/HMAC key files now fail hard when they can't be made private instead of logging a warning.

- Merge helpers now live once in `scripts/lib/json-merge.js`, so merge, uninstall, and inspection all drop `__proto__`, `constructor`, and `prototype`; uninstall never removes a key EGC never installed.
- Key files are opened without following links and without blocking, with chmod, stat, and read all on one descriptor, so a link (even dangling), a swapped path, or a file readable by others is refused; only ENOENT counts as absent, and Windows skips the mode check.
- A fresh key is written to an exclusively-created private temp file, then linked into place so concurrent creators adopt the key that landed.
- The script-side HMAC key no longer falls back to an ephemeral one-lifetime key; snapshot and consolidate load the integrity key before writing, and a permission error on a script-side key read reaches the caller instead of silently resolving to null.

<sup>Written for commit a824f6ca1121b247ac36e27fe794a7dbbe1a1de4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

