### PR TITLE
docs(upgrade): tell Windows users to close the tools that run EGC before npm install -g

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -40,6 +40,32 @@ If you prefer not to change your Node installation, the alternative is to [confi
 
 ---
 
+## `EBUSY: resource busy or locked` during `npm install -g` on Windows
+
+**Symptom:** `npm install -g @egchq/egc@latest` fails while EGC is already installed:
+
+```
+npm error code EBUSY
+npm error syscall rename
+npm error path C:\Users\<you>\AppData\Roaming\npm\node_modules\@egchq\egc\dashboard
+npm error errno -4082
+npm error EBUSY: resource busy or locked, rename '...\@egchq\egc\dashboard' -> '...\@egchq\.egc-XXXXXXXX\dashboard'
+```
+
+**Cause:** npm upgrades a global package by renaming the old package folder aside before unpacking the new one. Windows refuses to rename a folder while any process holds a file inside it. The usual holders are an AI tool that is running the EGC MCP servers (`egc-memory` and `egc-guardian` live inside that package) and a terminal where an EGC hook is running.
+
+**Fix:** close the AI tools and terminals that run EGC, then run the install again:
+
+```powershell
+npm install -g @egchq/egc@latest
+egc auto-update
+egc doctor
+```
+
+If the lock does not clear, a reboot releases it. Nothing needs to be uninstalled first: `egc auto-update` reinstalls the new version into every managed target and `egc doctor` confirms the result.
+
+---
+
 ## Node.js version conflict with mise / asdf (multiple Node installations)
 
 **Symptom:** `egc auto-update` fails with a confusing git error, or `egc` reports version issues even though it is already up to date. Common when using [mise](https://mise.jdx.dev) or [asdf](https://asdf-vm.com) with multiple Node versions.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -191,6 +191,7 @@ cd EGC
   ```
 - **Antigravity free tier**: the starter quota is limited. Expect to exhaust it within a few exchanges. Upgrade or use Claude Code / Cursor for longer sessions.
 - **Gemini CLI**: free tier discontinued June 18, 2026. Use Antigravity CLI as a replacement on Windows.
+- **Upgrading with `npm install -g @egchq/egc@latest`**: close the AI tools and terminals that run EGC first. npm renames the package folder during the update, and Windows refuses the rename while any process holds a file inside it (an AI tool running the EGC MCP servers, a terminal with a hook mid-run). The failure reads `EBUSY: resource busy or locked` on a path under `node_modules\@egchq\egc`. A reboot clears the lock too. See [Troubleshooting](TROUBLESHOOTING.md#ebusy-resource-busy-or-locked-during-npm-install--g-on-windows).
 
 ---
 
@@ -359,7 +360,7 @@ You never need to type any of these. Talk to your AI naturally, in any language,
 
 ### Getting a fix before it ships to npm
 
-`egc auto-update` only runs a real `git pull` when the install directory has a `.git` folder (i.e. you installed via `git clone`, not `npm install -g`). On a git-based install, `auto-update` pulls straight from `origin/main`, so a fix that has merged but not yet been published as an npm release still reaches you. On an npm-only install, there is no repository to pull from: `auto-update` prints a reminder to run `npm install -g @egchq/egc@latest`, which only helps once a new version has actually been published. If you need a fix that is on `main` but not yet released, `git clone` + `sh scripts/install.sh` (or `.\scripts\install.ps1`) is the reliable path, not `npm install -g`.
+`egc auto-update` only runs a real `git pull` when the install directory has a `.git` folder (i.e. you installed via `git clone`, not `npm install -g`). On a git-based install, `auto-update` pulls straight from `origin/main`, so a fix that has merged but not yet been published as an npm release still reaches you. On an npm-only install, there is no repository to pull from: `auto-update` prints a reminder to run `npm install -g @egchq/egc@latest`, which only helps once a new version has actually been published. On Windows, close the AI tools and terminals that run EGC before that command, or npm fails with `EBUSY` on a file it cannot rename (see the Windows notes above). If you need a fix that is on `main` but not yet released, `git clone` + `sh scripts/install.sh` (or `.\scripts\install.ps1`) is the reliable path, not `npm install -g`.
 
 ---
 

--- a/scripts/auto-update.js
+++ b/scripts/auto-update.js
@@ -140,12 +140,29 @@ function runExternalCommand(command, args, options = {}) {
   return result;
 }
 
+// npm renames the package folder during a global update, and Windows refuses
+// the rename while any process holds a file inside it: an AI tool running the
+// EGC MCP servers, or a terminal with a hook mid-run, is enough to fail the
+// upgrade with EBUSY. Say so where the upgrade command is suggested (#1380).
+function npmUpgradeHint(platform = process.platform) {
+  const lines = [
+    `EGC is installed via npm (v${PKG_VERSION}).`,
+    'To upgrade to a newer version, run: npm install -g @egchq/egc@latest',
+  ];
+  if (platform === 'win32') {
+    lines.push(
+      '  On Windows, close the AI tools and terminals that run EGC before that command:',
+      '  a file held open inside the package folder makes npm fail with EBUSY.',
+    );
+  }
+  return lines;
+}
+
 function performGitUpdate(repoRoot, env, execute) {
   const isGitRepo = fs.existsSync(path.join(repoRoot, '.git'));
   if (!isGitRepo) {
     // npm-installed: git pull is not applicable. Reinstall from current package.
-    console.log(`EGC is installed via npm (v${PKG_VERSION}).`);
-    console.log('To upgrade to a newer version, run: npm install -g @egchq/egc@latest');
+    for (const line of npmUpgradeHint()) console.log(line);
     console.log('Reinstalling current version into managed targets...\n');
   } else {
     execute('git', ['fetch', '--all', '--prune'], { cwd: repoRoot, env });
@@ -426,6 +443,7 @@ module.exports = {
   deriveRepoRootFromState,
   buildInstallApplyArgs,
   determineInstallCwd,
+  npmUpgradeHint,
   runCognitiveBootstrap,
   runAutoUpdate,
 };

--- a/tests/scripts/auto-update.test.js
+++ b/tests/scripts/auto-update.test.js
@@ -13,6 +13,7 @@ const {
   deriveRepoRootFromState,
   buildInstallApplyArgs,
   determineInstallCwd,
+  npmUpgradeHint,
   runCognitiveBootstrap,
   runAutoUpdate,
 } = require('../../scripts/auto-update');
@@ -159,6 +160,18 @@ function runTests() {
       () => parseArgs(['node', 'scripts/auto-update.js', '--bogus']),
       /Unknown argument: --bogus/
     );
+  })) passed += 1; else failed += 1;
+
+  if (test('the npm upgrade hint warns Windows about files held open in the package folder, and only Windows', () => {
+    const windows = npmUpgradeHint('win32');
+    assert.ok(windows[1].includes('npm install -g @egchq/egc@latest'), 'the upgrade command stays first');
+    assert.ok(windows.some(line => line.includes('EBUSY')), 'Windows must be told what the failure looks like');
+    assert.ok(windows.some(line => line.includes('close the AI tools and terminals')), 'and what to do before upgrading');
+    for (const platform of ['linux', 'darwin']) {
+      const lines = npmUpgradeHint(platform);
+      assert.strictEqual(lines.length, 2, `${platform} gets the two original lines and nothing else`);
+      assert.ok(!lines.join(' ').includes('EBUSY'));
+    }
   })) passed += 1; else failed += 1;
 
   if (test('deriveRepoRootFromState uses sourcePath and sourceRelativePath', () => {


### PR DESCRIPTION
## What Changed

Windows users upgrading an npm install now hear about the file lock before they hit it, in the three places that point them at `npm install -g @egchq/egc@latest`:

- `scripts/auto-update.js`: the npm-install branch prints its two lines through a new `npmUpgradeHint(platform)`; on `win32` it adds two more, saying to close the AI tools and terminals that run EGC first because a file held open inside the package folder makes npm fail with `EBUSY`. Other platforms keep the exact two lines they had. Exported and covered by a unit test for `win32`, `linux` and `darwin`.
- `docs/installation.md`: a bullet under Windows notes with the symptom, the cause and the two ways out (close the tools, or reboot), plus one sentence in the `auto-update` paragraph that recommends the npm upgrade command.
- `docs/TROUBLESHOOTING.md`: a new section, `EBUSY: resource busy or locked during npm install -g on Windows`, in the same symptom, cause, fix shape as the existing entries, with the exact npm error block and the three commands to run afterwards.

## Why This Change

npm upgrades a global package by renaming the old folder aside, and Windows refuses the rename while any process holds a file inside it. An AI tool running the EGC MCP servers, which live inside that package, is enough. Nothing in the docs or in the CLI said so, and the first person to hit it had to guess (a reboot worked). The Windows tester who reported it in #1380 is the source for the symptom block.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated (not applicable: output and documentation only)

## Type of Change
- [x] `docs:` Documentation

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (not needed: the README does not carry upgrade instructions)

## Credit

Reported by @Akisolu in #1380 during the v1.1.21 upgrade mission on Windows 10: first `npm install -g` failed with `EBUSY` on the package folder, a reboot cleared it, and she wrote down the whole block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Windows users upgrading via npm now see a warning to close the AI tools and terminals running EGC before `npm install -g @egchq/egc@latest`, preventing the `EBUSY` failure that happens when Windows refuses to rename a package folder a process holds open.

- The `npmUpgradeHint()` function adds the two Windows-only lines; Linux and macOS output is unchanged, and a new unit test covers all three platforms.
- The warning appears in the auto-update output, the installation guide, and a new troubleshooting entry with the exact error block and fix commands (`npm install`, `egc auto-update`, `egc doctor`).

<sup>Written for commit 9aa6f100abdc684ef7ebb587a64a96e275f12126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

