### PR TITLE
fix(cli): resolve commands on Windows with one shell string so Node 24 stops printing DEP0190

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -491,8 +491,11 @@ function commandExists(cmd) {
   // real process.
   try {
     if (process.platform === 'win32') {
-      // shell:true inherits PATHEXT so `where npm` resolves npm.cmd/.exe correctly
-      const result = spawnSync('where', [cmd], { stdio: 'pipe', shell: true });
+      // shell:true inherits PATHEXT so `where npm` resolves npm.cmd/.exe
+      // correctly. One string, not an args array: Node 24 deprecates the
+      // array form with a shell (DEP0190), and cmd is validated above to
+      // letters, digits, dot, dash and underscore, so nothing needs escaping.
+      const result = spawnSync(`where ${cmd}`, { stdio: 'pipe', shell: true });
       if (result.status === 0) return true;
     } else {
       const result = spawnSync('which', [cmd], { stdio: 'pipe' });

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -9,6 +9,7 @@ const { maybeSkipBaselineAbsent } = require('./baseline-absent');
 
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const { spawnSync } = require('child_process');
 
 const utils = require('../../scripts/lib/utils');
@@ -584,6 +585,29 @@ function runTests() {
   if (test('commandExists finds node', () => {
     const exists = utils.commandExists('node');
     assert.strictEqual(exists, true);
+  })) passed++; else failed++;
+
+  if (test('commandExists resolves a real command in a child process without a DEP0190 warning', () => {
+    // The Windows branch shells out to `where` with shell:true; Node 24 warns
+    // (DEP0190) when an args array is passed with a shell, and the warning
+    // lands in the middle of egc init output on Windows (#1394). The child
+    // process is what makes the warning observable: it is printed once per
+    // process, on stderr, by the runtime itself.
+    const utilsPath = path.join(__dirname, '..', '..', 'scripts', 'lib', 'utils.js');
+    const scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-command-exists-'));
+    const scriptPath = path.join(scriptDir, 'probe.js');
+    try {
+      fs.writeFileSync(scriptPath, [
+        `const utils = require(${JSON.stringify(utilsPath)});`,
+        "process.stdout.write(String(utils.commandExists('node')));",
+      ].join('\n'));
+      const result = spawnSync(process.execPath, [scriptPath], { encoding: 'utf8', timeout: 10000 });
+      assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+      assert.strictEqual(result.stdout, 'true', 'node must be found on PATH');
+      assert.ok(!result.stderr.includes('DEP0190'), `the lookup must not trigger DEP0190, got: ${result.stderr}`);
+    } finally {
+      fs.rmSync(scriptDir, { recursive: true, force: true });
+    }
   })) passed++; else failed++;
 
   if (test('commandExists returns false for fake command', () => {

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -11,6 +11,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { spawnSync } = require('child_process');
+const { CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 
 const utils = require('../../scripts/lib/utils');
 
@@ -601,7 +602,7 @@ function runTests() {
         `const utils = require(${JSON.stringify(utilsPath)});`,
         "process.stdout.write(String(utils.commandExists('node')));",
       ].join('\n'));
-      const result = spawnSync(process.execPath, [scriptPath], { encoding: 'utf8', timeout: 10000 });
+      const result = spawnSync(process.execPath, [scriptPath], { encoding: 'utf8', timeout: CLI_TIMEOUT_MS });
       assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
       assert.strictEqual(result.stdout, 'true', 'node must be found on PATH');
       assert.ok(!result.stderr.includes('DEP0190'), `the lookup must not trigger DEP0190, got: ${result.stderr}`);


### PR DESCRIPTION
## What Changed

`scripts/lib/utils.js`, `commandExists`: the Windows branch calls `where` through the shell with one string (`where <cmd>`) instead of an args array. The shell stays, because it is what makes `where npm` resolve `npm.cmd` through `PATHEXT`; the command name is validated to letters, digits, dot, dash and underscore before this point, so joining it needs no escaping.

`tests/lib/utils.test.js`: a new case runs `commandExists('node')` in a child process and asserts exit 0, `true` on stdout, and no `DEP0190` on stderr. The warning is printed by the runtime once per process, which is why the child process is needed to observe it; on Windows it exercises the branch that used to warn, elsewhere it guards the POSIX branch.

## Why This Change

Node 24 deprecates passing an args array together with `shell: true` and prints `[DEP0190] DeprecationWarning` on every `egc init` on Windows. It has been in every Windows report since v1.1.17 without a ticket. Fixes #1394.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated (not applicable)

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation (comment at the call site)
- [x] Added comments for complex logic
- [ ] README updated (not needed)

## Credit

Reported by @Akisolu on Windows 10 with Node 24 in #1049, #1217 and #1380.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Node 24 from printing a DEP0190 deprecation warning on Windows during `egc init` by passing `where` a single shell string instead of an args array, preserving `PATHEXT` resolution. The command name is validated to safe characters before this point, so no escaping is needed. Fixes #1394.

- Adds a child-process test asserting `commandExists('node')` finds the command and prints no DEP0190 on stderr, using the shared subprocess timeout fixture.

<sup>Written for commit dd46dcb9f227f62db4f3a992359cb7a3b85b2f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

