### PR TITLE
docs(security): the supported versions table names the 1.1.x line

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 | :--- | :--- |
-| 1.0.x | Yes |
+| 1.1.x | Yes |
+| < 1.1 | No |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## What

`.github/SECURITY.md` listed `1.0.x` as the only supported version line. That line has not shipped a release since v1.1.0; every release since then is 1.1.x. The Supported Versions table now reads:

| Version | Supported |
| :--- | :--- |
| 1.1.x | Yes |
| < 1.1 | No |

## Why

The rest of the policy (private vulnerability reporting through GitHub advisories, the e-mail fallback, the response timeline and the scope) was checked against the repository settings and is current; only the table was stale.

## Verification

- Docs parity tests: `node --test tests/ci/*.test.js`, 7 passed.
- No code touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the supported versions table in `.github/SECURITY.md` so it lists `1.1.x` as the supported line instead of `1.0.x`, which hasn't shipped a release since v1.1.0. The rest of the security policy was verified against repository settings and is current.

<sup>Written for commit fe84ee7c81ae4716ffe2b06988aafcfb735fff53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

