### PR TITLE
fix(mcp): treat empty or whitespace-only JSON configs as empty objects

### DIFF
--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -195,16 +195,20 @@ function registerJson(targetPath, bins) {
   let obj = { mcpServers: {} };
   const existingContent = readFileIfExists(targetPath);
   if (existingContent !== null) {
-    try {
-      obj = JSON.parse(existingContent);
-    } catch (err) {
-      if (err instanceof SyntaxError) {
-        throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
+    const trimmed = existingContent.trim();
+    if (trimmed.length > 0) {
+      try {
+        obj = JSON.parse(trimmed);
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
+        }
+        throw err;
       }
-      throw err;
     }
   }
-  if (!obj.mcpServers) obj.mcpServers = {};
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) obj = { mcpServers: {} };
+  if (!obj.mcpServers || typeof obj.mcpServers !== 'object' || Array.isArray(obj.mcpServers)) obj.mcpServers = {};
   let changed = false;
   if (!obj.mcpServers['egc-guardian']) {
     obj.mcpServers['egc-guardian'] = { command: 'node', args: [guardianBin] };
@@ -340,15 +344,21 @@ function registerZedContextServers(targetPath, bins) {
 
   let settings = {};
   if (fs.existsSync(targetPath)) {
-    try {
-      settings = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
-    } catch (err) {
-      if (err instanceof SyntaxError) {
-        throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
+    const raw = fs.readFileSync(targetPath, 'utf8');
+    const trimmed = raw.trim();
+    if (trimmed.length > 0) {
+      try {
+        settings = JSON.parse(trimmed);
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
+        }
+        throw err;
       }
-      throw err;
     }
   }
+
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) settings = {};
 
   if (!settings.context_servers) settings.context_servers = {};
   let changed = false;

--- a/scripts/lib/mcp-register.js
+++ b/scripts/lib/mcp-register.js
@@ -182,6 +182,31 @@ function buildMcpRegistrationTargets(homeDir) {
 }
 
 /**
+ * Parses raw JSON configuration content as an object.
+ * Returns {} if content is null, empty, or whitespace-only.
+ * Throws SyntaxError wrapped in Error if malformed JSON.
+ * Throws TypeError if the root value is not an object or is an array.
+ */
+function parseJsonObject(targetPath, rawContent, rootEntityName = 'config') {
+  if (rawContent === null || rawContent === undefined) return {};
+  const trimmed = rawContent.trim();
+  if (trimmed.length === 0) return {};
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
+    }
+    throw err;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new TypeError(`existing file at ${targetPath} is not a valid ${rootEntityName} object - left untouched`);
+  }
+  return parsed;
+}
+
+/**
  * Merges egc-guardian / egc-memory into a JSON mcpServers config, preserving
  * whatever else is already in the file. Returns true if the file was
  * created/changed, false if both entries were already present (a legitimate,
@@ -192,23 +217,13 @@ function buildMcpRegistrationTargets(homeDir) {
  */
 function registerJson(targetPath, bins) {
   const { guardianBin, memoryBin } = bins;
-  let obj = { mcpServers: {} };
   const existingContent = readFileIfExists(targetPath);
-  if (existingContent !== null) {
-    const trimmed = existingContent.trim();
-    if (trimmed.length > 0) {
-      try {
-        obj = JSON.parse(trimmed);
-      } catch (err) {
-        if (err instanceof SyntaxError) {
-          throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
-        }
-        throw err;
-      }
-    }
+  const obj = parseJsonObject(targetPath, existingContent, 'MCP config');
+  if (obj.mcpServers === null || obj.mcpServers === undefined) {
+    obj.mcpServers = {};
+  } else if (typeof obj.mcpServers !== 'object' || Array.isArray(obj.mcpServers)) {
+    throw new TypeError(`existing file at ${targetPath} has an invalid mcpServers object - left untouched`);
   }
-  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) obj = { mcpServers: {} };
-  if (!obj.mcpServers || typeof obj.mcpServers !== 'object' || Array.isArray(obj.mcpServers)) obj.mcpServers = {};
   let changed = false;
   if (!obj.mcpServers['egc-guardian']) {
     obj.mcpServers['egc-guardian'] = { command: 'node', args: [guardianBin] };
@@ -342,25 +357,13 @@ function registerZedContextServers(targetPath, bins) {
     .replaceAll('__MEMORY_BIN__', jsonStringBody(memoryBin));
   const incoming = JSON.parse(template);
 
-  let settings = {};
-  if (fs.existsSync(targetPath)) {
-    const raw = fs.readFileSync(targetPath, 'utf8');
-    const trimmed = raw.trim();
-    if (trimmed.length > 0) {
-      try {
-        settings = JSON.parse(trimmed);
-      } catch (err) {
-        if (err instanceof SyntaxError) {
-          throw new Error(`existing file at ${targetPath} is not valid JSON - left untouched: ${err.message}`, { cause: err });
-        }
-        throw err;
-      }
-    }
+  const existingContent = readFileIfExists(targetPath);
+  const settings = parseJsonObject(targetPath, existingContent, 'settings');
+  if (settings.context_servers === null || settings.context_servers === undefined) {
+    settings.context_servers = {};
+  } else if (typeof settings.context_servers !== 'object' || Array.isArray(settings.context_servers)) {
+    throw new TypeError(`existing file at ${targetPath} has an invalid context_servers object - left untouched`);
   }
-
-  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) settings = {};
-
-  if (!settings.context_servers) settings.context_servers = {};
   let changed = false;
   for (const [key, value] of Object.entries(incoming.context_servers)) {
     if (!settings.context_servers[key]) {
@@ -491,6 +494,7 @@ function registerMcpServers(homeDir, bins, callbacks = {}) {
 
 module.exports = {
   buildMcpRegistrationTargets,
+  parseJsonObject,
   registerJson,
   registerToml,
   registerContinueYaml,

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -398,6 +398,22 @@ function runTests() {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
 
+  (test('registerJson treats an empty (0-byte) or whitespace-only file as an empty object and adds both servers', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.gemini', 'config');
+    fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, 'mcp_config.json');
+    fs.writeFileSync(target, '   \n\t  ');
+
+    const changed = registerJson(target, bins);
+    assert.strictEqual(changed, true);
+    const written = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.ok(written.mcpServers['egc-guardian']);
+    assert.ok(written.mcpServers['egc-memory']);
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
   // ── registerToml (unchanged behavior, guards against regressions) ──
 
   (test('registerToml appends both mcp_servers blocks to a fresh file', () => {

--- a/tests/lib/mcp-register.test.js
+++ b/tests/lib/mcp-register.test.js
@@ -398,7 +398,23 @@ function runTests() {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
 
-  (test('registerJson treats an empty (0-byte) or whitespace-only file as an empty object and adds both servers', () => {
+  (test('registerJson treats a 0-byte empty file as an empty object and adds both servers', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.gemini', 'config');
+    fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, 'mcp_config.json');
+    fs.writeFileSync(target, '');
+
+    const changed = registerJson(target, bins);
+    assert.strictEqual(changed, true);
+    const written = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.ok(written.mcpServers['egc-guardian']);
+    assert.ok(written.mcpServers['egc-memory']);
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerJson treats a whitespace-only file as an empty object and adds both servers', () => {
     const tmpHome = makeTempDir();
     const dir = path.join(tmpHome, '.gemini', 'config');
     fs.mkdirSync(dir, { recursive: true });
@@ -410,6 +426,31 @@ function runTests() {
     const written = JSON.parse(fs.readFileSync(target, 'utf8'));
     assert.ok(written.mcpServers['egc-guardian']);
     assert.ok(written.mcpServers['egc-memory']);
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerJson throws on invalid root shape (array or primitive) to protect user data', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.cursor');
+    fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, 'mcp.json');
+    fs.writeFileSync(target, '[1, 2, 3]');
+
+    assert.throws(() => registerJson(target, bins), /not a valid MCP config object/);
+    assert.strictEqual(fs.readFileSync(target, 'utf8'), '[1, 2, 3]', 'invalid root file must be left untouched');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerJson throws on invalid mcpServers shape (array or primitive) to protect user data', () => {
+    const tmpHome = makeTempDir();
+    const dir = path.join(tmpHome, '.cursor');
+    fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, 'mcp.json');
+    fs.writeFileSync(target, JSON.stringify({ mcpServers: [1, 2, 3] }));
+
+    assert.throws(() => registerJson(target, bins), /invalid mcpServers object/);
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
@@ -711,6 +752,51 @@ function runTests() {
 
     const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
     assert.strictEqual(parsed.context_servers['egc-guardian'].command.args[0], quotedPath, 'a path with a double quote should round-trip exactly');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerZedContextServers treats a 0-byte empty file as an empty object and adds servers', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.config', 'zed', 'settings.json');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, '');
+
+    const changed = registerZedContextServers(target, bins);
+    assert.strictEqual(changed, true);
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.ok(parsed.context_servers['egc-guardian']);
+    assert.ok(parsed.context_servers['egc-memory']);
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerZedContextServers treats a whitespace-only file as an empty object and adds servers', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.config', 'zed', 'settings.json');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, '  \n\t  ');
+
+    const changed = registerZedContextServers(target, bins);
+    assert.strictEqual(changed, true);
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+    assert.ok(parsed.context_servers['egc-guardian']);
+    assert.ok(parsed.context_servers['egc-memory']);
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  (test('registerZedContextServers throws on invalid settings root or context_servers shape to protect user data', () => {
+    const tmpHome = makeTempDir();
+    const target = path.join(tmpHome, '.config', 'zed', 'settings.json');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, '[1, 2, 3]');
+
+    assert.throws(() => registerZedContextServers(target, bins), /not a valid settings object/);
+    assert.strictEqual(fs.readFileSync(target, 'utf8'), '[1, 2, 3]', 'invalid root file must be left untouched');
+
+    fs.writeFileSync(target, JSON.stringify({ context_servers: [1, 2, 3] }));
+    assert.throws(() => registerZedContextServers(target, bins), /invalid context_servers object/);
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);


### PR DESCRIPTION
## Summary

Fixes the configuration registration issue identified during testing in #1383.

When an existing tool config file (such as `~/.gemini/config/mcp_config.json` created upon initializing Antigravity or Gemini CLI) is 0 bytes or contains only whitespace, `JSON.parse` previously threw a `SyntaxError: Unexpected end of JSON input`.

Because this was caught as a general SyntaxError, `egc init` treated the file as malformed JSON and left it untouched with a warning, preventing `egc-guardian` and `egc-memory` from being registered into the target tool's configuration.

## Changes

- **`scripts/lib/mcp-register.js`**:
  - `registerJson`: Trim content before parsing. If empty or whitespace-only, default to `{ mcpServers: {} }` and proceed with server registration.
  - `registerZedContextServers`: Apply the same empty/whitespace safeguard for Zed settings.
  - Genuinely broken JSON (e.g. `not valid json {{{`) continues to throw and remains untouched.
- **`tests/lib/mcp-register.test.js`**:
  - Added unit test asserting that 0-byte/whitespace-only config files are correctly populated with both `egc-guardian` and `egc-memory`.

## Verification

- Unit tests: `node tests/lib/mcp-register.test.js` (38/38 passed).
- Real environment: Verified with empty `~/.gemini/config/mcp_config.json` -> `egc init` cleanly registered servers (`✓ Gemini CLI`) and initialized `~/.egc/memory/state.db`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats empty or whitespace-only MCP config files as empty objects so `egc init` registers `egc-guardian` and `egc-memory` instead of skipping them with a warning.

- Applies the same safeguard to Gemini CLI configs and Zed settings.
- Malformed JSON or invalid config shapes (arrays, primitives, bad `mcpServers`/`context_servers`) still error and are left untouched.
- Adds unit tests covering 0-byte, whitespace-only, and invalid-shape config files.

<sup>Written for commit c19017006c8851601b6de2d03e6af03ff0f0c172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty, whitespace-only, malformed, or unexpected configuration files.
  * Configuration registration now reports invalid server collections instead of silently replacing them.
  * Prevented invalid configuration data from overwriting existing server registrations.
  * Ensured required server entries are written when configuration files are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->