### PR TITLE
fix(memory): hardening round on the branch detector, with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to EGC are documented here.
 
 ### Security
 
+- **The branch detector went through a hardening round, with a test for every form now refused** (#1430). No documented behavior changes.
 - **Hardening round on the Guardian git checks, with a test for every form now refused** (#1403 by @prateeekbuilds, mission #1382): the checks on `git push` refspecs, on `git config` writes in any flag order or letter case, on inline `-c` and `--config-env` overrides and on alias values were tightened across nine review rounds, each case probed against `main` before it was closed.
 - **Five advisories published on 9 September 2026 cleared in the three lockfiles**: `smol-toml` 1.7.2 in the root lockfile (#1422, GHSA-7w5x-hrqm-74c2, denial of service through a malformed TOML document, a dependency of the markdown linter only), flagged by the supply-chain scorecard on the main branch an hour after the lockfile bump of #1418 and cleared within the range that linter allows; `js-yaml` 4.3.2 (GHSA for the merge-key CPU bound, high), and `hono` raised from the 4.12.34 pin of #1184 to 4.13.7 with `@hono/node-server` 2.1.1, which closes the three moderate advisories against `hono` below 4.13.5 (`toSSG()` path escape GHSA-gqvv-2mrq-wpjv, `parseBody()` nesting GHSA-g6gw-c38x-mqfc, query parsing past the fragment GHSA-crvj-82cr-hjcx). The pin moves in the root package and in both MCP servers; `npm audit` reports zero findings in each.
 

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -30,14 +30,16 @@ function branchStateKey(branch) {
   return `${readablePrefix}--${digest}`;
 }
 
-// Whether a link sits at the path (a dangling one included): such a
-// component is never appended lexically, since a target created or moved
-// later would redirect it past the check.
-function isLink(p) {
+// What sits at a path that does not resolve: 'absent' (nothing there, or
+// a parent that is not a directory), 'link' (a link, a dangling one
+// included: never appended lexically, since a target created or moved
+// later would redirect it past the check), or 'unknown' when the path
+// cannot be inspected at all, which the caller treats like a link.
+function unresolvedComponent(p) {
   try {
-    return fs.lstatSync(p).isSymbolicLink();
-  } catch {
-    return false;
+    return fs.lstatSync(p).isSymbolicLink() ? 'link' : 'plain';
+  } catch (error) {
+    return error.code === 'ENOENT' || error.code === 'ENOTDIR' ? 'absent' : 'unknown';
   }
 }
 
@@ -57,7 +59,8 @@ function canonicalPath(p) {
     } catch (error) {
       if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') return null;
     }
-    if (isLink(existing)) return null;
+    const component = unresolvedComponent(existing);
+    if (component === 'link' || component === 'unknown') return null;
     const parent = path.dirname(existing);
     if (parent === existing) return null;
     tail.unshift(path.basename(existing));

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -30,18 +30,19 @@ function branchStateKey(branch) {
   return `${readablePrefix}--${digest}`;
 }
 
-// Validates a resolved absolute path is within a trusted directory root
-// (home or tmp) and contains '.git' as a path segment. Using startsWith
-// against os.homedir()/os.tmpdir() -- which are untainted system values --
-// satisfies SonarCloud's path-injection sanitization requirement and also
-// prevents traversal to unrelated filesystem locations.
-function isGitRelatedPath(p) {
+// The resolved absolute form of a git path when it sits under a trusted
+// root (the home directory or the temp directory, untainted system values)
+// and carries '.git' as a path segment; null otherwise. The value returned
+// here is the one every read below uses, so a path handed in by a hook
+// payload or a CLI argument never reaches the filesystem unchecked, and a
+// traversal to an unrelated location is refused before any read.
+function trustedGitPath(p) {
   const resolved = path.resolve(p);
   const home = os.homedir() + path.sep;
   const tmp = os.tmpdir() + path.sep;
   const underTrustedRoot = resolved.startsWith(home) || resolved.startsWith(tmp);
   const hasGitSegment = resolved.split(path.sep).includes('.git');
-  return underTrustedRoot && hasGitSegment;
+  return underTrustedRoot && hasGitSegment ? resolved : null;
 }
 
 // Branch detection reads .git/HEAD instead of spawning git: no PATH
@@ -61,17 +62,17 @@ function detectBranch(projectPath) {
   try {
     const rawGitDir = findGitDir(projectPath);
     if (!rawGitDir) return null;
-    let gitDir = path.resolve(rawGitDir);
-    if (!isGitRelatedPath(gitDir)) return null;
+    let gitDir = trustedGitPath(rawGitDir);
+    if (!gitDir) return null;
     if (fs.statSync(gitDir).isFile()) {
       // Worktrees and submodules store a pointer file instead of a directory
       const pointer = fs.readFileSync(gitDir, 'utf8').trim();
       if (!pointer.startsWith('gitdir:')) return null;
-      gitDir = path.resolve(path.dirname(gitDir), pointer.slice('gitdir:'.length).trim());
-      if (!isGitRelatedPath(gitDir)) return null;
+      gitDir = trustedGitPath(path.resolve(path.dirname(gitDir), pointer.slice('gitdir:'.length).trim()));
+      if (!gitDir) return null;
     }
-    const headPath = path.resolve(gitDir, 'HEAD');
-    if (!isGitRelatedPath(headPath)) return null;
+    const headPath = trustedGitPath(path.resolve(gitDir, 'HEAD'));
+    if (!headPath) return null;
     const head = fs.readFileSync(headPath, 'utf8').trim();
     const refPrefix = 'ref: refs/heads/';
     // Detached HEAD stores a bare commit hash; treat it as no branch
@@ -141,6 +142,7 @@ module.exports = {
   sanitizeBranchName,
   branchStateKey,
   detectBranch,
+  trustedGitPath,
   flatStateFile,
   branchStateFile,
   legacyBranchStateFile,

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -30,19 +30,49 @@ function branchStateKey(branch) {
   return `${readablePrefix}--${digest}`;
 }
 
-// The resolved absolute form of a git path when it sits under a trusted
+// The canonical absolute form of a path: links are resolved through the
+// nearest existing ancestor and the rest is appended lexically, so a link
+// planted at .git or above it cannot lead a read outside the trusted roots
+// while the lexical path still looks inside them. A path that cannot be
+// canonicalised (a link loop, a parent that cannot be inspected) is null.
+function canonicalPath(p) {
+  let existing = path.resolve(p);
+  const tail = [];
+  for (;;) {
+    try {
+      const real = fs.realpathSync.native(existing);
+      return tail.length > 0 ? path.join(real, ...tail) : real;
+    } catch (error) {
+      if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') return null;
+    }
+    const parent = path.dirname(existing);
+    if (parent === existing) return null;
+    tail.unshift(path.basename(existing));
+    existing = parent;
+  }
+}
+
+function trustedRoot(dir) {
+  try {
+    return fs.realpathSync.native(dir) + path.sep;
+  } catch {
+    return path.resolve(dir) + path.sep;
+  }
+}
+
+// The canonical absolute form of a git path when it sits under a trusted
 // root (the home directory or the temp directory, untainted system values)
 // and carries '.git' as a path segment; null otherwise. The value returned
 // here is the one every read below uses, so a path handed in by a hook
 // payload or a CLI argument never reaches the filesystem unchecked, and a
-// traversal to an unrelated location is refused before any read.
+// traversal or a link leading to an unrelated location is refused before
+// any read.
 function trustedGitPath(p) {
-  const resolved = path.resolve(p);
-  const home = os.homedir() + path.sep;
-  const tmp = os.tmpdir() + path.sep;
-  const underTrustedRoot = resolved.startsWith(home) || resolved.startsWith(tmp);
-  const hasGitSegment = resolved.split(path.sep).includes('.git');
-  return underTrustedRoot && hasGitSegment ? resolved : null;
+  const canonical = canonicalPath(p);
+  if (!canonical) return null;
+  const underTrustedRoot = canonical.startsWith(trustedRoot(os.homedir())) || canonical.startsWith(trustedRoot(os.tmpdir()));
+  const hasGitSegment = canonical.split(path.sep).includes('.git');
+  return underTrustedRoot && hasGitSegment ? canonical : null;
 }
 
 // Branch detection reads .git/HEAD instead of spawning git: no PATH

--- a/scripts/lib/branch-state.js
+++ b/scripts/lib/branch-state.js
@@ -30,11 +30,23 @@ function branchStateKey(branch) {
   return `${readablePrefix}--${digest}`;
 }
 
+// Whether a link sits at the path (a dangling one included): such a
+// component is never appended lexically, since a target created or moved
+// later would redirect it past the check.
+function isLink(p) {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
 // The canonical absolute form of a path: links are resolved through the
 // nearest existing ancestor and the rest is appended lexically, so a link
 // planted at .git or above it cannot lead a read outside the trusted roots
 // while the lexical path still looks inside them. A path that cannot be
-// canonicalised (a link loop, a parent that cannot be inspected) is null.
+// canonicalised (a link loop, a dangling link on the way, a parent that
+// cannot be inspected) is null.
 function canonicalPath(p) {
   let existing = path.resolve(p);
   const tail = [];
@@ -45,6 +57,7 @@ function canonicalPath(p) {
     } catch (error) {
       if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') return null;
     }
+    if (isLink(existing)) return null;
     const parent = path.dirname(existing);
     if (parent === existing) return null;
     tail.unshift(path.basename(existing));
@@ -52,11 +65,15 @@ function canonicalPath(p) {
   }
 }
 
+function withTrailingSeparator(dir) {
+  return dir.endsWith(path.sep) ? dir : dir + path.sep;
+}
+
 function trustedRoot(dir) {
   try {
-    return fs.realpathSync.native(dir) + path.sep;
+    return withTrailingSeparator(fs.realpathSync.native(dir));
   } catch {
-    return path.resolve(dir) + path.sep;
+    return withTrailingSeparator(path.resolve(dir));
   }
 }
 

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -17,6 +17,7 @@ const {
   legacyBranchStateFile,
   resolveStateRead,
   resolveStateWrite,
+  trustedGitPath,
 } = require('../../scripts/lib/branch-state');
 
 const { collectMemoryState } = require('../../scripts/status');
@@ -101,6 +102,14 @@ function runTests() {
   if (test('detectBranch returns the current branch in a git repo', () => {
     const repo = makeGitRepo('feature/auth');
     assert.strictEqual(detectBranch(repo), 'feature/auth');
+  })) passed++; else failed++;
+
+  if (test('trustedGitPath returns the resolved path only under a trusted root with a .git segment', () => {
+    const under = path.join(os.tmpdir(), 'egc-trusted', '.git', 'HEAD');
+    assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), 'egc-trusted', 'sub', '..', '.git', 'HEAD')), under, 'resolved and normalised');
+    assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), 'egc-trusted', 'HEAD')), null, 'no .git segment');
+    assert.strictEqual(trustedGitPath(path.join(path.sep, 'etc', '.git', 'HEAD')), null, 'outside the home and temp roots');
+    assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), '..', 'other', '.git')), null, 'a traversal that leaves the temp root is refused');
   })) passed++; else failed++;
 
   if (test('detectBranch returns null outside a git repo', () => {

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -130,6 +130,17 @@ function runTests() {
         // created or moved later and redirect the read past the check.
         fs.symlinkSync(path.join(base, 'not-yet'), path.join(base, 'dangling'));
         assert.strictEqual(trustedGitPath(path.join(base, 'dangling', '.git', 'HEAD')), null, 'a dangling link on the way is refused');
+        // A parent that cannot be inspected: refused, never guessed.
+        if (typeof process.getuid === 'function' && process.getuid() !== 0) {
+          const sealed = path.join(base, 'sealed');
+          fs.mkdirSync(sealed);
+          fs.chmodSync(sealed, 0o000);
+          try {
+            assert.strictEqual(trustedGitPath(path.join(sealed, 'repo', '.git', 'HEAD')), null, 'a path behind a sealed parent is refused');
+          } finally {
+            fs.chmodSync(sealed, 0o700);
+          }
+        }
       } finally {
         fs.rmSync(base, { recursive: true, force: true });
       }

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -126,6 +126,10 @@ function runTests() {
         // A link loop cannot be canonicalised: refused.
         fs.symlinkSync(path.join(base, 'loop'), path.join(base, 'loop'));
         assert.strictEqual(trustedGitPath(path.join(base, 'loop', '.git', 'HEAD')), null, 'a link loop is refused');
+        // A dangling link on the way is refused too: its target could be
+        // created or moved later and redirect the read past the check.
+        fs.symlinkSync(path.join(base, 'not-yet'), path.join(base, 'dangling'));
+        assert.strictEqual(trustedGitPath(path.join(base, 'dangling', '.git', 'HEAD')), null, 'a dangling link on the way is refused');
       } finally {
         fs.rmSync(base, { recursive: true, force: true });
       }

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -130,16 +130,24 @@ function runTests() {
         // created or moved later and redirect the read past the check.
         fs.symlinkSync(path.join(base, 'not-yet'), path.join(base, 'dangling'));
         assert.strictEqual(trustedGitPath(path.join(base, 'dangling', '.git', 'HEAD')), null, 'a dangling link on the way is refused');
-        // A parent that cannot be inspected: refused, never guessed.
-        if (typeof process.getuid === 'function' && process.getuid() !== 0) {
-          const sealed = path.join(base, 'sealed');
-          fs.mkdirSync(sealed);
-          fs.chmodSync(sealed, 0o000);
+        // A parent that cannot be inspected: refused, never guessed. Only
+        // asserted where the mode bits actually seal the directory (not as
+        // root, not in a sandbox that overrides them).
+        const sealed = path.join(base, 'sealed');
+        fs.mkdirSync(sealed);
+        fs.chmodSync(sealed, 0o000);
+        try {
+          let sealedForReal = false;
           try {
-            assert.strictEqual(trustedGitPath(path.join(sealed, 'repo', '.git', 'HEAD')), null, 'a path behind a sealed parent is refused');
-          } finally {
-            fs.chmodSync(sealed, 0o700);
+            fs.readdirSync(sealed);
+          } catch (error) {
+            sealedForReal = error.code === 'EACCES' || error.code === 'EPERM';
           }
+          if (sealedForReal) {
+            assert.strictEqual(trustedGitPath(path.join(sealed, 'repo', '.git', 'HEAD')), null, 'a path behind a sealed parent is refused');
+          }
+        } finally {
+          fs.chmodSync(sealed, 0o700);
         }
       } finally {
         fs.rmSync(base, { recursive: true, force: true });

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -141,7 +141,8 @@ function runTests() {
           try {
             fs.readdirSync(sealed);
           } catch (error) {
-            sealedForReal = error.code === 'EACCES' || error.code === 'EPERM';
+            if (error.code !== 'EACCES' && error.code !== 'EPERM') throw error;
+            sealedForReal = true;
           }
           if (sealedForReal) {
             assert.strictEqual(trustedGitPath(path.join(sealed, 'repo', '.git', 'HEAD')), null, 'a path behind a sealed parent is refused');

--- a/tests/lib/branch-state.test.js
+++ b/tests/lib/branch-state.test.js
@@ -104,12 +104,32 @@ function runTests() {
     assert.strictEqual(detectBranch(repo), 'feature/auth');
   })) passed++; else failed++;
 
-  if (test('trustedGitPath returns the resolved path only under a trusted root with a .git segment', () => {
-    const under = path.join(os.tmpdir(), 'egc-trusted', '.git', 'HEAD');
-    assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), 'egc-trusted', 'sub', '..', '.git', 'HEAD')), under, 'resolved and normalised');
+  if (test('trustedGitPath returns the canonical path only under a trusted root with a .git segment', () => {
+    const realTmp = fs.realpathSync.native(os.tmpdir());
+    const under = path.join(realTmp, 'egc-trusted', '.git', 'HEAD');
+    assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), 'egc-trusted', 'sub', '..', '.git', 'HEAD')), under, 'resolved, normalised and canonical');
     assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), 'egc-trusted', 'HEAD')), null, 'no .git segment');
-    assert.strictEqual(trustedGitPath(path.join(path.sep, 'etc', '.git', 'HEAD')), null, 'outside the home and temp roots');
-    assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), '..', 'other', '.git')), null, 'a traversal that leaves the temp root is refused');
+    const outside = path.join(path.parse(realTmp).root, 'egc-nowhere', '.git', 'HEAD');
+    assert.strictEqual(trustedGitPath(outside), null, 'outside the home and temp roots');
+    assert.strictEqual(trustedGitPath(path.join(os.tmpdir(), 'egc-trusted', '..', '..', '..', '..', '..', '..', '..', '..', 'egc-nowhere', '.git')), null, 'a traversal that leaves both roots is refused');
+    if (process.platform !== 'win32') {
+      const base = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-trusted-link-'));
+      try {
+        // A link at .git pointing outside both roots: the lexical path looks
+        // inside the temp root, the canonical one does not.
+        fs.symlinkSync(path.parse(realTmp).root, path.join(base, '.git'), 'dir');
+        assert.strictEqual(trustedGitPath(path.join(base, '.git', 'HEAD')), null, 'a link leading outside the roots is refused');
+        // A link that stays inside the temp root is followed and accepted.
+        fs.mkdirSync(path.join(base, 'real', '.git'), { recursive: true });
+        fs.symlinkSync(path.join(base, 'real'), path.join(base, 'alias'), 'dir');
+        assert.strictEqual(trustedGitPath(path.join(base, 'alias', '.git', 'HEAD')), path.join(fs.realpathSync.native(base), 'real', '.git', 'HEAD'), 'a link inside the roots resolves to its canonical target');
+        // A link loop cannot be canonicalised: refused.
+        fs.symlinkSync(path.join(base, 'loop'), path.join(base, 'loop'));
+        assert.strictEqual(trustedGitPath(path.join(base, 'loop', '.git', 'HEAD')), null, 'a link loop is refused');
+      } finally {
+        fs.rmSync(base, { recursive: true, force: true });
+      }
+    }
   })) passed++; else failed++;
 
   if (test('detectBranch returns null outside a git repo', () => {

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -10,8 +10,9 @@ const { execFileSync } = require('child_process');
 const { applyInstallPlan } = require('../../scripts/lib/install/apply');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-apply.js');
-const { FULL_INSTALL_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
+const { FULL_INSTALL_TIMEOUT_MS, CLI_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
 const DEFAULT_INSTALL_APPLY_TIMEOUT_MS = FULL_INSTALL_TIMEOUT_MS;
+const PROBE = { timeout: CLI_TIMEOUT_MS };
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -88,7 +89,7 @@ function runTests() {
 
 
   if (test('shows help with --help', () => {
-    const result = run(['--help']);
+    const result = run(['--help'], PROBE);
     assert.strictEqual(result.code, 0);
     assert.ok(result.stdout.includes('Usage:'));
     assert.ok(result.stdout.includes('--dry-run'));
@@ -845,7 +846,7 @@ function runTests() {
   })) passed++; else failed++;
 
   if (test('rejects unknown explicit manifest modules before resolution', () => {
-    const result = run(['--modules', 'ghost-module']);
+    const result = run(['--modules', 'ghost-module'], PROBE);
     assert.strictEqual(result.code, 1);
     assert.ok(result.stderr.includes('Unknown install module: ghost-module'));
   })) passed++; else failed++;

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -10,7 +10,8 @@ const { execFileSync } = require('child_process');
 const { applyInstallPlan } = require('../../scripts/lib/install/apply');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-apply.js');
-const DEFAULT_INSTALL_APPLY_TIMEOUT_MS = process.platform === 'win32' ? 30000 : 10000;
+const { FULL_INSTALL_TIMEOUT_MS } = require('../fixtures/subprocess-timeouts');
+const DEFAULT_INSTALL_APPLY_TIMEOUT_MS = FULL_INSTALL_TIMEOUT_MS;
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));


### PR DESCRIPTION
## Summary

Hardening round on the branch detector (`scripts/lib/branch-state.js`), with a test for every form now refused. No documented behavior changes; every caller keeps the same results on a normal checkout, a worktree and a detached HEAD.

## Tests

`tests/lib/branch-state.test.js` gains a case for the check itself; the branch-state, state-snapshot, session-context-loader, hooks and export suites pass locally, full suite included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the branch detector so hook-payload or CLI paths are refused unless their real on-disk form sits under the home or temp root with a `.git` segment. The check resolves symlinks before validating, so a link that escapes the roots, loops, or dangles is refused; no documented behavior changes.

**Refactors**
- `trustedGitPath` returns the canonical resolved path instead of a boolean, and every read uses that same validated value.
- Tests cover resolved, normalized, refused, traversal, symlink (escape, loop, dangling), and unreadable-parent forms; the sealed-parent case rethrows unexpected failures instead of skipping.
- The install-apply suite uses the shared subprocess budgets instead of a platform-fixed timeout.

<sup>Written for commit 7cc39c19bf993cb6c91501dbdc0529b1b3de1135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

