### PR TITLE
fix(release): keep the packaging checks off stdout so npm pack --json parses

### DIFF
--- a/scripts/check-internal-tool-leak.js
+++ b/scripts/check-internal-tool-leak.js
@@ -77,7 +77,7 @@ function checkTree() {
 
 function report(leaks, context) {
   if (leaks.length === 0) {
-    console.log('internal-tool leak check: clean');
+    console.error('internal-tool leak check: clean');
     return 0;
   }
   console.error(`BLOCKED: internal/personal tool references must never be public. Found in ${context}:`);
@@ -91,7 +91,7 @@ function report(leaks, context) {
 function checkText(text) {
   const hits = findHits(text);
   if (hits.length === 0) {
-    console.log('internal-tool leak check: clean');
+    console.error('internal-tool leak check: clean');
     return 0;
   }
   console.error(`BLOCKED: internal/personal tool reference found in PR title/body: ${hits.join(', ')}`);

--- a/scripts/check-state-leak.js
+++ b/scripts/check-state-leak.js
@@ -166,7 +166,7 @@ function checkPackagedTree() {
     if (!notARepo && !gitMissing) {
       throw error;
     }
-    console.log(`state-leak check: skipped (${notARepo ? 'not a git checkout' : 'git unavailable'}: ${String(error.message).split('\n')[0]})`);
+    console.error(`state-leak check: skipped (${notARepo ? 'not a git checkout' : 'git unavailable'}: ${String(error.message).split('\n')[0]})`);
     return [];
   }
   const packagedFiles = listing.split('\0').filter(Boolean)
@@ -187,7 +187,7 @@ function main() {
     }
     for (const file of files) {
       fs.writeFileSync(file, cleanContent(fs.readFileSync(file, 'utf8')));
-      console.log(`cleaned: ${file}`);
+      console.error(`cleaned: ${file}`);
     }
     return;
   }
@@ -210,7 +210,10 @@ function main() {
     leaks = checkTree();
   }
   if (leaks.length === 0) {
-    console.log('state-leak check: clean');
+    // Status lines go to stderr: `npm pack --json` runs this script through
+    // the prepack hook and parses stdout as JSON, so stdout stays reserved
+    // for the --stdin filter output.
+    console.error('state-leak check: clean');
     return;
   }
 

--- a/tests/check-state-leak.test.js
+++ b/tests/check-state-leak.test.js
@@ -150,6 +150,21 @@ run('packaged-tree passes when only unpackaged files are populated', () => {
   assert.strictEqual(res.status, 0, res.stderr);
 });
 
+run('a clean packaged tree keeps stdout empty so npm pack --json can parse its output', () => {
+  const { dir, git } = makeRepo();
+  try {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0', files: ['scripts/'] }, null, 2));
+    git('add', '.');
+    git('commit', '-q', '-m', 'init');
+    const res = runScript(dir, '--packaged-tree');
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.strictEqual(res.stdout, '', 'status lines must not reach stdout');
+    assert.ok(res.stderr.includes('state-leak check: clean'), res.stderr);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 run('packaged-tree skips with a notice outside a git checkout', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-leak-nogit-'));
   try {
@@ -158,7 +173,7 @@ run('packaged-tree skips with a notice outside a git checkout', () => {
     fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 't', version: '0.0.0', files: ['.trae/'] }, null, 2));
     const res = runScript(dir, '--packaged-tree');
     assert.strictEqual(res.status, 0, res.stderr);
-    assert.ok(res.stdout.includes('skipped (not a git checkout'), res.stdout);
+    assert.ok(res.stderr.includes('skipped (not a git checkout'), res.stderr);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Why

The v1.1.21 release workflow failed at the tarball step: `npm pack --json` runs the prepack hook, and the state-leak and internal-tool checks wrote their status lines to stdout in front of the JSON, so the parse failed before anything was published.

## What changed

- `scripts/check-state-leak.js` and `scripts/check-internal-tool-leak.js`: status lines (clean, skipped, cleaned) go to stderr; stdout stays reserved for the `--stdin` filter output.
- `tests/check-state-leak.test.js`: the skipped-notice assertion reads stderr, and a new case asserts that a clean packaged tree leaves stdout empty.

## Proof

- In a clean clone of this branch both checkers write 0 bytes to stdout and `npm pack --json` parses to `egchq-egc-1.1.21.tgz`; on main the same command fails to parse.
- The release workflow for the existing `v1.1.21` tag is re-run after this lands (the tag points at the version bump, the workflow checks out the tag, so the fix must be in the tag or the run re-dispatched from main: see the follow-up).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow's tarball step so `npm pack --json` parses correctly. The state-leak and internal-tool checks wrote status lines to stdout during the prepack hook, corrupting the JSON; those lines now go to stderr.

- Both checkers now send all status lines (clean, skipped, cleaned) to stderr, leaving stdout reserved for the `--stdin` filter output.
- Tests updated to assert stdout stays empty on a clean packaged tree and that the skipped notice comes from stderr.
- The existing `v1.1.21` tag needs this fix or the workflow must be re-dispatched from main.

<sup>Written for commit ff28e410cde9478e212e38af034e75c961f3a717. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

