### PR TITLE
docs(security): the advisory link is a proper link

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,7 +12,7 @@
 Do not open public GitHub issues for security vulnerabilities.
 
 Use GitHub's private vulnerability reporting:
-https://github.com/Fmarzochi/EGC/security/advisories/new
+<https://github.com/Fmarzochi/EGC/security/advisories/new>
 
 Alternatively, email [fmarzochi@gmail.com](mailto:fmarzochi@gmail.com).
 


### PR DESCRIPTION
## What

`.github/SECURITY.md`: the private vulnerability reporting address is now written as `<https://github.com/Fmarzochi/EGC/security/advisories/new>` instead of a bare URL. Same destination, rendered as a link in every Markdown renderer, and the only lint finding on the file is gone.

## Verification

- `markdownlint-cli2 .github/SECURITY.md`: 0 issues.
- Docs parity tests: `node --test tests/ci/*.test.js`, 7 passed.
- No code touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wraps the private vulnerability reporting URL in angle brackets in `.github/SECURITY.md` so it renders as a proper link in every Markdown renderer, fixing the last lint finding on the file. The destination is unchanged, and no code was touched.

<sup>Written for commit 6ce1d5282b04ade10170ec5f52639bcc11daf263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Fmarzochi/EGC/pull/1444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

