### PR TITLE
feat(maintenance): archive merged state.db sources on --apply so the doctor stops flagging them

### DIFF
--- a/scripts/maintenance/merge-fragmented-state-dbs.js
+++ b/scripts/maintenance/merge-fragmented-state-dbs.js
@@ -108,17 +108,28 @@ function mergeOneTable(canonicalDb, srcDb, name, pk, apply) {
   };
 }
 
-// Filesystem identity, not spelling: a symlink to the canonical store, or the
-// same file spelled in another case on Windows, must be refused too.
-function samePath(a, b) {
-  const resolvedA = path.resolve(a);
-  const resolvedB = path.resolve(b);
-  try {
-    return fs.realpathSync.native(resolvedA) === fs.realpathSync.native(resolvedB);
-  } catch {
-    const fold = value => (process.platform === 'win32' ? value.toLowerCase() : value);
-    return fold(resolvedA) === fold(resolvedB);
-  }
+// Filesystem identity, not spelling: the live store reached through a
+// symlink, a hard link, or another spelling of its name on Windows must be
+// refused too. Both files exist by the time this runs (the source was
+// checked, the canonical store was just opened), so device and inode settle
+// it; a filesystem that reports no inode falls back to the resolved names,
+// case-folded on Windows.
+function sameFile(a, b) {
+  const statA = fs.statSync(a, { bigint: true });
+  const statB = fs.statSync(b, { bigint: true });
+  const fold = value => (process.platform === 'win32' ? value.toLowerCase() : value);
+  return statA.ino !== 0n && statB.ino !== 0n
+    ? statA.dev === statB.dev && statA.ino === statB.ino
+    : fold(path.resolve(a)) === fold(path.resolve(b));
+}
+
+// A link is not a copy: archiving a symlink leaves its target behind for the
+// doctor to flag again, and archiving one name of a hard-linked file leaves
+// the archive tied to whatever the other names keep writing.
+function refuseLinkedSource(srcPath) {
+  if (fs.lstatSync(srcPath).isSymbolicLink()) return 'source is a symbolic link; pass the file it points to';
+  if (fs.statSync(srcPath).nlink > 1) return 'source has other hard links; archiving would not detach it';
+  return null;
 }
 
 async function mergeOneSource(canonicalDb, srcPath, apply, canonicalPath) {
@@ -128,10 +139,15 @@ async function mergeOneSource(canonicalDb, srcPath, apply, canonicalPath) {
     srcReport.error = 'file not found';
     return srcReport;
   }
-  if (canonicalPath !== ':memory:' && samePath(srcPath, canonicalPath)) {
+  if (canonicalPath !== ':memory:' && sameFile(srcPath, canonicalPath)) {
     // Merging the store into itself is a no-op, and archiving it afterwards
     // would take the live store away.
     srcReport.error = 'source is the canonical store';
+    return srcReport;
+  }
+  const linked = refuseLinkedSource(srcPath);
+  if (linked) {
+    srcReport.error = linked;
     return srcReport;
   }
 
@@ -178,7 +194,7 @@ function archiveOneSource(srcPath, stamp) {
       done.push([from, to]);
     }
   } catch (err) {
-    for (const [from, to] of done.reverse()) {
+    for (const [from, to] of done.toReversed()) {
       try {
         fs.renameSync(to, from);
       } catch {
@@ -193,8 +209,7 @@ function archiveOneSource(srcPath, stamp) {
 // A file none of whose tables could be read is not a merged copy: renaming
 // it would only hide it from the doctor with everything still inside.
 function nothingMerged(report) {
-  const tables = Object.values(report.tables);
-  return tables.length === 0 || tables.every(table => table.skipped);
+  return Object.values(report.tables).every(table => table.skipped);
 }
 
 // Only after the canonical store is written, flushed and closed: a source

--- a/scripts/maintenance/merge-fragmented-state-dbs.js
+++ b/scripts/maintenance/merge-fragmented-state-dbs.js
@@ -108,8 +108,17 @@ function mergeOneTable(canonicalDb, srcDb, name, pk, apply) {
   };
 }
 
+// Filesystem identity, not spelling: a symlink to the canonical store, or the
+// same file spelled in another case on Windows, must be refused too.
 function samePath(a, b) {
-  return path.resolve(a) === path.resolve(b);
+  const resolvedA = path.resolve(a);
+  const resolvedB = path.resolve(b);
+  try {
+    return fs.realpathSync.native(resolvedA) === fs.realpathSync.native(resolvedB);
+  } catch {
+    const fold = value => (process.platform === 'win32' ? value.toLowerCase() : value);
+    return fold(resolvedA) === fold(resolvedB);
+  }
 }
 
 async function mergeOneSource(canonicalDb, srcPath, apply, canonicalPath) {
@@ -149,13 +158,43 @@ function backupBeforeApply(canonicalPath) {
 // they belong to the file they sit beside, so they move with it.
 const SIDECAR_SUFFIXES = ['-wal', '-shm', '-journal'];
 
+// The store and its sidecars move together or not at all: every destination
+// is checked first (a rename would silently replace an existing archive), and
+// a rename that fails midway puts the files already moved back under their
+// original names before the error surfaces.
 function archiveOneSource(srcPath, stamp) {
   const archivedTo = `${srcPath}.merged-${stamp}.bak`;
-  fs.renameSync(srcPath, archivedTo);
+  const moves = [[srcPath, archivedTo]];
   for (const suffix of SIDECAR_SUFFIXES) {
-    if (fs.existsSync(`${srcPath}${suffix}`)) fs.renameSync(`${srcPath}${suffix}`, `${archivedTo}${suffix}`);
+    if (fs.existsSync(`${srcPath}${suffix}`)) moves.push([`${srcPath}${suffix}`, `${archivedTo}${suffix}`]);
+  }
+  for (const [, to] of moves) {
+    if (fs.existsSync(to)) throw new Error(`archive destination already exists: ${to}`);
+  }
+  const done = [];
+  try {
+    for (const [from, to] of moves) {
+      fs.renameSync(from, to);
+      done.push([from, to]);
+    }
+  } catch (err) {
+    for (const [from, to] of done.reverse()) {
+      try {
+        fs.renameSync(to, from);
+      } catch {
+        // best-effort rollback: the rename that failed is the error reported
+      }
+    }
+    throw err;
   }
   return archivedTo;
+}
+
+// A file none of whose tables could be read is not a merged copy: renaming
+// it would only hide it from the doctor with everything still inside.
+function nothingMerged(report) {
+  const tables = Object.values(report.tables);
+  return tables.length === 0 || tables.every(table => table.skipped);
 }
 
 // Only after the canonical store is written, flushed and closed: a source
@@ -167,6 +206,10 @@ function archiveSources(reports) {
   const archived = [];
   for (const report of reports) {
     if (report.error) continue;
+    if (nothingMerged(report)) {
+      report.archiveSkipped = 'no table could be merged from this source';
+      continue;
+    }
     try {
       const archivedTo = archiveOneSource(report.source, stamp);
       report.archivedTo = archivedTo;
@@ -230,4 +273,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { mergeStateDbs, MERGE_TABLES };
+module.exports = { mergeStateDbs, archiveOneSource, MERGE_TABLES };

--- a/scripts/maintenance/merge-fragmented-state-dbs.js
+++ b/scripts/maintenance/merge-fragmented-state-dbs.js
@@ -22,7 +22,6 @@
 //   node merge-fragmented-state-dbs.js --canonical <path> --source <path> [--source <path> ...] [--apply] [--keep-sources]
 
 const fs = require('node:fs');
-const path = require('node:path');
 const { openDatabase } = require('../lib/state-store/db-adapter');
 const { applyMigrations } = require('../lib/state-store/migrations');
 const { resolveStateStorePath } = require('../lib/state-store');
@@ -110,17 +109,16 @@ function mergeOneTable(canonicalDb, srcDb, name, pk, apply) {
 
 // Filesystem identity, not spelling: the live store reached through a
 // symlink, a hard link, or another spelling of its name on Windows must be
-// refused too. Both files exist by the time this runs (the source was
-// checked, the canonical store was just opened), so device and inode settle
-// it; a filesystem that reports no inode falls back to the resolved names,
-// case-folded on Windows.
+// refused too. The caller only asks about files that exist, so device and
+// inode settle it; a filesystem that reports no inode falls back to the
+// real paths (links followed), case-folded on Windows.
 function sameFile(a, b) {
   const statA = fs.statSync(a, { bigint: true });
   const statB = fs.statSync(b, { bigint: true });
   const fold = value => (process.platform === 'win32' ? value.toLowerCase() : value);
   return statA.ino !== 0n && statB.ino !== 0n
     ? statA.dev === statB.dev && statA.ino === statB.ino
-    : fold(path.resolve(a)) === fold(path.resolve(b));
+    : fold(fs.realpathSync.native(a)) === fold(fs.realpathSync.native(b));
 }
 
 // A link is not a copy: archiving a symlink leaves its target behind for the
@@ -139,7 +137,7 @@ async function mergeOneSource(canonicalDb, srcPath, apply, canonicalPath) {
     srcReport.error = 'file not found';
     return srcReport;
   }
-  if (canonicalPath !== ':memory:' && sameFile(srcPath, canonicalPath)) {
+  if (canonicalPath !== ':memory:' && fs.existsSync(canonicalPath) && sameFile(srcPath, canonicalPath)) {
     // Merging the store into itself is a no-op, and archiving it afterwards
     // would take the live store away.
     srcReport.error = 'source is the canonical store';
@@ -185,7 +183,9 @@ function archiveOneSource(srcPath, stamp) {
     if (fs.existsSync(`${srcPath}${suffix}`)) moves.push([`${srcPath}${suffix}`, `${archivedTo}${suffix}`]);
   }
   for (const [, to] of moves) {
-    if (fs.existsSync(to)) throw new Error(`archive destination already exists: ${to}`);
+    // lstat, not exists: a dangling symlink at the destination would report
+    // absent and be replaced by the rename.
+    if (fs.lstatSync(to, { throwIfNoEntry: false })) throw new Error(`archive destination already exists: ${to}`);
   }
   const done = [];
   try {
@@ -252,7 +252,9 @@ async function mergeStateDbs({ canonicalPath, sourcePaths, apply = false, keepSo
   if (apply) await canonicalDb.flush();
   canonicalDb.close();
 
-  const archived = apply && !keepSources ? archiveSources(reports) : [];
+  // An in-memory canonical store keeps nothing after close, so the sources
+  // stay the only copy and must not be archived.
+  const archived = apply && !keepSources && resolvedCanonicalPath !== ':memory:' ? archiveSources(reports) : [];
   return { apply, canonical: resolvedCanonicalPath, backupPath, keepSources, archived, reports };
 }
 

--- a/scripts/maintenance/merge-fragmented-state-dbs.js
+++ b/scripts/maintenance/merge-fragmented-state-dbs.js
@@ -13,11 +13,16 @@
 //   - schema_migrations is never merged: each db file tracks its own
 //     migration history, copying those rows would be meaningless.
 //   - Dry-run by default; pass --apply to actually write.
+//   - After a successful --apply each merged source is renamed next to itself
+//     (state.db.merged-<timestamp>.bak, sidecar -wal/-shm/-journal files along
+//     with it) so egc doctor stops listing it as a stray copy (#1390). Nothing
+//     is ever deleted; --keep-sources leaves the files where they are.
 //
 // CLI usage:
-//   node merge-fragmented-state-dbs.js --canonical <path> --source <path> [--source <path> ...] [--apply]
+//   node merge-fragmented-state-dbs.js --canonical <path> --source <path> [--source <path> ...] [--apply] [--keep-sources]
 
 const fs = require('node:fs');
+const path = require('node:path');
 const { openDatabase } = require('../lib/state-store/db-adapter');
 const { applyMigrations } = require('../lib/state-store/migrations');
 const { resolveStateStorePath } = require('../lib/state-store');
@@ -103,11 +108,21 @@ function mergeOneTable(canonicalDb, srcDb, name, pk, apply) {
   };
 }
 
-async function mergeOneSource(canonicalDb, srcPath, apply) {
+function samePath(a, b) {
+  return path.resolve(a) === path.resolve(b);
+}
+
+async function mergeOneSource(canonicalDb, srcPath, apply, canonicalPath) {
   const srcReport = { source: srcPath, tables: {} };
 
   if (!fs.existsSync(srcPath)) {
     srcReport.error = 'file not found';
+    return srcReport;
+  }
+  if (canonicalPath !== ':memory:' && samePath(srcPath, canonicalPath)) {
+    // Merging the store into itself is a no-op, and archiving it afterwards
+    // would take the live store away.
+    srcReport.error = 'source is the canonical store';
     return srcReport;
   }
 
@@ -119,15 +134,51 @@ async function mergeOneSource(canonicalDb, srcPath, apply) {
   return srcReport;
 }
 
+function fileStamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
 function backupBeforeApply(canonicalPath) {
   if (canonicalPath === ':memory:' || !fs.existsSync(canonicalPath)) return null;
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const backupPath = `${canonicalPath}.backup-${stamp}`;
+  const backupPath = `${canonicalPath}.backup-${fileStamp()}`;
   fs.copyFileSync(canonicalPath, backupPath);
   return backupPath;
 }
 
-async function mergeStateDbs({ canonicalPath, sourcePaths, apply = false }) {
+// SQLite may leave a write-ahead log or a rollback journal next to a store;
+// they belong to the file they sit beside, so they move with it.
+const SIDECAR_SUFFIXES = ['-wal', '-shm', '-journal'];
+
+function archiveOneSource(srcPath, stamp) {
+  const archivedTo = `${srcPath}.merged-${stamp}.bak`;
+  fs.renameSync(srcPath, archivedTo);
+  for (const suffix of SIDECAR_SUFFIXES) {
+    if (fs.existsSync(`${srcPath}${suffix}`)) fs.renameSync(`${srcPath}${suffix}`, `${archivedTo}${suffix}`);
+  }
+  return archivedTo;
+}
+
+// Only after the canonical store is written, flushed and closed: a source
+// that failed to merge stays where it is, and a rename that fails (a file
+// held open by another process on Windows) is reported, not thrown, since
+// the merge itself already succeeded.
+function archiveSources(reports) {
+  const stamp = fileStamp();
+  const archived = [];
+  for (const report of reports) {
+    if (report.error) continue;
+    try {
+      const archivedTo = archiveOneSource(report.source, stamp);
+      report.archivedTo = archivedTo;
+      archived.push({ source: report.source, archivedTo });
+    } catch (err) {
+      report.archiveError = String(err?.message ?? err);
+    }
+  }
+  return archived;
+}
+
+async function mergeStateDbs({ canonicalPath, sourcePaths, apply = false, keepSources = false }) {
   const resolvedCanonicalPath = canonicalPath || resolveStateStorePath();
   const backupPath = apply ? backupBeforeApply(resolvedCanonicalPath) : null;
 
@@ -137,35 +188,38 @@ async function mergeStateDbs({ canonicalPath, sourcePaths, apply = false }) {
 
   const reports = [];
   const commit = canonicalDb.transaction(() => {});
-  for (const src of sourcePaths) reports.push(await mergeOneSource(canonicalDb, src, apply));
+  for (const src of sourcePaths) reports.push(await mergeOneSource(canonicalDb, src, apply, resolvedCanonicalPath));
   if (apply) commit(); // no-op body; forces a single persist after all inserts above
 
   if (apply) await canonicalDb.flush();
   canonicalDb.close();
 
-  return { apply, canonical: resolvedCanonicalPath, backupPath, reports };
+  const archived = apply && !keepSources ? archiveSources(reports) : [];
+  return { apply, canonical: resolvedCanonicalPath, backupPath, keepSources, archived, reports };
 }
 
 function parseArgs(argv) {
-  const out = { sourcePaths: [], apply: false, canonicalPath: null };
+  const out = { sourcePaths: [], apply: false, canonicalPath: null, keepSources: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--canonical') out.canonicalPath = argv[++i];
     else if (a === '--source') out.sourcePaths.push(argv[++i]);
     else if (a === '--apply') out.apply = true;
+    else if (a === '--keep-sources') out.keepSources = true;
   }
   return out;
 }
 
 async function main() {
-  const { canonicalPath, sourcePaths, apply } = parseArgs(process.argv.slice(2));
+  const { canonicalPath, sourcePaths, apply, keepSources } = parseArgs(process.argv.slice(2));
   if (sourcePaths.length === 0) {
-    console.error('Usage: node merge-fragmented-state-dbs.js [--canonical <path>] --source <path> [--source <path> ...] [--apply]');
+    console.error('Usage: node merge-fragmented-state-dbs.js [--canonical <path>] --source <path> [--source <path> ...] [--apply] [--keep-sources]');
+    console.error('  After --apply each merged source is renamed to <source>.merged-<timestamp>.bak next to itself; --keep-sources leaves it in place.');
     console.error('  --canonical defaults to the real resolveStateStorePath() (~/.egc/egc/state.db) when omitted.');
     process.exitCode = 1;
     return;
   }
-  const result = await mergeStateDbs({ canonicalPath, sourcePaths, apply });
+  const result = await mergeStateDbs({ canonicalPath, sourcePaths, apply, keepSources });
   console.log(JSON.stringify(result, null, 2));
 }
 

--- a/tests/scripts/merge-fragmented-state-dbs.test.js
+++ b/tests/scripts/merge-fragmented-state-dbs.test.js
@@ -11,8 +11,9 @@ const { mergeStateDbs, archiveOneSource } = require('../../scripts/maintenance/m
 const { openDatabase } = require('../../scripts/lib/state-store/db-adapter');
 const { applyMigrations } = require('../../scripts/lib/state-store/migrations');
 
+const { CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
+
 const DOCTOR_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'doctor.js');
-const CLI_TIMEOUT_MS = process.platform === 'win32' ? 30000 : 10000;
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));

--- a/tests/scripts/merge-fragmented-state-dbs.test.js
+++ b/tests/scripts/merge-fragmented-state-dbs.test.js
@@ -7,7 +7,7 @@ const path = require('path');
 
 const { execFileSync } = require('child_process');
 
-const { mergeStateDbs } = require('../../scripts/maintenance/merge-fragmented-state-dbs');
+const { mergeStateDbs, archiveOneSource } = require('../../scripts/maintenance/merge-fragmented-state-dbs');
 const { openDatabase } = require('../../scripts/lib/state-store/db-adapter');
 const { applyMigrations } = require('../../scripts/lib/state-store/migrations');
 
@@ -393,6 +393,140 @@ async function runTests() {
       assert.strictEqual(applied.archived.length, 1);
       assert.ok(fs.existsSync(applied.archived[0].archivedTo));
       assert.ok(!fs.existsSync(sourcePath));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a rename that fails is reported on that source while the merge result stands', async () => {
+    const dir = createTempDir('egc-merge-archive-error-');
+    const originalRename = fs.renameSync;
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+
+      // The script and this test share the same fs module object, so a
+      // rename that throws here is exactly what a file held open by another
+      // process produces on Windows, on every platform the suite runs on.
+      fs.renameSync = () => {
+        const error = new Error('EBUSY: resource busy or locked');
+        error.code = 'EBUSY';
+        throw error;
+      };
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      fs.renameSync = originalRename;
+
+      assert.strictEqual(result.apply, true);
+      assert.ok(result.backupPath && fs.existsSync(result.backupPath), 'the canonical backup was still taken');
+      assert.deepStrictEqual(result.archived, [], 'nothing was archived');
+      assert.strictEqual(result.reports[0].archivedTo, undefined);
+      assert.ok(result.reports[0].archiveError.includes('EBUSY'), 'the failure is reported on the source entry');
+      assert.ok(fs.existsSync(sourcePath), 'the source stays under its own name');
+    } finally {
+      fs.renameSync = originalRename;
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('the canonical store reached through a symlink or another spelling is refused all the same', async () => {
+    const dir = createTempDir('egc-merge-alias-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      await seedDb(canonicalPath);
+
+      let alias;
+      if (process.platform === 'win32') {
+        // NTFS resolves both spellings to the same file.
+        alias = path.join(dir, 'CANONICAL.DB');
+      } else {
+        alias = path.join(dir, 'alias.db');
+        fs.symlinkSync(canonicalPath, alias);
+      }
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [alias], apply: true });
+      assert.strictEqual(result.reports[0].error, 'source is the canonical store');
+      assert.deepStrictEqual(result.archived, []);
+      assert.ok(fs.existsSync(canonicalPath), 'the live store must still be there under its own name');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('an archive destination that already exists is never overwritten', async () => {
+    const dir = createTempDir('egc-merge-collision-');
+    try {
+      const sourcePath = path.join(dir, 'source.db');
+      fs.writeFileSync(sourcePath, 'live-bytes');
+      const taken = `${sourcePath}.merged-fixed.bak`;
+      fs.writeFileSync(taken, 'older-archive');
+
+      assert.throws(() => archiveOneSource(sourcePath, 'fixed'), /archive destination already exists/);
+      assert.strictEqual(fs.readFileSync(taken, 'utf8'), 'older-archive', 'the earlier archive must survive');
+      assert.strictEqual(fs.readFileSync(sourcePath, 'utf8'), 'live-bytes', 'and the source must not move');
+
+      fs.renameSync(taken, `${taken}-wal`);
+      fs.writeFileSync(`${sourcePath}-wal`, 'live-wal');
+      assert.throws(() => archiveOneSource(sourcePath, 'fixed'), /archive destination already exists/, 'a sidecar destination counts too');
+      assert.ok(fs.existsSync(sourcePath), 'nothing moves when any destination is taken');
+      assert.strictEqual(fs.readFileSync(`${taken}-wal`, 'utf8'), 'older-archive');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a sidecar that fails to move puts the store back under its original name', async () => {
+    const dir = createTempDir('egc-merge-rollback-');
+    const originalRename = fs.renameSync;
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+      const sidecar = `${sourcePath}-wal`;
+      fs.writeFileSync(sidecar, 'wal-bytes');
+
+      fs.renameSync = (from, to) => {
+        if (from.endsWith('-wal')) {
+          const error = new Error('EPERM: operation not permitted');
+          error.code = 'EPERM';
+          throw error;
+        }
+        return originalRename(from, to);
+      };
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      fs.renameSync = originalRename;
+
+      assert.ok(result.reports[0].archiveError.includes('EPERM'));
+      assert.deepStrictEqual(result.archived, []);
+      assert.ok(fs.existsSync(sourcePath), 'the store must be rolled back to its original name');
+      assert.ok(fs.existsSync(sidecar), 'the sidecar never moved');
+      assert.ok(!fs.readdirSync(dir).some(name => name.includes('.merged-')), 'no half-archive may be left behind');
+    } finally {
+      fs.renameSync = originalRename;
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a source none of whose tables could be read stays in place and says why', async () => {
+    const dir = createTempDir('egc-merge-unreadable-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      // An empty SQLite file: valid database, none of the EGC tables.
+      const empty = await openDatabase(sourcePath);
+      empty.exec('CREATE TABLE unrelated (id TEXT PRIMARY KEY)');
+      await empty.flush();
+      empty.close();
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      assert.ok(Object.values(result.reports[0].tables).every(table => table.skipped), 'every table must have been skipped');
+      assert.strictEqual(result.reports[0].archiveSkipped, 'no table could be merged from this source');
+      assert.strictEqual(result.reports[0].archivedTo, undefined);
+      assert.deepStrictEqual(result.archived, []);
+      assert.ok(fs.existsSync(sourcePath), 'the file stays where the doctor can still see it');
     } finally {
       cleanup(dir);
     }

--- a/tests/scripts/merge-fragmented-state-dbs.test.js
+++ b/tests/scripts/merge-fragmented-state-dbs.test.js
@@ -532,6 +532,112 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await test('a source reached through a symlink is refused so its target never stays behind', async () => {
+    if (process.platform === 'win32') {
+      // Creating a symlink needs a privilege the CI runner does not hold; the
+      // hard-link case below exercises the same refusal path on Windows.
+      return;
+    }
+    const dir = createTempDir('egc-merge-symlink-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const target = path.join(dir, 'fragment', 'state.db');
+      const link = path.join(dir, 'link.db');
+      await seedDb(canonicalPath);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      await seedDb(target);
+      fs.symlinkSync(target, link);
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [link], apply: true });
+      assert.strictEqual(result.reports[0].error, 'source is a symbolic link; pass the file it points to');
+      assert.deepStrictEqual(result.archived, []);
+      assert.ok(fs.existsSync(target) && fs.existsSync(link), 'neither the link nor its target moved');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a source with other hard links is refused, and a hard link to the live store counts as the live store', async () => {
+    const dir = createTempDir('egc-merge-hardlink-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const fragment = path.join(dir, 'fragment.db');
+      const twin = path.join(dir, 'twin.db');
+      const aliasOfCanonical = path.join(dir, 'alias-of-canonical.db');
+      await seedDb(canonicalPath);
+      await seedDb(fragment);
+      fs.linkSync(fragment, twin);
+      fs.linkSync(canonicalPath, aliasOfCanonical);
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [fragment, aliasOfCanonical], apply: true });
+      assert.strictEqual(result.reports[0].error, 'source has other hard links; archiving would not detach it');
+      assert.strictEqual(result.reports[1].error, 'source is the canonical store');
+      assert.deepStrictEqual(result.archived, []);
+      for (const file of [fragment, twin, canonicalPath, aliasOfCanonical]) {
+        assert.ok(fs.existsSync(file), `${path.basename(file)} must stay where it is`);
+      }
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a dry run against a canonical store that does not exist yet still tells the source apart from it', async () => {
+    const dir = createTempDir('egc-merge-fresh-');
+    try {
+      const canonicalPath = path.join(dir, 'fresh', 'state.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(sourcePath);
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: false });
+      assert.strictEqual(result.reports[0].error, undefined, 'the source must be merged, not mistaken for the missing store');
+      assert.ok(fs.existsSync(sourcePath));
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a rollback that fails too still leaves the original error on the source entry', async () => {
+    const dir = createTempDir('egc-merge-rollback-fail-');
+    const originalRename = fs.renameSync;
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+      fs.writeFileSync(`${sourcePath}-wal`, 'wal-bytes');
+
+      fs.renameSync = (from, to) => {
+        if (from.endsWith('-wal') || to === sourcePath) throw new Error('EPERM: operation not permitted');
+        return originalRename(from, to);
+      };
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      fs.renameSync = originalRename;
+
+      assert.ok(result.reports[0].archiveError.includes('EPERM'), 'the forward failure is the one reported');
+      assert.deepStrictEqual(result.archived, []);
+    } finally {
+      fs.renameSync = originalRename;
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('the CLI exits with code 1 and prints the error when a source is not a database', async () => {
+    const dir = createTempDir('egc-merge-cli-error-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      fs.writeFileSync(sourcePath, 'this is not a sqlite file');
+
+      const run = runMergeCli(['--canonical', canonicalPath, '--source', sourcePath]);
+      assert.strictEqual(run.code, 1, run.stdout);
+      assert.ok(run.stderr.length > 0, 'the failure must be printed');
+      assert.ok(fs.existsSync(sourcePath), 'a failed run never touches the source');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/merge-fragmented-state-dbs.test.js
+++ b/tests/scripts/merge-fragmented-state-dbs.test.js
@@ -5,12 +5,47 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const { execFileSync } = require('child_process');
+
 const { mergeStateDbs } = require('../../scripts/maintenance/merge-fragmented-state-dbs');
 const { openDatabase } = require('../../scripts/lib/state-store/db-adapter');
 const { applyMigrations } = require('../../scripts/lib/state-store/migrations');
 
+const DOCTOR_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'doctor.js');
+const CLI_TIMEOUT_MS = process.platform === 'win32' ? 30000 : 10000;
+
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+const MERGE_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'maintenance', 'merge-fragmented-state-dbs.js');
+
+function runMergeCli(args) {
+  try {
+    const stdout = execFileSync('node', [MERGE_SCRIPT, ...args], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: CLI_TIMEOUT_MS,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (error) {
+    return { code: error.status ?? 1, stdout: error.stdout ?? '', stderr: error.stderr ?? '' };
+  }
+}
+
+function runDoctor(homeDir, cwd) {
+  try {
+    const stdout = execFileSync('node', [DOCTOR_SCRIPT], {
+      cwd,
+      env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: CLI_TIMEOUT_MS,
+    });
+    return { code: 0, stdout };
+  } catch (error) {
+    return { code: error.status ?? 1, stdout: error.stdout ?? '' };
+  }
 }
 
 function cleanup(dirPath) {
@@ -178,10 +213,12 @@ async function runTests() {
       srcDb.close();
 
       const before = fs.readFileSync(sourcePath);
-      await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true });
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: true, keepSources: true });
       const after = fs.readFileSync(sourcePath);
 
       assert.deepStrictEqual(before, after, 'source db file must be byte-identical, merge is read-only on sources');
+      assert.deepStrictEqual(result.archived, [], '--keep-sources must leave every source in place');
+      assert.strictEqual(result.keepSources, true);
     } finally {
       cleanup(dir);
     }
@@ -219,6 +256,143 @@ async function runTests() {
         apply: true,
       });
       assert.strictEqual(result.reports[0].error, 'file not found');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('--apply renames each merged source to a .merged-<timestamp>.bak next to itself, sidecars included, byte for byte', async () => {
+    const dir = createTempDir('egc-merge-archive-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sources = [path.join(dir, 'gemini', 'state.db'), path.join(dir, 'opencode', 'state.db')];
+      await seedDb(canonicalPath);
+      for (const source of sources) {
+        fs.mkdirSync(path.dirname(source), { recursive: true });
+        await seedDb(source);
+      }
+      const sidecar = `${sources[0]}-wal`;
+      fs.writeFileSync(sidecar, 'wal-bytes');
+      const originalBytes = sources.map(source => fs.readFileSync(source));
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: sources, apply: true });
+
+      assert.strictEqual(result.keepSources, false);
+      assert.strictEqual(result.archived.length, 2, 'both merged sources must be archived');
+      sources.forEach((source, index) => {
+        const entry = result.archived[index];
+        assert.strictEqual(entry.source, source);
+        assert.strictEqual(result.reports[index].archivedTo, entry.archivedTo, 'the per-source report must carry the new name too');
+        assert.ok(entry.archivedTo.startsWith(`${source}.merged-`), 'the archive must sit next to the source it replaces');
+        assert.ok(entry.archivedTo.endsWith('.bak'));
+        assert.ok(!fs.existsSync(source), 'the original name must be gone so the doctor stops flagging it');
+        assert.deepStrictEqual(fs.readFileSync(entry.archivedTo), originalBytes[index], 'archiving is a rename: the bytes must survive untouched');
+      });
+      assert.ok(!fs.existsSync(sidecar), 'the write-ahead log must move with its store');
+      assert.ok(fs.existsSync(`${result.archived[0].archivedTo}-wal`), 'and keep its suffix next to the archived name');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('a dry run archives nothing, and neither does a source that could not be merged', async () => {
+    const dir = createTempDir('egc-merge-noarchive-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      const missingPath = path.join(dir, 'missing.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+
+      const dryRun = await mergeStateDbs({ canonicalPath, sourcePaths: [sourcePath], apply: false });
+      assert.deepStrictEqual(dryRun.archived, [], 'a dry run must not rename anything');
+      assert.ok(fs.existsSync(sourcePath));
+
+      const applied = await mergeStateDbs({ canonicalPath, sourcePaths: [missingPath, sourcePath], apply: true });
+      assert.strictEqual(applied.reports[0].error, 'file not found');
+      assert.strictEqual(applied.reports[0].archivedTo, undefined, 'a source that failed to merge stays as it is');
+      assert.strictEqual(applied.archived.length, 1, 'the source that did merge is archived');
+      assert.strictEqual(applied.archived[0].source, sourcePath);
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('the canonical store handed in as a source is refused and left in place', async () => {
+    const dir = createTempDir('egc-merge-self-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      await seedDb(canonicalPath);
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: [path.join(dir, '.', 'canonical.db')], apply: true });
+      assert.strictEqual(result.reports[0].error, 'source is the canonical store');
+      assert.deepStrictEqual(result.archived, []);
+      assert.ok(fs.existsSync(canonicalPath), 'the live store must never be renamed');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('after --apply the doctor no longer lists the merged copies as stray', async () => {
+    const homeDir = createTempDir('egc-merge-home-');
+    const projectRoot = createTempDir('egc-merge-project-');
+    try {
+      const canonicalPath = path.join(homeDir, '.egc', 'egc', 'state.db');
+      const memoryPath = path.join(homeDir, '.egc', 'memory', 'state.db');
+      const strays = [
+        path.join(homeDir, '.gemini', 'egc', 'state.db'),
+        path.join(homeDir, '.config', 'opencode', 'egc', 'state.db'),
+      ];
+      for (const file of [canonicalPath, ...strays]) {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        await seedDb(file);
+      }
+      fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
+      fs.writeFileSync(memoryPath, '');
+
+      const before = runDoctor(homeDir, projectRoot);
+      assert.strictEqual(before.code, 0, before.stdout);
+      assert.ok(before.stdout.includes('2 stray state.db copies'), 'the fixture must reproduce the warning first');
+
+      const result = await mergeStateDbs({ canonicalPath, sourcePaths: strays, apply: true });
+      assert.strictEqual(result.archived.length, 2);
+
+      const after = runDoctor(homeDir, projectRoot);
+      assert.strictEqual(after.code, 0, after.stdout);
+      assert.ok(!after.stdout.includes('stray state.db'), `the doctor must come back clean, got:\n${after.stdout}`);
+      assert.ok(fs.existsSync(canonicalPath), 'the canonical store stays');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (await test('the CLI honours --keep-sources and explains the archive step in its usage text', async () => {
+    const dir = createTempDir('egc-merge-cli-');
+    try {
+      const canonicalPath = path.join(dir, 'canonical.db');
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(canonicalPath);
+      await seedDb(sourcePath);
+
+      const usage = runMergeCli(['--canonical', canonicalPath]);
+      assert.strictEqual(usage.code, 1, 'no --source must still exit with the usage text');
+      assert.ok(usage.stderr.includes('--keep-sources'), 'the usage must list the new flag');
+      assert.ok(usage.stderr.includes('.merged-<timestamp>.bak'), 'and say what --apply does to the sources');
+
+      const kept = runMergeCli(['--canonical', canonicalPath, '--source', sourcePath, '--apply', '--keep-sources']);
+      assert.strictEqual(kept.code, 0, kept.stderr);
+      const parsed = JSON.parse(kept.stdout);
+      assert.strictEqual(parsed.keepSources, true);
+      assert.deepStrictEqual(parsed.archived, []);
+      assert.ok(fs.existsSync(sourcePath), 'the source must stay under its own name');
+
+      const archived = runMergeCli(['--canonical', canonicalPath, '--source', sourcePath, '--apply']);
+      assert.strictEqual(archived.code, 0, archived.stderr);
+      const applied = JSON.parse(archived.stdout);
+      assert.strictEqual(applied.archived.length, 1);
+      assert.ok(fs.existsSync(applied.archived[0].archivedTo));
+      assert.ok(!fs.existsSync(sourcePath));
     } finally {
       cleanup(dir);
     }

--- a/tests/scripts/merge-fragmented-state-dbs.test.js
+++ b/tests/scripts/merge-fragmented-state-dbs.test.js
@@ -471,6 +471,13 @@ async function runTests() {
       assert.throws(() => archiveOneSource(sourcePath, 'fixed'), /archive destination already exists/, 'a sidecar destination counts too');
       assert.ok(fs.existsSync(sourcePath), 'nothing moves when any destination is taken');
       assert.strictEqual(fs.readFileSync(`${taken}-wal`, 'utf8'), 'older-archive');
+
+      if (process.platform !== 'win32') {
+        fs.renameSync(`${taken}-wal`, `${dir}/older-archive.bak`);
+        fs.symlinkSync(path.join(dir, 'gone.db'), taken);
+        assert.throws(() => archiveOneSource(sourcePath, 'fixed'), /archive destination already exists/, 'a dangling symlink at the destination counts as taken');
+        assert.ok(fs.existsSync(sourcePath));
+      }
     } finally {
       cleanup(dir);
     }
@@ -633,6 +640,21 @@ async function runTests() {
       assert.strictEqual(run.code, 1, run.stdout);
       assert.ok(run.stderr.length > 0, 'the failure must be printed');
       assert.ok(fs.existsSync(sourcePath), 'a failed run never touches the source');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  if (await test('an in-memory canonical store never archives the sources, since nothing outlives the run', async () => {
+    const dir = createTempDir('egc-merge-memory-');
+    try {
+      const sourcePath = path.join(dir, 'source.db');
+      await seedDb(sourcePath);
+
+      const result = await mergeStateDbs({ canonicalPath: ':memory:', sourcePaths: [sourcePath], apply: true });
+      assert.strictEqual(result.canonical, ':memory:');
+      assert.deepStrictEqual(result.archived, []);
+      assert.ok(fs.existsSync(sourcePath), 'the only copy on disk must stay');
     } finally {
       cleanup(dir);
     }


### PR DESCRIPTION
## What Changed

`scripts/maintenance/merge-fragmented-state-dbs.js` now finishes the job it starts. After a successful `--apply`, each merged source is renamed next to itself:

```
<source>/state.db  ->  <source>/state.db.merged-<timestamp>.bak
```

- SQLite sidecars that belong to the source (`-wal`, `-shm`, `-journal`) move with it and keep their suffix.
- Nothing is deleted, same rule as the canonical backup the script already takes before writing.
- The rename happens only after the canonical store is written, flushed and closed. A source that failed to merge (file not found) stays where it is. A rename that fails, for example a file held open by another process on Windows, is reported in that source's entry as `archiveError` instead of failing a merge that already succeeded.
- `--keep-sources` opts out. Dry runs never rename anything.
- The JSON result gains `keepSources` and `archived` (one `{ source, archivedTo }` per renamed file); each per-source report gains `archivedTo`.
- New guard: a `--source` that resolves to the canonical store is refused with `source is the canonical store`, so the live store can never be archived by mistake.
- The usage text lists the flag and says what `--apply` does to the sources.

Tests (11 in the suite, 5 new): archive with sidecar and byte-for-byte check, dry run and failed source leave files alone, canonical passed as source refused, the CLI with and without `--keep-sources`, and an integration case that seeds a home with two stray copies, runs `egc doctor` before (two strays listed) and after `--apply` (clean).

## Why This Change

`egc doctor` scans for the exact filename `state.db` under each tool's `egc/` folder. The merge script never touched its sources, so right after the person did what the doctor asked, the doctor printed the same warning again. Fixes #1390.

Leaving the copies in place also kept the memory server's harness probe (`resolveStateStoreDbPath` in `mcp/servers/egc-memory/src/index.ts`) pointing `detect_patterns` at the stale copy instead of the canonical store.

Pairs with #1391, which makes the doctor print a runnable command: run it, add `--apply`, run `egc doctor`, clean.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated (not applicable: the script is a manual one-off tool that renames files no session writes to anymore; a rename that loses the race is reported, never retried)

## Type of Change
- [x] `feat:` New feature

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation (script header and usage text)
- [x] Added comments for complex logic
- [ ] README updated (not needed)

## Credit

Reported by @Akisolu in #1380: the first run of the consolidation script on real Windows state, dry run and `--apply`, followed by a doctor that still listed both copies. The archive-and-never-delete shape is the one she proposed.

## Hardening after review

Four points raised in review, all taken:

- The canonical guard compares filesystem identity (`fs.realpathSync.native` on both sides, case-folded fallback on Windows when a path does not exist yet), so a symlink to the live store or the same file spelled in another case is refused too. Test: symlink on POSIX, upper-cased name on Windows.
- Every destination, main file and sidecars, is checked before the first rename; an existing archive is never replaced. Test through the exported `archiveOneSource` with a fixed stamp.
- The store and its sidecars move together or not at all: a rename that fails midway puts the files already moved back under their original names, then the error is reported on that source. Test: sidecar rename forced to fail, store back in place, no half-archive on disk.
- A source none of whose tables could be read is not archived; its entry says `archiveSkipped: no table could be merged from this source` and the file stays where the doctor can still see it. Test: a SQLite file with an unrelated table.

Suite: 16 tests in the file, full run green.

Second round, two more points taken:

- Identity is settled by device and inode (`fs.statSync` with bigint) on both files, which now catches a hard link to the live store as well; a filesystem that reports no inode falls back to the resolved names, case-folded on Windows. Both files exist by the time the check runs, so there is no unreachable fallback.
- Linked sources are refused before the merge: a symlink (`source is a symbolic link; pass the file it points to`) because archiving the link would leave its target for the doctor to flag, and a file with other hard links (`source has other hard links; archiving would not detach it`) because the archive would stay tied to whatever the other names write. Tests: symlink to a fragment on POSIX, hard link twin and hard link to the canonical on every platform.

Two Sonar findings on the first round fixed as well (`toReversed()` in the rollback, redundant empty-array check removed), plus tests for the failed rollback and the CLI error exit. 21 tests in the file.

Third round, from the full review:

- The canonical guard runs only when the canonical file exists on disk, so it no longer leans on the adapter persisting the store synchronously at open time (it does today, which is why the fresh-store dry run test passed; the guard removes the coupling).
- On a filesystem that reports no inode, the fallback compares real paths (links followed), not spellings.
- Archive destinations are checked with `lstat`, so a dangling symlink at the destination counts as taken instead of being replaced by the rename.
- With `--canonical :memory:` and `--apply`, nothing is archived: the in-memory store keeps nothing after close, so the sources stay the only copy.
- Two requests to skip archiving a copy whose rows are all already present were declined on purpose: that copy is exactly what the doctor must stop listing (the two files in #1380 were that case), and the archive is a rename next to the original.

22 tests in the file, full run green.
