### PR TITLE
fix(ci): exit early if dco-result artifact is missing or empty

### DIFF
--- a/.github/workflows/dco-comment.yml
+++ b/.github/workflows/dco-comment.yml
@@ -32,6 +32,12 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
+            const dirPath = '/tmp/dco-result';
+            if (!fs.existsSync(dirPath) || fs.readdirSync(dirPath).length === 0) {
+              console.log('No DCO result artifact found. Skipping comment post cleanly.');
+              process.exit(0);
+            }
+
             // download-artifact extracts a single-file artifact directly
             // into the download path (no per-artifact subdirectory) when
             // exactly one artifact matches the pattern, which is always the

--- a/.github/workflows/dco-comment.yml
+++ b/.github/workflows/dco-comment.yml
@@ -35,7 +35,7 @@ jobs:
             const dirPath = '/tmp/dco-result';
             if (!fs.existsSync(dirPath) || fs.readdirSync(dirPath).length === 0) {
               console.log('No DCO result artifact found. Skipping comment post cleanly.');
-              process.exit(0);
+              return;
             }
 
             // download-artifact extracts a single-file artifact directly


### PR DESCRIPTION
## What Changed
- Added an early guard check in `.github/workflows/dco-comment.yml` within the `Post guidance comment` step.
- The step now verifies if `/tmp/dco-result` exists and is non-empty before attempting to read its contents using `fs.existsSync` and `fs.readdirSync`.
- If the directory is missing or empty, the step logs a message (`No DCO result artifact found. Skipping comment post cleanly.`) and exits with code `0`.
- Kept the security validation check intact that verifies the artifact's PR against the `workflow_run` payload.

## Why This Change
Fixes #1429.

When a triggering DCO workflow run was skipped or cancelled, `download-artifact` left `/tmp/dco-result` non-existent or empty. This caused `fs.readdirSync('/tmp/dco-result')` to throw an unhandled `ENOENT` error, failing the `dco-comment` workflow. Adding an early exit guard handles this scenario gracefully without breaking CI runs.

## Testing Done
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
- [ ] If this PR touches a file shared across concurrent EGC processes (encryption key, state files, install-state, lockfiles under `~/.egc/`), a concurrent-access test was added or updated

Tested on my personal fork by placing the change on `main` and triggering `workflow_run` events:
1. **Clean Exit (no artifact present):** Verified that missing artifact directory triggers early exit (`exit 0`) without throwing `ENOENT`.
2. **Normal Evaluation (artifact present):** Verified that when an artifact exists, the workflow proceeds and evaluates DCO sign-off status as expected.

Proof of runs:
- Clean exit run: https://github.com/Akisolu/EGC/actions/runs/34670057813 associated with https://github.com/Akisolu/EGC/pull/1
- Validated run: https://github.com/Akisolu/EGC/actions/runs/34670610061 associated with https://github.com/Akisolu/EGC/pull/2

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [x] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DCO comment workflow crashing with an `ENOENT` error when the `dco-result` artifact is missing or empty. The `Post guidance comment` step now checks that `/tmp/dco-result` exists and is non-empty before reading it, logging a message and returning early when the triggering DCO workflow run is skipped or cancelled. Fixes #1429.

<sup>Written for commit 3466ecf1b10c6880f966a5496ca7b4e978f16212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow reliability when result artifacts are unavailable.
  - The process now exits cleanly with an informational message instead of failing when no artifact is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->