### PR TITLE
fix(install): resolve source shape transitions at installed destinations (#1428)

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -120,6 +120,7 @@ function printHumanPlan(plan, dryRun) {
 
   printRetirements(plan, dryRun);
   printLegacyLinks(plan, dryRun);
+  printShapeTransitions(plan, dryRun);
 
   if (!dryRun) {
     console.log(`\nDone. Install-state written to ${plan.installStatePath}`);
@@ -152,6 +153,34 @@ function printLegacyLinks(plan, dryRun) {
     : '\nMigrated legacy links:');
   for (const link of links) {
     console.log(`- ${dryRun ? '' : 'migrated legacy link: '}${link.linkPath} (pointed at ${link.resolvedTo})`);
+  }
+}
+
+// Destinations whose source changed shape between installs: a file that
+// became a source directory, or back, keeps its name but not its shape at
+// the installed destination. The apply retires those files through the same
+// identity check the retirement path uses and refuses anything else; the dry
+// run lists the resolvable transitions and every refusal so the whole state
+// is visible before anything runs.
+function printShapeTransitions(plan, dryRun) {
+  const transitions = plan.shapeTransitions || [];
+  const refusals = plan.shapeRefusals || [];
+  if (transitions.length > 0) {
+    console.log(dryRun
+      ? '\nShape transitions (a source changed between a file and a directory):'
+      : '\nShape transitions applied:');
+    for (const transition of transitions) {
+      const direction = transition.type === 'file-to-dir'
+        ? 'file retired, written as a directory'
+        : 'directory retired, written as a file';
+      console.log(`- ${transition.destinationPath}: ${direction}`);
+    }
+  }
+  if (dryRun && refusals.length > 0) {
+    console.log('\nShape transitions that would refuse the install:');
+    for (const refusal of refusals) {
+      console.log(`- ${refusal.destinationPath}: ${refusal.reason}`);
+    }
   }
 }
 
@@ -380,11 +409,17 @@ function main() {
     enforceTargetDetection(plan, options);
 
     if (options.dryRun) {
-      const { findLegacyLinks, retirableFiles } = require('./lib/install/apply');
+      const { collectShapeTransitions, findLegacyLinks, retirableFiles } = require('./lib/install/apply');
       plan.legacyLinks = findLegacyLinks(plan);
       // The same test the apply runs: a file the person replaced is not
       // listed, because it would not be removed.
       plan.retirements = retirableFiles(plan);
+      // Same again for destinations whose source changed shape: the apply
+      // resolves a transition only when every file passes identity, so the
+      // dry run lists the resolvable transitions and every refusal.
+      const shapeResult = collectShapeTransitions(plan);
+      plan.shapeTransitions = shapeResult.transitions;
+      plan.shapeRefusals = shapeResult.refusals;
       emitDryRunPlan(options, plan);
       return;
     }

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -630,6 +630,97 @@ function collectShapeBlockingEntries(directory) {
   return { files, directories, blocking, inspectable };
 }
 
+// Resolves a destination the plan writes as a directory out of what is today
+// a file: it may be turned into the directory only when the scan can prove
+// the file is EGC's by a previous install. Comes back as a refusal otherwise,
+// or null when the destination already satisfies the planned shape.
+function resolveFileToDirCandidate(destinationPath, { recorded, plan, onDiskFile, onDiskLink, legacyLinks }) {
+  if (onDiskLink) {
+    if (legacyLinks().has(destinationPath)) return null;
+    return {
+      refusal: {
+        destinationPath,
+        reason: 'a symbolic link or special file is in the way that EGC would not migrate',
+      },
+    };
+  }
+  if (!onDiskFile) return null;
+  const recordedEntry = recorded.get(destinationPath);
+  if (!recordedEntry) {
+    return {
+      refusal: {
+        destinationPath,
+        reason: 'a file EGC did not install must not be turned into a directory',
+      },
+    };
+  }
+  if (!isShapeTransitionRemovable(destinationPath, plan)) {
+    return {
+      refusal: {
+        destinationPath,
+        reason: 'a file is in the way that is EGC-modified or changed since install',
+      },
+    };
+  }
+  return {
+    transition: {
+      type: 'file-to-dir',
+      destinationPath,
+      sourceRelativePath: recordedEntry.sourceRelativePath || '',
+    },
+  };
+}
+
+// Resolves a destination the plan writes as a file out of what is today a
+// directory: every regular file inside must be proven EGC's by a previous
+// install, or the transition is refused with the directory untouched. A link
+// or special entry inside, or a directory that cannot even be listed, refuses
+// too -- the walk's empty directories are dropped, being indistinguishable
+// from ones the person made.
+function resolveDirToFileCandidate(destinationPath, { recorded, plan }) {
+  const summary = collectShapeBlockingEntries(destinationPath);
+  if (!summary.inspectable) {
+    return {
+      refusal: {
+        destinationPath,
+        reason: 'a directory that could not be listed must not be silently emptied',
+      },
+    };
+  }
+  if (summary.blocking.length > 0) {
+    return {
+      refusal: {
+        destinationPath,
+        reason: `a symbolic link or special file refuses the transition: ${summary.blocking
+          .map(filePath => path.relative(path.resolve(destinationPath), filePath))
+          .join(', ')}`,
+      },
+    };
+  }
+  const unreconciled = summary.files.filter(filePath => {
+    const recordedEntry = recorded.get(filePath);
+    return !recordedEntry || !isShapeTransitionRemovable(filePath, plan);
+  });
+  if (unreconciled.length > 0) {
+    return {
+      refusal: {
+        destinationPath,
+        reason: `files are in the way whose content is not in this package anymore, so EGC cannot prove they are untouched: ${unreconciled
+          .map(filePath => path.relative(path.resolve(destinationPath), filePath))
+          .join(', ')}`,
+      },
+    };
+  }
+  return {
+    transition: {
+      type: 'dir-to-file',
+      destinationPath,
+      children: [...summary.files].sort((a, b) => a.localeCompare(b)),
+      directories: [...summary.directories, destinationPath].sort((a, b) => a.localeCompare(b)),
+    },
+  };
+}
+
 // Scans the destinations a plan will write to or into for shape transitions,
 // read-only: the dry run lists them and the apply runs them. Anything the
 // scan cannot reconcile is returned as a refusal instead of throwing, so a
@@ -652,11 +743,23 @@ function collectShapeTransitions(plan) {
     return legacyLinkPaths;
   };
 
-  for (const destinationPath of [...plannedFiles, ...plannedParents]) {
+  for (const destinationPath of new Set([...plannedFiles, ...plannedParents])) {
     if (!roots.some(candidate => destinationPath === candidate || destinationPath.startsWith(candidate + path.sep))) continue;
 
     const wantsFile = plannedFiles.has(destinationPath);
     const wantsDirectory = plannedParents.has(destinationPath);
+
+    // The plan both writes this path and writes into it -- structurally
+    // impossible, never let install.sh find out the hard way. Raised before
+    // the destination is even read, so a broken plan refuses on a fresh
+    // install too, and a path in both sets is visited once, for one refusal.
+    if (wantsFile && wantsDirectory) {
+      refusals.push({
+        destinationPath,
+        reason: 'the plan writes this path as both a file and a directory',
+      });
+      continue;
+    }
 
     let stat;
     try {
@@ -666,109 +769,25 @@ function collectShapeTransitions(plan) {
     }
     const onDiskDirectory = stat.isDirectory();
     const onDiskFile = stat.isFile();
-    if (!onDiskFile && !onDiskDirectory) {
-      if (legacyLinks().has(destinationPath)) continue;
-      refusals.push({
-        destinationPath,
-        reason: 'a symbolic link is in the way that EGC would not migrate',
-      });
-      continue;
-    }
 
-    // The plan both writes this path and writes into it -- structurally
-    // impossible, never let install.sh find out the hard way.
-    if (wantsFile && wantsDirectory) {
-      refusals.push({
-        destinationPath,
-        reason: 'the plan writes this path as both a file and a directory',
+    if (wantsDirectory && !onDiskDirectory) {
+      const result = resolveFileToDirCandidate(destinationPath, {
+        recorded,
+        plan,
+        onDiskFile,
+        onDiskLink: !onDiskFile && !onDiskDirectory,
+        legacyLinks,
       });
-      continue;
-    }
-
-    if (wantsDirectory && onDiskFile) {
-      const recordedEntry = recorded.get(destinationPath);
-      if (!recordedEntry) {
-        refusals.push({
-          destinationPath,
-          reason: 'a file EGC did not install must not be turned into a directory',
-        });
-        continue;
-      }
-      if (!isShapeTransitionRemovable(destinationPath, plan)) {
-        refusals.push({
-          destinationPath,
-          reason: 'a file is in the way that is EGC-modified or changed since install',
-        });
-        continue;
-      }
-      transitions.push({
-        type: 'file-to-dir',
-        destinationPath,
-        sourceRelativePath: recordedEntry.sourceRelativePath || '',
-      });
+      if (result.transition) transitions.push(result.transition);
+      else if (result.refusal) refusals.push(result.refusal);
       continue;
     }
 
     if (wantsFile && onDiskDirectory) {
-      const summary = collectShapeBlockingEntries(destinationPath);
-      if (!summary.inspectable) {
-        refusals.push({
-          destinationPath,
-          reason: 'a directory that could not be listed must not be silently emptied',
-        });
-        continue;
-      }
-      if (summary.blocking.length > 0) {
-        refusals.push({
-          destinationPath,
-          reason: `a symbolic link or special file refuses the transition: ${summary.blocking
-            .map(filePath => path.relative(path.resolve(destinationPath), filePath))
-            .join(', ')}`,
-        });
-        continue;
-      }
-      const unreconciled = summary.files.filter(filePath => {
-        const recordedEntry = recorded.get(filePath);
-        return !recordedEntry || !isShapeTransitionRemovable(filePath, plan);
-      });
-      if (unreconciled.length > 0) {
-        refusals.push({
-          destinationPath,
-          reason: `files are in the way that are EGC-modified or changed since install: ${unreconciled
-            .map(filePath => path.relative(path.resolve(destinationPath), filePath))
-            .join(', ')}`,
-        });
-        continue;
-      }
-      // Every directory the walk met, short of the destination itself, must
-      // be proven EGC's by at least one recorded file beneath it. An empty
-      // directory under the destination has no such proof -- it cannot be
-      // told apart from a directory the person made -- so it is refused
-      // instead of silently deleted.
-      const accountedDirectories = new Set();
-      for (const filePath of summary.files) {
-        for (let dir = path.dirname(filePath); dir.startsWith(destinationPath + path.sep); dir = path.dirname(dir)) {
-          accountedDirectories.add(dir);
-        }
-      }
-      const unaccounted = summary.directories.filter(dirPath => !accountedDirectories.has(dirPath));
-      if (unaccounted.length > 0) {
-        refusals.push({
-          destinationPath,
-          reason: `a directory no recorded EGC file accounts for refuses the transition: ${unaccounted
-            .map(filePath => path.relative(path.resolve(destinationPath), filePath))
-            .join(', ')}`,
-        });
-        continue;
-      }
-      // The scan walks filesystem enumeration order; a plan and its report
-      // carry a deterministic order instead.
-      transitions.push({
-        type: 'dir-to-file',
-        destinationPath,
-        children: [...summary.files].sort(),
-        directories: [...summary.directories, destinationPath].sort(),
-      });
+      const result = resolveDirToFileCandidate(destinationPath, { recorded, plan });
+      if (result.transition) transitions.push(result.transition);
+      else if (result.refusal) refusals.push(result.refusal);
+      continue;
     }
   }
 
@@ -779,7 +798,7 @@ function formatShapeTransitionsRefusal(refusals) {
   const lines = refusals.map(refusal => `  ${refusal.destinationPath}: ${refusal.reason}`);
   return (
     `Shape transition refused:\n${lines.join('\n')}\n` +
-    'Move or remove the conflicting paths manually (egc repair only restores files EGC itself copied), then run the install again.'
+    'Move or remove the conflicting destination by hand, then run the install again.'
   );
 }
 
@@ -792,40 +811,59 @@ function performShapeTransitions(transitions, plan) {
   const deepestFirst = [...transitions].sort((a, b) => segments(b.destinationPath) - segments(a.destinationPath));
   const offenders = [];
   for (const transition of deepestFirst) {
-    if (transition.type === 'file-to-dir') {
-      if (!isShapeTransitionRemovable(transition.destinationPath, plan)) {
-        offenders.push({ destinationPath: transition.destinationPath, reason: 'no longer a byte-identical EGC copy' });
-      }
-      continue;
-    }
-    for (const childPath of transition.children) {
-      if (!isShapeTransitionRemovable(childPath, plan)) {
-        offenders.push({ destinationPath: childPath, reason: 'no longer a byte-identical EGC copy' });
-      }
-    }
+    const offender = verifyShapeTransition(transition, plan);
+    if (offender) offenders.push(offender);
   }
   if (offenders.length > 0) {
     throw new Error(formatShapeTransitionsRefusal(offenders));
   }
   for (const transition of deepestFirst) {
-    if (transition.type === 'file-to-dir') {
-      fs.rmSync(transition.destinationPath, { force: true });
-      continue;
+    if (transition.type === 'file-to-dir') performFileToDir(transition);
+    else performDirToFile(transition);
+  }
+}
+
+// Re-checks the bytes of one transition against the disk right before the
+// removals, so nothing EGC cannot prove is its own ever goes: the single file
+// of a file-to-dir transition, every child of a dir-to-file one. Returns the
+// first offender, or null when the transition may proceed.
+function verifyShapeTransition(transition, plan) {
+  if (transition.type === 'file-to-dir') {
+    if (!isShapeTransitionRemovable(transition.destinationPath, plan)) {
+      return { destinationPath: transition.destinationPath, reason: 'no longer a byte-identical EGC copy' };
     }
-    for (const childPath of transition.children) {
-      fs.rmSync(childPath, { force: true });
+    return null;
+  }
+  for (const childPath of transition.children) {
+    if (!isShapeTransitionRemovable(childPath, plan)) {
+      return { destinationPath: childPath, reason: 'no longer a byte-identical EGC copy' };
     }
-    const emptiestFirst = [...transition.directories].sort((a, b) => segments(b) - segments(a));
-    for (const directoryPath of emptiestFirst) {
-      try {
-        fs.rmdirSync(directoryPath);
-      } catch (error) {
-        if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
-        throw new Error(
-          `Refusing to turn ${transition.destinationPath} into a file: ${directoryPath} grew content during the install`,
-          { cause: error }
-        );
-      }
+  }
+  return null;
+}
+
+// Retires the EGC-installed file making room for the planned directory.
+function performFileToDir(transition) {
+  fs.rmSync(transition.destinationPath, { force: true });
+}
+
+// Retires the EGC-installed directory making room for the planned file: its
+// children first, then the directories that held them, deepest first. A
+// directory that grew content while the install ran is refused, not removed.
+function performDirToFile(transition) {
+  for (const childPath of transition.children) {
+    fs.rmSync(childPath, { force: true });
+  }
+  const emptiestFirst = [...transition.directories].sort((a, b) => segments(b) - segments(a));
+  for (const directoryPath of emptiestFirst) {
+    try {
+      fs.rmdirSync(directoryPath);
+    } catch (error) {
+      if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
+      throw new Error(
+        `Refusing to turn ${transition.destinationPath} into a file: ${directoryPath} grew content during the install`,
+        { cause: error }
+      );
     }
   }
 }

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -778,6 +778,10 @@ function collectShapeTransitions(plan) {
         onDiskLink: !onDiskFile && !onDiskDirectory,
         legacyLinks,
       });
+      // null means the destination is a legacy link EGC migrates itself
+      // (#1400) or already satisfies the planned shape: neither a transition
+      // nor a refusal, and the apply's own link machinery owns it.
+      if (!result) continue;
       if (result.transition) transitions.push(result.transition);
       else if (result.refusal) refusals.push(result.refusal);
       continue;

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -5,7 +5,7 @@ const crypto = require('node:crypto');
 const os = require('node:os');
 const path = require('node:path');
 
-const { writeInstallState } = require('../install-state');
+const { readInstallState, writeInstallState } = require('../install-state');
 const { syncInstallStateToStore } = require('../install-state-store-sync');
 const { assertSafeMcpConfig, filterMcpConfig, isMcpConfigPath, parseDisabledMcpServers, parseMcpConfigText } = require('../mcp-config');
 const { copyFileKeepingMode, replaceFileWith, writeTextKeepingMode } = require('./preserving-write');
@@ -512,10 +512,290 @@ function segments(filePath) {
   return path.resolve(filePath).split(path.sep).length;
 }
 
+// A shape transition is a destination where the plan must convert an
+// existing file into a directory, or the reverse: the recorded source moved
+// from one shape to the other (rules/foo.md being a file, then becoming a
+// directory keeps its name but not its shape). A naive apply would falter on
+// EEXIST here after already writing part of the layout, so the transition is
+// resolved first: files are retired through the same identity check
+// retirement uses -- a file a previous install recorded and that is still
+// byte-identical to something this plan copies may go, everything else is
+// refused with a clear message.
+
+// Every copy-file destination a plan writes to or into: the planned files
+// themselves and the directories that contain them, up to each managed root.
+// Only these paths can change shape; a destination the plan stops touching
+// is the retirement path's business, not ours.
+function plannedWriteShapes(plan) {
+  const roots = managedRootsOf(plan);
+  const files = new Set();
+  const parents = new Set();
+  for (const operation of plan.operations) {
+    if (operation.kind !== 'copy-file') continue;
+    const destinationPath = path.resolve(operation.destinationPath);
+    files.add(destinationPath);
+    // The directories the install materializes for that file, each strictly
+    // inside a managed root: a destination the installer writes outside its
+    // roots must not get one of its parents turned into a directory.
+    for (let dir = path.dirname(destinationPath); dir !== path.dirname(dir); dir = path.dirname(dir)) {
+      const root = roots.find(candidate => dir === candidate || dir.startsWith(candidate + path.sep));
+      if (!root) break;
+      parents.add(dir);
+      if (dir === root) break;
+    }
+  }
+  return { files, parents };
+}
+
+// The managed copy-file destinations a previous install recorded, keyed by
+// their resolved path. A missing or unreadable state explains nothing: the
+// caller gets an empty map and every potential retirement is refused, which
+// is the honest answer when we cannot prove a file is ours.
+function previousStateManagedCopies(plan) {
+  const recorded = new Map();
+  let operations;
+  try {
+    operations = readInstallState(plan.installStatePath).operations || [];
+  } catch {
+    return recorded;
+  }
+  for (const operation of operations) {
+    if (operation.kind !== 'copy-file' || operation.ownership !== 'managed') continue;
+    recorded.set(path.resolve(operation.destinationPath), operation);
+  }
+  return recorded;
+}
+
+// The identity check for a file a shape transition wants to retire. Where a
+// normal retirement also allows the original source file to still exist and
+// match, a transition's recorded source is by definition gone or changed
+// shape, so identity is only ever established against the files this plan
+// copies today.
+function isShapeTransitionRemovable(filePath, plan) {
+  let stat;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch {
+    return false;
+  }
+  if (!stat.isFile()) return false;
+  const root = managedRootFor(plan, filePath);
+  if (!root) return false;
+  for (let dir = path.dirname(filePath); dir !== root && dir.startsWith(root + path.sep); dir = path.dirname(dir)) {
+    if (isSymbolicLink(dir)) return false;
+  }
+  let content;
+  try {
+    content = fs.readFileSync(filePath);
+  } catch {
+    return false;
+  }
+  return plannedContentHashes(plan).has(sha256(content));
+}
+
+// Everything inside a directory a dir-to-file transition has to give way for,
+// recursed depth-first: the regular files (each must pass identity before it
+// can go), the directories that hold them (dropped once empty), and anything
+// that is neither -- a link, a socket... -- that refuses the transition
+// outright. A directory that cannot even be listed cannot be safely emptied,
+// so it refuses too.
+function collectShapeBlockingEntries(directory) {
+  const files = [];
+  const directories = [];
+  const blocking = [];
+  let inspectable = true;
+
+  const walk = current => {
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      inspectable = false;
+      return;
+    }
+    for (const entry of entries) {
+      const resolved = path.join(current, entry.name);
+      if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+        blocking.push(resolved);
+      } else if (entry.isDirectory()) {
+        directories.push(resolved);
+        walk(resolved);
+      } else {
+        files.push(resolved);
+      }
+    }
+  };
+
+  walk(directory);
+  return { files, directories, blocking, inspectable };
+}
+
+// Scans the destinations a plan will write to or into for shape transitions,
+// read-only: the dry run lists them and the apply runs them. Anything the
+// scan cannot reconcile is returned as a refusal instead of throwing, so a
+// dry run can show every problem at once and the apply refuses before the
+// first write.
+function collectShapeTransitions(plan) {
+  const recorded = previousStateManagedCopies(plan);
+  const transitions = [];
+  const refusals = [];
+  const { files: plannedFiles, parents: plannedParents } = plannedWriteShapes(plan);
+  const roots = managedRootsOf(plan);
+
+  for (const destinationPath of [...plannedFiles, ...plannedParents]) {
+    if (!roots.some(candidate => destinationPath === candidate || destinationPath.startsWith(candidate + path.sep))) continue;
+
+    const wantsFile = plannedFiles.has(destinationPath);
+    const wantsDirectory = plannedParents.has(destinationPath);
+
+    let stat;
+    try {
+      stat = fs.lstatSync(destinationPath);
+    } catch {
+      continue;
+    }
+    const onDiskDirectory = stat.isDirectory();
+    const onDiskFile = stat.isFile();
+    if (!onDiskFile && !onDiskDirectory) continue; // a link is the apply's business
+
+    // The plan both writes this path and writes into it -- structurally
+    // impossible, never let install.sh find out the hard way.
+    if (wantsFile && wantsDirectory) {
+      refusals.push({
+        destinationPath,
+        reason: 'the plan writes this path as both a file and a directory',
+      });
+      continue;
+    }
+
+    if (wantsDirectory && onDiskFile) {
+      const recordedEntry = recorded.get(destinationPath);
+      if (!recordedEntry) {
+        refusals.push({
+          destinationPath,
+          reason: 'a file EGC did not install must not be turned into a directory',
+        });
+        continue;
+      }
+      if (!isShapeTransitionRemovable(destinationPath, plan)) {
+        refusals.push({
+          destinationPath,
+          reason: 'a file is in the way that is EGC-modified or changed since install',
+        });
+        continue;
+      }
+      transitions.push({
+        type: 'file-to-dir',
+        destinationPath,
+        sourceRelativePath: recordedEntry.sourceRelativePath || '',
+      });
+      continue;
+    }
+
+    if (wantsFile && onDiskDirectory) {
+      const summary = collectShapeBlockingEntries(destinationPath);
+      if (!summary.inspectable) {
+        refusals.push({
+          destinationPath,
+          reason: 'a directory that could not be listed must not be silently emptied',
+        });
+        continue;
+      }
+      if (summary.blocking.length > 0) {
+        refusals.push({
+          destinationPath,
+          reason: `a symbolic link or special file refuses the transition: ${summary.blocking
+            .map(filePath => path.relative(path.resolve(destinationPath), filePath))
+            .join(', ')}`,
+        });
+        continue;
+      }
+      const unreconciled = summary.files.filter(filePath => {
+        const recordedEntry = recorded.get(filePath);
+        return !recordedEntry || !isShapeTransitionRemovable(filePath, plan);
+      });
+      if (unreconciled.length > 0) {
+        refusals.push({
+          destinationPath,
+          reason: `files are in the way that are EGC-modified or changed since install: ${unreconciled
+            .map(filePath => path.relative(path.resolve(destinationPath), filePath))
+            .join(', ')}`,
+        });
+        continue;
+      }
+      transitions.push({
+        type: 'dir-to-file',
+        destinationPath,
+        children: summary.files,
+        directories: [...summary.directories, destinationPath],
+      });
+    }
+  }
+
+  return { transitions, refusals };
+}
+
+function formatShapeTransitionsRefusal(refusals) {
+  const lines = refusals.map(refusal => `  ${refusal.destinationPath}: ${refusal.reason}`);
+  return (
+    `Shape transition refused before anything was written:\n${lines.join('\n')}\n` +
+    'Overwrite with care, or clean up the destination and try the install again.'
+  );
+}
+
+// Converts the collected transitions. Deepest first so a nested transition is
+// resolved before the one it is inside. Every file is re-verified again
+// immediately before it is removed (a scan is a snapshot, the filesystem is
+// not) and directories are only removed once empty, so a path that changed
+// between the scan and the removal is refused, never deleted.
+function performShapeTransitions(transitions, plan) {
+  const deepestFirst = [...transitions].sort((a, b) => segments(b.destinationPath) - segments(a.destinationPath));
+  for (const transition of deepestFirst) {
+    if (transition.type === 'file-to-dir') {
+      if (!isShapeTransitionRemovable(transition.destinationPath, plan)) {
+        throw new Error(
+          `Refusing to turn ${transition.destinationPath} into a directory: it is no longer a byte-identical EGC copy`
+        );
+      }
+      fs.rmSync(transition.destinationPath, { force: true });
+      continue;
+    }
+    for (const childPath of transition.children) {
+      if (!isShapeTransitionRemovable(childPath, plan)) {
+        throw new Error(
+          `Refusing to turn ${transition.destinationPath} into a file: ${childPath} is no longer a byte-identical EGC copy`
+        );
+      }
+      fs.rmSync(childPath, { force: true });
+    }
+    const emptiestFirst = [...transition.directories].sort((a, b) => segments(b) - segments(a));
+    for (const directoryPath of emptiestFirst) {
+      try {
+        fs.rmdirSync(directoryPath);
+      } catch (error) {
+        if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
+        throw new Error(
+          `Refusing to turn ${transition.destinationPath} into a file: ${directoryPath} grew content during the install`,
+          { cause: error }
+        );
+      }
+    }
+  }
+}
+
 function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
 
   const resolvedClaudeHooksPlan = buildResolvedClaudeHooks(plan);
   const disabledServers = parseDisabledMcpServers(process.env.EGC_DISABLED_MCPS || process.env.ECC_DISABLED_MCPS);
+
+  // Shape transitions are resolved before the first write: a refusal throws
+  // with the layout still untouched, so a source that changed shape between
+  // installs fails clearly instead of hitting EEXIST mid-copy.
+  const shapeResult = collectShapeTransitions(plan);
+  if (shapeResult.refusals.length > 0) {
+    throw new Error(formatShapeTransitionsRefusal(shapeResult.refusals));
+  }
+  plan.shapeTransitions = shapeResult.transitions;
 
   // Every destination is checked before the first write, the state file and
   // the hooks file included, so a planted link fails the install before it
@@ -526,6 +806,7 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
   // after this point is refused like any other.
   const migratedLegacyLinks = findLegacyLinks(plan, { strict: true });
   removeLegacyLinks(migratedLegacyLinks, plan.targetRoot);
+  performShapeTransitions(plan.shapeTransitions, plan);
   refuseLinkedDestination(plan.installStatePath, plan.targetRoot);
   if (resolvedClaudeHooksPlan) refuseLinkedDestination(resolvedClaudeHooksPlan.hooksDestinationPath, plan.targetRoot);
   for (const operation of plan.operations) {
@@ -583,7 +864,7 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
     },
   });
 
-  const result = { ...plan, applied: true, migratedLegacyLinks, retiredFiles };
+  const result = { ...plan, applied: true, migratedLegacyLinks, retiredFiles, shapeTransitions: shapeResult.transitions };
   Object.defineProperty(result, 'syncPromise', {
     value: syncPromise,
     enumerable: false,
@@ -605,6 +886,9 @@ module.exports = {
   removeLegacyLinks,
   writeGuardianCliMarker,
   writeManagedText,
+  collectShapeTransitions,
+  performShapeTransitions,
+  formatShapeTransitionsRefusal,
 
 
 

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -641,6 +641,16 @@ function collectShapeTransitions(plan) {
   const refusals = [];
   const { files: plannedFiles, parents: plannedParents } = plannedWriteShapes(plan);
   const roots = managedRootsOf(plan);
+  // The links this run migrates as EGC's own June 2026 legacy layout
+  // (#1400). A planned path that is one of them is the apply's business and
+  // is left for it; any other link the scan meets is refused here too, so a
+  // dry run shows exactly what the apply will do. Resolved on the first link
+  // the scan meets, never before one.
+  let legacyLinkPaths = null;
+  const legacyLinks = () => {
+    if (!legacyLinkPaths) legacyLinkPaths = new Set(findLegacyLinks(plan).map(link => link.linkPath));
+    return legacyLinkPaths;
+  };
 
   for (const destinationPath of [...plannedFiles, ...plannedParents]) {
     if (!roots.some(candidate => destinationPath === candidate || destinationPath.startsWith(candidate + path.sep))) continue;
@@ -656,7 +666,14 @@ function collectShapeTransitions(plan) {
     }
     const onDiskDirectory = stat.isDirectory();
     const onDiskFile = stat.isFile();
-    if (!onDiskFile && !onDiskDirectory) continue; // a link is the apply's business
+    if (!onDiskFile && !onDiskDirectory) {
+      if (legacyLinks().has(destinationPath)) continue;
+      refusals.push({
+        destinationPath,
+        reason: 'a symbolic link is in the way that EGC would not migrate',
+      });
+      continue;
+    }
 
     // The plan both writes this path and writes into it -- structurally
     // impossible, never let install.sh find out the hard way.
@@ -723,11 +740,34 @@ function collectShapeTransitions(plan) {
         });
         continue;
       }
+      // Every directory the walk met, short of the destination itself, must
+      // be proven EGC's by at least one recorded file beneath it. An empty
+      // directory under the destination has no such proof -- it cannot be
+      // told apart from a directory the person made -- so it is refused
+      // instead of silently deleted.
+      const accountedDirectories = new Set();
+      for (const filePath of summary.files) {
+        for (let dir = path.dirname(filePath); dir.startsWith(destinationPath + path.sep); dir = path.dirname(dir)) {
+          accountedDirectories.add(dir);
+        }
+      }
+      const unaccounted = summary.directories.filter(dirPath => !accountedDirectories.has(dirPath));
+      if (unaccounted.length > 0) {
+        refusals.push({
+          destinationPath,
+          reason: `a directory no recorded EGC file accounts for refuses the transition: ${unaccounted
+            .map(filePath => path.relative(path.resolve(destinationPath), filePath))
+            .join(', ')}`,
+        });
+        continue;
+      }
+      // The scan walks filesystem enumeration order; a plan and its report
+      // carry a deterministic order instead.
       transitions.push({
         type: 'dir-to-file',
         destinationPath,
-        children: summary.files,
-        directories: [...summary.directories, destinationPath],
+        children: [...summary.files].sort(),
+        directories: [...summary.directories, destinationPath].sort(),
       });
     }
   }
@@ -738,34 +778,41 @@ function collectShapeTransitions(plan) {
 function formatShapeTransitionsRefusal(refusals) {
   const lines = refusals.map(refusal => `  ${refusal.destinationPath}: ${refusal.reason}`);
   return (
-    `Shape transition refused before anything was written:\n${lines.join('\n')}\n` +
-    'Overwrite with care, or clean up the destination and try the install again.'
+    `Shape transition refused:\n${lines.join('\n')}\n` +
+    'Move or remove the conflicting paths manually (egc repair only restores files EGC itself copied), then run the install again.'
   );
 }
 
 // Converts the collected transitions. Deepest first so a nested transition is
-// resolved before the one it is inside. Every file is re-verified again
-// immediately before it is removed (a scan is a snapshot, the filesystem is
-// not) and directories are only removed once empty, so a path that changed
-// between the scan and the removal is refused, never deleted.
+// resolved before the one it is inside. Every file is verified before any is
+// removed -- a transition is all-or-nothing, never a child at a time -- so a
+// file that changed between the scan and the removal is refused with the
+// whole layout still in place, and directories are only removed once empty.
 function performShapeTransitions(transitions, plan) {
   const deepestFirst = [...transitions].sort((a, b) => segments(b.destinationPath) - segments(a.destinationPath));
+  const offenders = [];
   for (const transition of deepestFirst) {
     if (transition.type === 'file-to-dir') {
       if (!isShapeTransitionRemovable(transition.destinationPath, plan)) {
-        throw new Error(
-          `Refusing to turn ${transition.destinationPath} into a directory: it is no longer a byte-identical EGC copy`
-        );
+        offenders.push({ destinationPath: transition.destinationPath, reason: 'no longer a byte-identical EGC copy' });
       }
-      fs.rmSync(transition.destinationPath, { force: true });
       continue;
     }
     for (const childPath of transition.children) {
       if (!isShapeTransitionRemovable(childPath, plan)) {
-        throw new Error(
-          `Refusing to turn ${transition.destinationPath} into a file: ${childPath} is no longer a byte-identical EGC copy`
-        );
+        offenders.push({ destinationPath: childPath, reason: 'no longer a byte-identical EGC copy' });
       }
+    }
+  }
+  if (offenders.length > 0) {
+    throw new Error(formatShapeTransitionsRefusal(offenders));
+  }
+  for (const transition of deepestFirst) {
+    if (transition.type === 'file-to-dir') {
+      fs.rmSync(transition.destinationPath, { force: true });
+      continue;
+    }
+    for (const childPath of transition.children) {
       fs.rmSync(childPath, { force: true });
     }
     const emptiestFirst = [...transition.directories].sort((a, b) => segments(b) - segments(a));
@@ -797,6 +844,28 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
   }
   plan.shapeTransitions = shapeResult.transitions;
 
+  // A transition is only performed when the operation that will consume it is
+  // reached: a dir-to-file right before the file write that replaces the
+  // directory, a file-to-dir before the first child copy that needs it. A
+  // failure in an earlier operation then leaves the old layout in place
+  // instead of deleting it and never replacing it.
+  const pendingTransitions = new Map(
+    (plan.shapeTransitions || []).map(transition => [path.resolve(transition.destinationPath), transition])
+  );
+  const performPendingTransitionsFor = destinationPath => {
+    const resolved = path.resolve(destinationPath);
+    const due = [];
+    for (const [target, transition] of pendingTransitions) {
+      if (resolved === target || resolved.startsWith(target + path.sep)) due.push(transition);
+    }
+    if (due.length === 0) return;
+    due.sort((a, b) => segments(b.destinationPath) - segments(a.destinationPath));
+    for (const transition of due) {
+      performShapeTransitions([transition], plan);
+      pendingTransitions.delete(path.resolve(transition.destinationPath));
+    }
+  };
+
   // Every destination is checked before the first write, the state file and
   // the hooks file included, so a planted link fails the install before it
   // changes anything. Links that are EGC's own legacy layout (#1400) are
@@ -806,12 +875,12 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
   // after this point is refused like any other.
   const migratedLegacyLinks = findLegacyLinks(plan, { strict: true });
   removeLegacyLinks(migratedLegacyLinks, plan.targetRoot);
-  performShapeTransitions(plan.shapeTransitions, plan);
   refuseLinkedDestination(plan.installStatePath, plan.targetRoot);
   if (resolvedClaudeHooksPlan) refuseLinkedDestination(resolvedClaudeHooksPlan.hooksDestinationPath, plan.targetRoot);
   for (const operation of plan.operations) {
 
     refuseLinkedDestination(operation.destinationPath, managedRootFor(plan, operation.destinationPath));
+    performPendingTransitionsFor(operation.destinationPath);
 
     fs.mkdirSync(path.dirname(operation.destinationPath), { recursive: true });
 
@@ -831,6 +900,11 @@ function applyInstallPlan(plan, { onWarning, homeDir, dbPath } = {}) {
 
     }
   }
+
+  // A listed transition always has its consuming operation; a transition
+  // still pending here could not have been reached by the loop and is
+  // resolved so the report matches the disk.
+  performShapeTransitions([...pendingTransitions.values()], plan);
 
   if (resolvedClaudeHooksPlan) {
     refuseLinkedDestination(resolvedClaudeHooksPlan.hooksDestinationPath, plan.targetRoot);

--- a/tests/lib/install-apply-links.test.js
+++ b/tests/lib/install-apply-links.test.js
@@ -579,7 +579,7 @@ function runTests() {
       assert.deepStrictEqual(transitions[0], {
         type: 'dir-to-file',
         destinationPath: path.join(root, 'widget'),
-        children: [path.join(root, 'widget', 'use.md'), path.join(root, 'widget', 'notes.md')].sort(),
+        children: [path.join(root, 'widget', 'use.md'), path.join(root, 'widget', 'notes.md')].sort((a, b) => a.localeCompare(b)),
         directories: [path.join(root, 'widget')],
       }, 'the apply reports the transition in a deterministic order');
     })) passed++; else failed++;
@@ -768,9 +768,73 @@ function runTests() {
       assert.ok(fs.lstatSync(path.join(root, 'rules', 'foo.md')).isSymbolicLink(), 'the link is untouched');
       assert.ok(!fs.existsSync(path.join(root, 'rules', 'foo.md', 'index.md')), 'nothing is written behind it');
       })) passed++; else failed++;
+
+      if (test('a symbolic link inside the directory a dir-to-file wants refuses the transition', () => {
+        const base = path.join(dir, 'shape-d2f-linkchild');
+        const sourceDir = path.join(base, 'source');
+        const root = path.join(base, 'root');
+        const statePath = path.join(base, 'egc', 'install-state.json');
+        const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+        fs.mkdirSync(sourceDir, { recursive: true });
+        ['widget', 'widget-old-use.md'].forEach(name =>
+          fs.writeFileSync(path.join(sourceDir, name), name === 'widget' ? 'new widget' : `${name} bytes`)
+        );
+        fs.mkdirSync(path.join(root, 'widget'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'widget-old-use.md bytes');
+        const ghostDir = path.join(base, 'foreign');
+        fs.mkdirSync(ghostDir, { recursive: true });
+        fs.writeFileSync(path.join(ghostDir, 'ghost.md'), 'not EGC');
+        fs.symlinkSync(path.join(ghostDir, 'ghost.md'), path.join(root, 'widget', 'link.md'));
+        const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+          kind: 'copy-file',
+          moduleId: 'egc-universal',
+          sourcePath,
+          sourceRelativePath,
+          destinationPath,
+          strategy: 'preserve-relative-path',
+          ownership: 'managed',
+          scaffoldOnly: false,
+        });
+        const buildState = operations => createInstallState({
+          adapter,
+          targetRoot: root,
+          installStatePath: statePath,
+          request: { profile: null },
+          resolution: {},
+          source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+          operations,
+        });
+        writeInstallState(statePath, buildState([
+          copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+        ]));
+        const operations = [
+          copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
+          copyOp(path.join(sourceDir, 'widget-old-use.md'), 'widget-old-use.md', path.join(root, 'widget-old-use.md')),
+        ];
+        const plan = {
+          adapter,
+          targetRoot: root,
+          managedRoots: [root],
+          installStatePath: statePath,
+          retirements: [],
+          operations,
+          statePreview: buildState(operations),
+        };
+        const { transitions, refusals } = collectShapeTransitions(plan);
+        assert.strictEqual(transitions.length, 0, 'nothing is promised while a link sits inside the directory');
+        assert.strictEqual(refusals.length, 1, 'the link refuses the dir-to-file transition');
+        assert.strictEqual(refusals[0].destinationPath, path.join(root, 'widget'));
+        assert.ok(refusals[0].reason.includes('symbolic link or special file'), refusals[0].reason);
+        assert.ok(refusals[0].reason.includes('link.md'), 'the refusal names the blocking entry');
+        assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the apply refuses before anything changes');
+        assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'the directory stays');
+        assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'widget-old-use.md bytes', 'the reconcilable child stays');
+        assert.ok(fs.lstatSync(path.join(root, 'widget', 'link.md')).isSymbolicLink(), 'the link stays');
+        assert.ok(!fs.existsSync(path.join(root, 'widget-old-use.md')), 'nothing is written');
+      })) passed++; else failed++;
     }
 
-    if (test('a directory in the way of a file that contains an empty subdirectory no recorded file accounts for refuses', () => {
+    if (test('an empty subdirectory the person made inside a dir-to-file directory is dropped with the transition (settled in review)', () => {
       const base = path.join(dir, 'shape-d2f-emptydir');
       const sourceDir = path.join(base, 'source');
       const root = path.join(base, 'root');
@@ -807,9 +871,10 @@ function runTests() {
         copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
       ]));
       // The widget children reconcile against the flattened old files the
-      // plan still copies; only the empty subdirectory the person made is
-      // unaccounted for, and it refuses the transition instead of being
-      // silently deleted.
+      // plan still copies. The empty unused/ subdirectory the person made has
+      // no recorded file beneath it; the review settled that it is
+      // indistinguishable from a directory EGC itself made, so it goes with
+      // the transition -- a file inside it would refuse it instead.
       const operations = [
         copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
         copyOp(path.join(sourceDir, 'widget-old-use.md'), 'widget-old-use.md', path.join(root, 'widget-old-use.md')),
@@ -825,14 +890,163 @@ function runTests() {
         statePreview: buildState(operations),
       };
       const { transitions, refusals } = collectShapeTransitions(plan);
-      assert.strictEqual(transitions.length, 0, 'nothing is promised while an unaccounted directory sits in the way');
-      assert.strictEqual(refusals.length, 1, 'the empty subdirectory the person made refuses, it is not silently deleted');
-      assert.strictEqual(refusals[0].destinationPath, path.join(root, 'widget'));
-      assert.ok(refusals[0].reason.includes('no recorded EGC file accounts for'), refusals[0].reason);
-      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the apply refuses too');
-      assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'the directory stays');
-      assert.ok(fs.statSync(path.join(root, 'widget', 'unused')).isDirectory(), 'the person-made subdirectory stays');
-      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'widget-old-use.md bytes');
+      assert.strictEqual(transitions.length, 1, 'the resolvable dir-to-file transition is listed');
+      assert.strictEqual(refusals.length, 0, 'an empty unrecorded subdirectory does not refuse');
+      assert.ok(transitions[0].directories.includes(path.join(root, 'widget', 'unused')), 'the dropped subdirectory is part of the transition');
+      const result = applyInstallPlan(plan, { homeDir: base });
+      assert.ok(fs.statSync(path.join(root, 'widget')).isFile(), 'the directory becomes the file');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget'), 'utf8'), 'new widget', 'the file content is EGC\'s');
+      assert.ok(!fs.existsSync(path.join(root, 'widget', 'unused')), 'the empty subdirectory the person made is dropped with the transition');
+      assert.strictEqual(result.shapeTransitions.length, 1, 'the apply reports the transition');
+    })) passed++; else failed++;
+
+    if (test('a destination the plan writes both as a file and a directory refuses on a fresh install, exactly once', () => {
+      const base = path.join(dir, 'shape-both-shapes');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(path.join(sourceDir, 'rules', 'foo.md'), { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, 'rules', 'foo.md', 'index.md'), 'foo child');
+      fs.writeFileSync(path.join(sourceDir, 'rules-file.md'), 'rules as a file');
+      fs.mkdirSync(root, { recursive: true });
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([]));
+      // The same path is a planned file (root/rules) and a planned parent
+      // (root/rules/foo.md/index.md writes into it): structurally impossible.
+      const operations = [
+        copyOp(path.join(sourceDir, 'rules-file.md'), 'rules-file.md', path.join(root, 'rules')),
+        copyOp(path.join(sourceDir, 'rules', 'foo.md', 'index.md'), 'rules/foo.md/index.md', path.join(root, 'rules', 'foo.md', 'index.md')),
+      ];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      // Fresh install: root/rules does not exist, and the refusal still fires,
+      // because the plan is structurally broken no matter what is on disk.
+      const fresh = collectShapeTransitions(plan);
+      assert.strictEqual(fresh.transitions.length, 0, 'nothing is promised');
+      assert.strictEqual(fresh.refusals.length, 1, 'the both-shapes path refuses once, not twice');
+      assert.strictEqual(fresh.refusals[0].destinationPath, path.join(root, 'rules'));
+      assert.ok(fresh.refusals[0].reason.includes('both a file and a directory'), fresh.refusals[0].reason);
+      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the apply refuses on a fresh install too');
+      assert.ok(!fs.existsSync(path.join(root, 'rules')), 'nothing was written before the refusal');
+      // With the path present as a directory, the same single refusal holds:
+      // the path is visited once across both planned sets.
+      fs.mkdirSync(path.join(root, 'rules'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'rules', 'person.md'), 'mine');
+      const existing = collectShapeTransitions(plan);
+      assert.strictEqual(existing.transitions.length, 0, 'still nothing promised');
+      assert.strictEqual(existing.refusals.length, 1, 'still exactly one refusal');
+      assert.ok(existing.refusals[0].reason.includes('both a file and a directory'), existing.refusals[0].reason);
+      assert.strictEqual(fs.readFileSync(path.join(root, 'rules', 'person.md'), 'utf8'), 'mine', 'the existing path was touched by nothing');
+      assert.ok(fs.statSync(path.join(root, 'rules')).isDirectory(), 'the directory the person made stays');
+    })) passed++; else failed++;
+
+    if (test('a directory in the way of a file that cannot be listed refuses the dir-to-file transition', () => {
+      const base = path.join(dir, 'shape-d2f-unlistable');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(sourceDir, { recursive: true });
+      ['widget', 'widget-old-use.md'].forEach(name =>
+        fs.writeFileSync(path.join(sourceDir, name), name === 'widget' ? 'new widget' : `${name} bytes`)
+      );
+      fs.mkdirSync(path.join(root, 'widget'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'widget-old-use.md bytes');
+      fs.mkdirSync(path.join(root, 'widget', 'sealed'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'sealed', 'gone.ts'), 'x');
+      // A subdirectory the walk cannot list must refuse the whole transition,
+      // never be silently emptied. Whether the mode really seals it is
+      // checked, not assumed: root, and any uid with CAP_DAC_OVERRIDE, reads
+      // it anyway.
+      fs.chmodSync(path.join(root, 'widget', 'sealed'), 0o300);
+      let unreadable = false;
+      try {
+        fs.readdirSync(path.join(root, 'widget', 'sealed'));
+      } catch {
+        unreadable = true;
+      }
+      if (!unreadable) {
+        fs.chmodSync(path.join(root, 'widget', 'sealed'), 0o700);
+        console.log('  - skipped: this process can read a mode 0300 directory');
+        return;
+      }
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([
+        copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+      ]));
+      const operations = [
+        copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
+        copyOp(path.join(sourceDir, 'widget-old-use.md'), 'widget-old-use.md', path.join(root, 'widget-old-use.md')),
+      ];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      try {
+        const { transitions, refusals } = collectShapeTransitions(plan);
+        assert.strictEqual(transitions.length, 0, 'nothing is promised while a directory cannot be listed');
+        assert.strictEqual(refusals.length, 1, 'the unlistable directory refuses the transition');
+        assert.strictEqual(refusals[0].destinationPath, path.join(root, 'widget'));
+        assert.ok(refusals[0].reason.includes('could not be listed'), refusals[0].reason);
+        assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the apply refuses before anything changes');
+        assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'the directory stays');
+        assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'widget-old-use.md bytes', 'the reconcilable child stays');
+      } finally {
+        try {
+          fs.chmodSync(path.join(root, 'widget', 'sealed'), 0o700);
+        } catch {
+          /* restore best effort */
+        }
+      }
     })) passed++; else failed++;
 
     if (test('a flatten whose replacement matches none of the recorded children refuses: the honest outcome when the content is new', () => {

--- a/tests/lib/install-apply-links.test.js
+++ b/tests/lib/install-apply-links.test.js
@@ -9,7 +9,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { checkedDestinations, findLegacyLinks, managedRootFor, refuseLinkedDestination, removeLegacyLinks, retirePlannedFiles, writeGuardianCliMarker, writeManagedText } = require('../../scripts/lib/install/apply');
+const { applyInstallPlan, checkedDestinations, collectShapeTransitions, findLegacyLinks, managedRootFor, refuseLinkedDestination, removeLegacyLinks, retirePlannedFiles, writeGuardianCliMarker, writeManagedText } = require('../../scripts/lib/install/apply');
 
 const { createInstallState, writeInstallState } = require('../../scripts/lib/install-state');
 
@@ -406,6 +406,361 @@ function runTests() {
         if (fs.existsSync(sealed)) fs.chmodSync(sealed, 0o700);
       }
       assert.ok(fs.existsSync(sealed), 'a parent that could not be read is left where it is');
+    })) passed++; else failed++;
+
+    if (test('a destination file whose source became a directory is retired and replaced by the directory (file-to-dir)', () => {
+      const base = path.join(dir, 'shape-f2d-ok');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(path.join(sourceDir, 'rules', 'foo.md'), { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, 'rules', 'foo.md', 'index.md'), 'foo child');
+      fs.mkdirSync(path.join(root, 'rules'), { recursive: true });
+      // A previous install wrote rules/foo.md as a FILE whose bytes happen to
+      // match the child the now-directory source carries today.
+      fs.writeFileSync(path.join(root, 'rules', 'foo.md'), 'foo child');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([copyOp(
+        path.join(sourceDir, 'rules', 'foo.md'),
+        'rules/foo.md',
+        path.join(root, 'rules', 'foo.md')
+      )]));
+      const operations = [copyOp(
+        path.join(sourceDir, 'rules', 'foo.md', 'index.md'),
+        'rules/foo.md/index.md',
+        path.join(root, 'rules', 'foo.md', 'index.md')
+      )];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      const result = applyInstallPlan(plan, { homeDir: base });
+      assert.ok(fs.statSync(path.join(root, 'rules', 'foo.md')).isDirectory(), 'the old file becomes the directory');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'rules', 'foo.md', 'index.md'), 'utf8'), 'foo child', 'the child lands inside');
+      assert.deepStrictEqual(result.shapeTransitions, [
+        { type: 'file-to-dir', destinationPath: path.join(root, 'rules', 'foo.md'), sourceRelativePath: 'rules/foo.md' },
+      ], 'the apply reports the transition');
+    })) passed++; else failed++;
+
+    if (test('a file in the way of a directory that is no longer a byte-identical EGC copy refuses the file-to-dir transition', () => {
+      const base = path.join(dir, 'shape-f2d-edit');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(path.join(sourceDir, 'rules', 'foo.md'), { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, 'rules', 'foo.md', 'index.md'), 'foo child');
+      fs.mkdirSync(path.join(root, 'rules'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'rules', 'foo.md'), 'user edited this, not EGC');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([copyOp(
+        path.join(sourceDir, 'rules', 'foo.md'),
+        'rules/foo.md',
+        path.join(root, 'rules', 'foo.md')
+      )]));
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations: [copyOp(
+          path.join(sourceDir, 'rules', 'foo.md', 'index.md'),
+          'rules/foo.md/index.md',
+          path.join(root, 'rules', 'foo.md', 'index.md')
+        )],
+        statePreview: buildState([]),
+      };
+      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'nothing is written when the file would have to go');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'rules', 'foo.md'), 'utf8'), 'user edited this, not EGC', 'the file the person changed stays');
+      assert.ok(!fs.existsSync(path.join(root, 'rules', 'foo.md', 'index.md')), 'nothing is written under it');
+    })) passed++; else failed++;
+
+    if (test('a destination directory whose source became a file is emptied and replaced by the file (dir-to-file)', () => {
+      const base = path.join(dir, 'shape-d2f-ok');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      // The package flattened widget/use.md and widget/notes.md and turned
+      // widget into a plain file: the old bytes survive at new destinations.
+      fs.mkdirSync(sourceDir, { recursive: true });
+      ['widget', 'widget-old-use.md', 'widget-old-notes.md'].forEach(name =>
+        fs.writeFileSync(path.join(sourceDir, name), name === 'widget' ? 'new widget' : `${name} bytes`)
+      );
+      fs.mkdirSync(path.join(root, 'widget'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'widget-old-use.md bytes');
+      fs.writeFileSync(path.join(root, 'widget', 'notes.md'), 'widget-old-notes.md bytes');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([
+        copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+        copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
+      ]));
+      const operations = [
+        copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
+        copyOp(path.join(sourceDir, 'widget-old-use.md'), 'widget-old-use.md', path.join(root, 'widget-old-use.md')),
+        copyOp(path.join(sourceDir, 'widget-old-notes.md'), 'widget-old-notes.md', path.join(root, 'widget-old-notes.md')),
+      ];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      const result = applyInstallPlan(plan, { homeDir: base });
+      assert.ok(fs.statSync(path.join(root, 'widget')).isFile(), 'the directory becomes the file');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget'), 'utf8'), 'new widget', 'the file content is EGC\'s');
+      assert.ok(!fs.existsSync(path.join(root, 'widget', 'use.md')), 'the moved-away child is gone');
+      const transitions = result.shapeTransitions;
+      assert.strictEqual(transitions.length, 1, 'one transition reported');
+      assert.deepStrictEqual(transitions[0], {
+        type: 'dir-to-file',
+        destinationPath: path.join(root, 'widget'),
+        children: process.platform === 'win32'
+          ? [path.join(root, 'widget', 'notes.md'), path.join(root, 'widget', 'use.md')].sort()
+          : [path.join(root, 'widget', 'use.md'), path.join(root, 'widget', 'notes.md')].sort(),
+        directories: [path.join(root, 'widget')],
+      }, 'the apply reports the transition');
+    })) passed++; else failed++;
+
+    if (test('a directory in the way of a file whose child is no longer a byte-identical EGC copy refuses the dir-to-file transition', () => {
+      const base = path.join(dir, 'shape-d2f-edit');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(sourceDir, { recursive: true });
+      ['widget', 'widget-old-use.md', 'widget-old-notes.md'].forEach(name =>
+        fs.writeFileSync(path.join(sourceDir, name), name === 'widget' ? 'new widget' : `${name} bytes`)
+      );
+      fs.mkdirSync(path.join(root, 'widget'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'the person changed this child');
+      fs.writeFileSync(path.join(root, 'widget', 'notes.md'), 'widget-old-notes.md bytes');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([
+        copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+        copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
+      ]));
+      const operations = [copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget'))];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the whole directory refuses before anything goes');
+      assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'the directory stays intact');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'the person changed this child', 'the changed child stays');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'notes.md'), 'utf8'), 'widget-old-notes.md bytes', 'and so does the rest of it');
+      assert.ok(!fs.existsSync(path.join(root, 'widget-old-use.md')), 'nothing is written');
+    })) passed++; else failed++;
+
+    if (test('collectShapeTransitions is read-only: it lists the resolvable transitions and every refusal without touching the disk (the dry run)', () => {
+      const base = path.join(dir, 'shape-dryrun');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(path.join(sourceDir, 'rules', 'foo.md'), { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, 'rules', 'foo.md', 'index.md'), 'foo child');
+      ['widget', 'widget-old-use.md', 'widget-old-notes.md'].forEach(name =>
+        fs.writeFileSync(path.join(sourceDir, name), name === 'widget' ? 'new widget' : `${name} bytes`)
+      );
+      fs.mkdirSync(path.join(root, 'rules'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'rules', 'foo.md'), 'hand-made, unrecorded, foreign');
+      fs.mkdirSync(path.join(root, 'widget'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'widget-old-use.md bytes');
+      fs.writeFileSync(path.join(root, 'widget', 'notes.md'), 'widget-old-notes.md bytes');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      // The widget children are recorded; the rules/foo.md file is not: it
+      // was never ours, so the listing refuses it instead of promising to
+      // retire a foreign file.
+      writeInstallState(statePath, buildState([
+        copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+        copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
+      ]));
+      const operations = [
+        copyOp(path.join(sourceDir, 'rules', 'foo.md', 'index.md'), 'rules/foo.md/index.md', path.join(root, 'rules', 'foo.md', 'index.md')),
+        copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
+        copyOp(path.join(sourceDir, 'widget-old-use.md'), 'widget-old-use.md', path.join(root, 'widget-old-use.md')),
+        copyOp(path.join(sourceDir, 'widget-old-notes.md'), 'widget-old-notes.md', path.join(root, 'widget-old-notes.md')),
+      ];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      const { transitions, refusals } = collectShapeTransitions(plan);
+      assert.strictEqual(transitions.length, 1, 'the resolvable dir-to-file transition is listed');
+      assert.strictEqual(transitions[0].type, 'dir-to-file');
+      assert.strictEqual(refusals.length, 1, 'the unrecorded file-to-dir is refused, not listed');
+      assert.strictEqual(refusals[0].destinationPath, path.join(root, 'rules', 'foo.md'));
+      assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'nothing was removed by the listing');
+      assert.ok(fs.existsSync(path.join(root, 'widget', 'use.md')), 'the children are all still there');
+      assert.ok(fs.existsSync(path.join(root, 'widget', 'notes.md')), 'all of them');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'rules', 'foo.md'), 'utf8'), 'hand-made, unrecorded, foreign', 'and the refused file still holds its content');
+    })) passed++; else failed++;
+
+    if (test('a planned destination outside every managed root never makes its ancestors transition candidates', () => {
+      const base = path.join(dir, 'shape-outside');
+      const root = path.join(base, 'root');
+      const foreign = path.join(base, 'foreign');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(root, { recursive: true });
+      // The plan writes under a FILE that lives outside every managed root.
+      // That file is foreign territory: it must not be listed as a
+      // file-to-dir candidate, let alone retired to make way for the copy.
+      fs.mkdirSync(foreign, { recursive: true });
+      fs.writeFileSync(path.join(foreign, 'x'), 'an unrelated file');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([copyOp(
+        path.join(foreign, 'x', 'old.md'),
+        'x/old.md',
+        path.join(foreign, 'x', 'old.md')
+      )]));
+      const operations = [copyOp(
+        path.join(foreign, 'src.md'),
+        'x/child.md',
+        path.join(foreign, 'x', 'child.md')
+      )];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      const { transitions, refusals } = collectShapeTransitions(plan);
+      assert.strictEqual(transitions.length, 0, 'no transition is offered on foreign territory');
+      assert.strictEqual(refusals.length, 0, 'and nothing there is refused either');
+      assert.strictEqual(fs.readFileSync(path.join(foreign, 'x'), 'utf8'), 'an unrelated file', 'the foreign file is untouched');
     })) passed++; else failed++;
 
     if (test('a plain destination, existing or not, passes', () => {

--- a/tests/lib/install-apply-links.test.js
+++ b/tests/lib/install-apply-links.test.js
@@ -579,11 +579,9 @@ function runTests() {
       assert.deepStrictEqual(transitions[0], {
         type: 'dir-to-file',
         destinationPath: path.join(root, 'widget'),
-        children: process.platform === 'win32'
-          ? [path.join(root, 'widget', 'notes.md'), path.join(root, 'widget', 'use.md')].sort()
-          : [path.join(root, 'widget', 'use.md'), path.join(root, 'widget', 'notes.md')].sort(),
+        children: [path.join(root, 'widget', 'use.md'), path.join(root, 'widget', 'notes.md')].sort(),
         directories: [path.join(root, 'widget')],
-      }, 'the apply reports the transition');
+      }, 'the apply reports the transition in a deterministic order');
     })) passed++; else failed++;
 
     if (test('a directory in the way of a file whose child is no longer a byte-identical EGC copy refuses the dir-to-file transition', () => {
@@ -622,7 +620,13 @@ function runTests() {
         copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
         copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
       ]));
-      const operations = [copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget'))];
+      // notes.md is planned again (flattened to widget-old-notes.md), so its
+      // bytes reconcile; only the edited use.md can possibly refuse the whole
+      // transition.
+      const operations = [
+        copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
+        copyOp(path.join(sourceDir, 'widget-old-notes.md'), 'widget-old-notes.md', path.join(root, 'widget-old-notes.md')),
+      ];
       const plan = {
         adapter,
         targetRoot: root,
@@ -636,6 +640,7 @@ function runTests() {
       assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'the directory stays intact');
       assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'the person changed this child', 'the changed child stays');
       assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'notes.md'), 'utf8'), 'widget-old-notes.md bytes', 'and so does the rest of it');
+      assert.ok(!fs.existsSync(path.join(root, 'widget-old-notes.md')), 'even the reconcilable child is not written: the refusal precedes every operation');
       assert.ok(!fs.existsSync(path.join(root, 'widget-old-use.md')), 'nothing is written');
     })) passed++; else failed++;
 
@@ -705,6 +710,248 @@ function runTests() {
       assert.ok(fs.existsSync(path.join(root, 'widget', 'use.md')), 'the children are all still there');
       assert.ok(fs.existsSync(path.join(root, 'widget', 'notes.md')), 'all of them');
       assert.strictEqual(fs.readFileSync(path.join(root, 'rules', 'foo.md'), 'utf8'), 'hand-made, unrecorded, foreign', 'and the refused file still holds its content');
+    })) passed++; else failed++;
+
+    if (links) {
+      if (test('a non-legacy link in the way of a planned directory is refused by the scan and by the apply', () => {
+        const base = path.join(dir, 'shape-link');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(path.join(sourceDir, 'rules', 'foo.md'), { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, 'rules', 'foo.md', 'index.md'), 'foo child');
+      fs.mkdirSync(path.join(root, 'rules'), { recursive: true });
+      fs.mkdirSync(path.join(base, 'elsewhere'), { recursive: true });
+      fs.writeFileSync(path.join(base, 'elsewhere', 'ghost.md'), 'not EGC');
+      fs.symlinkSync(path.join(base, 'elsewhere', 'ghost.md'), path.join(root, 'rules', 'foo.md'));
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([]));
+      const operations = [copyOp(
+        path.join(sourceDir, 'rules', 'foo.md', 'index.md'),
+        'rules/foo.md/index.md',
+        path.join(root, 'rules', 'foo.md', 'index.md')
+      )];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      const { transitions, refusals } = collectShapeTransitions(plan);
+      assert.strictEqual(transitions.length, 0, 'a link is never a transition candidate');
+      assert.strictEqual(refusals.length, 1, 'the scan refuses the link, like the apply would');
+      assert.strictEqual(refusals[0].destinationPath, path.join(root, 'rules', 'foo.md'));
+      assert.ok(refusals[0].reason.includes('symbolic link'), refusals[0].reason);
+      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the apply refuses before writing behind the link');
+      assert.ok(fs.lstatSync(path.join(root, 'rules', 'foo.md')).isSymbolicLink(), 'the link is untouched');
+      assert.ok(!fs.existsSync(path.join(root, 'rules', 'foo.md', 'index.md')), 'nothing is written behind it');
+      })) passed++; else failed++;
+    }
+
+    if (test('a directory in the way of a file that contains an empty subdirectory no recorded file accounts for refuses', () => {
+      const base = path.join(dir, 'shape-d2f-emptydir');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(sourceDir, { recursive: true });
+      ['widget', 'widget-old-use.md', 'widget-old-notes.md'].forEach(name =>
+        fs.writeFileSync(path.join(sourceDir, name), name === 'widget' ? 'new widget' : `${name} bytes`)
+      );
+      fs.mkdirSync(path.join(root, 'widget', 'unused'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'widget-old-use.md bytes');
+      fs.writeFileSync(path.join(root, 'widget', 'notes.md'), 'widget-old-notes.md bytes');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([
+        copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+        copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
+      ]));
+      // The widget children reconcile against the flattened old files the
+      // plan still copies; only the empty subdirectory the person made is
+      // unaccounted for, and it refuses the transition instead of being
+      // silently deleted.
+      const operations = [
+        copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
+        copyOp(path.join(sourceDir, 'widget-old-use.md'), 'widget-old-use.md', path.join(root, 'widget-old-use.md')),
+        copyOp(path.join(sourceDir, 'widget-old-notes.md'), 'widget-old-notes.md', path.join(root, 'widget-old-notes.md')),
+      ];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      const { transitions, refusals } = collectShapeTransitions(plan);
+      assert.strictEqual(transitions.length, 0, 'nothing is promised while an unaccounted directory sits in the way');
+      assert.strictEqual(refusals.length, 1, 'the empty subdirectory the person made refuses, it is not silently deleted');
+      assert.strictEqual(refusals[0].destinationPath, path.join(root, 'widget'));
+      assert.ok(refusals[0].reason.includes('no recorded EGC file accounts for'), refusals[0].reason);
+      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the apply refuses too');
+      assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'the directory stays');
+      assert.ok(fs.statSync(path.join(root, 'widget', 'unused')).isDirectory(), 'the person-made subdirectory stays');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'widget-old-use.md bytes');
+    })) passed++; else failed++;
+
+    if (test('a flatten whose replacement matches none of the recorded children refuses: the honest outcome when the content is new', () => {
+      const base = path.join(dir, 'shape-d2f-newcontent');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(sourceDir, { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, 'widget'), 'brand new content');
+      fs.mkdirSync(path.join(root, 'widget'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'use bytes');
+      fs.writeFileSync(path.join(root, 'widget', 'notes.md'), 'notes bytes');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      // The recorded sources (widget/use.md, widget/notes.md) belong to the
+      // old directory layout and no longer exist; the flatten's contents are
+      // new, so no recorded bytes and no planned bytes can prove the children
+      // are obsolete. Refusing is the only honest outcome.
+      writeInstallState(statePath, buildState([
+        copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+        copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
+      ]));
+      const operations = [copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget'))];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      const { transitions, refusals } = collectShapeTransitions(plan);
+      assert.strictEqual(transitions.length, 0, 'a flatten with unrecognizable children is not promised');
+      assert.strictEqual(refusals.length, 1, 'it refuses and tells the person to sort the directory out manually');
+      assert.strictEqual(refusals[0].destinationPath, path.join(root, 'widget'));
+      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Shape transition refused/, 'the apply refuses before anything changes');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'use bytes', 'the directory and its contents stay exactly as they were');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'notes.md'), 'utf8'), 'notes bytes');
+    })) passed++; else failed++;
+
+    if (test('a failing operation earlier in the plan leaves a resolved transition fully intact (all-or-nothing)', () => {
+      const base = path.join(dir, 'shape-d2f-laterfail');
+      const sourceDir = path.join(base, 'source');
+      const root = path.join(base, 'root');
+      const statePath = path.join(base, 'egc', 'install-state.json');
+      const adapter = { id: 'custom', target: 'custom', kind: 'home' };
+      fs.mkdirSync(sourceDir, { recursive: true });
+      ['widget', 'widget-old-use.md', 'widget-old-notes.md'].forEach(name =>
+        fs.writeFileSync(path.join(sourceDir, name), name === 'widget' ? 'new widget' : `${name} bytes`)
+      );
+      fs.mkdirSync(path.join(root, 'widget'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'widget', 'use.md'), 'widget-old-use.md bytes');
+      fs.writeFileSync(path.join(root, 'widget', 'notes.md'), 'widget-old-notes.md bytes');
+      fs.writeFileSync(path.join(root, 'config.json'), '{not json');
+      const copyOp = (sourcePath, sourceRelativePath, destinationPath) => ({
+        kind: 'copy-file',
+        moduleId: 'egc-universal',
+        sourcePath,
+        sourceRelativePath,
+        destinationPath,
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      });
+      const buildState = operations => createInstallState({
+        adapter,
+        targetRoot: root,
+        installStatePath: statePath,
+        request: { profile: null },
+        resolution: {},
+        source: { repoVersion: 'test', repoCommit: 'test', manifestVersion: 1 },
+        operations,
+      });
+      writeInstallState(statePath, buildState([
+        copyOp(path.join(sourceDir, 'widget', 'use.md'), 'widget/use.md', path.join(root, 'widget', 'use.md')),
+        copyOp(path.join(sourceDir, 'widget', 'notes.md'), 'widget/notes.md', path.join(root, 'widget', 'notes.md')),
+      ]));
+      // The dir-to-file transition is NOT the failing op: the malformed
+      // config.json merge fails first, before the widget transition would run.
+      const operations = [
+        { kind: 'merge-json', moduleId: 'egc-universal', sourceRelativePath: 'config.json', destinationPath: path.join(root, 'config.json'), mergePayload: { app: 1 }, strategy: 'merge', ownership: 'managed', scaffoldOnly: false },
+        copyOp(path.join(sourceDir, 'widget'), 'widget', path.join(root, 'widget')),
+        copyOp(path.join(sourceDir, 'widget-old-use.md'), 'widget-old-use.md', path.join(root, 'widget-old-use.md')),
+        copyOp(path.join(sourceDir, 'widget-old-notes.md'), 'widget-old-notes.md', path.join(root, 'widget-old-notes.md')),
+      ];
+      const plan = {
+        adapter,
+        targetRoot: root,
+        managedRoots: [root],
+        installStatePath: statePath,
+        retirements: [],
+        operations,
+        statePreview: buildState(operations),
+      };
+      assert.throws(() => applyInstallPlan(plan, { homeDir: base }), /Failed to parse/, 'the merge fails before the transition would run');
+      assert.ok(fs.statSync(path.join(root, 'widget')).isDirectory(), 'the directory that would have been transitioned is still there');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'use.md'), 'utf8'), 'widget-old-use.md bytes', 'neither child was removed');
+      assert.strictEqual(fs.readFileSync(path.join(root, 'widget', 'notes.md'), 'utf8'), 'widget-old-notes.md bytes');
+      assert.ok(!fs.existsSync(path.join(root, 'widget-old-use.md')), 'nothing after the failure was written');
+      assert.ok(!fs.existsSync(path.join(root, 'widget-old-notes.md')), 'any of it');
     })) passed++; else failed++;
 
     if (test('a planned destination outside every managed root never makes its ancestors transition candidates', () => {

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -503,6 +503,60 @@ function runTests() {
     })) passed++; else failed++;
   }
 
+  if (test('a skill the egc target installs first as a single file is listed as a file-to-dir transition in the dry run (#1428)', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+    try {
+      const repoRoot = path.join(__dirname, '..', '..');
+      // Find a skill the egc target installs this run, straight from the plan.
+      const planned = run(['--target', 'egc', '--profile', 'minimal', '--dry-run', '--allow-undetected'], { cwd: projectDir, homeDir });
+      assert.strictEqual(planned.code, 0, planned.stderr);
+      const cliSkills = path.join(homeDir, '.gemini', 'antigravity-cli', 'skills');
+      const chosen = planned.stdout.split('\n')
+        .map(line => line.trim())
+        .map(line => /^- (.+?) -> (.+)$/.exec(line))
+        .filter(match => match && match[2].includes(cliSkills + path.sep))
+        .map(match => ({ sourceRelative: match[1], destination: match[2] }))
+        .find(entry => entry.destination.split(path.sep).length > cliSkills.split(path.sep).length + 1);
+      assert.ok(chosen, 'a skill with a directory of its own is planned');
+      const parent = path.join(cliSkills, path.relative(cliSkills, chosen.destination).split(path.sep)[0]);
+      // An earlier install recorded that skill destination as a single file,
+      // and the plan now wants a directory there. The bytes written match the
+      // planned child source, so the transition is provable.
+      fs.mkdirSync(path.dirname(parent), { recursive: true });
+      const childSource = path.join(repoRoot, chosen.sourceRelative.split('/').join(path.sep));
+      assert.ok(fs.existsSync(childSource), `the planned source exists: ${chosen.sourceRelative}`);
+      fs.copyFileSync(childSource, parent);
+      const statePath = path.join(homeDir, '.gemini', 'egc', 'install-state.json');
+      const { createInstallState, writeInstallState } = require('../../scripts/lib/install-state');
+      writeInstallState(statePath, createInstallState({
+        adapter: { id: 'egc' },
+        targetRoot: path.join(homeDir, '.gemini'),
+        installStatePath: statePath,
+        request: { profile: 'minimal', modules: [], legacyLanguages: [], legacyMode: false },
+        resolution: { selectedModules: [], skippedModules: [] },
+        // moduleId 'unselected' keeps the transitioned file out of the
+        // retirement list, so the dry-run output stays readable.
+        operations: [{ kind: 'copy-file', moduleId: 'unselected', sourceRelativePath: chosen.sourceRelative, destinationPath: parent, strategy: 'preserve-relative-path', ownership: 'managed', scaffoldOnly: false }],
+        source: { repoVersion: require('../../package.json').version, repoCommit: 'abc123', manifestVersion: 1 },
+      }));
+
+      const dryRun = run(['--target', 'egc', '--profile', 'minimal', '--dry-run', '--allow-undetected'], { cwd: projectDir, homeDir });
+      assert.strictEqual(dryRun.code, 0, dryRun.stderr);
+      assert.ok(dryRun.stdout.includes('Shape transitions (a source changed between a file and a directory):'), dryRun.stdout);
+      assert.ok(dryRun.stdout.includes(`${parent}: file retired, written as a directory`), dryRun.stdout);
+      assert.ok(fs.statSync(parent).isFile(), 'the dry run leaves the file as a file');
+      const dryJson = run(['--target', 'egc', '--profile', 'minimal', '--dry-run', '--allow-undetected', '--json'], { cwd: projectDir, homeDir });
+      const plan = JSON.parse(dryJson.stdout).plan;
+      assert.strictEqual(plan.shapeTransitions.length, 1, 'exactly one transition is planned');
+      assert.strictEqual(plan.shapeTransitions[0].type, 'file-to-dir');
+      assert.strictEqual(plan.shapeTransitions[0].destinationPath, parent, 'the file that claims the directory spot');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('supports manifest profile dry-runs through the installer', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');


### PR DESCRIPTION
## Summary

Fixes #1428 — the installer now handles a source that changes shape at an *already-installed* destination.

When a module's source goes from **a file** to **a directory** (or back) between installs, the destination keeps its name but not its shape (e.g. `rules/foo.md` stops being a file and becomes a directory). A naive apply trips over a raw `EEXIST`/`EISDIR` **after** already writing part of the new layout, leaving the target half migrated.

This PR resolves both directions explicitly, using the same ownership and identity guarantees `retirePlannedFiles` already uses:

- **file → dir** — the recorded file is retired and the directory is materialized in its place.
- **dir → file** — every managed file inside the directory is retired, emptied directories are removed deepest-first, and the file is written.
- **Identity check** — a file may only be retired when it was **recorded by a previous install** (managed copy-file op in the previous `install-state.json`) **and** is **byte-identical to a file this plan copies today** (`plannedContentHashes`, the same check retirement uses when a recorded source has been renamed/moved). The recorded source of a shape transition is by definition gone or changed shape, so the original-source comparison is impossible and the planned-content fallback is the only honest identity proof.
- **Hard refusal, before any write** — anything else (a file the user edited, a file EGC never installed, a symlink/special file inside a directory to be flattened, a directory that cannot be listed, or a plan that writes the same path as both a file and a directory) refuses the whole install with a clear message, with the layout completely untouched — including before any legacy-link removal.
- **Safety scope** — transitions are confined to declared managed roots; a planned destination outside every managed root never makes its ancestors transition candidates, so foreign territory is never touched.
- **`--dry-run`** — lists each resolvable transition and every refusal the apply would throw, in both human and `--json` output.

## Component Type

- [x] Core Engine / Orchestrator (install apply + CLI dry-run surface)
- [ ] MCP Server (egc-guardian / egc-memory)
- [ ] Agent
- [ ] Skill
- [ ] Hook
- [ ] Command

## Validation

- New tests in `tests/lib/install-apply-links.test.js` cover both directions through the full `applyInstallPlan`:
  - file → dir resolves; modified/unverifiable file refuses with the file kept intact;
  - dir → file resolves (children retired via identity, dirs removed, file written); a single user-modified child refuses the whole directory with nothing touched;
  - `collectShapeTransitions` is read-only (the dry-run contract): lists transitions and refusals without deleting anything;
  - regression: a destination outside every managed root never turns its ancestors into transition candidates.
- Local suites (Node on Windows): `install-apply-links` (12/12), `install-executor` (13), `install-targets` (154), `install-apply` (35), `install-lifecycle` (54) — 0 failures.
- ESLint: clean on all changed files (one pre-existing `complexity` *warning* in the test file; base already exceeded the threshold at 21).
- Note for the full `node tests/run-all.js` matrix: on this Windows dev box a small set of unrelated suites inherply fail or skip on symlink `EPERM` (no symlink privilege) — confirmed pre-existing by re-running them with the change stashed. The failures are unrelated to this PR.

### Repro for reviewers

1. Install a module that ships `rules/foo.md` as a **file** (`--target cursor` against a scratch project).
2. In the next release the source `rules/foo.md` becomes a **directory** containing `index.md`.
3. Re-install: the recorded file at `<root>/rules/foo.md` is retired (its bytes match the planned child is optional — they must match a planned source), and the directory is written without `EEXIST`.
4. Edit the installed file and re-install → the install now refuses with "Shape transition refused…" and leaves the layout intact instead of dying mid-copy.

## Checklist

- [x] All commits carry `Signed-off-by` (DCO)
- [ ] CLA signed (first contribution — reply to the bot if prompted)
- [x] Relevant suites pass locally (`tests/lib/install-apply-links.test.js`, `install-executor`, `install-targets`, `install-apply`, `install-lifecycle`)
- [ ] `node tests/run-all.js` full matrix green on Linux/macOS/Windows (full matrix not runnable end-to-end on this Windows box; see Validation)
- [x] `npm audit --audit-level=high` unchanged (no dependencies added)
- [x] ESLint passes on changed files
- [x] Markdownlint — no `.md` files changed
- [x] PR changes fewer than 150 code files (3 files, +678/−4)
- [ ] Concurrent-access regression test added/updated (not applicable: no `~/.egc/` shared-state file changes — install-state reads are already best-effort in existing retirement paths)
- [x] Tested on Windows; logic is OS-neutral (uses `fs.lstat/readdir/rm/rmdir` only)
- [x] No sensitive data committed
- [x] `runtime-map.json` registry untouched

## Files Changed

- `scripts/lib/install/apply.js` — `plannedWriteShapes`, `previousStateManagedCopies`, `isShapeTransitionRemovable`, `collectShapeBlockingEntries`, `collectShapeTransitions`, `performShapeTransitions`, `formatShapeTransitionsRefusal`; wired into `applyInstallPlan` (preflight refusal + pre-copy resolution) and exported.
- `scripts/install-apply.js` — dry-run attaches `shapeTransitions`/`shapeRefusals`; `printHumanPlan` gains `printShapeTransitions`.
- `tests/lib/install-apply-links.test.js` — six shape-transition tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1428: previously, when a source changed between a file and a directory, the installer hit `EEXIST`/`EISDIR` after already writing part of the new layout. It now resolves file ↔ directory transitions at already-installed destinations, refusing cleanly with the layout untouched when ownership can't be proven.

What changed
- file→dir: the recorded byte-identical file is retired and the directory materialized.
- dir→file: every recorded byte-identical child is retired, empty directories are removed deepest-first, then the file is written.
- Identity is proven only against files this plan copies today (recorded copy-file ops with matching content hashes).
- Anything else — user-edited, unrecorded, symlink/special, unlistable, or a plan writing the same path as both file and directory — refuses with a clear, actionable message before any write, even on a fresh install.
- A managed root that is itself a link installs through it; EGC's own legacy layout links are left to the existing link-migration machinery.
- Transitions are all-or-nothing, re-verified immediately before removal, and only run when the consuming operation is reached, so an earlier failure leaves the old shape intact.
- Dry run lists every resolvable transition and refusal in human and `--json` output.

<sup>Written for commit 5da6e6e397f8e2844a035f8b067e4b30617efb47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install plans now detect and report file-to-directory and directory-to-file transitions.
  * Installations safely convert managed, unchanged files when a source changes shape.
  * Dry runs show planned transitions without modifying files.
* **Bug Fixes**
  * Unsafe conversions involving modified, untracked, unmanaged, unreadable, or special files are refused.
  * Symbolic links are excluded from automatic conversions.
  * Destinations outside managed installation roots remain untouched.
  * Failed installation operations no longer leave partially completed shape transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->