### PR TITLE
fix(doctor): print the consolidation hint with the canonical store and one --source per stray copy

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -7,6 +7,7 @@ const { doctor: doctorOp } = require('./lib/operations/index');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { getEGCDir, getKnownHarnessDirs } = require('./lib/utils');
 const { parseTargetArgs } = require('./lib/cli-target-args');
+const { consolidateCommand } = require('./lib/doctor-summary');
 
 // Printed as an absolute path: the hint is read from wherever the person ran
 // egc doctor (a project folder, a global npm install on Windows), and a
@@ -143,7 +144,7 @@ function checkStateDb(homeDir) {
   }
   // One predictable shape for --json consumers no matter which condition
   // fired.
-  return { missing, dbPath, memoryDbPath, hasHarnessDb, hasMemoryDb, cliStoreMisplaced, fragments };
+  return { missing, dbPath, canonicalDbPath, memoryDbPath, hasHarnessDb, hasMemoryDb, cliStoreMisplaced, fragments };
 }
 
 function printStateStoreReport(stateDb) {
@@ -157,7 +158,8 @@ function printStateStoreReport(stateDb) {
     console.log(`    ${stateDb.dbPath}`);
     console.log('  It belongs in the shared ~/.egc store; in a harness directory its');
     console.log('  history is invisible to the rest of EGC. Consolidate it with:');
-    console.log(`    node "${CONSOLIDATE_SCRIPT}"`);
+    console.log(`    ${consolidateCommand(CONSOLIDATE_SCRIPT, [stateDb.dbPath], stateDb.canonicalDbPath)}`);
+    console.log('  Review the dry run, then run the same command with --apply at the end.');
   }
   if (stateDb.fragments.length > 0) {
     const plural = stateDb.fragments.length === 1 ? 'copy' : 'copies';
@@ -167,7 +169,8 @@ function printStateStoreReport(stateDb) {
     }
     console.log('  Nothing is lost, but new sessions no longer write there. Consolidate');
     console.log('  them into the main store (dry-run by default) with:');
-    console.log(`    node "${CONSOLIDATE_SCRIPT}"`);
+    console.log(`    ${consolidateCommand(CONSOLIDATE_SCRIPT, stateDb.fragments.map(fragment => fragment.path), stateDb.canonicalDbPath)}`);
+    console.log('  Review the dry run, then run the same command with --apply at the end.');
   }
   if (stateDb.hasHarnessDb && !stateDb.hasMemoryDb) {
     // "Nothing to do." only when no warning printed above it in this

--- a/scripts/lib/doctor-summary.js
+++ b/scripts/lib/doctor-summary.js
@@ -57,17 +57,31 @@ function issueLines(results) {
   return lines;
 }
 
+// The merge script refuses to run without at least one --source, and its
+// default canonical store follows the same directory resolution that put a
+// copy in the wrong place to begin with. The doctor already knows every path
+// involved, so the printed command carries all of them: it runs as pasted
+// (dry-run by default) from any shell and any cwd (#1389).
+function consolidateCommand(scriptPath, sourcePaths, canonicalPath) {
+  const parts = [`node "${scriptPath}"`];
+  if (canonicalPath) parts.push(`--canonical "${canonicalPath}"`);
+  for (const sourcePath of sourcePaths) parts.push(`--source "${sourcePath}"`);
+  return parts.join(' ');
+}
+
 function stateStoreNotes(stateDb, repoRoot) {
   if (!stateDb) return [];
   const notes = [];
-  const consolidate = `node "${path.join(repoRoot, 'scripts', 'maintenance', 'merge-fragmented-state-dbs.js')}"`;
+  const script = path.join(repoRoot, 'scripts', 'maintenance', 'merge-fragmented-state-dbs.js');
   if (stateDb.missing) {
     notes.push(`state store not found at ${stateDb.dbPath}; run egc init again`);
   }
   if (stateDb.cliStoreMisplaced) {
+    const consolidate = consolidateCommand(script, [stateDb.dbPath], stateDb.canonicalDbPath);
     notes.push(`the CLI event store landed in a harness directory (${stateDb.dbPath}); consolidate it with: ${consolidate}`);
   }
   if (Array.isArray(stateDb.fragments) && stateDb.fragments.length > 0) {
+    const consolidate = consolidateCommand(script, stateDb.fragments.map(fragment => fragment.path), stateDb.canonicalDbPath);
     notes.push(`${pluralize(stateDb.fragments.length, 'stray state.db copy', 'stray state.db copies')} left by older versions; consolidate with: ${consolidate}`);
   }
   return notes;
@@ -210,4 +224,4 @@ function summarizeRepairResult(result) {
   };
 }
 
-module.exports = { summarizeDoctorReport, summarizeRepairResult, describeIssue, targetName };
+module.exports = { summarizeDoctorReport, summarizeRepairResult, describeIssue, targetName, consolidateCommand };

--- a/tests/lib/doctor-summary.test.js
+++ b/tests/lib/doctor-summary.test.js
@@ -5,7 +5,7 @@
 
 const assert = require('assert');
 const path = require('path');
-const { summarizeDoctorReport, summarizeRepairResult, targetName } = require('../../scripts/lib/doctor-summary');
+const { summarizeDoctorReport, summarizeRepairResult, targetName, consolidateCommand } = require('../../scripts/lib/doctor-summary');
 
 let passed = 0;
 let failed = 0;
@@ -182,7 +182,33 @@ test('state store findings become notes with the consolidation command, and down
   assert.strictEqual(summary.notes.length, 1);
   assert.ok(summary.notes[0].startsWith('1 stray state.db copy left by older versions'));
   assert.ok(summary.notes[0].includes(path.join('/repo', 'scripts', 'maintenance', 'merge-fragmented-state-dbs.js')));
+  assert.ok(summary.notes[0].includes('--source "/home/user/.claude/egc/state.db"'), 'the note must name the copy the script has to read');
   assert.deepStrictEqual(summary.commands, []);
+});
+
+test('the consolidation command carries the canonical store and one --source per copy, quoted for any shell', () => {
+  const script = path.join('/repo', 'scripts', 'maintenance', 'merge-fragmented-state-dbs.js');
+  const canonical = '/srv/egc-home/egc/state.db';
+  const windowsCopy = String.raw`C:\Users\comp\.gemini\egc\state.db`;
+  const two = consolidateCommand(script, ['/home/user/.claude/egc/state.db', windowsCopy], canonical);
+  assert.strictEqual(
+    two,
+    `node "${script}" --canonical "${canonical}" --source "/home/user/.claude/egc/state.db" --source "${windowsCopy}"`
+  );
+  const bare = consolidateCommand(script, ['/x/state.db']);
+  assert.strictEqual(bare, `node "${script}" --source "/x/state.db"`, 'without a known canonical the script keeps its own default');
+});
+
+test('a misplaced CLI store is consolidated from its own path into the canonical store', () => {
+  const canonical = '/srv/egc-home/egc/state.db';
+  const stateDb = {
+    missing: false, dbPath: '/home/user/.gemini/egc/state.db', canonicalDbPath: canonical,
+    memoryDbPath: '/srv/egc-home/memory/state.db', hasHarnessDb: true, hasMemoryDb: true, cliStoreMisplaced: true, fragments: [],
+  };
+  const summary = summarizeDoctorReport(report(TWELVE, { stateDb }), { repoRoot: '/repo' });
+  assert.strictEqual(summary.notes.length, 1);
+  assert.ok(summary.notes[0].includes(`--canonical "${canonical}"`));
+  assert.ok(summary.notes[0].includes('--source "/home/user/.gemini/egc/state.db"'));
 });
 
 test('a healthy two-store layout adds no note', () => {

--- a/tests/scripts/doctor.test.js
+++ b/tests/scripts/doctor.test.js
@@ -669,6 +669,46 @@ function runTests() {
       assert.ok(result.stdout.includes(strayPath));
       const consolidateScript = path.join(__dirname, '..', '..', 'scripts', 'maintenance', 'merge-fragmented-state-dbs.js');
       assert.ok(result.stdout.includes(`node "${consolidateScript}"`), 'must point at the consolidation script by absolute path, runnable from any cwd');
+      const canonicalDb = path.join(homeDir, '.egc', 'egc', 'state.db');
+      assert.ok(
+        result.stdout.includes(`node "${consolidateScript}" --canonical "${canonicalDb}" --source "${strayPath}"`),
+        'the hint must run as pasted: the script exits with its usage text when no --source is given (#1389)'
+      );
+      assert.ok(result.stdout.includes('with --apply at the end'), 'the person must learn how to turn the dry run into a write');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('names every stray copy as its own --source when more than one is left behind', () => {
+    const homeDir = createTempDir('doctor-home-');
+    const projectRoot = createTempDir('doctor-project-');
+
+    try {
+      const egcDir = computeEGCDirForHome(homeDir);
+      fs.mkdirSync(path.join(egcDir, 'egc'), { recursive: true });
+      fs.mkdirSync(path.join(egcDir, 'memory'), { recursive: true });
+      fs.writeFileSync(path.join(egcDir, 'egc', 'state.db'), '');
+      fs.writeFileSync(path.join(egcDir, 'memory', 'state.db'), '');
+      const strays = [
+        path.join(homeDir, '.gemini', 'egc', 'state.db'),
+        path.join(homeDir, '.config', 'opencode', 'egc', 'state.db'),
+      ];
+      for (const stray of strays) {
+        fs.mkdirSync(path.dirname(stray), { recursive: true });
+        fs.writeFileSync(stray, 'stale-bytes');
+      }
+
+      const result = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('2 stray state.db copies'));
+      const hint = result.stdout.split('\n').find(line => line.includes('merge-fragmented-state-dbs.js'));
+      assert.ok(hint, 'the consolidation hint must be printed');
+      for (const stray of strays) {
+        assert.ok(hint.includes(`--source "${stray}"`), `the hint must carry --source for ${stray}`);
+      }
+      assert.strictEqual(hint.split('--source ').length - 1, strays.length, 'one --source per copy, nothing else');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);
@@ -718,6 +758,10 @@ function runTests() {
       assert.strictEqual(result.code, 0, result.stderr);
       assert.ok(result.stdout.includes('WARNING: the CLI event store landed in a harness directory'));
       assert.ok(result.stdout.includes(misplacedDb));
+      assert.ok(
+        result.stdout.includes(`--canonical "${canonicalDb}" --source "${misplacedDb}"`),
+        'the misplaced store is the source and the shared store the explicit destination, since the default resolution is what misplaced it'
+      );
       assert.ok(!result.stdout.includes(`${canonicalDb} (`), 'the canonical ~/.egc store must never be listed as a stray copy');
     } finally {
       cleanup(homeDir);
@@ -733,7 +777,7 @@ function runTests() {
       const result = run(['--json'], { cwd: projectRoot, homeDir });
       const parsed = JSON.parse(result.stdout);
       assert.ok(parsed.stateDb, 'missing stores must still produce a stateDb block');
-      for (const key of ['missing', 'dbPath', 'memoryDbPath', 'hasHarnessDb', 'hasMemoryDb', 'cliStoreMisplaced', 'fragments']) {
+      for (const key of ['missing', 'dbPath', 'canonicalDbPath', 'memoryDbPath', 'hasHarnessDb', 'hasMemoryDb', 'cliStoreMisplaced', 'fragments']) {
         assert.ok(Object.hasOwn(parsed.stateDb, key), `stateDb must always carry ${key}`);
       }
       assert.strictEqual(parsed.stateDb.missing, true);


### PR DESCRIPTION
## What Changed

`egc doctor` and the `egc init` summary now print the state-db consolidation hint as a command that runs as pasted:

```
node "<package>/scripts/maintenance/merge-fragmented-state-dbs.js" --canonical "<home>/.egc/egc/state.db" --source "<copy 1>" --source "<copy 2>"
```

- `scripts/lib/doctor-summary.js`: new `consolidateCommand(scriptPath, sourcePaths, canonicalPath)` builds the line, one `--source` per stray copy, the canonical store passed explicitly, every path double-quoted so it works in PowerShell and in POSIX shells. The init summary notes use it for both the stray copies case and the misplaced CLI store case.
- `scripts/doctor.js`: the two hint branches use the same helper, and each is followed by one line saying how to turn the dry run into a write (`--apply` at the end). The `--json` report gains `canonicalDbPath`, additive, so consumers can build the same command.
- Tests: the doctor CLI tests assert the exact command for one copy, for two copies (one `--source` each, nothing else) and for the misplaced store; the summary tests cover the helper directly, including a Windows path, and the note text.

## Why This Change

The merge script requires at least one `--source` and exits with its usage text otherwise, so the hint the doctor printed since 1.1.21 could be copied but not run. Fixes #1389.

The canonical store is passed explicitly because the script's default follows the same directory resolution that can land a store in a harness directory in the first place; the doctor already knows the shared store path, so the hint should not depend on the environment of the shell that runs it.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated (not applicable: output only, no file is written)

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation (the printed guidance is the documentation for this hint)
- [x] Added comments for complex logic
- [ ] README updated (not needed)

## Credit

Reported by @Akisolu in #1380, the first run of the consolidation script on real Windows state: the line printed by the doctor only showed the usage text and exited with code 1.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `egc doctor` and `egc init` consolidation hint so the printed command runs as pasted instead of failing with the merge script's usage text (#1389).

- The hint now passes the canonical store explicitly and one `--source` per stray copy, with all paths double-quoted for PowerShell and POSIX shells.
- The dry-run command is followed by a line explaining to append `--apply` to write changes.
- The `--json` report gains `canonicalDbPath` so consumers can build the same command.

<sup>Written for commit e7bc6a43a3eccc388e99ec062f648773d5b406e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

