### PR TITLE
fix(memory): second hardening pass on the memory CLI messages, with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to EGC are documented here.
 
 ### Security
 
+- **Second hardening pass on the memory CLI messages, with tests** (#1432). No documented behavior changes.
 - **The branch detector went through a hardening round, with a test for every form now refused** (#1430). No documented behavior changes.
 - **Hardening round on the Guardian git checks, with a test for every form now refused** (#1403 by @prateeekbuilds, mission #1382): the checks on `git push` refspecs, on `git config` writes in any flag order or letter case, on inline `-c` and `--config-env` overrides and on alias values were tightened across nine review rounds, each case probed against `main` before it was closed.
 - **Five advisories published on 9 September 2026 cleared in the three lockfiles**: `smol-toml` 1.7.2 in the root lockfile (#1422, GHSA-7w5x-hrqm-74c2, denial of service through a malformed TOML document, a dependency of the markdown linter only), flagged by the supply-chain scorecard on the main branch an hour after the lockfile bump of #1418 and cleared within the range that linter allows; `js-yaml` 4.3.2 (GHSA for the merge-key CPU bound, high), and `hono` raised from the 4.12.34 pin of #1184 to 4.13.7 with `@hono/node-server` 2.1.1, which closes the three moderate advisories against `hono` below 4.13.5 (`toSSG()` path escape GHSA-gqvv-2mrq-wpjv, `parseBody()` nesting GHSA-g6gw-c38x-mqfc, query parsing past the fragment GHSA-crvj-82cr-hjcx). The pin moves in the root package and in both MCP servers; `npm audit` reports zero findings in each.

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -191,7 +191,7 @@ function loadKeyReadOnly() {
   }
   if (key) return key;
   if (!present(stateCrypto.defaultKeyPath(), 'key')) fail(3, 'the memory is encrypted and the key is missing');
-  return fail(1, `the key at ${stateCrypto.defaultKeyPath()} is malformed`);
+  return fail(1, 'the key is present but malformed');
 }
 
 function decryptedContent(target) {

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -140,7 +140,7 @@ function present(filePath) {
     return true;
   } catch (err) {
     if (err.code === 'ENOENT') return false;
-    return fail(1, `cannot inspect ${filePath}: ${err.message}`);
+    return fail(1, `cannot inspect the state file: ${err.message}`);
   }
 }
 
@@ -172,9 +172,9 @@ function readStateBytes(target) {
     // A link at the path is refused by the no-follow open (ELOOP), the
     // same refusal as a link seen before the open.
     if (err.code === 'ELOOP') raw = null;
-    else fail(1, `cannot read ${target.file}: ${err.message}`);
+    else fail(1, `cannot read the state file: ${err.message}`);
   }
-  if (raw === null) fail(1, `${target.file} is not a regular file inside the state directory, or changed while it was read`);
+  if (raw === null) fail(1, 'the state file is not a regular file inside the state directory, or changed while it was read');
   return raw;
 }
 
@@ -198,7 +198,7 @@ function decryptedContent(target) {
   if (!stateCrypto.isEncryptedBuffer(raw)) return raw;
   const keyMaterial = loadKeyReadOnly();
   const content = stateCrypto.decryptStateBuffer(raw, undefined, { keyMaterial });
-  if (content === null) fail(1, `${target.file} cannot be decrypted with the key (truncated or tampered)`);
+  if (content === null) fail(1, 'the state file cannot be decrypted with the key (truncated or tampered)');
   return content;
 }
 

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -133,21 +133,22 @@ function fail(code, message) {
 
 // Whether anything sits at the path (a link, even a dangling one, counts).
 // Only a definite ENOENT is an absence; a path that cannot be inspected is
-// an error, never a silent "no memory".
-function present(filePath) {
+// an error, never a silent "no memory". The message names the file by its
+// role and the failure by its code: never the path.
+function present(filePath, role) {
   try {
     fs.lstatSync(filePath);
     return true;
   } catch (err) {
     if (err.code === 'ENOENT') return false;
-    return fail(1, `cannot inspect the state file: ${err.message}`);
+    return fail(1, `cannot inspect the ${role} (${err.code || err.name})`);
   }
 }
 
 function resolveDocument(opts) {
   if (opts.scope === 'global') {
     const file = globalState.globalStateFilePath();
-    return { file, root: statePlaintext.stateRoot(path.dirname(file)), exists: present(file), label: 'global memory' };
+    return { file, root: statePlaintext.stateRoot(path.dirname(file)), exists: present(file, 'state file'), label: 'global memory' };
   }
   const projectPath = path.resolve(opts.project || process.cwd());
   const stateDir = branchState.getStateDir();
@@ -172,7 +173,7 @@ function readStateBytes(target) {
     // A link at the path is refused by the no-follow open (ELOOP), the
     // same refusal as a link seen before the open.
     if (err.code === 'ELOOP') raw = null;
-    else fail(1, `cannot read the state file: ${err.message}`);
+    else fail(1, `cannot read the state file (${err.code || err.name})`);
   }
   if (raw === null) fail(1, 'the state file is not a regular file inside the state directory, or changed while it was read');
   return raw;
@@ -189,7 +190,7 @@ function loadKeyReadOnly() {
     fail(1, err.message);
   }
   if (key) return key;
-  if (!present(stateCrypto.defaultKeyPath())) fail(3, 'the memory is encrypted and the key is missing');
+  if (!present(stateCrypto.defaultKeyPath(), 'key')) fail(3, 'the memory is encrypted and the key is missing');
   return fail(1, `the key at ${stateCrypto.defaultKeyPath()} is malformed`);
 }
 

--- a/scripts/lib/state-snapshot.js
+++ b/scripts/lib/state-snapshot.js
@@ -57,7 +57,7 @@ function withStateFileLockSync(stateFile, fn) {
   // own update_state on the same file, risking a lost merge or a partially
   // overwritten ciphertext -- exactly what this lock exists to prevent.
   if (!acquireLockSync(lockFile)) {
-    throw new Error(`Timeout acquiring state file lock: ${lockFile}`);
+    throw new Error('Timeout acquiring the state file lock: another process holds it');
   }
   try {
     return fn();

--- a/tests/lib/state-snapshot.test.js
+++ b/tests/lib/state-snapshot.test.js
@@ -17,7 +17,7 @@ const os = require('os');
 const path = require('path');
 
 const { decryptStateBuffer, isEncryptedBuffer } = require('../../scripts/lib/state-crypto');
-const { writeSnapshotToDisk, applyMinedMemory } = require('../../scripts/lib/state-snapshot');
+const { writeSnapshotToDisk, applyMinedMemory, withStateFileLockSync } = require('../../scripts/lib/state-snapshot');
 
 function test(name, fn) {
   try {
@@ -163,6 +163,20 @@ function runTests() {
     } finally {
       cleanup(home);
       cleanup(projectPath);
+    }
+  })) passed++; else failed++;
+
+  if (test('the lock timeout names no path: a lock held by a live process is reported by its role only', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'egc-lock-msg-'));
+    try {
+      const stateFile = path.join(dir, 'state.md');
+      fs.writeFileSync(`${stateFile}.merge.lock`, String(process.pid));
+      assert.throws(
+        () => withStateFileLockSync(stateFile, () => 'never'),
+        error => error.message === 'Timeout acquiring the state file lock: another process holds it'
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   })) passed++; else failed++;
 

--- a/tests/scripts/export.test.js
+++ b/tests/scripts/export.test.js
@@ -295,7 +295,8 @@ async function main() {
         assert.strictEqual(result.status, 1, result.stderr);
         assert.strictEqual(result.stdout, '');
         assert.ok(result.stderr.includes('cannot read'), result.stderr);
-        assert.ok(result.stderr.includes('cannot read the state file'), 'the message names the file by role; the system error may still carry the path');
+        assert.ok(result.stderr.includes('cannot read the state file (EACCES)'), result.stderr);
+        assert.ok(!result.stderr.includes(path.join('.egc', 'state')), 'the message names the file by role and the failure by its code, never the path');
       } finally {
         fs.chmodSync(file, 0o600);
       }
@@ -345,7 +346,8 @@ async function main() {
         const result = run(['--scope', 'global'], home);
         assert.strictEqual(result.status, 1, result.stderr);
         assert.strictEqual(result.stdout, '');
-        assert.ok(result.stderr.includes('cannot inspect'), result.stderr);
+        assert.ok(result.stderr.includes('cannot inspect the state file (EACCES)'), result.stderr);
+        assert.ok(!result.stderr.includes(path.join('.egc', 'global')), 'never the path');
       } finally {
         fs.chmodSync(globalDir, 0o700);
       }

--- a/tests/scripts/export.test.js
+++ b/tests/scripts/export.test.js
@@ -295,7 +295,7 @@ async function main() {
         assert.strictEqual(result.status, 1, result.stderr);
         assert.strictEqual(result.stdout, '');
         assert.ok(result.stderr.includes('cannot read'), result.stderr);
-        assert.ok(!result.stderr.includes(path.join('.egc', 'state', projectSlug(project))), 'the message names the file by role, not by path');
+        assert.ok(result.stderr.includes('cannot read the state file'), 'the message names the file by role; the system error may still carry the path');
       } finally {
         fs.chmodSync(file, 0o600);
       }

--- a/tests/scripts/export.test.js
+++ b/tests/scripts/export.test.js
@@ -274,6 +274,7 @@ async function main() {
       assert.strictEqual(result.status, 1, result.stderr);
       assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('regular file'), result.stderr);
+      assert.ok(!result.stderr.includes(stateDirFor(home)), 'the message names the file by role, not by path');
       assert.strictEqual(fs.readFileSync(elsewhere, 'utf8'), 'not the memory');
     } finally {
       cleanup(home);
@@ -294,6 +295,7 @@ async function main() {
         assert.strictEqual(result.status, 1, result.stderr);
         assert.strictEqual(result.stdout, '');
         assert.ok(result.stderr.includes('cannot read'), result.stderr);
+        assert.ok(!result.stderr.includes(path.join('.egc', 'state', projectSlug(project))), 'the message names the file by role, not by path');
       } finally {
         fs.chmodSync(file, 0o600);
       }


### PR DESCRIPTION
## Summary

Second hardening pass on the memory CLI messages: the messages of `egc export` and the state file lock name the file by its role instead of echoing it. No documented behavior changes; every exit code and every wording the tests check is kept.

## Tests

`tests/scripts/export.test.js` checks the role wording on the linked and the unreadable state file; the export, state-snapshot, consolidate and hooks suites pass locally, full suite included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the memory CLI messages in `egc export` and the state file lock so error messages name the file by its role and the failure by its code, never echoing the path or the system text. No documented behavior changes; exit codes and previously tested wording are kept.

**Tests**
- Adds assertions that export errors name the file by role and the failure by code, never the path.
- Adds a test that the lock timeout message reports the role, not the path.

<sup>Written for commit 52e3d21f8665913f3ad98cf45198dec3f1ba57a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

