### PR TITLE
fix(opencode): load the plugin as an ES module so OpenCode 1.18 accepts it again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to EGC are documented here.
 
 ### Fixed
 
+- **The OpenCode plugin loads again on OpenCode 1.18** (#1438): OpenCode imports plugins as ES modules and refused the CommonJS export with `Plugin export is not a function`, which left the Guardian, the Token Crusher and the session restoration silently off; the plugin file keeps its path and now ships as an ES module with the plugin function exported by name.
 - **The DCO Comment job ends quietly when the triggering run has no result artifact** (#1435 by @Akisolu, closes #1429): a skipped or cancelled DCO run no longer paints a red `DCO Comment` run on `main` after a merge; a run that produced a result keeps posting the guidance, and the check that refuses to comment on a mismatched artifact is unchanged.
 - **The state file lock helper takes an optional retry budget, and its timeout test stops waiting five seconds** (#1436, closes #1433): `withStateFileLockSync` accepts `retries` and `retryDelayMs` with the previous 50 x 100 ms as the defaults, so no caller sees a change and the test finishes in milliseconds.
 - **The last four subprocess suites take their budget from the shared fixture** (#1434, closes #1431): install-sh, egc-session-bridge, doctor and consolidate read `CLI_TIMEOUT_MS` from `tests/fixtures/subprocess-timeouts.js` instead of a budget fixed per platform, so a slow hosted lane stops reading as a flake. No behavior change.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,7 +36,7 @@ module.exports = [
         }
     },
     {
-        files: ['**/*.mjs'],
+        files: ['**/*.mjs', 'scripts/hooks/opencode-egc-plugin.js'],
         languageOptions: {
             sourceType: 'module'
         }

--- a/scripts/hooks/opencode-egc-plugin.js
+++ b/scripts/hooks/opencode-egc-plugin.js
@@ -1,12 +1,18 @@
-'use strict';
-
 // EGC SessionStart + Guardian + Token Crusher plugin for OpenCode. OpenCode
-// loads this file in-process; Guardian and Crusher run directly, while session
-// restoration is delegated to a fail-open Node adapter around the shared,
-// host-neutral session-context-loader core.
+// loads this file in-process as an ES module (a CommonJS export object is
+// rejected with "Plugin export is not a function" since OpenCode 1.18), so the
+// file uses ESM syntax and exports the plugin function by name. Guardian and
+// Crusher run directly, while session restoration is delegated to a fail-open
+// Node adapter around the shared, host-neutral session-context-loader core.
 
-const path = require('node:path');
-const { spawn } = require('node:child_process');
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+// The hook scripts installed next to this plugin are CommonJS modules.
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const { run: runGuardian } = require('../scripts/hooks/pre-bash-guardian-validate');
 const { run: runWriteGuardian } = require('../scripts/hooks/pre-write-guardian-validate');
 const { run: runCrusherRewrite } = require('../scripts/hooks/pre-bash-crusher-rewrite');
@@ -228,4 +234,4 @@ const EgcGuardianCrusher = async ({ client, directory } = {}) => {
   };
 };
 
-module.exports = { EgcGuardianCrusher };
+export { EgcGuardianCrusher };

--- a/tests/hooks/opencode-egc-plugin.test.js
+++ b/tests/hooks/opencode-egc-plugin.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const http = require('http');
 const os = require('os');
 const path = require('path');
+const { pathToFileURL } = require('url');
 const { planInstallTargetScaffold } = require('../../scripts/lib/install-targets/registry');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
@@ -131,11 +132,13 @@ async function runTests() {
     const bridgePath = path.join(root, 'scripts', 'hooks', 'opencode-session-start.js');
     let EgcGuardianCrusher;
 
-    if (await test('installs the plugin and host-neutral session dependency tree', () => {
+    if (await test('installs the plugin and host-neutral session dependency tree', async () => {
       assert.ok(fs.existsSync(pluginPath));
       for (const relative of SESSION_FILES) assert.ok(fs.existsSync(path.join(root, relative)), relative);
-      delete require.cache[require.resolve(pluginPath)];
-      ({ EgcGuardianCrusher } = require(pluginPath));
+      // OpenCode imports the plugin as an ES module; Node needs the package
+      // type hint to do the same for a .js file, so the temp layout gets one.
+      fs.writeFileSync(path.join(root, 'plugins', 'package.json'), '{ "type": "module" }\n');
+      ({ EgcGuardianCrusher } = await import(pathToFileURL(pluginPath).href));
       assert.strictEqual(typeof EgcGuardianCrusher, 'function');
     })) passed++; else failed++;
 


### PR DESCRIPTION
## What changed

OpenCode imports plugin files as ES modules and rejects a CommonJS export object with `Plugin export is not a function`, which left the Guardian, the Token Crusher and the session restoration silently disabled on OpenCode 1.18 (the run continues, the plugin never loads). The plugin file keeps its installed path and now uses ESM syntax: `import` for the builtins, `createRequire` for the CommonJS hook scripts it reuses, `__dirname` from `import.meta.url`, and the plugin function exported by name.

The installed-layout test imports the plugin the way OpenCode does (`await import`), with a `package.json` type hint written only in the temp layout so Node 20 parses the `.js` file as a module. `eslint.config.js` parses the plugin file as a module.

## Evidence

- `opencode run --print-logs --log-level DEBUG` on OpenCode 1.18.18: `failed to load plugin ... error="Plugin export is not a function"` with the current file.
- Isolated config home with a `.js` plugin using ESM syntax and a named export: zero plugin errors, run completes.

## Test plan

- [x] tests/hooks/opencode-egc-plugin.test.js 10/10
- [x] tests/lib/install-targets.test.js 154/154
- [x] eslint on the three files
- [x] full suite locally: 4140/4140
- [ ] CI matrix green
- [ ] after merge: `egc auto-update` on a real machine, then `opencode run --print-logs` shows no `failed to load plugin` line

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenCode plugin on OpenCode 1.18, where OpenCode imports plugins as ES modules and rejects CommonJS exports with `Plugin export is not a function`, leaving the Guardian, Token Crusher, and session restoration silently disabled. The plugin now uses ESM syntax, keeps its installed path, and exports the plugin function by name.

- Loads the CommonJS hook scripts through `createRequire` and builds `__dirname` from `import.meta.url`.
- Updates the installed-layout test to import the plugin with `await import`, adding a `package.json` type hint in the temp layout so Node parses the `.js` file as a module.
- Makes ESLint parse the plugin file as a module.

<sup>Written for commit e9f5899239863d1315ea577ca1c2ac1943243e9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

