### PR TITLE
fix(deps): clear the js-yaml and hono advisories of 9 September in the three lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to EGC are documented here.
 
 - **`egc init` ends with a compact install check instead of the full doctor report** (#1384): a healthy install is one line (`12 targets healthy`); only targets that need attention are listed, each with the exact command to run (`egc repair` for drift and version skew, `egc install --target <name> --profile full` for what the automatic repair could not fix, with `egc uninstall --target <name>` offered when the tool is no longer in use), and a bare install shows the full-profile command right there. The check runs behind a live spinner on an interactive terminal and prints one plain line without a TTY. The memory and Token Crusher lines moved above the check and now report real state (the CLI state store the bootstrap created, the crusher shim on PATH) instead of a fixed sentence; the closing tip and the compression claim are gone; the dashboard is one check line with its URL and the command to close it, headless runs print the same line as the other installers, and `Installation complete.` is the last line. `egc doctor` keeps its full report and its JSON contract.
 
+### Security
+
+- **Four advisories published on 9 September 2026 cleared in the three lockfiles**: `js-yaml` 4.3.2 (GHSA for the merge-key CPU bound, high), and `hono` raised from the 4.12.34 pin of #1184 to 4.13.7 with `@hono/node-server` 2.1.1, which closes the three moderate advisories against `hono` below 4.13.5 (`toSSG()` path escape GHSA-gqvv-2mrq-wpjv, `parseBody()` nesting GHSA-g6gw-c38x-mqfc, query parsing past the fragment GHSA-crvj-82cr-hjcx). The pin moves in the root package and in both MCP servers; `npm audit` reports zero findings in each.
+
 ## [1.1.21] - 2026-09-05
 
 ### Added

--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
-      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/mcp/servers/egc-guardian/package-lock.json
+++ b/mcp/servers/egc-guardian/package-lock.json
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp/servers/egc-guardian/package.json
+++ b/mcp/servers/egc-guardian/package.json
@@ -22,6 +22,6 @@
     "undici": "^6.27.0",
     "@hono/node-server": "^2.0.5",
     "ip-address": "10.4.0",
-    "hono": "4.12.34"
+    "hono": "4.13.7"
   }
 }

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
-      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/mcp/servers/egc-memory/package-lock.json
+++ b/mcp/servers/egc-memory/package-lock.json
@@ -1178,9 +1178,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp/servers/egc-memory/package.json
+++ b/mcp/servers/egc-memory/package.json
@@ -25,6 +25,6 @@
     "undici": "^6.27.0",
     "@hono/node-server": "^2.0.5",
     "ip-address": "10.4.0",
-    "hono": "4.12.34"
+    "hono": "4.13.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
-      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -2583,9 +2583,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2887,9 +2887,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "markdown-it": "^14.2.0",
     "undici": "^6.27.0",
     "@hono/node-server": "^2.0.5",
-    "hono": "4.12.34"
+    "hono": "4.13.7"
   },
   "pnpm": {
     "overrides": {
@@ -147,7 +147,7 @@
       "markdown-it": "^14.2.0",
       "undici": "^6.27.0",
       "@hono/node-server": "^2.0.5",
-      "hono": "4.12.34"
+      "hono": "4.13.7"
     }
   }
 }


### PR DESCRIPTION
Four advisories published on 9 September 2026 started failing `Security Scan / npm audit` on every open PR (first seen on #1406). None of them is reachable through EGC's own code paths, but the rule is zero findings.

## What changes

- `js-yaml` 4.3.1 to 4.3.2 (high: `maxTotalMergeKeys` does not bound CPU for empty merge sources).
- `hono` raised from the 4.12.34 pin of #1184 to 4.13.7, with `@hono/node-server` 2.0.12 to 2.1.1. That closes the three moderate advisories against `hono` below 4.13.5: `toSSG()` writing outside the output directory (GHSA-gqvv-2mrq-wpjv), unbounded dot-notation nesting in `parseBody()` (GHSA-g6gw-c38x-mqfc), and query parameters read past the URL fragment (GHSA-crvj-82cr-hjcx). The pin lives in the root `package.json` overrides (npm and pnpm) and in both MCP servers, so all three move together.
- Lockfiles regenerated with `--package-lock-only --ignore-scripts`: the diff is exactly those three packages in each file, lockfile version unchanged.
- CHANGELOG entry under Unreleased / Security.

## Verification

`npm audit` reports zero findings in the root and in `mcp/servers/egc-memory` and `mcp/servers/egc-guardian`. Full suite green locally (4694 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the four npm audit advisories published on 9 September 2026 so `Security Scan / npm audit` passes on every PR; none are reachable through EGC's own code paths, but the rule is zero findings.

**Dependencies**
- `js-yaml` 4.3.1 → 4.3.2 (high: `maxTotalMergeKeys` does not bound CPU for empty merge sources).
- `hono` 4.12.34 → 4.13.7 and `@hono/node-server` 2.0.12 → 2.1.1, closing the three moderate advisories against `hono` below 4.13.5.
- The `hono` pin moves in the root `package.json` overrides and in both MCP servers, so all three lockfiles move together.

<sup>Written for commit 549dfcd351f95b7a2ff5128b7c4e8d484c93b922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

