### PR TITLE
fix(security): exempt only the harness settings file from the gate, and refuse to run a hook whose plugin root does not resolve

### DIFF
--- a/scripts/hooks/egc-session-bridge.js
+++ b/scripts/hooks/egc-session-bridge.js
@@ -40,12 +40,15 @@ function resolvePluginRoot() {
 }
 
 // A bridge that cannot be found does not run, and the session must not
-// look as if it had been bridged: the reason goes to stderr and the hook
-// exits non-zero, so a broken install is seen instead of silently losing
-// every session event.
+// look as if it had been bridged: the refusal is returned in the shape the
+// hook runner honours (an exit code with the reason on stderr), so a
+// broken install is seen instead of silently losing every session event,
+// whether the hook runs directly or through run-with-flags.
 function refuse(reason) {
-  process.stderr.write(`[${HOOK_ID}] refused: ${reason}; set EGC_PLUGIN_ROOT to the EGC install directory or reinstall with egc install --target gemini\n`);
-  return 1;
+  return {
+    exitCode: 1,
+    stderr: `[${HOOK_ID}] refused: ${reason}; set EGC_PLUGIN_ROOT to the EGC install directory or reinstall with egc install --target gemini\n`,
+  };
 }
 
 function resolvePythonBin(pluginRoot) {
@@ -116,7 +119,12 @@ function run() {
 }
 
 if (require.main === module) {
-  process.exit(run());
+  const outcome = run();
+  if (outcome && typeof outcome === 'object') {
+    if (outcome.stderr) process.stderr.write(outcome.stderr);
+    process.exit(Number.isInteger(outcome.exitCode) ? outcome.exitCode : 0);
+  }
+  process.exit(outcome);
 }
 
 module.exports = { run };

--- a/scripts/hooks/egc-session-bridge.js
+++ b/scripts/hooks/egc-session-bridge.js
@@ -29,10 +29,23 @@ function parsePayload(raw) {
   try { return JSON.parse(raw); } catch (_) { return {}; } // NOSONAR: malformed payload is treated as empty
 }
 
+// The plugin root: the environment when it names an existing directory,
+// otherwise the package this hook ships in. A root set in the environment
+// that does not exist is reported, never silently replaced.
 function resolvePluginRoot() {
   const fromEnv = process.env.EGC_PLUGIN_ROOT || process.env.ECC_PLUGIN_ROOT || process.env.GEMINI_PLUGIN_ROOT;
-  if (fromEnv && fs.existsSync(fromEnv)) return fromEnv;
-  return path.resolve(__dirname, '..', '..');
+  if (!fromEnv) return { root: path.resolve(__dirname, '..', '..'), error: null };
+  if (fs.existsSync(fromEnv)) return { root: fromEnv, error: null };
+  return { root: null, error: `plugin root ${fromEnv} does not exist` };
+}
+
+// A bridge that cannot be found does not run, and the session must not
+// look as if it had been bridged: the reason goes to stderr and the hook
+// exits non-zero, so a broken install is seen instead of silently losing
+// every session event.
+function refuse(reason) {
+  process.stderr.write(`[${HOOK_ID}] refused: ${reason}; set EGC_PLUGIN_ROOT to the EGC install directory or reinstall with egc install --target gemini\n`);
+  return 1;
 }
 
 function resolvePythonBin(pluginRoot) {
@@ -68,9 +81,10 @@ function run() {
   const sessionId = payload.session_id || process.env.EGC_SESSION_ID || process.env.ECC_SESSION_ID
     || `egc-${Date.now()}`;
 
-  const pluginRoot = resolvePluginRoot();
+  const { root: pluginRoot, error: rootError } = resolvePluginRoot();
+  if (rootError) return refuse(rootError);
   const bridgePy = path.join(pluginRoot, 'scripts', 'runtime', 'session_bridge.py');
-  if (!fs.existsSync(bridgePy)) return 0;
+  if (!fs.existsSync(bridgePy)) return refuse(`bridge ${bridgePy} is missing under plugin root ${pluginRoot}`);
 
   const python = resolvePythonBin(pluginRoot);
   const env = { ...process.env };

--- a/scripts/hooks/egc-session-bridge.js
+++ b/scripts/hooks/egc-session-bridge.js
@@ -76,7 +76,7 @@ function deriveEventName(payload) {
 }
 
 function run() {
-  if (disabled()) return 0;
+  if (disabled()) return { exitCode: 0 };
 
   const raw = readStdin();
   const payload = parsePayload(raw);
@@ -110,21 +110,18 @@ function run() {
       ? `timed out after ${DEFAULT_TIMEOUT_MS}ms`
       : result.error.message;
     process.stderr.write(`[${HOOK_ID}] soft-fail: ${detail}\n`);
-    return 0;
+    return { exitCode: 0 };
   }
   if ((result.stderr || '').trim()) {
     process.stderr.write(`[${HOOK_ID}] ${String(result.stderr).trim().split('\n').pop()}\n`);
   }
-  return 0;
+  return { exitCode: 0 };
 }
 
 if (require.main === module) {
   const outcome = run();
-  if (outcome && typeof outcome === 'object') {
-    if (outcome.stderr) process.stderr.write(outcome.stderr);
-    process.exit(Number.isInteger(outcome.exitCode) ? outcome.exitCode : 0);
-  }
-  process.exit(outcome);
+  if (outcome.stderr) process.stderr.write(outcome.stderr);
+  process.exit(Number.isInteger(outcome.exitCode) ? outcome.exitCode : 0);
 }
 
 module.exports = { run };

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -405,9 +405,13 @@ function normalizeForMatch(value) {
     .toLowerCase();
 }
 
+// The settings file of the harness the gate runs under, Claude Code's or
+// Gemini CLI's (`.claude/settings.json`, `.gemini/settings.local.json`,
+// ...): an edit there is how the hook itself is configured or disabled, so
+// it is never gated. Nothing else under those directories is exempt.
 function isClaudeSettingsPath(filePath) {
   const normalized = normalizeForMatch(filePath);
-  return /(^|\/)\.gemini\/settings(?:\.[^/]+)?\.json$/.test(normalized);
+  return /(^|\/)\.(?:claude|gemini)\/settings(?:\.[^/]+)?\.json$/.test(normalized);
 }
 
 const SAFE_GIT_SUBCOMMANDS = {

--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -42,6 +42,9 @@ function resolveTarget(rootDir, relPath) {
   ) {
     throw new Error(`Path traversal rejected: ${relPath}`);
   }
+  if (!fs.existsSync(resolvedTarget)) {
+    throw new Error(`hook script missing: ${resolvedTarget}; the EGC install under ${resolvedRoot} is incomplete`);
+  }
   return resolvedTarget;
 }
 
@@ -120,34 +123,48 @@ function sanitizeArgs(args) {
   return args.filter(a => typeof a === 'string' && !a.includes('\0'));
 }
 
+// A hook that cannot be resolved does not run, and a hook that does not run
+// must not look as if it had: the call is refused with the blocking status
+// every harness honours and the reason on stderr, so a broken install is
+// seen the first time instead of leaving the session silently unguarded.
+const REFUSED_STATUS = 2;
+const INSTALL_HINT = 'set EGC_PLUGIN_ROOT to the EGC install directory, or reinstall with egc install --target gemini';
+
+function refuse(reason) {
+  writeStderr(`[Hook] ${reason}; ${INSTALL_HINT}\n`);
+  process.exit(REFUSED_STATUS);
+}
+
+function refuseUnlessResolvable(mode, relPath, rootDir) {
+  if (!mode || !relPath) {
+    refuse(`bootstrap called without a mode or a target script (mode: ${mode || 'none'}, target: ${relPath || 'none'}); check the hook registration`);
+  }
+  if (!rootDir) {
+    refuse('EGC plugin root not resolved');
+  }
+  if (!fs.existsSync(rootDir)) {
+    refuse(`EGC plugin root ${rootDir} does not exist`);
+  }
+}
+
+function runTarget(mode, rootDir, relPath, raw, args) {
+  try {
+    if (mode === 'node') return spawnNode(rootDir, relPath, raw, args);
+    if (mode === 'shell') return spawnShell(rootDir, relPath, raw, args);
+    return refuse(`unknown bootstrap mode: ${mode}`);
+  } catch (error) {
+    return refuse(`bootstrap resolution failed: ${error.message}`);
+  }
+}
+
 function main() {
   const [, , mode, relPath, ...args] = process.argv;
   const raw = readStdinRaw();
   const rootDir = process.env.EGC_PLUGIN_ROOT || process.env.ECC_PLUGIN_ROOT || process.env.GEMINI_PLUGIN_ROOT;
 
   trace('hook:bootstrap:entry', { mode, relPath, args, rootDir });
-
-  if (!mode || !relPath || !rootDir) {
-    process.stdout.write(raw);
-    process.exit(0);
-  }
-
-  let result;
-  try {
-    if (mode === 'node') {
-      result = spawnNode(rootDir, relPath, raw, args);
-    } else if (mode === 'shell') {
-      result = spawnShell(rootDir, relPath, raw, args);
-    } else {
-      writeStderr(`[Hook] unknown bootstrap mode: ${mode}\n`);
-      process.stdout.write(raw);
-      process.exit(0);
-    }
-  } catch (error) {
-    writeStderr(`[Hook] bootstrap resolution failed: ${error.message}\n`);
-    process.stdout.write(raw);
-    process.exit(0);
-  }
+  refuseUnlessResolvable(mode, relPath, rootDir);
+  const result = runTarget(mode, rootDir, relPath, raw, args);
 
   passthrough(raw, result);
   writeStderr(result.stderr);

--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -93,6 +93,9 @@ function spawnNode(rootDir, relPath, raw, args) {
 }
 
 function spawnShell(rootDir, relPath, raw, args) {
+  // The target is resolved and checked before the runtime question, so a
+  // missing hook is refused whether or not a shell is available.
+  const target = resolveTarget(rootDir, relPath);
   const shell = findShellBinary();
   if (!shell) {
     return {
@@ -102,7 +105,7 @@ function spawnShell(rootDir, relPath, raw, args) {
     };
   }
 
-  return spawnSync(shell, [resolveTarget(rootDir, relPath), ...sanitizeArgs(args)], { // NOSONAR jssecurity:S8705
+  return spawnSync(shell, [target, ...sanitizeArgs(args)], { // NOSONAR jssecurity:S8705
     input: raw,
     encoding: 'utf8',
     env: {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -797,6 +797,27 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // --- Test 16b: the Claude Code settings file is exempt the same way, the rest of .claude/ is not ---
+  clearState();
+  if (test('allows edits to .claude/settings.local.json without gating, and still gates .claude/CLAUDE.md', () => {
+    const settings = runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: '/workspace/app/.claude/settings.local.json', old_string: '{}', new_string: '{"hooks":[]}' }
+    });
+    const settingsOutput = parseOutput(settings.stdout);
+    assert.ok(settingsOutput, 'should produce valid JSON output');
+    assert.notStrictEqual(settingsOutput.hookSpecificOutput?.permissionDecision, 'deny', 'the settings file must not be gated');
+    clearState();
+    const memory = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: '/workspace/app/.claude/CLAUDE.md', content: '# rules' }
+    });
+    const memoryOutput = parseOutput(memory.stdout);
+    assert.ok(memoryOutput, 'should produce valid JSON output');
+    const gated = memoryOutput.hookSpecificOutput?.permissionDecision === 'deny' || memoryOutput.decision === 'block';
+    assert.ok(gated, `a first write under .claude/ is still gated: ${memory.stdout.slice(0, 200)}`);
+  })) passed++; else failed++;
+
   // --- Test 17: allows read-only git introspection without first-bash gating ---
   clearState();
   if (test('allows read-only git status without first-bash gating', () => {

--- a/tests/hooks/plugin-hook-bootstrap.test.js
+++ b/tests/hooks/plugin-hook-bootstrap.test.js
@@ -218,6 +218,23 @@ process.exit(7);
     }
   })) passed++; else failed++;
 
+  if (test('shell mode refuses a missing target even when no shell runtime is available', () => {
+    const root = createTempDir();
+    try {
+      const result = run(['shell', path.join('scripts', 'missing.sh')], {
+        root,
+        input: 'raw-input',
+        env: { PATH: '', BASH: '' },
+      });
+
+      assert.strictEqual(result.status, 2);
+      assert.strictEqual(result.stdout, '');
+      assert.ok(result.stderr.includes('hook script missing'), result.stderr);
+    } finally {
+      cleanup(root);
+    }
+  })) passed++; else failed++;
+
   if (test('rejects target paths that escape the plugin root', () => {
     const root = createTempDir();
     try {

--- a/tests/hooks/plugin-hook-bootstrap.test.js
+++ b/tests/hooks/plugin-hook-bootstrap.test.js
@@ -60,13 +60,32 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
-  if (test('passes stdin through when required bootstrap inputs are missing', () => {
+  if (test('refuses to run when the bootstrap inputs are missing', () => {
     const result = run([], { input: '{"ok":true}' });
 
-    assert.strictEqual(result.status, 0);
-    assert.strictEqual(result.stdout, '{"ok":true}');
-    assert.strictEqual(result.stderr, '');
+    assert.strictEqual(result.status, 2);
+    assert.strictEqual(result.stdout, '');
+    assert.ok(result.stderr.includes('without a mode or a target script'), result.stderr);
   })) passed++; else failed++;
+
+  if (test('refuses to run when the plugin root is not resolved or does not exist', () => {
+    const unresolved = run(['node', 'hook.js'], { input: 'raw-input', root: '' });
+    assert.strictEqual(unresolved.status, 2);
+    assert.strictEqual(unresolved.stdout, '');
+    assert.ok(unresolved.stderr.includes('plugin root not resolved'), unresolved.stderr);
+    assert.ok(unresolved.stderr.includes('EGC_PLUGIN_ROOT'), unresolved.stderr);
+
+    const root = createTempDir();
+    try {
+      const gone = run(['node', 'hook.js'], { input: 'raw-input', root: path.join(root, 'gone') });
+      assert.strictEqual(gone.status, 2);
+      assert.strictEqual(gone.stdout, '');
+      assert.ok(gone.stderr.includes('does not exist'), gone.stderr);
+    } finally {
+      cleanup(root);
+    }
+  })) passed++; else failed++;
+
 
   if (test('node mode runs target script with plugin root environment', () => {
     const root = createTempDir();
@@ -207,15 +226,15 @@ process.exit(7);
         input: 'raw-input',
       });
 
-      assert.strictEqual(result.status, 0);
-      assert.strictEqual(result.stdout, 'raw-input');
+      assert.strictEqual(result.status, 2);
+      assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('Path traversal rejected'));
     } finally {
       cleanup(root);
     }
   })) passed++; else failed++;
 
-  if (test('unknown mode fails open with stderr warning', () => {
+  if (test('unknown mode is refused with the reason on stderr', () => {
     const root = createTempDir();
     try {
       const result = run(['python', 'hook.py'], {
@@ -223,15 +242,15 @@ process.exit(7);
         input: 'raw-input',
       });
 
-      assert.strictEqual(result.status, 0);
-      assert.strictEqual(result.stdout, 'raw-input');
+      assert.strictEqual(result.status, 2);
+      assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('unknown bootstrap mode: python'));
     } finally {
       cleanup(root);
     }
   })) passed++; else failed++;
 
-  if (test('missing node target returns child failure diagnostics', () => {
+  if (test('missing node target is refused with the install hint', () => {
     const root = createTempDir();
     try {
       const result = run(['node', path.join('scripts', 'missing.js')], {
@@ -239,9 +258,10 @@ process.exit(7);
         input: 'raw-input',
       });
 
-      assert.strictEqual(result.status, 1);
+      assert.strictEqual(result.status, 2);
       assert.strictEqual(result.stdout, '');
-      assert.ok(result.stderr.includes('Cannot find module'));
+      assert.ok(result.stderr.includes('hook script missing'), result.stderr);
+      assert.ok(result.stderr.includes('egc install --target gemini'), result.stderr);
     } finally {
       cleanup(root);
     }

--- a/tests/scripts/egc-session-bridge.test.js
+++ b/tests/scripts/egc-session-bridge.test.js
@@ -103,6 +103,28 @@ test('fails closed when the bridge is missing under the plugin root', () => {
   }
 });
 
+test('a refusal reaches the hook runner as a non-zero exit, not a passthrough', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-bridge-wrapper-'));
+  try {
+    const copy = path.join(root, 'scripts', 'hooks', 'egc-session-bridge.js');
+    fs.mkdirSync(path.dirname(copy), { recursive: true });
+    fs.copyFileSync(HOOK, copy);
+    const runner = path.join(REPO_ROOT, 'scripts', 'hooks', 'run-with-flags.js');
+    const r = spawnSync(process.execPath, [runner, 'sessionstart:egc-session-bridge', 'scripts/hooks/egc-session-bridge.js', 'standard,strict'], {
+      cwd: root,
+      env: { ...process.env, EGC_PLUGIN_ROOT: root, HOOK_EVENT_NAME: 'SessionStart', EGC_HOOK_PROFILE: 'standard' },
+      input: '{}',
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: process.platform === 'win32' ? 30000 : 10000,
+    });
+    assert.strictEqual(r.status, 1, `${r.stdout}\n${r.stderr}`);
+    assert.ok(r.stderr.includes('is missing under plugin root'), r.stderr);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('hook is a no-op when EGC_SESSION_BRIDGE=off', () => {
   const tmp = createTempDir('egc-bridge-off-');
   try {

--- a/tests/scripts/egc-session-bridge.test.js
+++ b/tests/scripts/egc-session-bridge.test.js
@@ -85,6 +85,24 @@ test('hooks.json registers SessionStart + SessionEnd entries', () => {
   assert.ok(endMatches, 'SessionEnd missing egc-session-bridge entry');
 });
 
+test('fails closed when the plugin root does not resolve', () => {
+  const r = runHook('SessionStart', 'egc-test-root', { pluginRoot: path.join(REPO_ROOT, 'no-such-plugin-root') });
+  assert.strictEqual(r.status, 1, r.stderr);
+  assert.ok(r.stderr.includes('does not exist'), r.stderr);
+  assert.ok(r.stderr.includes('EGC_PLUGIN_ROOT'), r.stderr);
+});
+
+test('fails closed when the bridge is missing under the plugin root', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-bridge-root-'));
+  try {
+    const r = runHook('SessionStart', 'egc-test-bridge', { pluginRoot: root });
+    assert.strictEqual(r.status, 1, r.stderr);
+    assert.ok(r.stderr.includes('is missing under plugin root'), r.stderr);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('hook is a no-op when EGC_SESSION_BRIDGE=off', () => {
   const tmp = createTempDir('egc-bridge-off-');
   try {


### PR DESCRIPTION
## Why

Security schedule, day 18 (audit 2026-08-17): "`isClaudeSettingsPath()` in gateguard-fact-force.js actually matches `.gemini/settings*.json`, never `.claude/...`", and "Gemini CLI plugin-bootstrap fails open silently if its plugin root can't be resolved".

## What changed

Fact-forcing gate (`scripts/hooks/gateguard-fact-force.js`):
- The exemption covers the settings file of the harness the gate runs under, `.claude/settings*.json` as well as `.gemini/settings*.json` (that file is how the hook itself is configured or disabled). Nothing else under those directories is exempt: a first write to `.claude/CLAUDE.md` is still gated.

Gemini plugin bootstrap (`scripts/hooks/plugin-hook-bootstrap.js`):
- When the mode or the target is missing, the plugin root is unset or does not exist, the target escapes the root, the mode is unknown, or the hook script is not there, the call is refused (exit 2, the blocking status every harness honours) with the reason and the fix on stderr, instead of writing the input back and exiting 0 as if the hook had run. Execution failures of a hook that did start (timeout, signal) keep their soft handling.

Session bridge (`scripts/hooks/egc-session-bridge.js`):
- A plugin root set in the environment that does not exist is reported, not silently replaced by the package directory; a missing bridge script is reported; both exit 1 with the fix on stderr.

## Proof

- `tests/hooks/gateguard-fact-force.test.js`: `.claude/settings.local.json` edits pass without gating, a first write to `.claude/CLAUDE.md` is still gated.
- `tests/hooks/plugin-hook-bootstrap.test.js`: missing inputs, unresolved root, missing root, traversal, unknown mode and missing target all exit 2 with empty stdout and the reason on stderr.
- `tests/scripts/egc-session-bridge.test.js`: a root that does not exist and a missing bridge both exit 1 with the reason.
- Live run: with the plugin root pointed at a directory that does not exist, the bootstrap refuses with `[Hook] EGC plugin root /nonexistent-egc-root does not exist; set EGC_PLUGIN_ROOT ...` and exit 2.
- Full suite green locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the fact-forcing gate so its settings exemption matches the harness it runs under, and makes the Gemini plugin bootstrap and session bridge fail closed when the plugin root can't be resolved instead of passing input through as if the hook had run.

**Bug Fixes**
- The gate now exempts `.claude/settings*.json` in addition to `.gemini/settings*.json`; nothing else under those directories is exempt.
- The bootstrap exits 2 with the reason and install hint when the mode, target, or plugin root is missing, the root doesn't exist, the target escapes the root, or the hook script is missing.
- Shell-mode hooks check the target before the runtime, so a missing hook is refused even with no shell available.
- The session bridge returns one result shape on every path, so a refusal for a missing root or bridge script is a non-zero exit through `run-with-flags` as well.
- Hooks that start but fail at runtime keep their existing soft handling.

<sup>Written for commit 8d1e4ebb7556349c7ca265e3466bd71f6b990910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

